### PR TITLE
Refine address and calendar handlers

### DIFF
--- a/app/routers/calendar.py
+++ b/app/routers/calendar.py
@@ -146,6 +146,21 @@ def _list_events(calendar_id: str) -> List[Dict[str, Any]]:
     return response.get("Items", [])
 
 
+def _event_out(item: Dict[str, Any], calendar_id: str) -> EventOut:
+    return EventOut(
+        event_id=item["event_id"],
+        calendar_id=calendar_id,
+        name=item["name"],
+        description=item.get("description", ""),
+        timezone=item.get("timezone", "UTC"),
+        start_utc=item.get("start_utc"),
+        end_utc=item.get("end_utc"),
+        all_day=item.get("all_day", False),
+        all_day_date=item.get("all_day_date"),
+        created_at_utc=item.get("created_at_utc", ""),
+    )
+
+
 @router.post("/calendars", response_model=CalendarOut)
 async def create_calendar(body: CalendarCreateIn, ctx: Dict[str, str] = Depends(require_ui_session)):
     calendar_id = uuid.uuid4().hex
@@ -207,21 +222,7 @@ async def create_event(
 @router.get("/calendars/{calendar_id}/events", response_model=list[EventOut])
 async def list_events(calendar_id: str, ctx: Dict[str, str] = Depends(require_ui_session)):
     _load_calendar(calendar_id, ctx["user_sub"])
-    events = []
-    for item in _list_events(calendar_id):
-        events.append(EventOut(
-            event_id=item["event_id"],
-            calendar_id=calendar_id,
-            name=item["name"],
-            description=item.get("description", ""),
-            timezone=item.get("timezone", "UTC"),
-            start_utc=item.get("start_utc"),
-            end_utc=item.get("end_utc"),
-            all_day=item.get("all_day", False),
-            all_day_date=item.get("all_day_date"),
-            created_at_utc=item.get("created_at_utc", ""),
-        ))
-    return events
+    return [_event_out(item, calendar_id) for item in _list_events(calendar_id)]
 
 
 @router.get("/calendars/{calendar_id}/openings", response_model=list[OpeningsOut])

--- a/app/services/addresses.py
+++ b/app/services/addresses.py
@@ -110,11 +110,7 @@ def delete_address(user_sub: str, address_id: str) -> Dict[str, Any]:
 
 def set_primary_address(user_sub: str, address_id: str) -> Dict[str, Any]:
     addresses = list_addresses(user_sub)
-    target = None
-    for address in addresses:
-        if address.get("address_id") == address_id:
-            target = address
-            break
+    target = next((address for address in addresses if address.get("address_id") == address_id), None)
     if not target:
         raise HTTPException(404, "address not found")
 


### PR DESCRIPTION
### Motivation
- Clean up recently added address management and calendar scheduling code to reduce duplication and improve readability.
- Remove small boilerplate in primary-address selection and centralize calendar event serialization for consistent output.
- Skills used: none — these are small, local refactors applied directly to the codebase.

### Description
- Add `_event_out` helper in `app/routers/calendar.py` to centralize `EventOut` construction and replace the manual loop with a list comprehension.
- Simplify `set_primary_address` in `app/services/addresses.py` by using `next(...)` to find the target address instead of an explicit loop.
- Preserve existing behavior for updating the DB and applying profile updates when primary mailing addresses change.

### Testing
- Ran `pytest` which executed the full test suite and all tests passed; `159 passed in 3.66s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ca333c98832b999ebe6ef16b740e)