### PR TITLE
Refactor billing/profile optional dependency checks

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import importlib.util
+import sys
 import secrets
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 from urllib.parse import urljoin
 
-try:
+if "stripe" in sys.modules:
+    stripe = sys.modules["stripe"]  # type: ignore
+elif importlib.util.find_spec("stripe") is not None:
     import stripe  # type: ignore
-except Exception:  # pragma: no cover
+else:  # pragma: no cover
     stripe = None  # type: ignore
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -17,7 +21,6 @@ from app.core.time import now_ts
 from app.models import (
     AddChargeReq,
     BillingCheckoutReq,
-    StripePaymentMethodOut,
     PayBalanceReq,
     SetAutopayReq,
     SetDefaultReq,
@@ -195,6 +198,7 @@ def pm_sk(payment_method_id: str) -> str:
 def list_payment_methods_ddb(user_id: str) -> List[Dict[str, Any]]:
     items = ddb_query_pk(T.billing, user_pk(user_id))
     return [it for it in items if it["sk"].startswith("PM#")]
+
 
 def list_payment_records_ddb(user_id: str) -> List[Dict[str, Any]]:
     items = ddb_query_pk(T.billing, user_pk(user_id))

--- a/app/routers/profile.py
+++ b/app/routers/profile.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.util
+
 from fastapi import APIRouter, Depends, HTTPException, File, Request, UploadFile
 
 from app.models import ProfilePatchReq, ProfilePutReq
@@ -9,11 +11,7 @@ from app.services.sessions import require_ui_session
 
 router = APIRouter(prefix="/ui/profile", tags=["profile"])
 
-try:  # pragma: no cover - optional dependency for file uploads
-    import multipart  # type: ignore  # noqa: F401
-    _MULTIPART_AVAILABLE = True
-except Exception:  # pragma: no cover
-    _MULTIPART_AVAILABLE = False
+_MULTIPART_AVAILABLE = importlib.util.find_spec("multipart") is not None
 
 @router.get("")
 async def ui_get_profile(ctx=Depends(require_ui_session)):


### PR DESCRIPTION
### Motivation

- Optional dependencies for billing (`stripe`) and profile uploads (`python-multipart`) were being imported with try/except which caused brittle behavior during test collection and runtime.

### Description

- Use `importlib.util.find_spec` and `sys.modules` to detect the optional `stripe` package instead of a try/except import, and fall back to `None` when absent in `app/routers/billing.py`.
- Replace the `try/except` multipart import in `app/routers/profile.py` with `importlib.util.find_spec` to set `_MULTIPART_AVAILABLE` more robustly.
- Tidy billing router imports and remove a duplicate model import to clean up the module surface.

### Testing

- Ran `pytest` after fixes; initial collection failed due to `stripe.__spec__` not being set, and was resolved by the `sys.modules` + `find_spec` check. 
- Final test run: `pytest` -> all tests passed (`127 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a846c76c832b938e8ea0f6bc91da)