### PR TITLE
Align app endpoints and services with reference backend (alerts, MFA, API keys, push, sessions)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,8 @@ from app.routers.ui_mfa import router as ui_mfa_router
 from app.routers.mfa_devices import router as mfa_devices_router
 from app.routers.api_keys import router as api_keys_router
 from app.routers.alerts import router as alerts_router
+from app.routers.push import router as push_router
+from app.routers.recovery import router as recovery_router
 from app.routers.misc import router as misc_router
 
 def create_app() -> FastAPI:
@@ -26,6 +28,8 @@ def create_app() -> FastAPI:
     app.include_router(mfa_devices_router)
     app.include_router(api_keys_router)
     app.include_router(alerts_router)
+    app.include_router(push_router)
+    app.include_router(recovery_router)
     app.include_router(misc_router)
 
     return app

--- a/app/routers/alerts.py
+++ b/app/routers/alerts.py
@@ -1,28 +1,60 @@
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import Any, Dict, List, Optional
 
 from boto3.dynamodb.conditions import Key
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from app.core.crypto import sha256_str
 from app.core.cursor import decode_cursor, encode_cursor
+from app.core.normalize import normalize_email, normalize_phone
+from app.core.settings import S
 from app.core.tables import T
-from app.models import MarkReadReq
-from app.services.alerts import ALERT_EVENT_TYPES, get_alert_prefs, set_alert_prefs, sse_subscribe, sse_unsubscribe
-from app.services.sessions import require_ui_session
 from app.core.time import now_ts
+from app.models import (
+    AlertEmailBeginReq,
+    AlertEmailConfirmReq,
+    AlertEmailPrefsReq,
+    AlertEmailRemoveReq,
+    AlertPushPrefsReq,
+    AlertSmsBeginReq,
+    AlertSmsConfirmReq,
+    AlertSmsPrefsReq,
+    AlertSmsRemoveReq,
+    AlertToastPrefsReq,
+    MarkReadReq,
+)
+from app.services.alerts import (
+    ALERT_EVENT_TYPES,
+    audit_event,
+    get_alert_prefs,
+    send_alert_email,
+    send_alert_sms,
+    set_alert_prefs,
+    sse_subscribe,
+    sse_unsubscribe,
+)
+from app.services.mfa import gen_numeric_code
+from app.services.rate_limit import can_send_verification
+from app.services.sessions import create_action_challenge, load_challenge_or_401, require_ui_session, revoke_challenge
 
 router = APIRouter(prefix="/ui", tags=["alerts"])
 
+
 @router.get("/alerts/types")
 async def alert_types(_: Dict[str, str] = Depends(require_ui_session)):
-    return {"event_types": ALERT_EVENT_TYPES}
+    return {"types": ALERT_EVENT_TYPES, "event_types": ALERT_EVENT_TYPES}
+
 
 @router.get("/alerts")
-async def list_alerts(limit: int = 50, cursor: Optional[str] = None, ctx: Dict[str, str] = Depends(require_ui_session)):
+async def list_alerts(
+    limit: int = 50,
+    cursor: Optional[str] = None,
+    unread_only: int = 0,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
     eks = decode_cursor(cursor)
     r = T.alerts.query(
         KeyConditionExpression=Key("user_sub").eq(ctx["user_sub"]),
@@ -32,9 +64,10 @@ async def list_alerts(limit: int = 50, cursor: Optional[str] = None, ctx: Dict[s
     )
     items = r.get("Items", [])
     next_cursor = encode_cursor(r.get("LastEvaluatedKey"))
-    # strip large details
     out = []
     for it in items:
+        if unread_only and it.get("read", False):
+            continue
         out.append({
             "alert_id": it.get("alert_id"),
             "ts": it.get("ts"),
@@ -44,12 +77,15 @@ async def list_alerts(limit: int = 50, cursor: Optional[str] = None, ctx: Dict[s
             "details": it.get("details", {}),
             "read": it.get("read", False),
             "read_at": it.get("read_at", 0),
+            "toast_delivered": it.get("toast_delivered", False),
         })
     return {"alerts": out, "next_cursor": next_cursor}
+
 
 @router.post("/alerts/mark_read")
 async def mark_read(body: MarkReadReq, ctx: Dict[str, str] = Depends(require_ui_session)):
     ts = now_ts()
+    updated = 0
     for aid in body.alert_ids[:200]:
         try:
             T.alerts.update_item(
@@ -58,44 +94,196 @@ async def mark_read(body: MarkReadReq, ctx: Dict[str, str] = Depends(require_ui_
                 ExpressionAttributeNames={"#r": "read"},
                 ExpressionAttributeValues={":t": True, ":ts": ts},
             )
+            updated += 1
         except Exception:
             pass
-    return {"status":"ok"}
+    return {"ok": True, "updated": updated}
+
 
 @router.get("/alerts/email_prefs")
 async def get_email_prefs(ctx: Dict[str, str] = Depends(require_ui_session)):
-    prefs = get_alert_prefs(ctx["user_sub"])
-    return {"emails": prefs["emails"], "event_types": prefs["email_event_types"]}
+    return get_alert_prefs(ctx["user_sub"])
+
 
 @router.post("/alerts/email_prefs")
-async def set_email_prefs(body: Dict[str, Any], ctx: Dict[str, str] = Depends(require_ui_session)):
-    prefs = set_alert_prefs(ctx["user_sub"], email_event_types=body.get("event_types", []))
-    return {"status":"ok","event_types": prefs["email_event_types"]}
+async def set_email_prefs(body: AlertEmailPrefsReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    prefs = set_alert_prefs(ctx["user_sub"], email_event_types=body.email_event_types)
+    audit_event("alerts_email_prefs_set", ctx["user_sub"], None, outcome="success", enabled=len(prefs.get("email_event_types") or []))
+    return prefs
+
 
 @router.get("/alerts/sms_prefs")
 async def get_sms_prefs(ctx: Dict[str, str] = Depends(require_ui_session)):
     prefs = get_alert_prefs(ctx["user_sub"])
     return {"sms_numbers": prefs["sms_numbers"], "event_types": prefs["sms_event_types"]}
 
+
 @router.post("/alerts/sms_prefs")
-async def set_sms_prefs(body: Dict[str, Any], ctx: Dict[str, str] = Depends(require_ui_session)):
-    prefs = set_alert_prefs(ctx["user_sub"], sms_event_types=body.get("event_types", []))
-    return {"status":"ok","event_types": prefs["sms_event_types"]}
+async def set_sms_prefs(body: AlertSmsPrefsReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    prefs = set_alert_prefs(ctx["user_sub"], sms_event_types=body.sms_event_types)
+    audit_event("alerts_sms_prefs_set", ctx["user_sub"], None, outcome="success", enabled=len(prefs.get("sms_event_types") or []))
+    return prefs
+
 
 @router.get("/alerts/toast_prefs")
 async def get_toast_prefs(ctx: Dict[str, str] = Depends(require_ui_session)):
     prefs = get_alert_prefs(ctx["user_sub"])
     return {"event_types": prefs["toast_event_types"]}
 
+
 @router.post("/alerts/toast_prefs")
-async def set_toast_prefs(body: Dict[str, Any], ctx: Dict[str, str] = Depends(require_ui_session)):
-    prefs = set_alert_prefs(ctx["user_sub"], toast_event_types=body.get("event_types", []))
-    return {"status":"ok","event_types": prefs["toast_event_types"]}
+async def set_toast_prefs(body: AlertToastPrefsReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    prefs = set_alert_prefs(ctx["user_sub"], toast_event_types=body.toast_event_types)
+    audit_event("alerts_toast_prefs_set", ctx["user_sub"], None, outcome="success", enabled=len(prefs.get("toast_event_types") or []))
+    return prefs
+
+
+@router.post("/alerts/push_prefs")
+async def set_push_prefs(body: AlertPushPrefsReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    prefs = set_alert_prefs(ctx["user_sub"], push_event_types=body.push_event_types)
+    audit_event("alerts_push_prefs_set", ctx["user_sub"], None, outcome="success", enabled=len(prefs.get("push_event_types") or []))
+    return prefs
+
 
 @router.post("/alerts/mark_toast_delivered")
-async def mark_toast_delivered(_: Dict[str, Any], __: Dict[str, str] = Depends(require_ui_session)):
-    # left as a hook; implement per-session delivery receipts if needed
-    return {"status":"ok"}
+async def mark_toast_delivered(body: Dict[str, Any], ctx: Dict[str, str] = Depends(require_ui_session)):
+    updated = 0
+    for aid in (body.get("alert_ids") or [])[:200]:
+        try:
+            T.alerts.update_item(
+                Key={"user_sub": ctx["user_sub"], "alert_id": aid},
+                UpdateExpression="SET toast_delivered = :t, toast_delivered_at = :now",
+                ExpressionAttributeValues={":t": True, ":now": now_ts()},
+            )
+            updated += 1
+        except Exception:
+            pass
+    return {"ok": True, "updated": updated}
+
+
+def _check_attempt_budget(chal: Dict[str, Any], *, prefix: str, max_attempts: int, window_seconds: int) -> None:
+    attempts = int(chal.get(f"{prefix}_attempts", 0))
+    sent_at = int(chal.get(f"{prefix}_sent_at", 0) or chal.get("created_at", 0))
+    if attempts >= max_attempts and (now_ts() - sent_at) < window_seconds:
+        raise HTTPException(429, "Too many attempts; wait and retry")
+
+
+def _bump_attempt(user_sub: str, challenge_id: str, prefix: str, attempts: int) -> None:
+    try:
+        T.sessions.update_item(
+            Key={"user_sub": user_sub, "session_id": challenge_id},
+            UpdateExpression=f"SET {prefix}_attempts = :n",
+            ExpressionAttributeValues={":n": attempts + 1},
+        )
+    except Exception:
+        pass
+
+
+@router.post("/alerts/sms/begin")
+async def alert_sms_add_begin(req: Request, body: AlertSmsBeginReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    phone = normalize_phone(body.phone)
+    code = gen_numeric_code(6)
+    code_hash = sha256_str(code)
+    challenge_id = create_action_challenge(
+        req,
+        user_sub=user_sub,
+        purpose="alert_sms_add",
+        send_to=[phone],
+        payload={"sms_code_hash": code_hash, "phone": phone, "sms_code_attempts": 0, "sms_code_sent_at": now_ts()},
+        ttl_seconds=600,
+    )
+    send_alert_sms([phone], f"Your confirmation code is: {code}")
+    audit_event("alerts_sms_add_begin", user_sub, req, outcome="success", phone=phone)
+    return {"challenge_id": challenge_id, "sent_to": phone}
+
+
+@router.post("/alerts/sms/confirm")
+async def alert_sms_add_confirm(req: Request, body: AlertSmsConfirmReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    chal = load_challenge_or_401(user_sub, body.challenge_id)
+    if chal.get("purpose") != "alert_sms_add":
+        raise HTTPException(400, "Bad challenge")
+    _check_attempt_budget(chal, prefix="sms_code", max_attempts=S.sms_code_max_attempts, window_seconds=S.sms_code_attempt_window_seconds)
+    if sha256_str(body.code.strip()) != chal.get("sms_code_hash"):
+        _bump_attempt(user_sub, body.challenge_id, "sms_code", int(chal.get("sms_code_attempts", 0)))
+        audit_event("alerts_sms_add_confirm", user_sub, req, outcome="failure", reason="bad_code")
+        raise HTTPException(401, "Bad SMS code")
+    phone = chal.get("phone")
+    prefs = get_alert_prefs(user_sub)
+    nums = prefs.get("sms_numbers") or []
+    if phone and phone not in nums:
+        nums.append(phone)
+    prefs2 = set_alert_prefs(user_sub, sms_numbers=nums)
+    revoke_challenge(user_sub, body.challenge_id)
+    audit_event("alerts_sms_add_confirm", user_sub, req, outcome="success", phone=phone)
+    return prefs2
+
+
+@router.post("/alerts/sms/remove")
+async def alert_sms_remove(req: Request, body: AlertSmsRemoveReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    phone = normalize_phone(body.phone)
+    prefs = get_alert_prefs(user_sub)
+    nums = [n for n in (prefs.get("sms_numbers") or []) if n != phone]
+    prefs2 = set_alert_prefs(user_sub, sms_numbers=nums)
+    audit_event("alerts_sms_remove", user_sub, req, outcome="success", phone=phone)
+    return prefs2
+
+
+@router.post("/alerts/emails/begin")
+async def alert_email_add_begin(req: Request, body: AlertEmailBeginReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    email = normalize_email(body.email)
+    if not can_send_verification(user_sub, "email"):
+        raise HTTPException(429, "Too many verification emails; try again later")
+    code = gen_numeric_code(6)
+    code_hash = sha256_str(code)
+    challenge_id = create_action_challenge(
+        req,
+        user_sub=user_sub,
+        purpose="alert_email_add",
+        send_to=[email],
+        payload={"email_code_hash": code_hash, "email": email, "email_code_attempts": 0, "email_code_sent_at": now_ts()},
+        ttl_seconds=600,
+    )
+    send_alert_email([email], "Confirm alerts email", f"Your confirmation code is: {code}\n\nIf you didn't request this, ignore.")
+    audit_event("alerts_email_add_begin", user_sub, req, outcome="success", email=email)
+    return {"challenge_id": challenge_id, "sent_to": email}
+
+
+@router.post("/alerts/emails/confirm")
+async def alert_email_add_confirm(req: Request, body: AlertEmailConfirmReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    chal = load_challenge_or_401(user_sub, body.challenge_id)
+    if chal.get("purpose") != "alert_email_add":
+        raise HTTPException(400, "Bad challenge")
+    _check_attempt_budget(chal, prefix="email_code", max_attempts=S.email_code_max_attempts, window_seconds=S.email_code_attempt_window_seconds)
+    if sha256_str(body.code.strip()) != chal.get("email_code_hash"):
+        _bump_attempt(user_sub, body.challenge_id, "email_code", int(chal.get("email_code_attempts", 0)))
+        audit_event("alerts_email_add_confirm", user_sub, req, outcome="failure", reason="bad_code")
+        raise HTTPException(401, "Bad email code")
+    email = chal.get("email")
+    prefs = get_alert_prefs(user_sub)
+    emails = prefs.get("emails") or []
+    if email and email not in emails:
+        emails.append(email)
+    prefs2 = set_alert_prefs(user_sub, emails=emails)
+    revoke_challenge(user_sub, body.challenge_id)
+    audit_event("alerts_email_add_confirm", user_sub, req, outcome="success", email=email)
+    return prefs2
+
+
+@router.post("/alerts/emails/remove")
+async def alert_email_remove(req: Request, body: AlertEmailRemoveReq, ctx: Dict[str, str] = Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    email = normalize_email(body.email)
+    prefs = get_alert_prefs(user_sub)
+    emails = [e for e in (prefs.get("emails") or []) if e != email]
+    prefs2 = set_alert_prefs(user_sub, emails=emails)
+    audit_event("alerts_email_remove", user_sub, req, outcome="success", email=email)
+    return prefs2
+
 
 @router.get("/alerts/stream")
 async def alerts_stream(ctx: Dict[str, str] = Depends(require_ui_session)):

--- a/app/routers/api_keys.py
+++ b/app/routers/api_keys.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
 
-from app.auth.deps import get_authenticated_user_sub
 from app.models import CreateApiKeyReq, RevokeApiKeyReq, ApiKeyIpRulesReq
 from app.services.api_keys import create_api_key, list_api_keys, revoke_api_key, set_api_key_ip_rules
 from app.services.alerts import audit_event
@@ -12,22 +11,22 @@ router = APIRouter(prefix="/ui", tags=["api-keys"])
 
 @router.get("/api_keys")
 async def ui_list_api_keys(ctx=Depends(require_ui_session)):
-    return {"api_keys": list_api_keys(ctx["user_sub"])}
+    return {"keys": list_api_keys(ctx["user_sub"])}
 
 @router.post("/api_keys")
 async def ui_create_api_key(req: Request, body: CreateApiKeyReq, ctx=Depends(require_ui_session)):
-    created = create_api_key(ctx["user_sub"], body.label, ip_rules=body.ip_rules)
-    audit_event("api_key_create", ctx["user_sub"], req, outcome="success", api_key_id=created["api_key_id"])
+    created = create_api_key(ctx["user_sub"], body.label or "")
+    audit_event("api_key_create", ctx["user_sub"], req, outcome="success", key_id=created["key_id"])
     return created
 
 @router.post("/api_keys/revoke")
 async def ui_revoke_api_key(req: Request, body: RevokeApiKeyReq, ctx=Depends(require_ui_session)):
-    revoke_api_key(ctx["user_sub"], body.api_key_id)
-    audit_event("api_key_revoke", ctx["user_sub"], req, outcome="success", api_key_id=body.api_key_id)
-    return {"status":"ok"}
+    revoke_api_key(ctx["user_sub"], body.key_id)
+    audit_event("api_key_revoke", ctx["user_sub"], req, outcome="success", key_id=body.key_id)
+    return {"ok": True}
 
 @router.post("/api_keys/ip_rules")
 async def ui_set_api_key_ip_rules(req: Request, body: ApiKeyIpRulesReq, ctx=Depends(require_ui_session)):
-    rules = set_api_key_ip_rules(ctx["user_sub"], body.api_key_id, body.ip_rules)
-    audit_event("api_key_ip_rules_set", ctx["user_sub"], req, outcome="success", api_key_id=body.api_key_id, ip_rules=rules)
-    return {"status":"ok","ip_rules": rules}
+    rules = set_api_key_ip_rules(ctx["user_sub"], body.key_id, body.allow_cidrs, body.deny_cidrs)
+    audit_event("api_key_ip_rules_set", ctx["user_sub"], req, outcome="success", key_id=body.key_id, allow=len(rules["allow_cidrs"]), deny=len(rules["deny_cidrs"]))
+    return {"ok": True, "allow_cidrs": rules["allow_cidrs"], "deny_cidrs": rules["deny_cidrs"]}

--- a/app/routers/mfa_devices.py
+++ b/app/routers/mfa_devices.py
@@ -1,23 +1,36 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from boto3.dynamodb.conditions import Key
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.models import (
     TotpDeviceBeginReq, TotpDeviceConfirmReq,
-    SmsDeviceBeginReq, SmsDeviceConfirmReq, SmsDeviceRemoveBeginReq, SmsDeviceRemoveConfirmReq,
-    EmailDeviceBeginReq, EmailDeviceConfirmReq, EmailDeviceRemoveBeginReq, EmailDeviceRemoveConfirmReq,
+    TotpDeviceRemoveReq,
+    SmsDeviceBeginReq, SmsDeviceConfirmReq, SmsDeviceRemoveConfirmReq,
+    EmailDeviceBeginReq, EmailDeviceConfirmReq, EmailDeviceRemoveConfirmReq,
 )
+from app.core.crypto import sha256_str
+from app.core.normalize import normalize_phone, normalize_email
+from app.core.settings import S
 from app.services.alerts import audit_event
 from app.services.mfa import (
     totp_begin_enroll, totp_confirm_enroll,
-    sms_begin_enroll, sms_confirm_enroll,
-    email_begin_enroll, email_confirm_enroll,
+    gen_numeric_code,
+    list_enabled_emails,
+    list_enabled_sms_numbers,
+    send_email_code,
+    totp_verify_any_enabled,
+    twilio_start_sms,
+    verify_code_any_sms,
+    new_recovery_codes,
+    store_recovery_codes,
 )
-from app.services.sessions import require_ui_session
+from app.services.rate_limit import rate_limit_or_429
+from app.services.sessions import create_action_challenge, load_challenge_or_401, require_ui_session, revoke_challenge
 from app.core.tables import T
+from app.core.time import now_ts
 
 router = APIRouter(prefix="/ui/mfa", tags=["mfa-devices"])
 
@@ -26,7 +39,13 @@ async def totp_devices(ctx=Depends(require_ui_session)):
     r = T.totp.query(KeyConditionExpression=Key("user_sub").eq(ctx["user_sub"]))
     devices = []
     for it in r.get("Items", []):
-        devices.append({"device_id": it["device_id"], "label": it.get("label",""), "enabled": it.get("enabled", False), "created_at": it.get("created_at",0)})
+        devices.append({
+            "device_id": it["device_id"],
+            "label": it.get("label",""),
+            "enabled": it.get("enabled", False),
+            "created_at": it.get("created_at",0),
+            "last_used_at": it.get("last_used_at",0),
+        })
     devices.sort(key=lambda x: x.get("created_at",0), reverse=True)
     return {"devices": devices}
 
@@ -38,85 +57,251 @@ async def totp_devices_begin(req: Request, body: TotpDeviceBeginReq, ctx=Depends
 
 @router.post("/totp/devices/confirm")
 async def totp_devices_confirm(req: Request, body: TotpDeviceConfirmReq, ctx=Depends(require_ui_session)):
-    totp_confirm_enroll(ctx["user_sub"], body.device_id, body.code)
+    totp_confirm_enroll(ctx["user_sub"], body.device_id, body.totp_code)
     audit_event("totp_device_confirm", ctx["user_sub"], req, outcome="success", device_id=body.device_id)
-    return {"status":"ok"}
+    return {"ok": True}
 
 @router.post("/totp/devices/{device_id}/remove")
-async def totp_devices_remove(req: Request, device_id: str, ctx=Depends(require_ui_session)):
+async def totp_devices_remove(req: Request, device_id: str, body: TotpDeviceRemoveReq, ctx=Depends(require_ui_session)):
+    if not totp_verify_any_enabled(ctx["user_sub"], body.totp_code):
+        raise HTTPException(401, "Bad TOTP")
     try:
         T.totp.delete_item(Key={"user_sub": ctx["user_sub"], "device_id": device_id})
     except Exception:
         raise HTTPException(404, "Unknown device")
     audit_event("totp_device_remove", ctx["user_sub"], req, outcome="success", device_id=device_id)
-    return {"status":"ok"}
+    return {"ok": True}
 
 @router.get("/sms/devices")
 async def sms_devices(ctx=Depends(require_ui_session)):
     r = T.sms.query(KeyConditionExpression=Key("user_sub").eq(ctx["user_sub"]))
     devices=[]
     for it in r.get("Items", []):
-        devices.append({"sms_device_id": it["sms_device_id"], "phone_e164": it.get("phone_e164",""), "label": it.get("label",""), "enabled": it.get("enabled", False), "created_at": it.get("created_at",0)})
+        devices.append({
+            "sms_device_id": it["sms_device_id"],
+            "phone_e164": it.get("phone_e164",""),
+            "label": it.get("label",""),
+            "enabled": it.get("enabled", False),
+            "pending": it.get("pending", False),
+            "created_at": it.get("created_at",0),
+            "last_used_at": it.get("last_used_at",0),
+        })
     devices.sort(key=lambda x: x.get("created_at",0), reverse=True)
     return {"devices": devices}
 
 @router.post("/sms/devices/begin")
 async def sms_devices_begin(req: Request, body: SmsDeviceBeginReq, ctx=Depends(require_ui_session)):
-    out = sms_begin_enroll(ctx["user_sub"], body.phone_e164, body.label)
-    audit_event("sms_device_begin", ctx["user_sub"], req, outcome="success", sms_device_id=out["sms_device_id"])
-    return out
+    user_sub = ctx["user_sub"]
+    rate_limit_or_429(user_sub, "enroll_sms")
+    phone = normalize_phone(body.phone_e164)
+    r = T.sms.query(KeyConditionExpression=Key("user_sub").eq(user_sub))
+    existing = r.get("Items", [])
+    enabled_or_pending = [d for d in existing if d.get("enabled", False) or d.get("pending", False)]
+    if len(enabled_or_pending) >= S.sms_device_limit:
+        raise HTTPException(400, f"SMS device limit reached ({S.sms_device_limit})")
+    sms_device_id = "sms_" + sha256_str(f"{user_sub}:{phone}:{now_ts()}")[:20]
+    ts = now_ts()
+    T.sms.put_item(Item={
+        "user_sub": user_sub,
+        "sms_device_id": sms_device_id,
+        "phone_e164": phone,
+        "label": (body.label or "")[:64],
+        "enabled": False,
+        "pending": True,
+        "created_at": ts,
+        "last_used_at": 0,
+    })
+    send_to = list(dict.fromkeys(list_enabled_sms_numbers(user_sub) + [phone]))
+    for n in send_to:
+        twilio_start_sms(n)
+    challenge_id = create_action_challenge(
+        req,
+        user_sub=user_sub,
+        purpose="sms_enroll",
+        send_to=send_to,
+        payload={"sms_device_id": sms_device_id},
+    )
+    audit_event("sms_device_begin", ctx["user_sub"], req, outcome="success", sms_device_id=sms_device_id)
+    return {"challenge_id": challenge_id, "sent_to": send_to, "sms_device_id": sms_device_id}
 
 @router.post("/sms/devices/confirm")
 async def sms_devices_confirm(req: Request, body: SmsDeviceConfirmReq, ctx=Depends(require_ui_session)):
-    sms_confirm_enroll(ctx["user_sub"], body.sms_device_id)
-    audit_event("sms_device_confirm", ctx["user_sub"], req, outcome="success", sms_device_id=body.sms_device_id)
-    return {"status":"ok"}
+    user_sub = ctx["user_sub"]
+    chal = load_challenge_or_401(user_sub, body.challenge_id)
+    if chal.get("purpose") != "sms_enroll":
+        raise HTTPException(400, "Wrong challenge purpose")
+    send_to = chal.get("send_to", []) or []
+    if not verify_code_any_sms(send_to, body.code.strip()):
+        raise HTTPException(401, "Bad SMS code")
+    sms_device_id = chal["sms_device_id"]
+    T.sms.update_item(
+        Key={"user_sub": user_sub, "sms_device_id": sms_device_id},
+        UpdateExpression="SET enabled = :t, pending = :f",
+        ExpressionAttributeValues={":t": True, ":f": False},
+    )
+    r = T.sms.query(KeyConditionExpression=Key("user_sub").eq(user_sub))
+    enabled_count = sum(1 for d in r.get("Items", []) if d.get("enabled", False))
+    recovery_codes: List[str] = []
+    if enabled_count == 1:
+        recovery_codes = new_recovery_codes(10)
+        store_recovery_codes(user_sub, "sms", recovery_codes)
+    revoke_challenge(user_sub, body.challenge_id)
+    audit_event("sms_device_confirm", ctx["user_sub"], req, outcome="success", sms_device_id=sms_device_id)
+    return {"ok": True, "sms_device_id": sms_device_id, "recovery_codes": recovery_codes}
 
 @router.post("/sms/devices/{sms_device_id}/remove/begin")
-async def sms_devices_remove_begin(_: Request, sms_device_id: str, __=Depends(require_ui_session)):
-    # TODO: require step-up before removal; kept for compatibility
-    return {"status":"ok","sms_device_id": sms_device_id}
+async def sms_devices_remove_begin(req: Request, sms_device_id: str, ctx=Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    rate_limit_or_429(user_sub, "remove_sms")
+    it = T.sms.get_item(Key={"user_sub": user_sub, "sms_device_id": sms_device_id}).get("Item")
+    if not it:
+        raise HTTPException(404, "SMS device not found")
+    nums = list_enabled_sms_numbers(user_sub)
+    target = it.get("phone_e164")
+    send_to = [n for n in nums if n != target]
+    if not send_to:
+        raise HTTPException(400, "No other enabled SMS numbers to confirm removal (use SMS recovery code)")
+    for n in send_to:
+        twilio_start_sms(n)
+    challenge_id = create_action_challenge(
+        req,
+        user_sub=user_sub,
+        purpose="sms_remove",
+        send_to=send_to,
+        payload={"sms_device_id": sms_device_id},
+    )
+    return {"challenge_id": challenge_id, "sent_to": send_to}
 
 @router.post("/sms/devices/remove/confirm")
 async def sms_devices_remove_confirm(req: Request, body: SmsDeviceRemoveConfirmReq, ctx=Depends(require_ui_session)):
-    try:
-        T.sms.delete_item(Key={"user_sub": ctx["user_sub"], "sms_device_id": body.sms_device_id})
-    except Exception:
-        raise HTTPException(404, "Unknown device")
-    audit_event("sms_device_remove", ctx["user_sub"], req, outcome="success", sms_device_id=body.sms_device_id)
-    return {"status":"ok"}
+    user_sub = ctx["user_sub"]
+    chal = load_challenge_or_401(user_sub, body.challenge_id)
+    if chal.get("purpose") != "sms_remove":
+        raise HTTPException(400, "Wrong challenge purpose")
+    send_to = chal.get("send_to", []) or []
+    if not verify_code_any_sms(send_to, body.code.strip()):
+        raise HTTPException(401, "Bad SMS code")
+    sms_device_id = chal["sms_device_id"]
+    T.sms.delete_item(Key={"user_sub": user_sub, "sms_device_id": sms_device_id})
+    revoke_challenge(user_sub, body.challenge_id)
+    audit_event("sms_device_remove", ctx["user_sub"], req, outcome="success", sms_device_id=sms_device_id)
+    return {"ok": True}
 
 @router.get("/email/devices")
 async def email_devices(ctx=Depends(require_ui_session)):
     r = T.email.query(KeyConditionExpression=Key("user_sub").eq(ctx["user_sub"]))
     devices=[]
     for it in r.get("Items", []):
-        devices.append({"email_device_id": it["email_device_id"], "email": it.get("email",""), "label": it.get("label",""), "enabled": it.get("enabled", False), "created_at": it.get("created_at",0)})
+        devices.append({
+            "email_device_id": it["email_device_id"],
+            "email": it.get("email",""),
+            "label": it.get("label",""),
+            "enabled": it.get("enabled", False),
+            "pending": it.get("pending", False),
+            "created_at": it.get("created_at",0),
+            "last_used_at": it.get("last_used_at",0),
+        })
     devices.sort(key=lambda x: x.get("created_at",0), reverse=True)
     return {"devices": devices}
 
 @router.post("/email/devices/begin")
 async def email_devices_begin(req: Request, body: EmailDeviceBeginReq, ctx=Depends(require_ui_session)):
-    out = email_begin_enroll(ctx["user_sub"], body.email, body.label)
-    audit_event("email_device_begin", ctx["user_sub"], req, outcome="success", email_device_id=out["email_device_id"])
-    return out
+    user_sub = ctx["user_sub"]
+    rate_limit_or_429(user_sub, "enroll_email")
+    email = normalize_email(body.email)
+    r = T.email.query(KeyConditionExpression=Key("user_sub").eq(user_sub))
+    existing = r.get("Items", [])
+    enabled_or_pending = [d for d in existing if d.get("enabled", False) or d.get("pending", False)]
+    if len(enabled_or_pending) >= S.email_device_limit:
+        raise HTTPException(400, f"Email device limit reached ({S.email_device_limit})")
+    email_device_id = "em_" + sha256_str(f"{user_sub}:{email}:{now_ts()}")[:20]
+    ts = now_ts()
+    T.email.put_item(Item={
+        "user_sub": user_sub,
+        "email_device_id": email_device_id,
+        "email": email,
+        "label": (body.label or "")[:64],
+        "enabled": False,
+        "pending": True,
+        "created_at": ts,
+        "last_used_at": 0,
+    })
+    enabled_emails = [d["email"] for d in existing if d.get("enabled", False)]
+    send_to = list(dict.fromkeys(enabled_emails + [email]))
+    code = gen_numeric_code(6)
+    code_hash = sha256_str(code)
+    challenge_id = create_action_challenge(
+        req,
+        user_sub=user_sub,
+        purpose="email_enroll",
+        send_to=send_to,
+        payload={"email_device_id": email_device_id, "email_code_hash": code_hash},
+    )
+    for e in send_to:
+        send_email_code(e, "add-email", code)
+    audit_event("email_device_begin", ctx["user_sub"], req, outcome="success", email_device_id=email_device_id)
+    return {"challenge_id": challenge_id, "sent_to": send_to, "email_device_id": email_device_id}
 
 @router.post("/email/devices/confirm")
 async def email_devices_confirm(req: Request, body: EmailDeviceConfirmReq, ctx=Depends(require_ui_session)):
-    email_confirm_enroll(ctx["user_sub"], body.email_device_id)
-    audit_event("email_device_confirm", ctx["user_sub"], req, outcome="success", email_device_id=body.email_device_id)
-    return {"status":"ok"}
+    user_sub = ctx["user_sub"]
+    chal = load_challenge_or_401(user_sub, body.challenge_id)
+    if chal.get("purpose") != "email_enroll":
+        raise HTTPException(400, "Wrong challenge purpose")
+    if sha256_str(body.code.strip()) != chal.get("email_code_hash"):
+        raise HTTPException(401, "Bad email code")
+    email_device_id = chal["email_device_id"]
+    T.email.update_item(
+        Key={"user_sub": user_sub, "email_device_id": email_device_id},
+        UpdateExpression="SET enabled = :t, pending = :f",
+        ExpressionAttributeValues={":t": True, ":f": False, ":p": True},
+        ConditionExpression="pending = :p",
+    )
+    r = T.email.query(KeyConditionExpression=Key("user_sub").eq(user_sub))
+    enabled_count = sum(1 for d in r.get("Items", []) if d.get("enabled", False))
+    recovery_codes: List[str] = []
+    if enabled_count == 1:
+        recovery_codes = new_recovery_codes(10)
+        store_recovery_codes(user_sub, "email", recovery_codes)
+    revoke_challenge(user_sub, body.challenge_id)
+    audit_event("email_device_confirm", ctx["user_sub"], req, outcome="success", email_device_id=email_device_id)
+    return {"ok": True, "email_device_id": email_device_id, "recovery_codes": recovery_codes}
 
 @router.post("/email/devices/{email_device_id}/remove/begin")
-async def email_devices_remove_begin(_: Request, email_device_id: str, __=Depends(require_ui_session)):
-    # TODO: require step-up before removal; kept for compatibility
-    return {"status":"ok","email_device_id": email_device_id}
+async def email_devices_remove_begin(req: Request, email_device_id: str, ctx=Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    rate_limit_or_429(user_sub, "remove_email")
+    it = T.email.get_item(Key={"user_sub": user_sub, "email_device_id": email_device_id}).get("Item")
+    if not it:
+        raise HTTPException(404, "Email device not found")
+    enabled = list_enabled_emails(user_sub)
+    target = it.get("email")
+    send_to = [e for e in enabled if e != target]
+    if not send_to:
+        raise HTTPException(400, "No other enabled emails to confirm removal (use email recovery code)")
+    code = gen_numeric_code(6)
+    code_hash = sha256_str(code)
+    challenge_id = create_action_challenge(
+        req,
+        user_sub=user_sub,
+        purpose="email_remove",
+        send_to=send_to,
+        payload={"email_device_id": email_device_id, "email_code_hash": code_hash},
+    )
+    for e in send_to:
+        send_email_code(e, "remove-email", code)
+    return {"challenge_id": challenge_id, "sent_to": send_to}
 
 @router.post("/email/devices/remove/confirm")
 async def email_devices_remove_confirm(req: Request, body: EmailDeviceRemoveConfirmReq, ctx=Depends(require_ui_session)):
-    try:
-        T.email.delete_item(Key={"user_sub": ctx["user_sub"], "email_device_id": body.email_device_id})
-    except Exception:
-        raise HTTPException(404, "Unknown device")
-    audit_event("email_device_remove", ctx["user_sub"], req, outcome="success", email_device_id=body.email_device_id)
-    return {"status":"ok"}
+    user_sub = ctx["user_sub"]
+    chal = load_challenge_or_401(user_sub, body.challenge_id)
+    if chal.get("purpose") != "email_remove":
+        raise HTTPException(400, "Wrong challenge purpose")
+    if sha256_str(body.code.strip()) != chal.get("email_code_hash"):
+        raise HTTPException(401, "Bad email code")
+    email_device_id = chal["email_device_id"]
+    T.email.delete_item(Key={"user_sub": user_sub, "email_device_id": email_device_id})
+    revoke_challenge(user_sub, body.challenge_id)
+    audit_event("email_device_remove", ctx["user_sub"], req, outcome="success", email_device_id=email_device_id)
+    return {"ok": True}

--- a/app/routers/push.py
+++ b/app/routers/push.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from app.core.settings import S
+from app.models import PushRegisterReq, PushRevokeReq
+from app.services.alerts import audit_event
+from app.services.push import list_push_devices, revoke_push_device, send_push_for_alert, upsert_push_device
+from app.services.sessions import require_ui_session
+
+router = APIRouter(prefix="/ui", tags=["push"])
+
+
+@router.get("/push/devices")
+async def ui_list_push_devices(ctx=Depends(require_ui_session)):
+    return {"devices": list_push_devices(ctx["user_sub"])}
+
+
+@router.post("/push/register")
+async def ui_register_push(req: Request, body: PushRegisterReq, ctx=Depends(require_ui_session)):
+    if not S.push_enabled:
+        raise HTTPException(400, "Push disabled")
+    token = (body.token or "").strip()
+    if len(token) < 20:
+        raise HTTPException(400, "Bad token")
+    platform = (body.platform or "").strip()[:32]
+    it = upsert_push_device(ctx["user_sub"], token, platform)
+    audit_event("push_device_register", ctx["user_sub"], req, outcome="success", platform=platform)
+    return it
+
+
+@router.post("/push/revoke")
+async def ui_revoke_push(req: Request, body: PushRevokeReq, ctx=Depends(require_ui_session)):
+    revoke_push_device(ctx["user_sub"], body.device_id)
+    audit_event("push_device_revoke", ctx["user_sub"], req, outcome="success", device_id=body.device_id)
+    return {"ok": True}
+
+
+@router.post("/push/test")
+async def ui_push_test(req: Request, ctx=Depends(require_ui_session)):
+    send_push_for_alert(ctx["user_sub"], "security_event", "Test notification", "This is a test push.", "test")
+    audit_event("push_test", ctx["user_sub"], req, outcome="success")
+    return {"ok": True}

--- a/app/routers/recovery.py
+++ b/app/routers/recovery.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from app.auth.deps import get_authenticated_user_sub
+from app.models import RecoveryReq
+from app.services.alerts import audit_event
+from app.services.mfa import consume_recovery_code
+from app.services.sessions import load_challenge_or_401, mark_factor_passed, maybe_finalize
+
+router = APIRouter(prefix="/ui", tags=["recovery"])
+
+
+def _recover(req: Request, user_sub: str, factor: str, body: RecoveryReq):
+    chal = load_challenge_or_401(user_sub, body.challenge_id)
+    if factor not in ("totp", "sms", "email"):
+        raise HTTPException(400, "Invalid factor")
+    if factor not in (chal.get("required_factors") or []):
+        raise HTTPException(400, "Factor not required")
+    consume_recovery_code(user_sub, factor, body.recovery_code)
+    mark_factor_passed(user_sub, body.challenge_id, factor)
+    sid = maybe_finalize(req, user_sub, body.challenge_id)
+    audit_event("mfa_recovery", user_sub, req, outcome="success", challenge_id=body.challenge_id, factor=factor)
+    return {"ok": True, "session_id": sid}
+
+
+@router.post("/recovery/{factor}")
+async def recovery_factor(req: Request, factor: str, body: RecoveryReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    return _recover(req, user_sub, factor, body)
+
+
+@router.post("/recovery/totp")
+async def recovery_totp(req: Request, body: RecoveryReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    return _recover(req, user_sub, "totp", body)
+
+
+@router.post("/recovery/sms")
+async def recovery_sms(req: Request, body: RecoveryReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    return _recover(req, user_sub, "sms", body)
+
+
+@router.post("/recovery/email")
+async def recovery_email(req: Request, body: RecoveryReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    return _recover(req, user_sub, "email", body)

--- a/app/services/alerts.py
+++ b/app/services/alerts.py
@@ -13,6 +13,7 @@ from app.core.settings import S
 from app.core.tables import T
 from app.core.time import now_ts
 from app.services.rate_limit import can_send_alert_channel
+from app.services.push import send_push_for_alert
 from app.services.ttl import with_ttl
 
 ALERT_EVENT_TYPES: List[str] = [
@@ -253,6 +254,7 @@ def audit_event(event: str, user_sub: str, request=None, **fields: Any) -> None:
         title = pretty.get(event, event.replace("_", " "))
         wr = write_alert(user_sub, event=event, outcome=outcome, title=title, details={**payload, "alert_type": alert_type})
         alert_id = (wr or {}).get("alert_id", "")
+        send_push_for_alert(user_sub, alert_type, title, f"{event} ({outcome})", alert_id or "")
     except Exception:
         alert_id = ""
 

--- a/app/services/api_keys.py
+++ b/app/services/api_keys.py
@@ -16,40 +16,48 @@ from app.services.ttl import with_ttl
 def new_api_key_secret() -> str:
     return secrets.token_urlsafe(32)
 
+def parse_api_key(api_key: str) -> Dict[str, str]:
+    if not api_key or not api_key.startswith("ak_") or "." not in api_key:
+        raise HTTPException(401, "Invalid API key format")
+    kid, secret = api_key.split(".", 1)
+    key_id = kid[len("ak_"):]
+    if not key_id or not secret:
+        raise HTTPException(401, "Invalid API key format")
+    return {"key_id": key_id, "secret": secret}
+
 def api_key_hash(secret: str) -> str:
     if not S.api_key_pepper:
         raise RuntimeError("API_KEY_PEPPER not set")
     return sha256_str(secret + "|" + S.api_key_pepper)
 
-def create_api_key(user_sub: str, label: str, *, ip_rules: Optional[List[str]] = None) -> Dict[str, Any]:
+def create_api_key(user_sub: str, label: str) -> Dict[str, Any]:
     ts = now_ts()
-    api_key_id = secrets.token_hex(8)
+    key_id = secrets.token_hex(16)
     secret = new_api_key_secret()
     secret_hash = api_key_hash(secret)
     ttl = ts + 365 * 86400  # 1y; rotate as you like
 
-    ip_rules_n = []
-    for r in ip_rules or []:
-        ip_rules_n.append(normalize_cidr(r))
-
     item = with_ttl({
-        "api_key_id": api_key_id,
+        "key_id": key_id,
         "user_sub": user_sub,
         "secret_hash": secret_hash,
         "label": (label or "")[:64],
         "created_at": ts,
+        "last_used_at": 0,
         "revoked": False,
         "revoked_at": 0,
-        "ip_rules": ip_rules_n,
+        "prefix": f"ak_{key_id[:8]}",
+        "allow_cidrs": [],
+        "deny_cidrs": [],
     }, ttl_epoch=ttl)
 
     T.api_keys.put_item(Item=item)
-    return {"api_key_id": api_key_id, "api_key_secret": secret, "label": item["label"], "created_at": ts, "ip_rules": ip_rules_n}
+    return {"key_id": key_id, "api_key": f"ak_{key_id}.{secret}", "label": item["label"], "created_at": ts}
 
-def revoke_api_key(user_sub: str, api_key_id: str) -> None:
+def revoke_api_key(user_sub: str, key_id: str) -> None:
     try:
         T.api_keys.update_item(
-            Key={"api_key_id": api_key_id},
+            Key={"key_id": key_id},
             UpdateExpression="SET revoked = :t, revoked_at = :now",
             ConditionExpression="user_sub = :u",
             ExpressionAttributeValues={":t": True, ":now": now_ts(), ":u": user_sub},
@@ -57,40 +65,53 @@ def revoke_api_key(user_sub: str, api_key_id: str) -> None:
     except Exception:
         raise HTTPException(404, "API key not found")
 
-def set_api_key_ip_rules(user_sub: str, api_key_id: str, ip_rules: List[str]) -> List[str]:
-    rules = [normalize_cidr(r) for r in (ip_rules or [])]
+def set_api_key_ip_rules(user_sub: str, key_id: str, allow_cidrs: List[str], deny_cidrs: List[str]) -> Dict[str, List[str]]:
+    allow = [normalize_cidr(r) for r in (allow_cidrs or []) if (r or "").strip()]
+    deny = [normalize_cidr(r) for r in (deny_cidrs or []) if (r or "").strip()]
     try:
         T.api_keys.update_item(
-            Key={"api_key_id": api_key_id},
-            UpdateExpression="SET ip_rules = :r, updated_at=:now",
-            ConditionExpression="user_sub = :u AND revoked = :f",
-            ExpressionAttributeValues={":r": rules, ":u": user_sub, ":f": False, ":now": now_ts()},
+            Key={"key_id": key_id},
+            UpdateExpression="SET allow_cidrs = :a, deny_cidrs = :d, updated_at=:now",
+            ConditionExpression="user_sub = :u",
+            ExpressionAttributeValues={":a": allow, ":d": deny, ":u": user_sub, ":now": now_ts()},
         )
     except Exception:
-        raise HTTPException(404, "API key not found or revoked")
-    return rules
+        raise HTTPException(404, "API key not found")
+    return {"allow_cidrs": allow, "deny_cidrs": deny}
 
 def list_api_keys(user_sub: str) -> List[Dict[str, Any]]:
     r = T.api_keys.query(IndexName=S.api_keys_user_index, KeyConditionExpression=Key("user_sub").eq(user_sub), ScanIndexForward=False, Limit=100)
     out = []
     for it in r.get("Items", []):
         out.append({
-            "api_key_id": it["api_key_id"],
+            "key_id": it.get("key_id") or it.get("api_key_id"),
             "label": it.get("label",""),
             "created_at": it.get("created_at",0),
+            "last_used_at": it.get("last_used_at", 0),
             "revoked": it.get("revoked",False),
             "revoked_at": it.get("revoked_at",0),
-            "ip_rules": it.get("ip_rules", []),
+            "prefix": it.get("prefix",""),
+            "allow_cidrs": it.get("allow_cidrs", []),
+            "deny_cidrs": it.get("deny_cidrs", []),
         })
+    out.sort(key=lambda x: int(x.get("created_at") or 0), reverse=True)
     return out
 
+def enforce_api_key_ip_rules(client_ip: str, key_item: Dict[str, Any]) -> None:
+    allow = key_item.get("allow_cidrs") or []
+    deny = key_item.get("deny_cidrs") or []
+    if not allow and not deny:
+        return
+    if allow and not ip_in_any_cidr(client_ip, allow):
+        raise HTTPException(403, "API key not allowed from this IP")
+    if deny and ip_in_any_cidr(client_ip, deny):
+        raise HTTPException(403, "API key denied from this IP")
+
 def check_api_key_allowed(api_key_id: str, api_key_secret: str, client_ip: str) -> Dict[str, Any]:
-    it = T.api_keys.get_item(Key={"api_key_id": api_key_id}).get("Item")
+    it = T.api_keys.get_item(Key={"key_id": api_key_id}).get("Item")
     if not it or it.get("revoked", False):
         raise HTTPException(401, "Invalid API key")
+    enforce_api_key_ip_rules(client_ip, it)
     if api_key_hash(api_key_secret) != it.get("secret_hash"):
         raise HTTPException(401, "Invalid API key")
-    rules = it.get("ip_rules") or []
-    if rules and (not ip_in_any_cidr(client_ip, rules)):
-        raise HTTPException(403, "API key not allowed from this IP")
     return it

--- a/app/services/push.py
+++ b/app/services/push.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+from boto3.dynamodb.conditions import Key
+
+from app.core.settings import S
+from app.core.tables import T
+from app.core.time import now_ts
+from app.services.rate_limit import can_send_alert_channel
+from app.services.ttl import with_ttl
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("utf-8").rstrip("=")
+
+
+_HAS_REQUESTS = importlib.util.find_spec("requests") is not None
+_HAS_CRYPTO = importlib.util.find_spec("cryptography") is not None
+
+
+def fcm_access_token() -> Optional[str]:
+    if not S.fcm_enabled:
+        return None
+    if not (S.fcm_project_id and S.fcm_client_email and S.fcm_private_key):
+        return None
+    if not (_HAS_REQUESTS and _HAS_CRYPTO):
+        return None
+
+    try:
+        import requests
+        import cryptography.hazmat.primitives.serialization as serialization
+        from cryptography.hazmat.primitives.asymmetric import padding
+        from cryptography.hazmat.primitives import hashes
+        key_pem = S.fcm_private_key.replace("\\n", "\n").encode("utf-8")
+        key = serialization.load_pem_private_key(key_pem, password=None)
+        now = int(time.time())
+        header = {"alg": "RS256", "typ": "JWT"}
+        payload = {
+            "iss": S.fcm_client_email,
+            "scope": "https://www.googleapis.com/auth/firebase.messaging",
+            "aud": "https://oauth2.googleapis.com/token",
+            "iat": now,
+            "exp": now + 3600,
+        }
+        signing_input = f"{_b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))}.{_b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))}"
+        sig = key.sign(signing_input.encode("utf-8"), padding.PKCS1v15(), hashes.SHA256())
+        jwt = signing_input + "." + _b64url(sig)
+        r = requests.post(
+            "https://oauth2.googleapis.com/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "assertion": jwt,
+            },
+            timeout=5,
+        )
+        if r.status_code != 200:
+            return None
+        return r.json().get("access_token")
+    except Exception:
+        return None
+
+
+def fcm_send(token: str, title: str, body: str, data: Optional[Dict[str, str]] = None) -> bool:
+    at = fcm_access_token()
+    if not at:
+        return False
+    if not _HAS_REQUESTS:
+        return False
+    import requests
+    url = f"https://fcm.googleapis.com/v1/projects/{S.fcm_project_id}/messages:send"
+    msg = {
+        "message": {
+            "token": token,
+            "notification": {"title": title[:60], "body": body[:180]},
+            "data": data or {},
+        }
+    }
+    try:
+        r = requests.post(url, headers={"Authorization": f"Bearer {at}"}, json=msg, timeout=5)
+        return r.status_code in (200, 202)
+    except Exception:
+        return False
+
+
+def push_device_id(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:32]
+
+
+def list_push_devices(user_sub: str) -> List[Dict[str, Any]]:
+    try:
+        r = T.push_devices.query(KeyConditionExpression=Key("user_sub").eq(user_sub), Limit=200)
+        out = []
+        for it in r.get("Items", []):
+            out.append({
+                "device_id": it.get("device_id"),
+                "platform": it.get("platform"),
+                "created_at": it.get("created_at"),
+                "last_seen_at": it.get("last_seen_at"),
+            })
+        out.sort(key=lambda x: x.get("created_at", 0), reverse=True)
+        return out
+    except Exception:
+        return []
+
+
+def upsert_push_device(user_sub: str, token: str, platform: str) -> Dict[str, Any]:
+    did = push_device_id(token)
+    now = now_ts()
+    ttl = now + 60 * 60 * 24 * 180
+    T.push_devices.put_item(Item=with_ttl({
+        "user_sub": user_sub,
+        "device_id": did,
+        "token": token,
+        "platform": platform,
+        "created_at": now,
+        "last_seen_at": now,
+    }, ttl_epoch=ttl))
+    return {"device_id": did, "platform": platform, "created_at": now, "last_seen_at": now}
+
+
+def revoke_push_device(user_sub: str, device_id: str) -> None:
+    try:
+        T.push_devices.delete_item(Key={"user_sub": user_sub, "device_id": device_id})
+    except Exception:
+        pass
+
+
+def send_push_for_alert(user_sub: str, alert_type: str, title: str, body: str, alert_id: str) -> None:
+    if not S.push_enabled:
+        return
+    from app.services.alerts import get_alert_prefs
+    prefs = get_alert_prefs(user_sub)
+    enabled = set(prefs.get("push_event_types") or [])
+    if alert_type not in enabled:
+        return
+    if not can_send_alert_channel(user_sub, "push"):
+        return
+    try:
+        r = T.push_devices.query(KeyConditionExpression=Key("user_sub").eq(user_sub), Limit=200)
+        items = r.get("Items", [])
+        for it in items[:25]:
+            tok = it.get("token")
+            if not tok:
+                continue
+            fcm_send(tok, title, body, data={"alert_id": alert_id, "alert_type": alert_type})
+    except Exception:
+        pass


### PR DESCRIPTION
### Motivation
- Bring `app/` behavior in line with the reference implementation so the UI works correctly with the backend features it expects.
- Add missing flows for alert recipient management, push notifications, MFA device enroll/remove, and recovery codes used by the UI.
- Normalize API key format and IP allow/deny semantics to match the reference design.

### Description
- Updated Pydantic request/response models in `app/models.py` to support aliases and the UI naming (e.g. `totp_code`, `recovery_code`, `key_id`/`api_key_id`, and alert preference models) and to return `auth_required`/`session_id` semantics for session start via `UiSessionStartResp`.
- Implemented API key changes in `app/services/api_keys.py` and `app/routers/api_keys.py` including `parse_api_key`, `enforce_api_key_ip_rules`, `prefix/key_id` usage, `allow_cidrs`/`deny_cidrs` storage, and updated create/revoke/list semantics to produce `api_key` strings matching the UI.
- Expanded session and step-up challenge handling in `app/services/sessions.py` with `create_action_challenge`, and updated `app/routers/ui_session.py` so `POST /ui/session/start` creates a real session when no factors are required and returns `auth_required` appropriately.
- Reworked MFA device flows and endpoints in `app/services/mfa.py` and `app/routers/mfa_devices.py` to support enroll-confirm/remove flows that send verification codes to enabled devices, store `last_used_at`, create action challenges, generate recovery codes when first device enabled, and include rate-limits and attempt budgets.
- Adjusted UI MFA endpoints in `app/routers/ui_mfa.py` to return `sent_to` lists and to use the renamed fields (`totp_code`, `recovery_code`).
- Reimplemented alert management in `app/services/alerts.py` and `app/routers/alerts.py` to mirror reference behavior: pref types, email/SMS add/confirm/remove flows, toast delivery marking, unread filtering, attempt budgets for confirm flows, and emitting push notifications when appropriate.
- Added push support: new `app/services/push.py` and `app/routers/push.py` to register/revoke/list push devices and send FCM notifications (guarded by availability of `requests`/`cryptography` and `S.fcm_enabled`).
- Added recovery endpoints in `app/routers/recovery.py` to consume recovery codes and finalize step-up challenges.
- Minor glue and utility updates: `ui/me` now includes client IP via `client_ip_from_request`, `ui/sessions` includes `is_current` and `revoked_at`, and various audit_event hooks were added for preference changes and alert flows.

### Testing
- No automated tests were executed as part of this change.
- Changes were implemented to mirror the reference API and wiring so the UI should be able to exercise the new endpoints when run with matching environment configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696747d7eb70832b87e48f82ef609587)