### PR TITLE
Add device trust tracking & management, enforce fresh MFA, and strengthen recovery/ratelimits

### DIFF
--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -108,6 +108,9 @@ async def get_authenticated_user_sub(request: Request) -> str:
             raise HTTPException(401, "Token missing subject")
         return str(user_sub)
 
+    if not S.dev_mode:
+        raise HTTPException(401, "Authentication not configured")
+
     fallback_user = request.headers.get("x-user-sub")
     if fallback_user:
         return fallback_user

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -38,6 +38,7 @@ class Settings:
     ui_session_ttl_seconds: int = int(os.environ.get("UI_SESSION_TTL_SECONDS", str(30 * 24 * 3600)))
     ui_inactivity_seconds: int = int(os.environ.get("UI_INACTIVITY_SECONDS", "900"))
     session_challenge_ttl_seconds: int = int(os.environ.get("SESSION_CHALLENGE_TTL_SECONDS", "300"))
+    ui_stepup_max_age_seconds: int = int(os.environ.get("UI_STEPUP_MAX_AGE_SECONDS", "300"))
 
     # MFA rate limiting
     mfa_send_min_interval_seconds: int = int(os.environ.get("MFA_SEND_MIN_INTERVAL_SECONDS", "30"))
@@ -48,6 +49,10 @@ class Settings:
     email_code_attempt_window_seconds: int = int(os.environ.get("EMAIL_CODE_ATTEMPT_WINDOW_SECONDS", "600"))
     sms_code_max_attempts: int = int(os.environ.get("SMS_CODE_MAX_ATTEMPTS", "8"))
     sms_code_attempt_window_seconds: int = int(os.environ.get("SMS_CODE_ATTEMPT_WINDOW_SECONDS", "600"))
+    login_attempt_max_per_window: int = int(os.environ.get("LOGIN_ATTEMPT_MAX_PER_WINDOW", "10"))
+    login_attempt_window_seconds: int = int(os.environ.get("LOGIN_ATTEMPT_WINDOW_SECONDS", "900"))
+    mfa_verify_max_per_window: int = int(os.environ.get("MFA_VERIFY_MAX_PER_WINDOW", "10"))
+    mfa_verify_window_seconds: int = int(os.environ.get("MFA_VERIFY_WINDOW_SECONDS", "600"))
 
     # Device limits
     sms_device_limit: int = int(os.environ.get("SMS_DEVICE_LIMIT", "3"))
@@ -89,6 +94,7 @@ class Settings:
     fcm_private_key: str = os.environ.get("FCM_PRIVATE_KEY", "")  # keep \n escaped
 
     audit_log_enabled: bool = os.environ.get("AUDIT_LOG_ENABLED", "1") not in ("0","false","False")
+    dev_mode: bool = os.environ.get("DEV_MODE", "1") not in ("0", "false", "False")
 
     # Billing / CCBill
     ccbill_base_url: str = os.environ.get("CCBILL_BASE_URL", "https://api.ccbill.com").rstrip("/")

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.routers.messaging import router as messaging_router
 from app.routers.filemanager import router as filemanager_router
 from app.routers.addresses import router as addresses_router
 from app.routers.calendar import router as calendar_router
+from app.routers.device_trust import router as device_trust_router
 from app.routers.newsfeed import router as newsfeed_router, startup as newsfeed_startup
 from app.routers.purchase_history import router as purchase_history_router
 from app.routers.shoppingcart import router as shoppingcart_router
@@ -74,6 +75,7 @@ def create_app() -> FastAPI:
     app.include_router(filemanager_router)
     app.include_router(addresses_router)
     app.include_router(calendar_router)
+    app.include_router(device_trust_router)
     app.include_router(newsfeed_router)
     app.add_event_handler("startup", newsfeed_startup)
     app.include_router(purchase_history_router)

--- a/app/models.py
+++ b/app/models.py
@@ -118,6 +118,25 @@ class AlertEmailConfirmReq(BaseModel):
     challenge_id: str
     code: str
 
+class TokenRefreshReq(BaseModel):
+    refresh_token: str
+
+class TokenRefreshResp(BaseModel):
+    access_token: str
+    id_token: Optional[str] = None
+    expires_in: Optional[int] = None
+
+class DeviceTrustOut(BaseModel):
+    device_id: str
+    user_agent: str
+    first_seen_at: int
+    last_seen_at: int
+    last_ip: str
+    trusted: bool
+
+class DeviceTrustListOut(BaseModel):
+    devices: List[DeviceTrustOut] = Field(default_factory=list)
+
 
 class PurchaseMoneyIn(BaseModel):
     amount: float = Field(..., gt=0)

--- a/app/routers/api_keys.py
+++ b/app/routers/api_keys.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Request
 from app.models import CreateApiKeyReq, RevokeApiKeyReq, ApiKeyIpRulesReq
 from app.services.api_keys import create_api_key, list_api_keys, revoke_api_key, set_api_key_ip_rules
 from app.services.alerts import audit_event
-from app.services.sessions import require_ui_session
+from app.services.sessions import require_ui_session, require_fresh_mfa
 
 router = APIRouter(prefix="/ui", tags=["api-keys"])
 
@@ -15,18 +15,21 @@ async def ui_list_api_keys(ctx=Depends(require_ui_session)):
 
 @router.post("/api_keys")
 async def ui_create_api_key(req: Request, body: CreateApiKeyReq, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
     created = create_api_key(ctx["user_sub"], body.label or "")
     audit_event("api_key_create", ctx["user_sub"], req, outcome="success", key_id=created["key_id"])
     return created
 
 @router.post("/api_keys/revoke")
 async def ui_revoke_api_key(req: Request, body: RevokeApiKeyReq, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
     revoke_api_key(ctx["user_sub"], body.key_id)
     audit_event("api_key_revoke", ctx["user_sub"], req, outcome="success", key_id=body.key_id)
     return {"ok": True}
 
 @router.post("/api_keys/ip_rules")
 async def ui_set_api_key_ip_rules(req: Request, body: ApiKeyIpRulesReq, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
     rules = set_api_key_ip_rules(ctx["user_sub"], body.key_id, body.allow_cidrs, body.deny_cidrs)
     audit_event("api_key_ip_rules_set", ctx["user_sub"], req, outcome="success", key_id=body.key_id, allow=len(rules["allow_cidrs"]), deny=len(rules["deny_cidrs"]))
     return {"ok": True, "allow_cidrs": rules["allow_cidrs"], "deny_cidrs": rules["deny_cidrs"]}

--- a/app/routers/device_trust.py
+++ b/app/routers/device_trust.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from app.models import DeviceTrustListOut
+from app.services.device_trust import list_devices, trust_device, revoke_device
+from app.services.sessions import require_ui_session, require_fresh_mfa
+from app.services.alerts import audit_event
+
+router = APIRouter(prefix="/ui/devices", tags=["device-trust"])
+
+
+@router.get("", response_model=DeviceTrustListOut)
+async def ui_devices(ctx=Depends(require_ui_session)):
+    return DeviceTrustListOut(devices=list_devices(ctx["user_sub"]))
+
+
+@router.post("/{device_id}/trust")
+async def ui_device_trust(req: Request, device_id: str, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
+    trust_device(ctx["user_sub"], device_id)
+    audit_event("device_trust", ctx["user_sub"], req, outcome="success", device_id=device_id)
+    return {"status": "ok"}
+
+
+@router.post("/{device_id}/revoke")
+async def ui_device_revoke(req: Request, device_id: str, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
+    revoke_device(ctx["user_sub"], device_id)
+    audit_event("device_revoke", ctx["user_sub"], req, outcome="success", device_id=device_id)
+    return {"status": "ok"}

--- a/app/routers/mfa_devices.py
+++ b/app/routers/mfa_devices.py
@@ -28,7 +28,7 @@ from app.services.mfa import (
     store_recovery_codes,
 )
 from app.services.rate_limit import rate_limit_or_429
-from app.services.sessions import create_action_challenge, load_challenge_or_401, require_ui_session, revoke_challenge
+from app.services.sessions import create_action_challenge, load_challenge_or_401, require_ui_session, revoke_challenge, require_fresh_mfa
 from app.core.tables import T
 from app.core.time import now_ts
 
@@ -57,18 +57,21 @@ async def totp_devices(ctx=Depends(require_ui_session)):
 
 @router.post("/totp/devices/begin")
 async def totp_devices_begin(req: Request, body: TotpDeviceBeginReq, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
     out = totp_begin_enroll(ctx["user_sub"], body.label)
     audit_event("totp_device_begin", ctx["user_sub"], req, outcome="success", device_id=out["device_id"])
     return out
 
 @router.post("/totp/devices/confirm")
 async def totp_devices_confirm(req: Request, body: TotpDeviceConfirmReq, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
     totp_confirm_enroll(ctx["user_sub"], body.device_id, body.totp_code)
     audit_event("totp_device_confirm", ctx["user_sub"], req, outcome="success", device_id=body.device_id)
     return {"ok": True}
 
 @router.post("/totp/devices/{device_id}/remove")
 async def totp_devices_remove(req: Request, device_id: str, body: TotpDeviceRemoveReq, ctx=Depends(require_ui_session)):
+    require_fresh_mfa(ctx)
     if not totp_verify_any_enabled(ctx["user_sub"], body.totp_code):
         raise HTTPException(401, "Bad TOTP")
     try:
@@ -97,6 +100,7 @@ async def sms_devices(ctx=Depends(require_ui_session)):
 @router.post("/sms/devices/begin")
 async def sms_devices_begin(req: Request, body: SmsDeviceBeginReq, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     rate_limit_or_429(user_sub, "enroll_sms")
     phone = normalize_phone(body.phone_e164)
     r = T.sms.query(KeyConditionExpression=Key("user_sub").eq(user_sub))
@@ -132,6 +136,7 @@ async def sms_devices_begin(req: Request, body: SmsDeviceBeginReq, ctx=Depends(r
 @router.post("/sms/devices/confirm")
 async def sms_devices_confirm(req: Request, body: SmsDeviceConfirmReq, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if chal.get("purpose") != "sms_enroll":
         raise HTTPException(400, "Wrong challenge purpose")
@@ -157,6 +162,7 @@ async def sms_devices_confirm(req: Request, body: SmsDeviceConfirmReq, ctx=Depen
 @router.post("/sms/devices/{sms_device_id}/remove/begin")
 async def sms_devices_remove_begin(req: Request, sms_device_id: str, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     rate_limit_or_429(user_sub, "remove_sms")
     it = T.sms.get_item(Key={"user_sub": user_sub, "sms_device_id": sms_device_id}).get("Item")
     if not it:
@@ -180,6 +186,7 @@ async def sms_devices_remove_begin(req: Request, sms_device_id: str, ctx=Depends
 @router.post("/sms/devices/remove/confirm")
 async def sms_devices_remove_confirm(req: Request, body: SmsDeviceRemoveConfirmReq, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if chal.get("purpose") != "sms_remove":
         raise HTTPException(400, "Wrong challenge purpose")
@@ -211,6 +218,7 @@ async def email_devices(ctx=Depends(require_ui_session)):
 @router.post("/email/devices/begin")
 async def email_devices_begin(req: Request, body: EmailDeviceBeginReq, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     rate_limit_or_429(user_sub, "enroll_email")
     email = normalize_email(body.email)
     r = T.email.query(KeyConditionExpression=Key("user_sub").eq(user_sub))
@@ -249,6 +257,7 @@ async def email_devices_begin(req: Request, body: EmailDeviceBeginReq, ctx=Depen
 @router.post("/email/devices/confirm")
 async def email_devices_confirm(req: Request, body: EmailDeviceConfirmReq, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if chal.get("purpose") != "email_enroll":
         raise HTTPException(400, "Wrong challenge purpose")
@@ -274,6 +283,7 @@ async def email_devices_confirm(req: Request, body: EmailDeviceConfirmReq, ctx=D
 @router.post("/email/devices/{email_device_id}/remove/begin")
 async def email_devices_remove_begin(req: Request, email_device_id: str, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     rate_limit_or_429(user_sub, "remove_email")
     it = T.email.get_item(Key={"user_sub": user_sub, "email_device_id": email_device_id}).get("Item")
     if not it:
@@ -299,6 +309,7 @@ async def email_devices_remove_begin(req: Request, email_device_id: str, ctx=Dep
 @router.post("/email/devices/remove/confirm")
 async def email_devices_remove_confirm(req: Request, body: EmailDeviceRemoveConfirmReq, ctx=Depends(require_ui_session)):
     user_sub = ctx["user_sub"]
+    require_fresh_mfa(ctx)
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if chal.get("purpose") != "email_remove":
         raise HTTPException(400, "Wrong challenge purpose")

--- a/app/routers/misc.py
+++ b/app/routers/misc.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.core.crypto import mint_ws_token
+from app.models import TokenRefreshReq, TokenRefreshResp
+from app.services.cognito import cognito_refresh_tokens
 from app.services.sessions import require_ui_session
 
 router = APIRouter(tags=["misc"])
@@ -14,3 +16,15 @@ async def ui_ws_token(ctx=Depends(require_ui_session)):
 @router.get("/api/ping")
 async def ping():
     return {"ok": True}
+
+@router.post("/ui/token/refresh", response_model=TokenRefreshResp)
+async def ui_refresh_token(req: Request, body: TokenRefreshReq):
+    refresh_token = body.refresh_token or req.cookies.get("refresh_token", "")
+    if not refresh_token:
+        raise HTTPException(400, "Missing refresh token")
+    result = cognito_refresh_tokens(refresh_token)
+    return TokenRefreshResp(
+        access_token=result.get("AccessToken", ""),
+        id_token=result.get("IdToken"),
+        expires_in=result.get("ExpiresIn"),
+    )

--- a/app/routers/password_recovery.py
+++ b/app/routers/password_recovery.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from app.core.crypto import sha256_str
 from app.core.settings import S
+from app.core.normalize import client_ip_from_request
 from app.core.tables import T
 from app.core.time import now_ts
 from app.models import (
@@ -29,13 +30,15 @@ from app.services.mfa import (
     twilio_check_sms,
     twilio_start_sms,
 )
-from app.services.rate_limit import can_send_verification, rate_limit_or_429
+from app.services.api_keys import revoke_all_api_keys
+from app.services.rate_limit import can_send_verification, rate_limit_or_429, rate_limit_mfa_verify
 from app.services.sessions import (
     compute_required_factors,
     create_stepup_challenge,
     load_challenge_or_401,
     mark_factor_passed,
     revoke_challenge,
+    revoke_all_sessions,
 )
 
 router = APIRouter(prefix="/ui", tags=["password-recovery"])
@@ -117,12 +120,21 @@ async def password_recovery_confirm(req: Request, body: PasswordRecoveryConfirmR
             raise HTTPException(401, "Complete all challenges before confirming")
         revoke_challenge(username, body.challenge_id)
     cognito_confirm_forgot_password(username, body.confirmation_code, body.new_password)
+    try:
+        revoke_all_sessions(username)
+    except Exception:
+        pass
+    try:
+        revoke_all_api_keys(username)
+    except Exception:
+        pass
     audit_event("password_recovery_confirm", username, req, outcome="success")
     return {"status": "ok"}
 
 
 @router.post("/password-recovery/challenge/totp/verify")
 async def password_recovery_totp_verify(req: Request, body: PasswordRecoveryTotpVerifyReq) -> Dict[str, Any]:
+    rate_limit_mfa_verify(body.username, client_ip_from_request(req), "totp")
     chal = _load_password_recovery_challenge(body.username, body.challenge_id)
     _ensure_factor_required(chal, "totp")
     dev = totp_verify_any_enabled(body.username, body.totp_code)
@@ -144,6 +156,11 @@ async def password_recovery_sms_begin(req: Request, body: PasswordRecoveryChalle
     if not can_send_verification(body.username, "sms"):
         raise HTTPException(429, "Rate limited")
     rate_limit_or_429(body.username, "sms_recovery")
+    T.sessions.update_item(
+        Key={"user_sub": body.username, "session_id": body.challenge_id},
+        UpdateExpression="SET sms_code_sent_at=:t, sms_code_attempts=:z",
+        ExpressionAttributeValues={":t": now_ts(), ":z": 0},
+    )
     send_to = nums[:S.sms_device_limit]
     for n in send_to:
         twilio_start_sms(n)
@@ -153,8 +170,21 @@ async def password_recovery_sms_begin(req: Request, body: PasswordRecoveryChalle
 
 @router.post("/password-recovery/challenge/sms/verify")
 async def password_recovery_sms_verify(req: Request, body: PasswordRecoverySmsVerifyReq) -> Dict[str, Any]:
+    rate_limit_mfa_verify(body.username, client_ip_from_request(req), "sms")
     chal = _load_password_recovery_challenge(body.username, body.challenge_id)
     _ensure_factor_required(chal, "sms")
+    attempts = int(chal.get("sms_code_attempts", 0))
+    sent_at = int(chal.get("sms_code_sent_at", 0))
+    if attempts >= S.sms_code_max_attempts and (now_ts() - sent_at) < S.sms_code_attempt_window_seconds:
+        audit_event(
+            "password_recovery_sms_verify",
+            body.username,
+            req,
+            outcome="failure",
+            challenge_id=body.challenge_id,
+            reason="too_many_attempts",
+        )
+        raise HTTPException(429, "Too many attempts; wait and retry")
     nums = list_enabled_sms_numbers(body.username)
     if not nums:
         raise HTTPException(400, "No SMS devices")
@@ -167,8 +197,21 @@ async def password_recovery_sms_verify(req: Request, body: PasswordRecoverySmsVe
         except Exception:
             continue
     if not ok:
+        T.sessions.update_item(
+            Key={"user_sub": body.username, "session_id": body.challenge_id},
+            UpdateExpression="SET sms_code_attempts = :n",
+            ExpressionAttributeValues={":n": attempts + 1},
+        )
         audit_event("password_recovery_sms_verify", body.username, req, outcome="failure", challenge_id=body.challenge_id)
         raise HTTPException(401, "Bad SMS code")
+    try:
+        T.sessions.update_item(
+            Key={"user_sub": body.username, "session_id": body.challenge_id},
+            UpdateExpression="REMOVE sms_code_sent_at SET sms_code_attempts = :z",
+            ExpressionAttributeValues={":z": 0},
+        )
+    except Exception:
+        pass
     mark_factor_passed(body.username, body.challenge_id, "sms")
     audit_event("password_recovery_sms_verify", body.username, req, outcome="success", challenge_id=body.challenge_id)
     return {"status": "ok"}
@@ -199,6 +242,7 @@ async def password_recovery_email_begin(req: Request, body: PasswordRecoveryChal
 
 @router.post("/password-recovery/challenge/email/verify")
 async def password_recovery_email_verify(req: Request, body: PasswordRecoveryEmailVerifyReq) -> Dict[str, Any]:
+    rate_limit_mfa_verify(body.username, client_ip_from_request(req), "email")
     chal = _load_password_recovery_challenge(body.username, body.challenge_id)
     _ensure_factor_required(chal, "email")
     expected = chal.get("email_code_hash", "")
@@ -231,6 +275,7 @@ async def password_recovery_email_verify(req: Request, body: PasswordRecoveryEma
 
 @router.post("/password-recovery/challenge/recovery")
 async def password_recovery_code(req: Request, body: PasswordRecoveryRecoveryCodeReq) -> Dict[str, Any]:
+    rate_limit_mfa_verify(body.username, client_ip_from_request(req), f"recovery_{body.factor}")
     chal = _load_password_recovery_challenge(body.username, body.challenge_id)
     factor = body.factor
     if factor not in ("totp", "sms", "email"):

--- a/app/routers/ui_mfa.py
+++ b/app/routers/ui_mfa.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.auth.deps import get_authenticated_user_sub
 from app.core.settings import S
+from app.core.normalize import client_ip_from_request
 from app.models import EmailBeginReq, EmailVerifyReq, SmsBeginReq, SmsVerifyReq, TotpVerifyReq, RecoveryReq
 from app.services.alerts import audit_event
 from app.services.mfa import (
@@ -16,7 +17,7 @@ from app.services.mfa import (
     twilio_start_sms,
     consume_recovery_code,
 )
-from app.services.rate_limit import rate_limit_or_429, can_send_verification
+from app.services.rate_limit import rate_limit_or_429, can_send_verification, rate_limit_mfa_verify
 from app.services.sessions import load_challenge_or_401, mark_factor_passed, maybe_finalize, revoke_challenge
 from app.core.tables import T
 from app.core.time import now_ts
@@ -36,6 +37,7 @@ def _challenge_progress(chal: dict, passed_factor: str) -> dict:
 
 @router.post("/totp/verify")
 async def ui_totp_verify(req: Request, body: TotpVerifyReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    rate_limit_mfa_verify(user_sub, client_ip_from_request(req), "totp")
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if "totp" not in (chal.get("required_factors") or []):
         raise HTTPException(400, "TOTP not required")
@@ -59,6 +61,11 @@ async def ui_sms_begin(req: Request, body: SmsBeginReq, user_sub: str = Depends(
     if not can_send_verification(user_sub, "sms"):
         raise HTTPException(429, "Rate limited")
     rate_limit_or_429(user_sub, "sms_login")
+    T.sessions.update_item(
+        Key={"user_sub": user_sub, "session_id": body.challenge_id},
+        UpdateExpression="SET sms_code_sent_at=:t, sms_code_attempts=:z",
+        ExpressionAttributeValues={":t": now_ts(), ":z": 0},
+    )
     # Send to all enabled numbers
     send_to = nums[:S.sms_device_limit]
     for n in send_to:
@@ -68,9 +75,15 @@ async def ui_sms_begin(req: Request, body: SmsBeginReq, user_sub: str = Depends(
 
 @router.post("/sms/verify")
 async def ui_sms_verify(req: Request, body: SmsVerifyReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    rate_limit_mfa_verify(user_sub, client_ip_from_request(req), "sms")
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if "sms" not in (chal.get("required_factors") or []):
         raise HTTPException(400, "SMS not required")
+    attempts = int(chal.get("sms_code_attempts", 0))
+    sent_at = int(chal.get("sms_code_sent_at", 0))
+    if attempts >= S.sms_code_max_attempts and (now_ts() - sent_at) < S.sms_code_attempt_window_seconds:
+        audit_event("mfa_sms_verify", user_sub, req, outcome="failure", challenge_id=body.challenge_id, reason="too_many_attempts")
+        raise HTTPException(429, "Too many attempts; wait and retry")
     nums = list_enabled_sms_numbers(user_sub)
     if not nums:
         raise HTTPException(400, "No SMS devices")
@@ -83,8 +96,21 @@ async def ui_sms_verify(req: Request, body: SmsVerifyReq, user_sub: str = Depend
         except Exception:
             continue
     if not ok:
+        T.sessions.update_item(
+            Key={"user_sub": user_sub, "session_id": body.challenge_id},
+            UpdateExpression="SET sms_code_attempts = :n",
+            ExpressionAttributeValues={":n": attempts + 1},
+        )
         audit_event("mfa_sms_verify", user_sub, req, outcome="failure", challenge_id=body.challenge_id)
         raise HTTPException(401, "Bad SMS code")
+    try:
+        T.sessions.update_item(
+            Key={"user_sub": user_sub, "session_id": body.challenge_id},
+            UpdateExpression="REMOVE sms_code_sent_at SET sms_code_attempts = :z",
+            ExpressionAttributeValues={":z": 0},
+        )
+    except Exception:
+        pass
     mark_factor_passed(user_sub, body.challenge_id, "sms")
     sid = maybe_finalize(req, user_sub, body.challenge_id)
     audit_event("mfa_sms_verify", user_sub, req, outcome="success", challenge_id=body.challenge_id)
@@ -113,6 +139,7 @@ async def ui_email_begin(req: Request, body: EmailBeginReq, user_sub: str = Depe
 
 @router.post("/email/verify")
 async def ui_email_verify(req: Request, body: EmailVerifyReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    rate_limit_mfa_verify(user_sub, client_ip_from_request(req), "email")
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if "email" not in (chal.get("required_factors") or []):
         raise HTTPException(400, "Email not required")
@@ -144,6 +171,7 @@ async def ui_email_verify(req: Request, body: EmailVerifyReq, user_sub: str = De
 
 @router.post("/recovery/{factor}")
 async def ui_recovery_factor(req: Request, factor: str, body: RecoveryReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    rate_limit_mfa_verify(user_sub, client_ip_from_request(req), f"recovery_{factor}")
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     if factor not in ("totp","sms","email"):
         raise HTTPException(400, "Invalid factor")

--- a/app/routers/ui_session.py
+++ b/app/routers/ui_session.py
@@ -9,6 +9,7 @@ from app.auth.deps import get_authenticated_user_sub
 from app.models import UiSessionFinalizeReq, UiSessionStartReq, UiSessionStartResp
 from app.core.normalize import client_ip_from_request
 from app.services.alerts import audit_event
+from app.services.rate_limit import rate_limit_login_attempt
 from app.services.sessions import (
     compute_required_factors,
     create_real_session,
@@ -26,6 +27,7 @@ router = APIRouter(prefix="/ui", tags=["ui-session"])
 
 @router.post("/session/start", response_model=UiSessionStartResp)
 async def ui_session_start(req: Request, body: UiSessionStartReq, user_sub: str = Depends(get_authenticated_user_sub)):
+    rate_limit_login_attempt(user_sub, client_ip_from_request(req))
     required = compute_required_factors(user_sub)
     if not required:
         sid = create_real_session(req, user_sub)

--- a/app/services/alerts.py
+++ b/app/services/alerts.py
@@ -22,6 +22,7 @@ ALERT_EVENT_TYPES: List[str] = [
     "login_success","login_failure","mfa_success","mfa_failure","challenge_created","challenge_revoked",
     "challenge_failed","api_key_created","api_key_revoked","api_key_ip_rules_updated","session_revoked",
     "totp_device_added","totp_device_removed","rate_limited","access_denied","security_event",
+    "device_new","device_location_mismatch","device_trust","device_revoke",
 ]
 
 # In-memory pubsub for SSE (single-process). For multi-process, swap with Redis/SQS/etc.
@@ -266,6 +267,10 @@ def audit_event(event: str, user_sub: str, request=None, **fields: Any) -> None:
             "ui_session_revoke_others": "Other sessions revoked",
             "totp_device_confirm": "TOTP device added",
             "totp_device_remove": "TOTP device removed",
+            "device_new": "New device detected",
+            "device_location_mismatch": "Device location mismatch",
+            "device_trust": "Device trusted",
+            "device_revoke": "Device trust revoked",
         }
         title = pretty.get(event, event.replace("_", " "))
         wr = write_alert(user_sub, event=event, outcome=outcome, title=title, details={**payload, "alert_type": alert_type})

--- a/app/services/api_keys.py
+++ b/app/services/api_keys.py
@@ -78,6 +78,37 @@ def revoke_api_key(user_sub: str, key_id: str) -> None:
     except Exception:
         raise HTTPException(404, "API key not found")
 
+def revoke_all_api_keys(user_sub: str) -> int:
+    revoked = 0
+    last_key = None
+    while True:
+        kwargs: Dict[str, Any] = {
+            "IndexName": S.api_keys_user_index,
+            "KeyConditionExpression": Key("user_sub").eq(user_sub),
+            "Limit": 200,
+        }
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = T.api_keys.query(**kwargs)
+        items = resp.get("Items", [])
+        for it in items:
+            key_id = it.get("key_id") or it.get("api_key_id")
+            if not key_id:
+                continue
+            try:
+                T.api_keys.update_item(
+                    Key={"key_id": key_id},
+                    UpdateExpression="SET revoked = :t, revoked_at = :now",
+                    ExpressionAttributeValues={":t": True, ":now": now_ts()},
+                )
+                revoked += 1
+            except Exception:
+                pass
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+    return revoked
+
 def set_api_key_ip_rules(user_sub: str, key_id: str, allow_cidrs: List[str], deny_cidrs: List[str]) -> Dict[str, List[str]]:
     allow = [normalize_cidr(r) for r in (allow_cidrs or []) if (r or "").strip()]
     deny = [normalize_cidr(r) for r in (deny_cidrs or []) if (r or "").strip()]

--- a/app/services/cognito.py
+++ b/app/services/cognito.py
@@ -38,3 +38,21 @@ def cognito_confirm_forgot_password(username: str, code: str, new_password: str)
         ConfirmationCode=code,
         Password=new_password,
     )
+
+
+def cognito_refresh_tokens(refresh_token: str) -> Dict[str, Any]:
+    client = cognito_client()
+    try:
+        resp = client.initiate_auth(
+            ClientId=_cognito_client_id(),
+            AuthFlow="REFRESH_TOKEN_AUTH",
+            AuthParameters={"REFRESH_TOKEN": refresh_token},
+        )
+    except client.exceptions.NotAuthorizedException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(401, "Invalid refresh token") from exc
+    except client.exceptions.InvalidParameterException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(400, "Invalid refresh token") from exc
+    result = resp.get("AuthenticationResult") or {}
+    if not result:
+        raise HTTPException(401, "Refresh token rejected")
+    return result

--- a/app/services/device_trust.py
+++ b/app/services/device_trust.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, List, Optional
+
+from boto3.dynamodb.conditions import Key
+from fastapi import HTTPException, Request
+
+from app.core.normalize import client_ip_from_request
+from app.core.time import now_ts
+from app.core.tables import T
+from app.services.alerts import audit_event
+
+
+def _ip_prefix(ip: str) -> str:
+    if not ip:
+        return ""
+    if ":" in ip:
+        parts = ip.split(":")
+        return ":".join(parts[:4])
+    parts = ip.split(".")
+    return ".".join(parts[:3]) if len(parts) >= 3 else ip
+
+
+def _device_id(user_agent: str) -> str:
+    ua = (user_agent or "").strip()
+    return hashlib.sha256(ua.encode("utf-8")).hexdigest()[:32]
+
+
+def record_device_login(req: Request, user_sub: str) -> Dict[str, Any]:
+    ip = client_ip_from_request(req)
+    user_agent = (req.headers.get("user-agent", "")[:512])
+    device_id = _device_id(user_agent)
+    sid = f"dev#{device_id}"
+    ts = now_ts()
+    ip_prefix = _ip_prefix(ip)
+    it = T.sessions.get_item(Key={"user_sub": user_sub, "session_id": sid}).get("Item")
+    if not it:
+        T.sessions.put_item(Item={
+            "user_sub": user_sub,
+            "session_id": sid,
+            "device_id": device_id,
+            "user_agent": user_agent,
+            "first_seen_at": ts,
+            "last_seen_at": ts,
+            "last_ip": ip,
+            "last_ip_prefix": ip_prefix,
+            "trusted": False,
+        })
+        audit_event("device_new", user_sub, req, outcome="info", device_id=device_id, ip=ip, ip_prefix=ip_prefix)
+        return {"device_id": device_id, "new_device": True, "location_mismatch": False}
+
+    last_prefix = it.get("last_ip_prefix", "")
+    location_mismatch = bool(last_prefix and ip_prefix and last_prefix != ip_prefix)
+    if location_mismatch:
+        audit_event("device_location_mismatch", user_sub, req, outcome="warning", device_id=device_id, ip=ip, ip_prefix=ip_prefix, previous_ip_prefix=last_prefix)
+
+    try:
+        T.sessions.update_item(
+            Key={"user_sub": user_sub, "session_id": sid},
+            UpdateExpression="SET last_seen_at=:t, last_ip=:ip, last_ip_prefix=:p, user_agent=:ua",
+            ExpressionAttributeValues={":t": ts, ":ip": ip, ":p": ip_prefix, ":ua": user_agent},
+        )
+    except Exception:
+        pass
+
+    return {"device_id": device_id, "new_device": False, "location_mismatch": location_mismatch}
+
+
+def list_devices(user_sub: str) -> List[Dict[str, Any]]:
+    r = T.sessions.query(KeyConditionExpression=Key("user_sub").eq(user_sub), Limit=200)
+    out = []
+    for it in r.get("Items", []):
+        sid = it.get("session_id", "")
+        if not sid.startswith("dev#"):
+            continue
+        out.append({
+            "device_id": it.get("device_id", sid.replace("dev#", "")),
+            "user_agent": it.get("user_agent", ""),
+            "first_seen_at": it.get("first_seen_at", 0),
+            "last_seen_at": it.get("last_seen_at", 0),
+            "last_ip": it.get("last_ip", ""),
+            "trusted": bool(it.get("trusted", False)),
+        })
+    out.sort(key=lambda x: int(x.get("last_seen_at") or 0), reverse=True)
+    return out
+
+
+def _update_trust(user_sub: str, device_id: str, trusted: bool) -> None:
+    sid = f"dev#{device_id}"
+    try:
+        T.sessions.update_item(
+            Key={"user_sub": user_sub, "session_id": sid},
+            UpdateExpression="SET trusted=:t, trust_updated_at=:now",
+            ExpressionAttributeValues={":t": trusted, ":now": now_ts()},
+        )
+    except Exception:
+        raise HTTPException(404, "Device not found")
+
+
+def trust_device(user_sub: str, device_id: str) -> None:
+    _update_trust(user_sub, device_id, True)
+
+
+def revoke_device(user_sub: str, device_id: str) -> None:
+    _update_trust(user_sub, device_id, False)

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -63,6 +63,22 @@ def _bucket_limit(user_sub: str, sid: str, max_n: int, win: int) -> bool:
         pass
     return True
 
+def _ip_user(ip: str) -> str:
+    return f"ip#{ip}" if ip else "ip#unknown"
+
+def rate_limit_login_attempt(user_sub: str, ip: str) -> None:
+    if not _bucket_limit(user_sub, "rl#login", S.login_attempt_max_per_window, S.login_attempt_window_seconds):
+        raise HTTPException(429, "Too many login attempts; try again later")
+    if not _bucket_limit(_ip_user(ip), "rl#login", S.login_attempt_max_per_window, S.login_attempt_window_seconds):
+        raise HTTPException(429, "Too many login attempts; try again later")
+
+def rate_limit_mfa_verify(user_sub: str, ip: str, factor: str) -> None:
+    sid = f"rl#mfa_verify#{factor}"
+    if not _bucket_limit(user_sub, sid, S.mfa_verify_max_per_window, S.mfa_verify_window_seconds):
+        raise HTTPException(429, "Too many verification attempts; try again later")
+    if not _bucket_limit(_ip_user(ip), sid, S.mfa_verify_max_per_window, S.mfa_verify_window_seconds):
+        raise HTTPException(429, "Too many verification attempts; try again later")
+
 def can_send_verification(user_sub: str, channel: str) -> bool:
     if channel == "email":
         return _bucket_limit(user_sub, "rl#verify_email", S.verify_email_max_per_window, S.verify_email_window_seconds)

--- a/app/services/sessions.py
+++ b/app/services/sessions.py
@@ -11,7 +11,8 @@ from app.core.normalize import client_ip_from_request
 from app.core.settings import S
 from app.core.tables import T
 from app.core.time import now_ts
-from app.metrics import record_session_created
+from app.metrics import record_session_created, record_session_revoked
+from app.services.device_trust import record_device_login
 from app.services.ttl import with_ttl
 
 def is_real_ui_session_id(session_id: str) -> bool:
@@ -51,12 +52,12 @@ async def require_ui_session(
     request.state.user_sub = user_sub
     return {"user_sub": user_sub, "session_id": x_session_id}
 
-def create_real_session(req: Request, user_sub: str) -> str:
+def create_real_session(req: Request, user_sub: str, *, mfa_verified_at: Optional[int] = None) -> str:
     session_id = str(uuid.uuid4())
     ts = now_ts()
     ttl = ts + S.ui_session_ttl_seconds
     is_new_user = _is_new_user(user_sub)
-    T.sessions.put_item(Item=with_ttl({
+    item: Dict[str, Any] = {
         "user_sub": user_sub,
         "session_id": session_id,
         "created_at": ts,
@@ -65,7 +66,14 @@ def create_real_session(req: Request, user_sub: str) -> str:
         "user_agent": (req.headers.get("user-agent", "")[:512]),
         "revoked": False,
         "pending_auth": False,
-    }, ttl_epoch=ttl))
+    }
+    if mfa_verified_at:
+        item["mfa_verified_at"] = mfa_verified_at
+    T.sessions.put_item(Item=with_ttl(item, ttl_epoch=ttl))
+    try:
+        record_device_login(req, user_sub)
+    except Exception:
+        pass
     record_session_created(user_sub, is_new_user)
     return session_id
 
@@ -192,6 +200,46 @@ def maybe_finalize(req: Request, user_sub: str, challenge_id: str) -> Optional[s
         return None
     if chal.get("purpose"):
         return None
-    sid = create_real_session(req, user_sub)
+    sid = create_real_session(req, user_sub, mfa_verified_at=now_ts())
     revoke_challenge(user_sub, challenge_id)
     return sid
+
+def revoke_all_sessions(user_sub: str) -> None:
+    last_key = None
+    ts = now_ts()
+    while True:
+        kwargs: Dict[str, Any] = {
+            "KeyConditionExpression": Key("user_sub").eq(user_sub),
+            "Limit": 200,
+        }
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = T.sessions.query(**kwargs)
+        items = resp.get("Items", [])
+        for it in items:
+            sid = it.get("session_id", "")
+            if not sid:
+                continue
+            try:
+                T.sessions.update_item(
+                    Key={"user_sub": user_sub, "session_id": sid},
+                    UpdateExpression="SET revoked=:t, revoked_at=:now",
+                    ExpressionAttributeValues={":t": True, ":now": ts},
+                )
+            except Exception:
+                pass
+            if is_real_ui_session_id(sid):
+                record_session_revoked(user_sub)
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+def require_fresh_mfa(ctx: Dict[str, str], *, max_age_seconds: Optional[int] = None) -> None:
+    required = compute_required_factors(ctx["user_sub"])
+    if not required:
+        return
+    max_age = max_age_seconds or S.ui_stepup_max_age_seconds
+    it = T.sessions.get_item(Key={"user_sub": ctx["user_sub"], "session_id": ctx["session_id"]}).get("Item") or {}
+    verified_at = int(it.get("mfa_verified_at", 0) or 0)
+    if not verified_at or (now_ts() - verified_at) > max_age:
+        raise HTTPException(401, "Fresh MFA required")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -290,6 +290,15 @@
   </div>
 
   <div class="card">
+    <h3>Trusted Devices</h3>
+    <div class="muted">Review devices and trust or revoke access when something looks off.</div>
+    <div class="row-inline" style="margin-top:10px;">
+      <button id="deviceRefreshBtn">Refresh</button>
+    </div>
+    <div id="deviceList" class="list"></div>
+  </div>
+
+  <div class="card">
     <h3>Account Suspension & Reactivation</h3>
     <div class="muted">Start a suspension or reactivation request for this account.</div>
     <div class="section">

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -111,12 +111,29 @@ function maybePrependAlertToHistory(a) {
 const API_BASE_DEFAULT = (window.API_BASE || window.location.origin);
 let API_BASE = lsGet("api_base") || API_BASE_DEFAULT;
 
-/* ===================== localStorage helpers ===================== */
+/* ===================== storage helpers ===================== */
 function lsGet(k){ try{return localStorage.getItem(k);}catch(e){return null;} }
 function lsSet(k,v){ try{localStorage.setItem(k,v);}catch(e){} }
 function lsDel(k){ try{localStorage.removeItem(k);}catch(e){} }
+function ssGet(k){ try{return sessionStorage.getItem(k);}catch(e){return null;} }
+function ssSet(k,v){ try{sessionStorage.setItem(k,v);}catch(e){} }
+function ssDel(k){ try{sessionStorage.removeItem(k);}catch(e){} }
 
-function accessToken(){ return lsGet("access_token"); }
+function migrateToken(k) {
+  const existing = ssGet(k);
+  if (existing) return existing;
+  const legacy = lsGet(k);
+  if (legacy) {
+    ssSet(k, legacy);
+    lsDel(k);
+    return legacy;
+  }
+  return null;
+}
+
+function accessToken(){ return migrateToken("access_token"); }
+function idToken(){ return migrateToken("id_token"); }
+function refreshToken(){ return migrateToken("refresh_token"); }
 function sessionId(){ return lsGet("session_id"); }
 
 /* ===================== modal helpers ===================== */
@@ -154,12 +171,12 @@ function openTokenModal() {
   modalShow({
     title: "Connection + Tokens",
     bodyHtml: `
-      <div class="muted">Paste your Cognito <b>access token</b> (JWT). Stored in localStorage.</div>
+      <div class="muted">Paste your Cognito <b>access token</b> (JWT). Stored in sessionStorage.</div>
       <input id="cfgApiBase" class="mono" placeholder="API base URL" value="${curBase}"/>
-      <input id="cfgAccessTok" class="mono" placeholder="access_token (Bearer)" value="${lsGet("access_token")||""}"/>
-      <div class="muted" style="margin-top:8px;">Optional: id_token / refresh_token (not used by this page)</div>
-      <input id="cfgIdTok" class="mono" placeholder="id_token" value="${lsGet("id_token")||""}"/>
-      <input id="cfgRefreshTok" class="mono" placeholder="refresh_token" value="${lsGet("refresh_token")||""}"/>
+      <input id="cfgAccessTok" class="mono" placeholder="access_token (Bearer)" value="${accessToken()||""}"/>
+      <div class="muted" style="margin-top:8px;">Optional: id_token / refresh_token (used for refresh)</div>
+      <input id="cfgIdTok" class="mono" placeholder="id_token" value="${idToken()||""}"/>
+      <input id="cfgRefreshTok" class="mono" placeholder="refresh_token" value="${refreshToken()||""}"/>
       <div id="cfgErr" class="err" style="margin-top:8px;"></div>
     `,
     actions: [
@@ -171,9 +188,9 @@ function openTokenModal() {
           if (!at) { document.getElementById("cfgErr").textContent = "access_token is required."; return; }
           lsSet("api_base", base);
           API_BASE = base;
-          lsSet("access_token", at);
-          lsSet("id_token", document.getElementById("cfgIdTok").value.trim());
-          lsSet("refresh_token", document.getElementById("cfgRefreshTok").value.trim());
+          ssSet("access_token", at);
+          ssSet("id_token", document.getElementById("cfgIdTok").value.trim());
+          ssSet("refresh_token", document.getElementById("cfgRefreshTok").value.trim());
           lsDel("session_id"); // force re-stepup
           modalClose();
           if (!accessToken()) {
@@ -187,8 +204,25 @@ function openTokenModal() {
 }
 
 /* ===================== generic API helper ===================== */
-async function api(path, {method="GET", body=null, includeSession=true}={}) {
-  const tok = accessToken();
+async function refreshAccessToken() {
+  const rt = refreshToken();
+  if (!rt) throw new Error("Missing refresh_token; please re-authenticate.");
+  const res = await fetch(API_BASE + "/ui/token/refresh", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refresh_token: rt }),
+  });
+  const txt = await res.text();
+  if (!res.ok) throw new Error(res.status + ": " + txt);
+  const data = txt ? JSON.parse(txt) : {};
+  if (!data.access_token) throw new Error("Refresh failed: missing access_token.");
+  ssSet("access_token", data.access_token);
+  if (data.id_token) ssSet("id_token", data.id_token);
+  return data.access_token;
+}
+
+async function authFetch(path, {method="GET", body=null, includeSession=true}={}) {
+  let tok = accessToken();
   if (!tok) throw new Error("Missing access_token (Cognito login not completed).");
   const headers = { "Authorization": "Bearer " + tok };
   if (includeSession) {
@@ -197,12 +231,22 @@ async function api(path, {method="GET", body=null, includeSession=true}={}) {
     headers["X-SESSION-ID"] = sid;
   }
   if (body !== null) headers["Content-Type"] = "application/json";
-
-  const res = await fetch(API_BASE + path, {
+  const doFetch = () => fetch(API_BASE + path, {
     method,
     headers,
     body: (body !== null ? JSON.stringify(body) : undefined),
   });
+  let res = await doFetch();
+  if (res.status === 401 && refreshToken()) {
+    tok = await refreshAccessToken();
+    headers["Authorization"] = "Bearer " + tok;
+    res = await doFetch();
+  }
+  return res;
+}
+
+async function api(path, {method="GET", body=null, includeSession=true}={}) {
+  const res = await authFetch(path, {method, body, includeSession});
   const txt = await res.text();
   if (!res.ok) throw new Error(res.status + ": " + txt);
   return txt ? JSON.parse(txt) : {};
@@ -1073,6 +1117,31 @@ function renderPasswordRecovery() {
   }
 }
 
+function rememberRecoveryReturn() {
+  const state = {
+    hash: window.location.hash || "",
+    scrollY: window.scrollY || 0,
+  };
+  ssSet("pw_recovery_return", JSON.stringify(state));
+}
+
+function resumeAfterPasswordReset() {
+  const pending = ssGet("pw_recovery_resume_pending");
+  if (!pending || !accessToken()) return;
+  const raw = ssGet("pw_recovery_return");
+  ssDel("pw_recovery_resume_pending");
+  if (!raw) return;
+  try {
+    const state = JSON.parse(raw);
+    if (state.hash !== undefined) {
+      window.location.hash = state.hash;
+    }
+    if (Number.isFinite(state.scrollY)) {
+      window.scrollTo(0, state.scrollY);
+    }
+  } catch (e) {}
+}
+
 async function startPasswordRecovery() {
   const username = (document.getElementById("pwRecoveryUsername").value || "").trim();
   if (!username) {
@@ -1080,6 +1149,7 @@ async function startPasswordRecovery() {
     renderPasswordRecovery();
     return;
   }
+  rememberRecoveryReturn();
   resetPasswordRecoveryState();
   passwordRecoveryState.username = username;
   try {
@@ -1117,7 +1187,12 @@ async function confirmPasswordRecovery() {
         challenge_id: passwordRecoveryState.challengeId,
       },
     });
-    passwordRecoveryState.lastErr = "Password updated. You can now log in.";
+    ssSet("pw_recovery_resume_pending", "1");
+    ssDel("access_token");
+    ssDel("id_token");
+    ssDel("refresh_token");
+    lsDel("session_id");
+    passwordRecoveryState.lastErr = "Password updated. Please log in again to continue where you left off.";
   } catch (e) {
     passwordRecoveryState.lastErr = String(e);
   }
@@ -1156,12 +1231,7 @@ async function ensureUiSession() {
   const needEmail = required.includes("email");
 
   async function postBearer(path, payload) {
-    const tok = accessToken();
-    const res = await fetch(API_BASE + path, {
-      method: "POST",
-      headers: { "Authorization": "Bearer " + tok, "Content-Type": "application/json" },
-      body: JSON.stringify(payload)
-    });
+    const res = await authFetch(path, { method: "POST", body: payload, includeSession: false });
     const txt = await res.text();
     if (!res.ok) throw new Error(res.status + ": " + txt);
     return txt ? JSON.parse(txt) : {};
@@ -1453,9 +1523,9 @@ function handleAccountClosureSuccess() {
 }
 
 function clearAuthTokens() {
-  lsDel("access_token");
-  lsDel("id_token");
-  lsDel("refresh_token");
+  ssDel("access_token");
+  ssDel("id_token");
+  ssDel("refresh_token");
   lsDel("session_id");
 }
 
@@ -2038,6 +2108,44 @@ async function refreshSessions() {
   });
 }
 
+/* ===================== Devices ===================== */
+async function refreshDevices() {
+  await ensureUiSession();
+  const res = await apiGet("/ui/devices");
+  const el = document.getElementById("deviceList");
+  if (!el) return;
+  el.innerHTML = "";
+  (res.devices || []).forEach(d => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    const trustBadge = d.trusted ? "<span class='pill'>trusted</span>" : "<span class='pill'>new</span>";
+    row.innerHTML = `
+      <div class="grow">
+        <div class="mono">${escapeHtml(d.device_id)} ${trustBadge}</div>
+        <div class="muted">last ${fmtTs(d.last_seen_at)} • ${escapeHtml(d.last_ip || "")}</div>
+        <div class="muted">${escapeHtml((d.user_agent || "").slice(0, 120))}</div>
+      </div>
+      <div>
+        <button class="primary" ${d.trusted ? "disabled" : ""} data-action="trust">Trust</button>
+        <button class="danger" ${d.trusted ? "" : "disabled"} data-action="revoke">Revoke</button>
+      </div>
+    `;
+    row.querySelectorAll("button").forEach(btn => {
+      btn.onclick = async () => {
+        const action = btn.getAttribute("data-action");
+        if (!action) return;
+        if (action === "trust") {
+          await apiPost(`/ui/devices/${encodeURIComponent(d.device_id)}/trust`, {});
+        } else {
+          await apiPost(`/ui/devices/${encodeURIComponent(d.device_id)}/revoke`, {});
+        }
+        await refreshDevices();
+      };
+    });
+    el.appendChild(row);
+  });
+}
+
 /* ===================== Account Status ===================== */
 async function loadAccountStatus() {
   await ensureUiSession();
@@ -2386,6 +2494,7 @@ async function refreshAll() {
       refreshSmsDevices(),
       refreshEmailDevices(),
       refreshSessions(),
+      refreshDevices(),
       refreshKeys(),
       refreshAccountStatus(),
       refreshAlertEmailSettings(),
@@ -2399,6 +2508,7 @@ async function refreshAll() {
       refreshCalendarEvents(),
     ]);
     await pollToastsOnce();
+    resumeAfterPasswordReset();
   } catch (e) {
     document.getElementById("globalErr").textContent = String(e);
   }
@@ -4456,6 +4566,7 @@ document.getElementById("sessRevokeOthersBtn").onclick = async () => {
   await apiPost("/ui/sessions/revoke_others", {});
   await refreshSessions();
 };
+document.getElementById("deviceRefreshBtn").onclick = async () => { await refreshDevices(); };
 document.getElementById("totpAddBtn").onclick = async () => { await ensureUiSession(); openTotpAddModal(); };
 
 


### PR DESCRIPTION
### Motivation
- Detect and record new or changing devices on UI login to surface anomalies and let users mark trusted devices.  
- Provide server endpoints and a simple UI for listing/trusting/revoking devices so users can manage device trust.  
- Harden authentication flows by enforcing fresh MFA for sensitive actions, adding per-IP/user rate limits for logins and MFA verification, and revoking sessions/API keys after password recovery.  

### Description
- Added a new service `app/services/device_trust.py` with `record_device_login`, `list_devices`, `trust_device`, and `revoke_device` to persist device entries in the sessions table and emit alert events.  
- Call `record_device_login` from `create_real_session` in `app/services/sessions.py`, and added `revoke_all_sessions` and `require_fresh_mfa` helpers to sessions management.  
- Exposed device management endpoints in `app/routers/device_trust.py` and registered the router in `app/main.py`, and added `DeviceTrust*` models in `app/models.py`.  
- Added UI elements and client logic: inserted a "Trusted Devices" card in `app/static/index.html`, and implemented `refreshDevices`, trust/revoke actions, token migration to `sessionStorage`, refresh-token flow, and password-recovery resume behavior in `app/static/main.js`.  
- Added `revoke_all_api_keys` to `app/services/api_keys.py` and call-sites to revoke API keys and sessions from `POST /ui/password-recovery/confirm` in `app/routers/password_recovery.py`.  
- Introduced server-side token refresh utility `cognito_refresh_tokens` and a client API endpoint `POST /ui/token/refresh` in `app/routers/misc.py`.  
- Expanded alert event types and pretty titles in `app/services/alerts.py` to include device events.  
- Added new rate-limiting helpers in `app/services/rate_limit.py` and related `Settings` keys in `app/core/settings.py`, and wired rate limiting and attempt-tracking into relevant MFA/login/password-recovery flows.  
- Applied `require_fresh_mfa` to sensitive UI endpoints (API key operations, device/mfa changes, etc.) to require recent MFA step-up.  

### Testing
- Started the development server with `uvicorn app.main:app` and used a Playwright script to open the root page and capture a screenshot demonstrating the new UI, which completed successfully and produced an artifact.  
- No automated unit tests or integration test suites were run beyond the server start + Playwright screenshot check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d7b57c54c832b93a432861c44a3fa)