### PR TITLE
Refactor newsfeed pagination and fix newsfeed markup

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -125,6 +125,9 @@
     <div class="hr"></div>
     <h4 style="margin:0 0 6px 0;">Live SSE</h4>
     <div id="newsfeedSseLog" class="item mono newsfeed-log"></div>
+  </div>
+</div>
+
 <div class="row" id="shoppingCartSection">
   <div class="card" style="width:100%">
     <h3>Shopping Cart</h3>


### PR DESCRIPTION
### Motivation
- Consolidate duplicated pagination logic for the newsfeed and comments into a single helper to make pagination behavior easier to maintain and reduce bugs.
- Ensure the Newsfeed card/row wrappers are properly closed so the page layout (e.g. Shopping Cart section) renders correctly.

### Description
- Add `applyNewsfeedPage(result, { listKey, cursorKey, reset })` to centralize applying paginated results and updating cursors.
- Replace duplicated pagination code in `refreshNewsfeed` and `loadNewsfeedComments` with calls to `applyNewsfeedPage` and keep behavior unchanged.
- Normalize usage of the computed `locked` variable when rendering feed items to avoid relying on inconsistent `item.locked` references.
- Add the missing closing `</div></div>` in `app/static/index.html` to restore the intended Newsfeed layout.

### Testing
- No automated tests were run for this refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766873a068832bacf72cd4a123a0b2)