### PR TITLE
Add frontend unit tests for control panel helpers

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -3958,7 +3958,9 @@ document.getElementById("msgLoadMessagesBtn").onclick = loadMessagingMessages;
 document.getElementById("msgSendBtn").onclick = sendMessagingMessage;
 
 /* ===================== boot ===================== */
-setCalendarId(getCalendarId());
-if (!accessToken()) { openTokenModal(); } else { refreshAll(); }
-startToastSSE();
-startToastPolling();
+if (!window.__SKIP_BOOT__) {
+  setCalendarId(getCalendarId());
+  if (!accessToken()) { openTokenModal(); } else { refreshAll(); }
+  startToastSSE();
+  startToastPolling();
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "testlogon-frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:frontend": "node --test tests/frontend/*.test.js"
+  },
+  "devDependencies": {
+    "jsdom": "^24.0.0"
+  }
+}

--- a/tests/frontend/main.test.js
+++ b/tests/frontend/main.test.js
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+function loadUiDom() {
+  const html = readFileSync(new URL('../../app/static/index.html', import.meta.url), 'utf8');
+  const dom = new JSDOM(html, {
+    runScripts: 'outside-only',
+    url: 'http://localhost/',
+  });
+
+  dom.window.__SKIP_BOOT__ = true;
+  dom.window.fetch = async () => {
+    throw new Error('fetch should not be called during frontend unit tests');
+  };
+
+  const script = readFileSync(new URL('../../app/static/main.js', import.meta.url), 'utf8');
+  dom.window.eval(script);
+  return dom;
+}
+
+test('escapeHtml escapes reserved characters', () => {
+  const dom = loadUiDom();
+  const { escapeHtml } = dom.window;
+  assert.equal(
+    escapeHtml('<div class="x">&\"\'</div>'),
+    '&lt;div class=&quot;x&quot;&gt;&amp;&quot;&#39;&lt;/div&gt;'
+  );
+});
+
+test('fmtBytes formats sizes with expected precision', () => {
+  const dom = loadUiDom();
+  const { fmtBytes } = dom.window;
+  assert.equal(fmtBytes(0), '0 B');
+  assert.equal(fmtBytes(1024), '1 KB');
+  assert.equal(fmtBytes(1536), '1.5 KB');
+});
+
+test('fmtDurSec renders human readable durations', () => {
+  const dom = loadUiDom();
+  const { fmtDurSec } = dom.window;
+  assert.equal(fmtDurSec(59), '59s');
+  assert.equal(fmtDurSec(3661), '1h 1m 1s');
+});
+
+test('fmtMoney adds currency and sign', () => {
+  const dom = loadUiDom();
+  const { fmtMoney } = dom.window;
+  assert.equal(fmtMoney(1234, 'usd'), '12.34 USD');
+  assert.equal(fmtMoney(-250, 'eur'), '-2.50 EUR');
+});
+
+test('modalShow and modalClose manage modal lifecycle', () => {
+  const dom = loadUiDom();
+  const { modalShow, modalClose, document } = dom.window;
+
+  modalShow({
+    title: 'Test Modal',
+    bodyHtml: '<p>Body</p>',
+    actions: [{ text: 'Ok', onClick: () => {} }],
+  });
+
+  const modal = document.querySelector('.modal-backdrop');
+  assert.ok(modal);
+  assert.equal(document.querySelectorAll('.modal-backdrop').length, 1);
+
+  modalClose();
+  assert.equal(document.querySelectorAll('.modal-backdrop').length, 0);
+});
+
+test('parseHttpError returns status codes when present', () => {
+  const dom = loadUiDom();
+  const { parseHttpError } = dom.window;
+  assert.equal(parseHttpError('403: Forbidden'), 403);
+  assert.equal(parseHttpError('Boom'), null);
+});


### PR DESCRIPTION
### Motivation
- Provide a way to unit-test static UI helper code (formatters, escaping, modal lifecycle, etc.) without bootstrapping the full interactive UI or making network calls.
- Make frontend helper behavior explicit and verifiable in CI/local dev environments.

### Description
- Add a test-only boot guard to the static UI script by wrapping boot code in `if (!window.__SKIP_BOOT__) { ... }` so the script can be loaded safely inside a test DOM (`app/static/main.js`).
- Add Node/jsdom-based unit tests that exercise `escapeHtml`, `fmtBytes`, `fmtDurSec`, `fmtMoney`, `modalShow`/`modalClose`, and `parseHttpError` (`tests/frontend/main.test.js`).
- Add a minimal `package.json` with a `test:frontend` script and `jsdom` listed as a dev dependency to document how to run the tests (`package.json`).
- Tests avoid network activity by setting `dom.window.__SKIP_BOOT__ = true` and stubbing `fetch` in the test harness.

### Testing
- Created tests and a `package.json` but running `npm install --package-lock-only` failed due to registry access (`403 Forbidden`), so `jsdom` could not be installed and frontend tests were not executed.
- The tests are runnable locally or in CI with network access by running `npm run test:frontend` (which runs `node --test tests/frontend/*.test.js`).
- The test harness is designed to fail fast if network calls occur by overriding `fetch`, and loading the UI script with `__SKIP_BOOT__` prevents background boot behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975a3695078832ba279bcb5f02e4b81)