### PR TITLE
Add modular frontend UI for security control panel

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from app.routers.ui_session import router as ui_session_router
 from app.routers.ui_mfa import router as ui_mfa_router
@@ -14,6 +18,13 @@ from app.routers.misc import router as misc_router
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Security Backend (refactored)", version="0.1.0")
+    static_dir = Path(__file__).resolve().parent / "static"
+
+    app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+    @app.get("/")
+    async def index():
+        return FileResponse(static_dir / "index.html")
 
     app.add_middleware(
         CORSMiddleware,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Security Control Panel</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+
+<div class="topbar">
+  <div>
+    <div><b>Control Panel</b></div>
+    <div class="muted" id="whoami">Not logged in</div>
+  </div>
+  <div class="toolbar">
+    <button id="btnRefreshAll">Refresh</button>
+    <button id="btnSetTokens">Set tokens</button>
+    <button id="btnClearSession">Logout UI session</button>
+    <button id="btnClearTokens">Clear tokens</button>
+  </div>
+</div>
+
+<div class="row">
+  <div class="card">
+    <h3>API Key IP Allowlist</h3>
+    <div class="muted">CIDR or IP. If empty → all IPs allowed.</div>
+    <div class="muted">Selected key: <code class="mono" id="allowKeyId">none</code></div>
+    <div class="row-inline" style="margin-top:8px;">
+      <input id="allowAddVal" placeholder="1.2.3.4 or 1.2.3.0/24" style="margin-top:0; flex:1;" />
+      <button id="allowAddBtn">Add</button>
+    </div>
+    <table id="allowTbl">
+      <thead><tr><th>IP/CIDR</th><th></th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>API Keys</h3>
+    <div class="muted">Manage API keys and IP rules.</div>
+    <div class="row-inline" style="margin-top:10px;">
+      <button id="keysRefreshBtn">Refresh</button>
+      <button id="keysCreateBtn">Create key</button>
+    </div>
+    <div id="keysList" class="list"></div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="card">
+    <h3>TOTP Devices</h3>
+    <div class="row-inline" style="margin-top:10px;">
+      <button id="totpAddBtn">Add device</button>
+      <button id="totpRefreshBtn">Refresh</button>
+    </div>
+    <div class="muted">Any one device can satisfy TOTP factor. Adding/removing requires a TOTP code.</div>
+    <table id="totpTbl">
+      <thead><tr><th>Label</th><th>Enabled</th><th>Last Used</th><th></th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>SMS Devices</h3>
+    <div class="muted">Up to 3 phone numbers. Login SMS codes are sent to all enabled numbers.</div>
+    <div class="row-inline" style="margin-top:10px;">
+      <button id="smsRefreshBtn">Refresh</button>
+      <button id="smsAddBtn">Add phone</button>
+    </div>
+    <table id="smsTbl">
+      <thead><tr><th>Phone</th><th>Label</th><th>Enabled</th><th>Last Used</th><th></th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<div class="row">
+  <div class="card">
+    <h3>Email Devices</h3>
+    <div class="muted">Up to 5 emails. Login email codes are sent to all enabled emails.</div>
+    <div class="row-inline" style="margin-top:10px;">
+      <button id="emailRefreshBtn">Refresh</button>
+      <button id="emailAddBtn">Add email</button>
+    </div>
+    <table id="emailTbl">
+      <thead><tr><th>Email</th><th>Label</th><th>Enabled</th><th>Last Used</th><th></th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Web UI Sessions</h3>
+    <div class="muted">Your active UI sessions (this browser will show as “current”).</div>
+    <div class="row-inline" style="margin-top:10px;">
+      <button id="sessRefreshBtn">Refresh</button>
+      <button id="sessRevokeOthersBtn">Revoke all other sessions</button>
+    </div>
+    <div id="sessList" class="list"></div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="card">
+    <h3>Alert Recipients</h3>
+    <div class="section">
+      <b>Email recipients</b>
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="alertEmailInput" placeholder="security@example.com" />
+        <button id="alertEmailAddBtn">Add</button>
+      </div>
+      <div id="alertEmailList" class="list"></div>
+    </div>
+    <div class="section">
+      <b>SMS recipients</b>
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="alertSmsInput" placeholder="+15551234567 or 5551234567" />
+        <button id="alertSmsAddBtn">Add</button>
+      </div>
+      <div id="alertSmsList" class="list"></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>Alert Preferences</h3>
+    <div class="section">
+      <b>Email alert types</b>
+      <div class="muted">Checked types will send email when those events occur.</div>
+      <div id="alertTypeChecklist" class="list" style="margin-top:8px;"></div>
+      <div class="row-inline" style="margin-top:10px;">
+        <button id="alertTypesSaveBtn">Save</button>
+      </div>
+      <div id="alertTypesMsg" class="muted"></div>
+    </div>
+    <div class="section">
+      <b>SMS alert types</b>
+      <div class="muted">Checked types will send SMS when those events occur.</div>
+      <div id="alertSmsTypeChecklist" class="list" style="margin-top:8px;"></div>
+      <div class="row-inline" style="margin-top:10px;">
+        <button id="alertSmsTypesSaveBtn">Save</button>
+      </div>
+      <div id="alertSmsTypesMsg" class="muted"></div>
+    </div>
+    <div class="section">
+      <b>Toast alert types</b>
+      <div class="muted">Checked types will show a toast notification on all active web sessions.</div>
+      <div id="alertToastTypeChecklist" class="list" style="margin-top:8px;"></div>
+      <div class="row-inline" style="margin-top:10px;">
+        <button id="alertToastTypesSaveBtn">Save</button>
+      </div>
+      <div id="alertToastTypesMsg" class="muted"></div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="card">
+    <h3>Push Notifications</h3>
+    <div class="muted">Register this browser for push alerts.</div>
+    <div class="row-inline" style="margin-top:10px;">
+      <button id="btnEnablePush">Enable push on this browser</button>
+      <button id="btnPushTest">Send test push</button>
+    </div>
+    <div id="pushMsg" class="muted"></div>
+    <div class="section">
+      <b>Push alert types</b>
+      <div id="alertPushTypeChecklist" class="list" style="margin-top:8px;"></div>
+      <div class="row-inline" style="margin-top:10px;">
+        <button id="alertPushTypesSaveBtn">Save</button>
+      </div>
+      <div id="alertPushTypesMsg" class="muted"></div>
+    </div>
+    <div class="section">
+      <b>Registered push devices</b>
+      <div id="pushDevicesList" class="list"></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>Recent Alerts</h3>
+    <div class="muted">Latest alerts for this account.</div>
+    <div id="alertsList" class="list"></div>
+  </div>
+</div>
+
+<div class="err" id="globalErr" style="margin-top:12px;"></div>
+
+<div id="toastContainer" class="toast-container"></div>
+
+<script src="/static/main.js"></script>
+</body>
+</html>

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,1561 @@
+// Optional WebSocket fanout (set window.WS_URL = "wss://.../prod")
+const WS_URL = window.WS_URL || null;
+
+
+
+
+let toastSse = null;
+
+
+let toastWs = null;
+
+async function startToastWebSocket() {
+  if (toastWs) return true;
+  if (!WS_URL) return false;
+  try {
+    await ensureUiSession();
+    const tok = await apiGet("/ui/ws_token");
+    const url = WS_URL + (WS_URL.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(tok.token);
+    toastWs = new WebSocket(url);
+
+    toastWs.onmessage = async (ev) => {
+      try {
+        const msg = JSON.parse(ev.data || "{}");
+        if (msg.type !== "alert") return;
+        const a = msg.alert;
+        if (!a) return;
+        // Use same toast filtering + delivery mark
+        const prefs = await loadEmailPrefs();
+        const enabled = new Set(prefs.toast_event_types || []);
+        if (enabled.size === 0) return;
+        const aid = a.alert_id;
+        if (!aid || a.toast_delivered || seenToasts.has(aid)) return;
+        const t = (a.details && a.details.alert_type) ? a.details.alert_type : "";
+        if (!enabled.has(t)) return;
+        maybePrependAlertToHistory(a);
+        seenToasts.add(aid);
+        showToast(a.title || a.event || "Alert", `${t} • ${fmtTs(a.ts)}`);
+        await apiPost("/ui/alerts/mark_toast_delivered", { alert_ids: [aid] });
+      } catch (e) {}
+    };
+
+    toastWs.onclose = () => {
+      toastWs = null;
+      // retry after short delay
+      setTimeout(() => { startToastSSE(); }, 2000);
+    };
+    return true;
+  } catch (e) {
+    toastWs = null;
+    return false;
+  }
+}
+
+async function startToastSSE() {
+  // Prefer WebSocket fanout when configured; fallback to SSE.
+  const ok = await startToastWebSocket();
+  if (ok) return;
+  if (toastSse) return;
+  try {
+    toastSse = new EventSource("/ui/alerts/stream");
+    toastSse.addEventListener("hello", () => {});
+    toastSse.addEventListener("ping", () => {});
+    toastSse.addEventListener("alert", async (ev) => {
+      try {
+        const a = JSON.parse(ev.data || "{}");
+        const prefs = await loadEmailPrefs(); // includes toast_event_types
+        const enabled = new Set(prefs.toast_event_types || []);
+        if (enabled.size === 0) return;
+
+        const aid = a.alert_id;
+        if (!aid) return;
+        if (a.toast_delivered) return;
+        if (seenToasts.has(aid)) return;
+
+        const t = (a.details && a.details.alert_type) ? a.details.alert_type : "";
+        if (!enabled.has(t)) return;
+
+        maybePrependAlertToHistory(a);
+        seenToasts.add(aid);
+        showToast(a.title || a.event || "Alert", `${t} • ${fmtTs(a.ts)}`);
+        await apiPost("/ui/alerts/mark_toast_delivered", { alert_ids: [aid] });
+      } catch (e) {
+        // ignore
+      }
+    });
+    toastSse.onerror = () => {
+      // auto-reconnect is handled by EventSource; if it hard fails, recreate
+    };
+  } catch (e) {
+    // If SSE unsupported, keep existing behavior (manual refresh still works)
+  }
+}
+
+function maybePrependAlertToHistory(a) {
+  const el = document.getElementById("alertsList");
+  if (!el) return;
+  // Avoid duplicates by checking first few items
+  const existing = el.querySelectorAll("button[data-aid]");
+  for (let i=0; i<Math.min(existing.length, 10); i++) {
+    if (existing[i].getAttribute("data-aid") === a.alert_id) return;
+  }
+  // Prepend to list for live update (optional)
+  try {
+    const row = renderAlertRow(a);
+    el.insertBefore(row, el.firstChild);
+  } catch(e) {}
+}
+/* ===================== CONFIG ===================== */
+const API_BASE_DEFAULT = (window.API_BASE || window.location.origin);
+let API_BASE = lsGet("api_base") || API_BASE_DEFAULT;
+
+/* ===================== localStorage helpers ===================== */
+function lsGet(k){ try{return localStorage.getItem(k);}catch(e){return null;} }
+function lsSet(k,v){ try{localStorage.setItem(k,v);}catch(e){} }
+function lsDel(k){ try{localStorage.removeItem(k);}catch(e){} }
+
+function accessToken(){ return lsGet("access_token"); }
+function sessionId(){ return lsGet("session_id"); }
+
+/* ===================== modal helpers ===================== */
+let _modalEl = null;
+function modalClose() {
+  if (_modalEl) { _modalEl.remove(); _modalEl = null; }
+}
+function modalShow({title, bodyHtml, actions}) {
+  modalClose();
+  const back = document.createElement("div");
+  back.className = "modal-backdrop";
+  back.innerHTML = `
+    <div class="modal" role="dialog" aria-modal="true">
+      <h2>${title}</h2>
+      <div class="modal-body">${bodyHtml || ""}</div>
+      <div class="modal-actions"></div>
+    </div>
+  `;
+  const actionsEl = back.querySelector(".modal-actions");
+  (actions || []).forEach(a => {
+    const b = document.createElement("button");
+    b.textContent = a.text;
+    b.onclick = a.onClick;
+    actionsEl.appendChild(b);
+  });
+  back.onclick = (e) => { if (e.target === back) modalClose(); };
+  document.body.appendChild(back);
+  _modalEl = back;
+}
+
+
+/* ===================== token / api base modal ===================== */
+function openTokenModal() {
+  const curBase = lsGet("api_base") || API_BASE_DEFAULT;
+  modalShow({
+    title: "Connection + Tokens",
+    bodyHtml: `
+      <div class="muted">Paste your Cognito <b>access token</b> (JWT). Stored in localStorage.</div>
+      <input id="cfgApiBase" class="mono" placeholder="API base URL" value="${curBase}"/>
+      <input id="cfgAccessTok" class="mono" placeholder="access_token (Bearer)" value="${lsGet("access_token")||""}"/>
+      <div class="muted" style="margin-top:8px;">Optional: id_token / refresh_token (not used by this page)</div>
+      <input id="cfgIdTok" class="mono" placeholder="id_token" value="${lsGet("id_token")||""}"/>
+      <input id="cfgRefreshTok" class="mono" placeholder="refresh_token" value="${lsGet("refresh_token")||""}"/>
+      <div id="cfgErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Save", onClick: async () => {
+          const base = document.getElementById("cfgApiBase").value.trim();
+          const at = document.getElementById("cfgAccessTok").value.trim();
+          if (!base) { document.getElementById("cfgErr").textContent = "API base is required."; return; }
+          if (!at) { document.getElementById("cfgErr").textContent = "access_token is required."; return; }
+          lsSet("api_base", base);
+          API_BASE = base;
+          lsSet("access_token", at);
+          lsSet("id_token", document.getElementById("cfgIdTok").value.trim());
+          lsSet("refresh_token", document.getElementById("cfgRefreshTok").value.trim());
+          lsDel("session_id"); // force re-stepup
+          modalClose();
+          if (!accessToken()) {
+            openTokenModal();
+          } else {
+            await refreshAll();
+          }
+      }},
+    ]
+  });
+}
+
+/* ===================== generic API helper ===================== */
+async function api(path, {method="GET", body=null, includeSession=true}={}) {
+  const tok = accessToken();
+  if (!tok) throw new Error("Missing access_token (Cognito login not completed).");
+  const headers = { "Authorization": "Bearer " + tok };
+  if (includeSession) {
+    const sid = sessionId();
+    if (!sid) throw new Error("Missing UI session_id; call ensureUiSession() first.");
+    headers["X-SESSION-ID"] = sid;
+  }
+  if (body !== null) headers["Content-Type"] = "application/json";
+
+  const res = await fetch(API_BASE + path, {
+    method,
+    headers,
+    body: (body !== null ? JSON.stringify(body) : undefined),
+  });
+  const txt = await res.text();
+  if (!res.ok) throw new Error(res.status + ": " + txt);
+  return txt ? JSON.parse(txt) : {};
+}
+
+function apiGet(path, { includeSession = true } = {}) {
+  return api(path, { method: "GET", includeSession });
+}
+
+function apiPost(path, body, { includeSession = true } = {}) {
+  return api(path, { method: "POST", body, includeSession });
+}
+
+function parseHttpError(errStr){
+  const m = String(errStr).match(/^(\d+):\s/);
+  return m ? parseInt(m[1],10) : null;
+}
+
+/* ===================== small formatters ===================== */
+function escapeHtml(str) {
+  return String(str ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function fmtDurSec(sec){
+  sec = Math.max(0, Math.floor(sec||0));
+  const d=Math.floor(sec/86400); sec-=d*86400;
+  const h=Math.floor(sec/3600); sec-=h*3600;
+  const m=Math.floor(sec/60); sec-=m*60;
+  const parts=[];
+  if(d) parts.push(d+'d');
+  if(h||d) parts.push(h+'h');
+  if(m||h||d) parts.push(m+'m');
+  parts.push(sec+'s');
+  return parts.join(' ');
+}
+
+function fmtTs(ts) {
+  if (!ts || ts === 0) return "";
+  try { return new Date(ts*1000).toLocaleString(); } catch(e) { return String(ts); }
+}
+
+function renderAlertRow(a) {
+  const row = document.createElement("button");
+  row.type = "button";
+  row.className = "list-item list-button";
+  if (a.alert_id) row.setAttribute("data-aid", a.alert_id);
+  row.innerHTML = `
+    <div class="grow">
+      <div><b>${escapeHtml(a.title || a.event || "Alert")}</b></div>
+      <div class="muted mono">${escapeHtml((a.details && a.details.alert_type) || "")} • ${fmtTs(a.ts)}</div>
+    </div>
+    <div class="muted">${a.read ? "Read" : "Unread"}</div>
+  `;
+  row.onclick = async () => {
+    if (!a.alert_id || a.read) return;
+    try {
+      await apiPost("/ui/alerts/mark_read", { alert_ids: [a.alert_id] });
+      row.classList.add("list-item-muted");
+    } catch (e) {
+      // ignore
+    }
+  };
+  return row;
+}
+
+/* ===================== session start ===================== */
+async function sessionStart() {
+  const tok = accessToken();
+  const res = await fetch(API_BASE + "/ui/session/start", {
+    method: "POST",
+    headers: { "Authorization": "Bearer " + tok, "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  const txt = await res.text();
+  if (!res.ok) throw new Error(res.status + ": " + txt);
+  return txt ? JSON.parse(txt) : {};
+}
+
+/* ============================================================
+   FULL ensureUiSession() (TOTP + SMS + Email, auto-send SMS/email once)
+   ============================================================ */
+async function ensureUiSession() {
+  if (sessionId()) return true;
+
+  const r = await sessionStart();
+  if (!r.auth_required) {
+    lsSet("session_id", r.session_id);
+    return true;
+  }
+
+  const challengeId = r.challenge_id;
+  const required = r.required_factors || [];
+  const needTotp  = required.includes("totp");
+  const needSms   = required.includes("sms");
+  const needEmail = required.includes("email");
+
+  async function postBearer(path, payload) {
+    const tok = accessToken();
+    const res = await fetch(API_BASE + path, {
+      method: "POST",
+      headers: { "Authorization": "Bearer " + tok, "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const txt = await res.text();
+    if (!res.ok) throw new Error(res.status + ": " + txt);
+    return txt ? JSON.parse(txt) : {};
+  }
+
+  return new Promise((resolve, reject) => {
+    const state = {
+      challengeId,
+      needTotp, needSms, needEmail,
+
+      totpDone: false,
+      smsDone: false,
+      emailDone: false,
+
+      smsSending: false,
+      smsSentOnce: false,
+      smsSentTo: [],
+
+      emailSending: false,
+      emailSentOnce: false,
+      emailSentTo: [],
+
+      lastErr: "",
+    };
+
+    function badge(done) {
+      return done ? `<span class="pill">✅ verified</span>` : `<span class="pill">required</span>`;
+    }
+
+    async function tryFinalizeOrClose(res) {
+      if (res && res.session_id) {
+        lsSet("session_id", res.session_id);
+        modalClose();
+        resolve(true);
+        return true;
+      }
+      return false;
+    }
+
+    async function autoSendSmsOnce() {
+      if (!state.needSms || state.smsDone || state.smsSentOnce || state.smsSending) return;
+      state.smsSending = true;
+      state.lastErr = "";
+      render();
+      try {
+        const res = await postBearer("/ui/mfa/sms/begin", { challenge_id: challengeId });
+        state.smsSentTo = res.sent_to || [];
+        state.smsSentOnce = true;
+      } catch (e) {
+        state.lastErr = String(e);
+      } finally {
+        state.smsSending = false;
+        render();
+      }
+    }
+
+    async function autoSendEmailOnce() {
+      if (!state.needEmail || state.emailDone || state.emailSentOnce || state.emailSending) return;
+      state.emailSending = true;
+      state.lastErr = "";
+      render();
+      try {
+        const res = await postBearer("/ui/mfa/email/begin", { challenge_id: challengeId });
+        state.emailSentTo = res.sent_to || [];
+        state.emailSentOnce = true;
+      } catch (e) {
+        state.lastErr = String(e);
+      } finally {
+        state.emailSending = false;
+        render();
+      }
+    }
+
+    function render() {
+      const totpSection = !state.needTotp ? "" : `
+        <div style="border:1px solid #eee; padding:10px; border-radius:10px; margin-top:10px;">
+          <div style="display:flex; justify-content:space-between; align-items:center; gap:10px;">
+            <div><b>TOTP</b> ${badge(state.totpDone)}</div>
+          </div>
+
+          <input id="totpCode" placeholder="123456" inputmode="numeric" autocomplete="one-time-code"
+                 ${state.totpDone ? "disabled" : ""} />
+
+          <div style="display:flex; gap:8px; flex-wrap:wrap;">
+            <button id="totpVerifyBtn" ${state.totpDone ? "disabled" : ""}>Verify TOTP</button>
+            <button id="totpRecoveryBtn" ${state.totpDone ? "disabled" : ""}>Use TOTP recovery</button>
+          </div>
+          <small>Any registered authenticator works.</small>
+        </div>
+      `;
+
+      const smsSection = !state.needSms ? "" : `
+        <div style="border:1px solid #eee; padding:10px; border-radius:10px; margin-top:10px;">
+          <div style="display:flex; justify-content:space-between; align-items:center; gap:10px;">
+            <div><b>SMS</b> ${badge(state.smsDone)}</div>
+            <div>
+              <button id="smsResendBtn" ${state.smsDone || state.smsSending ? "disabled" : ""}>
+                ${state.smsSentOnce ? "Resend SMS" : "Send SMS"}
+              </button>
+            </div>
+          </div>
+
+          <div style="margin-top:6px;">
+            ${state.smsSentTo.length
+              ? `<small>Sent to: ${state.smsSentTo.map(x=>`<code>${x}</code>`).join(" ")}</small>`
+              : `<small>We will text a code to all your enabled numbers.</small>`}
+          </div>
+
+          <input id="smsCode" placeholder="SMS code" inputmode="numeric" autocomplete="one-time-code"
+                 ${state.smsDone ? "disabled" : ""} />
+
+          <div style="display:flex; gap:8px; flex-wrap:wrap;">
+            <button id="smsVerifyBtn" ${state.smsDone ? "disabled" : ""}>Verify SMS</button>
+            <button id="smsRecoveryBtn" ${state.smsDone ? "disabled" : ""}>Use SMS recovery</button>
+          </div>
+        </div>
+      `;
+
+      const emailSection = !state.needEmail ? "" : `
+        <div style="border:1px solid #eee; padding:10px; border-radius:10px; margin-top:10px;">
+          <div style="display:flex; justify-content:space-between; align-items:center; gap:10px;">
+            <div><b>Email</b> ${badge(state.emailDone)}</div>
+            <div>
+              <button id="emailResendBtn" ${state.emailDone || state.emailSending ? "disabled" : ""}>
+                ${state.emailSentOnce ? "Resend Email" : "Send Email"}
+              </button>
+            </div>
+          </div>
+
+          <div style="margin-top:6px;">
+            ${state.emailSentTo.length
+              ? `<small>Sent to: ${state.emailSentTo.map(x=>`<code>${x}</code>`).join(" ")}</small>`
+              : `<small>We will email a code to all your enabled addresses.</small>`}
+          </div>
+
+          <input id="emailCode" placeholder="Email code" inputmode="numeric" autocomplete="one-time-code"
+                 ${state.emailDone ? "disabled" : ""} />
+
+          <div style="display:flex; gap:8px; flex-wrap:wrap;">
+            <button id="emailVerifyBtn" ${state.emailDone ? "disabled" : ""}>Verify Email</button>
+            <button id="emailRecoveryBtn" ${state.emailDone ? "disabled" : ""}>Use Email recovery</button>
+          </div>
+        </div>
+      `;
+
+      modalShow({
+        title: "Step-up verification required",
+        bodyHtml: `
+          <div>Complete all required factors to create a web session.</div>
+          <div style="margin-top:6px;"><small>Challenge: <code class="mono">${challengeId}</code></small></div>
+          ${totpSection}${smsSection}${emailSection}
+          <div id="loginErr" class="err" style="margin-top:10px;">${state.lastErr || ""}</div>
+        `,
+        actions: [
+          { text: "Cancel", onClick: () => { modalClose(); reject(new Error("Login cancelled")); } }
+        ]
+      });
+
+      // TOTP handlers
+      if (state.needTotp) {
+        const v = document.getElementById("totpVerifyBtn");
+        const r = document.getElementById("totpRecoveryBtn");
+        if (v) v.onclick = async () => {
+          state.lastErr = ""; render();
+          try {
+            const code = document.getElementById("totpCode").value.trim();
+            const res = await postBearer("/ui/mfa/totp/verify", { challenge_id: challengeId, totp_code: code });
+            if (await tryFinalizeOrClose(res)) return;
+            state.totpDone = true; render();
+          } catch (e) { state.lastErr = String(e); render(); }
+        };
+        if (r) r.onclick = async () => {
+          const rc = prompt("Enter a TOTP recovery code:") || "";
+          if (!rc.trim()) return;
+          state.lastErr = ""; render();
+          try {
+            const res = await postBearer("/ui/recovery/totp", { challenge_id: challengeId, recovery_code: rc.trim() });
+            if (await tryFinalizeOrClose(res)) return;
+            state.totpDone = true; render();
+          } catch (e) { state.lastErr = String(e); render(); }
+        };
+      }
+
+      // SMS handlers
+      if (state.needSms) {
+        const resend = document.getElementById("smsResendBtn");
+        const verify = document.getElementById("smsVerifyBtn");
+        const recov  = document.getElementById("smsRecoveryBtn");
+
+        if (resend) resend.onclick = async () => {
+          if (state.smsDone || state.smsSending) return;
+          state.smsSending = true; state.lastErr = ""; render();
+          try {
+            const res = await postBearer("/ui/mfa/sms/begin", { challenge_id: challengeId });
+            state.smsSentTo = res.sent_to || [];
+            state.smsSentOnce = true;
+          } catch (e) { state.lastErr = String(e); }
+          finally { state.smsSending = false; render(); }
+        };
+
+        if (verify) verify.onclick = async () => {
+          state.lastErr = ""; render();
+          try {
+            const code = document.getElementById("smsCode").value.trim();
+            const res = await postBearer("/ui/mfa/sms/verify", { challenge_id: challengeId, code });
+            if (await tryFinalizeOrClose(res)) return;
+            state.smsDone = true; render();
+          } catch (e) { state.lastErr = String(e); render(); }
+        };
+
+        if (recov) recov.onclick = async () => {
+          const rc = prompt("Enter an SMS recovery code:") || "";
+          if (!rc.trim()) return;
+          state.lastErr = ""; render();
+          try {
+            const res = await postBearer("/ui/recovery/sms", { challenge_id: challengeId, recovery_code: rc.trim() });
+            if (await tryFinalizeOrClose(res)) return;
+            state.smsDone = true; render();
+          } catch (e) { state.lastErr = String(e); render(); }
+        };
+      }
+
+      // Email handlers
+      if (state.needEmail) {
+        const resend = document.getElementById("emailResendBtn");
+        const verify = document.getElementById("emailVerifyBtn");
+        const recov  = document.getElementById("emailRecoveryBtn");
+
+        if (resend) resend.onclick = async () => {
+          if (state.emailDone || state.emailSending) return;
+          state.emailSending = true; state.lastErr = ""; render();
+          try {
+            const res = await postBearer("/ui/mfa/email/begin", { challenge_id: challengeId });
+            state.emailSentTo = res.sent_to || [];
+            state.emailSentOnce = true;
+          } catch (e) { state.lastErr = String(e); }
+          finally { state.emailSending = false; render(); }
+        };
+
+        if (verify) verify.onclick = async () => {
+          state.lastErr = ""; render();
+          try {
+            const code = document.getElementById("emailCode").value.trim();
+            const res = await postBearer("/ui/mfa/email/verify", { challenge_id: challengeId, code });
+            if (await tryFinalizeOrClose(res)) return;
+            state.emailDone = true; render();
+          } catch (e) { state.lastErr = String(e); render(); }
+        };
+
+        if (recov) recov.onclick = async () => {
+          const rc = prompt("Enter an Email recovery code:") || "";
+          if (!rc.trim()) return;
+          state.lastErr = ""; render();
+          try {
+            const res = await postBearer("/ui/recovery/email", { challenge_id: challengeId, recovery_code: rc.trim() });
+            if (await tryFinalizeOrClose(res)) return;
+            state.emailDone = true; render();
+          } catch (e) { state.lastErr = String(e); render(); }
+        };
+      }
+
+      // Focus first incomplete
+      setTimeout(() => {
+        if (state.needTotp && !state.totpDone) { const el = document.getElementById("totpCode"); if (el) el.focus(); }
+        else if (state.needSms && !state.smsDone) { const el = document.getElementById("smsCode"); if (el) el.focus(); }
+        else if (state.needEmail && !state.emailDone) { const el = document.getElementById("emailCode"); if (el) el.focus(); }
+      }, 50);
+    }
+
+    render();
+    autoSendSmsOnce();
+    autoSendEmailOnce();
+  });
+}
+
+/* ===================== UI: ME ===================== */
+async function refreshMe() {
+  await ensureUiSession();
+  const me = await api("/ui/me", {method:"GET", includeSession:true});
+  document.getElementById("whoami").textContent = `user_sub=${me.user_sub} session=${me.session_id}`;
+}
+
+/* ===================== TOTP Devices (wired to backend we wrote) ===================== */
+async function totpDevicesList() { return await api("/ui/mfa/totp/devices", {method:"GET", includeSession:true}); }
+async function totpBegin(label) { return await api("/ui/mfa/totp/devices/begin", {method:"POST", body:{label}, includeSession:true}); }
+async function totpConfirm(device_id, totp_code) { return await api("/ui/mfa/totp/devices/confirm", {method:"POST", body:{device_id, totp_code}, includeSession:true}); }
+async function totpRemove(device_id, totp_code) { return await api(`/ui/mfa/totp/devices/${encodeURIComponent(device_id)}/remove`, {method:"POST", body:{totp_code}, includeSession:true}); }
+
+async function refreshTotpDevices() {
+  const data = await totpDevicesList();
+  const tbody = document.getElementById("totpTbl").querySelector("tbody");
+  tbody.innerHTML = "";
+  (data.devices || []).forEach(d => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${d.label || ""}</td>
+      <td>${d.enabled ? "yes" : "no"}</td>
+      <td>${fmtTs(d.last_used_at)}</td>
+      <td><button class="rm">Remove</button></td>
+    `;
+    tr.querySelector(".rm").onclick = async () => {
+      const code = prompt("Enter a TOTP code to confirm removal:") || "";
+      if (!code.trim()) return;
+      await totpRemove(d.device_id, code.trim());
+      await refreshTotpDevices();
+    };
+    tbody.appendChild(tr);
+  });
+}
+
+/* ===================== SMS Devices (wired to backend we wrote) ===================== */
+async function smsDevicesList() { return await api("/ui/mfa/sms/devices", {method:"GET", includeSession:true}); }
+async function smsDeviceBegin(phone_e164, label) { return await api("/ui/mfa/sms/devices/begin", {method:"POST", body:{phone_e164, label}, includeSession:true}); }
+async function smsDeviceConfirm(challenge_id, code) { return await api("/ui/mfa/sms/devices/confirm", {method:"POST", body:{challenge_id, code}, includeSession:true}); }
+async function smsRemoveBegin(sms_device_id) { return await api(`/ui/mfa/sms/devices/${encodeURIComponent(sms_device_id)}/remove/begin`, {method:"POST", includeSession:true}); }
+async function smsRemoveConfirm(challenge_id, code) { return await api("/ui/mfa/sms/devices/remove/confirm", {method:"POST", body:{challenge_id, code}, includeSession:true}); }
+
+async function refreshSmsDevices() {
+  const data = await smsDevicesList();
+  const tbody = document.getElementById("smsTbl").querySelector("tbody");
+  tbody.innerHTML = "";
+  (data.devices || []).sort((a,b)=> (b.enabled===true)-(a.enabled===true)).forEach(d => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td><code>${d.phone_e164 || ""}</code></td>
+      <td>${d.label || ""}</td>
+      <td>${d.enabled ? "yes" : (d.pending ? "pending" : "no")}</td>
+      <td>${fmtTs(d.last_used_at)}</td>
+      <td>${d.enabled ? `<button class="rm">Remove</button>` : ""}</td>
+    `;
+    const rm = tr.querySelector(".rm");
+    if (rm) rm.onclick = async () => openSmsRemoveModal(d.sms_device_id, d.phone_e164);
+    tbody.appendChild(tr);
+  });
+}
+
+function openSmsAddModal() {
+  modalShow({
+    title: "Add SMS phone (E.164)",
+    bodyHtml: `
+      <div class="muted">Example: <code>+15551234567</code> (max 3 phones)</div>
+      <input id="smsPhone" placeholder="+15551234567" class="mono" />
+      <input id="smsLabel" placeholder="Label (optional) e.g. Work iPhone" />
+      <div id="smsAddErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Send verification SMS", onClick: async () => {
+          try {
+            const phone = document.getElementById("smsPhone").value.trim();
+            const label = document.getElementById("smsLabel").value.trim() || null;
+            const r = await smsDeviceBegin(phone, label);
+            openSmsAddConfirmModal(r.challenge_id, r.sent_to || [], r.sms_device_id);
+          } catch (e) {
+            document.getElementById("smsAddErr").textContent = String(e);
+          }
+      }},
+    ]
+  });
+}
+
+function openSmsAddConfirmModal(challengeId, sentTo, smsDeviceId) {
+  modalShow({
+    title: "Confirm SMS phone",
+    bodyHtml: `
+      <div>We sent a verification code to:</div>
+      <div style="margin:6px 0;">${sentTo.map(n => `<code>${n}</code>`).join(" ")}</div>
+      <input id="smsAddCode" placeholder="SMS code" inputmode="numeric" autocomplete="one-time-code" />
+      <div class="muted" style="margin-top:8px;">Challenge: <code class="mono">${challengeId}</code></div>
+      <div class="muted">Device: <code class="mono">${smsDeviceId}</code></div>
+      <div id="smsAddConfErr" class="err" style="margin-top:8px;"></div>
+      <div id="smsRecoveryOut" style="margin-top:10px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Confirm phone", onClick: async () => {
+          try {
+            const code = document.getElementById("smsAddCode").value.trim();
+            const r = await smsDeviceConfirm(challengeId, code);
+            const rec = r.recovery_codes || [];
+            if (rec.length) {
+              document.getElementById("smsRecoveryOut").innerHTML =
+                `<div><b>SMS recovery codes (save now — shown once):</b></div>
+                 <pre class="mono" style="max-height:160px;">${rec.join("\n")}</pre>`;
+              await refreshSmsDevices();
+              return;
+            }
+            modalClose();
+            await refreshSmsDevices();
+          } catch (e) {
+            document.getElementById("smsAddConfErr").textContent = String(e);
+          }
+      }},
+      { text: "Done", onClick: async () => { modalClose(); await refreshSmsDevices(); } },
+    ]
+  });
+}
+
+async function openSmsRemoveModal(smsDeviceId, phoneE164) {
+  const r = await smsRemoveBegin(smsDeviceId);
+  modalShow({
+    title: "Remove SMS phone",
+    bodyHtml: `
+      <div>To remove <code>${phoneE164}</code>, we sent a code to your other enabled SMS numbers:</div>
+      <div style="margin:6px 0;">${(r.sent_to || []).map(n => `<code>${n}</code>`).join(" ")}</div>
+      <input id="smsRmCode" placeholder="SMS code" inputmode="numeric" autocomplete="one-time-code" />
+      <div class="muted" style="margin-top:8px;">Challenge: <code class="mono">${r.challenge_id}</code></div>
+      <div id="smsRmErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Confirm removal", onClick: async () => {
+          try {
+            const code = document.getElementById("smsRmCode").value.trim();
+            await smsRemoveConfirm(r.challenge_id, code);
+            modalClose();
+            await refreshSmsDevices();
+          } catch (e) {
+            document.getElementById("smsRmErr").textContent = String(e);
+          }
+      }},
+    ]
+  });
+}
+
+/* ===================== Email Devices (wired to SES-based backend) ===================== */
+async function emailDevicesList() { return await api("/ui/mfa/email/devices", {method:"GET", includeSession:true}); }
+async function emailDeviceBegin(email, label) { return await api("/ui/mfa/email/devices/begin", {method:"POST", body:{email, label}, includeSession:true}); }
+async function emailDeviceConfirm(challenge_id, code) { return await api("/ui/mfa/email/devices/confirm", {method:"POST", body:{challenge_id, code}, includeSession:true}); }
+async function emailRemoveBegin(email_device_id) { return await api(`/ui/mfa/email/devices/${encodeURIComponent(email_device_id)}/remove/begin`, {method:"POST", includeSession:true}); }
+async function emailRemoveConfirm(challenge_id, code) { return await api("/ui/mfa/email/devices/remove/confirm", {method:"POST", body:{challenge_id, code}, includeSession:true}); }
+
+async function refreshEmailDevices() {
+  const data = await emailDevicesList();
+  const tbody = document.getElementById("emailTbl").querySelector("tbody");
+  tbody.innerHTML = "";
+  (data.devices || []).sort((a,b)=> (b.enabled===true)-(a.enabled===true)).forEach(d => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td><code>${d.email || ""}</code></td>
+      <td>${d.label || ""}</td>
+      <td>${d.enabled ? "yes" : (d.pending ? "pending" : "no")}</td>
+      <td>${fmtTs(d.last_used_at)}</td>
+      <td>${d.enabled ? `<button class="rm">Remove</button>` : ""}</td>
+    `;
+    const rm = tr.querySelector(".rm");
+    if (rm) rm.onclick = async () => openEmailRemoveModal(d.email_device_id, d.email);
+    tbody.appendChild(tr);
+  });
+}
+
+function openEmailAddModal() {
+  modalShow({
+    title: "Add Email",
+    bodyHtml: `
+      <div class="muted">Max 5 emails. Codes are sent to all enabled emails.</div>
+      <input id="emailVal" placeholder="name@example.com" />
+      <input id="emailLabel" placeholder="Label (optional) e.g. Work" />
+      <div id="emailAddErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Send email code", onClick: async () => {
+          try {
+            const email = document.getElementById("emailVal").value.trim();
+            const label = document.getElementById("emailLabel").value.trim() || null;
+            const r = await emailDeviceBegin(email, label);
+            openEmailAddConfirmModal(r.challenge_id, r.sent_to || [], r.email_device_id);
+          } catch (e) {
+            document.getElementById("emailAddErr").textContent = String(e);
+          }
+      }},
+    ]
+  });
+}
+
+function openEmailAddConfirmModal(challengeId, sentTo, emailDeviceId) {
+  modalShow({
+    title: "Confirm Email",
+    bodyHtml: `
+      <div>We sent a verification code to:</div>
+      <div style="margin:6px 0;">${sentTo.map(e => `<code>${e}</code>`).join(" ")}</div>
+      <input id="emailCode" placeholder="Email code" inputmode="numeric" autocomplete="one-time-code" />
+      <div class="muted" style="margin-top:8px;">Challenge: <code class="mono">${challengeId}</code></div>
+      <div class="muted">Device: <code class="mono">${emailDeviceId}</code></div>
+      <div id="emailConfErr" class="err" style="margin-top:8px;"></div>
+      <div id="emailRecoveryOut" style="margin-top:10px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Confirm email", onClick: async () => {
+          try {
+            const code = document.getElementById("emailCode").value.trim();
+            const r = await emailDeviceConfirm(challengeId, code);
+            const rec = r.recovery_codes || [];
+            if (rec.length) {
+              document.getElementById("emailRecoveryOut").innerHTML =
+                `<div><b>Email recovery codes (save now — shown once):</b></div>
+                 <pre class="mono" style="max-height:160px;">${rec.join("\n")}</pre>`;
+              await refreshEmailDevices();
+              return;
+            }
+            modalClose();
+            await refreshEmailDevices();
+          } catch (e) {
+            document.getElementById("emailConfErr").textContent = String(e);
+          }
+      }},
+      { text: "Done", onClick: async () => { modalClose(); await refreshEmailDevices(); } },
+    ]
+  });
+}
+
+async function openEmailRemoveModal(emailDeviceId, email) {
+  const r = await emailRemoveBegin(emailDeviceId);
+  modalShow({
+    title: "Remove Email",
+    bodyHtml: `
+      <div>To remove <code>${email}</code>, we sent a code to your other enabled emails:</div>
+      <div style="margin:6px 0;">${(r.sent_to || []).map(e => `<code>${e}</code>`).join(" ")}</div>
+      <input id="emailRmCode" placeholder="Email code" inputmode="numeric" autocomplete="one-time-code" />
+      <div class="muted" style="margin-top:8px;">Challenge: <code class="mono">${r.challenge_id}</code></div>
+      <div id="emailRmErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Confirm removal", onClick: async () => {
+          try {
+            const code = document.getElementById("emailRmCode").value.trim();
+            await emailRemoveConfirm(r.challenge_id, code);
+            modalClose();
+            await refreshEmailDevices();
+          } catch (e) {
+            document.getElementById("emailRmErr").textContent = String(e);
+          }
+      }},
+    ]
+  });
+}
+
+/* ===================== refreshAll ===================== */
+
+/* ===================== Sessions ===================== */
+async function refreshSessions() {
+  await ensureUiSession();
+  const res = await apiGet("/ui/sessions");
+  const el = document.getElementById("sessList");
+  el.innerHTML = "";
+  (res.sessions || []).forEach(s => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <div class="grow">
+        <div class="mono">${escapeHtml(s.session_id)} ${s.is_current ? "<span class='pill'>current</span>" : ""} ${s.revoked ? "<span class='pill'>revoked</span>" : ""}</div>
+        <div class="muted">created ${fmtTs(s.created_at)} • last ${fmtTs(s.last_seen_at)} • age ${fmtDurSec((Date.now()/1000)-(s.created_at||0))} • ${escapeHtml(s.ip||"")} • ${escapeHtml((s.user_agent||"").slice(0,80))}</div>
+      </div>
+      <div>
+        <button ${s.is_current || s.revoked ? "disabled" : ""} data-sid="${escapeHtml(s.session_id)}">Revoke</button>
+      </div>
+    `;
+    const btns = row.querySelectorAll("button");
+    btns[0].onclick = async (e) => {
+      const sid = e.target.getAttribute("data-sid");
+      if (!sid) return;
+      await apiPost("/ui/sessions/revoke", { session_id: sid });
+      await refreshSessions();
+    };
+    el.appendChild(row);
+  });
+}
+
+/* ===================== TOTP add flow ===================== */
+async function totpBegin(label) {
+  return await apiPost("/ui/mfa/totp/devices/begin", { label: label || "" });
+}
+async function totpConfirm(device_id, totp_code) {
+  return await apiPost("/ui/mfa/totp/devices/confirm", { device_id, totp_code });
+}
+
+function openTotpAddModal() {
+  modalShow({
+    title: "Add TOTP Device",
+    bodyHtml: `
+      <div class="muted">1) Click “Begin” to get a QR code URI. 2) Scan it in your authenticator app. 3) Enter the 6‑digit code to confirm.</div>
+      <input id="totpLabel" placeholder="Label (optional)"/>
+      <div class="row-inline" style="margin-top:8px;">
+        <button id="totpBeginBtn">Begin</button>
+      </div>
+      <div id="totpBeginOut" style="margin-top:10px;"></div>
+      <div id="totpConfirmWrap" style="display:none; margin-top:10px;">
+        <input id="totpDeviceId" class="mono" placeholder="device_id" readonly/>
+        <input id="totpCode" class="mono" placeholder="6-digit code"/>
+        <button id="totpConfirmBtn">Confirm</button>
+      </div>
+      <div id="totpAddErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [{ text: "Close", onClick: modalClose }]
+  });
+
+  document.getElementById("totpBeginBtn").onclick = async () => {
+    try {
+      await ensureUiSession();
+      const label = document.getElementById("totpLabel").value.trim();
+      const r = await totpBegin(label);
+      // Display otpauth URI as text (user can paste into QR generator if desired).
+      document.getElementById("totpBeginOut").innerHTML = `
+        <div class="muted">otpauth URI:</div>
+        <div class="mono break">${escapeHtml(r.otpauth_uri)}</div>
+      `;
+      document.getElementById("totpDeviceId").value = r.device_id;
+      document.getElementById("totpConfirmWrap").style.display = "block";
+    } catch (e) {
+      document.getElementById("totpAddErr").textContent = String(e);
+    }
+  };
+
+  document.getElementById("totpConfirmBtn").onclick = async () => {
+    try {
+      const device_id = document.getElementById("totpDeviceId").value.trim();
+      const code = document.getElementById("totpCode").value.trim();
+      const r = await totpConfirm(device_id, code);
+      if (r.recovery_codes && r.recovery_codes.length) {
+        alert("Recovery codes (save these now):\n\n" + r.recovery_codes.join("\n"));
+      }
+      modalClose();
+      await refreshTotpDevices();
+    } catch (e) {
+      document.getElementById("totpAddErr").textContent = String(e);
+    }
+  };
+}
+
+
+/* ===================== API Keys ===================== */
+async function refreshKeys() {
+  await ensureUiSession();
+  const res = await apiGet("/ui/api_keys");
+  const el = document.getElementById("keysList");
+  if (!el) return;
+  el.innerHTML = "";
+  (res.keys || []).forEach(k => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <div class="grow">
+        <div><b>${escapeHtml(k.label||"(no label)")}</b> <span class="muted mono">${escapeHtml(k.prefix||"")}</span></div>
+        <div class="muted">id ${escapeHtml(k.key_id)} • created ${fmtTs(k.created_at)} • last used ${k.last_used_at ? fmtTs(k.last_used_at) : "never"} • allow ${((k.allow_cidrs||[]).length)} • deny ${((k.deny_cidrs||[]).length)} ${k.revoked ? "• revoked" : ""}</div>
+      </div>
+      <div>
+        <button ${k.revoked ? "disabled" : ""} data-kid="${escapeHtml(k.key_id)}">Revoke</button>
+        <button ${k.revoked ? "disabled" : ""} data-kid="${escapeHtml(k.key_id)}" data-allow="${escapeHtml((k.allow_cidrs||[]).join(","))}" data-deny="${escapeHtml((k.deny_cidrs||[]).join(","))}">Edit IP rules</button>
+      </div>
+    `;
+    const btns = row.querySelectorAll("button");
+    btns[0].onclick = async (e) => {
+      const kid = e.target.getAttribute("data-kid");
+      await apiPost("/ui/api_keys/revoke", { key_id: kid });
+      await refreshKeys();
+    };
+    btns[1].onclick = async (e) => {
+      const kid = e.target.getAttribute("data-kid");
+      const allowCsv = e.target.getAttribute("data-allow") || "";
+      const denyCsv = e.target.getAttribute("data-deny") || "";
+      openIpRulesModal(kid, allowCsv, denyCsv);
+    };
+    el.appendChild(row);
+  });
+}
+
+
+async function setIpRules(key_id, allow_cidrs, deny_cidrs) {
+  return await apiPost("/ui/api_keys/ip_rules", { key_id, allow_cidrs, deny_cidrs });
+}
+
+function csvToList(s) {
+  return (s||"").split(/[,\n]/).map(x => x.trim()).filter(Boolean);
+}
+
+function openIpRulesModal(key_id, allowCsv, denyCsv) {
+  const allow = csvToList(allowCsv);
+  const deny = csvToList(denyCsv);
+  modalShow({
+    title: "API Key IP Rules",
+    bodyHtml: `
+      <div class="muted">If both lists are empty, the API key has <b>no IP restrictions</b>.<br/>
+      If allowlist has entries, the request IP must match <b>at least one</b> allow CIDR/IP.<br/>
+      Denylist is applied <b>after</b> allowlist: if it matches, access is blocked.</div>
+      <div style="margin-top:10px;"><b>Allowlist (IPs/CIDRs)</b></div>
+      <textarea id="ipAllow" class="mono" rows="5" placeholder="1.2.3.4\n10.0.0.0/8">${escapeHtml(allow.join("\n"))}</textarea>
+      <div style="margin-top:10px;"><b>Denylist (IPs/CIDRs)</b></div>
+      <textarea id="ipDeny" class="mono" rows="5" placeholder="5.6.7.8\n192.168.0.0/16">${escapeHtml(deny.join("\n"))}</textarea>
+      <div id="ipRuleErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Save", onClick: async () => {
+          try {
+            const a = csvToList(document.getElementById("ipAllow").value);
+            const d = csvToList(document.getElementById("ipDeny").value);
+            await ensureUiSession();
+            await setIpRules(key_id, a, d);
+            modalClose();
+            await refreshKeys();
+          } catch (e) {
+            document.getElementById("ipRuleErr").textContent = String(e);
+          }
+      }},
+    ]
+  });
+}
+
+function openCreateKeyModal() {
+  modalShow({
+    title: "Create API Key",
+    bodyHtml: `
+      <div class="muted">Add an optional label. The API key will be shown once.</div>
+      <input id="keyLabel" placeholder="Label (optional)"/>
+      <div id="keyOut" style="margin-top:10px;"></div>
+      <div id="keyErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Create", onClick: async () => {
+          try {
+            await ensureUiSession();
+            const label = document.getElementById("keyLabel").value.trim();
+            const r = await apiPost("/ui/api_keys", { label });
+            document.getElementById("keyOut").innerHTML = `
+              <div class="muted">Copy and store this key now:</div>
+              <div class="mono break">${escapeHtml(r.api_key)}</div>
+            `;
+            await refreshKeys();
+          } catch (e) {
+            document.getElementById("keyErr").textContent = String(e);
+          }
+      }},
+      { text: "Close", onClick: modalClose },
+    ]
+  });
+}
+
+
+/* ===================== Alert Email Settings ===================== */
+let alertTypesCache = [];
+
+async function loadAlertTypes() {
+  await ensureUiSession();
+  const res = await apiGet("/ui/alerts/types");
+  alertTypesCache = res.types || [];
+  return alertTypesCache;
+}
+
+async function loadEmailPrefs() {
+  await ensureUiSession();
+  return await apiGet("/ui/alerts/email_prefs");
+}
+
+function renderEmailList(emails) {
+  const el = document.getElementById("alertEmailList");
+  if (!el) return;
+  el.innerHTML = "";
+  (emails||[]).forEach(e => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <div class="grow mono">${escapeHtml(e)}</div>
+      <div><button data-email="${escapeHtml(e)}">Remove</button></div>
+    `;
+    row.querySelector("button").onclick = async (ev) => {
+      const em = ev.target.getAttribute("data-email");
+      await apiPost("/ui/alerts/emails/remove", { email: em });
+      await refreshAlertEmailSettings();
+    };
+    el.appendChild(row);
+  });
+}
+
+function renderTypeChecklist(types, enabled) {
+  const el = document.getElementById("alertTypeChecklist");
+  if (!el) return;
+  el.innerHTML = "";
+  const en = new Set(enabled||[]);
+  types.forEach(t => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <label style="display:flex;gap:10px;align-items:center;">
+        <input type="checkbox" data-type="${escapeHtml(t)}" ${en.has(t) ? "checked" : ""}/>
+        <span class="mono">${escapeHtml(t)}</span>
+      </label>
+    `;
+    el.appendChild(row);
+  });
+}
+
+async function refreshAlertEmailSettings() {
+  const prefs = await loadEmailPrefs();
+  const types = alertTypesCache.length ? alertTypesCache : await loadAlertTypes();
+  renderEmailList(prefs.emails || []);
+  renderTypeChecklist(types, prefs.email_event_types || []);
+  renderSmsList(prefs.sms_numbers || []);
+  renderSmsTypeChecklist(types, prefs.sms_event_types || []);
+  renderToastTypeChecklist(types, prefs.toast_event_types || []);
+  const msg = document.getElementById("alertTypesMsg");
+  if (msg) msg.textContent = "";
+}
+
+async function beginAddAlertEmail(email) {
+  await ensureUiSession();
+  return await apiPost("/ui/alerts/emails/begin", { email });
+}
+
+async function confirmAddAlertEmail(challenge_id, code) {
+  await ensureUiSession();
+  return await apiPost("/ui/alerts/emails/confirm", { challenge_id, code });
+}
+
+function openConfirmEmailModal(sentTo, challenge_id) {
+  modalShow({
+    title: "Confirm email recipient",
+    bodyHtml: `
+      <div class="muted">We sent a confirmation code to <b>${escapeHtml(sentTo)}</b>.</div>
+      <input id="alertEmailCode" class="mono" placeholder="6-digit code"/>
+      <div id="alertEmailErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Confirm", onClick: async () => {
+          try {
+            const code = document.getElementById("alertEmailCode").value.trim();
+            await confirmAddAlertEmail(challenge_id, code);
+            modalClose();
+            await refreshAlertEmailSettings();
+          } catch (e) {
+            document.getElementById("alertEmailErr").textContent = String(e);
+          }
+      }},
+    ]
+  });
+}
+
+async function refreshAll() {
+  document.getElementById("globalErr").textContent = "";
+  try {
+    await refreshMe();
+    await Promise.allSettled([
+      refreshTotpDevices(),
+      refreshSmsDevices(),
+      refreshEmailDevices(),
+      refreshSessions(),
+      refreshKeys(),
+      refreshAlertEmailSettings(),
+      refreshPushUI(),
+      refreshAlerts(),
+    ]);
+    await pollToastsOnce();
+  } catch (e) {
+    document.getElementById("globalErr").textContent = String(e);
+  }
+}
+
+async function refreshAlerts() {
+  const el = document.getElementById("alertsList");
+  if (!el) return;
+  await ensureUiSession();
+  const res = await apiGet("/ui/alerts?limit=20");
+  el.innerHTML = "";
+  (res.alerts || []).forEach(a => {
+    el.appendChild(renderAlertRow(a));
+  });
+}
+
+
+function renderSmsList(nums) {
+  const el = document.getElementById("alertSmsList");
+  if (!el) return;
+  el.innerHTML = "";
+  (nums||[]).forEach(n => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <div class="grow mono">${escapeHtml(n)}</div>
+      <div><button data-phone="${escapeHtml(n)}">Remove</button></div>
+    `;
+    row.querySelector("button").onclick = async (ev) => {
+      const ph = ev.target.getAttribute("data-phone");
+      await apiPost("/ui/alerts/sms/remove", { phone: ph });
+      await refreshAlertEmailSettings();
+    };
+    el.appendChild(row);
+  });
+}
+
+function renderSmsTypeChecklist(types, enabled) {
+  const el = document.getElementById("alertSmsTypeChecklist");
+  if (!el) return;
+  el.innerHTML = "";
+  const en = new Set(enabled||[]);
+  types.forEach(t => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <label style="display:flex;gap:10px;align-items:center;">
+        <input type="checkbox" data-type="${escapeHtml(t)}" ${en.has(t) ? "checked" : ""}/>
+        <span class="mono">${escapeHtml(t)}</span>
+      </label>
+    `;
+    el.appendChild(row);
+  });
+}
+
+async function beginAddAlertSms(phone) {
+  await ensureUiSession();
+  return await apiPost("/ui/alerts/sms/begin", { phone });
+}
+async function confirmAddAlertSms(challenge_id, code) {
+  await ensureUiSession();
+  return await apiPost("/ui/alerts/sms/confirm", { challenge_id, code });
+}
+
+function openConfirmSmsModal(sentTo, challenge_id) {
+  modalShow({
+    title: "Confirm SMS recipient",
+    bodyHtml: `
+      <div class="muted">We sent a confirmation code to <b>${escapeHtml(sentTo)}</b>.</div>
+      <input id="alertSmsCode" class="mono" placeholder="6-digit code"/>
+      <div id="alertSmsErr" class="err" style="margin-top:8px;"></div>
+    `,
+    actions: [
+      { text: "Cancel", onClick: modalClose },
+      { text: "Confirm", onClick: async () => {
+          try {
+            const code = document.getElementById("alertSmsCode").value.trim();
+            await confirmAddAlertSms(challenge_id, code);
+            modalClose();
+            await refreshAlertEmailSettings();
+          } catch (e) {
+            document.getElementById("alertSmsErr").textContent = String(e);
+          }
+      }},
+    ]
+  });
+}
+
+/* ===================== Push (FCM Web) =====================
+   You MUST fill firebaseConfig + VAPID key for your Firebase project.
+   For production, don't hardcode secrets; these are public config values.
+*/
+const firebaseConfig = window.FIREBASE_CONFIG || null; // set window.FIREBASE_CONFIG = {...}
+const firebaseVapidKey = window.FIREBASE_VAPID_KEY || null; // Web Push certificate key pair (public)
+
+async function loadFirebaseMessaging() {
+  if (!firebaseConfig) throw new Error("Missing window.FIREBASE_CONFIG");
+  if (!firebaseVapidKey) throw new Error("Missing window.FIREBASE_VAPID_KEY");
+
+  // Lazy-load firebase libs from CDN
+  if (!window.firebase) {
+    await loadScript("https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js");
+    await loadScript("https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js");
+  }
+  if (!firebase.apps || firebase.apps.length === 0) {
+    firebase.initializeApp(firebaseConfig);
+  }
+  return firebase.messaging();
+}
+
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const s = document.createElement("script");
+    s.src = src;
+    s.onload = resolve;
+    s.onerror = () => reject(new Error("Failed to load " + src));
+    document.head.appendChild(s);
+  });
+}
+
+async function ensureServiceWorker() {
+  if (!("serviceWorker" in navigator)) throw new Error("Service worker not supported");
+  // You must host /firebase-messaging-sw.js at your site root.
+  // This file handles background notifications.
+  const reg = await navigator.serviceWorker.register("/firebase-messaging-sw.js");
+  return reg;
+}
+
+async function enablePushOnThisBrowser() {
+  await ensureUiSession();
+  const msgEl = document.getElementById("pushMsg");
+  try {
+    msgEl.textContent = "Requesting permission...";
+    const perm = await Notification.requestPermission();
+    if (perm !== "granted") throw new Error("Notification permission not granted");
+
+    const reg = await ensureServiceWorker();
+    const messaging = await loadFirebaseMessaging();
+    const token = await messaging.getToken({ vapidKey: firebaseVapidKey, serviceWorkerRegistration: reg });
+    if (!token) throw new Error("Failed to obtain FCM token");
+
+    await apiPost("/ui/push/register", { token, platform: "web_fcm" });
+    msgEl.textContent = "Push enabled for this browser.";
+    await refreshPushUI();
+  } catch (e) {
+    msgEl.textContent = String(e);
+  }
+}
+
+async function refreshPushUI() {
+  await ensureUiSession();
+  const [typesRes, prefs, devs] = await Promise.all([apiGet("/ui/alerts/types"), loadEmailPrefs(), apiGet("/ui/push/devices")]);
+  renderPushTypeChecklist(typesRes.types || [], prefs.push_event_types || []);
+  renderPushDevices(devs.devices || []);
+}
+
+function renderPushDevices(devs) {
+  const el = document.getElementById("pushDevicesList");
+  if (!el) return;
+  el.innerHTML = "";
+  (devs||[]).forEach(d => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <div class="grow">
+        <div class="mono">${escapeHtml(d.device_id||"")}</div>
+        <div class="muted">${escapeHtml(d.platform||"")} • created ${fmtTs(d.created_at)} • last ${fmtTs(d.last_seen_at)}</div>
+      </div>
+      <div><button data-did="${escapeHtml(d.device_id||"")}">Revoke</button></div>
+    `;
+    row.querySelector("button").onclick = async (ev) => {
+      const did = ev.target.getAttribute("data-did");
+      await apiPost("/ui/push/revoke", { device_id: did });
+      await refreshPushUI();
+    };
+    el.appendChild(row);
+  });
+}
+
+function renderPushTypeChecklist(types, enabled) {
+  const el = document.getElementById("alertPushTypeChecklist");
+  if (!el) return;
+  el.innerHTML = "";
+  const en = new Set(enabled||[]);
+  types.forEach(t => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <label style="display:flex;gap:10px;align-items:center;">
+        <input type="checkbox" data-type="${escapeHtml(t)}" ${en.has(t) ? "checked" : ""}/>
+        <span class="mono">${escapeHtml(t)}</span>
+      </label>
+    `;
+    el.appendChild(row);
+  });
+}
+
+/* ===================== Toasts ===================== */
+const seenToasts = new Set();
+
+function showToast(title, subtitle) {
+  const cont = document.getElementById("toastContainer");
+  if (!cont) return;
+  const el = document.createElement("div");
+  el.className = "toast";
+  el.innerHTML = `<div class="t-title">${escapeHtml(title||"Alert")}</div><div class="t-sub">${escapeHtml(subtitle||"")}</div>`;
+  cont.appendChild(el);
+  setTimeout(() => { try { el.remove(); } catch(e) {} }, 6000);
+}
+
+function renderToastTypeChecklist(types, enabled) {
+  const el = document.getElementById("alertToastTypeChecklist");
+  if (!el) return;
+  el.innerHTML = "";
+  const en = new Set(enabled||[]);
+  types.forEach(t => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <label style="display:flex;gap:10px;align-items:center;">
+        <input type="checkbox" data-type="${escapeHtml(t)}" ${en.has(t) ? "checked" : ""}/>
+        <span class="mono">${escapeHtml(t)}</span>
+      </label>
+    `;
+    el.appendChild(row);
+  });
+}
+
+async function pollToastsOnce() {
+  try {
+    await ensureUiSession();
+    const prefs = await loadEmailPrefs(); // contains toast_event_types too
+    const enabled = new Set(prefs.toast_event_types || []);
+    if (enabled.size === 0) return;
+
+    const res = await apiGet("/ui/alerts?limit=20&unread_only=1");
+    const alerts = res.alerts || [];
+    const deliver = [];
+    for (const a of alerts) {
+      const aid = a.alert_id;
+      if (!aid) continue;
+      if (a.toast_delivered) continue;
+      if (seenToasts.has(aid)) continue;
+      const t = (a.details && a.details.alert_type) ? a.details.alert_type : "";
+      if (!enabled.has(t)) continue;
+      seenToasts.add(aid);
+      showToast(a.title || a.event || "Alert", `${t} • ${fmtTs(a.ts)}`);
+      deliver.push(aid);
+    }
+    if (deliver.length) {
+      await apiPost("/ui/alerts/mark_toast_delivered", { alert_ids: deliver });
+    }
+  } catch (e) {
+    // ignore polling errors
+  }
+}
+
+let toastPollTimer = null;
+function startToastPolling() {
+  if (toastPollTimer) return;
+  toastPollTimer = setInterval(pollToastsOnce, 5000);
+}
+
+
+/* ===================== wire buttons ===================== */
+
+document.getElementById("sessRefreshBtn").onclick = async () => { await refreshSessions(); };
+document.getElementById("sessRevokeOthersBtn").onclick = async () => {
+  await apiPost("/ui/sessions/revoke_others", {});
+  await refreshSessions();
+};
+document.getElementById("totpAddBtn").onclick = async () => { await ensureUiSession(); openTotpAddModal(); };
+
+
+document.getElementById("keysRefreshBtn").onclick = async () => { await refreshKeys(); };
+document.getElementById("keysCreateBtn").onclick = async () => { openCreateKeyModal(); };
+
+
+
+document.getElementById("alertSmsAddBtn").onclick = async () => {
+  const phone = document.getElementById("alertSmsInput").value.trim();
+  if (!phone) return;
+  try {
+    const r = await beginAddAlertSms(phone);
+    openConfirmSmsModal(r.sent_to, r.challenge_id);
+    document.getElementById("alertSmsInput").value = "";
+  } catch (e) {
+    alert(String(e));
+  }
+};
+
+
+document.getElementById("alertToastTypesSaveBtn").onclick = async () => {
+  try {
+    await ensureUiSession();
+    const boxes = document.querySelectorAll("#alertToastTypeChecklist input[type=checkbox]");
+    const enabled = [];
+    boxes.forEach(b => { if (b.checked) enabled.push(b.getAttribute("data-type")); });
+    await apiPost("/ui/alerts/toast_prefs", { toast_event_types: enabled });
+    const msg = document.getElementById("alertToastTypesMsg");
+    if (msg) msg.textContent = "Saved.";
+  } catch (e) {
+    const msg = document.getElementById("alertToastTypesMsg");
+    if (msg) msg.textContent = String(e);
+  }
+};
+
+document.getElementById("alertSmsTypesSaveBtn").onclick = async () => {
+  try {
+    await ensureUiSession();
+    const boxes = document.querySelectorAll("#alertSmsTypeChecklist input[type=checkbox]");
+    const enabled = [];
+    boxes.forEach(b => { if (b.checked) enabled.push(b.getAttribute("data-type")); });
+    await apiPost("/ui/alerts/sms_prefs", { sms_event_types: enabled });
+    const msg = document.getElementById("alertSmsTypesMsg");
+    if (msg) msg.textContent = "Saved.";
+  } catch (e) {
+    const msg = document.getElementById("alertSmsTypesMsg");
+    if (msg) msg.textContent = String(e);
+  }
+};
+
+document.getElementById("alertEmailAddBtn").onclick = async () => {
+  const email = document.getElementById("alertEmailInput").value.trim();
+  if (!email) return;
+  try {
+    const r = await beginAddAlertEmail(email);
+    openConfirmEmailModal(r.sent_to, r.challenge_id);
+    document.getElementById("alertEmailInput").value = "";
+  } catch (e) {
+    alert(String(e));
+  }
+};
+
+document.getElementById("alertTypesSaveBtn").onclick = async () => {
+  try {
+    await ensureUiSession();
+    const boxes = document.querySelectorAll("#alertTypeChecklist input[type=checkbox]");
+    const enabled = [];
+    boxes.forEach(b => { if (b.checked) enabled.push(b.getAttribute("data-type")); });
+    await apiPost("/ui/alerts/email_prefs", { email_event_types: enabled });
+    const msg = document.getElementById("alertTypesMsg");
+    if (msg) msg.textContent = "Saved.";
+  } catch (e) {
+    const msg = document.getElementById("alertTypesMsg");
+    if (msg) msg.textContent = String(e);
+  }
+};
+
+
+document.getElementById("btnEnablePush").onclick = enablePushOnThisBrowser;
+document.getElementById("btnPushTest").onclick = async () => {
+  try {
+    await ensureUiSession();
+    await apiPost("/ui/push/test", {});
+    document.getElementById("pushMsg").textContent = "Sent test push (if enabled for this alert type).";
+  } catch (e) {
+    document.getElementById("pushMsg").textContent = String(e);
+  }
+};
+document.getElementById("alertPushTypesSaveBtn").onclick = async () => {
+  try {
+    await ensureUiSession();
+    const boxes = document.querySelectorAll("#alertPushTypeChecklist input[type=checkbox]");
+    const enabled = [];
+    boxes.forEach(b => { if (b.checked) enabled.push(b.getAttribute("data-type")); });
+    await apiPost("/ui/alerts/push_prefs", { push_event_types: enabled });
+    const msg = document.getElementById("alertPushTypesMsg");
+    if (msg) msg.textContent = "Saved.";
+  } catch (e) {
+    const msg = document.getElementById("alertPushTypesMsg");
+    if (msg) msg.textContent = String(e);
+  }
+};
+
+document.getElementById("btnRefreshAll").onclick = refreshAll;
+document.getElementById("btnClearSession").onclick = () => { lsDel("session_id"); alert("UI session cleared."); };
+document.getElementById("btnSetTokens").onclick = openTokenModal;
+
+document.getElementById("btnClearTokens").onclick = () => { lsDel("access_token"); lsDel("id_token"); lsDel("refresh_token"); lsDel("session_id"); alert("Tokens cleared."); };
+
+document.getElementById("totpRefreshBtn").onclick = async () => { await ensureUiSession(); await refreshTotpDevices(); };
+
+
+document.getElementById("smsRefreshBtn").onclick = async () => { await ensureUiSession(); await refreshSmsDevices(); };
+document.getElementById("smsAddBtn").onclick = async () => { await ensureUiSession(); openSmsAddModal(); };
+
+document.getElementById("emailRefreshBtn").onclick = async () => { await ensureUiSession(); await refreshEmailDevices(); };
+document.getElementById("emailAddBtn").onclick = async () => { await ensureUiSession(); openEmailAddModal(); };
+
+/* ===================== boot ===================== */
+if (!accessToken()) { openTokenModal(); } else { refreshAll(); }
+startToastSSE();
+startToastPolling();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,36 @@
+body { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif; margin: 16px; background:#f7f7f7; color:#222; }
+.row { display:flex; gap:12px; flex-wrap:wrap; align-items:flex-start; }
+.row-inline { display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+.card { border:1px solid #e5e5e5; border-radius:12px; padding:12px; min-width:360px; flex:1; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.04); }
+h3 { margin: 0 0 8px 0; }
+button { padding:8px 10px; border-radius:10px; border:1px solid #ddd; background:#fff; cursor:pointer; }
+button:disabled { opacity: 0.55; cursor: not-allowed; }
+input, textarea { width: 100%; padding: 8px 10px; border-radius: 10px; border:1px solid #ddd; margin-top:8px; box-sizing:border-box; font: inherit; }
+textarea { resize: vertical; }
+table { width:100%; border-collapse:collapse; margin-top:10px; }
+th, td { border-top:1px solid #eee; padding:8px; text-align:left; vertical-align:top; }
+th { font-size: 12px; color:#444; }
+code.mono, pre.mono, .mono { font-family: ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace; }
+.break { word-break: break-all; }
+.pill { display:inline-block; padding:2px 8px; border-radius:999px; border:1px solid #ddd; font-size:12px; }
+.topbar { display:flex; gap:10px; align-items:center; justify-content:space-between; margin-bottom: 12px; }
+.toolbar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.muted { color:#666; font-size: 12px; }
+.err { color:#b00020; }
+.list { margin-top:10px; display:flex; flex-direction:column; gap:8px; }
+.list-item { border:1px solid #eee; border-radius:10px; padding:10px; background:#fafafa; display:flex; gap:12px; align-items:center; justify-content:space-between; }
+.list-button { width:100%; text-align:left; cursor:pointer; background:#fafafa; }
+.list-item-muted { opacity:0.6; }
+.grow { flex:1; }
+.section { margin-top:14px; }
+
+/* Modal */
+.modal-backdrop { position:fixed; inset:0; background: rgba(0,0,0,0.35); display:flex; align-items:center; justify-content:center; padding:18px; z-index:9999; }
+.modal { background:#fff; width:min(720px, 100%); border-radius:14px; padding:14px; box-shadow: 0 12px 42px rgba(0,0,0,0.25); }
+.modal h2 { margin:0 0 8px 0; font-size:18px; }
+.modal-actions { display:flex; gap:10px; justify-content:flex-end; margin-top:12px; flex-wrap:wrap; }
+
+.toast-container{position:fixed;top:16px;right:16px;z-index:9999;display:flex;flex-direction:column;gap:10px;max-width:360px}
+.toast{padding:12px 14px;border-radius:12px;box-shadow:0 6px 24px rgba(0,0,0,.18);background:rgba(30,30,30,.92);color:#fff}
+.toast .t-title{font-weight:700;margin-bottom:4px}
+.toast .t-sub{opacity:.85;font-size:12px}


### PR DESCRIPTION
### Motivation
- Replace the single monolithic reference UI with a modular frontend split into HTML, JS and CSS so it is easier to maintain and extend.
- Provide a static control-panel UI that exercises the existing backend endpoints for API keys, MFA devices, sessions, alerts and push registration.
- Serve the new static assets from the FastAPI app so the UI can be hosted alongside the existing API.

### Description
- Added new static frontend files `app/static/index.html`, `app/static/main.js`, and `app/static/styles.css` which contain the split HTML, client logic and styles respectively.
- Updated the server bootstrap in `app/main.py` to mount the static directory at `/static` and to serve `index.html` at `/` using `StaticFiles` and `FileResponse`.
- Refactored and modularized client-side logic in `main.js`: added `apiGet`/`apiPost`, `escapeHtml`, `renderAlertRow`, toast handling (WebSocket + SSE + polling), push registration helpers, and explicit refresh flows for sessions, API keys, alerts and push UI.
- Wired UI controls to the new client functions (button handlers, modals, and refresh orchestration) and made the default `API_BASE` fallback to `window.location.origin`.

### Testing
- Launched a static file server with `python -m http.server` in `app/static` and used a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot, which completed successfully (visual smoke test of the frontend assets).
- No backend unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69686dccf6a0832b96414426a16071b3)