### PR TITLE
Add billing dunning worker: autopay retries, notifications and webhook hardening

### DIFF
--- a/app/core/normalize.py
+++ b/app/core/normalize.py
@@ -7,6 +7,8 @@ from typing import List
 from fastapi import HTTPException
 
 def client_ip_from_request(req) -> str:
+    if req is None:
+        return "0.0.0.0"
     xff = req.headers.get("x-forwarded-for")
     if xff:
         for part in xff.split(","):

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -106,6 +106,9 @@ class Settings:
     default_currency_code: int = int(os.environ.get("DEFAULT_CURRENCY_CODE", "840"))
     default_currency: str = os.environ.get("DEFAULT_CURRENCY", "usd")
     ccbill_webhook_ip_enforce: bool = os.environ.get("CCBILL_WEBHOOK_IP_ENFORCE", "false").lower() == "true"
+    ccbill_webhook_ip_ranges: str = os.environ.get("CCBILL_WEBHOOK_IP_RANGES", "")
+    ccbill_webhook_signature_secret: str = os.environ.get("CCBILL_WEBHOOK_SIGNATURE_SECRET", "")
+    ccbill_webhook_signature_header: str = os.environ.get("CCBILL_WEBHOOK_SIGNATURE_HEADER", "x-ccbill-signature")
     # Billing / PayPal
     billing_table_name: str = os.environ.get("BILLING_TABLE_NAME", os.environ.get("DDB_TABLE", ""))
     public_base_url: str = os.environ.get("PUBLIC_BASE_URL", "http://localhost:8000").rstrip("/")
@@ -126,6 +129,14 @@ class Settings:
     stripe_cancel_url: str = os.environ.get("STRIPE_CANCEL_URL", "")
     billing_table_name: str = os.environ.get("BILLING_TABLE_NAME", "billing")
     account_state_table_name: str = os.environ.get("ACCOUNT_STATE_TABLE_NAME", "account_state")
+    billing_reconcile_enabled: bool = os.environ.get("BILLING_RECONCILE_ENABLED", "false").lower() == "true"
+    billing_reconcile_interval_seconds: int = int(os.environ.get("BILLING_RECONCILE_INTERVAL_SECONDS", "900"))
+    billing_reconcile_pending_age_seconds: int = int(os.environ.get("BILLING_RECONCILE_PENDING_AGE_SECONDS", "3600"))
+    billing_reconcile_scan_limit: int = int(os.environ.get("BILLING_RECONCILE_SCAN_LIMIT", "200"))
+    billing_dunning_enabled: bool = os.environ.get("BILLING_DUNNING_ENABLED", "false").lower() == "true"
+    billing_dunning_interval_seconds: int = int(os.environ.get("BILLING_DUNNING_INTERVAL_SECONDS", "900"))
+    billing_dunning_retry_schedule_seconds: str = os.environ.get("BILLING_DUNNING_RETRY_SCHEDULE_SECONDS", "3600,86400,172800")
+    billing_dunning_scan_limit: int = int(os.environ.get("BILLING_DUNNING_SCAN_LIMIT", "200"))
 
     # Profile
     profile_table_name: str = os.environ.get("PROFILE_TABLE_NAME", "profiles")

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,8 @@ from app.routers.purchase_history import router as purchase_history_router
 from app.routers.shoppingcart import router as shoppingcart_router
 from app.routers.catalog import router as catalog_router
 from app.routers.subscription_server import router as subscription_server_router
+from app.services.billing_reconcile import start_billing_reconcile_task
+from app.services.billing_dunning import start_billing_dunning_task
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Security Backend (refactored)", version="0.1.0")
@@ -76,10 +78,12 @@ def create_app() -> FastAPI:
     app.include_router(calendar_router)
     app.include_router(newsfeed_router)
     app.add_event_handler("startup", newsfeed_startup)
+    app.add_event_handler("startup", start_billing_dunning_task)
     app.include_router(purchase_history_router)
     app.include_router(shoppingcart_router)
     app.include_router(catalog_router)
     app.include_router(subscription_server_router)
+    app.add_event_handler("startup", start_billing_reconcile_task)
 
     return app
 

--- a/app/models.py
+++ b/app/models.py
@@ -328,6 +328,9 @@ class PaymentMethodOut(BaseModel):
     payment_token_id: str
     label: Optional[str] = None
     priority: int
+    provider: Optional[str] = None
+    provider_method_id: Optional[str] = None
+    is_default: bool = False
 
 
 class SavePaymentTokenIn(BaseModel):
@@ -575,6 +578,12 @@ class AddChargeIn(BaseModel):
     reason: str = "usage"
 
 
+class RefundIn(BaseModel):
+    transaction_id: str
+    amount_cents: Optional[int] = Field(default=None, ge=1)
+    reason: Optional[str] = None
+
+
 class BillingCheckoutReq(BaseModel):
     amount_cents: int
     currency: Optional[str] = None
@@ -589,6 +598,9 @@ class StripePaymentMethodOut(BaseModel):
     exp_month: Optional[int] = None
     exp_year: Optional[int] = None
     priority: int
+    provider: Optional[str] = None
+    provider_method_id: Optional[str] = None
+    is_default: bool = False
 
 class SetPriorityReq(BaseModel):
     payment_method_id: str
@@ -609,6 +621,12 @@ class StripeChargeReq(BaseModel):
     payment_method_id: Optional[str] = None
     description: Optional[str] = None
     idempotency_key: Optional[str] = None
+
+
+class StripeRefundReq(BaseModel):
+    payment_intent_id: str
+    amount_cents: Optional[int] = Field(default=None, ge=1)
+    reason: Optional[str] = None
 
 class VerifyMicrodepositsReq(BaseModel):
     setup_intent_id: str

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -27,6 +27,7 @@ from app.models import (
     SetDefaultReq,
     SetPriorityReq,
     StripeChargeReq,
+    StripeRefundReq,
     StripePaymentMethodOut,
     VerifyMicrodepositsReq,
 )
@@ -47,6 +48,11 @@ from app.services.billing_shared import (
 )
 from app.services.profile import get_profile
 from app.services.purchase_history import mark_completed, mark_reverted, record_billing_transaction
+from app.services.billing_dunning import (
+    bump_dunning_after_payment_method_update,
+    schedule_autopay_disabled_notice,
+    schedule_dunning,
+)
 from app.services.ttl import with_ttl
 
 router = APIRouter(tags=["billing"])
@@ -264,6 +270,8 @@ def set_autopay(body: SetAutopayReq, req: Request = None, ctx=Depends(require_ui
         ddb_put(T.billing, {"pk": pk, "sk": "BILLING", "autopay_enabled": False, "currency": "usd", "default_payment_method_id": None})
     ddb_update(T.billing, pk, "BILLING", "SET autopay_enabled = :e", {":e": bool(body.enabled)})
     audit_event("billing_autopay_set", user_id, req, outcome="success", enabled=bool(body.enabled))
+    if not body.enabled:
+        schedule_autopay_disabled_notice(user_id, "stripe")
     return {"ok": True}
 
 
@@ -327,6 +335,7 @@ def verify_microdeposits(body: VerifyMicrodepositsReq, ctx=Depends(require_ui_se
 @dual_route("GET", "/billing/payment-methods", response_model=List[StripePaymentMethodOut])
 def list_payment_methods(ctx=Depends(require_ui_session)) -> List[StripePaymentMethodOut]:
     user_id = ctx["user_sub"]
+    default_pm = current_default_pm(user_id)
     pms = list_payment_methods_ddb(user_id)
 
     out: List[StripePaymentMethodOut] = []
@@ -340,6 +349,9 @@ def list_payment_methods(ctx=Depends(require_ui_session)) -> List[StripePaymentM
             exp_month=it.get("exp_month"),
             exp_year=it.get("exp_year"),
             priority=int(it.get("priority", 0)),
+            provider=it.get("provider") or "stripe",
+            provider_method_id=it.get("provider_method_id") or it.get("payment_method_id"),
+            is_default=it.get("payment_method_id") == default_pm,
         ))
     out.sort(key=lambda x: x.priority)
     return out
@@ -368,6 +380,7 @@ def set_default(body: SetDefaultReq, req: Request = None, ctx=Depends(require_ui
     set_default_pm(user_id, body.payment_method_id)
     stripe.Customer.modify(customer_id, invoice_settings={"default_payment_method": body.payment_method_id})
     audit_event("billing_payment_method_default", user_id, req, outcome="success", payment_method_id=body.payment_method_id)
+    bump_dunning_after_payment_method_update(user_id, "stripe")
     return {"ok": True}
 
 
@@ -603,6 +616,66 @@ def charge_once(body: StripeChargeReq, req: Request = None, ctx=Depends(require_
     return {"status": pi.get("status"), "payment_intent_id": pi["id"]}
 
 
+@dual_route("POST", "/billing/refund")
+def refund_payment(body: StripeRefundReq, req: Request = None, ctx=Depends(require_ui_session)) -> Dict[str, Any]:
+    ensure_stripe_configured()
+    user_id = ctx["user_sub"]
+    pk = user_pk(user_id)
+
+    pay = ddb_get(T.billing, pk, pay_sk(body.payment_intent_id))
+    if not pay:
+        raise HTTPException(404, "Payment record not found")
+
+    amount = int(body.amount_cents or pay.get("amount_cents", 0))
+    if amount <= 0:
+        raise HTTPException(400, "amount_cents must be greater than zero")
+
+    refund = stripe.Refund.create(
+        payment_intent=body.payment_intent_id,
+        amount=amount,
+        reason=body.reason,
+    )
+
+    led_sk_value, led_item = new_ledger_entry(
+        key_name="pk",
+        key_value=pk,
+        entry_type="adjustment",
+        amount_cents=amount,
+        state="settled",
+        reason="refund",
+        meta={"reason": body.reason},
+        extra={"stripe_payment_intent_id": body.payment_intent_id, "stripe_refund_id": refund.get("id")},
+    )
+    ddb_put(T.billing, led_item)
+
+    if pay.get("status") in ("processing", "requires_action"):
+        apply_balance_delta(T.billing, pk, {"payments_pending_cents": -amount}, currency=pay.get("currency", "usd"))
+    else:
+        apply_balance_delta(T.billing, pk, {"payments_settled_cents": -amount}, currency=pay.get("currency", "usd"))
+
+    if pay.get("ledger_sk"):
+        settle_or_reverse_ledger(T.billing, "pk", pk, pay["ledger_sk"], "reversed")
+
+    update_payment_status(user_id, body.payment_intent_id, "refunded", charge_id=refund.get("charge"))
+
+    purchase_txn_id = pay.get("purchase_txn_id")
+    if purchase_txn_id:
+        mark_reverted(user_id, purchase_txn_id, body.reason or "refund")
+
+    audit_event(
+        "billing_refund",
+        user_id,
+        req,
+        outcome="success",
+        provider="stripe",
+        payment_intent_id=body.payment_intent_id,
+        refund_id=refund.get("id"),
+        amount_cents=amount,
+        reason=body.reason,
+    )
+    return {"ok": True, "refund_id": refund.get("id"), "payment_intent_id": body.payment_intent_id}
+
+
 @dual_route("POST", "/billing/checkout_session")
 def create_checkout_session(body: BillingCheckoutReq, req: Request = None, ctx=Depends(require_ui_session)) -> Dict[str, str]:
     ensure_stripe_configured()
@@ -675,8 +748,12 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
 
         try:
             stripe.PaymentMethod.attach(pm_id, customer=customer_id)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "Stripe payment method attach failed",
+                extra={"user_id": user_id, "payment_method_id": pm_id, "customer_id": customer_id},
+                exc_info=exc,
+            )
 
         pm = stripe.PaymentMethod.retrieve(pm_id)
         pm_type = pm.get("type", "unknown")
@@ -706,6 +783,8 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
             "pk": pk,
             "sk": pm_sk(pm_id),
             "payment_method_id": pm_id,
+            "provider": "stripe",
+            "provider_method_id": pm_id,
             "method_type": pm_type,
             "label": label,
             "brand": brand,
@@ -715,10 +794,12 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
             "priority": next_priority,
             "created_at": now_ts(),
         })
+        bump_dunning_after_payment_method_update(user_id, "stripe")
 
         if not current_default_pm(user_id):
             set_default_pm(user_id, pm_id)
             stripe.Customer.modify(customer_id, invoice_settings={"default_payment_method": pm_id})
+            bump_dunning_after_payment_method_update(user_id, "stripe")
 
     elif event_type.startswith("payment_intent."):
         pi = event["data"]["object"]
@@ -806,6 +887,13 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
                 purchase_txn_id=purchase_txn_id,
                 reason=(pi.get("last_payment_error") or {}).get("message"),
             )
+            schedule_dunning(
+                user_id=user_id,
+                provider="stripe",
+                amount_cents=amount,
+                reason=status,
+                payment_ref=pi_id,
+            )
 
         elif status == "payment_failed":
             update_payment_status(user_id, pi_id, "payment_failed", charge_id=charge_id, last_error=pi.get("last_payment_error"))
@@ -833,6 +921,13 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
                 amount_cents=amount,
                 purchase_txn_id=purchase_txn_id,
                 reason=(pi.get("last_payment_error") or {}).get("message"),
+            )
+            schedule_dunning(
+                user_id=user_id,
+                provider="stripe",
+                amount_cents=amount,
+                reason=status,
+                payment_ref=pi_id,
             )
 
         else:
@@ -865,6 +960,7 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
         ensure_balance_row(T.billing, pk, S.stripe_default_currency or "usd")
 
         if event_type == "charge.dispute.funds_withdrawn":
+            pay = ddb_get(T.billing, pk, pay_sk(pi_id)) if pi_id else None
             led_sk_value, led_item = new_ledger_entry(
                 key_name="pk",
                 key_value=pk,
@@ -877,6 +973,10 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
             )
             ddb_put(T.billing, led_item)
             apply_balance_delta(T.billing, pk, {"owed_settled_cents": amount}, currency=currency)
+            if pay and pay.get("ledger_sk"):
+                settle_or_reverse_ledger(T.billing, "pk", pk, pay["ledger_sk"], "reversed")
+            if pay and pay.get("purchase_txn_id"):
+                mark_reverted(user_id, pay["purchase_txn_id"], "chargeback")
             audit_event(
                 "billing_dispute_funds_withdrawn",
                 user_id,

--- a/app/routers/billing_ccbill.py
+++ b/app/routers/billing_ccbill.py
@@ -17,6 +17,7 @@ from app.models import (
     OneTimeChargeIn,
     PayBalanceIn,
     PaymentMethodOut,
+    RefundIn,
     SavePaymentTokenIn,
     SetAutopayIn,
     SetDefaultIn,
@@ -34,13 +35,22 @@ from app.services.billing_ccbill import (
     new_ledger_entry,
     pay_balance,
     settle_or_reverse_ledger,
+    sanitize_ccbill_payload,
     subscribe_monthly,
     update_payment_status,
     upsert_subscription,
+    verify_ccbill_webhook_signature,
     webhook_remote_ip_allowed,
     put_payment_record,
 )
+from app.services.alerts import audit_event
 from app.services.sessions import require_ui_session
+from app.services.purchase_history import mark_reverted
+from app.services.billing_dunning import (
+    bump_dunning_after_payment_method_update,
+    schedule_ccbill_autopay_disabled_notice,
+    schedule_ccbill_dunning,
+)
 
 router = APIRouter(tags=["billing"])
 
@@ -63,6 +73,21 @@ def _ledger_items(user_sub: str, prefix: str) -> List[Dict[str, Any]]:
         ExpressionAttributeValues={":u": user_sub, ":p": prefix},
     )
     return resp.get("Items", [])
+
+
+def _safe_webhook_payload(payload: Any) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    sanitized = sanitize_ccbill_payload(payload)
+    return sanitized if isinstance(sanitized, dict) else {}
+
+
+def _webhook_meta(event_type: str, payload: Any, q: Any) -> Dict[str, Any]:
+    return {
+        "eventType": event_type,
+        "payload": _safe_webhook_payload(payload),
+        "q": _safe_webhook_payload(q),
+    }
 
 
 def _dollars_str_to_cents(s: Optional[str]) -> Optional[int]:
@@ -108,7 +133,7 @@ def get_settings(ctx=Depends(require_ui_session)):
 
 
 @router.post("/api/billing/autopay")
-def set_autopay(body: SetAutopayIn, ctx=Depends(require_ui_session)):
+def set_autopay(body: SetAutopayIn, req: Request = None, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
     existing = T.billing.get_item(Key={"user_sub": user_sub, "sk": "BILLING"}).get("Item")
     if not existing:
@@ -124,6 +149,9 @@ def set_autopay(body: SetAutopayIn, ctx=Depends(require_ui_session)):
         UpdateExpression="SET autopay_enabled = :e",
         ExpressionAttributeValues={":e": bool(body.enabled)},
     )
+    audit_event("billing_autopay_set", user_sub, req, outcome="success", provider="ccbill", enabled=bool(body.enabled))
+    if not body.enabled:
+        schedule_ccbill_autopay_disabled_notice(user_sub)
     return {"ok": True}
 
 
@@ -145,7 +173,7 @@ def get_balance(ctx=Depends(require_ui_session)):
 
 
 @router.post("/api/billing/payment-methods/ccbill-token")
-def save_payment_token(body: SavePaymentTokenIn, ctx=Depends(require_ui_session)):
+def save_payment_token(body: SavePaymentTokenIn, req: Request = None, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
     existing = list_payment_methods(user_sub)
     next_priority = 0 if not existing else (max(int(x.get("priority", 0)) for x in existing) + 1)
@@ -154,6 +182,8 @@ def save_payment_token(body: SavePaymentTokenIn, ctx=Depends(require_ui_session)
         "user_sub": user_sub,
         "sk": _pm_sk(body.payment_token_id),
         "payment_token_id": body.payment_token_id,
+        "provider": "ccbill",
+        "provider_method_id": body.payment_token_id,
         "label": body.label,
         "priority": next_priority,
         "created_at": now_ts(),
@@ -161,19 +191,33 @@ def save_payment_token(body: SavePaymentTokenIn, ctx=Depends(require_ui_session)
 
     if body.make_default or not _current_default_pm(user_sub):
         _set_default_pm(user_sub, body.payment_token_id)
+    bump_dunning_after_payment_method_update(user_sub, "ccbill")
 
+    audit_event(
+        "billing_payment_method_added",
+        user_sub,
+        req,
+        outcome="success",
+        provider="ccbill",
+        payment_token_id=body.payment_token_id,
+        make_default=bool(body.make_default),
+    )
     return {"ok": True}
 
 
 @router.get("/api/billing/payment-methods", response_model=List[PaymentMethodOut])
 def list_payment_methods_endpoint(ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    default_token = _current_default_pm(user_sub)
     pms = list_payment_methods(user_sub)
     out: List[PaymentMethodOut] = [
         PaymentMethodOut(
             payment_token_id=it["payment_token_id"],
             label=it.get("label"),
             priority=int(it.get("priority", 0)),
+            provider=it.get("provider") or "ccbill",
+            provider_method_id=it.get("provider_method_id") or it.get("payment_token_id"),
+            is_default=it.get("payment_token_id") == default_token,
         )
         for it in pms
     ]
@@ -182,7 +226,7 @@ def list_payment_methods_endpoint(ctx=Depends(require_ui_session)):
 
 
 @router.post("/api/billing/payment-methods/priority")
-def set_priority(body: SetPriorityIn, ctx=Depends(require_ui_session)):
+def set_priority(body: SetPriorityIn, req: Request = None, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
     sk = _pm_sk(body.payment_token_id)
     if not T.billing.get_item(Key={"user_sub": user_sub, "sk": sk}).get("Item"):
@@ -192,20 +236,38 @@ def set_priority(body: SetPriorityIn, ctx=Depends(require_ui_session)):
         UpdateExpression="SET priority = :p",
         ExpressionAttributeValues={":p": int(body.priority)},
     )
+    audit_event(
+        "billing_payment_method_priority",
+        user_sub,
+        req,
+        outcome="success",
+        provider="ccbill",
+        payment_token_id=body.payment_token_id,
+        priority=int(body.priority),
+    )
     return {"ok": True}
 
 
 @router.post("/api/billing/payment-methods/default")
-def set_default(body: SetDefaultIn, ctx=Depends(require_ui_session)):
+def set_default(body: SetDefaultIn, req: Request = None, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
     if not T.billing.get_item(Key={"user_sub": user_sub, "sk": _pm_sk(body.payment_token_id)}).get("Item"):
         raise HTTPException(404, "Payment method not found")
     _set_default_pm(user_sub, body.payment_token_id)
+    audit_event(
+        "billing_payment_method_default",
+        user_sub,
+        req,
+        outcome="success",
+        provider="ccbill",
+        payment_token_id=body.payment_token_id,
+    )
+    bump_dunning_after_payment_method_update(user_sub, "ccbill")
     return {"ok": True}
 
 
 @router.delete("/api/billing/payment-methods/{payment_token_id}")
-def remove_payment_method(payment_token_id: str, ctx=Depends(require_ui_session)):
+def remove_payment_method(payment_token_id: str, req: Request = None, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
     sk = _pm_sk(payment_token_id)
     if not T.billing.get_item(Key={"user_sub": user_sub, "sk": sk}).get("Item"):
@@ -216,7 +278,26 @@ def remove_payment_method(payment_token_id: str, ctx=Depends(require_ui_session)
     if _current_default_pm(user_sub) == payment_token_id:
         remaining = list_payment_methods(user_sub)
         remaining.sort(key=lambda x: int(x.get("priority", 0)))
-        _set_default_pm(user_sub, remaining[0]["payment_token_id"] if remaining else None)
+        new_default = remaining[0]["payment_token_id"] if remaining else None
+        _set_default_pm(user_sub, new_default)
+        audit_event(
+            "billing_payment_method_removed",
+            user_sub,
+            req,
+            outcome="success",
+            provider="ccbill",
+            payment_token_id=payment_token_id,
+            new_default_payment_token_id=new_default,
+        )
+    else:
+        audit_event(
+            "billing_payment_method_removed",
+            user_sub,
+            req,
+            outcome="success",
+            provider="ccbill",
+            payment_token_id=payment_token_id,
+        )
 
     return {"ok": True}
 
@@ -224,7 +305,7 @@ def remove_payment_method(payment_token_id: str, ctx=Depends(require_ui_session)
 @router.post("/api/billing/charge-once")
 async def charge_once_endpoint(body: OneTimeChargeIn, request: Request, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
-    return charge_once(
+    resp = charge_once(
         user_sub=user_sub,
         amount_cents=body.amount_cents,
         payment_token_id=body.payment_token_id,
@@ -232,23 +313,53 @@ async def charge_once_endpoint(body: OneTimeChargeIn, request: Request, ctx=Depe
         idempotency_key=body.idempotency_key,
         request=request,
     )
+    audit_event(
+        "billing_charge_once",
+        user_sub,
+        request,
+        outcome="success" if resp.get("approved") else "failure",
+        provider="ccbill",
+        amount_cents=int(body.amount_cents),
+        payment_token_id=body.payment_token_id,
+        reason=body.reason,
+        transaction_id=resp.get("transaction_id"),
+    )
+    if not resp.get("approved"):
+        schedule_ccbill_dunning(
+            user_sub=user_sub,
+            amount_cents=int(body.amount_cents),
+            reason="charge_failed",
+            payment_ref=resp.get("transaction_id"),
+        )
+    return resp
 
 
 @router.post("/api/billing/pay-balance")
 async def pay_balance_endpoint(body: PayBalanceIn, request: Request, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
-    return pay_balance(
+    resp = pay_balance(
         user_sub=user_sub,
         amount_cents=body.amount_cents,
         idempotency_key=body.idempotency_key,
         request=request,
     )
+    outcome = "success" if resp.get("status") not in ("failed", "no_settled_balance_due") else "failure"
+    audit_event(
+        "billing_pay_balance",
+        user_sub,
+        request,
+        outcome=outcome,
+        provider="ccbill",
+        amount_cents=body.amount_cents,
+        status=resp.get("status"),
+    )
+    return resp
 
 
 @router.post("/api/billing/subscribe-monthly")
 async def subscribe_monthly_endpoint(body: SubscribeMonthlyIn, request: Request, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
-    return subscribe_monthly(
+    resp = subscribe_monthly(
         user_sub=user_sub,
         plan_id=body.plan_id,
         monthly_price_cents=body.monthly_price_cents,
@@ -256,6 +367,81 @@ async def subscribe_monthly_endpoint(body: SubscribeMonthlyIn, request: Request,
         idempotency_key=body.idempotency_key,
         request=request,
     )
+    audit_event(
+        "billing_subscribe_monthly",
+        user_sub,
+        request,
+        outcome="success" if resp.get("approved") else "failure",
+        provider="ccbill",
+        plan_id=body.plan_id,
+        monthly_price_cents=body.monthly_price_cents,
+        payment_token_id=body.payment_token_id,
+        transaction_id=resp.get("transaction_id"),
+        subscription_id=resp.get("subscription_id"),
+    )
+    if not resp.get("approved"):
+        schedule_ccbill_dunning(
+            user_sub=user_sub,
+            amount_cents=int(body.monthly_price_cents or 0),
+            reason="subscription_failed",
+            payment_ref=resp.get("transaction_id"),
+        )
+    return resp
+
+
+@router.post("/api/billing/refund")
+def refund_payment(body: RefundIn, req: Request = None, ctx=Depends(require_ui_session)):
+    user_sub = ctx["user_sub"]
+    pay = T.billing.get_item(Key={"user_sub": user_sub, "sk": _pay_sk(body.transaction_id)}).get("Item")
+    if not pay:
+        raise HTTPException(404, "Payment record not found")
+
+    amount = int(body.amount_cents or pay.get("amount_cents", 0))
+    if amount <= 0:
+        raise HTTPException(400, "amount_cents must be greater than zero")
+
+    led_sk_value, led_item = new_ledger_entry(
+        user_sub=user_sub,
+        entry_type="adjustment",
+        amount_cents=amount,
+        state="settled",
+        reason="refund",
+        ccbill_transaction_id=str(body.transaction_id),
+        meta={"reason": body.reason},
+    )
+    T.billing.put_item(Item=led_item)
+
+    if pay.get("status") in ("pending", "processing", "requires_action"):
+        apply_balance_delta(user_sub, {"payments_pending_cents": -amount})
+    else:
+        apply_balance_delta(user_sub, {"payments_settled_cents": -amount})
+
+    if pay.get("ledger_sk"):
+        settle_or_reverse_ledger(user_sub, str(pay["ledger_sk"]), "reversed")
+
+    update_payment_status(
+        user_sub,
+        str(body.transaction_id),
+        "refunded",
+        raw={"reason": body.reason},
+    )
+
+    purchase_txn_id = pay.get("purchase_txn_id")
+    if purchase_txn_id:
+        mark_reverted(user_sub, purchase_txn_id, body.reason or "refund")
+
+    audit_event(
+        "billing_refund",
+        user_sub,
+        req,
+        outcome="success",
+        provider="ccbill",
+        transaction_id=str(body.transaction_id),
+        amount_cents=amount,
+        reason=body.reason,
+    )
+
+    return {"ok": True, "transaction_id": str(body.transaction_id), "ledger_sk": led_sk_value}
 
 
 @router.post("/api/billing/_dev/add-charge")
@@ -307,17 +493,10 @@ def list_subscriptions(ctx=Depends(require_ui_session), limit: int = 50):
 @router.post("/api/ccbill/webhook")
 async def ccbill_webhook(req: Request):
     remote_ip = client_ip_from_request(req)
-    if not webhook_remote_ip_allowed(remote_ip):
-        raise HTTPException(403, "Forbidden")
-
     q = dict(req.query_params)
     event_type = q.get("eventType", "")
 
     raw_body = await req.body()
-    dedupe_key = hashlib.sha256((event_type + "|").encode("utf-8") + raw_body).hexdigest()
-    if not mark_webhook_processed(dedupe_key):
-        return {"received": True, "deduped": True}
-
     ct = (req.headers.get("content-type") or "").lower()
     payload: Dict[str, Any] = {}
     if "application/json" in ct:
@@ -329,6 +508,45 @@ async def ccbill_webhook(req: Request):
         form = await req.form()
         payload = dict(form)
 
+    if not webhook_remote_ip_allowed(remote_ip):
+        _log_ccbill_webhook_rejection(
+            reason="ip_not_allowed",
+            remote_ip=remote_ip,
+            event_type=event_type,
+            q=q,
+            payload=payload,
+            req=req,
+            raw_body=raw_body,
+        )
+        raise HTTPException(403, "Forbidden")
+
+    signature_header = req.headers.get(S.ccbill_webhook_signature_header, "")
+    if not verify_ccbill_webhook_signature(raw_body, signature_header):
+        _log_ccbill_webhook_rejection(
+            reason="invalid_signature",
+            remote_ip=remote_ip,
+            event_type=event_type,
+            q=q,
+            payload=payload,
+            req=req,
+            raw_body=raw_body,
+        )
+        raise HTTPException(403, "Invalid webhook signature")
+
+    dedupe_key = hashlib.sha256((event_type + "|").encode("utf-8") + raw_body).hexdigest()
+    if not mark_webhook_processed(dedupe_key):
+        _log_ccbill_webhook_rejection(
+            reason="replay",
+            remote_ip=remote_ip,
+            event_type=event_type,
+            q=q,
+            payload=payload,
+            req=req,
+            raw_body=raw_body,
+            dedupe_key=dedupe_key,
+        )
+        return {"received": True, "deduped": True}
+
     user_sub = payload.get("X-app_user_id") or payload.get("X_app_user_id") or payload.get("X-user-id") or payload.get("X_user_id")
     transaction_id = payload.get("transactionId") or payload.get("transaction_id")
     subscription_id = payload.get("subscriptionId") or payload.get("subscription_id")
@@ -336,12 +554,13 @@ async def ccbill_webhook(req: Request):
     ledger_sk_hint = payload.get("X-ledger_sk") or payload.get("X_ledger_sk")
 
     if not user_sub:
+        safe_meta = _webhook_meta(event_type, payload, q)
         T.billing.put_item(Item={
             "user_sub": "CCBILL_WEBHOOK_UNMATCHED",
             "sk": f"{now_ts()}#{dedupe_key}",
             "eventType": event_type,
-            "q": q,
-            "payload": payload,
+            "q": safe_meta["q"],
+            "payload": safe_meta["payload"],
             "created_at": now_ts(),
         })
         return {"received": True, "unmatched": True}
@@ -358,18 +577,19 @@ async def ccbill_webhook(req: Request):
     if event_type == "NewSaleSuccess":
         pay, led_sk_value = _try_find_pay_and_ledger(transaction_id)
         amount = int(pay["amount_cents"]) if pay else (_dollars_str_to_cents(payload.get("initialPrice")) or S.default_monthly_price_cents)
+        safe_meta = _webhook_meta(event_type, payload, q)
 
         led_sk_to_settle = led_sk_value
         if not led_sk_to_settle and ledger_sk_hint:
             if T.billing.get_item(Key={"user_sub": user_sub, "sk": str(ledger_sk_hint)}).get("Item"):
                 led_sk_to_settle = str(ledger_sk_hint)
 
-        if led_sk_to_settle:
-            if pay and pay.get("status") in ("pending", "processing", "requires_action"):
-                apply_balance_delta(user_sub, {"payments_pending_cents": -amount, "payments_settled_cents": amount})
-            settle_or_reverse_ledger(user_sub, led_sk_to_settle, "settled")
-            if transaction_id:
-                update_payment_status(user_sub, str(transaction_id), "succeeded", raw={"eventType": event_type, "payload": payload, "q": q})
+            if led_sk_to_settle:
+                if pay and pay.get("status") in ("pending", "processing", "requires_action"):
+                    apply_balance_delta(user_sub, {"payments_pending_cents": -amount, "payments_settled_cents": amount})
+                settle_or_reverse_ledger(user_sub, led_sk_to_settle, "settled")
+                if transaction_id:
+                    update_payment_status(user_sub, str(transaction_id), "succeeded", raw=safe_meta)
         else:
             led_sk_value2, led_item = new_ledger_entry(
                 user_sub=user_sub,
@@ -379,7 +599,7 @@ async def ccbill_webhook(req: Request):
                 reason="subscription_signup_webhook",
                 ccbill_transaction_id=str(transaction_id) if transaction_id else None,
                 ccbill_subscription_id=str(subscription_id) if subscription_id else None,
-                meta={"eventType": event_type, "q": q, "payload": payload},
+                meta=safe_meta,
             )
             T.billing.put_item(Item=led_item)
             apply_balance_delta(user_sub, {"payments_settled_cents": amount})
@@ -392,7 +612,7 @@ async def ccbill_webhook(req: Request):
                     status="succeeded",
                     ledger_sk_value=led_sk_value2,
                     subscription_id=str(subscription_id) if subscription_id else None,
-                    raw={"eventType": event_type, "payload": payload, "q": q},
+                    raw=safe_meta,
                 )
 
         if subscription_id:
@@ -403,22 +623,31 @@ async def ccbill_webhook(req: Request):
                 plan_id=plan_id,
                 next_renewal_date=payload.get("nextRenewalDate"),
                 last_transaction_id=str(transaction_id) if transaction_id else None,
-                raw={"eventType": event_type, "payload": payload, "q": q},
+                raw=safe_meta,
             )
 
     elif event_type == "NewSaleFailure":
         pay, led_sk_value = _try_find_pay_and_ledger(transaction_id)
+        safe_meta = _webhook_meta(event_type, payload, q)
         if pay and led_sk_value:
             amount = int(pay.get("amount_cents", 0))
             if pay.get("status") in ("pending", "processing", "requires_action"):
                 apply_balance_delta(user_sub, {"payments_pending_cents": -amount})
             settle_or_reverse_ledger(user_sub, led_sk_value, "reversed")
-            update_payment_status(user_sub, str(transaction_id), "failed", raw={"eventType": event_type, "payload": payload, "q": q})
+            update_payment_status(user_sub, str(transaction_id), "failed", raw=safe_meta)
         if subscription_id:
-            upsert_subscription(user_sub=user_sub, subscription_id=str(subscription_id), status="failed", plan_id=plan_id, raw={"eventType": event_type, "payload": payload, "q": q})
+            upsert_subscription(user_sub=user_sub, subscription_id=str(subscription_id), status="failed", plan_id=plan_id, raw=safe_meta)
+        if pay:
+            schedule_ccbill_dunning(
+                user_sub=user_sub,
+                amount_cents=int(pay.get("amount_cents", 0)),
+                reason="webhook_new_sale_failure",
+                payment_ref=str(transaction_id) if transaction_id else None,
+            )
 
     elif event_type == "RenewalSuccess":
         billed_cents = _dollars_str_to_cents(payload.get("billedAmount")) or S.default_monthly_price_cents
+        safe_meta = _webhook_meta(event_type, payload, q)
         led_sk_value2, led_item = new_ledger_entry(
             user_sub=user_sub,
             entry_type="credit",
@@ -427,7 +656,7 @@ async def ccbill_webhook(req: Request):
             reason="subscription_rebill",
             ccbill_transaction_id=str(transaction_id) if transaction_id else None,
             ccbill_subscription_id=str(subscription_id) if subscription_id else None,
-            meta={"eventType": event_type, "q": q, "payload": payload},
+            meta=safe_meta,
         )
         T.billing.put_item(Item=led_item)
         apply_balance_delta(user_sub, {"payments_settled_cents": billed_cents})
@@ -441,7 +670,7 @@ async def ccbill_webhook(req: Request):
                 status="succeeded",
                 ledger_sk_value=led_sk_value2,
                 subscription_id=str(subscription_id) if subscription_id else None,
-                raw={"eventType": event_type, "payload": payload, "q": q},
+                raw=safe_meta,
             )
 
         if subscription_id:
@@ -452,10 +681,11 @@ async def ccbill_webhook(req: Request):
                 plan_id=plan_id,
                 next_renewal_date=payload.get("nextRenewalDate"),
                 last_transaction_id=str(transaction_id) if transaction_id else None,
-                raw={"eventType": event_type, "payload": payload, "q": q},
+                raw=safe_meta,
             )
 
     elif event_type == "RenewalFailure":
+        safe_meta = _webhook_meta(event_type, payload, q)
         if subscription_id:
             upsert_subscription(
                 user_sub=user_sub,
@@ -464,10 +694,18 @@ async def ccbill_webhook(req: Request):
                 plan_id=plan_id,
                 next_renewal_date=payload.get("nextRenewalDate"),
                 last_transaction_id=str(transaction_id) if transaction_id else None,
-                raw={"eventType": event_type, "payload": payload, "q": q},
+                raw=safe_meta,
+            )
+        if transaction_id:
+            schedule_ccbill_dunning(
+                user_sub=user_sub,
+                amount_cents=_dollars_str_to_cents(payload.get("billedAmount")) or 0,
+                reason="webhook_renewal_failure",
+                payment_ref=str(transaction_id),
             )
 
     elif event_type == "Cancellation":
+        safe_meta = _webhook_meta(event_type, payload, q)
         if subscription_id:
             upsert_subscription(
                 user_sub=user_sub,
@@ -475,11 +713,12 @@ async def ccbill_webhook(req: Request):
                 status="canceled",
                 plan_id=plan_id,
                 last_transaction_id=str(transaction_id) if transaction_id else None,
-                raw={"eventType": event_type, "payload": payload, "q": q},
+                raw=safe_meta,
             )
 
     elif event_type in ("Chargeback", "Refund", "Void", "Return"):
         amount = _dollars_str_to_cents(payload.get("billedAmount")) or 0
+        safe_meta = _webhook_meta(event_type, payload, q)
         led_sk_value2, led_item = new_ledger_entry(
             user_sub=user_sub,
             entry_type="adjustment",
@@ -488,23 +727,69 @@ async def ccbill_webhook(req: Request):
             reason=event_type.lower(),
             ccbill_transaction_id=str(transaction_id) if transaction_id else None,
             ccbill_subscription_id=str(subscription_id) if subscription_id else None,
-            meta={"eventType": event_type, "q": q, "payload": payload},
+            meta=safe_meta,
         )
         T.billing.put_item(Item=led_item)
         if amount:
             apply_balance_delta(user_sub, {"owed_settled_cents": amount})
 
+        if transaction_id:
+            pay = T.billing.get_item(Key={"user_sub": user_sub, "sk": _pay_sk(str(transaction_id))}).get("Item")
+        else:
+            pay = None
+
+        if pay and pay.get("ledger_sk"):
+            settle_or_reverse_ledger(user_sub, str(pay["ledger_sk"]), "reversed")
+            apply_balance_delta(user_sub, {"payments_settled_cents": -amount})
+
+        if transaction_id:
+            update_payment_status(user_sub, str(transaction_id), "chargeback" if event_type == "Chargeback" else "refunded", raw=safe_meta)
+
+        if pay and pay.get("purchase_txn_id"):
+            mark_reverted(user_sub, pay["purchase_txn_id"], event_type.lower())
+
     else:
+        safe_meta = _webhook_meta(event_type, payload, q)
         T.billing.put_item(Item={
             "user_sub": "CCBILL_WEBHOOK_OTHER",
             "sk": f"{now_ts()}#{dedupe_key}",
             "eventType": event_type,
-            "q": q,
-            "payload": payload,
+            "q": safe_meta["q"],
+            "payload": safe_meta["payload"],
             "created_at": now_ts(),
         })
 
     return {"received": True}
+
+
+def _log_ccbill_webhook_rejection(
+    *,
+    reason: str,
+    remote_ip: str,
+    event_type: str,
+    q: Dict[str, Any],
+    payload: Dict[str, Any],
+    req: Request,
+    raw_body: bytes,
+    dedupe_key: Optional[str] = None,
+) -> None:
+    safe_headers = {}
+    for key in ("content-type", "user-agent", S.ccbill_webhook_signature_header):
+        val = req.headers.get(key)
+        if val:
+            safe_headers[key] = "[REDACTED]" if key == S.ccbill_webhook_signature_header else val
+    T.billing.put_item(Item={
+        "user_sub": "CCBILL_WEBHOOK_REJECTED",
+        "sk": f"{now_ts()}#{dedupe_key or hashlib.sha256(raw_body).hexdigest()}",
+        "reason": reason,
+        "remote_ip": remote_ip,
+        "eventType": event_type,
+        "q": sanitize_ccbill_payload(q),
+        "payload": sanitize_ccbill_payload(payload),
+        "headers": safe_headers,
+        "body_sha256": hashlib.sha256(raw_body).hexdigest(),
+        "created_at": now_ts(),
+    })
 
 
 def _current_default_pm(user_sub: str) -> Optional[str]:

--- a/app/routers/paypal.py
+++ b/app/routers/paypal.py
@@ -567,6 +567,9 @@ class PaymentMethodOut(BaseModel):
     label: Optional[str] = None
     priority: int
     pm_type: Optional[str] = None
+    provider: Optional[str] = None
+    provider_method_id: Optional[str] = None
+    is_default: bool = False
 
 
 class SetAutopayIn(BaseModel):
@@ -747,6 +750,8 @@ def exchange_setup_token(body: ExchangeTokenIn, x_user_id: Optional[str] = Heade
             "pk": pk,
             "sk": pm_sk(payment_token_id),
             "payment_token_id": payment_token_id,
+            "provider": "paypal",
+            "provider_method_id": payment_token_id,
             "label": body.label,
             "pm_type": pm_type,
             "priority": next_priority,
@@ -764,6 +769,7 @@ def exchange_setup_token(body: ExchangeTokenIn, x_user_id: Optional[str] = Heade
 @router.get("/api/billing/payment-methods", response_model=List[PaymentMethodOut])
 def list_payment_methods(x_user_id: Optional[str] = Header(default=None)):
     user_id = require_user(x_user_id)
+    default_token = current_default_pm(user_id)
     pms = list_payment_methods_ddb(user_id)
     out: List[PaymentMethodOut] = [
         PaymentMethodOut(
@@ -771,6 +777,9 @@ def list_payment_methods(x_user_id: Optional[str] = Header(default=None)):
             label=it.get("label"),
             priority=int(it.get("priority", 0)),
             pm_type=it.get("pm_type"),
+            provider=it.get("provider") or "paypal",
+            provider_method_id=it.get("provider_method_id") or it.get("payment_token_id"),
+            is_default=it.get("payment_token_id") == default_token,
         )
         for it in pms
     ]
@@ -1045,9 +1054,6 @@ def list_subscriptions(x_user_id: Optional[str] = Header(default=None), limit: i
 @router.post("/api/paypal/webhook")
 async def paypal_webhook(req: Request):
     raw_body = await req.body()
-    dedupe_key = hashlib.sha256(raw_body).hexdigest()
-    if not mark_webhook_processed(dedupe_key):
-        return {"received": True, "deduped": True}
 
     if not S.paypal_webhook_id:
         raise HTTPException(500, "PAYPAL_WEBHOOK_ID not set; cannot verify webhook signatures")
@@ -1059,7 +1065,26 @@ async def paypal_webhook(req: Request):
     auth_algo = req.headers.get("paypal-auth-algo", "")
 
     if not (transmission_id and transmission_time and transmission_sig and cert_url and auth_algo):
+        _log_paypal_webhook_rejection(
+            reason="missing_headers",
+            req=req,
+            raw_body=raw_body,
+            transmission_id=transmission_id,
+            transmission_time=transmission_time,
+        )
         raise HTTPException(400, "Missing PayPal webhook verification headers")
+
+    dedupe_key = transmission_id or hashlib.sha256(raw_body).hexdigest()
+    if not mark_webhook_processed(dedupe_key):
+        _log_paypal_webhook_rejection(
+            reason="replay",
+            req=req,
+            raw_body=raw_body,
+            transmission_id=transmission_id,
+            transmission_time=transmission_time,
+            dedupe_key=dedupe_key,
+        )
+        return {"received": True, "deduped": True}
 
     verified = paypal_verify_webhook_signature(
         transmission_id=transmission_id,
@@ -1071,6 +1096,15 @@ async def paypal_webhook(req: Request):
         raw_body=raw_body,
     )
     if not verified:
+        _log_paypal_webhook_rejection(
+            reason="invalid_signature",
+            req=req,
+            raw_body=raw_body,
+            transmission_id=transmission_id,
+            transmission_time=transmission_time,
+            cert_url=cert_url,
+            auth_algo=auth_algo,
+        )
         raise HTTPException(403, "Invalid webhook signature")
 
     event = json.loads(raw_body.decode("utf-8") or "{}")
@@ -1209,3 +1243,43 @@ async def paypal_webhook(req: Request):
         )
 
     return {"received": True}
+
+
+def _log_paypal_webhook_rejection(
+    *,
+    reason: str,
+    req: Request,
+    raw_body: bytes,
+    transmission_id: str,
+    transmission_time: str,
+    cert_url: Optional[str] = None,
+    auth_algo: Optional[str] = None,
+    dedupe_key: Optional[str] = None,
+) -> None:
+    event_type = ""
+    try:
+        event = json.loads(raw_body.decode("utf-8") or "{}")
+        event_type = event.get("event_type", "")
+    except Exception:
+        event = {}
+    safe_headers = {}
+    for key in ("content-type", "user-agent", "paypal-transmission-id", "paypal-transmission-time"):
+        val = req.headers.get(key)
+        if val:
+            safe_headers[key] = val
+    ddb_put(
+        {
+            "pk": "PAYPAL_WEBHOOK_REJECTED",
+            "sk": f"{now_ts()}#{dedupe_key or hashlib.sha256(raw_body).hexdigest()}",
+            "reason": reason,
+            "eventType": event_type,
+            "transmission_id": transmission_id,
+            "transmission_time": transmission_time,
+            "cert_url": cert_url,
+            "auth_algo": auth_algo,
+            "headers": safe_headers,
+            "body_sha256": hashlib.sha256(raw_body).hexdigest(),
+            "created_at": now_ts(),
+            "event": event or None,
+        }
+    )

--- a/app/services/billing_ccbill.py
+++ b/app/services/billing_ccbill.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import ipaddress
 import json
 import time
@@ -21,13 +23,15 @@ from app.services.billing_shared import (
     new_ledger_entry as new_ledger_entry_shared,
     settle_or_reverse_ledger as settle_or_reverse_ledger_shared,
 )
+from app.services.purchase_history import record_billing_transaction
 
-CCBILL_WEBHOOK_IP_RANGES = [
+_DEFAULT_CCBILL_WEBHOOK_IP_RANGES = [
     ("64.38.212.0", "64.38.212.255"),
     ("64.38.215.0", "64.38.215.255"),
     ("64.38.240.0", "64.38.240.255"),
     ("64.38.241.0", "64.38.241.255"),
 ]
+_CCBILL_IP_RANGE_CACHE: Optional[List[Tuple[ipaddress._BaseAddress, ipaddress._BaseAddress]]] = None
 
 _OAUTH_CACHE: Dict[str, Tuple[str, int]] = {}
 _REDACTED_VALUE = "[REDACTED]"
@@ -93,6 +97,64 @@ def _sanitize_ccbill_raw(raw: Any) -> Any:
     return str(raw)
 
 
+def sanitize_ccbill_payload(payload: Any) -> Any:
+    return _sanitize_ccbill_raw(payload)
+
+
+def _parse_ccbill_ip_ranges(raw: str) -> List[Tuple[ipaddress._BaseAddress, ipaddress._BaseAddress]]:
+    tokens = [tok.strip() for tok in raw.split(",") if tok.strip()]
+    ranges: List[Tuple[ipaddress._BaseAddress, ipaddress._BaseAddress]] = []
+    for token in tokens:
+        try:
+            if "/" in token:
+                net = ipaddress.ip_network(token, strict=False)
+                ranges.append((net.network_address, net.broadcast_address))
+                continue
+            if "-" in token:
+                start, end = token.split("-", 1)
+                ranges.append((ipaddress.ip_address(start.strip()), ipaddress.ip_address(end.strip())))
+                continue
+            ip = ipaddress.ip_address(token)
+            ranges.append((ip, ip))
+        except ValueError:
+            continue
+    return ranges
+
+
+def _ccbill_ip_ranges() -> List[Tuple[ipaddress._BaseAddress, ipaddress._BaseAddress]]:
+    global _CCBILL_IP_RANGE_CACHE
+    if _CCBILL_IP_RANGE_CACHE is not None:
+        return _CCBILL_IP_RANGE_CACHE
+    raw = S.ccbill_webhook_ip_ranges.strip()
+    if not raw:
+        _CCBILL_IP_RANGE_CACHE = [
+            (ipaddress.ip_address(a), ipaddress.ip_address(b)) for a, b in _DEFAULT_CCBILL_WEBHOOK_IP_RANGES
+        ]
+        return _CCBILL_IP_RANGE_CACHE
+    parsed = _parse_ccbill_ip_ranges(raw)
+    if not parsed:
+        _CCBILL_IP_RANGE_CACHE = [
+            (ipaddress.ip_address(a), ipaddress.ip_address(b)) for a, b in _DEFAULT_CCBILL_WEBHOOK_IP_RANGES
+        ]
+        return _CCBILL_IP_RANGE_CACHE
+    _CCBILL_IP_RANGE_CACHE = parsed
+    return _CCBILL_IP_RANGE_CACHE
+
+
+def verify_ccbill_webhook_signature(raw_body: bytes, signature_header: str) -> bool:
+    secret = S.ccbill_webhook_signature_secret
+    if not secret:
+        return True
+    if not signature_header:
+        return False
+    sig = signature_header.strip()
+    if "=" in sig:
+        _, sig = sig.split("=", 1)
+        sig = sig.strip()
+    digest = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(digest, sig)
+
+
 def _billing_sk(kind: str, identifier: str) -> str:
     return f"{kind}#{identifier}"
 
@@ -153,6 +215,7 @@ def put_payment_record(
     payment_token_id: Optional[str] = None,
     subscription_id: Optional[str] = None,
     raw: Optional[Dict[str, Any]] = None,
+    purchase_txn_id: Optional[str] = None,
 ) -> None:
     item = {
         "user_sub": user_sub,
@@ -168,6 +231,8 @@ def put_payment_record(
         "created_at": now_ts(),
         "updated_at": now_ts(),
     }
+    if purchase_txn_id:
+        item["purchase_txn_id"] = purchase_txn_id
     if raw:
         item["raw"] = _sanitize_ccbill_raw(raw)
     T.billing.put_item(Item=item)
@@ -363,8 +428,8 @@ def webhook_remote_ip_allowed(ip_str: str) -> bool:
         ip = ipaddress.ip_address(ip_str)
     except Exception:
         return False
-    for a, b in CCBILL_WEBHOOK_IP_RANGES:
-        if ipaddress.ip_address(a) <= ip <= ipaddress.ip_address(b):
+    for start, end in _ccbill_ip_ranges():
+        if start <= ip <= end:
             return True
     return False
 
@@ -412,10 +477,20 @@ def charge_once(
         apply_balance_delta(user_sub, {"payments_pending_cents": -amount, "payments_settled_cents": amount})
         settle_or_reverse_ledger(user_sub, led_sk_value, "settled")
         status = "succeeded"
+        purchase_txn_id = record_billing_transaction(
+            user_sub=user_sub,
+            amount_cents=amount,
+            currency=S.default_currency,
+            description=f"CCBill charge once ({reason})",
+            status="COMPLETED",
+            external_ref=str(transaction_id or ""),
+            metadata={"provider": "ccbill", "payment_token_id": token, "transaction_id": str(transaction_id or "")},
+        )
     else:
         apply_balance_delta(user_sub, {"payments_pending_cents": -amount})
         settle_or_reverse_ledger(user_sub, led_sk_value, "reversed")
         status = "failed"
+        purchase_txn_id = None
 
     if transaction_id:
         put_payment_record(
@@ -426,6 +501,7 @@ def charge_once(
             status=status,
             ledger_sk_value=led_sk_value,
             payment_token_id=token,
+            purchase_txn_id=purchase_txn_id,
             raw=resp,
         )
 
@@ -482,11 +558,27 @@ def subscribe_monthly(
         settle_or_reverse_ledger(user_sub, led_sk_value, "settled")
         pay_status = "succeeded"
         sub_status = "active"
+        purchase_txn_id = record_billing_transaction(
+            user_sub=user_sub,
+            amount_cents=monthly_cents,
+            currency=S.default_currency,
+            description="CCBill subscription signup",
+            status="COMPLETED",
+            external_ref=str(transaction_id or ""),
+            metadata={
+                "provider": "ccbill",
+                "payment_token_id": token,
+                "transaction_id": str(transaction_id or ""),
+                "subscription_id": str(subscription_id or ""),
+                "plan_id": plan_id,
+            },
+        )
     else:
         apply_balance_delta(user_sub, {"payments_pending_cents": -monthly_cents})
         settle_or_reverse_ledger(user_sub, led_sk_value, "reversed")
         pay_status = "failed"
         sub_status = "failed"
+        purchase_txn_id = None
 
     if transaction_id:
         put_payment_record(
@@ -498,6 +590,7 @@ def subscribe_monthly(
             ledger_sk_value=led_sk_value,
             payment_token_id=token,
             subscription_id=str(subscription_id) if subscription_id else None,
+            purchase_txn_id=purchase_txn_id,
             raw=resp,
         )
 

--- a/app/services/billing_dunning.py
+++ b/app/services/billing_dunning.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+from boto3.dynamodb.conditions import Attr
+
+from app.core.settings import S
+from app.core.tables import T
+from app.core.time import now_ts
+from app.services.alerts import audit_event
+from app.services.billing_shared import compute_due, ddb_get, ddb_update, user_pk
+
+logger = logging.getLogger(__name__)
+
+
+def _retry_schedule_seconds() -> List[int]:
+    raw = S.billing_dunning_retry_schedule_seconds
+    out: List[int] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.append(max(60, int(part)))
+        except ValueError:
+            continue
+    return out or [3600, 86400, 172800]
+
+
+def _dunning_sk(next_attempt_ts: int) -> str:
+    return f"DUNNING#{next_attempt_ts}#{uuid.uuid4().hex}"
+
+
+def schedule_dunning(
+    *,
+    user_id: str,
+    provider: str,
+    amount_cents: int,
+    reason: str,
+    payment_ref: Optional[str],
+    next_attempt_ts: Optional[int] = None,
+) -> None:
+    ts = now_ts()
+    next_ts = next_attempt_ts or ts
+    pk = user_pk(user_id)
+    item = {
+        "pk": pk,
+        "sk": _dunning_sk(next_ts),
+        "provider": provider,
+        "amount_cents": int(amount_cents),
+        "reason": reason,
+        "payment_ref": payment_ref,
+        "status": "pending",
+        "retry_count": 0,
+        "next_attempt_ts": next_ts,
+        "created_at": ts,
+        "updated_at": ts,
+    }
+    if S.ddb_ttl_attr:
+        item[S.ddb_ttl_attr] = ts + 60 * 60 * 24 * 30
+    T.billing.put_item(Item=item)
+
+
+def schedule_ccbill_dunning(
+    *,
+    user_sub: str,
+    amount_cents: int,
+    reason: str,
+    payment_ref: Optional[str],
+    next_attempt_ts: Optional[int] = None,
+) -> None:
+    ts = now_ts()
+    next_ts = next_attempt_ts or ts
+    item = {
+        "user_sub": user_sub,
+        "sk": _dunning_sk(next_ts),
+        "provider": "ccbill",
+        "amount_cents": int(amount_cents),
+        "reason": reason,
+        "payment_ref": payment_ref,
+        "status": "pending",
+        "retry_count": 0,
+        "next_attempt_ts": next_ts,
+        "created_at": ts,
+        "updated_at": ts,
+    }
+    if S.ddb_ttl_attr:
+        item[S.ddb_ttl_attr] = ts + 60 * 60 * 24 * 30
+    T.billing.put_item(Item=item)
+
+
+def schedule_autopay_disabled_notice(user_id: str, provider: str) -> None:
+    pk = user_pk(user_id)
+    bal = ddb_get(T.billing, pk, "BALANCE") or {}
+    due = compute_due(bal)
+    due_cents = int(due.get("due_settled_cents", 0))
+    if due_cents <= 0:
+        return
+    schedule_dunning(
+        user_id=user_id,
+        provider=provider,
+        amount_cents=due_cents,
+        reason="autopay_disabled",
+        payment_ref=None,
+        next_attempt_ts=now_ts() + _retry_schedule_seconds()[0],
+    )
+    audit_event(
+        "billing_dunning_autopay_disabled",
+        user_id,
+        None,
+        outcome="info",
+        provider=provider,
+        amount_cents=due_cents,
+    )
+
+
+def schedule_ccbill_autopay_disabled_notice(user_sub: str) -> None:
+    bal = T.billing.get_item(Key={"user_sub": user_sub, "sk": "BALANCE"}).get("Item") or {}
+    due = compute_due(bal)
+    due_cents = int(due.get("due_settled_cents", 0))
+    if due_cents <= 0:
+        return
+    schedule_ccbill_dunning(
+        user_sub=user_sub,
+        amount_cents=due_cents,
+        reason="autopay_disabled",
+        payment_ref=None,
+        next_attempt_ts=now_ts() + _retry_schedule_seconds()[0],
+    )
+    audit_event(
+        "billing_dunning_autopay_disabled",
+        user_sub,
+        None,
+        outcome="info",
+        provider="ccbill",
+        amount_cents=due_cents,
+    )
+
+
+def bump_dunning_after_payment_method_update(user_id: str, provider: str) -> None:
+    schedule_dunning(
+        user_id=user_id,
+        provider=provider,
+        amount_cents=0,
+        reason="payment_method_updated",
+        payment_ref=None,
+        next_attempt_ts=now_ts(),
+    )
+
+
+def _scan_dunning_items(limit: int) -> List[Dict[str, Any]]:
+    if limit <= 0:
+        return []
+    items: List[Dict[str, Any]] = []
+    last_key: Optional[Dict[str, Any]] = None
+    filter_expr = Attr("sk").begins_with("DUNNING#") & Attr("status").eq("pending") & Attr("next_attempt_ts").lte(now_ts())
+    while len(items) < limit:
+        scan_kwargs: Dict[str, Any] = {"FilterExpression": filter_expr, "Limit": min(200, limit - len(items))}
+        if last_key:
+            scan_kwargs["ExclusiveStartKey"] = last_key
+        resp = T.billing.scan(**scan_kwargs)
+        items.extend(resp.get("Items", []))
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+    return items
+
+
+def _update_dunning(item: Dict[str, Any], *, status: str, retry_count: int, next_attempt_ts: Optional[int] = None) -> None:
+    key: Dict[str, Any] = {"sk": item["sk"]}
+    if "pk" in item:
+        key["pk"] = item["pk"]
+        key_name = "pk"
+    else:
+        key["user_sub"] = item["user_sub"]
+        key_name = "user_sub"
+    values = {":s": status, ":u": now_ts(), ":r": retry_count}
+    expr = "SET #s = :s, updated_at = :u, retry_count = :r"
+    if next_attempt_ts is not None:
+        values[":n"] = next_attempt_ts
+        expr += ", next_attempt_ts = :n"
+    T.billing.update_item(
+        Key=key,
+        UpdateExpression=expr,
+        ExpressionAttributeNames={"#s": "status"},
+        ExpressionAttributeValues=values,
+    )
+
+
+def _attempt_stripe_autopay(user_id: str, amount_cents: Optional[int]) -> bool:
+    from app.models import PayBalanceReq
+    from app.routers import billing as stripe_router
+
+    try:
+        stripe_router.pay_balance(PayBalanceReq(amount_cents=amount_cents), req=None, ctx={"user_sub": user_id})
+        return True
+    except Exception as exc:
+        logger.warning("Stripe dunning retry failed", extra={"user_id": user_id}, exc_info=exc)
+        return False
+
+
+def _attempt_ccbill_autopay(user_sub: str, amount_cents: Optional[int]) -> bool:
+    from app.services import billing_ccbill
+
+    try:
+        billing_ccbill.pay_balance(
+            user_sub=user_sub,
+            amount_cents=amount_cents,
+            idempotency_key=None,
+            request=None,
+        )
+        return True
+    except Exception as exc:
+        logger.warning("CCBill dunning retry failed", extra={"user_sub": user_sub}, exc_info=exc)
+        return False
+
+
+def process_dunning_queue() -> None:
+    schedule = _retry_schedule_seconds()
+    for item in _scan_dunning_items(int(S.billing_dunning_scan_limit)):
+        provider = item.get("provider", "")
+        retry_count = int(item.get("retry_count", 0))
+
+        user_id = None
+        user_sub = None
+        if "pk" in item:
+            pk = item.get("pk")
+            if isinstance(pk, str) and pk.startswith("USER#"):
+                user_id = pk.split("USER#", 1)[1]
+        if "user_sub" in item:
+            user_sub = item.get("user_sub")
+
+        if provider == "stripe" and user_id:
+            billing = ddb_get(T.billing, user_pk(user_id), "BILLING") or {}
+            if not billing.get("autopay_enabled", False):
+                audit_event("billing_dunning_autopay_disabled", user_id, None, outcome="info", provider="stripe")
+                next_ts = now_ts() + schedule[min(retry_count, len(schedule) - 1)]
+                _update_dunning(item, status="pending", retry_count=retry_count + 1, next_attempt_ts=next_ts)
+                continue
+            if not billing.get("default_payment_method_id"):
+                audit_event("billing_dunning_missing_payment_method", user_id, None, outcome="info", provider="stripe")
+                next_ts = now_ts() + schedule[min(retry_count, len(schedule) - 1)]
+                _update_dunning(item, status="pending", retry_count=retry_count + 1, next_attempt_ts=next_ts)
+                continue
+            ok = _attempt_stripe_autopay(user_id, item.get("amount_cents"))
+            if ok:
+                _update_dunning(item, status="completed", retry_count=retry_count)
+                audit_event("billing_dunning_succeeded", user_id, None, outcome="success", provider="stripe")
+            else:
+                next_ts = now_ts() + schedule[min(retry_count, len(schedule) - 1)]
+                _update_dunning(item, status="pending", retry_count=retry_count + 1, next_attempt_ts=next_ts)
+                audit_event("billing_dunning_retry_scheduled", user_id, None, outcome="failure", provider="stripe")
+        elif provider == "ccbill" and user_sub:
+            billing = T.billing.get_item(Key={"user_sub": user_sub, "sk": "BILLING"}).get("Item") or {}
+            if not billing.get("autopay_enabled", False):
+                audit_event("billing_dunning_autopay_disabled", user_sub, None, outcome="info", provider="ccbill")
+                next_ts = now_ts() + schedule[min(retry_count, len(schedule) - 1)]
+                _update_dunning(item, status="pending", retry_count=retry_count + 1, next_attempt_ts=next_ts)
+                continue
+            if not billing.get("default_payment_token_id"):
+                audit_event("billing_dunning_missing_payment_method", user_sub, None, outcome="info", provider="ccbill")
+                next_ts = now_ts() + schedule[min(retry_count, len(schedule) - 1)]
+                _update_dunning(item, status="pending", retry_count=retry_count + 1, next_attempt_ts=next_ts)
+                continue
+            ok = _attempt_ccbill_autopay(user_sub, item.get("amount_cents"))
+            if ok:
+                _update_dunning(item, status="completed", retry_count=retry_count)
+                audit_event("billing_dunning_succeeded", user_sub, None, outcome="success", provider="ccbill")
+            else:
+                next_ts = now_ts() + schedule[min(retry_count, len(schedule) - 1)]
+                _update_dunning(item, status="pending", retry_count=retry_count + 1, next_attempt_ts=next_ts)
+                audit_event("billing_dunning_retry_scheduled", user_sub, None, outcome="failure", provider="ccbill")
+        else:
+            _update_dunning(item, status="skipped", retry_count=retry_count)
+
+
+async def billing_dunning_loop() -> None:
+    interval = max(60, int(S.billing_dunning_interval_seconds))
+    while True:
+        try:
+            process_dunning_queue()
+        except Exception:
+            logger.exception("Billing dunning loop failed")
+        await asyncio.sleep(interval)
+
+
+def start_billing_dunning_task() -> None:
+    if not S.billing_dunning_enabled:
+        logger.info("Billing dunning disabled")
+        return
+    asyncio.create_task(billing_dunning_loop())

--- a/app/services/billing_reconcile.py
+++ b/app/services/billing_reconcile.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from boto3.dynamodb.conditions import Attr
+
+from app.core.settings import S
+from app.core.tables import T
+from app.core.time import now_ts
+from app.services.billing_ccbill import (
+    apply_balance_delta as ccbill_apply_balance_delta,
+    settle_or_reverse_ledger as ccbill_settle_or_reverse_ledger,
+    update_payment_status as ccbill_update_payment_status,
+)
+from app.services.billing_shared import apply_balance_delta, settle_or_reverse_ledger, user_pk
+
+logger = logging.getLogger(__name__)
+
+PENDING_STATUSES = {
+    "pending",
+    "processing",
+    "requires_action",
+    "requires_payment_method",
+    "requires_confirmation",
+    "requires_capture",
+}
+
+STRIPE_FAILURE_STATUSES = {"canceled", "payment_failed", "requires_payment_method"}
+PAYPAL_FAILURE_STATUSES = {"VOIDED", "CANCELLED", "CANCELED", "EXPIRED"}
+PAYPAL_PENDING_STATUSES = {"CREATED", "SAVED", "APPROVED", "PAYER_ACTION_REQUIRED"}
+
+
+def _pending_cutoff_ts() -> int:
+    return now_ts() - int(S.billing_reconcile_pending_age_seconds)
+
+
+def _age_ts(item: Dict[str, Any]) -> int:
+    return int(item.get("updated_at") or item.get("created_at") or 0)
+
+
+def _scan_pending_payments(limit: int) -> List[Dict[str, Any]]:
+    if limit <= 0:
+        return []
+    items: List[Dict[str, Any]] = []
+    last_key: Optional[Dict[str, Any]] = None
+    filter_expr = Attr("sk").begins_with("PAY#") & Attr("status").is_in(list(PENDING_STATUSES))
+    while len(items) < limit:
+        scan_kwargs: Dict[str, Any] = {
+            "FilterExpression": filter_expr,
+            "Limit": min(200, limit - len(items)),
+        }
+        if last_key:
+            scan_kwargs["ExclusiveStartKey"] = last_key
+        resp = T.billing.scan(**scan_kwargs)
+        items.extend(resp.get("Items", []))
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+    return items
+
+
+def _user_id_from_pk(pk: str) -> Optional[str]:
+    if not pk or not pk.startswith("USER#"):
+        return None
+    return pk.split("USER#", 1)[1]
+
+
+def _reconcile_stripe_payment(item: Dict[str, Any]) -> Optional[str]:
+    from app.routers import billing as stripe_router
+
+    stripe_router.ensure_stripe_configured()
+    if not stripe_router.stripe:
+        return None
+
+    pi_id = item.get("payment_intent_id")
+    if not pi_id:
+        return None
+
+    pk = item.get("pk")
+    user_id = _user_id_from_pk(pk) if isinstance(pk, str) else None
+    if not user_id:
+        return None
+
+    pi = stripe_router.stripe.PaymentIntent.retrieve(pi_id)
+    status = pi.get("status")
+    prior_status = item.get("status")
+    amount = int(item.get("amount_cents", 0))
+    ledger_sk = item.get("ledger_sk")
+    purchase_txn_id = item.get("purchase_txn_id")
+
+    charge_id = None
+    try:
+        charges = (pi.get("charges") or {}).get("data") or []
+        if charges:
+            charge_id = charges[0].get("id")
+    except Exception:
+        charge_id = None
+
+    if status == "succeeded":
+        stripe_router.update_payment_status(user_id, pi_id, "succeeded", charge_id=charge_id)
+        stripe_router._sync_purchase_history_status(
+            user_id=user_id,
+            purchase_txn_id=purchase_txn_id,
+            status="succeeded",
+            charge_id=charge_id,
+        )
+        if prior_status in PENDING_STATUSES:
+            apply_balance_delta(T.billing, pk, {"payments_pending_cents": -amount, "payments_settled_cents": amount}, currency=item.get("currency", "usd"))
+        if ledger_sk:
+            settle_or_reverse_ledger(T.billing, "pk", pk, ledger_sk, "settled")
+        return "succeeded"
+
+    if status in STRIPE_FAILURE_STATUSES:
+        stripe_router.update_payment_status(
+            user_id,
+            pi_id,
+            status,
+            charge_id=charge_id,
+            last_error=pi.get("last_payment_error"),
+        )
+        stripe_router._sync_purchase_history_status(
+            user_id=user_id,
+            purchase_txn_id=purchase_txn_id,
+            status=status,
+            charge_id=charge_id,
+            last_error=pi.get("last_payment_error"),
+        )
+        if prior_status in PENDING_STATUSES:
+            apply_balance_delta(T.billing, pk, {"payments_pending_cents": -amount}, currency=item.get("currency", "usd"))
+        if ledger_sk:
+            settle_or_reverse_ledger(T.billing, "pk", pk, ledger_sk, "reversed")
+        return status
+
+    stripe_router.update_payment_status(user_id, pi_id, status, charge_id=charge_id)
+    return status
+
+
+def _paypal_get_order_status(order_id: str) -> Optional[str]:
+    from app.routers import paypal as paypal_router
+
+    access = paypal_router.paypal_oauth()
+    url = f"{paypal_router.PAYPAL_BASE_URL}/v2/checkout/orders/{order_id}"
+    headers = {"Authorization": f"Bearer {access}", "Content-Type": "application/json"}
+    resp = paypal_router.requests.get(url, headers=headers, timeout=20)
+    if resp.status_code != 200:
+        logger.warning("PayPal order lookup failed", extra={"order_id": order_id, "status_code": resp.status_code})
+        return None
+    data = resp.json()
+    return data.get("status")
+
+
+def _reconcile_paypal_payment(item: Dict[str, Any]) -> Optional[str]:
+    from app.routers import paypal as paypal_router
+
+    external_id = item.get("external_id")
+    if not external_id:
+        return None
+
+    pk = item.get("pk")
+    user_id = _user_id_from_pk(pk) if isinstance(pk, str) else None
+    if not user_id:
+        return None
+
+    status = _paypal_get_order_status(str(external_id))
+    if not status:
+        return None
+
+    prior_status = item.get("status")
+    amount = int(item.get("amount_cents", 0))
+    ledger_sk = item.get("ledger_sk")
+
+    if status == "COMPLETED":
+        paypal_router.update_payment_status(user_id, str(external_id), "succeeded", raw={"order_status": status})
+        if prior_status in PENDING_STATUSES:
+            apply_balance_delta(T.billing, pk, {"payments_pending_cents": -amount, "payments_settled_cents": amount}, currency=item.get("currency", "usd"))
+        if ledger_sk:
+            settle_or_reverse_ledger(T.billing, "pk", pk, ledger_sk, "settled")
+        return "succeeded"
+
+    if status in PAYPAL_FAILURE_STATUSES:
+        paypal_router.update_payment_status(user_id, str(external_id), "failed", raw={"order_status": status})
+        if prior_status in PENDING_STATUSES:
+            apply_balance_delta(T.billing, pk, {"payments_pending_cents": -amount}, currency=item.get("currency", "usd"))
+        if ledger_sk:
+            settle_or_reverse_ledger(T.billing, "pk", pk, ledger_sk, "reversed")
+        return "failed"
+
+    if status in PAYPAL_PENDING_STATUSES:
+        paypal_router.update_payment_status(user_id, str(external_id), "pending", raw={"order_status": status})
+    return status
+
+
+def _reconcile_ccbill_payment(item: Dict[str, Any]) -> Optional[str]:
+    user_sub = item.get("user_sub")
+    if not user_sub:
+        return None
+
+    if item.get("status") not in PENDING_STATUSES:
+        return None
+
+    amount = int(item.get("amount_cents", 0))
+    ledger_sk = item.get("ledger_sk")
+    transaction_id = item.get("transaction_id")
+
+    ccbill_update_payment_status(str(user_sub), str(transaction_id), "stale", raw={"reason": "reconcile_timeout"})
+    ccbill_apply_balance_delta(str(user_sub), {"payments_pending_cents": -amount})
+    if ledger_sk:
+        ccbill_settle_or_reverse_ledger(str(user_sub), ledger_sk, "reversed")
+    return "stale"
+
+
+def reconcile_pending_payments() -> Dict[str, int]:
+    cutoff = _pending_cutoff_ts()
+    items = _scan_pending_payments(int(S.billing_reconcile_scan_limit))
+    results = {"processed": 0, "stripe": 0, "paypal": 0, "ccbill": 0}
+    for item in items:
+        if _age_ts(item) > cutoff:
+            continue
+        try:
+            provider = None
+            if "payment_intent_id" in item:
+                provider = "stripe"
+                _reconcile_stripe_payment(item)
+                results["stripe"] += 1
+            elif "external_id" in item:
+                provider = "paypal"
+                _reconcile_paypal_payment(item)
+                results["paypal"] += 1
+            elif "user_sub" in item:
+                provider = "ccbill"
+                _reconcile_ccbill_payment(item)
+                results["ccbill"] += 1
+            else:
+                provider = "unknown"
+            if provider:
+                results["processed"] += 1
+        except Exception:
+            logger.exception("Pending payment reconcile failed", extra={"provider": provider, "sk": item.get("sk")})
+    return results
+
+
+async def billing_reconcile_loop() -> None:
+    interval = max(60, int(S.billing_reconcile_interval_seconds))
+    while True:
+        try:
+            reconcile_pending_payments()
+        except Exception:
+            logger.exception("Billing reconciliation loop failed")
+        await asyncio.sleep(interval)
+
+
+def start_billing_reconcile_task() -> None:
+    if not S.billing_reconcile_enabled:
+        logger.info("Billing reconciliation disabled")
+        return
+    asyncio.create_task(billing_reconcile_loop())

--- a/docs/ccbill.md
+++ b/docs/ccbill.md
@@ -36,6 +36,9 @@ charge once, subscribe, and reconcile via webhooks.
 | `DEFAULT_CURRENCY_CODE` | ISO numeric currency code (e.g., 840 for USD). |
 | `DEFAULT_CURRENCY` | Currency string (e.g., `usd`). |
 | `CCBILL_WEBHOOK_IP_ENFORCE` | Set to `true` to enforce CCBill webhook IP ranges. |
+| `CCBILL_WEBHOOK_IP_RANGES` | Optional comma-delimited list of CIDR blocks, IPs, or IP ranges (`start-end`) to allow for webhooks. Defaults to the bundled range list. |
+| `CCBILL_WEBHOOK_SIGNATURE_SECRET` | Optional shared secret used to verify webhook payload signatures (HMAC SHA-256). |
+| `CCBILL_WEBHOOK_SIGNATURE_HEADER` | Header name containing the webhook signature (default: `x-ccbill-signature`). |
 
 ## Optional environment variables
 
@@ -95,6 +98,7 @@ All endpoints below require a valid UI session (`X-SESSION-ID`) + auth token.
 - **Widget loads but tokenization fails**: confirm `CCBILL_FRONTEND_CLIENT_ID` and `CCBILL_FRONTEND_CLIENT_SECRET` and ensure the widget config in `/api/billing/config` matches your CCBill account.
 - **Charges failing**: validate `CCBILL_BACKEND_CLIENT_ID` and `CCBILL_BACKEND_CLIENT_SECRET` and confirm account/sub-account numbers.
 - **Webhook rejected**: set `CCBILL_WEBHOOK_IP_ENFORCE=false` temporarily to validate payloads, then enable IP enforcement after confirming the CCBill IP range list.
+- **Webhook signature failures**: confirm `CCBILL_WEBHOOK_SIGNATURE_SECRET` matches the secret configured in CCBill and that the signature header name matches `CCBILL_WEBHOOK_SIGNATURE_HEADER`.
 
 ## DynamoDB Table Layout
 


### PR DESCRIPTION
### Motivation
- Provide automatic retry (dunning) workflows for failed or disabled autopay so owed balances are retried and customers are notified when appropriate.
- Trigger retry attempts automatically after payment-method updates so users who fix payment info have payments re-attempted.
- Harden CCBill/PayPal webhook handling (IP ranges, signature verification, sanitized logging) to improve security and observability.

### Description
- Add a dunning background worker and scheduling helpers in `app/services/billing_dunning.py` with configurable retry schedule, scan limits, and processing loop that attempts autopay for `stripe` and `ccbill` and schedules retries when needed.
- Add settings flags and retry configuration in `app/core/settings.py` (`BILLING_DUNNING_*`) and start the dunning task on app startup in `app/main.py` via `start_billing_dunning_task`.
- Wire dunning scheduling into Stripe and CCBill flows: schedule dunning on failed payments/webhook failures, on `autopay` being disabled, and bump the dunning queue when a payment method is added/updated (`app/routers/billing.py`, `app/routers/billing_ccbill.py`).
- Add CCBill webhook safety improvements: IP range parsing/config override, HMAC signature verification, sanitized webhook payload storing, and dedicated rejected-webhook logging (`app/services/billing_ccbill.py`, `app/routers/billing_ccbill.py`, `docs/ccbill.md`).
- Improve webhook/handler metadata sanitation and dedupe handling and add safer logging paths for PayPal and CCBill webhook rejections (`app/routers/billing_ccbill.py`, `app/routers/paypal.py`).
- Surface provider info and default flags on payment-method models and add refund request models (`app/models.py`) and wire notification/audit events for relevant billing operations.
- Minor utility fix to `client_ip_from_request` to handle a `None` request object (`app/core/normalize.py`).
- Integrate purchase-history recording for CCBill to link payments to purchase transactions and mark them reverted on refunds/chargebacks (`app/services/billing_ccbill.py`, `app/routers/billing_ccbill.py`).

### Testing
- No automated tests were executed for these changes.
- Manual validation recommended: exercise a failed payment flow to confirm dunning entries are created, update a payment method to verify immediate retry bump, and send CCBill/PayPal webhooks with invalid signatures/IP to confirm rejection logging (manual checks only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fc1584848832b9c25de7cc8616cfe)