### PR TITLE
Add calendar scheduling API, UI, and tests

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -129,5 +129,8 @@ class Settings:
     # Profile
     profile_table_name: str = os.environ.get("PROFILE_TABLE_NAME", "profiles")
 
+    # Calendar
+    calendar_table_name: str = os.environ.get("CALENDAR_TABLE_NAME", "calendar")
+
 
 S = Settings()

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -20,6 +20,7 @@ class Tables:
     billing: Any
     account_state: Any
     profile: Any
+    calendar: Any
 
 T = Tables(
     sessions=ddb.Table(S.ddb_sessions_table),
@@ -34,4 +35,5 @@ T = Tables(
     billing=ddb.Table(S.billing_table_name),
     account_state=ddb.Table(S.account_state_table_name),
     profile=ddb.Table(S.profile_table_name),
+    calendar=ddb.Table(S.calendar_table_name),
 )

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.routers.paypal import router as paypal_router
 from app.routers.billing import router as billing_router
 from app.routers.account_state import router as account_state_router
 from app.routers.profile import router as profile_router
+from app.routers.calendar import router as calendar_router
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Security Backend (refactored)", version="0.1.0")
@@ -61,6 +62,7 @@ def create_app() -> FastAPI:
     app.include_router(billing_router)
     app.include_router(account_state_router)
     app.include_router(profile_router)
+    app.include_router(calendar_router)
 
     return app
 

--- a/app/models.py
+++ b/app/models.py
@@ -200,6 +200,47 @@ class SetAutopayIn(BaseModel):
     enabled: bool
 
 
+class CalendarCreateIn(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    timezone: str = Field(default="UTC", max_length=64)
+
+
+class CalendarOut(BaseModel):
+    calendar_id: str
+    name: str
+    timezone: str
+    owner_user_id: str
+    created_at_utc: str
+
+
+class EventCreateIn(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    description: str = Field(default="", max_length=5000)
+    timezone: str | None = Field(default=None, max_length=64)
+    start_utc: str | None = None
+    end_utc: str | None = None
+    all_day: bool = False
+    all_day_date: str | None = None
+
+
+class EventOut(BaseModel):
+    event_id: str
+    calendar_id: str
+    name: str
+    description: str
+    timezone: str
+    start_utc: str | None = None
+    end_utc: str | None = None
+    all_day: bool
+    all_day_date: str | None = None
+    created_at_utc: str
+
+
+class OpeningsOut(BaseModel):
+    start_utc: str
+    end_utc: str
+
+
 class MailingAddress(BaseModel):
     line1: Optional[str] = None
     line2: Optional[str] = None

--- a/app/routers/calendar.py
+++ b/app/routers/calendar.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, date, timedelta, timezone
+from typing import Any, Dict, Iterable, List
+
+from boto3.dynamodb.conditions import Key
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.core.tables import T
+from app.models import CalendarCreateIn, CalendarOut, EventCreateIn, EventOut, OpeningsOut
+from app.services.sessions import require_ui_session
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - fallback for older Python
+    ZoneInfo = None
+
+router = APIRouter(prefix="/ui", tags=["calendar"])
+
+
+def _require_zoneinfo() -> None:
+    if ZoneInfo is None:
+        raise HTTPException(status_code=500, detail="zoneinfo not available. Use Python 3.9+.")
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso_utc(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_iso_dt(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid datetime: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_iso_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid date: {value}") from exc
+
+
+def overlap(a0: datetime, a1: datetime, b0: datetime, b1: datetime) -> bool:
+    return a0 < b1 and b0 < a1
+
+
+def merge_intervals(intervals: Iterable[tuple[datetime, datetime]]) -> list[tuple[datetime, datetime]]:
+    ordered = sorted(intervals, key=lambda pair: pair[0])
+    if not ordered:
+        return []
+    merged: list[tuple[datetime, datetime]] = [ordered[0]]
+    for start, end in ordered[1:]:
+        prev_start, prev_end = merged[-1]
+        if start <= prev_end:
+            merged[-1] = (prev_start, max(prev_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def invert_intervals(busy: list[tuple[datetime, datetime]], start: datetime, end: datetime) -> list[tuple[datetime, datetime]]:
+    clipped = [(max(s, start), min(e, end)) for s, e in busy if overlap(s, e, start, end)]
+    merged = merge_intervals(clipped)
+    free: list[tuple[datetime, datetime]] = []
+    cur = start
+    for s, e in merged:
+        if cur < s:
+            free.append((cur, s))
+        cur = max(cur, e)
+    if cur < end:
+        free.append((cur, end))
+    return free
+
+
+def _calendar_keys(calendar_id: str) -> Dict[str, str]:
+    return {"calendar_id": calendar_id, "sk": "meta"}
+
+
+def _event_key(event_id: str) -> str:
+    return f"event#{event_id}"
+
+
+def _normalize_event_times(calendar_tz: str, payload: EventCreateIn) -> Dict[str, Any]:
+    _require_zoneinfo()
+    tz_name = payload.timezone or calendar_tz
+    try:
+        ZoneInfo(tz_name)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid timezone") from exc
+
+    if payload.all_day:
+        if not payload.all_day_date:
+            raise HTTPException(status_code=400, detail="all_day_date is required for all-day events")
+        all_day_date = parse_iso_date(payload.all_day_date).isoformat()
+        return {"all_day": True, "timezone": tz_name, "all_day_date": all_day_date, "start_utc": None, "end_utc": None}
+
+    if not payload.start_utc or not payload.end_utc:
+        raise HTTPException(status_code=400, detail="start_utc and end_utc are required for timed events")
+    start = parse_iso_dt(payload.start_utc)
+    end = parse_iso_dt(payload.end_utc)
+    if end <= start:
+        raise HTTPException(status_code=400, detail="end_utc must be after start_utc")
+    return {
+        "all_day": False,
+        "timezone": tz_name,
+        "start_utc": iso_utc(start),
+        "end_utc": iso_utc(end),
+        "all_day_date": None,
+    }
+
+
+def _event_to_busy_interval(event: Dict[str, Any]) -> tuple[datetime, datetime]:
+    if event.get("all_day"):
+        _require_zoneinfo()
+        tz = ZoneInfo(event["timezone"])
+        d = parse_iso_date(event["all_day_date"])
+        local_start = datetime(d.year, d.month, d.day, 0, 0, 0, tzinfo=tz)
+        local_end = local_start + timedelta(days=1)
+        return local_start.astimezone(timezone.utc), local_end.astimezone(timezone.utc)
+    return parse_iso_dt(event["start_utc"]), parse_iso_dt(event["end_utc"])
+
+
+def _load_calendar(calendar_id: str, user_sub: str) -> Dict[str, Any]:
+    meta = T.calendar.get_item(Key=_calendar_keys(calendar_id)).get("Item")
+    if not meta:
+        raise HTTPException(status_code=404, detail="Calendar not found")
+    if meta.get("owner_user_sub") != user_sub:
+        raise HTTPException(status_code=403, detail="Calendar access denied")
+    return meta
+
+
+def _list_events(calendar_id: str) -> List[Dict[str, Any]]:
+    response = T.calendar.query(
+        KeyConditionExpression=Key("calendar_id").eq(calendar_id) & Key("sk").begins_with("event#"),
+        ScanIndexForward=True,
+    )
+    return response.get("Items", [])
+
+
+@router.post("/calendars", response_model=CalendarOut)
+async def create_calendar(body: CalendarCreateIn, ctx: Dict[str, str] = Depends(require_ui_session)):
+    calendar_id = uuid.uuid4().hex
+    now = iso_utc(utc_now())
+    item = {
+        "calendar_id": calendar_id,
+        "sk": "meta",
+        "type": "calendar",
+        "name": body.name,
+        "timezone": body.timezone,
+        "owner_user_sub": ctx["user_sub"],
+        "created_at_utc": now,
+    }
+    T.calendar.put_item(Item=item)
+    return CalendarOut(
+        calendar_id=calendar_id,
+        name=body.name,
+        timezone=body.timezone,
+        owner_user_id=ctx["user_sub"],
+        created_at_utc=now,
+    )
+
+
+@router.post("/calendars/{calendar_id}/events", response_model=EventOut)
+async def create_event(
+    calendar_id: str,
+    body: EventCreateIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    normalized = _normalize_event_times(meta["timezone"], body)
+    event_id = uuid.uuid4().hex
+    now = iso_utc(utc_now())
+    item = {
+        "calendar_id": calendar_id,
+        "sk": _event_key(event_id),
+        "type": "event",
+        "event_id": event_id,
+        "name": body.name,
+        "description": body.description,
+        "created_at_utc": now,
+        **normalized,
+    }
+    T.calendar.put_item(Item=item)
+    return EventOut(
+        event_id=event_id,
+        calendar_id=calendar_id,
+        name=body.name,
+        description=body.description,
+        timezone=normalized["timezone"],
+        start_utc=normalized["start_utc"],
+        end_utc=normalized["end_utc"],
+        all_day=normalized["all_day"],
+        all_day_date=normalized["all_day_date"],
+        created_at_utc=now,
+    )
+
+
+@router.get("/calendars/{calendar_id}/events", response_model=list[EventOut])
+async def list_events(calendar_id: str, ctx: Dict[str, str] = Depends(require_ui_session)):
+    _load_calendar(calendar_id, ctx["user_sub"])
+    events = []
+    for item in _list_events(calendar_id):
+        events.append(EventOut(
+            event_id=item["event_id"],
+            calendar_id=calendar_id,
+            name=item["name"],
+            description=item.get("description", ""),
+            timezone=item.get("timezone", "UTC"),
+            start_utc=item.get("start_utc"),
+            end_utc=item.get("end_utc"),
+            all_day=item.get("all_day", False),
+            all_day_date=item.get("all_day_date"),
+            created_at_utc=item.get("created_at_utc", ""),
+        ))
+    return events
+
+
+@router.get("/calendars/{calendar_id}/openings", response_model=list[OpeningsOut])
+async def list_openings(
+    calendar_id: str,
+    start_utc: str = Query(..., description="Start window in ISO-8601 UTC"),
+    end_utc: str = Query(..., description="End window in ISO-8601 UTC"),
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _load_calendar(calendar_id, ctx["user_sub"])
+    window_start = parse_iso_dt(start_utc)
+    window_end = parse_iso_dt(end_utc)
+    if window_end <= window_start:
+        raise HTTPException(status_code=400, detail="end_utc must be after start_utc")
+    busy = [_event_to_busy_interval(event) for event in _list_events(calendar_id)]
+    free = invert_intervals(busy, window_start, window_end)
+    return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in free]

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -298,6 +298,63 @@
 </div>
 
 <div class="row">
+  <div class="card" style="width:100%">
+    <h3>Scheduling</h3>
+    <div class="muted">Create calendars, add events, and view availability windows.</div>
+    <div class="row-inline" style="margin-top:10px;">
+      <input id="calendarIdInput" class="mono" placeholder="Calendar ID" style="flex:1;"/>
+      <button id="calendarSetBtn">Use calendar</button>
+      <button id="calendarCreateBtn" class="primary">Create calendar</button>
+    </div>
+    <div class="row-inline" style="margin-top:10px;">
+      <input id="calendarNameInput" placeholder="Calendar name" style="flex:1;"/>
+      <input id="calendarTimezoneInput" placeholder="Timezone (e.g. UTC)" style="width:220px;"/>
+    </div>
+    <div id="calendarStatus" class="muted" style="margin-top:6px;"></div>
+
+    <div class="section" style="margin-top:16px;">
+      <h4 style="margin:0 0 8px 0;">Create event</h4>
+      <div class="row-inline">
+        <input id="eventNameInput" placeholder="Event name" style="flex:1;"/>
+        <input id="eventTimezoneInput" placeholder="Timezone (optional)" style="width:220px;"/>
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <textarea id="eventDescriptionInput" placeholder="Description" rows="2" style="flex:1;"></textarea>
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <label style="display:flex;align-items:center;gap:8px;">
+          <input type="checkbox" id="eventAllDayToggle" />
+          All-day event
+        </label>
+        <input id="eventAllDayDateInput" type="date" style="width:200px;" />
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="eventStartInput" class="mono" placeholder="Start (ISO-8601, e.g. 2024-01-01T09:00:00Z)" style="flex:1;"/>
+        <input id="eventEndInput" class="mono" placeholder="End (ISO-8601, e.g. 2024-01-01T10:00:00Z)" style="flex:1;"/>
+        <button id="eventCreateBtn">Add event</button>
+      </div>
+      <div id="eventCreateStatus" class="muted" style="margin-top:6px;"></div>
+    </div>
+
+    <div class="section" style="margin-top:16px;">
+      <h4 style="margin:0 0 8px 0;">Events</h4>
+      <div class="row-inline">
+        <button id="eventsRefreshBtn">Refresh events</button>
+      </div>
+      <div id="calendarEventsList" class="list" style="margin-top:8px;"></div>
+    </div>
+
+    <div class="section" style="margin-top:16px;">
+      <h4 style="margin:0 0 8px 0;">Availability</h4>
+      <div class="row-inline">
+        <input id="openingsStartInput" class="mono" placeholder="Start window (ISO-8601 UTC)" style="flex:1;"/>
+        <input id="openingsEndInput" class="mono" placeholder="End window (ISO-8601 UTC)" style="flex:1;"/>
+        <button id="openingsLoadBtn">Load openings</button>
+      </div>
+      <div id="calendarOpeningsList" class="list" style="margin-top:8px;"></div>
+    </div>
+  </div>
+
   <div class="card">
     <h3>Alert Recipients</h3>
     <div class="section">

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -2382,6 +2382,7 @@ async function refreshAll() {
       refreshAlerts(),
       refreshProfile(),
       billingRefreshAll(),
+      refreshCalendarEvents(),
     ]);
     await pollToastsOnce();
   } catch (e) {
@@ -2442,6 +2443,137 @@ function renderSmsTypeChecklist(types, enabled) {
 async function beginAddAlertSms(phone) {
   await ensureUiSession();
   return await apiPost("/ui/alerts/sms/begin", { phone });
+}
+
+/* ===================== calendar ===================== */
+function getCalendarId() {
+  return lsGet("calendar_id") || "";
+}
+
+function setCalendarId(calendarId) {
+  if (calendarId) {
+    lsSet("calendar_id", calendarId);
+  } else {
+    lsDel("calendar_id");
+  }
+  const input = document.getElementById("calendarIdInput");
+  if (input) input.value = calendarId || "";
+}
+
+function setCalendarStatus(msg) {
+  const el = document.getElementById("calendarStatus");
+  if (el) el.textContent = msg || "";
+}
+
+function renderCalendarEvents(events) {
+  const wrap = document.getElementById("calendarEventsList");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  if (!events || events.length === 0) {
+    wrap.innerHTML = '<div class="muted">No events yet.</div>';
+    return;
+  }
+  events.forEach(evt => {
+    const row = document.createElement("div");
+    row.className = "item";
+    const when = evt.all_day
+      ? `All day ${escapeHtml(evt.all_day_date || "")}`
+      : `${escapeHtml(evt.start_utc || "")} → ${escapeHtml(evt.end_utc || "")}`;
+    row.innerHTML = `
+      <div class="row">
+        <div class="grow"><b>${escapeHtml(evt.name || "")}</b></div>
+        <div class="mono">${escapeHtml(evt.event_id || "")}</div>
+      </div>
+      <div class="muted">${when} (${escapeHtml(evt.timezone || "")})</div>
+      ${evt.description ? `<div class="muted">${escapeHtml(evt.description)}</div>` : ""}
+    `;
+    wrap.appendChild(row);
+  });
+}
+
+function renderCalendarOpenings(openings) {
+  const wrap = document.getElementById("calendarOpeningsList");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  if (!openings || openings.length === 0) {
+    wrap.innerHTML = '<div class="muted">No openings for selected window.</div>';
+    return;
+  }
+  openings.forEach(o => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `<div class="mono">${escapeHtml(o.start_utc)} → ${escapeHtml(o.end_utc)}</div>`;
+    wrap.appendChild(row);
+  });
+}
+
+async function createCalendar() {
+  try {
+    await ensureUiSession();
+    const name = document.getElementById("calendarNameInput").value.trim() || "My Calendar";
+    const timezone = document.getElementById("calendarTimezoneInput").value.trim() || "UTC";
+    const res = await apiPost("/ui/calendars", { name, timezone });
+    setCalendarId(res.calendar_id || "");
+    setCalendarStatus(`Created calendar ${res.calendar_id}`);
+    await refreshCalendarEvents();
+  } catch (e) {
+    setCalendarStatus("Error: " + e.message);
+  }
+}
+
+async function refreshCalendarEvents() {
+  const calendarId = getCalendarId();
+  if (!calendarId) return;
+  await ensureUiSession();
+  const events = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/events`);
+  renderCalendarEvents(events || []);
+}
+
+async function createCalendarEvent() {
+  const calendarId = getCalendarId();
+  if (!calendarId) {
+    setCalendarStatus("Set a calendar ID first.");
+    return;
+  }
+  try {
+    await ensureUiSession();
+    const payload = {
+      name: document.getElementById("eventNameInput").value.trim(),
+      description: document.getElementById("eventDescriptionInput").value.trim(),
+      timezone: document.getElementById("eventTimezoneInput").value.trim() || null,
+      all_day: document.getElementById("eventAllDayToggle").checked,
+      all_day_date: document.getElementById("eventAllDayDateInput").value || null,
+      start_utc: document.getElementById("eventStartInput").value.trim() || null,
+      end_utc: document.getElementById("eventEndInput").value.trim() || null,
+    };
+    const res = await apiPost(`/ui/calendars/${encodeURIComponent(calendarId)}/events`, payload);
+    document.getElementById("eventCreateStatus").textContent = `Added event ${res.event_id}`;
+    await refreshCalendarEvents();
+  } catch (e) {
+    document.getElementById("eventCreateStatus").textContent = "Error: " + e.message;
+  }
+}
+
+async function loadCalendarOpenings() {
+  const calendarId = getCalendarId();
+  if (!calendarId) {
+    setCalendarStatus("Set a calendar ID first.");
+    return;
+  }
+  const start = document.getElementById("openingsStartInput").value.trim();
+  const end = document.getElementById("openingsEndInput").value.trim();
+  if (!start || !end) {
+    setCalendarStatus("Enter start and end window.");
+    return;
+  }
+  try {
+    await ensureUiSession();
+    const qs = `?start_utc=${encodeURIComponent(start)}&end_utc=${encodeURIComponent(end)}`;
+    const res = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/openings${qs}`);
+    renderCalendarOpenings(res || []);
+  } catch (e) {
+    setCalendarStatus("Error: " + e.message);
+  }
 }
 async function confirmAddAlertSms(challenge_id, code) {
   await ensureUiSession();
@@ -2935,6 +3067,33 @@ document.getElementById("alertEmailAddBtn").onclick = async () => {
   }
 };
 
+document.getElementById("calendarSetBtn").onclick = async () => {
+  const calendarId = document.getElementById("calendarIdInput").value.trim();
+  setCalendarId(calendarId);
+  if (calendarId) {
+    setCalendarStatus(`Using calendar ${calendarId}`);
+    await refreshCalendarEvents();
+  } else {
+    setCalendarStatus("Calendar cleared.");
+  }
+};
+
+document.getElementById("calendarCreateBtn").onclick = async () => {
+  await createCalendar();
+};
+
+document.getElementById("eventCreateBtn").onclick = async () => {
+  await createCalendarEvent();
+};
+
+document.getElementById("eventsRefreshBtn").onclick = async () => {
+  await refreshCalendarEvents();
+};
+
+document.getElementById("openingsLoadBtn").onclick = async () => {
+  await loadCalendarOpenings();
+};
+
 document.getElementById("alertTypesSaveBtn").onclick = async () => {
   try {
     await ensureUiSession();
@@ -3136,6 +3295,7 @@ document.getElementById("stripeVerifyByDescriptorBtn").onclick = verifyBillingBy
 document.getElementById("stripeLoadLedgerBtn").onclick = loadBillingLedger;
 
 /* ===================== boot ===================== */
+setCalendarId(getCalendarId());
 if (!accessToken()) { openTokenModal(); } else { refreshAll(); }
 startToastSSE();
 startToastPolling();

--- a/tests/test_calendar_routes.py
+++ b/tests/test_calendar_routes.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import CalendarCreateIn, EventCreateIn
+from app.routers import calendar as calendar_router
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def build_ctx(user_sub: str = "user") -> dict[str, str]:
+    return {"user_sub": user_sub, "session_id": "sid"}
+
+
+def build_calendar_table(meta: dict | None = None, events: list[dict] | None = None) -> Mock:
+    table = Mock()
+    table.get_item.return_value = {"Item": meta} if meta else {}
+    table.query.return_value = {"Items": events or []}
+    return table
+
+
+def test_create_calendar_sets_owner_and_timezone():
+    table = build_calendar_table()
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        with patch.object(calendar_router.uuid, "uuid4", return_value=SimpleNamespace(hex="cal123")):
+            resp = run_async(calendar_router.create_calendar(CalendarCreateIn(name="Team", timezone="UTC"), ctx=build_ctx()))
+
+    assert resp.calendar_id == "cal123"
+    assert resp.owner_user_id == "user"
+    assert resp.timezone == "UTC"
+    table.put_item.assert_called_once()
+
+
+def test_create_event_requires_calendar_owner():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "owner", "timezone": "UTC"}
+    table = build_calendar_table(meta=meta)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        with pytest.raises(HTTPException):
+            run_async(calendar_router.create_event(
+                "cal123",
+                EventCreateIn(name="Event", description="", all_day=True, all_day_date="2024-05-01"),
+                ctx=build_ctx(user_sub="intruder"),
+            ))
+
+
+def test_create_event_all_day():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    table = build_calendar_table(meta=meta)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        with patch.object(calendar_router.uuid, "uuid4", return_value=SimpleNamespace(hex="evt123")):
+            resp = run_async(calendar_router.create_event(
+                "cal123",
+                EventCreateIn(
+                    name="Holiday",
+                    description="Office closed",
+                    all_day=True,
+                    all_day_date="2024-05-01",
+                ),
+                ctx=build_ctx(),
+            ))
+
+    assert resp.event_id == "evt123"
+    assert resp.all_day is True
+    assert resp.all_day_date == "2024-05-01"
+
+
+def test_list_openings_returns_free_windows():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    events = [
+        {
+            "event_id": "evt1",
+            "name": "Standup",
+            "timezone": "UTC",
+            "start_utc": "2024-01-01T10:00:00Z",
+            "end_utc": "2024-01-01T11:00:00Z",
+            "all_day": False,
+        },
+        {
+            "event_id": "evt2",
+            "name": "Review",
+            "timezone": "UTC",
+            "start_utc": "2024-01-01T13:00:00Z",
+            "end_utc": "2024-01-01T14:00:00Z",
+            "all_day": False,
+        },
+    ]
+    table = build_calendar_table(meta=meta, events=events)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        openings = run_async(calendar_router.list_openings(
+            "cal123",
+            start_utc="2024-01-01T09:00:00Z",
+            end_utc="2024-01-01T15:00:00Z",
+            ctx=build_ctx(),
+        ))
+
+    assert [(o.start_utc, o.end_utc) for o in openings] == [
+        ("2024-01-01T09:00:00Z", "2024-01-01T10:00:00Z"),
+        ("2024-01-01T11:00:00Z", "2024-01-01T13:00:00Z"),
+        ("2024-01-01T14:00:00Z", "2024-01-01T15:00:00Z"),
+    ]
+
+
+def test_invalid_timezone_rejected():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    table = build_calendar_table(meta=meta)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        with pytest.raises(HTTPException):
+            run_async(calendar_router.create_event(
+                "cal123",
+                EventCreateIn(
+                    name="Bad TZ",
+                    description="",
+                    start_utc="2024-01-01T09:00:00Z",
+                    end_utc="2024-01-01T10:00:00Z",
+                    timezone="Not/AZone",
+                ),
+                ctx=build_ctx(),
+            ))
+
+
+def test_list_events_returns_items():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    events = [
+        {
+            "event_id": "evt1",
+            "name": "Standup",
+            "timezone": "UTC",
+            "start_utc": "2024-01-01T10:00:00Z",
+            "end_utc": "2024-01-01T11:00:00Z",
+            "all_day": False,
+            "description": "Daily sync",
+            "created_at_utc": "2024-01-01T08:00:00Z",
+        },
+    ]
+    table = build_calendar_table(meta=meta, events=events)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        resp = run_async(calendar_router.list_events("cal123", ctx=build_ctx()))
+
+    assert len(resp) == 1
+    assert resp[0].event_id == "evt1"
+    assert resp[0].name == "Standup"
+    assert resp[0].description == "Daily sync"
+
+
+def test_openings_merge_overlapping_events():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    events = [
+        {
+            "event_id": "evt1",
+            "name": "Block A",
+            "timezone": "UTC",
+            "start_utc": "2024-02-01T10:00:00Z",
+            "end_utc": "2024-02-01T12:00:00Z",
+            "all_day": False,
+        },
+        {
+            "event_id": "evt2",
+            "name": "Block B",
+            "timezone": "UTC",
+            "start_utc": "2024-02-01T11:30:00Z",
+            "end_utc": "2024-02-01T13:00:00Z",
+            "all_day": False,
+        },
+    ]
+    table = build_calendar_table(meta=meta, events=events)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        openings = run_async(calendar_router.list_openings(
+            "cal123",
+            start_utc="2024-02-01T09:00:00Z",
+            end_utc="2024-02-01T15:00:00Z",
+            ctx=build_ctx(),
+        ))
+
+    assert [(o.start_utc, o.end_utc) for o in openings] == [
+        ("2024-02-01T09:00:00Z", "2024-02-01T10:00:00Z"),
+        ("2024-02-01T13:00:00Z", "2024-02-01T15:00:00Z"),
+    ]
+
+
+def test_openings_all_day_event_blocks_day():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    events = [
+        {
+            "event_id": "evt1",
+            "name": "Holiday",
+            "timezone": "UTC",
+            "all_day": True,
+            "all_day_date": "2024-03-10",
+        },
+    ]
+    table = build_calendar_table(meta=meta, events=events)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        openings = run_async(calendar_router.list_openings(
+            "cal123",
+            start_utc="2024-03-10T00:00:00Z",
+            end_utc="2024-03-11T00:00:00Z",
+            ctx=build_ctx(),
+        ))
+
+    assert openings == []
+
+
+def test_openings_rejects_invalid_window():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    table = build_calendar_table(meta=meta, events=[])
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        with pytest.raises(HTTPException):
+            run_async(calendar_router.list_openings(
+                "cal123",
+                start_utc="2024-01-01T10:00:00Z",
+                end_utc="2024-01-01T09:00:00Z",
+                ctx=build_ctx(),
+            ))


### PR DESCRIPTION
### Motivation
- Implement a lightweight calendar/scheduling feature set to create calendars, add events (timed and all-day), and compute availability windows.
- Wire a new calendar DynamoDB table into the core table registry so the router can persist calendar data.
- Provide a basic UI to manage calendars/events and to call the new endpoints.
- Ensure every new route has automated test coverage, including the previously-missing list-events route.

### Description
- Add `app/routers/calendar.py` which implements `/ui/calendars` (create calendar), `/ui/calendars/{calendar_id}/events` (create event and list events), and `/ui/calendars/{calendar_id}/openings` (list availability windows), plus helpers for timezone/interval handling.
- Add calendar-related models `CalendarCreateIn`, `CalendarOut`, `EventCreateIn`, `EventOut`, and `OpeningsOut` to `app/models.py`.
- Add `calendar_table_name` to `app/core/settings.py` and register `calendar` in `app/core/tables.py` so the router can use `T.calendar`.
- Include the calendar router in `app/main.py` and add scheduling UI markup to `app/static/index.html` with client logic and handlers in `app/static/main.js` to call the new endpoints.
- Add and extend tests in `tests/test_calendar_routes.py` to cover calendar creation, event creation (timed and all-day), list openings behaviors (merge overlapping events, all-day blocks day, invalid window rejection), and the `list_events` route.

### Testing
- Ran `pytest tests/test_calendar_routes.py` which executed the calendar router test suite and succeeded with `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c32f5dbc832b940e09620f4c414a)