### PR TITLE
Implement calendar and event update/delete flows (PATCH & DELETE)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -418,6 +418,11 @@ class CalendarOut(BaseModel):
     created_at_utc: str
 
 
+class CalendarUpdateIn(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    timezone: str | None = Field(default=None, max_length=64)
+
+
 class EventCreateIn(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     description: str = Field(default="", max_length=5000)
@@ -441,7 +446,23 @@ class EventOut(BaseModel):
     created_at_utc: str
 
 
+class EventUpdateIn(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
+    timezone: str | None = Field(default=None, max_length=64)
+    start_utc: str | None = None
+    end_utc: str | None = None
+    all_day: bool | None = None
+    all_day_date: str | None = None
+
+
 class OpeningsOut(BaseModel):
+    start_utc: str
+    end_utc: str
+
+
+class TeamAvailabilityIn(BaseModel):
+    calendar_ids: List[str] = Field(min_length=1)
     start_utc: str
     end_utc: str
 

--- a/app/routers/calendar.py
+++ b/app/routers/calendar.py
@@ -8,7 +8,16 @@ from boto3.dynamodb.conditions import Key
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.core.tables import T
-from app.models import CalendarCreateIn, CalendarOut, EventCreateIn, EventOut, OpeningsOut
+from app.models import (
+    CalendarCreateIn,
+    CalendarOut,
+    CalendarUpdateIn,
+    EventCreateIn,
+    EventOut,
+    EventUpdateIn,
+    OpeningsOut,
+    TeamAvailabilityIn,
+)
 from app.services.sessions import require_ui_session
 
 try:
@@ -81,6 +90,14 @@ def invert_intervals(busy: list[tuple[datetime, datetime]], start: datetime, end
     return free
 
 
+def parse_availability_window(start_utc: str, end_utc: str) -> tuple[datetime, datetime]:
+    window_start = parse_iso_dt(start_utc)
+    window_end = parse_iso_dt(end_utc)
+    if window_end <= window_start:
+        raise HTTPException(status_code=400, detail="end_utc must be after start_utc")
+    return window_start, window_end
+
+
 def _calendar_keys(calendar_id: str) -> Dict[str, str]:
     return {"calendar_id": calendar_id, "sk": "meta"}
 
@@ -89,13 +106,24 @@ def _event_key(event_id: str) -> str:
     return f"event#{event_id}"
 
 
-def _normalize_event_times(calendar_tz: str, payload: EventCreateIn) -> Dict[str, Any]:
+def _load_event(calendar_id: str, event_id: str) -> Dict[str, Any]:
+    item = T.calendar.get_item(Key={"calendar_id": calendar_id, "sk": _event_key(event_id)}).get("Item")
+    if not item:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return item
+
+
+def _validate_timezone(tz_name: str) -> None:
     _require_zoneinfo()
-    tz_name = payload.timezone or calendar_tz
     try:
         ZoneInfo(tz_name)
     except Exception as exc:
         raise HTTPException(status_code=400, detail="Invalid timezone") from exc
+
+
+def _normalize_event_times(calendar_tz: str, payload: EventCreateIn) -> Dict[str, Any]:
+    tz_name = payload.timezone or calendar_tz
+    _validate_timezone(tz_name)
 
     if payload.all_day:
         if not payload.all_day_date:
@@ -225,6 +253,81 @@ async def list_events(calendar_id: str, ctx: Dict[str, str] = Depends(require_ui
     return [_event_out(item, calendar_id) for item in _list_events(calendar_id)]
 
 
+@router.patch("/calendars/{calendar_id}", response_model=CalendarOut)
+async def update_calendar(
+    calendar_id: str,
+    body: CalendarUpdateIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    name = body.name if body.name is not None else meta.get("name", "")
+    timezone_name = body.timezone if body.timezone is not None else meta.get("timezone", "UTC")
+    if body.timezone is not None:
+        _validate_timezone(timezone_name)
+    updated = {**meta, "name": name, "timezone": timezone_name}
+    T.calendar.put_item(Item=updated)
+    return CalendarOut(
+        calendar_id=calendar_id,
+        name=updated["name"],
+        timezone=updated["timezone"],
+        owner_user_id=updated["owner_user_sub"],
+        created_at_utc=updated.get("created_at_utc", ""),
+    )
+
+
+@router.patch("/calendars/{calendar_id}/events/{event_id}", response_model=EventOut)
+async def update_event(
+    calendar_id: str,
+    event_id: str,
+    body: EventUpdateIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    item = _load_event(calendar_id, event_id)
+    payload = EventCreateIn(
+        name=body.name if body.name is not None else item["name"],
+        description=body.description if body.description is not None else item.get("description", ""),
+        timezone=body.timezone if body.timezone is not None else item.get("timezone"),
+        start_utc=body.start_utc if body.start_utc is not None else item.get("start_utc"),
+        end_utc=body.end_utc if body.end_utc is not None else item.get("end_utc"),
+        all_day=body.all_day if body.all_day is not None else item.get("all_day", False),
+        all_day_date=body.all_day_date if body.all_day_date is not None else item.get("all_day_date"),
+    )
+    normalized = _normalize_event_times(meta["timezone"], payload)
+    updated = {
+        **item,
+        "name": payload.name,
+        "description": payload.description,
+        **normalized,
+    }
+    T.calendar.put_item(Item=updated)
+    return _event_out(updated, calendar_id)
+
+
+@router.delete("/calendars/{calendar_id}/events/{event_id}")
+async def delete_event(
+    calendar_id: str,
+    event_id: str,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _load_calendar(calendar_id, ctx["user_sub"])
+    _load_event(calendar_id, event_id)
+    T.calendar.delete_item(Key={"calendar_id": calendar_id, "sk": _event_key(event_id)})
+    return {"ok": True}
+
+
+@router.delete("/calendars/{calendar_id}")
+async def delete_calendar(calendar_id: str, ctx: Dict[str, str] = Depends(require_ui_session)):
+    _load_calendar(calendar_id, ctx["user_sub"])
+    events = _list_events(calendar_id)
+    with T.calendar.batch_writer() as batch:
+        batch.delete_item(Key={"calendar_id": calendar_id, "sk": "meta"})
+        for event in events:
+            event_sk = event.get("sk") or _event_key(event["event_id"])
+            batch.delete_item(Key={"calendar_id": calendar_id, "sk": event_sk})
+    return {"ok": True}
+
+
 @router.get("/calendars/{calendar_id}/openings", response_model=list[OpeningsOut])
 async def list_openings(
     calendar_id: str,
@@ -233,10 +336,20 @@ async def list_openings(
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
     _load_calendar(calendar_id, ctx["user_sub"])
-    window_start = parse_iso_dt(start_utc)
-    window_end = parse_iso_dt(end_utc)
-    if window_end <= window_start:
-        raise HTTPException(status_code=400, detail="end_utc must be after start_utc")
+    window_start, window_end = parse_availability_window(start_utc, end_utc)
     busy = [_event_to_busy_interval(event) for event in _list_events(calendar_id)]
+    free = invert_intervals(busy, window_start, window_end)
+    return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in free]
+
+
+@router.post("/calendars/availability", response_model=list[OpeningsOut])
+async def list_team_openings(body: TeamAvailabilityIn, ctx: Dict[str, str] = Depends(require_ui_session)):
+    window_start, window_end = parse_availability_window(body.start_utc, body.end_utc)
+    if not body.calendar_ids:
+        raise HTTPException(status_code=400, detail="calendar_ids is required")
+    busy: list[tuple[datetime, datetime]] = []
+    for calendar_id in body.calendar_ids:
+        _load_calendar(calendar_id, ctx["user_sub"])
+        busy.extend(_event_to_busy_interval(event) for event in _list_events(calendar_id))
     free = invert_intervals(busy, window_start, window_end)
     return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in free]

--- a/tests/test_calendar_routes.py
+++ b/tests/test_calendar_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 from fastapi import HTTPException
@@ -23,6 +23,41 @@ def build_calendar_table(meta: dict | None = None, events: list[dict] | None = N
     table = Mock()
     table.get_item.return_value = {"Item": meta} if meta else {}
     table.query.return_value = {"Items": events or []}
+    return table
+
+
+def build_calendar_table_with_event(meta: dict, event: dict | None) -> Mock:
+    table = Mock()
+    table.get_item.side_effect = [
+        {"Item": meta},
+        {"Item": event} if event else {},
+    ]
+    table.query.return_value = {"Items": []}
+    return table
+
+
+def build_calendar_table_with_batch(meta: dict, events: list[dict]) -> Mock:
+    table = Mock()
+    table.get_item.return_value = {"Item": meta}
+    table.query.return_value = {"Items": events}
+    batch = Mock()
+    batch.__enter__ = Mock(return_value=batch)
+    batch.__exit__ = Mock(return_value=None)
+    table.batch_writer.return_value = batch
+    return table
+
+
+def build_calendar_table_map(metas: dict[str, dict], events_sequence: list[list[dict]]) -> Mock:
+    table = Mock()
+
+    def get_item_side_effect(**kwargs):
+        key = kwargs.get("Key", {})
+        calendar_id = key.get("calendar_id")
+        meta = metas.get(calendar_id)
+        return {"Item": meta} if meta else {}
+
+    table.get_item.side_effect = get_item_side_effect
+    table.query.side_effect = [{"Items": events} for events in events_sequence]
     return table
 
 
@@ -218,3 +253,147 @@ def test_openings_rejects_invalid_window():
                 end_utc="2024-01-01T09:00:00Z",
                 ctx=build_ctx(),
             ))
+
+
+def test_team_openings_merge_multiple_calendars():
+    metas = {
+        "cal1": {"calendar_id": "cal1", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"},
+        "cal2": {"calendar_id": "cal2", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"},
+    }
+    events_sequence = [
+        [
+            {
+                "event_id": "evt1",
+                "name": "Standup",
+                "timezone": "UTC",
+                "start_utc": "2024-04-01T10:00:00Z",
+                "end_utc": "2024-04-01T11:00:00Z",
+                "all_day": False,
+            },
+        ],
+        [
+            {
+                "event_id": "evt2",
+                "name": "Review",
+                "timezone": "UTC",
+                "start_utc": "2024-04-01T12:00:00Z",
+                "end_utc": "2024-04-01T13:30:00Z",
+                "all_day": False,
+            },
+        ],
+    ]
+    table = build_calendar_table_map(metas=metas, events_sequence=events_sequence)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        openings = run_async(calendar_router.list_team_openings(
+            body=calendar_router.TeamAvailabilityIn(
+                calendar_ids=["cal1", "cal2"],
+                start_utc="2024-04-01T09:00:00Z",
+                end_utc="2024-04-01T15:00:00Z",
+            ),
+            ctx=build_ctx(),
+        ))
+
+    assert [(o.start_utc, o.end_utc) for o in openings] == [
+        ("2024-04-01T09:00:00Z", "2024-04-01T10:00:00Z"),
+        ("2024-04-01T11:00:00Z", "2024-04-01T12:00:00Z"),
+        ("2024-04-01T13:30:00Z", "2024-04-01T15:00:00Z"),
+    ]
+
+
+def test_update_calendar_changes_name_and_timezone():
+    meta = {
+        "calendar_id": "cal123",
+        "sk": "meta",
+        "owner_user_sub": "user",
+        "timezone": "UTC",
+        "name": "Old",
+        "created_at_utc": "2024-01-01T00:00:00Z",
+    }
+    table = build_calendar_table(meta=meta)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        resp = run_async(calendar_router.update_calendar(
+            "cal123",
+            calendar_router.CalendarUpdateIn(name="New", timezone="UTC"),
+            ctx=build_ctx(),
+        ))
+
+    assert resp.name == "New"
+    assert resp.timezone == "UTC"
+    table.put_item.assert_called_once()
+
+
+def test_update_event_updates_times():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    event = {
+        "calendar_id": "cal123",
+        "sk": "event#evt1",
+        "event_id": "evt1",
+        "name": "Standup",
+        "description": "Daily sync",
+        "timezone": "UTC",
+        "start_utc": "2024-01-01T10:00:00Z",
+        "end_utc": "2024-01-01T11:00:00Z",
+        "all_day": False,
+        "created_at_utc": "2024-01-01T08:00:00Z",
+    }
+    table = build_calendar_table_with_event(meta=meta, event=event)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        resp = run_async(calendar_router.update_event(
+            "cal123",
+            "evt1",
+            calendar_router.EventUpdateIn(start_utc="2024-01-01T12:00:00Z", end_utc="2024-01-01T13:00:00Z"),
+            ctx=build_ctx(),
+        ))
+
+    assert resp.start_utc == "2024-01-01T12:00:00Z"
+    assert resp.end_utc == "2024-01-01T13:00:00Z"
+    table.put_item.assert_called_once()
+
+
+def test_delete_event_removes_item():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    event = {
+        "calendar_id": "cal123",
+        "sk": "event#evt1",
+        "event_id": "evt1",
+        "name": "Standup",
+        "timezone": "UTC",
+        "start_utc": "2024-01-01T10:00:00Z",
+        "end_utc": "2024-01-01T11:00:00Z",
+        "all_day": False,
+    }
+    table = build_calendar_table_with_event(meta=meta, event=event)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        resp = run_async(calendar_router.delete_event("cal123", "evt1", ctx=build_ctx()))
+
+    assert resp == {"ok": True}
+    table.delete_item.assert_called_once_with(Key={"calendar_id": "cal123", "sk": "event#evt1"})
+
+
+def test_delete_calendar_removes_meta_and_events():
+    meta = {"calendar_id": "cal123", "sk": "meta", "owner_user_sub": "user", "timezone": "UTC"}
+    events = [
+        {
+            "calendar_id": "cal123",
+            "sk": "event#evt1",
+            "event_id": "evt1",
+            "name": "Standup",
+            "timezone": "UTC",
+            "start_utc": "2024-01-01T10:00:00Z",
+            "end_utc": "2024-01-01T11:00:00Z",
+            "all_day": False,
+        },
+    ]
+    table = build_calendar_table_with_batch(meta=meta, events=events)
+    with patch.object(calendar_router, "T", SimpleNamespace(calendar=table)):
+        resp = run_async(calendar_router.delete_calendar("cal123", ctx=build_ctx()))
+
+    assert resp == {"ok": True}
+    table.batch_writer.assert_called_once()
+    table.batch_writer.return_value.delete_item.assert_has_calls(
+        [
+            call(Key={"calendar_id": "cal123", "sk": "meta"}),
+            call(Key={"calendar_id": "cal123", "sk": "event#evt1"}),
+        ],
+        any_order=True,
+    )


### PR DESCRIPTION
### Motivation
- Expose missing lifecycle operations so clients can partially update calendars and events and remove calendars or events.  
- Ensure timezone validation is applied when updating calendars/events to avoid invalid zone names.  
- Add a team availability endpoint to compute openings across multiple calendars.

### Description
- Added input models `CalendarUpdateIn`, `EventUpdateIn`, and `TeamAvailabilityIn` to `app/models.py` to support partial updates and team availability requests.  
- Implemented `_load_event` and `_validate_timezone` helpers and refactored `_normalize_event_times` to validate/normalize event times during updates.  
- Added `PATCH /calendars/{calendar_id}` and `PATCH /calendars/{calendar_id}/events/{event_id}` endpoints that validate ownership/timezones, normalize times, and `put_item` updated records.  
- Added `DELETE /calendars/{calendar_id}` which uses `T.calendar.batch_writer()` to remove the calendar meta record and all associated events, and added `list_team_openings` for multi-calendar availability queries.

### Testing
- Ran `pytest -q tests/test_calendar_routes.py` and all tests passed: `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d56707464832b96ea12e9bf9dfdbf)