### PR TITLE
Harden WS token verification and IP normalization parsing

### DIFF
--- a/app/core/crypto.py
+++ b/app/core/crypto.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
+import time
 from typing import Any, Dict, Optional
 
 from .aws import kms
@@ -34,7 +35,6 @@ def b64url_decode(s: str) -> bytes:
 def mint_ws_token(user_sub: str, ttl_seconds: int = 60) -> str:
     if not S.ws_token_secret:
         raise RuntimeError("WS_TOKEN_SECRET not set")
-    import time
     now = int(time.time())
     payload = {"user_sub": user_sub, "exp": now + ttl_seconds, "iat": now}
     raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -42,6 +42,8 @@ def mint_ws_token(user_sub: str, ttl_seconds: int = 60) -> str:
     return f"{b64url(raw)}.{b64url(sig)}"
 
 def verify_ws_token(token: str) -> Optional[Dict[str, Any]]:
+    if not S.ws_token_secret:
+        return None
     try:
         raw_b64, sig_b64 = token.split(".", 1)
         raw = b64url_decode(raw_b64)
@@ -50,7 +52,9 @@ def verify_ws_token(token: str) -> Optional[Dict[str, Any]]:
         if not hmac.compare_digest(sig, expected):
             return None
         obj = json.loads(raw.decode("utf-8"))
-        if int(obj.get("exp", 0)) < int(__import__("time").time()):
+        if not isinstance(obj, dict):
+            return None
+        if int(obj.get("exp", 0)) < int(time.time()):
             return None
         return obj
     except Exception:

--- a/app/core/normalize.py
+++ b/app/core/normalize.py
@@ -9,7 +9,10 @@ from fastapi import HTTPException
 def client_ip_from_request(req) -> str:
     xff = req.headers.get("x-forwarded-for")
     if xff:
-        return xff.split(",")[0].strip()
+        for part in xff.split(","):
+            candidate = part.strip()
+            if candidate:
+                return candidate
     return req.client.host if req.client else "0.0.0.0"
 
 def normalize_email(s: str) -> str:
@@ -54,6 +57,6 @@ def ip_in_any_cidr(ip_str: str, cidrs: List[str]) -> bool:
             net = ipaddress.ip_network(c, strict=False)
             if ip in net:
                 return True
-        except Exception:
+        except ValueError:
             continue
     return False


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and silent failures when WebSocket token secrets are missing and ensure token payloads are validated before expiry checks.
- Make client IP extraction more robust by skipping empty entries in `x-forwarded-for` and avoid masking actual CIDR parse errors.

### Description
- In `app/core/crypto.py`, import `time` at module scope and remove the inline import in `mint_ws_token` to centralize time usage.
- In `app/core/crypto.py`, make `verify_ws_token` return `None` when `S.ws_token_secret` is not set, ensure the decoded JSON payload is a `dict` before inspecting `exp`, and use `time.time()` for expiry comparisons.
- In `app/core/normalize.py`, change `client_ip_from_request` to iterate `x-forwarded-for` parts and return the first non-empty candidate instead of blindly taking the first split element.
- In `app/core/normalize.py`, narrow CIDR parse error handling to catch `ValueError` only so unrelated exceptions are not swallowed.

### Testing
- No automated tests were executed for these changes.
- Manual review and static inspection were used to validate the small fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cd4e049f4832ba5030c22716e5467)