### PR TITLE
Expose delivery/read user lists; improve search; add presigned uploads, thumbnails, and link unfurling

### DIFF
--- a/app/routers/filemanager.py
+++ b/app/routers/filemanager.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, File, Query, UploadFile, Body, Request, HTTPException
+from pydantic import BaseModel, Field
 from fastapi.responses import StreamingResponse
 
 from app.services.filemanager import (
     create_empty_folder,
     download_file,
+    download_thumbnail,
     download_zip,
     is_previewable,
     list_children,
@@ -24,6 +26,8 @@ from app.services.filemanager import (
     upload_zip,
     get_node,
     search_text,
+    presign_upload,
+    register_presigned_upload,
 )
 from app.services.alerts import audit_event
 from app.services.sessions import require_ui_session
@@ -33,6 +37,25 @@ router = APIRouter(prefix="/v1/fs", tags=["filemanager"])
 
 def _current_user(ctx=Depends(require_ui_session)) -> str:
     return ctx["user_sub"]
+
+
+class PresignUploadIn(BaseModel):
+    path: str = Field(..., description="Full file path, e.g. /docs/a.txt")
+    content_type: Optional[str] = Field(default=None, description="Optional content type")
+
+
+class PresignUploadOut(BaseModel):
+    upload_url: str
+    bucket: str
+    key: str
+    path: str
+    content_type: str
+
+
+class CompleteUploadIn(BaseModel):
+    path: str = Field(..., description="Full file path, e.g. /docs/a.txt")
+    key: str = Field(..., description="S3 object key from presign response")
+    content_type: Optional[str] = Field(default=None, description="Optional content type override")
 
 
 @router.get("/list")
@@ -69,6 +92,8 @@ def file_info(path: str = Query(...), user: str = Depends(_current_user)):
         "last_download_at": it.get("last_download_at"),
         "last_download_by": it.get("last_download_by"),
         "size": it.get("size"),
+        "duration_seconds": it.get("duration_seconds"),
+        "thumbnail": it.get("thumbnail"),
         "content_type": it.get("content_type"),
         "shared": it.get("shared", False),
     }
@@ -115,6 +140,33 @@ def upload_fs_file(
         path=result.get("path"),
         size=result.get("size"),
         content_type=file.content_type,
+    )
+    return {"ok": True, **result}
+
+
+@router.post("/presign-upload", response_model=PresignUploadOut)
+def presign_fs_upload(inp: PresignUploadIn, user: str = Depends(_current_user)):
+    result = presign_upload(user, inp.path, content_type=inp.content_type)
+    return PresignUploadOut(
+        upload_url=result["upload_url"],
+        bucket=result["bucket"],
+        key=result["key"],
+        path=result["path"],
+        content_type=result["content_type"],
+    )
+
+
+@router.post("/complete-upload")
+def complete_fs_upload(inp: CompleteUploadIn, req: Request = None, user: str = Depends(_current_user)):
+    result = register_presigned_upload(user, inp.path, s3_key=inp.key, content_type=inp.content_type)
+    audit_event(
+        "filemgr_file_uploaded",
+        user,
+        req,
+        outcome="success",
+        path=result.get("path"),
+        size=result.get("size"),
+        content_type=result.get("content_type"),
     )
     return {"ok": True, **result}
 
@@ -176,6 +228,28 @@ def preview_fs_file(path: str = Query(...), req: Request = None, user: str = Dep
         gen(),
         media_type=node.get("content_type", "application/octet-stream"),
         headers={"Content-Disposition": f'inline; filename="{node["name"]}"'},
+    )
+
+
+@router.get("/thumbnail")
+def thumbnail_fs_file(path: str = Query(...), req: Request = None, user: str = Depends(_current_user)):
+    result = download_thumbnail(user, path)
+    node = result["node"]
+    thumb = result["thumbnail"]
+    obj = result["object"]
+
+    def gen():
+        body = obj["Body"]
+        while True:
+            chunk = body.read(1024 * 1024)
+            if not chunk:
+                break
+            yield chunk
+
+    return StreamingResponse(
+        gen(),
+        media_type=thumb.get("content_type", "image/jpeg"),
+        headers={"Content-Disposition": f'inline; filename="{node["name"]}_thumb.jpg"'},
     )
 
 

--- a/app/routers/messaging.py
+++ b/app/routers/messaging.py
@@ -6,7 +6,9 @@ import os
 import re
 import time
 import uuid
+from html.parser import HTMLParser
 from typing import Any, Dict, Iterable, List, Literal, Optional, Sequence
+from urllib.parse import urljoin, urlparse
 
 import anyio
 import boto3
@@ -15,6 +17,7 @@ from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.exceptions import ClientError, NoCredentialsError
 import requests
+import snowballstemmer
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -313,6 +316,7 @@ class MessageOut(BaseModel):
     revoked_at: Optional[int] = None
     revoked_by: Optional[str] = None
     delivered_to_count: Optional[int] = None
+    delivered_to_user_ids: Optional[List[str]] = None
     read_by_count: Optional[int] = None
     read_by_user_ids: Optional[List[str]] = None
     reactions_counts: Optional[Dict[str, int]] = None
@@ -353,18 +357,40 @@ def _tokenize_message(text: str, max_len: int = 32) -> list[str]:
     return [t[:max_len] for t in tokens if t]
 
 
+def _stem_tokens(tokens: Sequence[str]) -> list[str]:
+    stemmer = snowballstemmer.stemmer("english")
+    return [stem for stem in stemmer.stemWords(list(tokens)) if stem]
+
+
+def _token_ngrams(token: str, *, min_len: int = 3, max_len: int = 5) -> list[str]:
+    if len(token) < min_len:
+        return []
+    ngrams: list[str] = []
+    for size in range(min_len, min(max_len, len(token)) + 1):
+        for idx in range(0, len(token) - size + 1):
+            ngrams.append(token[idx : idx + size])
+    return ngrams
+
+
 def build_message_search_tokens(text: str, *, max_len: int = 32, max_prefix_len: int = 8) -> list[str]:
-    tokens = _tokenize_message(text, max_len=max_len)
+    tokens = _stem_tokens(_tokenize_message(text, max_len=max_len))
     out: list[str] = []
     for token in tokens:
         out.append(token)
         for i in range(1, min(len(token), max_prefix_len) + 1):
             out.append(token[:i])
+        out.extend(_token_ngrams(token))
     return list(dict.fromkeys(out))
 
 
 def build_message_query_tokens(query: str, *, max_len: int = 32) -> list[str]:
-    return list(dict.fromkeys(_tokenize_message(query, max_len=max_len)))
+    tokens = _stem_tokens(_tokenize_message(query, max_len=max_len))
+    out: list[str] = []
+    for token in tokens:
+        out.append(token)
+        out.extend(build_prefix_tokens(token))
+        out.extend(_token_ngrams(token))
+    return list(dict.fromkeys(out))
 
 
 def _message_search_key(conversation_id: str, message_id: str) -> str:
@@ -428,6 +454,7 @@ def _opensearch_index_message(
     sender_id: str,
     created_at: int,
     text: str,
+    kind: str,
 ) -> None:
     if not _opensearch_enabled():
         return
@@ -438,6 +465,8 @@ def _opensearch_index_message(
         "sender_id": sender_id,
         "created_at": int(created_at),
         "text": text,
+        "search_text": text,
+        "kind": kind,
     }
     _opensearch_request("PUT", f"/{OPENSEARCH_INDEX}/_doc/{doc_id}", body=body)
 
@@ -450,6 +479,7 @@ def _opensearch_search_messages(
     allowed_conversation_ids: Optional[set[str]] = None,
     sender_id: Optional[str] = None,
     after_ts: Optional[int] = None,
+    kinds: Optional[Sequence[str]] = None,
 ) -> Optional[list[str]]:
     if not _opensearch_enabled():
         return None
@@ -462,15 +492,22 @@ def _opensearch_search_messages(
         filters.append({"term": {"sender_id": sender_id}})
     if after_ts is not None:
         filters.append({"range": {"created_at": {"gte": int(after_ts)}}})
+    if kinds:
+        filters.append({"terms": {"kind": list(kinds)}})
     body: Dict[str, Any] = {
         "size": limit,
         "query": {
             "bool": {
-                "must": {"simple_query_string": {"query": query, "fields": ["text"]}},
+                "must": {
+                    "simple_query_string": {
+                        "query": query,
+                        "fields": ["text^2", "search_text^3"],
+                    }
+                },
                 "filter": filters,
             }
         },
-        "sort": [{"created_at": "desc"}],
+        "sort": [{"_score": "desc"}, {"created_at": "desc"}],
     }
     resp = _opensearch_request("POST", f"/{OPENSEARCH_INDEX}/_search", body=body)
     if not resp:
@@ -485,6 +522,8 @@ def index_message_search(
     sender_id: str,
     created_at: int,
     text: str,
+    *,
+    kind: str = "text",
 ) -> None:
     if _message_search_enabled():
         tokens = build_message_search_tokens(text)
@@ -505,7 +544,7 @@ def index_message_search(
                     )
         except ClientError:
             return
-    _opensearch_index_message(conversation_id, message_id, sender_id, created_at, text)
+    _opensearch_index_message(conversation_id, message_id, sender_id, created_at, text, kind)
 
 
 def remove_message_search(
@@ -531,6 +570,54 @@ def _filter_message_visible(message_item: dict, user_id: str) -> bool:
     if message_item.get("revoked_at"):
         return False
     return user_id not in deleted_for
+
+
+def _message_search_text(message_item: dict) -> str:
+    return str(message_item.get("search_text") or message_item.get("text") or "")
+
+
+def _is_searchable_kind(kind: Optional[str]) -> bool:
+    return kind in {"text", "file", "audio", "video"}
+
+
+def _filter_search_kinds(kinds: Optional[Sequence[str]]) -> Optional[set[str]]:
+    if not kinds:
+        return None
+    normalized = {str(k).strip().lower() for k in kinds if str(k).strip()}
+    allowed = {"text", "image", "file", "audio", "video"}
+    filtered = {k for k in normalized if k in allowed}
+    return filtered or None
+
+
+def _message_relevance_score(message_item: dict, query: str) -> float:
+    query = (query or "").lower().strip()
+    if not query:
+        return 0.0
+    text = _message_search_text(message_item).lower()
+    if not text:
+        return 0.0
+    tokens = _stem_tokens(_tokenize_message(query))
+    score = 0.0
+    for token in tokens:
+        if not token:
+            continue
+        if token in text:
+            score += 3.0
+        else:
+            ngrams = _token_ngrams(token, min_len=3, max_len=4)
+            if any(ngram in text for ngram in ngrams):
+                score += 1.0
+    created_at = int(message_item.get("created_at", 0) or 0)
+    if created_at:
+        age_days = max(0.0, (now_ts() - created_at) / 86400)
+        score += max(0.0, 1.5 - (age_days / 14.0))
+    return score
+
+
+def _rank_messages_by_relevance(items: list[dict], query: str) -> list[dict]:
+    scored = [(item, _message_relevance_score(item, query)) for item in items]
+    scored.sort(key=lambda x: (x[1], int(x[0].get("created_at", 0) or 0)), reverse=True)
+    return [item for item, _ in scored]
 
 
 def _message_out_from_item(message_item: dict, viewer_user_id: str) -> MessageOut:
@@ -624,6 +711,7 @@ def _fallback_search_messages(
     user_id: str,
     sender_id: Optional[str] = None,
     after_ts: Optional[int] = None,
+    kinds: Optional[set[str]] = None,
 ) -> list[dict]:
     query_lower = query.lower()
     matches: list[dict] = []
@@ -645,10 +733,12 @@ def _fallback_search_messages(
                 continue
             if after_ts is not None and int(item.get("created_at", 0)) < int(after_ts):
                 continue
-            if item.get("kind") != "text":
+            if kinds and item.get("kind") not in kinds:
                 continue
-            text = (item.get("text") or "").lower()
-            if query_lower in text:
+            if not _is_searchable_kind(item.get("kind")):
+                continue
+            text = _message_search_text(item).lower()
+            if text and query_lower in text:
                 matches.append(item)
                 if len(matches) >= limit:
                     break
@@ -704,7 +794,100 @@ def _serialize_preview(preview: Optional[LinkPreviewIn]) -> Optional[dict]:
     return preview.dict(exclude_none=True)
 
 
-def _message_receipt_summary(message_item: dict, participants: Sequence[dict]) -> tuple[int, List[str]]:
+class _LinkPreviewParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title: Optional[str] = None
+        self.meta: Dict[str, str] = {}
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        attrs_map = {k.lower(): v for k, v in attrs}
+        if tag.lower() == "title":
+            self._in_title = True
+            return
+        if tag.lower() == "meta":
+            key = attrs_map.get("property") or attrs_map.get("name")
+            content = attrs_map.get("content")
+            if key and content:
+                self.meta[key.lower()] = content.strip()
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title and not self.title:
+            text = data.strip()
+            if text:
+                self.title = text
+
+
+def _extract_first_url(text: str) -> Optional[str]:
+    if not text:
+        return None
+    match = re.search(r"(https?://[^\s<>()]+)", text)
+    if not match:
+        return None
+    url = match.group(1).rstrip(".,!?)]}\"'")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    return url
+
+
+def _fetch_link_preview(url: str) -> Optional[dict]:
+    try:
+        resp = requests.get(
+            url,
+            timeout=3,
+            headers={"User-Agent": "MessagingPreviewBot/1.0"},
+            stream=True,
+        )
+    except requests.RequestException:
+        return None
+    try:
+        if resp.status_code >= 400:
+            return None
+        content_type = resp.headers.get("Content-Type", "")
+        if "text/html" not in content_type:
+            return None
+        content = b""
+        try:
+            for chunk in resp.iter_content(chunk_size=65536):
+                if not chunk:
+                    break
+                content += chunk
+                if len(content) > 512000:
+                    break
+        except requests.RequestException:
+            return None
+    finally:
+        resp.close()
+    parser = _LinkPreviewParser()
+    try:
+        parser.feed(content.decode(errors="ignore"))
+    except Exception:
+        return None
+    title = parser.meta.get("og:title") or parser.title
+    description = parser.meta.get("og:description") or parser.meta.get("description")
+    image_url = parser.meta.get("og:image")
+    site_name = parser.meta.get("og:site_name")
+    if image_url:
+        image_url = urljoin(url, image_url)
+    preview = {
+        "url": url,
+        "title": title,
+        "description": description,
+        "image_url": image_url,
+        "site_name": site_name,
+    }
+    if not any(preview.values()):
+        return None
+    return {k: v for k, v in preview.items() if v}
+
+
+def _message_receipt_summary(message_item: dict, participants: Sequence[dict]) -> tuple[List[str], List[str]]:
     if _message_receipts_enabled():
         convo_id = message_item.get("conversation_id")
         message_id = message_item.get("message_id")
@@ -716,27 +899,30 @@ def _message_receipt_summary(message_item: dict, participants: Sequence[dict]) -
                 ScanIndexForward=True,
             )
             items = resp.get("Items", [])
-            delivered = [it for it in items if int(it.get("delivered_at", 0) or 0) > 0]
+            delivered_users = [it["user_id"] for it in items if int(it.get("delivered_at", 0) or 0) > 0]
             read_by = [it["user_id"] for it in items if int(it.get("read_at", 0) or 0) > 0]
+            delivered_users.sort()
             read_by.sort()
-            return len(delivered), read_by
+            return delivered_users, read_by
     active = [p for p in participants if p.get("status") == "active"]
     sender_id = message_item.get("sender_id")
     delivered = [p for p in active if p.get("user_id") != sender_id]
-    delivered_count = len(delivered)
+    delivered_users = [p["user_id"] for p in delivered if p.get("user_id")]
     created_at = int(message_item.get("created_at", 0) or 0)
     read_by = [
         p["user_id"]
         for p in active
         if int(p.get("last_read_at", 0) or 0) >= created_at
     ]
+    delivered_users.sort()
     read_by.sort()
-    return delivered_count, read_by
+    return delivered_users, read_by
 
 
 def _apply_message_receipts(message_out: MessageOut, message_item: dict, participants: Sequence[dict]) -> MessageOut:
-    delivered_count, read_by = _message_receipt_summary(message_item, participants)
-    message_out.delivered_to_count = delivered_count
+    delivered_users, read_by = _message_receipt_summary(message_item, participants)
+    message_out.delivered_to_user_ids = delivered_users
+    message_out.delivered_to_count = len(delivered_users)
     message_out.read_by_user_ids = read_by
     message_out.read_by_count = len(read_by)
     return message_out
@@ -1450,6 +1636,7 @@ def search_messages_in_conversation(
     limit: int = Query(50, ge=1, le=200),
     sender_id: Optional[str] = Query(None, max_length=64),
     after_ts: Optional[int] = Query(None, ge=0),
+    kind: Optional[List[str]] = Query(None),
     user_id: str = Depends(get_messaging_user_id),
 ):
     require_participant_active(user_id, conversation_id)
@@ -1457,21 +1644,24 @@ def search_messages_in_conversation(
         sender_id = None
     if not isinstance(after_ts, int):
         after_ts = None
+    kind_filter = _filter_search_kinds(kind)
     opensearch_keys = _opensearch_search_messages(
         q,
         limit=limit,
         conversation_id=conversation_id,
         sender_id=sender_id,
         after_ts=after_ts,
+        kinds=kind_filter,
     )
     if opensearch_keys is not None:
         message_items = _fetch_message_items(opensearch_keys)
         matches = [
             item
             for item in message_items
-            if item.get("kind") == "text" and _filter_message_visible(item, user_id)
+            if _is_searchable_kind(item.get("kind")) and _filter_message_visible(item, user_id)
             and (not sender_id or item.get("sender_id") == sender_id)
             and (after_ts is None or int(item.get("created_at", 0)) >= int(after_ts))
+            and (not kind_filter or item.get("kind") in kind_filter)
         ]
     else:
         query_tokens = build_message_query_tokens(q)
@@ -1490,18 +1680,20 @@ def search_messages_in_conversation(
                 user_id=user_id,
                 sender_id=sender_id,
                 after_ts=after_ts,
+                kinds=kind_filter,
             )
         else:
             message_items = _fetch_message_items([item["message_key"] for item in indexed])
             matches = [
                 item
                 for item in message_items
-                if item.get("kind") == "text" and _filter_message_visible(item, user_id)
+                if _is_searchable_kind(item.get("kind")) and _filter_message_visible(item, user_id)
                 and (not sender_id or item.get("sender_id") == sender_id)
                 and (after_ts is None or int(item.get("created_at", 0)) >= int(after_ts))
+                and (not kind_filter or item.get("kind") in kind_filter)
             ]
 
-    matches.sort(key=lambda x: int(x.get("created_at", 0)), reverse=True)
+    matches = _rank_messages_by_relevance(matches, q)
     parts = tbl_parts.query(IndexName="GSI1", KeyConditionExpression=Key("GSI1PK").eq(conversation_id)).get("Items", [])
     out = []
     for item in matches[:limit]:
@@ -1516,12 +1708,14 @@ def search_messages_all_conversations(
     limit: int = Query(50, ge=1, le=200),
     sender_id: Optional[str] = Query(None, max_length=64),
     after_ts: Optional[int] = Query(None, ge=0),
+    kind: Optional[List[str]] = Query(None),
     user_id: str = Depends(get_messaging_user_id),
 ):
     if not isinstance(sender_id, str):
         sender_id = None
     if not isinstance(after_ts, int):
         after_ts = None
+    kind_filter = _filter_search_kinds(kind)
     parts = tbl_parts.query(KeyConditionExpression=Key("user_id").eq(user_id), Limit=200).get("Items", [])
     allowed_conversation_ids = {p["conversation_id"] for p in parts if p.get("status") == "active"}
     if not allowed_conversation_ids:
@@ -1533,6 +1727,7 @@ def search_messages_all_conversations(
         allowed_conversation_ids=allowed_conversation_ids,
         sender_id=sender_id,
         after_ts=after_ts,
+        kinds=kind_filter,
     )
 
     matches: list[dict]
@@ -1542,10 +1737,11 @@ def search_messages_all_conversations(
             item
             for item in message_items
             if item.get("conversation_id") in allowed_conversation_ids
-            and item.get("kind") == "text"
+            and _is_searchable_kind(item.get("kind"))
             and _filter_message_visible(item, user_id)
             and (not sender_id or item.get("sender_id") == sender_id)
             and (after_ts is None or int(item.get("created_at", 0)) >= int(after_ts))
+            and (not kind_filter or item.get("kind") in kind_filter)
         ]
     else:
         query_tokens = build_message_query_tokens(q)
@@ -1569,6 +1765,7 @@ def search_messages_all_conversations(
                         user_id=user_id,
                         sender_id=sender_id,
                         after_ts=after_ts,
+                        kinds=kind_filter,
                     )
                 )
         else:
@@ -1577,13 +1774,14 @@ def search_messages_all_conversations(
                 item
                 for item in message_items
                 if item.get("conversation_id") in allowed_conversation_ids
-                and item.get("kind") == "text"
+                and _is_searchable_kind(item.get("kind"))
                 and _filter_message_visible(item, user_id)
                 and (not sender_id or item.get("sender_id") == sender_id)
                 and (after_ts is None or int(item.get("created_at", 0)) >= int(after_ts))
+                and (not kind_filter or item.get("kind") in kind_filter)
             ]
 
-    matches.sort(key=lambda x: int(x.get("created_at", 0)), reverse=True)
+    matches = _rank_messages_by_relevance(matches, q)
     convo_participants: Dict[str, List[dict]] = {}
     for item in matches[:limit]:
         cid = item.get("conversation_id")
@@ -1630,6 +1828,10 @@ def send_text_message(
         "reactions": {},
     }
     link_preview = _serialize_preview(inp.preview)
+    if not link_preview:
+        url = _extract_first_url(inp.text)
+        if url:
+            link_preview = _fetch_link_preview(url)
     if link_preview:
         item["preview"] = link_preview
     ttl = _message_retention_ttl(convo, ts)
@@ -1641,7 +1843,7 @@ def send_text_message(
     tbl_msgs.put_item(Item=item)
     _bump_unread_counts(conversation_id, user_id, resp.get("Items", []))
     _record_delivery_receipts(conversation_id, mid, user_id, resp.get("Items", []))
-    index_message_search(conversation_id, mid, user_id, ts, inp.text)
+    index_message_search(conversation_id, mid, user_id, ts, inp.text, kind="text")
 
     preview_text = inp.text[:140]
     tbl_convos.update_item(
@@ -1791,18 +1993,21 @@ def create_file_message(
     ts = now_ts()
     preview = _serialize_preview(inp.preview)
 
+    duration_seconds = inp.duration_seconds or node.get("duration_seconds")
     item: Dict[str, Any] = {
         "conversation_id": conversation_id,
         "message_id": mid,
         "sender_id": user_id,
         "created_at": ts,
         "kind": inp.kind,
+        "search_text": f"{node.get('name', '')} {node.get('path', '')}".strip(),
         "file": {
             "path": node.get("path"),
             "name": node.get("name"),
             "size": node.get("size"),
             "content_type": content_type,
-            "duration_seconds": inp.duration_seconds,
+            "duration_seconds": duration_seconds,
+            "thumbnail": node.get("thumbnail"),
         },
         "deleted_for": set(),
         "reactions": {},
@@ -1818,6 +2023,8 @@ def create_file_message(
     tbl_msgs.put_item(Item=item)
     _bump_unread_counts(conversation_id, user_id, resp.get("Items", []))
     _record_delivery_receipts(conversation_id, mid, user_id, resp.get("Items", []))
+    if item.get("search_text"):
+        index_message_search(conversation_id, mid, user_id, ts, item["search_text"], kind=inp.kind)
 
     preview_label = {
         "file": "[file]",
@@ -1922,8 +2129,8 @@ def revoke_message_for_all(
         UpdateExpression="SET revoked_at = :ts, revoked_by = :uid",
         ExpressionAttributeValues={":ts": ts, ":uid": user_id},
     )
-    if msg.get("kind") == "text":
-        remove_message_search(conversation_id, message_id, msg.get("text", ""))
+    if _is_searchable_kind(msg.get("kind")):
+        remove_message_search(conversation_id, message_id, _message_search_text(msg))
 
     fanout_event_to_conversation(
         conversation_id=conversation_id,
@@ -2192,6 +2399,7 @@ def forward_message(
 
     if kind == "text":
         item["text"] = src.get("text", "")
+        item["search_text"] = item["text"]
         if src.get("preview"):
             item["preview"] = src.get("preview")
         preview = "[fwd] " + (item["text"] or "")[:140]
@@ -2200,13 +2408,26 @@ def forward_message(
         preview = "[fwd image]"
     else:
         item["file"] = src.get("file")
+        if src.get("search_text"):
+            item["search_text"] = src.get("search_text")
+        elif item.get("file"):
+            name = item["file"].get("name") or ""
+            path = item["file"].get("path") or ""
+            item["search_text"] = f"{name} {path}".strip()
         if src.get("preview"):
             item["preview"] = src.get("preview")
         preview = f"[fwd {kind}]"
 
     tbl_msgs.put_item(Item=item)
-    if kind == "text":
-        index_message_search(target_conversation_id, mid, user_id, ts, item.get("text", ""))
+    if _is_searchable_kind(kind):
+        index_message_search(
+            target_conversation_id,
+            mid,
+            user_id,
+            ts,
+            _message_search_text(item),
+            kind=kind,
+        )
     _record_delivery_receipts(
         target_conversation_id,
         mid,

--- a/app/services/filemanager.py
+++ b/app/services/filemanager.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 import uuid
+import tempfile
 import zipfile
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -186,6 +189,95 @@ def _node_matches(tokens: List[str], item: Dict[str, Any]) -> bool:
     haystack = _node_haystack(item)
     return all(token in haystack for token in tokens)
 
+
+def _maybe_probe_duration(bucket: str, s3_key: str, content_type: Optional[str]) -> Optional[int]:
+    if not content_type or not (content_type.startswith("audio/") or content_type.startswith("video/")):
+        return None
+    if not shutil.which("ffprobe"):
+        return None
+    with tempfile.NamedTemporaryFile(suffix=".media") as tmp:
+        try:
+            _s3.download_fileobj(bucket, s3_key, tmp)
+            tmp.flush()
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    tmp.name,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except ClientError:
+            return None
+        except OSError:
+            return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(float(result.stdout.strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def _maybe_generate_thumbnail(
+    bucket: str,
+    s3_key: str,
+    content_type: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    if not content_type or not content_type.startswith("video/"):
+        return None
+    if not shutil.which("ffmpeg"):
+        return None
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = f"{tmpdir}/input"
+        output_path = f"{tmpdir}/thumb.jpg"
+        try:
+            with open(input_path, "wb") as infile:
+                _s3.download_fileobj(bucket, s3_key, infile)
+            result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    input_path,
+                    "-ss",
+                    "00:00:01",
+                    "-frames:v",
+                    "1",
+                    "-vf",
+                    "scale=320:-1",
+                    output_path,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except ClientError:
+            return None
+        except OSError:
+            return None
+        if result.returncode != 0:
+            return None
+        thumb_key = f"{s3_key}_thumb.jpg"
+        try:
+            _s3.upload_file(
+                Filename=output_path,
+                Bucket=bucket,
+                Key=thumb_key,
+                ExtraArgs={"ContentType": "image/jpeg"},
+            )
+        except ClientError:
+            return None
+    return {"bucket": bucket, "key": thumb_key, "content_type": "image/jpeg"}
+
+
 def _token_pk(user: str, token: str) -> str:
     return f"TOKEN#{token}#USER#{user}"
 
@@ -356,6 +448,9 @@ def upload_file(user: str, path: str, file: UploadFile) -> Dict[str, Any]:
     except ClientError as exc:
         raise HTTPException(500, f"s3 error: {exc}") from exc
 
+    duration_seconds = _maybe_probe_duration(bucket, s3_key, file.content_type)
+    thumbnail = _maybe_generate_thumbnail(bucket, s3_key, file.content_type)
+
     item = {
         "PK": pk_user(user),
         "SK": sk_node(p),
@@ -370,6 +465,8 @@ def upload_file(user: str, path: str, file: UploadFile) -> Dict[str, Any]:
         "upload_by": user,
         "size": size,
         "content_type": file.content_type or "application/octet-stream",
+        "duration_seconds": duration_seconds,
+        "thumbnail": thumbnail,
         "s3_bucket": bucket,
         "s3_key": s3_key,
         "etag": etag,
@@ -381,6 +478,88 @@ def upload_file(user: str, path: str, file: UploadFile) -> Dict[str, Any]:
     put_node(item)
     _put_token_entries(user, item)
     return {"path": p, "size": size}
+
+
+def presign_upload(user: str, path: str, *, content_type: Optional[str]) -> Dict[str, Any]:
+    bucket = _bucket()
+    p = norm_path(path, is_folder=False)
+    parent, name = split_parent_name(p)
+    ensure_folder_exists(user, parent)
+    require_not_exists(user, p)
+
+    obj_id = str(uuid.uuid4())
+    s3_key = f"{user}/objects/{obj_id}"
+    upload_url = _s3.generate_presigned_url(
+        ClientMethod="put_object",
+        Params={
+            "Bucket": bucket,
+            "Key": s3_key,
+            "ContentType": content_type or "application/octet-stream",
+        },
+        ExpiresIn=900,
+    )
+    return {
+        "upload_url": upload_url,
+        "bucket": bucket,
+        "key": s3_key,
+        "path": p,
+        "content_type": content_type or "application/octet-stream",
+        "name": name,
+        "parent": parent,
+    }
+
+
+def register_presigned_upload(
+    user: str,
+    path: str,
+    *,
+    s3_key: str,
+    content_type: Optional[str],
+) -> Dict[str, Any]:
+    bucket = _bucket()
+    p = norm_path(path, is_folder=False)
+    parent, name = split_parent_name(p)
+    ensure_folder_exists(user, parent)
+    require_not_exists(user, p)
+
+    try:
+        head = _s3.head_object(Bucket=bucket, Key=s3_key)
+        size = int(head.get("ContentLength", 0))
+        etag = head.get("ETag")
+        resolved_content_type = content_type or head.get("ContentType") or "application/octet-stream"
+    except ClientError as exc:
+        raise HTTPException(500, f"s3 error: {exc}") from exc
+
+    duration_seconds = _maybe_probe_duration(bucket, s3_key, resolved_content_type)
+    thumbnail = _maybe_generate_thumbnail(bucket, s3_key, resolved_content_type)
+
+    item = {
+        "PK": pk_user(user),
+        "SK": sk_node(p),
+        "type": "file",
+        "path": p,
+        "name": name,
+        "name_lc": name.lower(),
+        "parent": parent,
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
+        "upload_at": now_iso(),
+        "upload_by": user,
+        "size": size,
+        "content_type": resolved_content_type,
+        "duration_seconds": duration_seconds,
+        "thumbnail": thumbnail,
+        "s3_bucket": bucket,
+        "s3_key": s3_key,
+        "etag": etag,
+        "GSI1PK": pk_user(user),
+        "GSI1SK": f"NAME#{name.lower()}#PATH#{p}",
+        "GSI2PK": f"PARENT#{parent}",
+        "GSI2SK": f"TYPE#file#NAME#{name.lower()}#PATH#{p}",
+    }
+    put_node(item)
+    _put_token_entries(user, item)
+    return {"path": p, "size": size, "content_type": resolved_content_type, "duration_seconds": duration_seconds}
 
 
 def build_download_url(path: str) -> str:
@@ -507,6 +686,21 @@ def download_file(user: str, path: str) -> Dict[str, Any]:
         pass
 
     return {"node": node, "object": obj}
+
+
+def download_thumbnail(user: str, path: str) -> Dict[str, Any]:
+    p = norm_path(path, is_folder=False)
+    node = get_node(user, p)
+    if node.get("type") != "file":
+        raise HTTPException(400, "not a file")
+    thumb = node.get("thumbnail")
+    if not thumb:
+        raise HTTPException(404, "thumbnail not available")
+    try:
+        obj = _s3.get_object(Bucket=thumb["bucket"], Key=thumb["key"])
+    except ClientError as exc:
+        raise HTTPException(500, f"s3 error: {exc}") from exc
+    return {"node": node, "thumbnail": thumb, "object": obj}
 
 
 def is_previewable(node: Dict[str, Any]) -> bool:

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -70,6 +70,13 @@
       <input id="msgSearchQuery" placeholder="Search text" style="flex:1;" />
       <input id="msgSearchSender" placeholder="Sender ID (optional)" style="flex:1;" />
       <input id="msgSearchAfter" placeholder="After ts (unix seconds)" class="mono" style="flex:1;" />
+      <select id="msgSearchKind" multiple>
+        <option value="text">Text</option>
+        <option value="image">Image</option>
+        <option value="file">File</option>
+        <option value="audio">Audio</option>
+        <option value="video">Video</option>
+      </select>
     </div>
     <div class="row-inline" style="margin-top:8px;">
       <button id="msgSearchConvoBtn">Search convo</button>
@@ -84,6 +91,38 @@
     <div class="row-inline" style="margin-top:8px;">
       <button id="msgSendBtn">Send</button>
       <span class="muted" id="msgMessageStatus"></span>
+    </div>
+    <div class="section">
+      <h4 style="margin:0 0 6px 0;">Optional link preview</h4>
+      <div class="row-inline">
+        <input id="msgPreviewUrl" placeholder="Preview URL (optional)" style="flex:1;" />
+        <input id="msgPreviewTitle" placeholder="Title (optional)" style="flex:1;" />
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="msgPreviewDescription" placeholder="Description (optional)" style="flex:1;" />
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="msgPreviewImage" placeholder="Image URL (optional)" style="flex:1;" />
+        <input id="msgPreviewSite" placeholder="Site name (optional)" style="flex:1;" />
+      </div>
+    </div>
+    <div class="section">
+      <h4 style="margin:0 0 6px 0;">Attachments</h4>
+      <input id="msgFileInput" type="file" />
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="msgFilePath" placeholder="File-manager path (optional)" style="flex:1;" />
+        <select id="msgFileKind">
+          <option value="file">File</option>
+          <option value="audio">Voice note</option>
+          <option value="video">Video</option>
+        </select>
+        <input id="msgFileDuration" type="number" min="1" placeholder="Duration seconds (optional)" />
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <button id="msgSendFileBtn">Upload &amp; Send</button>
+        <button id="msgSendPathBtn">Send by path</button>
+        <span class="muted" id="msgAttachmentStatus"></span>
+      </div>
     </div>
   </div>
 </div>

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -3166,6 +3166,18 @@ function setMsgStatus(id, msg) {
   el.textContent = msg || "";
 }
 
+function setMsgAttachmentStatus(msg) {
+  setMsgStatus("msgAttachmentStatus", msg);
+}
+
+function uiSessionHeaders() {
+  const tok = accessToken();
+  if (!tok) throw new Error("Missing access_token (Cognito login not completed).");
+  const sid = sessionId();
+  if (!sid) throw new Error("Missing UI session_id; call ensureUiSession() first.");
+  return { Authorization: `Bearer ${tok}`, "X-SESSION-ID": sid };
+}
+
 async function msgRequest(path, { method = "GET", body = null } = {}) {
   const uid = msgUserId();
   const headers = {};
@@ -3192,6 +3204,173 @@ async function msgRequest(path, { method = "GET", body = null } = {}) {
   return res.json();
 }
 
+async function fileManagerUpload(path, file) {
+  const headers = uiSessionHeaders();
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch(`${msgApiBase()}/v1/fs/upload?path=${encodeURIComponent(path)}`, {
+    method: "POST",
+    headers,
+    body: form,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Upload failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+async function fileManagerPresignUpload(path, file) {
+  const headers = uiSessionHeaders();
+  headers["Content-Type"] = "application/json";
+  const res = await fetch(`${msgApiBase()}/v1/fs/presign-upload`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ path, content_type: file.type || "application/octet-stream" }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Presign failed: ${res.status}`);
+  }
+  const data = await res.json();
+  const uploadRes = await fetch(data.upload_url, {
+    method: "PUT",
+    headers: { "Content-Type": data.content_type || "application/octet-stream" },
+    body: file,
+  });
+  if (!uploadRes.ok) {
+    throw new Error(`Upload failed: ${uploadRes.status}`);
+  }
+  const completeRes = await fetch(`${msgApiBase()}/v1/fs/complete-upload`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ path: data.path, key: data.key, content_type: data.content_type }),
+  });
+  if (!completeRes.ok) {
+    const text = await completeRes.text();
+    throw new Error(text || `Complete upload failed: ${completeRes.status}`);
+  }
+  return completeRes.json();
+}
+
+async function fetchFileBlob(path, { preview }) {
+  const headers = uiSessionHeaders();
+  const endpoint = preview ? "/v1/fs/preview" : "/v1/fs/download";
+  const res = await fetch(`${msgApiBase()}${endpoint}?path=${encodeURIComponent(path)}`, { headers });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Download failed: ${res.status}`);
+  }
+  return res.blob();
+}
+
+async function downloadFilePath(path, filename) {
+  const blob = await fetchFileBlob(path, { preview: false });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename || "download";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function previewFilePath(path) {
+  const blob = await fetchFileBlob(path, { preview: true });
+  const url = URL.createObjectURL(blob);
+  window.open(url, "_blank", "noopener");
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function formatBytes(bytes) {
+  if (bytes === 0) return "0 B";
+  if (!bytes) return "";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const idx = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, idx);
+  return `${value.toFixed(value >= 10 || idx === 0 ? 0 : 1)} ${units[idx]}`;
+}
+
+function buildPreviewPayload() {
+  const url = readInput("msgPreviewUrl");
+  const title = readInput("msgPreviewTitle");
+  const description = readInput("msgPreviewDescription");
+  const imageUrl = readInput("msgPreviewImage");
+  const siteName = readInput("msgPreviewSite");
+  if (!url && (title || description || imageUrl || siteName)) {
+    return { error: "Preview URL is required when adding preview metadata." };
+  }
+  if (!url) return { preview: null };
+  return {
+    preview: {
+      url,
+      title: title || null,
+      description: description || null,
+      image_url: imageUrl || null,
+      site_name: siteName || null,
+    },
+  };
+}
+
+function renderLinkPreview(preview) {
+  if (!preview) return "";
+  const image = preview.image_url
+    ? `<div><img src="${preview.image_url}" alt="Preview image" style="max-width:200px;max-height:120px;border-radius:6px;" /></div>`
+    : "";
+  const title = preview.title ? `<div><b>${preview.title}</b></div>` : "";
+  const description = preview.description ? `<div class="muted">${preview.description}</div>` : "";
+  const site = preview.site_name ? `<div class="muted">${preview.site_name}</div>` : "";
+  const url = preview.url ? `<a href="${preview.url}" target="_blank" rel="noopener">${preview.url}</a>` : "";
+  return `
+    <div class="item" style="margin-top:8px;">
+      ${image}
+      ${title}
+      ${description}
+      ${site}
+      ${url}
+    </div>
+  `;
+}
+
+function renderFileMeta(file, kind) {
+  if (!file) return "";
+  const meta = [];
+  if (file.content_type) meta.push(file.content_type);
+  if (file.size) meta.push(formatBytes(file.size));
+  if (file.duration_seconds) meta.push(`${file.duration_seconds}s`);
+  const thumbnail = file.thumbnail
+    ? `<div><img src="${msgApiBase()}/v1/fs/thumbnail?path=${encodeURIComponent(file.path)}" alt="Attachment thumbnail" style="max-width:200px;max-height:120px;border-radius:6px;" /></div>`
+    : "";
+  const label = kind === "audio" ? "Voice note" : kind === "video" ? "Video" : "File";
+  return `
+    ${thumbnail}
+    <div><b>${label}</b> ${file.name || ""}</div>
+    <div class="muted">${meta.join(" • ")}</div>
+    ${file.path ? `<div class="muted mono">${file.path}</div>` : ""}
+  `;
+}
+
+async function createInlinePlayer({ kind, path, name, container }) {
+  const blob = await fetchFileBlob(path, { preview: false });
+  const url = URL.createObjectURL(blob);
+  let el = null;
+  if (kind === "audio") {
+    el = document.createElement("audio");
+  } else if (kind === "video") {
+    el = document.createElement("video");
+    el.style.maxWidth = "320px";
+  }
+  if (!el) return null;
+  el.controls = true;
+  el.src = url;
+  el.onended = () => URL.revokeObjectURL(url);
+  el.onpause = () => {};
+  el.title = name || "";
+  container.appendChild(el);
+  return el;
+}
+
 function renderMessagingConvos() {
   const list = document.getElementById("msgConvoList");
   if (!list) return;
@@ -3206,10 +3385,11 @@ function renderMessagingConvos() {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "list-button";
+    const unread = c.unread_count ? ` • unread ${c.unread_count}` : "";
     btn.innerHTML = `
       <div style="text-align:left;">
         <div><b>${c.title || c.conversation_id}</b></div>
-        <div class="muted">${c.type} • ${c.status} • participants ${c.participant_count}</div>
+        <div class="muted">${c.type} • ${c.status} • participants ${c.participant_count}${unread}</div>
         <div class="muted">${c.last_message_preview || "No messages yet"}</div>
       </div>
     `;
@@ -3238,13 +3418,79 @@ function renderMessagingMessages(messages) {
   messages.forEach((m) => {
     const row = document.createElement("div");
     row.className = "item";
-    const body = m.kind === "image"
-      ? `<em>[image]</em> ${m.image ? (m.image.key || "") : ""}`
-      : (m.text || "");
-    row.innerHTML = `
-      <div class="muted">${m.sender_id} • ${new Date(m.created_at * 1000).toLocaleString()}</div>
-      <div>${body}</div>
-    `;
+    const body = document.createElement("div");
+    if (m.kind === "image") {
+      body.innerHTML = `<div><em>[image]</em> ${m.image ? (m.image.key || "") : ""}</div>`;
+    } else if (m.kind === "file" || m.kind === "audio" || m.kind === "video") {
+      body.innerHTML = renderFileMeta(m.file, m.kind);
+    } else {
+      body.innerHTML = `<div>${m.text || ""}</div>`;
+    }
+    if (m.preview) {
+      body.insertAdjacentHTML("beforeend", renderLinkPreview(m.preview));
+    }
+    if (m.delivered_to_count || m.read_by_count) {
+      const delivered = m.delivered_to_count ? `Delivered to ${m.delivered_to_count}` : "";
+      const readBy = m.read_by_count ? `Read by ${m.read_by_count}` : "";
+      const statusText = [delivered, readBy].filter(Boolean).join(" • ");
+      if (statusText) {
+        body.insertAdjacentHTML("beforeend", `<div class="muted" style="margin-top:6px;">${statusText}</div>`);
+      }
+    }
+    row.innerHTML = `<div class="muted">${m.sender_id} • ${new Date(m.created_at * 1000).toLocaleString()}</div>`;
+    row.appendChild(body);
+    if (m.file && m.file.path) {
+      const actionRow = document.createElement("div");
+      actionRow.className = "row-inline";
+      actionRow.style.marginTop = "6px";
+      if (m.kind === "audio" || m.kind === "video") {
+        const playBtn = document.createElement("button");
+        playBtn.type = "button";
+        playBtn.textContent = "Play inline";
+        playBtn.onclick = async () => {
+          setMsgAttachmentStatus("Loading media...");
+          try {
+            await createInlinePlayer({
+              kind: m.kind,
+              path: m.file.path,
+              name: m.file.name,
+              container: actionRow,
+            });
+            setMsgAttachmentStatus("Media ready.");
+          } catch (e) {
+            setMsgAttachmentStatus(String(e.message || e));
+          }
+        };
+        actionRow.appendChild(playBtn);
+      }
+      const downloadBtn = document.createElement("button");
+      downloadBtn.type = "button";
+      downloadBtn.textContent = "Download";
+      downloadBtn.onclick = async () => {
+        setMsgAttachmentStatus("Downloading...");
+        try {
+          await downloadFilePath(m.file.path, m.file.name);
+          setMsgAttachmentStatus("Download started.");
+        } catch (e) {
+          setMsgAttachmentStatus(String(e.message || e));
+        }
+      };
+      const previewBtn = document.createElement("button");
+      previewBtn.type = "button";
+      previewBtn.textContent = "Preview";
+      previewBtn.onclick = async () => {
+        setMsgAttachmentStatus("Opening preview...");
+        try {
+          await previewFilePath(m.file.path);
+          setMsgAttachmentStatus("Preview opened.");
+        } catch (e) {
+          setMsgAttachmentStatus(String(e.message || e));
+        }
+      };
+      actionRow.appendChild(downloadBtn);
+      actionRow.appendChild(previewBtn);
+      row.appendChild(actionRow);
+    }
     list.appendChild(row);
   });
 }
@@ -3333,14 +3579,30 @@ function renderMessagingSearchResults(messages) {
   messages.forEach((m) => {
     const row = document.createElement("div");
     row.className = "item";
-    const body = m.kind === "image"
-      ? `<em>[image]</em> ${m.image ? (m.image.key || "") : ""}`
-      : (m.text || "");
+    let body = "";
+    if (m.kind === "image") {
+      body = `<em>[image]</em> ${m.image ? (m.image.key || "") : ""}`;
+    } else if (m.kind === "file" || m.kind === "audio" || m.kind === "video") {
+      body = renderFileMeta(m.file, m.kind);
+    } else {
+      body = m.text || "";
+    }
     const convo = m.conversation_id ? ` • ${m.conversation_id}` : "";
     row.innerHTML = `
       <div class="muted">${m.sender_id}${convo} • ${new Date(m.created_at * 1000).toLocaleString()}</div>
       <div>${body}</div>
     `;
+    if (m.preview) {
+      row.insertAdjacentHTML("beforeend", renderLinkPreview(m.preview));
+    }
+    if (m.delivered_to_count || m.read_by_count) {
+      const delivered = m.delivered_to_count ? `Delivered to ${m.delivered_to_count}` : "";
+      const readBy = m.read_by_count ? `Read by ${m.read_by_count}` : "";
+      const statusText = [delivered, readBy].filter(Boolean).join(" • ");
+      if (statusText) {
+        row.insertAdjacentHTML("beforeend", `<div class="muted" style="margin-top:6px;">${statusText}</div>`);
+      }
+    }
     list.appendChild(row);
   });
 }
@@ -3353,6 +3615,10 @@ async function searchMessagingMessages({ allConversations }) {
   }
   const senderId = readInput("msgSearchSender");
   const afterRaw = readInput("msgSearchAfter");
+  const kindSelect = document.getElementById("msgSearchKind");
+  const kinds = kindSelect
+    ? Array.from(kindSelect.selectedOptions).map((opt) => opt.value).filter(Boolean)
+    : [];
   let afterTs = null;
   if (afterRaw) {
     afterTs = parseInt(afterRaw, 10);
@@ -3368,6 +3634,9 @@ async function searchMessagingMessages({ allConversations }) {
   const params = new URLSearchParams({ q: query, limit: "200" });
   if (senderId) params.set("sender_id", senderId);
   if (afterTs !== null) params.set("after_ts", String(afterTs));
+  if (kinds.length) {
+    kinds.forEach((kind) => params.append("kind", kind));
+  }
   const path = allConversations
     ? `/messaging/messages/search?${params.toString()}`
     : `/messaging/conversations/${messagingState.activeConversationId}/messages/search?${params.toString()}`;
@@ -3385,6 +3654,12 @@ function clearMessagingSearch() {
   setInputValue("msgSearchQuery", "");
   setInputValue("msgSearchSender", "");
   setInputValue("msgSearchAfter", "");
+  const kindSelect = document.getElementById("msgSearchKind");
+  if (kindSelect) {
+    Array.from(kindSelect.options).forEach((opt) => {
+      opt.selected = false;
+    });
+  }
   setMsgStatus("msgSearchStatus", "");
   renderMessagingSearchResults([]);
 }
@@ -3400,18 +3675,93 @@ async function sendMessagingMessage() {
     setMsgStatus("msgMessageStatus", "Message text required.");
     return;
   }
+  const previewResult = buildPreviewPayload();
+  if (previewResult.error) {
+    setMsgStatus("msgMessageStatus", previewResult.error);
+    return;
+  }
   setMsgStatus("msgMessageStatus", "Sending...");
   try {
     await msgRequest(`/messaging/conversations/${cid}/messages`, {
       method: "POST",
-      body: { text },
+      body: { text, preview: previewResult.preview || null },
     });
     setInputValue("msgText", "");
+    setInputValue("msgPreviewUrl", "");
+    setInputValue("msgPreviewTitle", "");
+    setInputValue("msgPreviewDescription", "");
+    setInputValue("msgPreviewImage", "");
+    setInputValue("msgPreviewSite", "");
     await loadMessagingMessages();
     await loadMessagingConvos();
     setMsgStatus("msgMessageStatus", "Sent.");
   } catch (e) {
     setMsgStatus("msgMessageStatus", String(e));
+  }
+}
+
+async function sendMessagingAttachment({ useUpload }) {
+  const cid = messagingState.activeConversationId;
+  if (!cid) {
+    setMsgAttachmentStatus("Select a conversation first.");
+    return;
+  }
+  const kind = readInput("msgFileKind") || "file";
+  const durationRaw = readInput("msgFileDuration");
+  let duration = null;
+  if (durationRaw) {
+    duration = parseInt(durationRaw, 10);
+    if (Number.isNaN(duration) || duration <= 0) {
+      setMsgAttachmentStatus("Duration must be a positive number.");
+      return;
+    }
+  }
+  const previewResult = buildPreviewPayload();
+  if (previewResult.error) {
+    setMsgAttachmentStatus(previewResult.error);
+    return;
+  }
+  let path = readInput("msgFilePath");
+  const fileInput = document.getElementById("msgFileInput");
+  const file = fileInput ? fileInput.files[0] : null;
+
+  if (useUpload) {
+    if (!file) {
+      setMsgAttachmentStatus("Choose a file to upload.");
+      return;
+    }
+    if (!path) {
+      path = `/messaging/${cid}/${file.name}`;
+    }
+  } else {
+    if (!path) {
+      setMsgAttachmentStatus("Provide a file-manager path.");
+      return;
+    }
+  }
+
+  setMsgAttachmentStatus(useUpload ? "Uploading..." : "Sending...");
+  try {
+    if (useUpload) {
+      await fileManagerPresignUpload(path, file);
+    }
+    await msgRequest(`/messaging/conversations/${cid}/messages/file`, {
+      method: "POST",
+      body: {
+        path,
+        kind,
+        duration_seconds: duration || null,
+        preview: previewResult.preview || null,
+      },
+    });
+    if (fileInput) fileInput.value = "";
+    setInputValue("msgFilePath", "");
+    setInputValue("msgFileDuration", "");
+    await loadMessagingMessages();
+    await loadMessagingConvos();
+    setMsgAttachmentStatus("Sent.");
+  } catch (e) {
+    setMsgAttachmentStatus(String(e.message || e));
   }
 }
 
@@ -4966,6 +5316,8 @@ document.getElementById("msgCreateConvoBtn").onclick = createMessagingConvo;
 document.getElementById("msgAcceptConvoBtn").onclick = acceptMessagingConvo;
 document.getElementById("msgLoadMessagesBtn").onclick = loadMessagingMessages;
 document.getElementById("msgSendBtn").onclick = sendMessagingMessage;
+document.getElementById("msgSendFileBtn").onclick = () => sendMessagingAttachment({ useUpload: true });
+document.getElementById("msgSendPathBtn").onclick = () => sendMessagingAttachment({ useUpload: false });
 document.getElementById("msgSearchConvoBtn").onclick = () => searchMessagingMessages({ allConversations: false });
 document.getElementById("msgSearchAllBtn").onclick = () => searchMessagingMessages({ allConversations: true });
 document.getElementById("msgSearchClearBtn").onclick = clearMessagingSearch;

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pydantic==2.6.4
 pyotp==2.9.0
 twilio==9.0.5
 requests==2.31.0
+snowballstemmer==2.2.0
 stripe==8.5.0
 pytest==8.2.2
 prometheus-client==0.20.0


### PR DESCRIPTION
### Motivation
- Surface per-user delivery and read state for messages so clients can show who has received/read a message and surface unread counts.
- Improve message search recall and relevance and allow clients to filter by message kind.
- Support richer media messaging with client-side uploads via presigned URLs, store duration/thumbnail metadata, and make thumbnails available to the UI.
- Provide server-side link unfurling when the client does not supply a preview to improve UX.

### Description
- API/model: `MessageOut` now exposes `delivered_to_user_ids` and `delivered_to_count`, and `_message_receipt_summary`/_apply logic now returns and attaches user lists instead of only counts.
- Frontend: `app/static/index.html` and `app/static/main.js` render conversation `unread_count`, show delivered/read counts on messages and search results, add UI for optional link previews and attachments, and implement presign/upload/complete flows and inline preview/download/thumbnail handling.
- File manager/service: added `presign-upload` and `complete-upload` endpoints and `thumbnail` endpoint, and service functions `presign_upload`, `register_presigned_upload`, `download_thumbnail`, `_maybe_probe_duration`, and `_maybe_generate_thumbnail` (use `ffprobe`/`ffmpeg` when available), and persist `duration_seconds` and `thumbnail` on file nodes.
- Search & previews: added stemming (`snowballstemmer`), token n-grams, prefix expansion, `search_text` and `kind` indexing for OpenSearch, kind-based filtering, local relevance ranking, and server-side link unfurling (`_extract_first_url`, `_fetch_link_preview`, `_LinkPreviewParser`).
- Misc: updated `requirements.txt` to include `snowballstemmer` and wired the new search/indexing flags into existing indexing/search flows.

### Testing
- Ran a headless Playwright script against a local static server to load the messaging UI and captured `messaging-read-state.png`, which completed successfully and produced the artifact.
- Started a local static HTTP server to exercise the updated frontend during the Playwright run, which also succeeded; no unit `pytest` suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fdc8c95dc832b92dbebf8a6915fa2)