### PR TITLE
Add booking links and public reservation endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.routers.profile import router as profile_router
 from app.routers.messaging import router as messaging_router
 from app.routers.filemanager import router as filemanager_router
 from app.routers.addresses import router as addresses_router
+from app.routers.calendar import public_router as calendar_public_router
 from app.routers.calendar import router as calendar_router
 from app.routers.device_trust import router as device_trust_router
 from app.routers.newsfeed import router as newsfeed_router, startup as newsfeed_startup
@@ -77,6 +78,7 @@ def create_app() -> FastAPI:
     app.include_router(filemanager_router)
     app.include_router(addresses_router)
     app.include_router(calendar_router)
+    app.include_router(calendar_public_router)
     app.include_router(device_trust_router)
     app.include_router(newsfeed_router)
     app.add_event_handler("startup", newsfeed_startup)

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, conint
 
@@ -427,15 +427,28 @@ class ShoppingCartPurchaseOut(BaseModel):
     purchase_txn_id: Optional[str] = None
 
 
+class WorkingHoursWindow(BaseModel):
+    start: str
+    end: str
+
+
 class CalendarCreateIn(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     timezone: str = Field(default="UTC", max_length=64)
+    conflict_detection: bool = False
+    working_hours: Dict[str, List[WorkingHoursWindow]] | None = None
+    buffer_before_minutes: int = 0
+    buffer_after_minutes: int = 0
 
 
 class CalendarOut(BaseModel):
     calendar_id: str
     name: str
     timezone: str
+    conflict_detection: bool = False
+    working_hours: Dict[str, List[WorkingHoursWindow]] | None = None
+    buffer_before_minutes: int = 0
+    buffer_after_minutes: int = 0
     owner_user_id: str
     created_at_utc: str
 
@@ -443,6 +456,10 @@ class CalendarOut(BaseModel):
 class CalendarUpdateIn(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=200)
     timezone: str | None = Field(default=None, max_length=64)
+    conflict_detection: bool | None = None
+    working_hours: Dict[str, List[WorkingHoursWindow]] | None = None
+    buffer_before_minutes: int | None = None
+    buffer_after_minutes: int | None = None
 
 
 class EventCreateIn(BaseModel):
@@ -453,6 +470,12 @@ class EventCreateIn(BaseModel):
     end_utc: str | None = None
     all_day: bool = False
     all_day_date: str | None = None
+    attendees: List[str] = Field(default_factory=list)
+    booking_enabled: bool = False
+    approval_required: bool = False
+    status: str = "busy"
+    category: str | None = None
+    recurrence_rule: RecurrenceRule | None = None
 
 
 class EventOut(BaseModel):
@@ -465,6 +488,12 @@ class EventOut(BaseModel):
     end_utc: str | None = None
     all_day: bool
     all_day_date: str | None = None
+    attendees: List[str]
+    booking_enabled: bool
+    approval_required: bool
+    status: str
+    category: str | None = None
+    recurrence_rule: RecurrenceRule | None = None
     created_at_utc: str
 
 
@@ -476,11 +505,55 @@ class EventUpdateIn(BaseModel):
     end_utc: str | None = None
     all_day: bool | None = None
     all_day_date: str | None = None
+    attendees: List[str] | None = None
+    booking_enabled: bool | None = None
+    approval_required: bool | None = None
+    status: str | None = None
+    category: str | None = None
+    recurrence_rule: RecurrenceRule | None = None
 
 
 class OpeningsOut(BaseModel):
     start_utc: str
     end_utc: str
+
+
+class EventsPageOut(BaseModel):
+    events: List[EventOut]
+    next_cursor: str | None = None
+
+
+class RecurrenceRule(BaseModel):
+    freq: Literal["DAILY", "WEEKLY", "MONTHLY"]
+    interval: int = Field(default=1, ge=1)
+    until_utc: Optional[str] = None
+    count: Optional[int] = Field(default=None, ge=1)
+    byday: Optional[List[Literal["MO", "TU", "WE", "TH", "FR", "SA", "SU"]]] = None
+
+
+class BookingLinkCreateIn(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    duration_minutes: conint(ge=5, le=1440)
+    timezone: str | None = Field(default=None, max_length=64)
+
+
+class BookingLinkOut(BaseModel):
+    link_id: str
+    calendar_id: str
+    name: str
+    duration_minutes: int
+    timezone: str
+    created_at_utc: str
+    public_url: str
+
+
+class BookingRequestIn(BaseModel):
+    name: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
+    start_utc: str
+    end_utc: str
+    timezone: str | None = Field(default=None, max_length=64)
+    notify: bool = False
 
 
 class TeamAvailabilityIn(BaseModel):

--- a/app/routers/calendar.py
+++ b/app/routers/calendar.py
@@ -1,23 +1,29 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, date, timedelta, timezone
+from datetime import datetime, date, time, timedelta, timezone
 from typing import Any, Dict, Iterable, List
 
-from boto3.dynamodb.conditions import Key
+from boto3.dynamodb.conditions import Attr, Key
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.core.tables import T
 from app.models import (
+    BookingLinkCreateIn,
+    BookingLinkOut,
+    BookingRequestIn,
     CalendarCreateIn,
     CalendarOut,
     CalendarUpdateIn,
+    EventsPageOut,
     EventCreateIn,
     EventOut,
     EventUpdateIn,
     OpeningsOut,
+    RecurrenceRule,
     TeamAvailabilityIn,
 )
+from app.services.alerts import audit_event
 from app.services.sessions import require_ui_session
 
 try:
@@ -26,6 +32,7 @@ except ImportError:  # pragma: no cover - fallback for older Python
     ZoneInfo = None
 
 router = APIRouter(prefix="/ui", tags=["calendar"])
+public_router = APIRouter(prefix="/booking", tags=["booking"])
 
 
 def _require_zoneinfo() -> None:
@@ -56,6 +63,10 @@ def parse_iso_date(value: str) -> date:
         return date.fromisoformat(value)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid date: {value}") from exc
+
+
+WEEKDAY_NAMES = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+RRULE_WEEKDAY_MAP = {"MO": 0, "TU": 1, "WE": 2, "TH": 3, "FR": 4, "SA": 5, "SU": 6}
 
 
 def overlap(a0: datetime, a1: datetime, b0: datetime, b1: datetime) -> bool:
@@ -106,11 +117,33 @@ def _event_key(event_id: str) -> str:
     return f"event#{event_id}"
 
 
+def _booking_link_key(link_id: str) -> str:
+    return f"booking#{link_id}"
+
+
 def _load_event(calendar_id: str, event_id: str) -> Dict[str, Any]:
     item = T.calendar.get_item(Key={"calendar_id": calendar_id, "sk": _event_key(event_id)}).get("Item")
     if not item:
         raise HTTPException(status_code=404, detail="Event not found")
     return item
+
+
+def _load_booking_link(link_id: str) -> Dict[str, Any]:
+    response = T.calendar.scan(
+        FilterExpression=Attr("sk").eq(_booking_link_key(link_id)) & Attr("type").eq("booking_link"),
+        Limit=1,
+    )
+    items = response.get("Items", [])
+    if not items:
+        raise HTTPException(status_code=404, detail="Booking link not found")
+    return items[0]
+
+
+def _load_calendar_public(calendar_id: str) -> Dict[str, Any]:
+    meta = T.calendar.get_item(Key=_calendar_keys(calendar_id)).get("Item")
+    if not meta:
+        raise HTTPException(status_code=404, detail="Calendar not found")
+    return meta
 
 
 def _validate_timezone(tz_name: str) -> None:
@@ -119,6 +152,57 @@ def _validate_timezone(tz_name: str) -> None:
         ZoneInfo(tz_name)
     except Exception as exc:
         raise HTTPException(status_code=400, detail="Invalid timezone") from exc
+
+
+def _parse_hhmm(value: str) -> time:
+    try:
+        return time.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid time: {value}") from exc
+
+
+def _validate_working_hours(working_hours: Dict[str, list[Dict[str, str]]] | None) -> None:
+    if working_hours is None:
+        return
+    for day, windows in working_hours.items():
+        if day not in WEEKDAY_NAMES:
+            raise HTTPException(status_code=400, detail=f"Invalid weekday: {day}")
+        for window in windows:
+            start = _parse_hhmm(window["start"])
+            end = _parse_hhmm(window["end"])
+            if end <= start:
+                raise HTTPException(status_code=400, detail="working_hours end must be after start")
+
+
+def _normalize_buffers(buffer_before_minutes: int, buffer_after_minutes: int) -> tuple[int, int]:
+    if buffer_before_minutes < 0 or buffer_after_minutes < 0:
+        raise HTTPException(status_code=400, detail="Buffers must be non-negative")
+    return buffer_before_minutes, buffer_after_minutes
+
+
+def _validate_booking_settings(booking_enabled: bool, approval_required: bool) -> None:
+    if approval_required and not booking_enabled:
+        raise HTTPException(status_code=400, detail="approval_required requires booking_enabled")
+
+
+def _normalize_event_status(status: str) -> str:
+    normalized = status.lower().strip()
+    allowed = {"busy", "tentative", "free", "out_of_office"}
+    if normalized not in allowed:
+        raise HTTPException(status_code=400, detail="Invalid event status")
+    return normalized
+
+
+def _is_busy_status(status: str) -> bool:
+    return _normalize_event_status(status) not in {"free", "tentative"}
+
+
+def _normalize_recurrence_rule(rule: RecurrenceRule | None) -> RecurrenceRule | None:
+    if rule is None:
+        return None
+    if rule.until_utc:
+        _ = parse_iso_dt(rule.until_utc)
+    return rule
 
 
 def _normalize_event_times(calendar_tz: str, payload: EventCreateIn) -> Dict[str, Any]:
@@ -146,7 +230,10 @@ def _normalize_event_times(calendar_tz: str, payload: EventCreateIn) -> Dict[str
     }
 
 
-def _event_to_busy_interval(event: Dict[str, Any]) -> tuple[datetime, datetime]:
+def _event_to_busy_interval(event: Dict[str, Any]) -> tuple[datetime, datetime] | None:
+    status = str(event.get("status", "busy"))
+    if not _is_busy_status(status):
+        return None
     if event.get("all_day"):
         _require_zoneinfo()
         tz = ZoneInfo(event["timezone"])
@@ -155,6 +242,190 @@ def _event_to_busy_interval(event: Dict[str, Any]) -> tuple[datetime, datetime]:
         local_end = local_start + timedelta(days=1)
         return local_start.astimezone(timezone.utc), local_end.astimezone(timezone.utc)
     return parse_iso_dt(event["start_utc"]), parse_iso_dt(event["end_utc"])
+
+
+def _event_payload_interval(normalized: Dict[str, Any]) -> tuple[datetime, datetime]:
+    if normalized.get("all_day"):
+        event = {
+            "all_day": True,
+            "timezone": normalized["timezone"],
+            "all_day_date": normalized["all_day_date"],
+            "status": normalized.get("status", "busy"),
+        }
+    else:
+        event = {
+            "all_day": False,
+            "start_utc": normalized["start_utc"],
+            "end_utc": normalized["end_utc"],
+            "status": normalized.get("status", "busy"),
+        }
+    interval = _event_to_busy_interval(event)
+    if interval is None:
+        raise HTTPException(status_code=400, detail="Non-busy events cannot be used for conflict checks")
+    return interval
+
+
+def _event_time_interval(event: Dict[str, Any]) -> tuple[datetime, datetime]:
+    if event.get("all_day"):
+        _require_zoneinfo()
+        tz = ZoneInfo(event["timezone"])
+        d = parse_iso_date(event["all_day_date"])
+        local_start = datetime(d.year, d.month, d.day, 0, 0, 0, tzinfo=tz)
+        local_end = local_start + timedelta(days=1)
+        return local_start.astimezone(timezone.utc), local_end.astimezone(timezone.utc)
+    return parse_iso_dt(event["start_utc"]), parse_iso_dt(event["end_utc"])
+
+
+def _expand_rrule(
+    series_start_utc: datetime,
+    series_end_utc: datetime,
+    rrule: RecurrenceRule,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[tuple[datetime, datetime]]:
+    if window_end <= window_start:
+        return []
+    until = parse_iso_dt(rrule.until_utc) if rrule.until_utc else None
+    remaining = rrule.count
+    duration = series_end_utc - series_start_utc
+    occs: list[tuple[datetime, datetime]] = []
+    if rrule.freq == "DAILY":
+        dt = series_start_utc
+        step = timedelta(days=rrule.interval)
+        while True:
+            if until and dt > until:
+                break
+            if remaining is not None and remaining <= 0:
+                break
+            occ_start = dt
+            occ_end = dt + duration
+            if overlap(occ_start, occ_end, window_start, window_end):
+                occs.append((occ_start, occ_end))
+            dt = dt + step
+            if remaining is not None:
+                remaining -= 1
+            if dt > window_end + timedelta(days=1):
+                break
+    elif rrule.freq == "WEEKLY":
+        bydays = rrule.byday or [list(RRULE_WEEKDAY_MAP.keys())[series_start_utc.weekday()]]
+        by_idxs = sorted({RRULE_WEEKDAY_MAP[d] for d in bydays})
+        week0_date = series_start_utc.date() - timedelta(days=series_start_utc.weekday())
+        week_start = datetime(
+            week0_date.year,
+            week0_date.month,
+            week0_date.day,
+            series_start_utc.hour,
+            series_start_utc.minute,
+            series_start_utc.second,
+            series_start_utc.microsecond,
+            tzinfo=timezone.utc,
+        )
+        while True:
+            for wi in by_idxs:
+                cand = week_start + timedelta(days=wi)
+                if cand < series_start_utc:
+                    continue
+                if until and cand > until:
+                    return sorted(occs, key=lambda x: x[0])
+                if remaining is not None and remaining <= 0:
+                    return sorted(occs, key=lambda x: x[0])
+                occ_start = cand
+                occ_end = cand + duration
+                if overlap(occ_start, occ_end, window_start, window_end):
+                    occs.append((occ_start, occ_end))
+                if remaining is not None:
+                    remaining -= 1
+            week_start = week_start + timedelta(weeks=rrule.interval)
+            if until and week_start > until + timedelta(days=7):
+                break
+            if week_start > window_end + timedelta(days=7):
+                break
+    elif rrule.freq == "MONTHLY":
+        def add_months(d: datetime, months: int) -> datetime | None:
+            y = d.year + (d.month - 1 + months) // 12
+            m = (d.month - 1 + months) % 12 + 1
+            try:
+                return d.replace(year=y, month=m, day=d.day)
+            except ValueError:
+                return None
+        k = 0
+        cur = series_start_utc
+        while True:
+            if until and cur > until:
+                break
+            if remaining is not None and remaining <= 0:
+                break
+            occ_start = cur
+            occ_end = cur + duration
+            if overlap(occ_start, occ_end, window_start, window_end):
+                occs.append((occ_start, occ_end))
+            if remaining is not None:
+                remaining -= 1
+            k += rrule.interval
+            nxt = add_months(series_start_utc, k)
+            if nxt is None:
+                continue
+            cur = nxt
+            if cur > window_end + timedelta(days=31):
+                break
+    return sorted(occs, key=lambda x: x[0])
+
+
+def _expand_event_occurrences(
+    event: Dict[str, Any],
+    window_start: datetime,
+    window_end: datetime,
+) -> list[Dict[str, Any]]:
+    rule_data = event.get("recurrence_rule")
+    if not rule_data:
+        return [event]
+    rule = RecurrenceRule(**rule_data)
+    series_start, series_end = _event_time_interval(event)
+    occs = _expand_rrule(series_start, series_end, rule, window_start, window_end)
+    if not occs:
+        return []
+    tz = ZoneInfo(event.get("timezone", "UTC"))
+    occurrences: list[Dict[str, Any]] = []
+    for occ_start, occ_end in occs:
+        occ = {**event}
+        if event.get("all_day"):
+            local_date = occ_start.astimezone(tz).date()
+            occ["all_day_date"] = local_date.isoformat()
+            occ["start_utc"] = None
+            occ["end_utc"] = None
+        else:
+            occ["start_utc"] = iso_utc(occ_start)
+            occ["end_utc"] = iso_utc(occ_end)
+        occurrences.append(occ)
+    return occurrences
+
+
+def _ensure_no_conflicts(
+    calendar_id: str,
+    normalized: Dict[str, Any],
+    *,
+    exclude_event_id: str | None = None,
+) -> None:
+    requested_start, requested_end = _event_payload_interval(normalized)
+    for event in _list_events(calendar_id)[0]:
+        if exclude_event_id and event.get("event_id") == exclude_event_id:
+            continue
+        if event.get("recurrence_rule"):
+            occurrences = _expand_event_occurrences(event, requested_start, requested_end)
+            for occ in occurrences:
+                interval = _event_to_busy_interval(occ)
+                if interval is None:
+                    continue
+                start, end = interval
+                if overlap(requested_start, requested_end, start, end):
+                    raise HTTPException(status_code=409, detail="Event conflicts with an existing event")
+        else:
+            interval = _event_to_busy_interval(event)
+            if interval is None:
+                continue
+            start, end = interval
+            if overlap(requested_start, requested_end, start, end):
+                raise HTTPException(status_code=409, detail="Event conflicts with an existing event")
 
 
 def _load_calendar(calendar_id: str, user_sub: str) -> Dict[str, Any]:
@@ -166,12 +437,142 @@ def _load_calendar(calendar_id: str, user_sub: str) -> Dict[str, Any]:
     return meta
 
 
-def _list_events(calendar_id: str) -> List[Dict[str, Any]]:
-    response = T.calendar.query(
-        KeyConditionExpression=Key("calendar_id").eq(calendar_id) & Key("sk").begins_with("event#"),
-        ScanIndexForward=True,
+def _list_events(
+    calendar_id: str,
+    *,
+    start_utc: datetime | None = None,
+    end_utc: datetime | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> tuple[list[Dict[str, Any]], str | None]:
+    items: list[Dict[str, Any]] = []
+    last_cursor = cursor
+    remaining = limit
+    while True:
+        query_kwargs: Dict[str, Any] = {
+            "KeyConditionExpression": Key("calendar_id").eq(calendar_id) & Key("sk").begins_with("event#"),
+            "ScanIndexForward": True,
+        }
+        if last_cursor:
+            query_kwargs["ExclusiveStartKey"] = {"calendar_id": calendar_id, "sk": last_cursor}
+        if remaining:
+            query_kwargs["Limit"] = min(200, remaining)
+        response = T.calendar.query(**query_kwargs)
+        page_items = response.get("Items", [])
+        for event in page_items:
+            if (start_utc or end_utc) and not event.get("recurrence_rule"):
+                event_start, event_end = _event_time_interval(event)
+                if start_utc and event_end <= start_utc:
+                    continue
+                if end_utc and event_start >= end_utc:
+                    continue
+            items.append(event)
+            if remaining:
+                remaining -= 1
+                if remaining == 0:
+                    last_cursor = event.get("sk") or _event_key(event["event_id"])
+                    return items, last_cursor
+        last_evaluated = response.get("LastEvaluatedKey")
+        if not last_evaluated:
+            return items, None
+        last_cursor = last_evaluated.get("sk")
+
+
+def _apply_buffers(
+    busy: list[tuple[datetime, datetime]],
+    buffer_before_minutes: int,
+    buffer_after_minutes: int,
+) -> list[tuple[datetime, datetime]]:
+    if not busy:
+        return []
+    before = timedelta(minutes=buffer_before_minutes)
+    after = timedelta(minutes=buffer_after_minutes)
+    adjusted = [(start - before, end + after) for start, end in busy]
+    return merge_intervals(adjusted)
+
+
+def _working_hours_intervals(
+    working_hours: Dict[str, list[Dict[str, str]]],
+    tz_name: str,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[tuple[datetime, datetime]]:
+    _require_zoneinfo()
+    tz = ZoneInfo(tz_name)
+    intervals: list[tuple[datetime, datetime]] = []
+    cur_day = window_start.astimezone(tz).date()
+    end_day = window_end.astimezone(tz).date()
+    while cur_day <= end_day:
+        weekday = WEEKDAY_NAMES[cur_day.weekday()]
+        for window in working_hours.get(weekday, []):
+            start_time = _parse_hhmm(window["start"])
+            end_time = _parse_hhmm(window["end"])
+            local_start = datetime.combine(cur_day, start_time, tzinfo=tz)
+            local_end = datetime.combine(cur_day, end_time, tzinfo=tz)
+            intervals.append((local_start.astimezone(timezone.utc), local_end.astimezone(timezone.utc)))
+        cur_day += timedelta(days=1)
+    return intervals
+
+
+def _calendar_openings(meta: Dict[str, Any], window_start: datetime, window_end: datetime) -> list[tuple[datetime, datetime]]:
+    busy: list[tuple[datetime, datetime]] = []
+    for event in _list_events(meta["calendar_id"])[0]:
+        expanded = _expand_event_occurrences(event, window_start, window_end)
+        for occ in expanded:
+            interval = _event_to_busy_interval(occ)
+            if interval is not None:
+                busy.append(interval)
+    buffer_before, buffer_after = _normalize_buffers(
+        int(meta.get("buffer_before_minutes", 0)),
+        int(meta.get("buffer_after_minutes", 0)),
     )
-    return response.get("Items", [])
+    busy = _apply_buffers(busy, buffer_before, buffer_after)
+    working_hours = meta.get("working_hours")
+    if not working_hours:
+        return invert_intervals(busy, window_start, window_end)
+    windows = _working_hours_intervals(working_hours, meta.get("timezone", "UTC"), window_start, window_end)
+    free: list[tuple[datetime, datetime]] = []
+    for start, end in windows:
+        free.extend(invert_intervals(busy, max(start, window_start), min(end, window_end)))
+    return merge_intervals(free)
+
+
+def _slot_in_openings(
+    openings: list[tuple[datetime, datetime]],
+    slot_start: datetime,
+    slot_end: datetime,
+) -> bool:
+    return any(slot_start >= start and slot_end <= end for start, end in openings)
+
+
+def _filter_openings_by_duration(
+    openings: list[tuple[datetime, datetime]],
+    duration_minutes: int,
+) -> list[tuple[datetime, datetime]]:
+    duration = timedelta(minutes=duration_minutes)
+    return [(start, end) for start, end in openings if end - start >= duration]
+
+
+def _intersect_intervals(
+    left: list[tuple[datetime, datetime]],
+    right: list[tuple[datetime, datetime]],
+) -> list[tuple[datetime, datetime]]:
+    if not left or not right:
+        return []
+    result: list[tuple[datetime, datetime]] = []
+    i = j = 0
+    left_sorted = sorted(left, key=lambda pair: pair[0])
+    right_sorted = sorted(right, key=lambda pair: pair[0])
+    while i < len(left_sorted) and j < len(right_sorted):
+        start = max(left_sorted[i][0], right_sorted[j][0])
+        end = min(left_sorted[i][1], right_sorted[j][1])
+        if start < end:
+            result.append((start, end))
+        if left_sorted[i][1] < right_sorted[j][1]:
+            i += 1
+        else:
+            j += 1
+    return result
 
 
 def _event_out(item: Dict[str, Any], calendar_id: str) -> EventOut:
@@ -185,6 +586,12 @@ def _event_out(item: Dict[str, Any], calendar_id: str) -> EventOut:
         end_utc=item.get("end_utc"),
         all_day=item.get("all_day", False),
         all_day_date=item.get("all_day_date"),
+        attendees=item.get("attendees", []),
+        booking_enabled=item.get("booking_enabled", False),
+        approval_required=item.get("approval_required", False),
+        status=item.get("status", "busy"),
+        category=item.get("category"),
+        recurrence_rule=item.get("recurrence_rule"),
         created_at_utc=item.get("created_at_utc", ""),
     )
 
@@ -193,12 +600,19 @@ def _event_out(item: Dict[str, Any], calendar_id: str) -> EventOut:
 async def create_calendar(body: CalendarCreateIn, ctx: Dict[str, str] = Depends(require_ui_session)):
     calendar_id = uuid.uuid4().hex
     now = iso_utc(utc_now())
+    _validate_timezone(body.timezone)
+    _validate_working_hours(body.working_hours)
+    buffer_before, buffer_after = _normalize_buffers(body.buffer_before_minutes, body.buffer_after_minutes)
     item = {
         "calendar_id": calendar_id,
         "sk": "meta",
         "type": "calendar",
         "name": body.name,
         "timezone": body.timezone,
+        "conflict_detection": body.conflict_detection,
+        "working_hours": body.working_hours,
+        "buffer_before_minutes": buffer_before,
+        "buffer_after_minutes": buffer_after,
         "owner_user_sub": ctx["user_sub"],
         "created_at_utc": now,
     }
@@ -207,6 +621,10 @@ async def create_calendar(body: CalendarCreateIn, ctx: Dict[str, str] = Depends(
         calendar_id=calendar_id,
         name=body.name,
         timezone=body.timezone,
+        conflict_detection=body.conflict_detection,
+        working_hours=body.working_hours,
+        buffer_before_minutes=buffer_before,
+        buffer_after_minutes=buffer_after,
         owner_user_id=ctx["user_sub"],
         created_at_utc=now,
     )
@@ -216,10 +634,17 @@ async def create_calendar(body: CalendarCreateIn, ctx: Dict[str, str] = Depends(
 async def create_event(
     calendar_id: str,
     body: EventCreateIn,
+    force: bool = Query(False, description="Allow conflicts when true"),
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
     meta = _load_calendar(calendar_id, ctx["user_sub"])
+    _validate_booking_settings(body.booking_enabled, body.approval_required)
+    status = _normalize_event_status(body.status)
+    recurrence_rule = _normalize_recurrence_rule(body.recurrence_rule)
     normalized = _normalize_event_times(meta["timezone"], body)
+    normalized["status"] = status
+    if meta.get("conflict_detection") and not force and _is_busy_status(status):
+        _ensure_no_conflicts(calendar_id, normalized)
     event_id = uuid.uuid4().hex
     now = iso_utc(utc_now())
     item = {
@@ -229,6 +654,12 @@ async def create_event(
         "event_id": event_id,
         "name": body.name,
         "description": body.description,
+        "attendees": body.attendees,
+        "booking_enabled": body.booking_enabled,
+        "approval_required": body.approval_required,
+        "status": status,
+        "category": body.category,
+        "recurrence_rule": recurrence_rule.model_dump() if recurrence_rule else None,
         "created_at_utc": now,
         **normalized,
     }
@@ -243,14 +674,78 @@ async def create_event(
         end_utc=normalized["end_utc"],
         all_day=normalized["all_day"],
         all_day_date=normalized["all_day_date"],
+        attendees=body.attendees,
+        booking_enabled=body.booking_enabled,
+        approval_required=body.approval_required,
+        status=status,
+        category=body.category,
+        recurrence_rule=recurrence_rule,
         created_at_utc=now,
     )
 
 
-@router.get("/calendars/{calendar_id}/events", response_model=list[EventOut])
-async def list_events(calendar_id: str, ctx: Dict[str, str] = Depends(require_ui_session)):
+@router.post("/calendars/{calendar_id}/booking_links", response_model=BookingLinkOut)
+async def create_booking_link(
+    calendar_id: str,
+    body: BookingLinkCreateIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    tz_name = body.timezone or meta.get("timezone", "UTC")
+    _validate_timezone(tz_name)
+    link_id = uuid.uuid4().hex
+    now = iso_utc(utc_now())
+    item = {
+        "calendar_id": calendar_id,
+        "sk": _booking_link_key(link_id),
+        "type": "booking_link",
+        "link_id": link_id,
+        "name": body.name,
+        "duration_minutes": int(body.duration_minutes),
+        "timezone": tz_name,
+        "created_at_utc": now,
+        "owner_user_sub": meta.get("owner_user_sub"),
+    }
+    T.calendar.put_item(Item=item)
+    return BookingLinkOut(
+        link_id=link_id,
+        calendar_id=calendar_id,
+        name=body.name,
+        duration_minutes=int(body.duration_minutes),
+        timezone=tz_name,
+        created_at_utc=now,
+        public_url=f"/booking/{link_id}",
+    )
+
+
+@router.get("/calendars/{calendar_id}/events", response_model=EventsPageOut)
+async def list_events(
+    calendar_id: str,
+    start_utc: str | None = Query(None, description="Filter events starting after this UTC timestamp"),
+    end_utc: str | None = Query(None, description="Filter events ending before this UTC timestamp"),
+    limit: int | None = Query(None, ge=1, le=200),
+    cursor: str | None = Query(None, description="Pagination cursor"),
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
     _load_calendar(calendar_id, ctx["user_sub"])
-    return [_event_out(item, calendar_id) for item in _list_events(calendar_id)]
+    start_dt = parse_iso_dt(start_utc) if start_utc else None
+    end_dt = parse_iso_dt(end_utc) if end_utc else None
+    items, next_cursor = _list_events(
+        calendar_id,
+        start_utc=start_dt,
+        end_utc=end_dt,
+        limit=limit,
+        cursor=cursor,
+    )
+    if start_dt and end_dt:
+        expanded: list[Dict[str, Any]] = []
+        for item in items:
+            expanded.extend(_expand_event_occurrences(item, start_dt, end_dt))
+        items = expanded
+    return EventsPageOut(
+        events=[_event_out(item, calendar_id) for item in items],
+        next_cursor=next_cursor,
+    )
 
 
 @router.patch("/calendars/{calendar_id}", response_model=CalendarOut)
@@ -264,12 +759,42 @@ async def update_calendar(
     timezone_name = body.timezone if body.timezone is not None else meta.get("timezone", "UTC")
     if body.timezone is not None:
         _validate_timezone(timezone_name)
-    updated = {**meta, "name": name, "timezone": timezone_name}
+    working_hours = body.working_hours if body.working_hours is not None else meta.get("working_hours")
+    _validate_working_hours(working_hours)
+    buffer_before = (
+        body.buffer_before_minutes
+        if body.buffer_before_minutes is not None
+        else int(meta.get("buffer_before_minutes", 0))
+    )
+    buffer_after = (
+        body.buffer_after_minutes
+        if body.buffer_after_minutes is not None
+        else int(meta.get("buffer_after_minutes", 0))
+    )
+    buffer_before, buffer_after = _normalize_buffers(buffer_before, buffer_after)
+    conflict_detection = (
+        meta.get("conflict_detection", False)
+        if body.conflict_detection is None
+        else body.conflict_detection
+    )
+    updated = {
+        **meta,
+        "name": name,
+        "timezone": timezone_name,
+        "conflict_detection": conflict_detection,
+        "working_hours": working_hours,
+        "buffer_before_minutes": buffer_before,
+        "buffer_after_minutes": buffer_after,
+    }
     T.calendar.put_item(Item=updated)
     return CalendarOut(
         calendar_id=calendar_id,
         name=updated["name"],
         timezone=updated["timezone"],
+        conflict_detection=updated.get("conflict_detection", False),
+        working_hours=updated.get("working_hours"),
+        buffer_before_minutes=int(updated.get("buffer_before_minutes", 0)),
+        buffer_after_minutes=int(updated.get("buffer_after_minutes", 0)),
         owner_user_id=updated["owner_user_sub"],
         created_at_utc=updated.get("created_at_utc", ""),
     )
@@ -284,6 +809,8 @@ async def update_event(
 ):
     meta = _load_calendar(calendar_id, ctx["user_sub"])
     item = _load_event(calendar_id, event_id)
+    raw_recurrence = body.recurrence_rule if body.recurrence_rule is not None else item.get("recurrence_rule")
+    recurrence_rule = RecurrenceRule(**raw_recurrence) if raw_recurrence else None
     payload = EventCreateIn(
         name=body.name if body.name is not None else item["name"],
         description=body.description if body.description is not None else item.get("description", ""),
@@ -292,12 +819,34 @@ async def update_event(
         end_utc=body.end_utc if body.end_utc is not None else item.get("end_utc"),
         all_day=body.all_day if body.all_day is not None else item.get("all_day", False),
         all_day_date=body.all_day_date if body.all_day_date is not None else item.get("all_day_date"),
+        attendees=body.attendees if body.attendees is not None else item.get("attendees", []),
+        booking_enabled=(
+            body.booking_enabled if body.booking_enabled is not None else item.get("booking_enabled", False)
+        ),
+        approval_required=(
+            body.approval_required if body.approval_required is not None else item.get("approval_required", False)
+        ),
+        status=body.status if body.status is not None else item.get("status", "busy"),
+        category=body.category if body.category is not None else item.get("category"),
+        recurrence_rule=recurrence_rule,
     )
+    _validate_booking_settings(payload.booking_enabled, payload.approval_required)
+    status = _normalize_event_status(payload.status)
+    recurrence_rule = _normalize_recurrence_rule(payload.recurrence_rule)
     normalized = _normalize_event_times(meta["timezone"], payload)
+    normalized["status"] = status
+    if meta.get("conflict_detection") and _is_busy_status(status):
+        _ensure_no_conflicts(calendar_id, normalized, exclude_event_id=event_id)
     updated = {
         **item,
         "name": payload.name,
         "description": payload.description,
+        "attendees": payload.attendees,
+        "booking_enabled": payload.booking_enabled,
+        "approval_required": payload.approval_required,
+        "status": status,
+        "category": payload.category,
+        "recurrence_rule": recurrence_rule.model_dump() if recurrence_rule else None,
         **normalized,
     }
     T.calendar.put_item(Item=updated)
@@ -319,7 +868,7 @@ async def delete_event(
 @router.delete("/calendars/{calendar_id}")
 async def delete_calendar(calendar_id: str, ctx: Dict[str, str] = Depends(require_ui_session)):
     _load_calendar(calendar_id, ctx["user_sub"])
-    events = _list_events(calendar_id)
+    events, _ = _list_events(calendar_id)
     with T.calendar.batch_writer() as batch:
         batch.delete_item(Key={"calendar_id": calendar_id, "sk": "meta"})
         for event in events:
@@ -335,10 +884,9 @@ async def list_openings(
     end_utc: str = Query(..., description="End window in ISO-8601 UTC"),
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
-    _load_calendar(calendar_id, ctx["user_sub"])
     window_start, window_end = parse_availability_window(start_utc, end_utc)
-    busy = [_event_to_busy_interval(event) for event in _list_events(calendar_id)]
-    free = invert_intervals(busy, window_start, window_end)
+    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    free = _calendar_openings(meta, window_start, window_end)
     return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in free]
 
 
@@ -347,9 +895,110 @@ async def list_team_openings(body: TeamAvailabilityIn, ctx: Dict[str, str] = Dep
     window_start, window_end = parse_availability_window(body.start_utc, body.end_utc)
     if not body.calendar_ids:
         raise HTTPException(status_code=400, detail="calendar_ids is required")
-    busy: list[tuple[datetime, datetime]] = []
+    combined: list[tuple[datetime, datetime]] | None = None
     for calendar_id in body.calendar_ids:
-        _load_calendar(calendar_id, ctx["user_sub"])
-        busy.extend(_event_to_busy_interval(event) for event in _list_events(calendar_id))
-    free = invert_intervals(busy, window_start, window_end)
+        meta = _load_calendar(calendar_id, ctx["user_sub"])
+        openings = _calendar_openings(meta, window_start, window_end)
+        combined = openings if combined is None else _intersect_intervals(combined, openings)
+    free = combined or []
     return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in free]
+
+
+@public_router.get("/{link_id}", response_model=BookingLinkOut)
+async def get_booking_link(link_id: str):
+    link = _load_booking_link(link_id)
+    return BookingLinkOut(
+        link_id=link["link_id"],
+        calendar_id=link["calendar_id"],
+        name=link.get("name", ""),
+        duration_minutes=int(link.get("duration_minutes", 0)),
+        timezone=link.get("timezone", "UTC"),
+        created_at_utc=link.get("created_at_utc", ""),
+        public_url=f"/booking/{link_id}",
+    )
+
+
+@public_router.get("/{link_id}/openings", response_model=list[OpeningsOut])
+async def list_booking_openings(
+    link_id: str,
+    start_utc: str = Query(..., description="Start window in ISO-8601 UTC"),
+    end_utc: str = Query(..., description="End window in ISO-8601 UTC"),
+    limit: int | None = Query(None, ge=1, le=200),
+):
+    link = _load_booking_link(link_id)
+    meta = _load_calendar_public(link["calendar_id"])
+    window_start, window_end = parse_availability_window(start_utc, end_utc)
+    openings = _calendar_openings(meta, window_start, window_end)
+    openings = _filter_openings_by_duration(openings, int(link.get("duration_minutes", 0)))
+    if limit is not None:
+        openings = openings[:limit]
+    return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in openings]
+
+
+@public_router.post("/{link_id}/reserve", response_model=EventOut)
+async def reserve_booking_slot(link_id: str, body: BookingRequestIn):
+    link = _load_booking_link(link_id)
+    meta = _load_calendar_public(link["calendar_id"])
+    start_dt = parse_iso_dt(body.start_utc)
+    end_dt = parse_iso_dt(body.end_utc)
+    duration = end_dt - start_dt
+    if duration.total_seconds() <= 0:
+        raise HTTPException(status_code=400, detail="end_utc must be after start_utc")
+    expected = timedelta(minutes=int(link.get("duration_minutes", 0)))
+    if expected and duration != expected:
+        raise HTTPException(status_code=400, detail="Slot duration does not match booking link")
+    openings = _calendar_openings(meta, start_dt, end_dt)
+    if not _slot_in_openings(openings, start_dt, end_dt):
+        raise HTTPException(status_code=409, detail="Requested slot is no longer available")
+    tz_name = body.timezone or link.get("timezone") or meta.get("timezone", "UTC")
+    _validate_timezone(tz_name)
+    payload = EventCreateIn(
+        name=body.name or link.get("name", "Booking"),
+        description=body.description or "",
+        timezone=tz_name,
+        start_utc=body.start_utc,
+        end_utc=body.end_utc,
+        all_day=False,
+        all_day_date=None,
+        attendees=[],
+        booking_enabled=False,
+        approval_required=False,
+        status="busy",
+        category="booking",
+        recurrence_rule=None,
+    )
+    status = _normalize_event_status(payload.status)
+    normalized = _normalize_event_times(meta.get("timezone", "UTC"), payload)
+    normalized["status"] = status
+    if meta.get("conflict_detection") and _is_busy_status(status):
+        _ensure_no_conflicts(meta["calendar_id"], normalized)
+    event_id = uuid.uuid4().hex
+    now = iso_utc(utc_now())
+    item = {
+        "calendar_id": meta["calendar_id"],
+        "sk": _event_key(event_id),
+        "type": "event",
+        "event_id": event_id,
+        "name": payload.name,
+        "description": payload.description,
+        "attendees": payload.attendees,
+        "booking_enabled": payload.booking_enabled,
+        "approval_required": payload.approval_required,
+        "status": status,
+        "category": payload.category,
+        "recurrence_rule": None,
+        "booking_link_id": link_id,
+        "created_at_utc": now,
+        **normalized,
+    }
+    T.calendar.put_item(Item=item)
+    if body.notify and meta.get("owner_user_sub"):
+        audit_event(
+            "calendar_booking_created",
+            meta["owner_user_sub"],
+            None,
+            outcome="success",
+            booking_link_id=link_id,
+            event_id=event_id,
+        )
+    return _event_out(item, meta["calendar_id"])

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -2679,7 +2679,8 @@ async function refreshCalendarEvents() {
   const calendarId = getCalendarId();
   if (!calendarId) return;
   await ensureUiSession();
-  const events = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/events`);
+  const res = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/events`);
+  const events = Array.isArray(res) ? res : res.events;
   renderCalendarEvents(events || []);
 }
 


### PR DESCRIPTION
### Motivation
- Provide public booking links tied to calendars so external users can view openings and reserve slots without full API access. 
- Reservations must create calendar events, respect existing availability/conflict detection, and optionally emit notifications for the calendar owner. 
- Integrate booking behavior with the existing openings calculation, recurrence expansion, working hours, and buffer logic so bookings reflect true availability.

### Description
- Added models `BookingLinkCreateIn`, `BookingLinkOut`, and `BookingRequestIn`, and extended calendar/event models to include working hours, buffers, booking flags, attendees, and recurrence fields in `app/models.py`.
- Implemented booking link support in `app/routers/calendar.py` including helper functions `_booking_link_key`, `_load_booking_link`, `_load_calendar_public`, `_slot_in_openings`, and `_filter_openings_by_duration` and a new public router `public_router` mounted at `/booking`.
- Added endpoints: UI-authenticated `POST /ui/calendars/{calendar_id}/booking_links` to create links, and public `GET /booking/{link_id}`, `GET /booking/{link_id}/openings`, and `POST /booking/{link_id}/reserve` to list link metadata, openings, and reserve a slot respectively; reservations materialize events, run conflict checks, apply buffers/working-hours, and persist `booking_link_id` on the created event.
- Extended calendar logic to support pagination and filtering in `_list_events`, expanded recurrence occurrences (`_expand_rrule`, `_expand_event_occurrences`), applied buffers and working-hours in `_calendar_openings`, and used `audit_event` to emit an alert on successful reservation when requested.
- Wired the public booking router into the application by including it in `app/main.py` and updated the static UI `app/static/main.js` to handle the paginated `/events` response shape.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fe6363a44832b84af7d8d5e5fd2f3)