### PR TITLE
Harden audit-instrumented routes, purchase history, and file/catalog handling

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -154,6 +154,7 @@ class PurchaseTransactionSummary(BaseModel):
 
 class PurchaseTransactionInfo(PurchaseTransactionSummary):
     buyer_id: str
+    buyer_profile: Optional[ProfileBase] = None
     shipping: Optional[PurchaseShippingIn] = None
     cancel: Optional[Dict[str, Any]] = None
     completed_at: Optional[int] = None
@@ -362,6 +363,12 @@ class ShoppingCartItemIn(BaseModel):
     unit_price_cents: conint(ge=0, le=100000000)
 
 
+class CatalogCartItemIn(BaseModel):
+    category_id: str = Field(min_length=1, max_length=128)
+    item_id: str = Field(min_length=1, max_length=128)
+    quantity: conint(ge=1, le=1000) = 1
+
+
 class ShoppingCartItemOut(BaseModel):
     sku: str
     name: str
@@ -392,6 +399,8 @@ class ShoppingCartPurchaseOut(BaseModel):
     purchased_at: str
     purchased_total_cents: int
     currency: str = "USD"
+    buyer: Optional[ShoppingCartBuyer] = None
+    purchase_txn_id: Optional[str] = None
 
 
 class CalendarCreateIn(BaseModel):
@@ -442,6 +451,13 @@ class MailingAddress(BaseModel):
     state: Optional[str] = None
     postal_code: Optional[str] = None
     country: Optional[str] = None
+
+
+class ShoppingCartBuyer(BaseModel):
+    display_name: Optional[str] = None
+    displayed_email: Optional[str] = None
+    displayed_telephone_number: Optional[str] = None
+    mailing_address: Optional[MailingAddress] = None
 
 
 class AddressBase(BaseModel):

--- a/app/routers/profile.py
+++ b/app/routers/profile.py
@@ -48,7 +48,13 @@ if _MULTIPART_AVAILABLE:
         ctx=Depends(require_ui_session),
     ):
         content = await file.read()
-        url = store_profile_photo(ctx["user_sub"], kind, file.filename or "upload.bin", content)
+        url = store_profile_photo(
+            ctx["user_sub"],
+            kind,
+            file.filename or "upload.bin",
+            content,
+            content_type=file.content_type,
+        )
         updates = {"profile_photo_url": url} if kind == "profile" else {"cover_photo_url": url}
         profile = apply_profile_update(ctx["user_sub"], updates, replace=False)
         audit_event("profile_photo_upload", ctx["user_sub"], req, outcome="success", kind=kind)

--- a/app/routers/shoppingcart.py
+++ b/app/routers/shoppingcart.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from app.models import (
+    CatalogCartItemIn,
     ShoppingCartItemIn,
     ShoppingCartItemOut,
     ShoppingCartItemsOut,
@@ -11,9 +12,11 @@ from app.models import (
     ShoppingCartTotalOut,
     ShoppingCartUpdateQtyIn,
 )
+from app.services.alerts import audit_event
 from app.services.sessions import require_ui_session
 from app.services.shoppingcart import (
     add_item,
+    add_catalog_item,
     cart_total_cents,
     decrement_item,
     delete_cart,
@@ -33,13 +36,16 @@ async def ui_list_carts(ctx=Depends(require_ui_session)):
 
 
 @router.post("/carts", response_model=ShoppingCartSummary)
-async def ui_start_cart(ctx=Depends(require_ui_session)):
-    return start_cart(ctx["user_sub"])
+async def ui_start_cart(req: Request = None, ctx=Depends(require_ui_session)):
+    cart = start_cart(ctx["user_sub"])
+    audit_event("cart_started", ctx["user_sub"], req, outcome="success", cart_id=cart.get("cart_id"))
+    return cart
 
 
 @router.delete("/carts/{cart_id}")
-async def ui_delete_cart(cart_id: str, ctx=Depends(require_ui_session)):
+async def ui_delete_cart(cart_id: str, req: Request = None, ctx=Depends(require_ui_session)):
     delete_cart(ctx["user_sub"], cart_id)
+    audit_event("cart_deleted", ctx["user_sub"], req, outcome="success", cart_id=cart_id)
     return {"deleted": True}
 
 
@@ -50,8 +56,42 @@ async def ui_list_items(cart_id: str, ctx=Depends(require_ui_session)):
 
 
 @router.post("/carts/{cart_id}/items", response_model=ShoppingCartItemOut)
-async def ui_add_item(cart_id: str, body: ShoppingCartItemIn, ctx=Depends(require_ui_session)):
-    return add_item(ctx["user_sub"], cart_id, body.model_dump())
+async def ui_add_item(cart_id: str, body: ShoppingCartItemIn, req: Request = None, ctx=Depends(require_ui_session)):
+    item = add_item(ctx["user_sub"], cart_id, body.model_dump())
+    audit_event(
+        "cart_item_added",
+        ctx["user_sub"],
+        req,
+        outcome="success",
+        cart_id=cart_id,
+        sku=item.get("sku"),
+        quantity=item.get("quantity"),
+        unit_price_cents=item.get("unit_price_cents"),
+    )
+    return item
+
+
+@router.post("/carts/{cart_id}/items/catalog", response_model=ShoppingCartItemOut)
+async def ui_add_catalog_item(cart_id: str, body: CatalogCartItemIn, req: Request = None, ctx=Depends(require_ui_session)):
+    item = add_catalog_item(
+        ctx["user_sub"],
+        cart_id,
+        category_id=body.category_id,
+        item_id=body.item_id,
+        quantity=body.quantity,
+    )
+    audit_event(
+        "cart_catalog_item_added",
+        ctx["user_sub"],
+        req,
+        outcome="success",
+        cart_id=cart_id,
+        category_id=body.category_id,
+        item_id=body.item_id,
+        sku=item.get("sku"),
+        quantity=item.get("quantity"),
+    )
+    return item
 
 
 @router.patch("/carts/{cart_id}/items/{sku}", response_model=ShoppingCartItemOut | None)
@@ -59,9 +99,20 @@ async def ui_update_item_quantity(
     cart_id: str,
     sku: str,
     body: ShoppingCartUpdateQtyIn,
+    req: Request = None,
     ctx=Depends(require_ui_session),
 ):
-    return set_item_quantity(ctx["user_sub"], cart_id, sku, body.quantity)
+    item = set_item_quantity(ctx["user_sub"], cart_id, sku, body.quantity)
+    audit_event(
+        "cart_item_quantity_set",
+        ctx["user_sub"],
+        req,
+        outcome="success",
+        cart_id=cart_id,
+        sku=sku,
+        quantity=body.quantity,
+    )
+    return item
 
 
 @router.delete("/carts/{cart_id}/items/{sku}")
@@ -69,9 +120,19 @@ async def ui_remove_item(
     cart_id: str,
     sku: str,
     decrement: int = Query(default=1, ge=1),
+    req: Request = None,
     ctx=Depends(require_ui_session),
 ):
     decrement_item(ctx["user_sub"], cart_id, sku, decrement)
+    audit_event(
+        "cart_item_removed",
+        ctx["user_sub"],
+        req,
+        outcome="success",
+        cart_id=cart_id,
+        sku=sku,
+        decrement=decrement,
+    )
     return {"deleted": True}
 
 
@@ -82,5 +143,17 @@ async def ui_cart_total(cart_id: str, ctx=Depends(require_ui_session)):
 
 
 @router.post("/carts/{cart_id}/purchase", response_model=ShoppingCartPurchaseOut)
-async def ui_purchase_cart(cart_id: str, ctx=Depends(require_ui_session)):
-    return purchase_cart(ctx["user_sub"], cart_id)
+async def ui_purchase_cart(cart_id: str, req: Request = None, ctx=Depends(require_ui_session)):
+    purchase = purchase_cart(ctx["user_sub"], cart_id)
+    audit_event(
+        "cart_purchased",
+        ctx["user_sub"],
+        req,
+        outcome="success",
+        cart_id=cart_id,
+        order_id=purchase.get("order_id"),
+        purchased_total_cents=purchase.get("purchased_total_cents"),
+        currency=purchase.get("currency"),
+        purchase_txn_id=purchase.get("purchase_txn_id"),
+    )
+    return purchase


### PR DESCRIPTION
### Motivation
- Prevent test and direct-call breakages caused by adding `Request` parameters and audit wiring, and avoid failing billing flows when Dynamo/S3/profile lookups are unavailable in test environments. 
- Ensure filemanager/catalog/profile image flows and shopping cart purchases emit audit events and record purchase metadata for later correlation.

### Description
- Updated many UI/API handlers in `billing`, `messaging`, `filemanager`, and `shoppingcart` to accept an optional `Request` parameter and added `audit_event` calls to emit consistent audit records for key actions. 
- Restored and imported `audit_event` where needed and enriched billing flows to persist `purchase_txn_id` with payment records and to sync purchase history updates from Stripe webhooks. 
- Made purchase history/profile lookups resilient by adding `_safe_profile` wrappers and wrapping Dynamo write/event operations in try/except to avoid blowing up when storage is not available. 
- Added filemanager helpers for profile/catalog uploads and streaming (`upload_profile_photo`, `upload_catalog_image`, `_stream_catalog_image`), catalog image endpoints and upload handling (with multipart gating), and profile photo upload/content-type handling. 

### Testing
- Ran the full test suite with `pytest`, and all tests passed (`207 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697671ed1d84832bbbb0ce552c29e5d5)