### PR TITLE
Mirror proration entries into ledger and billing transactions

### DIFF
--- a/app/routers/billing_ccbill.py
+++ b/app/routers/billing_ccbill.py
@@ -33,7 +33,9 @@ from app.services.billing_ccbill import (
     list_payment_methods,
     mark_webhook_processed,
     new_ledger_entry,
+    _parse_ccbill_date,
     pay_balance,
+    renewal_fields,
     settle_or_reverse_ledger,
     sanitize_ccbill_payload,
     subscribe_monthly,
@@ -53,6 +55,12 @@ from app.services.billing_dunning import (
 )
 
 router = APIRouter(tags=["billing"])
+
+
+def _trial_bounds(payload: Dict[str, Any]) -> Tuple[Optional[int], Optional[int]]:
+    trial_start = _parse_ccbill_date(payload.get("trialStartDate") or payload.get("trialStart") or payload.get("trial_start"))
+    trial_end = _parse_ccbill_date(payload.get("trialEndDate") or payload.get("trialEnd") or payload.get("trial_end"))
+    return trial_start, trial_end
 
 
 def _pm_sk(payment_token_id: str) -> str:
@@ -616,11 +624,23 @@ async def ccbill_webhook(req: Request):
                 )
 
         if subscription_id:
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = renewal_fields("active")
+            trial_start, trial_end = _trial_bounds(payload)
+            current_period_end = _parse_ccbill_date(payload.get("nextRenewalDate"))
             upsert_subscription(
                 user_sub=user_sub,
                 subscription_id=str(subscription_id),
                 status="active",
                 plan_id=plan_id,
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                current_period_end=current_period_end,
+                trial_start=trial_start,
+                trial_end=trial_end,
+                proration_policy="full",
+                price_cents=amount,
+                interval="month",
                 next_renewal_date=payload.get("nextRenewalDate"),
                 last_transaction_id=str(transaction_id) if transaction_id else None,
                 raw=safe_meta,
@@ -636,7 +656,24 @@ async def ccbill_webhook(req: Request):
             settle_or_reverse_ledger(user_sub, led_sk_value, "reversed")
             update_payment_status(user_sub, str(transaction_id), "failed", raw=safe_meta)
         if subscription_id:
-            upsert_subscription(user_sub=user_sub, subscription_id=str(subscription_id), status="failed", plan_id=plan_id, raw=safe_meta)
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = renewal_fields("failed")
+            trial_start, trial_end = _trial_bounds(payload)
+            current_period_end = _parse_ccbill_date(payload.get("nextRenewalDate"))
+            upsert_subscription(
+                user_sub=user_sub,
+                subscription_id=str(subscription_id),
+                status="failed",
+                plan_id=plan_id,
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                current_period_end=current_period_end,
+                trial_start=trial_start,
+                trial_end=trial_end,
+                proration_policy="full",
+                interval="month",
+                raw=safe_meta,
+            )
         if pay:
             schedule_ccbill_dunning(
                 user_sub=user_sub,
@@ -674,11 +711,23 @@ async def ccbill_webhook(req: Request):
             )
 
         if subscription_id:
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = renewal_fields("active")
+            trial_start, trial_end = _trial_bounds(payload)
+            current_period_end = _parse_ccbill_date(payload.get("nextRenewalDate"))
             upsert_subscription(
                 user_sub=user_sub,
                 subscription_id=str(subscription_id),
                 status="active",
                 plan_id=plan_id,
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                current_period_end=current_period_end,
+                trial_start=trial_start,
+                trial_end=trial_end,
+                proration_policy="full",
+                price_cents=billed_cents,
+                interval="month",
                 next_renewal_date=payload.get("nextRenewalDate"),
                 last_transaction_id=str(transaction_id) if transaction_id else None,
                 raw=safe_meta,
@@ -687,11 +736,22 @@ async def ccbill_webhook(req: Request):
     elif event_type == "RenewalFailure":
         safe_meta = _webhook_meta(event_type, payload, q)
         if subscription_id:
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = renewal_fields("past_due")
+            trial_start, trial_end = _trial_bounds(payload)
+            current_period_end = _parse_ccbill_date(payload.get("nextRenewalDate"))
             upsert_subscription(
                 user_sub=user_sub,
                 subscription_id=str(subscription_id),
                 status="past_due",
                 plan_id=plan_id,
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                current_period_end=current_period_end,
+                trial_start=trial_start,
+                trial_end=trial_end,
+                proration_policy="full",
+                interval="month",
                 next_renewal_date=payload.get("nextRenewalDate"),
                 last_transaction_id=str(transaction_id) if transaction_id else None,
                 raw=safe_meta,
@@ -707,11 +767,22 @@ async def ccbill_webhook(req: Request):
     elif event_type == "Cancellation":
         safe_meta = _webhook_meta(event_type, payload, q)
         if subscription_id:
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = renewal_fields("canceled")
+            trial_start, trial_end = _trial_bounds(payload)
+            current_period_end = _parse_ccbill_date(payload.get("nextRenewalDate"))
             upsert_subscription(
                 user_sub=user_sub,
                 subscription_id=str(subscription_id),
                 status="canceled",
                 plan_id=plan_id,
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                current_period_end=current_period_end,
+                trial_start=trial_start,
+                trial_end=trial_end,
+                proration_policy="full",
+                interval="month",
                 last_transaction_id=str(transaction_id) if transaction_id else None,
                 raw=safe_meta,
             )

--- a/app/routers/paypal.py
+++ b/app/routers/paypal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import secrets
+from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -217,6 +218,37 @@ def update_payment_status(user_id: str, external_id: str, status: str, raw: Opti
     ddb_update(pk, pay_sk(external_id), "SET " + ", ".join(sets), values, names=names)
 
 
+def _parse_iso_ts(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    try:
+        text = str(value)
+        if text.endswith("Z"):
+            text = text.replace("Z", "+00:00")
+        return int(datetime.fromisoformat(text).timestamp())
+    except Exception:
+        return None
+
+
+def _renewal_fields(status: str, cancel_at_period_end: Optional[bool] = None) -> Tuple[bool, str, bool]:
+    status_lower = (status or "").lower()
+    if cancel_at_period_end:
+        return False, "cancel_at_period_end", True
+    if status_lower in ("canceling",):
+        return False, "cancel_at_period_end", True
+    if status_lower in ("canceled", "cancelled", "expired", "suspended", "failed"):
+        return False, "manual", False
+    return True, "auto", False
+
+
+def _subscription_period_end(resource: Dict[str, Any]) -> int:
+    billing_info = resource.get("billing_info") or {}
+    period_end = _parse_iso_ts(billing_info.get("next_billing_time") or billing_info.get("final_payment_time"))
+    return int(period_end or 0)
+
+
 def upsert_subscription(
     user_id: str,
     subscription_id: str,
@@ -226,11 +258,43 @@ def upsert_subscription(
     payment_token_id: Optional[str] = None,
     next_renewal_time: Optional[str] = None,
     last_external_id: Optional[str] = None,
+    current_period_end: Optional[int] = None,
+    auto_renew: Optional[bool] = None,
+    renewal_policy: Optional[str] = None,
+    cancel_at_period_end: Optional[bool] = None,
+    trial_start: Optional[int] = None,
+    trial_end: Optional[int] = None,
+    proration_policy: Optional[str] = None,
+    price_cents: Optional[int] = None,
+    interval: Optional[str] = None,
     raw: Optional[Dict[str, Any]] = None,
 ) -> None:
     pk = user_pk(user_id)
     sk = sub_sk(subscription_id)
-    existing = ddb_get(pk, sk)
+    existing = ddb_get(pk, sk) or {}
+    status_lower = (status or "").lower()
+    default_cancel_at_period_end = status_lower == "canceling"
+    auto_renew_default, renewal_policy_default, cancel_default = _renewal_fields(
+        status_lower,
+        cancel_at_period_end=default_cancel_at_period_end,
+    )
+    auto_renew_value = auto_renew if auto_renew is not None else existing.get("auto_renew", auto_renew_default)
+    renewal_policy_value = renewal_policy or existing.get("renewal_policy") or renewal_policy_default
+    cancel_at_period_end_value = (
+        cancel_at_period_end
+        if cancel_at_period_end is not None
+        else existing.get("cancel_at_period_end", cancel_default)
+    )
+    current_period_end_value = (
+        current_period_end
+        if current_period_end is not None
+        else existing.get("current_period_end") or _parse_iso_ts(next_renewal_time) or 0
+    )
+    trial_start_value = trial_start if trial_start is not None else existing.get("trial_start", 0)
+    trial_end_value = trial_end if trial_end is not None else existing.get("trial_end", 0)
+    proration_policy_value = proration_policy or existing.get("proration_policy") or "full"
+    price_cents_value = price_cents if price_cents is not None else existing.get("price_cents", DEFAULT_MONTHLY_PRICE_CENTS)
+    interval_value = interval or existing.get("interval") or "month"
     item = existing or {
         "pk": pk,
         "sk": sk,
@@ -239,6 +303,15 @@ def upsert_subscription(
     }
     item["status"] = status
     item["plan_id"] = plan_id
+    item["current_period_end"] = int(current_period_end_value)
+    item["auto_renew"] = bool(auto_renew_value)
+    item["renewal_policy"] = renewal_policy_value
+    item["cancel_at_period_end"] = bool(cancel_at_period_end_value)
+    item["trial_start"] = int(trial_start_value)
+    item["trial_end"] = int(trial_end_value)
+    item["proration_policy"] = proration_policy_value
+    item["price_cents"] = int(price_cents_value)
+    item["interval"] = interval_value
     item["updated_at"] = now_ts()
     if payment_token_id:
         item["payment_token_id"] = payment_token_id
@@ -1032,11 +1105,20 @@ async def subscribe_monthly(body: SubscribeMonthlyIn, x_user_id: Optional[str] =
     approve = _find_link(resp, "approve") or _find_link(resp, "payer-action") or _find_link(resp, "payer_action")
 
     if sub_id:
+        auto_renew_value, renewal_policy_value, cancel_at_period_end_value = _renewal_fields(
+            (resp.get("status") or "created").lower()
+        )
         upsert_subscription(
             user_id=user_id,
             subscription_id=str(sub_id),
             status=(resp.get("status") or "created").lower(),
             plan_id=body.plan_id,
+            auto_renew=auto_renew_value,
+            renewal_policy=renewal_policy_value,
+            cancel_at_period_end=cancel_at_period_end_value,
+            proration_policy="full",
+            price_cents=DEFAULT_MONTHLY_PRICE_CENTS,
+            interval="month",
             raw={"create_subscription": resp},
         )
 
@@ -1048,7 +1130,17 @@ def cancel_subscription(body: CancelSubscriptionIn, x_user_id: Optional[str] = H
     user_id = require_user(x_user_id)
     idem = body.idempotency_key or f"subcancel:{user_id}:{body.subscription_id}:{int(now_ts()/300)}"
     paypal_cancel_subscription(subscription_id=body.subscription_id, reason=body.reason, idempotency_key=idem)
-    upsert_subscription(user_id, body.subscription_id, status="canceled", plan_id="unknown", raw={"cancel_reason": body.reason})
+    auto_renew_value, renewal_policy_value, cancel_at_period_end_value = _renewal_fields("canceled")
+    upsert_subscription(
+        user_id,
+        body.subscription_id,
+        status="canceled",
+        plan_id="unknown",
+        auto_renew=auto_renew_value,
+        renewal_policy=renewal_policy_value,
+        cancel_at_period_end=cancel_at_period_end_value,
+        raw={"cancel_reason": body.reason},
+    )
     return {"ok": True}
 
 
@@ -1270,26 +1362,83 @@ async def paypal_webhook(req: Request):
         if amount_cents:
             apply_balance_delta(pk, {"owed_settled_cents": amount_cents})
 
+    elif event_type == "BILLING.SUBSCRIPTION.CREATED":
+        sub_id = str(resource.get("id") or "")
+        if sub_id:
+            status_value = (resource.get("status") or "created").lower()
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = _renewal_fields(status_value)
+            upsert_subscription(
+                user_id,
+                sub_id,
+                status=status_value,
+                plan_id="monthly",
+                current_period_end=_subscription_period_end(resource),
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                proration_policy="full",
+                price_cents=DEFAULT_MONTHLY_PRICE_CENTS,
+                interval="month",
+                raw={"event": event},
+            )
+
     elif event_type == "BILLING.SUBSCRIPTION.ACTIVATED":
         sub_id = str(resource.get("id") or "")
         if sub_id:
-            upsert_subscription(user_id, sub_id, status="active", plan_id="monthly", raw={"event": event})
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = _renewal_fields("active")
+            upsert_subscription(
+                user_id,
+                sub_id,
+                status="active",
+                plan_id="monthly",
+                current_period_end=_subscription_period_end(resource),
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                proration_policy="full",
+                price_cents=DEFAULT_MONTHLY_PRICE_CENTS,
+                interval="month",
+                raw={"event": event},
+            )
 
     elif event_type in ("BILLING.SUBSCRIPTION.CANCELLED", "BILLING.SUBSCRIPTION.SUSPENDED", "BILLING.SUBSCRIPTION.EXPIRED"):
         sub_id = str(resource.get("id") or "")
         if sub_id:
+            status_value = event_type.split(".")[-1].lower()
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = _renewal_fields(status_value)
             upsert_subscription(
                 user_id,
                 sub_id,
-                status=event_type.split(".")[-1].lower(),
+                status=status_value,
                 plan_id="monthly",
+                current_period_end=_subscription_period_end(resource),
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                proration_policy="full",
+                price_cents=DEFAULT_MONTHLY_PRICE_CENTS,
+                interval="month",
                 raw={"event": event},
             )
 
     elif event_type in ("BILLING.SUBSCRIPTION.PAYMENT.FAILED",):
         sub_id = str(resource.get("billing_agreement_id") or resource.get("id") or "")
         if sub_id:
-            upsert_subscription(user_id, sub_id, status="past_due", plan_id="monthly", raw={"event": event})
+            auto_renew_value, renewal_policy_value, cancel_at_period_end_value = _renewal_fields("past_due")
+            upsert_subscription(
+                user_id,
+                sub_id,
+                status="past_due",
+                plan_id="monthly",
+                current_period_end=_subscription_period_end(resource),
+                auto_renew=auto_renew_value,
+                renewal_policy=renewal_policy_value,
+                cancel_at_period_end=cancel_at_period_end_value,
+                proration_policy="full",
+                price_cents=DEFAULT_MONTHLY_PRICE_CENTS,
+                interval="month",
+                raw={"event": event},
+            )
 
     else:
         ddb_put(

--- a/app/routers/subscription_server.py
+++ b/app/routers/subscription_server.py
@@ -352,6 +352,8 @@ class SubscriptionChangePlanIn(BaseModel):
     interval: Optional[Literal["month", "year"]] = None
     effective: Literal["immediate", "period_end"] = "immediate"
     proration_policy: Literal["none", "charge", "credit", "full"] = "full"
+    proration_amount_cents: Optional[int] = None
+    provider_invoice_id: Optional[str] = None
     reason: Optional[str] = None
 
 
@@ -1353,7 +1355,9 @@ async def change_subscription_plan(
         return attach_subscription_profiles(sub)
 
     proration_amount = 0
-    if body.proration_policy != "none":
+    if body.proration_amount_cents is not None:
+        proration_amount = int(body.proration_amount_cents)
+    elif body.proration_policy != "none":
         proration_amount = calculate_proration(
             current_price=int(sub["price_cents"]),
             new_price=int(new_price),
@@ -1361,10 +1365,12 @@ async def change_subscription_plan(
             period_start=int(sub.get("start_at") or ts),
             period_end=int(sub.get("current_period_end") or ts),
         )
-        if proration_amount > 0 and body.proration_policy == "credit":
-            proration_amount = 0
-        if proration_amount < 0 and body.proration_policy == "charge":
-            proration_amount = 0
+    if body.proration_policy == "none":
+        proration_amount = 0
+    elif proration_amount > 0 and body.proration_policy == "credit":
+        proration_amount = 0
+    elif proration_amount < 0 and body.proration_policy == "charge":
+        proration_amount = 0
 
     sub["plan_id"] = body.plan_id
     sub["interval"] = interval
@@ -1375,13 +1381,13 @@ async def change_subscription_plan(
     record_billing_subscription(sub)
 
     if proration_amount != 0:
-        invoice_id = new_id("inv")
+        invoice_id = body.provider_invoice_id or new_id("inv")
         proration_status = "paid" if proration_amount > 0 else "credited"
         invoice = {
             "invoice_id": invoice_id,
             "subscription_id": subscription_id,
             "subscriber_id": sub["subscriber_id"],
-            "provider_invoice_id": new_id("stub_inv"),
+            "provider_invoice_id": body.provider_invoice_id or new_id("stub_inv"),
             "amount_cents": abs(int(proration_amount)),
             "currency": sub["currency"],
             "status": proration_status,
@@ -1693,7 +1699,7 @@ async def list_earnings(
 
 @router.post("/api/billing/webhooks/{provider}")
 async def billing_webhook(provider: str, body: WebhookIn):
-    if provider != "stub":
+    if provider not in ("stub", "paypal", "ccbill"):
         raise HTTPException(status_code=400, detail="Unsupported provider")
     event_id = new_id("wh")
     ddb_put_item({
@@ -1717,7 +1723,58 @@ async def billing_webhook(provider: str, body: WebhookIn):
 
     ts = now_ts()
     event_type = body.event_type.lower()
-    if event_type == "invoice.paid":
+    if event_type in ("invoice.proration", "subscription.proration"):
+        proration_amount = body.metadata.get("proration_amount_cents")
+        if proration_amount is None:
+            proration_amount = body.metadata.get("amount_cents") or body.metadata.get("amount")
+        try:
+            proration_amount = int(proration_amount)
+        except (TypeError, ValueError):
+            proration_amount = 0
+        if proration_amount:
+            currency = body.metadata.get("currency", sub.get("currency", "usd"))
+            provider_invoice_id = body.metadata.get("provider_invoice_id")
+            invoice_id = body.metadata.get("invoice_id") or provider_invoice_id or new_id("inv")
+            invoice = {
+                "invoice_id": invoice_id,
+                "subscription_id": body.subscription_id,
+                "subscriber_id": sub["subscriber_id"],
+                "provider_invoice_id": provider_invoice_id or new_id("stub_inv"),
+                "amount_cents": abs(int(proration_amount)),
+                "currency": currency,
+                "status": "paid" if proration_amount > 0 else "credited",
+                "period_start": body.metadata.get("period_start", ts),
+                "period_end": body.metadata.get("period_end", sub.get("current_period_end")),
+                "created_at": ts,
+                "is_proration": True,
+                "proration_amount_cents": int(proration_amount),
+                "proration_period_start": body.metadata.get("proration_period_start", sub.get("start_at")),
+                "proration_period_end": body.metadata.get("proration_period_end", sub.get("current_period_end")),
+            }
+            save_invoice(invoice)
+            record_billing_payment(invoice, body.subscription_id)
+            record_billing_transaction(
+                user_sub=sub["subscriber_id"],
+                amount_cents=int(proration_amount),
+                currency=currency,
+                description=f"Subscription proration {body.subscription_id}",
+                status="COMPLETED",
+                external_ref=invoice_id,
+                metadata={"subscription_id": body.subscription_id, "creator_id": sub["creator_id"]},
+            )
+            entry_type = "proration_charge" if proration_amount > 0 else "proration_credit"
+            entry = {
+                "entry_id": new_id("led"),
+                "subscription_id": body.subscription_id,
+                "subscriber_id": sub["subscriber_id"],
+                "entry_type": entry_type,
+                "amount_cents": abs(int(proration_amount)),
+                "currency": currency,
+                "created_at": ts,
+                "metadata": {"invoice_id": invoice_id, "proration_amount_cents": proration_amount},
+            }
+            save_ledger_entry(sub["creator_id"], entry)
+    elif event_type == "invoice.paid":
         sub["status"] = "active"
         sub["current_period_end"] = ts + interval_seconds(sub.get("interval", "month"))
         sub["auto_renew"] = True

--- a/app/services/billing_ccbill.py
+++ b/app/services/billing_ccbill.py
@@ -5,6 +5,7 @@ import hmac
 import ipaddress
 import json
 import time
+from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -254,6 +255,37 @@ def update_payment_status(user_sub: str, transaction_id: str, status: str, raw: 
     )
 
 
+def _parse_ccbill_date(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value)
+    for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y%m%d"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return int(parsed.replace(tzinfo=timezone.utc).timestamp())
+        except ValueError:
+            continue
+    try:
+        if text.endswith("Z"):
+            text = text.replace("Z", "+00:00")
+        return int(datetime.fromisoformat(text).timestamp())
+    except ValueError:
+        return None
+
+
+def renewal_fields(status: str, cancel_at_period_end: Optional[bool] = None) -> Tuple[bool, str, bool]:
+    status_lower = (status or "").lower()
+    if cancel_at_period_end:
+        return False, "cancel_at_period_end", True
+    if status_lower in ("canceling",):
+        return False, "cancel_at_period_end", True
+    if status_lower in ("canceled", "cancelled", "expired", "suspended", "failed"):
+        return False, "manual", False
+    return True, "auto", False
+
+
 def upsert_subscription(
     user_sub: str,
     subscription_id: str,
@@ -263,9 +295,41 @@ def upsert_subscription(
     payment_token_id: Optional[str] = None,
     next_renewal_date: Optional[str] = None,
     last_transaction_id: Optional[str] = None,
+    current_period_end: Optional[int] = None,
+    auto_renew: Optional[bool] = None,
+    renewal_policy: Optional[str] = None,
+    cancel_at_period_end: Optional[bool] = None,
+    trial_start: Optional[int] = None,
+    trial_end: Optional[int] = None,
+    proration_policy: Optional[str] = None,
+    price_cents: Optional[int] = None,
+    interval: Optional[str] = None,
     raw: Optional[Dict[str, Any]] = None,
 ) -> None:
-    existing = T.billing.get_item(Key={"user_sub": user_sub, "sk": _billing_sk("SUB", subscription_id)}).get("Item")
+    existing = T.billing.get_item(Key={"user_sub": user_sub, "sk": _billing_sk("SUB", subscription_id)}).get("Item") or {}
+    status_lower = (status or "").lower()
+    default_cancel_at_period_end = status_lower == "canceling"
+    auto_renew_default, renewal_policy_default, cancel_default = renewal_fields(
+        status_lower,
+        cancel_at_period_end=default_cancel_at_period_end,
+    )
+    auto_renew_value = auto_renew if auto_renew is not None else existing.get("auto_renew", auto_renew_default)
+    renewal_policy_value = renewal_policy or existing.get("renewal_policy") or renewal_policy_default
+    cancel_at_period_end_value = (
+        cancel_at_period_end
+        if cancel_at_period_end is not None
+        else existing.get("cancel_at_period_end", cancel_default)
+    )
+    current_period_end_value = (
+        current_period_end
+        if current_period_end is not None
+        else existing.get("current_period_end") or _parse_ccbill_date(next_renewal_date) or 0
+    )
+    trial_start_value = trial_start if trial_start is not None else existing.get("trial_start", 0)
+    trial_end_value = trial_end if trial_end is not None else existing.get("trial_end", 0)
+    proration_policy_value = proration_policy or existing.get("proration_policy") or "full"
+    price_cents_value = price_cents if price_cents is not None else existing.get("price_cents", S.default_monthly_price_cents)
+    interval_value = interval or existing.get("interval") or "month"
     item = existing or {
         "user_sub": user_sub,
         "sk": _billing_sk("SUB", subscription_id),
@@ -274,6 +338,15 @@ def upsert_subscription(
     }
     item["status"] = status
     item["plan_id"] = plan_id
+    item["current_period_end"] = int(current_period_end_value)
+    item["auto_renew"] = bool(auto_renew_value)
+    item["renewal_policy"] = renewal_policy_value
+    item["cancel_at_period_end"] = bool(cancel_at_period_end_value)
+    item["trial_start"] = int(trial_start_value)
+    item["trial_end"] = int(trial_end_value)
+    item["proration_policy"] = proration_policy_value
+    item["price_cents"] = int(price_cents_value)
+    item["interval"] = interval_value
     item["updated_at"] = now_ts()
     if payment_token_id:
         item["payment_token_id"] = payment_token_id


### PR DESCRIPTION
### Motivation
- Ensure provider-originated proration events are materialized in our accounting so proration charges/credits produce an `invoice`, a billing transaction, and a ledger entry. 
- Accept provider-supplied proration amounts/ids and normalize lifecycle fields so webhook-driven changes produce the same internal records as server-driven plan changes.

### Description
- Add proration mirroring in the generic billing webhook so `invoice.proration` / `subscription.proration` events create an invoice (via `save_invoice`), a billing payment/transaction (`record_billing_payment` / `record_billing_transaction`), and a ledger entry (`save_ledger_entry`) using provider metadata for `provider_invoice_id` and `proration_amount_cents` in `app/routers/subscription_server.py`.
- Allow `paypal` and `ccbill` as accepted providers on the billing webhook and extract proration fields from `body.metadata` when present in `app/routers/subscription_server.py`.
- Extend subscription plan-change path to accept a provider-supplied proration amount via `proration_amount_cents` and to enforce `proration_policy` semantics when computing/pruning proration in `SubscriptionChangePlanIn` and `change_subscription_plan` in `app/routers/subscription_server.py`.
- Normalize subscription lifecycle and proration-related state across PayPal and CCBill codepaths by adding date parsing and renewal helpers (`_parse_iso_ts`, `_renewal_fields`, `_subscription_period_end`, `_trial_bounds`, `_parse_ccbill_date`, `renewal_fields`) and extending `upsert_subscription` to persist `auto_renew`, `renewal_policy`, `cancel_at_period_end`, `current_period_end`, `trial_start`, `trial_end`, `proration_policy`, `price_cents`, and `interval` in `app/routers/paypal.py` and `app/services/billing_ccbill.py`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980151ea2c4832bb9110d91a9013e2f)