### PR TITLE
Consolidate billing ledger semantics into shared helpers and refactor providers

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 import sys
-import secrets
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional
 from urllib.parse import urljoin
 
 if "stripe" in sys.modules:
@@ -41,6 +41,8 @@ from app.services.billing_shared import (
     ddb_query_pk,
     ddb_update,
     ensure_balance_row,
+    new_ledger_entry,
+    settle_or_reverse_ledger,
     user_pk,
 )
 from app.services.profile import get_profile
@@ -48,6 +50,7 @@ from app.services.purchase_history import mark_completed, mark_reverted, record_
 from app.services.ttl import with_ttl
 
 router = APIRouter(tags=["billing"])
+logger = logging.getLogger(__name__)
 
 
 def dual_route(methods: str | Iterable[str], path: str, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
@@ -78,10 +81,6 @@ def build_return_url(req: Request, fallback_query: str) -> str:
     return urljoin(str(req.base_url), fallback_query)
 
 
-def ulidish() -> str:
-    return f"{int(now_ts() * 1000)}_{secrets.token_hex(8)}"
-
-
 def get_or_create_customer(user_id: str) -> str:
     pk = user_pk(user_id)
     try:
@@ -98,8 +97,12 @@ def get_or_create_customer(user_id: str) -> str:
         if customer_payload:
             try:
                 stripe.Customer.modify(prof["stripe_customer_id"], **customer_payload)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(
+                    "Stripe customer update failed",
+                    extra={"user_id": user_id, "stripe_customer_id": prof.get("stripe_customer_id")},
+                    exc_info=exc,
+                )
         return prof["stripe_customer_id"]
 
     cust = stripe.Customer.create(metadata={"app_user_id": user_id}, **customer_payload)
@@ -113,47 +116,6 @@ def user_id_from_customer(customer_id: str) -> Optional[str]:
         return cust.get("metadata", {}).get("app_user_id")
     except Exception:
         return None
-
-
-def ledger_sk(ts: int, entry_id: str) -> str:
-    return f"LEDGER#{ts}#{entry_id}"
-
-
-def new_ledger_entry(
-    user_id: str,
-    entry_type: str,
-    amount_cents: int,
-    state: str,
-    reason: str,
-    stripe_payment_intent_id: Optional[str] = None,
-    stripe_charge_id: Optional[str] = None,
-    meta: Optional[Dict[str, Any]] = None,
-) -> Tuple[str, Dict[str, Any]]:
-    ts = now_ts()
-    entry_id = ulidish()
-    sk = ledger_sk(ts, entry_id)
-    item = {
-        "pk": user_pk(user_id),
-        "sk": sk,
-        "entry_id": entry_id,
-        "ts": ts,
-        "type": entry_type,
-        "amount_cents": int(amount_cents),
-        "state": state,
-        "reason": reason,
-    }
-    if stripe_payment_intent_id:
-        item["stripe_payment_intent_id"] = stripe_payment_intent_id
-    if stripe_charge_id:
-        item["stripe_charge_id"] = stripe_charge_id
-    if meta:
-        item["meta"] = meta
-    return sk, item
-
-
-def settle_or_reverse_ledger(user_id: str, ledger_sk_value: str, new_state: str) -> None:
-    pk = user_pk(user_id)
-    ddb_update(T.billing, pk, ledger_sk_value, "SET #s = :s", {":s": new_state}, names={"#s": "state"})
 
 
 def pay_sk(payment_intent_id: str) -> str:
@@ -501,19 +463,20 @@ def pay_balance(body: PayBalanceReq, req: Request = None, ctx=Depends(require_ui
         pass
 
     led_sk, led_item = new_ledger_entry(
-        user_id=user_id,
+        key_name="pk",
+        key_value=pk,
         entry_type="credit",
         amount_cents=amount,
         state="pending" if pi.get("status") in ("processing", "requires_action") else ("settled" if pi.get("status") == "succeeded" else "pending"),
         reason="payment",
-        stripe_payment_intent_id=pi["id"],
         meta={"idempotency_key": idem},
+        extra={"stripe_payment_intent_id": pi["id"]},
     )
     ddb_put(T.billing, led_item)
 
     if pi.get("status") == "succeeded":
         apply_balance_delta(T.billing, pk, {"payments_settled_cents": amount}, currency=billing.get("currency", "usd"))
-        settle_or_reverse_ledger(user_id, led_sk, "settled")
+        settle_or_reverse_ledger(T.billing, "pk", pk, led_sk, "settled")
     else:
         apply_balance_delta(T.billing, pk, {"payments_pending_cents": amount}, currency=billing.get("currency", "usd"))
 
@@ -597,19 +560,20 @@ def charge_once(body: StripeChargeReq, req: Request = None, ctx=Depends(require_
         state = "pending"
 
     led_sk, led_item = new_ledger_entry(
-        user_id=user_id,
+        key_name="pk",
+        key_value=pk,
         entry_type="credit",
         amount_cents=int(body.amount_cents),
         state=state,
         reason="charge_once",
-        stripe_payment_intent_id=pi["id"],
         meta={"idempotency_key": idem, "payment_method_id": payment_method_id},
+        extra={"stripe_payment_intent_id": pi["id"]},
     )
     ddb_put(T.billing, led_item)
 
     if pi.get("status") == "succeeded":
         apply_balance_delta(T.billing, pk, {"payments_settled_cents": int(body.amount_cents)}, currency=billing.get("currency", "usd"))
-        settle_or_reverse_ledger(user_id, led_sk, "settled")
+        settle_or_reverse_ledger(T.billing, "pk", pk, led_sk, "settled")
     else:
         apply_balance_delta(T.billing, pk, {"payments_pending_cents": int(body.amount_cents)}, currency=billing.get("currency", "usd"))
 
@@ -802,7 +766,7 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
             if pay.get("status") in ("processing", "requires_action"):
                 apply_balance_delta(T.billing, pk, {"payments_pending_cents": -amount, "payments_settled_cents": amount}, currency=pay.get("currency", "usd"))
             if led_sk_value:
-                settle_or_reverse_ledger(user_id, led_sk_value, "settled")
+                settle_or_reverse_ledger(T.billing, "pk", pk, led_sk_value, "settled")
             audit_event(
                 "billing_payment_intent_update",
                 user_id,
@@ -829,7 +793,7 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
             elif pay.get("status") == "succeeded":
                 apply_balance_delta(T.billing, pk, {"payments_settled_cents": -amount}, currency=pay.get("currency", "usd"))
             if led_sk_value:
-                settle_or_reverse_ledger(user_id, led_sk_value, "reversed")
+                settle_or_reverse_ledger(T.billing, "pk", pk, led_sk_value, "reversed")
             audit_event(
                 "billing_payment_intent_update",
                 user_id,
@@ -857,7 +821,7 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
             elif pay.get("status") == "succeeded":
                 apply_balance_delta(T.billing, pk, {"payments_settled_cents": -amount}, currency=pay.get("currency", "usd"))
             if led_sk_value:
-                settle_or_reverse_ledger(user_id, led_sk_value, "reversed")
+                settle_or_reverse_ledger(T.billing, "pk", pk, led_sk_value, "reversed")
             audit_event(
                 "billing_payment_intent_update",
                 user_id,
@@ -902,14 +866,14 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
 
         if event_type == "charge.dispute.funds_withdrawn":
             led_sk_value, led_item = new_ledger_entry(
-                user_id=user_id,
+                key_name="pk",
+                key_value=pk,
                 entry_type="adjustment",
                 amount_cents=amount,
                 state="settled",
                 reason="dispute_funds_withdrawn",
-                stripe_charge_id=charge_id,
-                stripe_payment_intent_id=pi_id,
                 meta={"currency": currency, "dispute_id": dispute.get("id")},
+                extra={"stripe_charge_id": charge_id, "stripe_payment_intent_id": pi_id},
             )
             ddb_put(T.billing, led_item)
             apply_balance_delta(T.billing, pk, {"owed_settled_cents": amount}, currency=currency)
@@ -927,14 +891,14 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
 
         elif event_type == "charge.dispute.funds_reinstated":
             led_sk_value, led_item = new_ledger_entry(
-                user_id=user_id,
+                key_name="pk",
+                key_value=pk,
                 entry_type="adjustment",
                 amount_cents=amount,
                 state="settled",
                 reason="dispute_funds_reinstated",
-                stripe_charge_id=charge_id,
-                stripe_payment_intent_id=pi_id,
                 meta={"currency": currency, "dispute_id": dispute.get("id")},
+                extra={"stripe_charge_id": charge_id, "stripe_payment_intent_id": pi_id},
             )
             ddb_put(T.billing, led_item)
             apply_balance_delta(T.billing, pk, {"owed_settled_cents": -amount}, currency=currency)
@@ -960,7 +924,8 @@ def dev_add_charge(body: AddChargeReq, ctx=Depends(require_ui_session)) -> Dict[
     ensure_balance_row(T.billing, pk, S.stripe_default_currency or "usd")
 
     led_sk_value, led_item = new_ledger_entry(
-        user_id=user_id,
+        key_name="pk",
+        key_value=pk,
         entry_type="debit",
         amount_cents=int(body.amount_cents),
         state=body.state,

--- a/app/services/billing_ccbill.py
+++ b/app/services/billing_ccbill.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ipaddress
 import json
-import secrets
 import time
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Dict, List, Optional, Tuple
@@ -15,13 +14,13 @@ from app.core.normalize import client_ip_from_request
 from app.core.settings import S
 from app.core.tables import T
 from app.core.time import now_ts
-
-BAL_FIELDS = [
-    "owed_pending_cents",
-    "owed_settled_cents",
-    "payments_pending_cents",
-    "payments_settled_cents",
-]
+from app.services.billing_shared import (
+    apply_balance_delta_for_key,
+    compute_due as compute_due_shared,
+    ensure_balance_row_for_key,
+    new_ledger_entry as new_ledger_entry_shared,
+    settle_or_reverse_ledger as settle_or_reverse_ledger_shared,
+)
 
 CCBILL_WEBHOOK_IP_RANGES = [
     ("64.38.212.0", "64.38.212.255"),
@@ -31,10 +30,67 @@ CCBILL_WEBHOOK_IP_RANGES = [
 ]
 
 _OAUTH_CACHE: Dict[str, Tuple[str, int]] = {}
+_REDACTED_VALUE = "[REDACTED]"
+_ALLOWED_RAW_KEYS = {
+    "approved",
+    "transactionId",
+    "paymentUniqueId",
+    "transaction_id",
+    "subscriptionId",
+    "subscription_id",
+    "eventType",
+    "responseCode",
+    "errorCode",
+    "message",
+    "reason",
+    "status",
+    "type",
+    "amount",
+    "currencyCode",
+    "payload",
+    "q",
+}
+_SENSITIVE_KEY_FRAGMENTS = (
+    "card",
+    "cvv",
+    "cvc",
+    "security",
+    "password",
+    "email",
+    "address",
+    "ip",
+    "phone",
+    "name",
+    "ssn",
+    "bank",
+    "routing",
+    "acct",
+)
 
 
-def _ulidish() -> str:
-    return f"{int(time.time() * 1000)}_{secrets.token_hex(8)}"
+def _is_sensitive_key(key: str) -> bool:
+    key_lower = key.lower()
+    return any(fragment in key_lower for fragment in _SENSITIVE_KEY_FRAGMENTS)
+
+
+def _sanitize_ccbill_raw(raw: Any) -> Any:
+    if isinstance(raw, dict):
+        sanitized: Dict[str, Any] = {}
+        for key, value in raw.items():
+            if key not in _ALLOWED_RAW_KEYS:
+                continue
+            if _is_sensitive_key(key):
+                sanitized[key] = _REDACTED_VALUE
+            elif key in {"payload", "q"}:
+                sanitized[key] = _sanitize_ccbill_raw(value)
+            else:
+                sanitized[key] = _sanitize_ccbill_raw(value)
+        return sanitized
+    if isinstance(raw, list):
+        return [_sanitize_ccbill_raw(item) for item in raw]
+    if isinstance(raw, (str, int, float, bool)) or raw is None:
+        return raw
+    return str(raw)
 
 
 def _billing_sk(kind: str, identifier: str) -> str:
@@ -42,61 +98,15 @@ def _billing_sk(kind: str, identifier: str) -> str:
 
 
 def ensure_balance_row(user_sub: str) -> None:
-    it = T.billing.get_item(Key={"user_sub": user_sub, "sk": "BALANCE"}).get("Item")
-    if not it:
-        T.billing.put_item(Item={
-            "user_sub": user_sub,
-            "sk": "BALANCE",
-            "currency": S.default_currency,
-            **{k: 0 for k in BAL_FIELDS},
-            "updated_at": now_ts(),
-        })
+    ensure_balance_row_for_key(T.billing, "user_sub", user_sub, S.default_currency)
 
 
 def apply_balance_delta(user_sub: str, delta: Dict[str, int]) -> None:
-    ensure_balance_row(user_sub)
-    sets = []
-    values: Dict[str, Any] = {":z": 0, ":t": now_ts()}
-    names: Dict[str, str] = {}
-
-    i = 0
-    for k, v in delta.items():
-        if v == 0:
-            continue
-        i += 1
-        nk = f"#k{i}"
-        dv = f":d{i}"
-        names[nk] = k
-        values[dv] = int(v)
-        sets.append(f"{nk} = if_not_exists({nk}, :z) + {dv}")
-
-    names["#u"] = "updated_at"
-    sets.append("#u = :t")
-    expr = "SET " + ", ".join(sets)
-    T.billing.update_item(
-        Key={"user_sub": user_sub, "sk": "BALANCE"},
-        UpdateExpression=expr,
-        ExpressionAttributeNames=names,
-        ExpressionAttributeValues=values,
-    )
+    apply_balance_delta_for_key(T.billing, "user_sub", user_sub, delta, currency=S.default_currency)
 
 
 def compute_due(balance_item: Dict[str, Any]) -> Dict[str, int]:
-    owed_settled = int(balance_item.get("owed_settled_cents", 0))
-    owed_pending = int(balance_item.get("owed_pending_cents", 0))
-    pay_settled = int(balance_item.get("payments_settled_cents", 0))
-    pay_pending = int(balance_item.get("payments_pending_cents", 0))
-
-    due_settled = owed_settled - pay_settled
-    due_if_all_settles = (owed_settled + owed_pending) - (pay_settled + pay_pending)
-    return {
-        "due_settled_cents": due_settled,
-        "due_if_all_settles_cents": due_if_all_settles,
-    }
-
-
-def ledger_sk(ts: int, entry_id: str) -> str:
-    return f"LEDGER#{ts}#{entry_id}"
+    return compute_due_shared(balance_item)
 
 
 def new_ledger_entry(
@@ -110,37 +120,27 @@ def new_ledger_entry(
     ccbill_subscription_id: Optional[str] = None,
     meta: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, Dict[str, Any]]:
-    ts = now_ts()
-    eid = _ulidish()
-    sk = ledger_sk(ts, eid)
-    item = {
-        "user_sub": user_sub,
-        "sk": sk,
-        "entry_id": eid,
-        "ts": ts,
-        "type": entry_type,
-        "amount_cents": int(amount_cents),
-        "state": state,
-        "reason": reason,
-    }
+    extra: Dict[str, Any] = {}
     if ccbill_payment_token_id:
-        item["ccbill_payment_token_id"] = ccbill_payment_token_id
+        extra["ccbill_payment_token_id"] = ccbill_payment_token_id
     if ccbill_transaction_id:
-        item["ccbill_transaction_id"] = ccbill_transaction_id
+        extra["ccbill_transaction_id"] = ccbill_transaction_id
     if ccbill_subscription_id:
-        item["ccbill_subscription_id"] = ccbill_subscription_id
-    if meta:
-        item["meta"] = meta
-    return sk, item
+        extra["ccbill_subscription_id"] = ccbill_subscription_id
+    return new_ledger_entry_shared(
+        key_name="user_sub",
+        key_value=user_sub,
+        entry_type=entry_type,
+        amount_cents=amount_cents,
+        state=state,
+        reason=reason,
+        meta=meta,
+        extra=extra or None,
+    )
 
 
 def settle_or_reverse_ledger(user_sub: str, ledger_sk_value: str, new_state: str) -> None:
-    T.billing.update_item(
-        Key={"user_sub": user_sub, "sk": ledger_sk_value},
-        UpdateExpression="SET #s = :s",
-        ExpressionAttributeNames={"#s": "state"},
-        ExpressionAttributeValues={":s": new_state},
-    )
+    settle_or_reverse_ledger_shared(T.billing, "user_sub", user_sub, ledger_sk_value, new_state)
 
 
 def put_payment_record(
@@ -169,7 +169,7 @@ def put_payment_record(
         "updated_at": now_ts(),
     }
     if raw:
-        item["raw"] = raw
+        item["raw"] = _sanitize_ccbill_raw(raw)
     T.billing.put_item(Item=item)
 
 
@@ -179,7 +179,7 @@ def update_payment_status(user_sub: str, transaction_id: str, status: str, raw: 
     sets = ["#st = :st", "#u = :u"]
     if raw is not None:
         names["#r"] = "raw"
-        values[":r"] = raw
+        values[":r"] = _sanitize_ccbill_raw(raw)
         sets.append("#r = :r")
     T.billing.update_item(
         Key={"user_sub": user_sub, "sk": _billing_sk("PAY", transaction_id)},
@@ -217,7 +217,7 @@ def upsert_subscription(
     if last_transaction_id:
         item["last_transaction_id"] = last_transaction_id
     if raw:
-        item["raw"] = raw
+        item["raw"] = _sanitize_ccbill_raw(raw)
     T.billing.put_item(Item=item)
 
 
@@ -555,4 +555,3 @@ def _get_default_token_or_400(user_sub: str) -> str:
     if not token:
         raise HTTPException(400, "No default payment method set")
     return token
-

--- a/app/services/billing_shared.py
+++ b/app/services/billing_shared.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import secrets
+from typing import Any, Dict, List, Optional, Tuple
 
 from app.core.time import now_ts
 
@@ -97,6 +98,56 @@ def apply_balance_delta(table: Any, pk: str, delta: Dict[str, int], *, currency:
     ddb_update(table, pk, "BALANCE", expr, values, names=names)
 
 
+def ensure_balance_row_for_key(table: Any, key_name: str, key_value: str, currency: str) -> None:
+    if not table.get_item(Key={key_name: key_value, "sk": "BALANCE"}).get("Item"):
+        table.put_item(
+            Item={
+                key_name: key_value,
+                "sk": "BALANCE",
+                "currency": currency,
+                **{k: 0 for k in BAL_FIELDS},
+                "updated_at": now_ts(),
+            },
+        )
+
+
+def apply_balance_delta_for_key(
+    table: Any,
+    key_name: str,
+    key_value: str,
+    delta: Dict[str, int],
+    *,
+    currency: str = "usd",
+) -> None:
+    ensure_balance_row_for_key(table, key_name, key_value, currency)
+
+    sets = []
+    values: Dict[str, Any] = {":z": 0, ":t": now_ts()}
+    names: Dict[str, str] = {}
+
+    i = 0
+    for key, value in delta.items():
+        if value == 0:
+            continue
+        i += 1
+        nk = f"#k{i}"
+        dv = f":d{i}"
+        names[nk] = key
+        values[dv] = int(value)
+        sets.append(f"{nk} = if_not_exists({nk}, :z) + {dv}")
+
+    names["#u"] = "updated_at"
+    sets.append("#u = :t")
+
+    expr = "SET " + ", ".join(sets)
+    table.update_item(
+        Key={key_name: key_value, "sk": "BALANCE"},
+        UpdateExpression=expr,
+        ExpressionAttributeValues=values,
+        ExpressionAttributeNames=names,
+    )
+
+
 def compute_due(balance_item: Dict[str, Any]) -> Dict[str, int]:
     owed_settled = int(balance_item.get("owed_settled_cents", 0))
     owed_pending = int(balance_item.get("owed_pending_cents", 0))
@@ -110,3 +161,57 @@ def compute_due(balance_item: Dict[str, Any]) -> Dict[str, int]:
         "due_settled_cents": due_settled,
         "due_if_all_settles_cents": due_if_all_settles,
     }
+
+
+def ulidish() -> str:
+    return f"{int(now_ts() * 1000)}_{secrets.token_hex(8)}"
+
+
+def ledger_sk(ts: int, entry_id: str) -> str:
+    return f"LEDGER#{ts}#{entry_id}"
+
+
+def new_ledger_entry(
+    *,
+    key_name: str,
+    key_value: str,
+    entry_type: str,
+    amount_cents: int,
+    state: str,
+    reason: str,
+    meta: Optional[Dict[str, Any]] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, Dict[str, Any]]:
+    ts = now_ts()
+    entry_id = ulidish()
+    sk = ledger_sk(ts, entry_id)
+    item = {
+        key_name: key_value,
+        "sk": sk,
+        "entry_id": entry_id,
+        "ts": ts,
+        "type": entry_type,
+        "amount_cents": int(amount_cents),
+        "state": state,
+        "reason": reason,
+    }
+    if extra:
+        item.update(extra)
+    if meta:
+        item["meta"] = meta
+    return sk, item
+
+
+def settle_or_reverse_ledger(
+    table: Any,
+    key_name: str,
+    key_value: str,
+    ledger_sk_value: str,
+    new_state: str,
+) -> None:
+    table.update_item(
+        Key={key_name: key_value, "sk": ledger_sk_value},
+        UpdateExpression="SET #s = :s",
+        ExpressionAttributeNames={"#s": "state"},
+        ExpressionAttributeValues={":s": new_state},
+    )


### PR DESCRIPTION
### Motivation
- Reduce duplication and drift between Stripe and CCBill provider implementations by centralizing ledger and balance semantics into a provider-agnostic core.
- Make ledger entry creation, settlement/reversal, and balance updates consistent across providers to simplify future provider adapters and audits.
- Improve observability by keeping the Stripe customer update logging change previously requested.

### Description
- Add a shared billing core in `app/services/billing_shared.py` with multi-key balance helpers and unified ledger helpers: `ensure_balance_row_for_key`, `apply_balance_delta_for_key`, `ulidish`, `ledger_sk`, `new_ledger_entry`, and `settle_or_reverse_ledger`, plus existing DDB helpers (`ddb_get`, `ddb_put`, `ddb_update`, etc.).
- Refactor Stripe plumbing in `app/routers/billing.py` to call the shared `new_ledger_entry` and `settle_or_reverse_ledger` (now using `key_name='pk'` / `key_value=pk`) and add back a structured warning log when `stripe.Customer.modify` fails.
- Refactor CCBill implementation in `app/services/billing_ccbill.py` to delegate balance and ledger behaviors to the shared core (`ensure_balance_row_for_key`, `apply_balance_delta_for_key`, `compute_due` and shared `new_ledger_entry` / `settle_or_reverse_ledger`) and keep provider-specific metadata via `extra` fields.
- Harden CCBill raw payload handling by applying an allowlist/redaction sanitizer (`_sanitize_ccbill_raw`) before persisting raw webhook or API payloads.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d56533574832baa2a6f8a3a45468e)