### PR TITLE
Silence duplicate zip warning in upload zip test

### DIFF
--- a/tests/test_filemanager_service.py
+++ b/tests/test_filemanager_service.py
@@ -1,5 +1,6 @@
 import io
 import unittest
+import warnings
 import zipfile
 from unittest.mock import Mock, patch
 
@@ -24,9 +25,11 @@ class TestFileManagerService(unittest.TestCase):
 
     def test_upload_zip_rejects_duplicate_paths(self):
         buf = io.BytesIO()
-        with zipfile.ZipFile(buf, "w") as zf:
-            zf.writestr("dup.txt", b"one")
-            zf.writestr("dup.txt", b"two")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("dup.txt", b"one")
+                zf.writestr("dup.txt", b"two")
         buf.seek(0)
         upload = UploadFile(filename="files.zip", file=buf)
 


### PR DESCRIPTION
### Motivation
- Avoid noisy `UserWarning` emitted when creating a test zip with duplicate filenames while retaining the duplicate-path coverage in the test.

### Description
- Wrap the test zip construction in `warnings.catch_warnings()` and `warnings.simplefilter("ignore", UserWarning)` in `tests/test_filemanager_service.py` to suppress the duplicate-name warning.

### Testing
- Ran `pytest -q tests/test_filemanager_service.py::TestFileManagerService::test_upload_zip_rejects_duplicate_paths` and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697556a6d868832b94f2e737f461b115)