### PR TITLE
Add shopping catalog API support

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -133,6 +133,9 @@ class Settings:
     # Calendar
     calendar_table_name: str = os.environ.get("CALENDAR_TABLE_NAME", "calendar")
 
+    # Catalog
+    catalog_table_name: str = os.environ.get("CATALOG_TABLE_NAME", "shopping_catalog")
+
     # File manager
     filemgr_table_name: str = os.environ.get("FILEMGR_TABLE", "")
     filemgr_bucket: str = os.environ.get("FILEMGR_BUCKET", "")

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -22,6 +22,7 @@ class Tables:
     profile: Any
     addresses: Any
     calendar: Any
+    catalog: Any
 
 T = Tables(
     sessions=ddb.Table(S.ddb_sessions_table),
@@ -38,4 +39,5 @@ T = Tables(
     profile=ddb.Table(S.profile_table_name),
     addresses=ddb.Table(S.addresses_table_name),
     calendar=ddb.Table(S.calendar_table_name),
+    catalog=ddb.Table(S.catalog_table_name),
 )

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.routers.messaging import router as messaging_router
 from app.routers.filemanager import router as filemanager_router
 from app.routers.addresses import router as addresses_router
 from app.routers.calendar import router as calendar_router
+from app.routers.catalog import router as catalog_router
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Security Backend (refactored)", version="0.1.0")
@@ -69,6 +70,7 @@ def create_app() -> FastAPI:
     app.include_router(filemanager_router)
     app.include_router(addresses_router)
     app.include_router(calendar_router)
+    app.include_router(catalog_router)
 
     return app
 

--- a/app/models.py
+++ b/app/models.py
@@ -118,6 +118,86 @@ class AlertEmailConfirmReq(BaseModel):
     challenge_id: str
     code: str
 
+
+class CatalogPageOut(BaseModel):
+    next_token: Optional[str] = None
+
+
+class CatalogCategoryCreateIn(BaseModel):
+    category_id: Optional[str] = None
+    name: str
+    description: Optional[str] = None
+
+
+class CatalogCategoryOut(BaseModel):
+    category_id: str
+    name: str
+    description: Optional[str] = None
+    created_at: str
+
+
+class CatalogCategoryListOut(CatalogPageOut):
+    items: List[CatalogCategoryOut]
+
+
+class CatalogItemCreateIn(BaseModel):
+    item_id: Optional[str] = None
+    name: str
+    description: Optional[str] = None
+    price_cents: int = Field(ge=0, le=10_000_000_00)
+    currency: str = "USD"
+    image_urls: List[str] = Field(default_factory=list)
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CatalogItemPatchIn(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    price_cents: Optional[int] = Field(default=None, ge=0, le=10_000_000_00)
+    currency: Optional[str] = None
+    image_urls: Optional[List[str]] = None
+    attributes: Optional[Dict[str, Any]] = None
+
+
+class CatalogItemOut(BaseModel):
+    category_id: str
+    item_id: str
+    name: str
+    description: Optional[str] = None
+    price_cents: int
+    currency: str
+    image_urls: List[str]
+    attributes: Dict[str, Any]
+    created_at: str
+    updated_at: str
+
+
+class CatalogItemListOut(CatalogPageOut):
+    items: List[CatalogItemOut]
+
+
+class CatalogReviewCreateIn(BaseModel):
+    review_id: Optional[str] = None
+    rating: int = Field(ge=1, le=5)
+    title: Optional[str] = None
+    body: Optional[str] = None
+    reviewer: Optional[str] = None
+
+
+class CatalogReviewOut(BaseModel):
+    item_id: str
+    review_id: str
+    rating: int
+    title: Optional[str] = None
+    body: Optional[str] = None
+    reviewer: Optional[str] = None
+    created_at: str
+
+
+class CatalogReviewListOut(CatalogPageOut):
+    items: List[CatalogReviewOut]
+
+
 class TotpDeviceBeginReq(BaseModel):
     label: Optional[str] = None
 

--- a/app/routers/catalog.py
+++ b/app/routers/catalog.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.core.tables import T
+from app.models import (
+    CatalogCategoryCreateIn,
+    CatalogCategoryListOut,
+    CatalogCategoryOut,
+    CatalogItemCreateIn,
+    CatalogItemListOut,
+    CatalogItemOut,
+    CatalogItemPatchIn,
+    CatalogReviewCreateIn,
+    CatalogReviewListOut,
+    CatalogReviewOut,
+)
+from app.services.sessions import require_ui_session
+
+router = APIRouter(prefix="/ui/catalog", tags=["catalog"])
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ulid_like() -> str:
+    return f"{int(time.time() * 1000)}_{uuid.uuid4().hex}"
+
+
+def cat_pk(category_id: str) -> str:
+    return f"CAT#{category_id}"
+
+
+def item_pk(item_id: str) -> str:
+    return f"ITEM#{item_id}"
+
+
+def item_sk(item_id: str) -> str:
+    return f"ITEM#{item_id}"
+
+
+def review_sk(review_id: str) -> str:
+    return f"REVIEW#{review_id}"
+
+
+def ddb_to_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _b64e(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+
+def _b64d(token: str) -> bytes:
+    pad = "=" * ((4 - (len(token) % 4)) % 4)
+    return base64.urlsafe_b64decode((token + pad).encode("utf-8"))
+
+
+def encode_next_token(last_evaluated_key: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not last_evaluated_key:
+        return None
+    raw = json.dumps(last_evaluated_key, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return _b64e(raw)
+
+
+def decode_next_token(token: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not token:
+        return None
+    try:
+        raw = _b64d(token)
+        obj = json.loads(raw.decode("utf-8"))
+        if not isinstance(obj, dict):
+            raise ValueError("token not dict")
+        return obj
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail="Invalid next_token") from exc
+
+
+def _query_page(
+    *,
+    pk: str,
+    sk_begins: str,
+    limit: int,
+    start_key: Optional[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    kwargs: Dict[str, Any] = {
+        "KeyConditionExpression": Key("PK").eq(pk) & Key("SK").begins_with(sk_begins),
+        "Limit": limit,
+    }
+    if start_key:
+        kwargs["ExclusiveStartKey"] = start_key
+    resp = T.catalog.query(**kwargs)
+    return resp.get("Items", []), resp.get("LastEvaluatedKey")
+
+
+def _gsi_categories_page(limit: int, start_key: Optional[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    kwargs: Dict[str, Any] = {
+        "IndexName": "GSI1",
+        "KeyConditionExpression": Key("GSI1PK").eq("CATS"),
+        "Limit": limit,
+    }
+    if start_key:
+        kwargs["ExclusiveStartKey"] = start_key
+    resp = T.catalog.query(**kwargs)
+    return resp.get("Items", []), resp.get("LastEvaluatedKey")
+
+
+def _scan_categories(limit: int, start_key: Optional[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    kwargs: Dict[str, Any] = {"Limit": limit}
+    if start_key:
+        kwargs["ExclusiveStartKey"] = start_key
+    resp = T.catalog.scan(**kwargs)
+    items = [item for item in resp.get("Items", []) if item.get("entity") == "category"]
+    return items, resp.get("LastEvaluatedKey")
+
+
+@router.post("/categories", response_model=CatalogCategoryOut)
+async def create_category(body: CatalogCategoryCreateIn, ctx=Depends(require_ui_session)):
+    category_id = body.category_id or uuid.uuid4().hex
+    item = {
+        "PK": cat_pk(category_id),
+        "SK": "META",
+        "entity": "category",
+        "category_id": category_id,
+        "name": body.name,
+        "description": body.description,
+        "created_at": now_iso(),
+        "GSI1PK": "CATS",
+        "GSI1SK": f"{body.name.lower()}#{category_id}",
+    }
+    try:
+        T.catalog.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            raise HTTPException(status_code=409, detail="Category already exists.") from exc
+        raise HTTPException(status_code=500, detail="Catalog storage error.") from exc
+    return CatalogCategoryOut(
+        category_id=category_id,
+        name=body.name,
+        description=body.description,
+        created_at=item["created_at"],
+    )
+
+
+@router.get("/categories", response_model=CatalogCategoryListOut)
+async def list_categories(
+    ctx=Depends(require_ui_session),
+    page_size: int = Query(default=50, ge=1, le=200),
+    next_token: Optional[str] = Query(default=None),
+):
+    start_key = decode_next_token(next_token)
+    try:
+        items, lek = _gsi_categories_page(page_size, start_key)
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] != "ValidationException":
+            raise HTTPException(status_code=500, detail="Catalog storage error.") from exc
+        items, lek = _scan_categories(page_size, start_key)
+    out = [
+        CatalogCategoryOut(
+            category_id=item["category_id"],
+            name=item["name"],
+            description=item.get("description"),
+            created_at=item["created_at"],
+        )
+        for item in items
+        if item.get("entity") == "category"
+    ]
+    return CatalogCategoryListOut(items=out, next_token=encode_next_token(lek))
+
+
+@router.delete("/categories/{category_id}")
+async def delete_category(
+    category_id: str,
+    cascade: bool = Query(default=False, description="Delete items in the category before removing it."),
+    ctx=Depends(require_ui_session),
+):
+    if cascade:
+        items, _ = _query_page(pk=cat_pk(category_id), sk_begins="ITEM#", limit=200, start_key=None)
+        with T.catalog.batch_writer() as batch:
+            for item in items:
+                batch.delete_item(Key={"PK": item["PK"], "SK": item["SK"]})
+        for item in items:
+            item_id = item.get("item_id")
+            if not item_id:
+                continue
+            reviews, _ = _query_page(pk=item_pk(item_id), sk_begins="REVIEW#", limit=200, start_key=None)
+            with T.catalog.batch_writer() as batch:
+                for review in reviews:
+                    batch.delete_item(Key={"PK": review["PK"], "SK": review["SK"]})
+    else:
+        existing, _ = _query_page(pk=cat_pk(category_id), sk_begins="ITEM#", limit=1, start_key=None)
+        if existing:
+            raise HTTPException(status_code=409, detail="Category has items. Use cascade=true to delete.")
+    T.catalog.delete_item(Key={"PK": cat_pk(category_id), "SK": "META"})
+    return {"ok": True}
+
+
+@router.post("/categories/{category_id}/items", response_model=CatalogItemOut)
+async def create_item(
+    category_id: str,
+    body: CatalogItemCreateIn,
+    ctx=Depends(require_ui_session),
+):
+    item_id = body.item_id or ulid_like()
+    now = now_iso()
+    item = {
+        "PK": cat_pk(category_id),
+        "SK": item_sk(item_id),
+        "entity": "item",
+        "category_id": category_id,
+        "item_id": item_id,
+        "name": body.name,
+        "description": body.description,
+        "price_cents": int(body.price_cents),
+        "currency": body.currency,
+        "image_urls": body.image_urls,
+        "attributes": body.attributes,
+        "created_at": now,
+        "updated_at": now,
+    }
+    try:
+        T.catalog.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            raise HTTPException(status_code=409, detail="Item already exists.") from exc
+        raise HTTPException(status_code=500, detail="Catalog storage error.") from exc
+    return CatalogItemOut(**item)
+
+
+@router.get("/categories/{category_id}/items", response_model=CatalogItemListOut)
+async def list_items(
+    category_id: str,
+    ctx=Depends(require_ui_session),
+    page_size: int = Query(default=50, ge=1, le=200),
+    next_token: Optional[str] = Query(default=None),
+):
+    start_key = decode_next_token(next_token)
+    items, lek = _query_page(pk=cat_pk(category_id), sk_begins="ITEM#", limit=page_size, start_key=start_key)
+    out: List[CatalogItemOut] = []
+    for item in items:
+        if item.get("entity") != "item":
+            continue
+        out.append(
+            CatalogItemOut(
+                category_id=item["category_id"],
+                item_id=item["item_id"],
+                name=item["name"],
+                description=item.get("description"),
+                price_cents=ddb_to_int(item["price_cents"]),
+                currency=item.get("currency", "USD"),
+                image_urls=item.get("image_urls", []),
+                attributes=item.get("attributes", {}),
+                created_at=item["created_at"],
+                updated_at=item["updated_at"],
+            )
+        )
+    return CatalogItemListOut(items=out, next_token=encode_next_token(lek))
+
+
+@router.patch("/categories/{category_id}/items/{item_id}", response_model=CatalogItemOut)
+async def update_item(
+    category_id: str,
+    item_id: str,
+    body: CatalogItemPatchIn,
+    ctx=Depends(require_ui_session),
+):
+    updates: List[str] = []
+    values: Dict[str, Any] = {":updated_at": now_iso()}
+    names: Dict[str, str] = {"#updated_at": "updated_at"}
+    updates.append("#updated_at = :updated_at")
+
+    if body.name is not None:
+        names["#name"] = "name"
+        values[":name"] = body.name
+        updates.append("#name = :name")
+    if body.description is not None:
+        names["#description"] = "description"
+        values[":description"] = body.description
+        updates.append("#description = :description")
+    if body.price_cents is not None:
+        names["#price_cents"] = "price_cents"
+        values[":price_cents"] = int(body.price_cents)
+        updates.append("#price_cents = :price_cents")
+    if body.currency is not None:
+        names["#currency"] = "currency"
+        values[":currency"] = body.currency
+        updates.append("#currency = :currency")
+    if body.image_urls is not None:
+        names["#image_urls"] = "image_urls"
+        values[":image_urls"] = body.image_urls
+        updates.append("#image_urls = :image_urls")
+    if body.attributes is not None:
+        names["#attributes"] = "attributes"
+        values[":attributes"] = body.attributes
+        updates.append("#attributes = :attributes")
+
+    if len(updates) == 1:
+        raise HTTPException(status_code=400, detail="No fields to update.")
+
+    try:
+        resp = T.catalog.update_item(
+            Key={"PK": cat_pk(category_id), "SK": item_sk(item_id)},
+            ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+            UpdateExpression="SET " + ", ".join(updates),
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+            ReturnValues="ALL_NEW",
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            raise HTTPException(status_code=404, detail="Item not found.") from exc
+        raise HTTPException(status_code=500, detail="Catalog storage error.") from exc
+
+    item = resp.get("Attributes")
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found.")
+    return CatalogItemOut(
+        category_id=item["category_id"],
+        item_id=item["item_id"],
+        name=item["name"],
+        description=item.get("description"),
+        price_cents=ddb_to_int(item["price_cents"]),
+        currency=item.get("currency", "USD"),
+        image_urls=item.get("image_urls", []),
+        attributes=item.get("attributes", {}),
+        created_at=item["created_at"],
+        updated_at=item["updated_at"],
+    )
+
+
+@router.delete("/categories/{category_id}/items/{item_id}")
+async def delete_item(
+    category_id: str,
+    item_id: str,
+    cascade_reviews: bool = Query(default=True, description="Delete item reviews before removing item."),
+    ctx=Depends(require_ui_session),
+):
+    if cascade_reviews:
+        reviews, _ = _query_page(pk=item_pk(item_id), sk_begins="REVIEW#", limit=200, start_key=None)
+        with T.catalog.batch_writer() as batch:
+            for review in reviews:
+                batch.delete_item(Key={"PK": review["PK"], "SK": review["SK"]})
+    else:
+        reviews, _ = _query_page(pk=item_pk(item_id), sk_begins="REVIEW#", limit=1, start_key=None)
+        if reviews:
+            raise HTTPException(status_code=409, detail="Item has reviews. Use cascade_reviews=true to delete.")
+    T.catalog.delete_item(Key={"PK": cat_pk(category_id), "SK": item_sk(item_id)})
+    return {"ok": True}
+
+
+@router.get("/items/{item_id}/reviews", response_model=CatalogReviewListOut)
+async def list_reviews(
+    item_id: str,
+    ctx=Depends(require_ui_session),
+    page_size: int = Query(default=50, ge=1, le=200),
+    next_token: Optional[str] = Query(default=None),
+):
+    start_key = decode_next_token(next_token)
+    items, lek = _query_page(pk=item_pk(item_id), sk_begins="REVIEW#", limit=page_size, start_key=start_key)
+    out: List[CatalogReviewOut] = []
+    for item in items:
+        if item.get("entity") != "review":
+            continue
+        out.append(
+            CatalogReviewOut(
+                item_id=item["item_id"],
+                review_id=item["review_id"],
+                rating=ddb_to_int(item["rating"]),
+                title=item.get("title"),
+                body=item.get("body"),
+                reviewer=item.get("reviewer"),
+                created_at=item["created_at"],
+            )
+        )
+    return CatalogReviewListOut(items=out, next_token=encode_next_token(lek))
+
+
+@router.post("/items/{item_id}/reviews", response_model=CatalogReviewOut)
+async def add_review(
+    item_id: str,
+    body: CatalogReviewCreateIn,
+    ctx=Depends(require_ui_session),
+):
+    review_id = body.review_id or ulid_like()
+    item = {
+        "PK": item_pk(item_id),
+        "SK": review_sk(review_id),
+        "entity": "review",
+        "item_id": item_id,
+        "review_id": review_id,
+        "rating": int(body.rating),
+        "title": body.title,
+        "body": body.body,
+        "reviewer": body.reviewer,
+        "created_at": now_iso(),
+    }
+    try:
+        T.catalog.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            raise HTTPException(status_code=409, detail="Review already exists.") from exc
+        raise HTTPException(status_code=500, detail="Catalog storage error.") from exc
+    return CatalogReviewOut(
+        item_id=item_id,
+        review_id=review_id,
+        rating=item["rating"],
+        title=item.get("title"),
+        body=item.get("body"),
+        reviewer=item.get("reviewer"),
+        created_at=item["created_at"],
+    )
+
+
+@router.delete("/items/{item_id}/reviews/{review_id}")
+async def delete_review(
+    item_id: str,
+    review_id: str,
+    ctx=Depends(require_ui_session),
+):
+    T.catalog.delete_item(Key={"PK": item_pk(item_id), "SK": review_sk(review_id)})
+    return {"ok": True}


### PR DESCRIPTION
### Motivation
- Provide shopping catalog functionality (categories, items, reviews) backed by DynamoDB and expose it via the API under `/ui/catalog`.
- Wire a dedicated catalog table configuration and table handle into the existing core settings and tables to isolate catalog storage.
- Offer paginated listing, cascade deletes, and review cascades so the catalog can be managed from the UI/API.

### Description
- Added a `CATALOG_TABLE_NAME` setting (`S.catalog_table_name`) in `app/core/settings.py` and registered `T.catalog = ddb.Table(S.catalog_table_name)` in `app/core/tables.py`.
- Introduced Pydantic request/response models for catalog operations in `app/models.py` (category/item/review models and paginated outputs).
- Implemented a new router `app/routers/catalog.py` that exposes endpoints for creating/listing/deleting categories, creating/listing/updating/deleting items, and creating/listing/deleting reviews with pagination (`next_token` encoding/decoding), GSI-based category listing (with scan fallback), cascade deletion helpers, and basic DynamoDB condition handling.
- Wired the new `catalog_router` into the main FastAPI app by including it in `app/main.py`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975addcc5d8832b921f19e5d5f3eb9e)