### PR TITLE
Mock prometheus_client for tests and restore PayPal billing wrappers

### DIFF
--- a/app/services/billing_shared.py
+++ b/app/services/billing_shared.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from app.core.time import now_ts
+
+BAL_FIELDS = [
+    "owed_pending_cents",
+    "owed_settled_cents",
+    "payments_pending_cents",
+    "payments_settled_cents",
+]
+
+
+def user_pk(user_id: str) -> str:
+    return f"USER#{user_id}"
+
+
+def ddb_get(table: Any, pk: str, sk: str) -> Optional[Dict[str, Any]]:
+    resp = table.get_item(Key={"pk": pk, "sk": sk})
+    return resp.get("Item")
+
+
+def ddb_put(table: Any, item: Dict[str, Any], *, condition_expression: Optional[str] = None) -> None:
+    kwargs: Dict[str, Any] = {"Item": item}
+    if condition_expression:
+        kwargs["ConditionExpression"] = condition_expression
+    table.put_item(**kwargs)
+
+
+def ddb_del(table: Any, pk: str, sk: str) -> None:
+    table.delete_item(Key={"pk": pk, "sk": sk})
+
+
+def ddb_query_pk(table: Any, pk: str) -> List[Dict[str, Any]]:
+    resp = table.query(
+        KeyConditionExpression="pk = :pk",
+        ExpressionAttributeValues={":pk": pk},
+    )
+    return resp.get("Items", [])
+
+
+def ddb_update(
+    table: Any,
+    pk: str,
+    sk: str,
+    expr: str,
+    values: Dict[str, Any],
+    names: Optional[Dict[str, str]] = None,
+) -> None:
+    kwargs: Dict[str, Any] = {
+        "Key": {"pk": pk, "sk": sk},
+        "UpdateExpression": expr,
+        "ExpressionAttributeValues": values,
+    }
+    if names:
+        kwargs["ExpressionAttributeNames"] = names
+    table.update_item(**kwargs)
+
+
+def ensure_balance_row(table: Any, pk: str, currency: str) -> None:
+    if not ddb_get(table, pk, "BALANCE"):
+        ddb_put(
+            table,
+            {
+                "pk": pk,
+                "sk": "BALANCE",
+                "currency": currency,
+                **{k: 0 for k in BAL_FIELDS},
+                "updated_at": now_ts(),
+            },
+        )
+
+
+def apply_balance_delta(table: Any, pk: str, delta: Dict[str, int], *, currency: str = "usd") -> None:
+    ensure_balance_row(table, pk, currency)
+
+    sets = []
+    values: Dict[str, Any] = {":z": 0, ":t": now_ts()}
+    names: Dict[str, str] = {}
+
+    i = 0
+    for key, value in delta.items():
+        if value == 0:
+            continue
+        i += 1
+        nk = f"#k{i}"
+        dv = f":d{i}"
+        names[nk] = key
+        values[dv] = int(value)
+        sets.append(f"{nk} = if_not_exists({nk}, :z) + {dv}")
+
+    names["#u"] = "updated_at"
+    sets.append("#u = :t")
+
+    expr = "SET " + ", ".join(sets)
+    ddb_update(table, pk, "BALANCE", expr, values, names=names)
+
+
+def compute_due(balance_item: Dict[str, Any]) -> Dict[str, int]:
+    owed_settled = int(balance_item.get("owed_settled_cents", 0))
+    owed_pending = int(balance_item.get("owed_pending_cents", 0))
+    pay_settled = int(balance_item.get("payments_settled_cents", 0))
+    pay_pending = int(balance_item.get("payments_pending_cents", 0))
+
+    due_settled = owed_settled - pay_settled
+    due_if_all_settles = (owed_settled + owed_pending) - (pay_settled + pay_pending)
+
+    return {
+        "due_settled_cents": due_settled,
+        "due_if_all_settles_cents": due_if_all_settles,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import sys
+from unittest.mock import MagicMock
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("prometheus_client", MagicMock())


### PR DESCRIPTION
### Motivation
- Avoid requiring the external `prometheus_client` package during test collection by providing a test-time stub. 
- Restore backwards-compatible DynamoDB helper wrappers in the PayPal router so existing code and tests that monkeypatch those functions continue to work. 
- Make billing table lookup tolerant to missing `billing_table_name` during tests.

### Description
- Added a test stub for `prometheus_client` by inserting `sys.modules.setdefault("prometheus_client", MagicMock())` in `tests/conftest.py` so tests don't need the real package. 
- Introduced `app/services/billing_shared.py` implementing shared DynamoDB helpers (`user_pk`, `ddb_get`, `ddb_put`, `ddb_del`, `ddb_query_pk`, `ddb_update`, `ensure_balance_row`, `apply_balance_delta`, `compute_due`). 
- Updated `app/routers/paypal.py` to import the shared helpers and expose thin wrapper functions (`ddb_get`, `ddb_put`, `ddb_del`, `ddb_query_pk`, `ddb_update`, `ensure_balance_row`, `apply_balance_delta`) that call the shared implementations with `_billing_table()` so test monkeypatches remain compatible. 
- Made `_billing_table()` tolerant of a missing `S.billing_table_name` during tests by returning `T.billing` when the attribute is not set, and kept error behavior when it is explicitly empty.
- Replaced direct time usage with `now_ts()` where appropriate in PayPal idempotency keys.

### Testing
- Ran `pytest -q`, which completed successfully with `98 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69730a421b10832b8c988d290acaee5d)