### PR TITLE
Add subscription proration/trial lifecycle, receipt generation/download tracking, and related tests

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -180,6 +180,8 @@ class PurchaseTransactionInfo(PurchaseTransactionSummary):
     reverted_at: Optional[int] = None
     version: int
     metadata: Optional[Dict[str, Any]] = None
+    receipt_path: Optional[str] = None
+    receipt_generated_at: Optional[int] = None
 
 
 class PurchaseTransactionCreated(BaseModel):
@@ -205,6 +207,15 @@ class PurchaseCancelReq(BaseModel):
 class PurchaseCancelRespondReq(BaseModel):
     decision: str
     note: Optional[str] = None
+
+
+class ReceiptLinkOut(BaseModel):
+    txn_id: str
+    receipt_path: str
+    receipt_url: str
+    generated_at: int
+
+
 class CatalogPageOut(BaseModel):
     next_token: Optional[str] = None
 

--- a/app/routers/filemanager.py
+++ b/app/routers/filemanager.py
@@ -26,6 +26,7 @@ from app.services.filemanager import (
     search_text,
 )
 from app.services.alerts import audit_event
+from app.services.purchase_history import record_receipt_download
 from app.services.sessions import require_ui_session
 
 router = APIRouter(prefix="/v1/fs", tags=["filemanager"])
@@ -132,6 +133,12 @@ def download_fs_file(path: str = Query(...), req: Request = None, user: str = De
         path=node.get("path"),
         size=node.get("size"),
     )
+    receipt_path = norm_path(path, is_folder=False)
+    if receipt_path.startswith("/billing/receipts/") and receipt_path.lower().endswith(".pdf"):
+        _, name = split_parent_name(receipt_path)
+        txn_id = name[:-4]
+        if txn_id:
+            record_receipt_download(user, txn_id, receipt_path)
 
     def gen():
         body = obj["Body"]

--- a/app/routers/paypal.py
+++ b/app/routers/paypal.py
@@ -25,6 +25,7 @@ from app.services.billing_shared import (
     ensure_balance_row as ensure_balance_row_shared,
     user_pk,
 )
+from app.services.purchase_history import mark_completed, mark_reverted, record_billing_transaction
 
 router = APIRouter(tags=["billing"])
 
@@ -179,6 +180,7 @@ def put_payment_record(
     ledger_sk_value: Optional[str],
     payment_token_id: Optional[str] = None,
     subscription_id: Optional[str] = None,
+    purchase_txn_id: Optional[str] = None,
     raw: Optional[Dict[str, Any]] = None,
 ) -> None:
     pk = user_pk(user_id)
@@ -196,6 +198,8 @@ def put_payment_record(
         "created_at": now_ts(),
         "updated_at": now_ts(),
     }
+    if purchase_txn_id:
+        item["purchase_txn_id"] = purchase_txn_id
     if raw:
         item["raw"] = raw
     ddb_put(item)
@@ -874,8 +878,24 @@ async def charge_once(body: OneTimeChargeIn, request: Request, x_user_id: Option
 
     order_id = order.get("id")
     approve = _find_link(order, "approve") or _find_link(order, "payer-action") or _find_link(order, "payer_action")
+    purchase_txn_id = None
 
     if order_id:
+        description = body.reason or "PayPal charge"
+        purchase_txn_id = record_billing_transaction(
+            user_sub=user_id,
+            amount_cents=amount,
+            currency=DEFAULT_CURRENCY,
+            description=description,
+            status="PENDING",
+            external_ref=str(order_id),
+            metadata={
+                "paypal_order_id": order_id,
+                "payment_token_id": token,
+                "ledger_sk": led_sk_value,
+                "reason": body.reason,
+            },
+        )
         put_payment_record(
             user_id=user_id,
             external_id=str(order_id),
@@ -884,6 +904,7 @@ async def charge_once(body: OneTimeChargeIn, request: Request, x_user_id: Option
             status="pending",
             ledger_sk_value=led_sk_value,
             payment_token_id=token,
+            purchase_txn_id=purchase_txn_id,
             raw={"order": order},
         )
 
@@ -910,14 +931,53 @@ async def capture_order(body: CaptureOrderIn, x_user_id: Optional[str] = Header(
     status = (cap.get("status") or "").upper()
     ok = status in ("COMPLETED",)
 
+    purchase_txn_id = pay.get("purchase_txn_id")
     if ok:
         apply_balance_delta(pk, {"payments_pending_cents": -amount, "payments_settled_cents": amount})
         settle_or_reverse_ledger(user_id, led_sk_value, "settled")
         update_payment_status(user_id, order_id, "succeeded", raw={"capture": cap})
+        if purchase_txn_id:
+            mark_completed(user_id, purchase_txn_id, order_id, "PayPal capture succeeded")
+        else:
+            purchase_txn_id = record_billing_transaction(
+                user_sub=user_id,
+                amount_cents=amount,
+                currency=DEFAULT_CURRENCY,
+                description="PayPal charge",
+                status="COMPLETED",
+                external_ref=str(order_id),
+                metadata={
+                    "paypal_order_id": order_id,
+                    "paypal_capture_status": status,
+                    "paypal_capture": cap,
+                },
+            )
+            ddb_update(
+                pk,
+                pay_sk(order_id),
+                "SET purchase_txn_id = :p, updated_at = :u",
+                {":p": purchase_txn_id, ":u": now_ts()},
+            )
     else:
         apply_balance_delta(pk, {"payments_pending_cents": -amount})
         settle_or_reverse_ledger(user_id, led_sk_value, "reversed")
         update_payment_status(user_id, order_id, "failed", raw={"capture": cap})
+        if purchase_txn_id:
+            mark_reverted(user_id, purchase_txn_id, status.lower() or "paypal_capture_failed")
+        else:
+            record_billing_transaction(
+                user_sub=user_id,
+                amount_cents=amount,
+                currency=DEFAULT_CURRENCY,
+                description="PayPal charge",
+                status="REVERTED",
+                external_ref=str(order_id),
+                metadata={
+                    "paypal_order_id": order_id,
+                    "paypal_capture_status": status,
+                    "paypal_capture": cap,
+                },
+            )
 
     return {"ok": ok, "order_id": order_id, "capture": cap}
 

--- a/app/routers/purchase_history.py
+++ b/app/routers/purchase_history.py
@@ -11,6 +11,7 @@ from app.models import (
     PurchaseTransactionInfo,
     PurchaseTransactionStatusReq,
     PurchaseTransactionSummary,
+    ReceiptLinkOut,
 )
 from app.services.purchase_history import (
     create_transaction,
@@ -24,6 +25,7 @@ from app.services.purchase_history import (
     respond_cancel,
     update_shipping,
 )
+from app.services.receipts import get_or_create_receipt
 from app.services.sessions import require_ui_session
 
 router = APIRouter(prefix="/ui/purchase-history", tags=["purchase-history"])
@@ -111,3 +113,8 @@ async def ui_list_events(
     limit: int = Query(50, ge=1, le=200),
 ):
     return {"txn_id": txn_id, "events": list_events(ctx["user_sub"], txn_id, limit)}
+
+
+@router.get("/transactions/{txn_id}/receipt", response_model=ReceiptLinkOut)
+async def ui_get_receipt(txn_id: str, ctx=Depends(require_ui_session)):
+    return get_or_create_receipt(ctx["user_sub"], txn_id)

--- a/app/routers/subscription_server.py
+++ b/app/routers/subscription_server.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import os
 import uuid
-from typing import Any, Dict, List, Literal, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
@@ -41,6 +42,14 @@ def interval_seconds(interval: str) -> int:
     if interval == "year":
         return 365 * 24 * 3600
     return 30 * 24 * 3600
+
+
+def _iso_utc_from_ts(ts: int) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _subscription_event_id(subscription_id: str, kind: str) -> str:
+    return f"sub_{subscription_id}_{kind}"
 
 
 def ddb_put_item(item: Dict[str, Any]) -> None:
@@ -125,6 +134,8 @@ def normalize_subscription(sub: Dict[str, Any]) -> Dict[str, Any]:
         return sub
     normalized = sub.copy()
     normalized["auto_renew"] = not bool(sub.get("cancel_at_period_end", False))
+    if "renewal_policy" not in normalized:
+        normalized["renewal_policy"] = "auto" if normalized["auto_renew"] else "manual"
     return normalized
 
 
@@ -170,6 +181,13 @@ def record_billing_subscription(sub: Dict[str, Any]) -> None:
         "updated_at": sub["updated_at"],
         "provider": sub["provider"],
         "provider_subscription_id": sub["provider_subscription_id"],
+        "interval": sub.get("interval"),
+        "auto_renew": sub.get("auto_renew"),
+        "cancel_at_period_end": sub.get("cancel_at_period_end"),
+        "trial_start": sub.get("trial_start"),
+        "trial_end": sub.get("trial_end"),
+        "proration_policy": sub.get("proration_policy"),
+        "renewal_policy": sub.get("renewal_policy"),
     }
     billing_put(T.billing, item)
 
@@ -284,6 +302,7 @@ class SubscribeIn(BaseModel):
     subscriber_id: Optional[str] = None
     interval: Optional[Literal["month", "year"]] = None
     discount_code: Optional[str] = None
+    trial_days: Optional[conint(ge=1, le=365)] = None
 
 
 class SubscriptionOut(BaseModel):
@@ -301,6 +320,10 @@ class SubscriptionOut(BaseModel):
     price_cents: int
     currency: str
     auto_renew: bool
+    trial_start: Optional[int] = None
+    trial_end: Optional[int] = None
+    proration_policy: Optional[str] = None
+    renewal_policy: Optional[str] = None
     created_at: int
     updated_at: int
     creator_profile: Optional[Dict[str, Optional[str]]] = None
@@ -320,6 +343,15 @@ class SubscriptionResumeIn(BaseModel):
 class SubscriptionRenewalIn(BaseModel):
     auto_renew: bool = True
     effective: Literal["immediate", "period_end"] = "period_end"
+    renewal_policy: Optional[Literal["auto", "manual", "cancel_at_period_end"]] = None
+    reason: Optional[str] = None
+
+
+class SubscriptionChangePlanIn(BaseModel):
+    plan_id: str
+    interval: Optional[Literal["month", "year"]] = None
+    effective: Literal["immediate", "period_end"] = "immediate"
+    proration_policy: Literal["none", "charge", "credit", "full"] = "full"
     reason: Optional[str] = None
 
 
@@ -333,6 +365,10 @@ class InvoiceOut(BaseModel):
     period_start: int
     period_end: int
     created_at: int
+    is_proration: Optional[bool] = None
+    proration_amount_cents: Optional[int] = None
+    proration_period_start: Optional[int] = None
+    proration_period_end: Optional[int] = None
 
 
 class EarningsOut(BaseModel):
@@ -478,12 +514,14 @@ def subscription_summary(sub: Dict[str, Any]) -> Dict[str, Any]:
     cancel_at_period_end = bool(sub.get("cancel_at_period_end", False))
     next_amount = 0
     next_renewal_at = None
-    if status in {"active", "past_due"} and not cancel_at_period_end:
+    if status in {"active", "past_due", "trialing"} and not cancel_at_period_end:
         next_amount = int(sub.get("price_cents", 0))
         discount = sub.get("discount") or {}
         if discount and sub.get("discount_remaining_months", 0):
             next_amount = _apply_discount(next_amount, discount)
         next_renewal_at = int(sub.get("current_period_end") or 0) or None
+        if status == "trialing":
+            next_amount = 0
 
     return {
         "subscription_id": sub["subscription_id"],
@@ -516,6 +554,121 @@ def build_ledger_item(creator_id: str, entry: Dict[str, Any]) -> Dict[str, Any]:
 def save_ledger_entry(creator_id: str, entry: Dict[str, Any]) -> None:
     ddb_put_item(build_ledger_item(creator_id, entry))
 
+
+def _calendar_meta(calendar_id: str) -> Optional[Dict[str, Any]]:
+    return T.calendar.get_item(Key={"calendar_id": calendar_id, "sk": "meta"}).get("Item")
+
+
+def _calendar_event_item(
+    *,
+    calendar_id: str,
+    event_id: str,
+    name: str,
+    description: str,
+    start_ts: int,
+    end_ts: int,
+    timezone_name: str,
+) -> Dict[str, Any]:
+    return {
+        "calendar_id": calendar_id,
+        "sk": f"event#{event_id}",
+        "event_id": event_id,
+        "name": name,
+        "description": description,
+        "timezone": timezone_name,
+        "start_utc": _iso_utc_from_ts(start_ts),
+        "end_utc": _iso_utc_from_ts(end_ts),
+        "all_day": False,
+        "all_day_date": None,
+        "created_at_utc": _iso_utc_from_ts(now_ts()),
+    }
+
+
+def _upsert_subscription_calendar_event(
+    calendar_id: str,
+    event_id: str,
+    *,
+    name: str,
+    description: str,
+    when_ts: Optional[int],
+    timezone_name: str,
+) -> None:
+    if not when_ts:
+        T.calendar.delete_item(Key={"calendar_id": calendar_id, "sk": f"event#{event_id}"})
+        return
+    start_ts = when_ts
+    end_ts = when_ts + 3600
+    item = _calendar_event_item(
+        calendar_id=calendar_id,
+        event_id=event_id,
+        name=name,
+        description=description,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        timezone_name=timezone_name,
+    )
+    T.calendar.put_item(Item=item)
+
+
+def refresh_subscription_calendar_events(sub: Dict[str, Any], plan: Optional[Dict[str, Any]] = None) -> None:
+    plan = plan or ddb_get_item(pk_plan(sub["plan_id"]), "META")
+    if not plan:
+        return
+    calendar_id = (plan.get("metadata") or {}).get("calendar_id")
+    if not calendar_id:
+        return
+    calendar_meta = _calendar_meta(calendar_id)
+    if not calendar_meta:
+        return
+    timezone_name = calendar_meta.get("timezone", "UTC")
+    sub_id = sub["subscription_id"]
+    trial_end = sub.get("trial_end")
+    renewal_at = sub.get("current_period_end") if not sub.get("cancel_at_period_end") else None
+    cancel_at = sub.get("current_period_end") if sub.get("cancel_at_period_end") else None
+
+    _upsert_subscription_calendar_event(
+        calendar_id,
+        _subscription_event_id(sub_id, "trial_end"),
+        name="Subscription trial ends",
+        description=f"Trial ends for subscription {sub_id}",
+        when_ts=trial_end,
+        timezone_name=timezone_name,
+    )
+    _upsert_subscription_calendar_event(
+        calendar_id,
+        _subscription_event_id(sub_id, "renewal"),
+        name="Subscription renewal",
+        description=f"Renewal for subscription {sub_id}",
+        when_ts=renewal_at,
+        timezone_name=timezone_name,
+    )
+    _upsert_subscription_calendar_event(
+        calendar_id,
+        _subscription_event_id(sub_id, "cancellation"),
+        name="Subscription cancellation",
+        description=f"Subscription {sub_id} ends",
+        when_ts=cancel_at,
+        timezone_name=timezone_name,
+    )
+
+
+def _proration_fraction(now: int, period_start: int, period_end: int) -> float:
+    remaining = max(0, period_end - now)
+    total = max(1, period_end - period_start)
+    return min(1.0, max(0.0, remaining / total))
+
+
+def calculate_proration(
+    *,
+    current_price: int,
+    new_price: int,
+    now: int,
+    period_start: int,
+    period_end: int,
+) -> int:
+    fraction = _proration_fraction(now, period_start, period_end)
+    difference = new_price - current_price
+    return int(round(difference * fraction))
 
 # -----------------------------
 # API endpoints
@@ -665,6 +818,14 @@ async def subscribe(
             "duration_months": discount.get("duration_months"),
         }
     price_cents = _apply_discount(base_price, discount) if applied_discount else base_price
+    trial_end = None
+    trial_start = None
+    status = "active"
+    if body.trial_days:
+        trial_start = ts
+        trial_end = ts + int(body.trial_days) * 86400
+        period_end = trial_end
+        status = "trialing"
     sub = {
         "subscription_id": subscription_id,
         "plan_id": plan_id,
@@ -673,13 +834,17 @@ async def subscribe(
         "interval": interval,
         "provider": "stub",
         "provider_subscription_id": provider_subscription_id,
-        "status": "active",
+        "status": status,
         "start_at": ts,
         "current_period_end": period_end,
         "cancel_at_period_end": False,
         "price_cents": price_cents,
         "currency": plan["currency"],
         "auto_renew": True,
+        "trial_start": trial_start,
+        "trial_end": trial_end,
+        "proration_policy": "full",
+        "renewal_policy": "auto",
         "created_at": ts,
         "updated_at": ts,
     }
@@ -696,56 +861,57 @@ async def subscribe(
     save_subscription(sub)
     record_billing_subscription(sub)
 
-    invoice_id = new_id("inv")
-    invoice = {
-        "invoice_id": invoice_id,
-        "subscription_id": subscription_id,
-        "subscriber_id": subscriber_id,
-        "provider_invoice_id": new_id("stub_inv"),
-        "amount_cents": int(sub["price_cents"]),
-        "currency": plan["currency"],
-        "status": "paid",
-        "period_start": ts,
-        "period_end": period_end,
-        "created_at": ts,
-    }
-    if applied_discount:
-        invoice["discount"] = applied_discount
-    save_invoice(invoice)
-    record_billing_payment(invoice, subscription_id)
-    record_billing_transaction(
-        user_sub=subscriber_id,
-        amount_cents=int(invoice["amount_cents"]),
-        currency=invoice["currency"],
-        description=f"Subscription {plan_id}",
-        status="COMPLETED",
-        external_ref=invoice_id,
-        metadata={"subscription_id": subscription_id, "creator_id": plan["creator_id"]},
-    )
+    if status != "trialing":
+        invoice_id = new_id("inv")
+        invoice = {
+            "invoice_id": invoice_id,
+            "subscription_id": subscription_id,
+            "subscriber_id": subscriber_id,
+            "provider_invoice_id": new_id("stub_inv"),
+            "amount_cents": int(sub["price_cents"]),
+            "currency": plan["currency"],
+            "status": "paid",
+            "period_start": ts,
+            "period_end": period_end,
+            "created_at": ts,
+        }
+        if applied_discount:
+            invoice["discount"] = applied_discount
+        save_invoice(invoice)
+        record_billing_payment(invoice, subscription_id)
+        record_billing_transaction(
+            user_sub=subscriber_id,
+            amount_cents=int(invoice["amount_cents"]),
+            currency=invoice["currency"],
+            description=f"Subscription {plan_id}",
+            status="COMPLETED",
+            external_ref=invoice_id,
+            metadata={"subscription_id": subscription_id, "creator_id": plan["creator_id"]},
+        )
 
-    fee_cents = int(invoice["amount_cents"] * FEE_BPS / 10000)
-    charge_entry = {
-        "entry_id": new_id("led"),
-        "subscription_id": subscription_id,
-        "subscriber_id": subscriber_id,
-        "entry_type": "charge",
-        "amount_cents": invoice["amount_cents"],
-        "currency": invoice["currency"],
-        "created_at": ts,
-        "metadata": {"invoice_id": invoice_id},
-    }
-    fee_entry = {
-        "entry_id": new_id("led"),
-        "subscription_id": subscription_id,
-        "subscriber_id": subscriber_id,
-        "entry_type": "fee",
-        "amount_cents": fee_cents,
-        "currency": invoice["currency"],
-        "created_at": ts,
-        "metadata": {"invoice_id": invoice_id},
-    }
-    save_ledger_entry(plan["creator_id"], charge_entry)
-    save_ledger_entry(plan["creator_id"], fee_entry)
+        fee_cents = int(invoice["amount_cents"] * FEE_BPS / 10000)
+        charge_entry = {
+            "entry_id": new_id("led"),
+            "subscription_id": subscription_id,
+            "subscriber_id": subscriber_id,
+            "entry_type": "charge",
+            "amount_cents": invoice["amount_cents"],
+            "currency": invoice["currency"],
+            "created_at": ts,
+            "metadata": {"invoice_id": invoice_id},
+        }
+        fee_entry = {
+            "entry_id": new_id("led"),
+            "subscription_id": subscription_id,
+            "subscriber_id": subscriber_id,
+            "entry_type": "fee",
+            "amount_cents": fee_cents,
+            "currency": invoice["currency"],
+            "created_at": ts,
+            "metadata": {"invoice_id": invoice_id},
+        }
+        save_ledger_entry(plan["creator_id"], charge_entry)
+        save_ledger_entry(plan["creator_id"], fee_entry)
 
     put_notification(
         recipient_user_id=plan["creator_id"],
@@ -777,6 +943,7 @@ async def subscribe(
         subscriber_id=subscriber_id,
     )
 
+    refresh_subscription_calendar_events(sub, plan)
     return attach_subscription_profiles(sub)
 
 
@@ -916,6 +1083,7 @@ async def cancel_subscription(
         raise HTTPException(status_code=403, detail="Not authorized to cancel this subscription")
     sub["cancel_at_period_end"] = body.cancel_at_period_end
     sub["auto_renew"] = False
+    sub["renewal_policy"] = "cancel_at_period_end" if body.cancel_at_period_end else "manual"
     if body.cancel_at_period_end:
         sub["status"] = "canceling"
     else:
@@ -952,6 +1120,7 @@ async def cancel_subscription(
         subscriber_id=sub["subscriber_id"],
         cancel_at_period_end=sub["cancel_at_period_end"],
     )
+    refresh_subscription_calendar_events(sub)
     return attach_subscription_profiles(sub)
 
 
@@ -972,6 +1141,7 @@ async def resume_subscription(
     sub["cancel_at_period_end"] = False
     sub["auto_renew"] = True
     sub["status"] = "active"
+    sub["renewal_policy"] = "auto"
     sub["updated_at"] = now_ts()
     save_subscription(sub)
     record_billing_subscription(sub)
@@ -1001,6 +1171,7 @@ async def resume_subscription(
         subscription_id=subscription_id,
         subscriber_id=sub["subscriber_id"],
     )
+    refresh_subscription_calendar_events(sub)
     return attach_subscription_profiles(sub)
 
 
@@ -1019,6 +1190,8 @@ async def update_subscription_renewal(
     if user_id not in (sub["subscriber_id"], sub["creator_id"]):
         raise HTTPException(status_code=403, detail="Not authorized to update renewal settings")
     sub["auto_renew"] = body.auto_renew
+    if body.renewal_policy:
+        sub["renewal_policy"] = body.renewal_policy
     if not body.auto_renew:
         if body.effective == "immediate":
             sub["status"] = "canceled"
@@ -1042,6 +1215,219 @@ async def update_subscription_renewal(
         auto_renew=body.auto_renew,
         effective=body.effective,
     )
+    refresh_subscription_calendar_events(sub)
+    return attach_subscription_profiles(sub)
+
+
+@router.post("/api/subscriptions/{subscription_id}/trial/convert", response_model=SubscriptionOut)
+async def convert_trial(
+    subscription_id: str,
+    request: Request,
+    x_user_id: Optional[str] = Header(default=None),
+):
+    sub = ddb_get_item(pk_subscription(subscription_id), "META")
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    sub = normalize_subscription(sub)
+    user_id = require_user(x_user_id)
+    if user_id not in (sub["subscriber_id"], sub["creator_id"]):
+        raise HTTPException(status_code=403, detail="Not authorized to convert trial")
+    if (sub.get("status") or "").lower() != "trialing":
+        raise HTTPException(status_code=400, detail="Subscription is not in trial")
+    plan = ddb_get_item(pk_plan(sub["plan_id"]), "META")
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    ts = now_ts()
+    sub["status"] = "active"
+    sub["trial_converted_at"] = ts
+    sub["current_period_end"] = ts + interval_seconds(sub["interval"])
+    sub["updated_at"] = ts
+    save_subscription(sub)
+    record_billing_subscription(sub)
+
+    invoice_id = new_id("inv")
+    invoice = {
+        "invoice_id": invoice_id,
+        "subscription_id": subscription_id,
+        "subscriber_id": sub["subscriber_id"],
+        "provider_invoice_id": new_id("stub_inv"),
+        "amount_cents": int(sub["price_cents"]),
+        "currency": sub["currency"],
+        "status": "paid",
+        "period_start": ts,
+        "period_end": sub["current_period_end"],
+        "created_at": ts,
+    }
+    save_invoice(invoice)
+    record_billing_payment(invoice, subscription_id)
+    record_billing_transaction(
+        user_sub=sub["subscriber_id"],
+        amount_cents=int(invoice["amount_cents"]),
+        currency=invoice["currency"],
+        description=f"Subscription {sub['plan_id']}",
+        status="COMPLETED",
+        external_ref=invoice_id,
+        metadata={"subscription_id": subscription_id, "creator_id": sub["creator_id"]},
+    )
+
+    fee_cents = int(invoice["amount_cents"] * FEE_BPS / 10000)
+    charge_entry = {
+        "entry_id": new_id("led"),
+        "subscription_id": subscription_id,
+        "subscriber_id": sub["subscriber_id"],
+        "entry_type": "charge",
+        "amount_cents": invoice["amount_cents"],
+        "currency": invoice["currency"],
+        "created_at": ts,
+        "metadata": {"invoice_id": invoice_id},
+    }
+    fee_entry = {
+        "entry_id": new_id("led"),
+        "subscription_id": subscription_id,
+        "subscriber_id": sub["subscriber_id"],
+        "entry_type": "fee",
+        "amount_cents": fee_cents,
+        "currency": invoice["currency"],
+        "created_at": ts,
+        "metadata": {"invoice_id": invoice_id},
+    }
+    save_ledger_entry(sub["creator_id"], charge_entry)
+    save_ledger_entry(sub["creator_id"], fee_entry)
+
+    audit_event(
+        "subscription_trial_converted",
+        sub["subscriber_id"],
+        request,
+        outcome="success",
+        subscription_id=subscription_id,
+        plan_id=sub["plan_id"],
+        creator_id=sub["creator_id"],
+    )
+    refresh_subscription_calendar_events(sub, plan)
+    return attach_subscription_profiles(sub)
+
+
+@router.post("/api/subscriptions/{subscription_id}/change-plan", response_model=SubscriptionOut)
+async def change_subscription_plan(
+    subscription_id: str,
+    body: SubscriptionChangePlanIn,
+    request: Request,
+    x_user_id: Optional[str] = Header(default=None),
+):
+    sub = ddb_get_item(pk_subscription(subscription_id), "META")
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    sub = normalize_subscription(sub)
+    user_id = require_user(x_user_id)
+    if user_id not in (sub["subscriber_id"], sub["creator_id"]):
+        raise HTTPException(status_code=403, detail="Not authorized to change plan")
+    plan = ddb_get_item(pk_plan(body.plan_id), "META")
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    if plan.get("status") != "active":
+        raise HTTPException(status_code=400, detail="Plan is not active")
+
+    interval = _plan_interval(plan, body.interval)
+    new_price = _select_plan_price(plan, interval)
+    ts = now_ts()
+
+    if body.effective == "period_end":
+        sub["pending_plan_id"] = body.plan_id
+        sub["pending_interval"] = interval
+        sub["pending_price_cents"] = new_price
+        sub["pending_apply_at"] = sub.get("current_period_end")
+        sub["updated_at"] = ts
+        save_subscription(sub)
+        record_billing_subscription(sub)
+        audit_event(
+            "subscription_plan_change_scheduled",
+            sub["subscriber_id"],
+            request,
+            outcome="success",
+            subscription_id=subscription_id,
+            plan_id=body.plan_id,
+            effective=body.effective,
+        )
+        refresh_subscription_calendar_events(sub, plan)
+        return attach_subscription_profiles(sub)
+
+    proration_amount = 0
+    if body.proration_policy != "none":
+        proration_amount = calculate_proration(
+            current_price=int(sub["price_cents"]),
+            new_price=int(new_price),
+            now=ts,
+            period_start=int(sub.get("start_at") or ts),
+            period_end=int(sub.get("current_period_end") or ts),
+        )
+        if proration_amount > 0 and body.proration_policy == "credit":
+            proration_amount = 0
+        if proration_amount < 0 and body.proration_policy == "charge":
+            proration_amount = 0
+
+    sub["plan_id"] = body.plan_id
+    sub["interval"] = interval
+    sub["price_cents"] = int(new_price)
+    sub["proration_policy"] = body.proration_policy
+    sub["updated_at"] = ts
+    save_subscription(sub)
+    record_billing_subscription(sub)
+
+    if proration_amount != 0:
+        invoice_id = new_id("inv")
+        proration_status = "paid" if proration_amount > 0 else "credited"
+        invoice = {
+            "invoice_id": invoice_id,
+            "subscription_id": subscription_id,
+            "subscriber_id": sub["subscriber_id"],
+            "provider_invoice_id": new_id("stub_inv"),
+            "amount_cents": abs(int(proration_amount)),
+            "currency": sub["currency"],
+            "status": proration_status,
+            "period_start": ts,
+            "period_end": sub.get("current_period_end"),
+            "created_at": ts,
+            "is_proration": True,
+            "proration_amount_cents": int(proration_amount),
+            "proration_period_start": sub.get("start_at"),
+            "proration_period_end": sub.get("current_period_end"),
+        }
+        save_invoice(invoice)
+        record_billing_payment(invoice, subscription_id)
+        record_billing_transaction(
+            user_sub=sub["subscriber_id"],
+            amount_cents=int(proration_amount),
+            currency=sub["currency"],
+            description=f"Subscription proration {subscription_id}",
+            status="COMPLETED",
+            external_ref=invoice_id,
+            metadata={"subscription_id": subscription_id, "creator_id": sub["creator_id"]},
+        )
+
+        entry_type = "proration_charge" if proration_amount > 0 else "proration_credit"
+        entry = {
+            "entry_id": new_id("led"),
+            "subscription_id": subscription_id,
+            "subscriber_id": sub["subscriber_id"],
+            "entry_type": entry_type,
+            "amount_cents": abs(int(proration_amount)),
+            "currency": sub["currency"],
+            "created_at": ts,
+            "metadata": {"invoice_id": invoice_id, "proration_amount_cents": proration_amount},
+        }
+        save_ledger_entry(sub["creator_id"], entry)
+
+    audit_event(
+        "subscription_plan_changed",
+        sub["subscriber_id"],
+        request,
+        outcome="success",
+        subscription_id=subscription_id,
+        plan_id=body.plan_id,
+        proration_amount_cents=proration_amount,
+    )
+    refresh_subscription_calendar_events(sub, plan)
     return attach_subscription_profiles(sub)
 
 
@@ -1063,6 +1449,7 @@ async def remove_subscriber(
     sub["status"] = "canceled"
     sub["auto_renew"] = False
     sub["cancel_at_period_end"] = False
+    sub["renewal_policy"] = "manual"
     sub["current_period_end"] = now_ts()
     sub["updated_at"] = now_ts()
     save_subscription(sub)
@@ -1105,6 +1492,7 @@ async def remove_subscriber(
         notif_type="subscription_removed",
         payload={"subscription_id": subscription_id, "creator_id": creator_id},
     )
+    refresh_subscription_calendar_events(sub)
     return attach_subscription_profiles(sub)
 
 
@@ -1126,6 +1514,7 @@ async def stop_subscriber_renewal(
     sub["auto_renew"] = False
     sub["cancel_at_period_end"] = True
     sub["status"] = "canceling"
+    sub["renewal_policy"] = "cancel_at_period_end"
     sub["updated_at"] = now_ts()
     save_subscription(sub)
     record_billing_subscription(sub)
@@ -1137,6 +1526,7 @@ async def stop_subscriber_renewal(
         subscription_id=subscription_id,
         subscriber_id=sub["subscriber_id"],
     )
+    refresh_subscription_calendar_events(sub)
     return attach_subscription_profiles(sub)
 
 

--- a/app/services/filemanager.py
+++ b/app/services/filemanager.py
@@ -436,6 +436,51 @@ def upload_profile_photo(
     return {"path": path, "size": size}
 
 
+def upload_billing_receipt(
+    user: str,
+    *,
+    txn_id: str,
+    content: bytes,
+) -> Dict[str, Any]:
+    bucket = _bucket()
+    obj_id = str(uuid.uuid4())
+    folder = norm_path("/billing/receipts/", is_folder=True)
+    _auto_create_parents(user, folder)
+    path = norm_path(f"{folder}{txn_id}.pdf", is_folder=False)
+    require_not_exists(user, path)
+
+    resp = _s3.put_object(Bucket=bucket, Key=f"{user}/objects/{obj_id}", Body=content, ContentType="application/pdf")
+    etag = resp.get("ETag")
+    size = len(content)
+
+    parent, name = split_parent_name(path)
+    item = {
+        "PK": pk_user(user),
+        "SK": sk_node(path),
+        "type": "file",
+        "path": path,
+        "name": name,
+        "name_lc": name.lower(),
+        "parent": parent,
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
+        "upload_at": now_iso(),
+        "upload_by": user,
+        "size": size,
+        "content_type": "application/pdf",
+        "s3_bucket": bucket,
+        "s3_key": f"{user}/objects/{obj_id}",
+        "etag": etag,
+        "GSI1PK": pk_user(user),
+        "GSI1SK": f"NAME#{name.lower()}#PATH#{path}",
+        "GSI2PK": f"PARENT#{parent}",
+        "GSI2SK": f"TYPE#file#NAME#{name.lower()}#PATH#{path}",
+    }
+    put_node(item)
+    _put_token_entries(user, item)
+    return {"path": path, "size": size}
+
+
 def upload_catalog_image(
     item_id: str,
     *,

--- a/app/services/purchase_history.py
+++ b/app/services/purchase_history.py
@@ -119,6 +119,8 @@ def _item_to_info(item: Dict[str, Any]) -> Dict[str, Any]:
             "reverted_at": item.get("reverted_at"),
             "version": int(item.get("version", 0)),
             "metadata": item.get("metadata"),
+            "receipt_path": item.get("receipt_path"),
+            "receipt_generated_at": item.get("receipt_generated_at"),
         },
     )
     return summary
@@ -133,6 +135,54 @@ def _fetch_txn(user_sub: str, txn_id: str) -> Optional[Dict[str, Any]]:
     )
     items = resp.get("Items", [])
     return items[0] if items else None
+
+
+def get_transaction_item(user_sub: str, txn_id: str) -> Dict[str, Any]:
+    item = _fetch_txn(user_sub, txn_id)
+    if not item:
+        raise HTTPException(404, "Transaction not found")
+    return item
+
+
+def set_receipt_info(user_sub: str, txn_id: str, receipt_path: str, generated_at: int) -> None:
+    item = _fetch_txn(user_sub, txn_id)
+    if not item:
+        raise HTTPException(404, "Transaction not found")
+    try:
+        T.purchase_transactions.update_item(
+            Key={"user_sub": item["user_sub"], "sk": item["sk"]},
+            UpdateExpression=(
+                "SET receipt_path = :p, receipt_generated_at = :g, "
+                "updated_at = :u, version = version + :one"
+            ),
+            ConditionExpression="version = :v",
+            ExpressionAttributeValues={
+                ":p": receipt_path,
+                ":g": int(generated_at),
+                ":u": now_ts(),
+                ":one": 1,
+                ":v": int(item.get("version", 0)),
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise HTTPException(409, "Conflict: transaction was updated by someone else") from exc
+        raise HTTPException(500, f"DDB error: {exc.response.get('Error', {}).get('Message')}") from exc
+    _record_event(
+        txn_id,
+        user_sub,
+        "receipt_generated",
+        {"receipt_path": receipt_path, "receipt_generated_at": int(generated_at)},
+    )
+
+
+def record_receipt_download(user_sub: str, txn_id: str, receipt_path: str) -> None:
+    _record_event(
+        txn_id,
+        user_sub,
+        "receipt_downloaded",
+        {"receipt_path": receipt_path},
+    )
 
 
 def create_transaction(user_sub: str, body: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/services/receipts.py
+++ b/app/services/receipts.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from app.core.tables import T
+from app.core.time import now_ts
+from app.services.billing_shared import ddb_query_pk, user_pk
+from app.services.filemanager import build_download_url, upload_billing_receipt
+from app.services.profile import get_profile
+from app.services.purchase_history import get_transaction_item, set_receipt_info
+
+
+@dataclass(frozen=True)
+class ReceiptPayload:
+    txn_id: str
+    status: str
+    amount: str
+    currency: str
+    created_at: int
+    completed_at: Optional[int]
+    description: Optional[str]
+    external_ref: Optional[str]
+    merchant_id: Optional[str]
+    profile: Dict[str, Any]
+    payment_record: Optional[Dict[str, Any]]
+
+
+def _pdf_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def _format_address(addr: Optional[Dict[str, Any]]) -> List[str]:
+    if not addr:
+        return []
+    parts = [
+        addr.get("line1"),
+        addr.get("line2"),
+        addr.get("city"),
+        addr.get("state"),
+        addr.get("postal_code"),
+        addr.get("country"),
+    ]
+    return [str(part) for part in parts if part]
+
+
+def _render_pdf(lines: List[str]) -> bytes:
+    content_lines = ["BT", "/F1 12 Tf", "72 720 Td"]
+    for line in lines:
+        content_lines.append(f"({_pdf_escape(line)}) Tj")
+        content_lines.append("0 -16 Td")
+    content_lines.append("ET")
+    content = "\n".join(content_lines)
+    content_bytes = content.encode("utf-8")
+
+    objects: List[bytes] = []
+    objects.append(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    objects.append(b"2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n")
+    objects.append(
+        b"3 0 obj\n"
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\n"
+        b"endobj\n"
+    )
+    objects.append(
+        b"4 0 obj\n"
+        + f"<< /Length {len(content_bytes)} >>\n".encode("utf-8")
+        + b"stream\n"
+        + content_bytes
+        + b"\nendstream\nendobj\n"
+    )
+    objects.append(b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+
+    offsets = [0]
+    pdf = bytearray(b"%PDF-1.4\n")
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf.extend(obj)
+    xref_offset = len(pdf)
+    pdf.extend(f"xref\n0 {len(objects) + 1}\n".encode("utf-8"))
+    pdf.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        pdf.extend(f"{offset:010d} 00000 n \n".encode("utf-8"))
+    pdf.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n".encode(
+            "utf-8"
+        )
+    )
+    return bytes(pdf)
+
+
+def _find_payment_record(user_sub: str, txn_id: str) -> Optional[Dict[str, Any]]:
+    items = ddb_query_pk(T.billing, user_pk(user_sub))
+    for item in items:
+        if item.get("sk", "").startswith("PAY#") and item.get("purchase_txn_id") == txn_id:
+            return item
+    return None
+
+
+def _build_receipt_payload(txn_item: Dict[str, Any]) -> ReceiptPayload:
+    user_sub = txn_item["user_sub"]
+    profile = get_profile(user_sub)
+    payment_record = _find_payment_record(user_sub, txn_item["txn_id"])
+    return ReceiptPayload(
+        txn_id=txn_item["txn_id"],
+        status=txn_item.get("status", ""),
+        amount=str(txn_item.get("amount", "")),
+        currency=str(txn_item.get("currency", "")),
+        created_at=int(txn_item.get("created_at", 0)),
+        completed_at=txn_item.get("completed_at"),
+        description=txn_item.get("description"),
+        external_ref=txn_item.get("external_ref"),
+        merchant_id=txn_item.get("merchant_id"),
+        profile=profile,
+        payment_record=payment_record,
+    )
+
+
+def _render_receipt_lines(payload: ReceiptPayload) -> List[str]:
+    lines = [
+        "Receipt",
+        f"Transaction ID: {payload.txn_id}",
+        f"Status: {payload.status}",
+        f"Amount: {payload.amount} {payload.currency.upper()}",
+        f"Created At: {payload.created_at}",
+    ]
+    if payload.completed_at:
+        lines.append(f"Completed At: {payload.completed_at}")
+    if payload.description:
+        lines.append(f"Description: {payload.description}")
+    if payload.external_ref:
+        lines.append(f"External Ref: {payload.external_ref}")
+    if payload.merchant_id:
+        lines.append(f"Merchant: {payload.merchant_id}")
+
+    name = payload.profile.get("display_name") or "Customer"
+    lines.append(f"Bill To: {name}")
+    email = payload.profile.get("displayed_email")
+    if email:
+        lines.append(f"Email: {email}")
+    address_lines = _format_address(payload.profile.get("mailing_address"))
+    if address_lines:
+        lines.append("Address:")
+        lines.extend([f"  {line}" for line in address_lines])
+
+    if payload.payment_record:
+        payment_id = payload.payment_record.get("payment_intent_id") or payload.payment_record.get("external_id")
+        if payment_id:
+            lines.append(f"Payment ID: {payment_id}")
+        method = payload.payment_record.get("payment_method_type") or payload.payment_record.get("kind")
+        if method:
+            lines.append(f"Payment Method: {method}")
+    return lines
+
+
+def get_or_create_receipt(user_sub: str, txn_id: str) -> Dict[str, Any]:
+    txn_item = get_transaction_item(user_sub, txn_id)
+    receipt_path = txn_item.get("receipt_path")
+    receipt_generated_at = txn_item.get("receipt_generated_at")
+    if receipt_path:
+        generated_at = int(receipt_generated_at) if receipt_generated_at else now_ts()
+        return {
+            "txn_id": txn_id,
+            "receipt_path": receipt_path,
+            "receipt_url": build_download_url(receipt_path),
+            "generated_at": generated_at,
+        }
+
+    payload = _build_receipt_payload(txn_item)
+    pdf = _render_pdf(_render_receipt_lines(payload))
+    upload = upload_billing_receipt(user_sub, txn_id=txn_id, content=pdf)
+    generated_at = now_ts()
+    set_receipt_info(user_sub, txn_id, upload["path"], generated_at)
+    return {
+        "txn_id": txn_id,
+        "receipt_path": upload["path"],
+        "receipt_url": build_download_url(upload["path"]),
+        "generated_at": generated_at,
+    }

--- a/tests/test_paypal_routes.py
+++ b/tests/test_paypal_routes.py
@@ -364,6 +364,35 @@ def test_missing_user_header_raises_401():
     assert excinfo.value.status_code == 401
 
 
+def test_charge_once_records_purchase_txn(monkeypatch):
+    recorded: Dict[str, Any] = {}
+
+    monkeypatch.setattr(paypal, "apply_balance_delta", lambda *args, **kwargs: None)
+    monkeypatch.setattr(paypal, "ddb_put", lambda item, **kwargs: recorded.setdefault("ledger_put", item))
+    monkeypatch.setattr(
+        paypal,
+        "new_ledger_entry",
+        lambda **kwargs: ("LEDGER#1", {"pk": "USER#user", "sk": "LEDGER#1"}),
+    )
+    monkeypatch.setattr(
+        paypal,
+        "paypal_create_order",
+        lambda **kwargs: {"id": "ORDER-1", "links": [{"rel": "approve", "href": "https://approve"}]},
+    )
+    monkeypatch.setattr(paypal, "record_billing_transaction", lambda **kwargs: "txn_1")
+
+    def fake_put_payment_record(**kwargs):
+        recorded["payment_record"] = kwargs
+
+    monkeypatch.setattr(paypal, "put_payment_record", fake_put_payment_record)
+
+    body = paypal.OneTimeChargeIn(amount_cents=2500, payment_token_id="pm_1", reason="one-time")
+    resp = asyncio.run(paypal.charge_once(body, request=None, x_user_id="user"))
+
+    assert resp["order_id"] == "ORDER-1"
+    assert recorded["payment_record"]["purchase_txn_id"] == "txn_1"
+
+
 def test_charge_once_requires_default_payment_method(monkeypatch):
     monkeypatch.setattr(paypal, "ddb_get", lambda pk, sk: {"autopay_enabled": False})
 

--- a/tests/test_purchase_history_receipts.py
+++ b/tests/test_purchase_history_receipts.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import patch
+
+from app.services import purchase_history
+
+
+class TestPurchaseHistoryReceipts(unittest.TestCase):
+    def test_record_receipt_download_emits_event(self):
+        with patch.object(purchase_history, "_record_event") as event_mock:
+            purchase_history.record_receipt_download(
+                "user-1",
+                "txn-1",
+                "/billing/receipts/txn-1.pdf",
+            )
+
+        event_mock.assert_called_once_with(
+            "txn-1",
+            "user-1",
+            "receipt_downloaded",
+            {"receipt_path": "/billing/receipts/txn-1.pdf"},
+        )

--- a/tests/test_receipts_service.py
+++ b/tests/test_receipts_service.py
@@ -1,0 +1,75 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from app.services import purchase_history, receipts
+
+
+class TestReceiptsService(unittest.TestCase):
+    def test_get_or_create_receipt_returns_existing(self):
+        txn_item = {
+            "user_sub": "user-1",
+            "txn_id": "txn-1",
+            "receipt_path": "/billing/receipts/txn-1.pdf",
+            "receipt_generated_at": 123,
+        }
+        with (
+            patch.object(receipts, "get_transaction_item", return_value=txn_item),
+            patch.object(receipts, "build_download_url", return_value="https://example/receipt.pdf"),
+            patch.object(receipts, "upload_billing_receipt") as upload_mock,
+            patch.object(receipts, "set_receipt_info") as set_mock,
+        ):
+            result = receipts.get_or_create_receipt("user-1", "txn-1")
+
+        self.assertEqual(result["receipt_path"], "/billing/receipts/txn-1.pdf")
+        self.assertEqual(result["receipt_url"], "https://example/receipt.pdf")
+        self.assertEqual(result["generated_at"], 123)
+        upload_mock.assert_not_called()
+        set_mock.assert_not_called()
+
+    def test_get_or_create_receipt_creates_pdf(self):
+        txn_item = {
+            "user_sub": "user-2",
+            "txn_id": "txn-2",
+            "status": "COMPLETED",
+            "amount": "10.00",
+            "currency": "usd",
+            "created_at": 10,
+            "completed_at": 11,
+        }
+        with (
+            patch.object(receipts, "get_transaction_item", return_value=txn_item),
+            patch.object(receipts, "get_profile", return_value={"display_name": "Ada"}),
+            patch.object(receipts, "_find_payment_record", return_value={"external_id": "pay_1", "kind": "paypal"}),
+            patch.object(receipts, "upload_billing_receipt", return_value={"path": "/billing/receipts/txn-2.pdf"}),
+            patch.object(receipts, "set_receipt_info") as set_mock,
+            patch.object(receipts, "build_download_url", return_value="https://example/txn-2.pdf"),
+            patch.object(receipts, "now_ts", return_value=456),
+        ):
+            result = receipts.get_or_create_receipt("user-2", "txn-2")
+
+        self.assertEqual(result["receipt_path"], "/billing/receipts/txn-2.pdf")
+        self.assertEqual(result["receipt_url"], "https://example/txn-2.pdf")
+        self.assertEqual(result["generated_at"], 456)
+        set_mock.assert_called_once_with("user-2", "txn-2", "/billing/receipts/txn-2.pdf", 456)
+
+
+class TestPurchaseHistoryReceiptInfo(unittest.TestCase):
+    def test_set_receipt_info_records_event(self):
+        txn_item = {"user_sub": "user-3", "sk": "TXN#1#abc", "version": 2}
+        fake_tables = SimpleNamespace(purchase_transactions=Mock())
+        with (
+            patch.object(purchase_history, "_fetch_txn", return_value=txn_item),
+            patch.object(purchase_history, "T", fake_tables),
+            patch.object(purchase_history, "now_ts", return_value=999),
+            patch.object(purchase_history, "_record_event") as event_mock,
+        ):
+            purchase_history.set_receipt_info("user-3", "txn-3", "/billing/receipts/txn-3.pdf", 321)
+
+        fake_tables.purchase_transactions.update_item.assert_called_once()
+        event_mock.assert_called_once_with(
+            "txn-3",
+            "user-3",
+            "receipt_generated",
+            {"receipt_path": "/billing/receipts/txn-3.pdf", "receipt_generated_at": 321},
+        )

--- a/tests/test_subscription_lifecycle.py
+++ b/tests/test_subscription_lifecycle.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+from app.routers import subscription_server
+
+
+def test_calculate_proration_mid_cycle():
+    proration = subscription_server.calculate_proration(
+        current_price=1000,
+        new_price=2000,
+        now=15,
+        period_start=0,
+        period_end=30,
+    )
+    assert proration == 500
+
+
+def test_refresh_subscription_calendar_events_upserts_and_deletes():
+    calendar_table = Mock()
+    calendar_table.get_item.return_value = {"Item": {"calendar_id": "cal1", "timezone": "UTC"}}
+    with patch.object(subscription_server, "T", SimpleNamespace(calendar=calendar_table)):
+        sub = {
+            "subscription_id": "sub1",
+            "plan_id": "plan1",
+            "trial_end": 200,
+            "current_period_end": 400,
+            "cancel_at_period_end": False,
+        }
+        plan = {"plan_id": "plan1", "metadata": {"calendar_id": "cal1"}}
+        subscription_server.refresh_subscription_calendar_events(sub, plan)
+
+    assert calendar_table.put_item.call_count == 2
+    calendar_table.delete_item.assert_called_once_with(Key={"calendar_id": "cal1", "sk": "event#sub_sub1_cancellation"})
+


### PR DESCRIPTION
### Motivation

- Improve subscription lifecycle handling by adding explicit trial support, proration calculations, and renewal policies so plan changes and trial conversions behave predictably.
- Surface subscription timing in an external calendar via scheduled events for trial end, renewal, and cancellation to keep creator calendars in sync.
- Support generating and tracking purchase receipts (PDFs) and record when users download them to improve auditability of purchase activity.

### Description

- Extended `app/routers/subscription_server.py` to add trial fields, renewal/proration policies, proration helpers (`_proration_fraction`, `calculate_proration`), calendar synchronization helpers (`_calendar_meta`, `_upsert_subscription_calendar_event`, `refresh_subscription_calendar_events`), and new endpoints `POST /api/subscriptions/{subscription_id}/trial/convert` and `POST /api/subscriptions/{subscription_id}/change-plan` implementing trial conversion and plan changes with proration invoices and ledger entries; updated subscription state transitions to persist `renewal_policy` where appropriate.
- Added billing/recording changes: `record_billing_subscription` now includes interval/auto-renew/trial/proration/renewal fields, and subscription summaries treat `trialing` status specially (no next charge).
- Implemented receipts service in `app/services/receipts.py` to render a minimal PDF receipt, upload it via `app/services/filemanager.upload_billing_receipt`, and provide `get_or_create_receipt` which stores receipt metadata using new helpers in `app/services/purchase_history.py` (`set_receipt_info`, `get_transaction_item`) and records `receipt_generated` events.
- Added download tracking by calling `record_receipt_download` from `app/routers/filemanager.py` when a downloaded path matches `/billing/receipts/*.pdf`, and added `record_receipt_download` in `app/services/purchase_history.py` to emit a `receipt_downloaded` event.
- Integrated purchase transaction linkage in PayPal flow in `app/routers/paypal.py` by attaching `purchase_txn_id` to payment records and mapping captures to `mark_completed` / `mark_reverted` or creating corresponding `record_billing_transaction` entries when appropriate.
- Added unit tests: `tests/test_subscription_lifecycle.py` (proration math and calendar event sync), `tests/test_receipts_service.py` (receipt generation and DB updates), and `tests/test_purchase_history_receipts.py` (receipt-download event emission).

### Testing

- Added unit tests in `tests/test_subscription_lifecycle.py`, `tests/test_receipts_service.py`, and `tests/test_purchase_history_receipts.py` to validate proration, calendar upserts/deletes, receipt creation, and event emission.
- Ran `pytest -q tests/test_subscription_lifecycle.py`, which reported `2 passed` (success); the other new tests were added but not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd13e2588832bb028610deb4b0489)