### PR TITLE
Add file reference and run/deploy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 Refactored FastAPI security backend (split from the original single-file server).
 
+## Documentation
+- [File reference](docs/file-reference.md)
+- [Run and deploy](docs/run-deploy.md)
+
 ## Run
 ```bash
 python -m venv .venv

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -1,0 +1,75 @@
+# File Reference
+
+This document lists each file in the repository with a short description of its purpose. Use it as a map when you need to locate a specific feature or component.
+
+## Root
+
+| Path | Purpose |
+| --- | --- |
+| `README.md` | Quick start instructions, required environment variables, and optional configuration notes. |
+| `requirements.txt` | Python dependencies for the FastAPI service and related tooling. |
+| `ref/index.full.v11.html` | Legacy full HTML reference from the original single-file version. |
+| `ref/main.cleaned.cognito.v16.py` | Legacy Python reference for the original single-file server (Cognito-focused). |
+
+## Application package (`app/`)
+
+| Path | Purpose |
+| --- | --- |
+| `app/__init__.py` | Package marker for the FastAPI app. |
+| `app/main.py` | FastAPI application factory, router registration, CORS, and static file mounting. |
+| `app/models.py` | Pydantic request/response models used by the API endpoints. |
+
+### Authentication (`app/auth/`)
+
+| Path | Purpose |
+| --- | --- |
+| `app/auth/__init__.py` | Package marker for authentication helpers. |
+| `app/auth/deps.py` | Authentication dependency placeholder (raise 501 until real auth is wired). |
+
+### Core utilities (`app/core/`)
+
+| Path | Purpose |
+| --- | --- |
+| `app/core/__init__.py` | Package marker for shared core helpers. |
+| `app/core/aws.py` | AWS client/session helpers (DynamoDB, KMS, optional SES/Twilio). |
+| `app/core/crypto.py` | Crypto helpers (hashing, KMS encrypt/decrypt, WS token HMAC). |
+| `app/core/cursor.py` | DynamoDB pagination cursor encoding/decoding helpers. |
+| `app/core/normalize.py` | Input normalization and validation (email, phone, CIDR, IP extraction). |
+| `app/core/settings.py` | Environment-backed configuration values. |
+| `app/core/tables.py` | DynamoDB table handles wired from settings. |
+| `app/core/time.py` | Timestamp helper (`now_ts`). |
+
+### Services (`app/services/`)
+
+| Path | Purpose |
+| --- | --- |
+| `app/services/__init__.py` | Package marker for service-layer helpers. |
+| `app/services/alerts.py` | Alert storage, SSE fanout, alert preferences, and outbound alert delivery helpers. |
+| `app/services/api_keys.py` | API key generation, storage, and enforcement of CIDR allow/deny rules. |
+| `app/services/mfa.py` | MFA operations (TOTP enrollment, SMS/email verification, recovery codes). |
+| `app/services/push.py` | Push notification registration and FCM delivery helpers. |
+| `app/services/rate_limit.py` | Rate limit checks for MFA and alert channels. |
+| `app/services/sessions.py` | UI session creation, step-up challenges, and session revocation helpers. |
+| `app/services/ttl.py` | TTL utilities for DynamoDB items. |
+
+### Routers (`app/routers/`)
+
+| Path | Purpose |
+| --- | --- |
+| `app/routers/__init__.py` | Package marker for API routers. |
+| `app/routers/alerts.py` | Alert history, preferences, SSE streaming, and alert delivery routes. |
+| `app/routers/api_keys.py` | API key CRUD routes and IP allow/deny management. |
+| `app/routers/mfa_devices.py` | Device management routes for TOTP, SMS, email, and recovery codes. |
+| `app/routers/misc.py` | Miscellaneous routes (health ping, WS token mint). |
+| `app/routers/push.py` | Push device registration and test push routes. |
+| `app/routers/recovery.py` | Recovery code verification routes. |
+| `app/routers/ui_mfa.py` | UI step-up MFA routes for TOTP/SMS/email challenges. |
+| `app/routers/ui_session.py` | UI session start/finalize, list, and revoke endpoints. |
+
+### Static web UI (`app/static/`)
+
+| Path | Purpose |
+| --- | --- |
+| `app/static/index.html` | Static control panel UI for managing sessions, MFA, and alerts. |
+| `app/static/main.js` | Client-side logic for the control panel UI (API calls, SSE/WS toasts). |
+| `app/static/styles.css` | Styles for the control panel UI. |

--- a/docs/run-deploy.md
+++ b/docs/run-deploy.md
@@ -1,0 +1,93 @@
+# Run and Deploy
+
+This service is a FastAPI application with DynamoDB-backed storage and optional AWS/Twilio integrations.
+
+## Run locally
+
+1. Create and activate a virtualenv.
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install dependencies.
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Export required environment variables.
+
+   ```bash
+   export AWS_REGION=us-east-1
+   export DDB_SESSIONS_TABLE=your_sessions_table
+   export DDB_TOTP_TABLE=your_totp_table
+   export DDB_SMS_TABLE=your_sms_table
+   export DDB_EMAIL_TABLE=your_email_table
+   export DDB_RECOVERY_TABLE=your_recovery_table
+   export API_KEYS_TABLE_NAME=api_keys
+   export API_KEYS_USER_INDEX=user_sub-index
+   export API_KEY_PEPPER=change_me
+   export ALERTS_TABLE_NAME=alerts
+   export ALERT_PREFS_TABLE_NAME=alert_prefs
+   export WS_TOKEN_SECRET=change_me
+   ```
+
+   Optional integrations are described in `README.md` (SES, Twilio, KMS, push, and alert fanout).
+
+4. Start the server.
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+5. Open the UI at `http://localhost:8000/`.
+
+## Deploy
+
+### Requirements
+
+- **AWS resources**: DynamoDB tables for sessions, MFA, recovery, API keys, alerts, and push devices.
+- **Credentials**: Runtime AWS credentials (IAM role, access keys, or environment-based auth) with read/write access to the tables and optional KMS/SES permissions.
+- **Secrets**: `API_KEY_PEPPER` and `WS_TOKEN_SECRET` should be set as secrets in your deployment environment.
+
+### Recommended production run command
+
+Use a production ASGI server with multiple workers (e.g., Gunicorn + Uvicorn workers):
+
+```bash
+pip install gunicorn
+
+gunicorn \
+  -k uvicorn.workers.UvicornWorker \
+  -w 2 \
+  -b 0.0.0.0:8000 \
+  app.main:app
+```
+
+### Container deployment (example)
+
+You can containerize the service with a minimal Dockerfile:
+
+```Dockerfile
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-w", "2", "-b", "0.0.0.0:8000", "app.main:app"]
+```
+
+Build and run:
+
+```bash
+docker build -t security-backend .
+docker run --rm -p 8000:8000 --env-file .env security-backend
+```
+
+### Notes
+
+- **Authentication**: `app/auth/deps.py` is a placeholder and must be replaced with real auth (e.g., Cognito JWT verification) before production use.
+- **Network placement**: deploy behind a load balancer/ingress with HTTPS termination.
+- **Observability**: wire your preferred logging/metrics stack (stdout logging is already supported). 


### PR DESCRIPTION
### Motivation
- Provide a per-file reference to help developers quickly find components and understand repository layout.
- Document how to run the service locally and recommended production deployment patterns to reduce onboarding friction.

### Description
- Add `docs/file-reference.md` with a file-by-file table describing the purpose of repository files and packages.
- Add `docs/run-deploy.md` with local run steps, required environment variables, a recommended `gunicorn` production command, and a Docker example.
- Update `README.md` to link to the new `docs/file-reference.md` and `docs/run-deploy.md` pages.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69687b932198832ba4fe31e6a746ef78)