### PR TITLE
Add recurrence exceptions and per‑occurrence overrides with UI controls

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -486,6 +486,26 @@ class CalendarOut(BaseModel):
     created_at_utc: str
 
 
+class CalendarShareIn(BaseModel):
+    user_sub: str = Field(min_length=1, max_length=200)
+    permission: Literal["read", "write"]
+
+
+class CalendarShareOut(BaseModel):
+    calendar_id: str
+    user_sub: str
+    permission: Literal["read", "write"]
+    created_at_utc: str
+
+
+class CalendarAccessOut(BaseModel):
+    calendar_id: str
+    name: str
+    timezone: str
+    owner_user_id: str
+    permission: Literal["owner", "read", "write"]
+
+
 class CalendarUpdateIn(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=200)
     timezone: str | None = Field(default=None, max_length=64)
@@ -493,6 +513,18 @@ class CalendarUpdateIn(BaseModel):
     working_hours: Dict[str, List[WorkingHoursWindow]] | None = None
     buffer_before_minutes: int | None = None
     buffer_after_minutes: int | None = None
+
+
+class EventOccurrenceOverrideIn(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
+    timezone: str | None = Field(default=None, max_length=64)
+    start_utc: str | None = None
+    end_utc: str | None = None
+    all_day: bool | None = None
+    all_day_date: str | None = None
+    status: str | None = None
+    category: str | None = None
 
 
 class EventCreateIn(BaseModel):
@@ -509,6 +541,8 @@ class EventCreateIn(BaseModel):
     status: str = "busy"
     category: str | None = None
     recurrence_rule: RecurrenceRule | None = None
+    exdates_utc: List[str] | None = None
+    recurrence_overrides: Dict[str, EventOccurrenceOverrideIn] | None = None
 
 
 class EventOut(BaseModel):
@@ -527,6 +561,8 @@ class EventOut(BaseModel):
     status: str
     category: str | None = None
     recurrence_rule: RecurrenceRule | None = None
+    exdates_utc: List[str] | None = None
+    recurrence_overrides: Dict[str, EventOccurrenceOverrideIn] | None = None
     created_at_utc: str
 
 
@@ -544,6 +580,27 @@ class EventUpdateIn(BaseModel):
     status: str | None = None
     category: str | None = None
     recurrence_rule: RecurrenceRule | None = None
+    exdates_utc: List[str] | None = None
+    recurrence_overrides: Dict[str, EventOccurrenceOverrideIn] | None = None
+
+
+class EventConflictPreviewIn(EventCreateIn):
+    event_id: str | None = None
+
+
+class EventConflictPreviewOut(BaseModel):
+    requested_start_utc: str
+    requested_end_utc: str
+    timezone: str
+    conflicts: List[EventOut]
+
+
+class EventSuggestionsIn(BaseModel):
+    start_utc: str
+    end_utc: str
+    duration_minutes: Optional[int] = Field(default=None, ge=1, le=1440)
+    limit: Optional[int] = Field(default=5, ge=1, le=50)
+    window_days: Optional[int] = Field(default=7, ge=1, le=30)
 
 
 class OpeningsOut(BaseModel):
@@ -571,6 +628,8 @@ class RecurrenceRule(BaseModel):
     until_utc: Optional[str] = None
     count: Optional[int] = Field(default=None, ge=1)
     byday: Optional[List[Literal["MO", "TU", "WE", "TH", "FR", "SA", "SU"]]] = None
+    bymonthday: Optional[List[int]] = None
+    bysetpos: Optional[List[int]] = None
 
 
 class BookingLinkCreateIn(BaseModel):

--- a/app/routers/calendar.py
+++ b/app/routers/calendar.py
@@ -12,13 +12,20 @@ from app.models import (
     BookingLinkCreateIn,
     BookingLinkOut,
     BookingRequestIn,
+    CalendarAccessOut,
     CalendarCreateIn,
     CalendarOut,
+    CalendarShareIn,
+    CalendarShareOut,
     CalendarUpdateIn,
+    EventConflictPreviewIn,
+    EventConflictPreviewOut,
     EventsPageOut,
     EventCreateIn,
+    EventOccurrenceOverrideIn,
     EventOut,
     EventUpdateIn,
+    EventSuggestionsIn,
     OpeningsOut,
     RecurrenceRule,
     TeamAvailabilityIn,
@@ -121,6 +128,18 @@ def _booking_link_key(link_id: str) -> str:
     return f"booking#{link_id}"
 
 
+def _share_key(user_sub: str) -> str:
+    return f"share#{user_sub}"
+
+
+def _access_partition(user_sub: str) -> str:
+    return f"user#{user_sub}"
+
+
+def _access_key(calendar_id: str) -> str:
+    return f"calendar#{calendar_id}"
+
+
 def _load_event(calendar_id: str, event_id: str) -> Dict[str, Any]:
     item = T.calendar.get_item(Key={"calendar_id": calendar_id, "sk": _event_key(event_id)}).get("Item")
     if not item:
@@ -202,7 +221,80 @@ def _normalize_recurrence_rule(rule: RecurrenceRule | None) -> RecurrenceRule | 
         return None
     if rule.until_utc:
         _ = parse_iso_dt(rule.until_utc)
+    if rule.bymonthday:
+        for day in rule.bymonthday:
+            if day == 0 or day < -31 or day > 31:
+                raise HTTPException(status_code=400, detail="Invalid bymonthday value")
+    if rule.bysetpos:
+        for pos in rule.bysetpos:
+            if pos == 0 or pos < -31 or pos > 31:
+                raise HTTPException(status_code=400, detail="Invalid bysetpos value")
     return rule
+
+
+def _normalize_exdates(exdates: list[str] | None, tz_name: str) -> list[str] | None:
+    if not exdates:
+        return None
+    _validate_timezone(tz_name)
+    tz = ZoneInfo(tz_name)
+    normalized: list[str] = []
+    for value in exdates:
+        if not value:
+            continue
+        try:
+            parsed = parse_iso_dt(value)
+        except HTTPException:
+            try:
+                parsed_date = parse_iso_date(value)
+            except HTTPException:
+                raise
+            parsed = datetime(parsed_date.year, parsed_date.month, parsed_date.day, 0, 0, 0, tzinfo=tz).astimezone(timezone.utc)
+        normalized.append(iso_utc(parsed))
+    return sorted(set(normalized))
+
+
+def _normalize_occurrence_override(calendar_tz: str, override: EventOccurrenceOverrideIn) -> Dict[str, Any]:
+    tz_name = override.timezone or calendar_tz
+    _validate_timezone(tz_name)
+    normalized: Dict[str, Any] = {
+        "name": override.name,
+        "description": override.description,
+        "timezone": tz_name,
+        "status": override.status,
+        "category": override.category,
+    }
+    if override.all_day is not None:
+        normalized["all_day"] = override.all_day
+    if override.all_day_date:
+        _ = parse_iso_date(override.all_day_date)
+        normalized["all_day_date"] = override.all_day_date
+    if normalized.get("all_day") and not normalized.get("all_day_date"):
+        raise HTTPException(status_code=400, detail="all_day_date is required for all-day overrides")
+    if override.start_utc:
+        normalized["start_utc"] = iso_utc(parse_iso_dt(override.start_utc))
+    if override.end_utc:
+        normalized["end_utc"] = iso_utc(parse_iso_dt(override.end_utc))
+    if normalized.get("start_utc") and normalized.get("end_utc"):
+        start = parse_iso_dt(normalized["start_utc"])
+        end = parse_iso_dt(normalized["end_utc"])
+        if end <= start:
+            raise HTTPException(status_code=400, detail="end_utc must be after start_utc")
+    return {k: v for k, v in normalized.items() if v is not None}
+
+
+def _normalize_overrides(
+    overrides: Dict[str, EventOccurrenceOverrideIn] | None,
+    calendar_tz: str,
+) -> Dict[str, Dict[str, Any]] | None:
+    if not overrides:
+        return None
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for key, value in overrides.items():
+        if not key:
+            continue
+        occ_key = iso_utc(parse_iso_dt(key))
+        normalized[occ_key] = _normalize_occurrence_override(calendar_tz, value)
+    return normalized or None
 
 
 def _normalize_event_times(calendar_tz: str, payload: EventCreateIn) -> Dict[str, Any]:
@@ -341,32 +433,75 @@ def _expand_rrule(
             if week_start > window_end + timedelta(days=7):
                 break
     elif rrule.freq == "MONTHLY":
-        def add_months(d: datetime, months: int) -> datetime | None:
-            y = d.year + (d.month - 1 + months) // 12
-            m = (d.month - 1 + months) % 12 + 1
-            try:
-                return d.replace(year=y, month=m, day=d.day)
-            except ValueError:
-                return None
-        k = 0
-        cur = series_start_utc
+        def month_last_day(year: int, month: int) -> int:
+            next_month = datetime(year + (month // 12), ((month % 12) + 1), 1, tzinfo=timezone.utc)
+            last_day = (next_month - timedelta(days=1)).day
+            return last_day
+
+        def add_months(year: int, month: int, months: int) -> tuple[int, int]:
+            total = (year * 12 + (month - 1)) + months
+            return total // 12, total % 12 + 1
+
+        def candidate_dates(year: int, month: int) -> list[date]:
+            last_day = month_last_day(year, month)
+            if rrule.bymonthday:
+                days: list[int] = []
+                for day in rrule.bymonthday:
+                    if day > 0 and day <= last_day:
+                        days.append(day)
+                    elif day < 0:
+                        target = last_day + day + 1
+                        if target >= 1:
+                            days.append(target)
+                return [date(year, month, d) for d in sorted(set(days))]
+            bydays = rrule.byday or [list(RRULE_WEEKDAY_MAP.keys())[series_start_utc.weekday()]]
+            weekday_idxs = sorted({RRULE_WEEKDAY_MAP[d] for d in bydays})
+            dates = [
+                date(year, month, day)
+                for day in range(1, last_day + 1)
+                if date(year, month, day).weekday() in weekday_idxs
+            ]
+            if rrule.bysetpos:
+                selected: list[date] = []
+                for pos in rrule.bysetpos:
+                    if pos > 0 and pos <= len(dates):
+                        selected.append(dates[pos - 1])
+                    elif pos < 0 and abs(pos) <= len(dates):
+                        selected.append(dates[pos])
+                return selected
+            return dates
+
+        start_year = series_start_utc.year
+        start_month = series_start_utc.month
+        month_offset = 0
         while True:
-            if until and cur > until:
+            year, month = add_months(start_year, start_month, month_offset)
+            for cand in candidate_dates(year, month):
+                occ_start = datetime(
+                    cand.year,
+                    cand.month,
+                    cand.day,
+                    series_start_utc.hour,
+                    series_start_utc.minute,
+                    series_start_utc.second,
+                    series_start_utc.microsecond,
+                    tzinfo=timezone.utc,
+                )
+                if occ_start < series_start_utc:
+                    continue
+                if until and occ_start > until:
+                    return sorted(occs, key=lambda x: x[0])
+                if remaining is not None and remaining <= 0:
+                    return sorted(occs, key=lambda x: x[0])
+                occ_end = occ_start + duration
+                if overlap(occ_start, occ_end, window_start, window_end):
+                    occs.append((occ_start, occ_end))
+                if remaining is not None:
+                    remaining -= 1
+            month_offset += rrule.interval
+            if until and datetime(year, month, 1, tzinfo=timezone.utc) > until + timedelta(days=31):
                 break
-            if remaining is not None and remaining <= 0:
-                break
-            occ_start = cur
-            occ_end = cur + duration
-            if overlap(occ_start, occ_end, window_start, window_end):
-                occs.append((occ_start, occ_end))
-            if remaining is not None:
-                remaining -= 1
-            k += rrule.interval
-            nxt = add_months(series_start_utc, k)
-            if nxt is None:
-                continue
-            cur = nxt
-            if cur > window_end + timedelta(days=31):
+            if datetime(year, month, 1, tzinfo=timezone.utc) > window_end + timedelta(days=31):
                 break
     return sorted(occs, key=lambda x: x[0])
 
@@ -385,8 +520,13 @@ def _expand_event_occurrences(
     if not occs:
         return []
     tz = ZoneInfo(event.get("timezone", "UTC"))
+    exdates = {str(value) for value in (event.get("exdates_utc") or [])}
+    overrides = event.get("recurrence_overrides") or {}
     occurrences: list[Dict[str, Any]] = []
     for occ_start, occ_end in occs:
+        occ_key = iso_utc(occ_start)
+        if occ_key in exdates:
+            continue
         occ = {**event}
         if event.get("all_day"):
             local_date = occ_start.astimezone(tz).date()
@@ -396,6 +536,17 @@ def _expand_event_occurrences(
         else:
             occ["start_utc"] = iso_utc(occ_start)
             occ["end_utc"] = iso_utc(occ_end)
+        override = overrides.get(occ_key)
+        if isinstance(override, dict):
+            occ.update(override)
+        try:
+            occ_interval = _event_time_interval(occ)
+        except Exception:
+            occ_interval = None
+        if occ_interval:
+            start, end = occ_interval
+            if not overlap(start, end, window_start, window_end):
+                continue
         occurrences.append(occ)
     return occurrences
 
@@ -428,13 +579,86 @@ def _ensure_no_conflicts(
                 raise HTTPException(status_code=409, detail="Event conflicts with an existing event")
 
 
-def _load_calendar(calendar_id: str, user_sub: str) -> Dict[str, Any]:
+def _find_conflicts(
+    calendar_id: str,
+    normalized: Dict[str, Any],
+    *,
+    exclude_event_id: str | None = None,
+) -> tuple[list[Dict[str, Any]], datetime, datetime]:
+    requested_start, requested_end = _event_payload_interval(normalized)
+    if not _is_busy_status(normalized.get("status", "busy")):
+        return [], requested_start, requested_end
+    conflicts: list[Dict[str, Any]] = []
+    for event in _list_events(calendar_id)[0]:
+        if exclude_event_id and event.get("event_id") == exclude_event_id:
+            continue
+        if event.get("recurrence_rule"):
+            occurrences = _expand_event_occurrences(event, requested_start, requested_end)
+            for occ in occurrences:
+                interval = _event_to_busy_interval(occ)
+                if interval is None:
+                    continue
+                start, end = interval
+                if overlap(requested_start, requested_end, start, end):
+                    conflicts.append(occ)
+        else:
+            interval = _event_to_busy_interval(event)
+            if interval is None:
+                continue
+            start, end = interval
+            if overlap(requested_start, requested_end, start, end):
+                conflicts.append(event)
+    return conflicts, requested_start, requested_end
+
+
+def _suggest_slots(
+    openings: list[tuple[datetime, datetime]],
+    duration: timedelta,
+    limit: int,
+) -> list[tuple[datetime, datetime]]:
+    suggestions: list[tuple[datetime, datetime]] = []
+    for start, end in openings:
+        if end - start < duration:
+            continue
+        suggestions.append((start, start + duration))
+        if len(suggestions) >= limit:
+            break
+    return suggestions
+
+
+def _load_calendar_access(calendar_id: str, user_sub: str, *, write: bool = False) -> Dict[str, Any]:
+    meta = T.calendar.get_item(Key=_calendar_keys(calendar_id)).get("Item")
+    if not meta:
+        raise HTTPException(status_code=404, detail="Calendar not found")
+    if meta.get("owner_user_sub") == user_sub:
+        return meta
+    share = T.calendar.get_item(Key={"calendar_id": calendar_id, "sk": _share_key(user_sub)}).get("Item")
+    if not share:
+        raise HTTPException(status_code=403, detail="Calendar access denied")
+    permission = share.get("permission", "read")
+    if write and permission != "write":
+        raise HTTPException(status_code=403, detail="Calendar write access denied")
+    return meta
+
+
+def _require_calendar_owner(calendar_id: str, user_sub: str) -> Dict[str, Any]:
     meta = T.calendar.get_item(Key=_calendar_keys(calendar_id)).get("Item")
     if not meta:
         raise HTTPException(status_code=404, detail="Calendar not found")
     if meta.get("owner_user_sub") != user_sub:
-        raise HTTPException(status_code=403, detail="Calendar access denied")
+        raise HTTPException(status_code=403, detail="Calendar owner access denied")
     return meta
+
+
+def _calendar_access_item(user_sub: str, calendar_id: str, permission: str) -> Dict[str, Any]:
+    return {
+        "calendar_id": _access_partition(user_sub),
+        "sk": _access_key(calendar_id),
+        "type": "calendar_access",
+        "target_calendar_id": calendar_id,
+        "permission": permission,
+        "created_at_utc": iso_utc(utc_now()),
+    }
 
 
 def _list_events(
@@ -592,6 +816,8 @@ def _event_out(item: Dict[str, Any], calendar_id: str) -> EventOut:
         status=item.get("status", "busy"),
         category=item.get("category"),
         recurrence_rule=item.get("recurrence_rule"),
+        exdates_utc=item.get("exdates_utc"),
+        recurrence_overrides=item.get("recurrence_overrides"),
         created_at_utc=item.get("created_at_utc", ""),
     )
 
@@ -617,6 +843,7 @@ async def create_calendar(body: CalendarCreateIn, ctx: Dict[str, str] = Depends(
         "created_at_utc": now,
     }
     T.calendar.put_item(Item=item)
+    T.calendar.put_item(Item=_calendar_access_item(ctx["user_sub"], calendar_id, "owner"))
     return CalendarOut(
         calendar_id=calendar_id,
         name=body.name,
@@ -630,6 +857,242 @@ async def create_calendar(body: CalendarCreateIn, ctx: Dict[str, str] = Depends(
     )
 
 
+@router.get("/calendars", response_model=list[CalendarAccessOut])
+async def list_calendars(ctx: Dict[str, str] = Depends(require_ui_session)):
+    access_response = T.calendar.query(
+        KeyConditionExpression=Key("calendar_id").eq(_access_partition(ctx["user_sub"])) & Key("sk").begins_with("calendar#"),
+        ScanIndexForward=True,
+    )
+    access_items = access_response.get("Items", [])
+    access_by_calendar = {item.get("target_calendar_id"): item for item in access_items if item.get("target_calendar_id")}
+    owner_scan = T.calendar.scan(
+        FilterExpression=Attr("sk").eq("meta")
+        & Attr("type").eq("calendar")
+        & Attr("owner_user_sub").eq(ctx["user_sub"])
+    )
+    for item in owner_scan.get("Items", []):
+        calendar_id = item.get("calendar_id")
+        if not calendar_id or calendar_id in access_by_calendar:
+            continue
+        access_item = _calendar_access_item(ctx["user_sub"], calendar_id, "owner")
+        access_by_calendar[calendar_id] = access_item
+        T.calendar.put_item(Item=access_item)
+    result: list[CalendarAccessOut] = []
+    for calendar_id, access in access_by_calendar.items():
+        if not calendar_id:
+            continue
+        meta = T.calendar.get_item(Key=_calendar_keys(calendar_id)).get("Item")
+        if not meta:
+            continue
+        permission = access.get("permission", "read")
+        result.append(
+            CalendarAccessOut(
+                calendar_id=calendar_id,
+                name=meta.get("name", ""),
+                timezone=meta.get("timezone", "UTC"),
+                owner_user_id=meta.get("owner_user_sub", ""),
+                permission=permission if permission in {"owner", "read", "write"} else "read",
+            )
+        )
+    return result
+
+
+@router.post("/calendars/{calendar_id}/shares", response_model=CalendarShareOut)
+async def share_calendar(
+    calendar_id: str,
+    body: CalendarShareIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _require_calendar_owner(calendar_id, ctx["user_sub"])
+    if body.user_sub == ctx["user_sub"]:
+        raise HTTPException(status_code=400, detail="Cannot share a calendar with yourself")
+    now = iso_utc(utc_now())
+    item = {
+        "calendar_id": calendar_id,
+        "sk": _share_key(body.user_sub),
+        "type": "calendar_share",
+        "user_sub": body.user_sub,
+        "permission": body.permission,
+        "created_at_utc": now,
+        "granted_by": ctx["user_sub"],
+    }
+    T.calendar.put_item(Item=item)
+    T.calendar.put_item(Item=_calendar_access_item(body.user_sub, calendar_id, body.permission))
+    audit_event(
+        "calendar_share_create",
+        ctx["user_sub"],
+        None,
+        outcome="success",
+        calendar_id=calendar_id,
+        shared_with=body.user_sub,
+        permission=body.permission,
+    )
+    return CalendarShareOut(
+        calendar_id=calendar_id,
+        user_sub=body.user_sub,
+        permission=body.permission,
+        created_at_utc=now,
+    )
+
+
+@router.get("/calendars/{calendar_id}/shares", response_model=list[CalendarShareOut])
+async def list_calendar_shares(
+    calendar_id: str,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _require_calendar_owner(calendar_id, ctx["user_sub"])
+    response = T.calendar.query(
+        KeyConditionExpression=Key("calendar_id").eq(calendar_id) & Key("sk").begins_with("share#"),
+        ScanIndexForward=True,
+    )
+    items = response.get("Items", [])
+    return [
+        CalendarShareOut(
+            calendar_id=calendar_id,
+            user_sub=item.get("user_sub", ""),
+            permission=item.get("permission", "read"),
+            created_at_utc=item.get("created_at_utc", ""),
+        )
+        for item in items
+    ]
+
+
+@router.delete("/calendars/{calendar_id}/shares/{user_sub}")
+async def delete_calendar_share(
+    calendar_id: str,
+    user_sub: str,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _require_calendar_owner(calendar_id, ctx["user_sub"])
+    T.calendar.delete_item(Key={"calendar_id": calendar_id, "sk": _share_key(user_sub)})
+    T.calendar.delete_item(Key={"calendar_id": _access_partition(user_sub), "sk": _access_key(calendar_id)})
+    audit_event(
+        "calendar_share_delete",
+        ctx["user_sub"],
+        None,
+        outcome="success",
+        calendar_id=calendar_id,
+        shared_with=user_sub,
+    )
+    return {"ok": True}
+
+
+@router.post("/calendars/{calendar_id}/events/conflicts", response_model=EventConflictPreviewOut)
+async def preview_event_conflicts(
+    calendar_id: str,
+    body: EventConflictPreviewIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    meta = _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
+    _validate_booking_settings(body.booking_enabled, body.approval_required)
+    status = _normalize_event_status(body.status)
+    recurrence_rule = _normalize_recurrence_rule(body.recurrence_rule)
+    normalized = _normalize_event_times(meta["timezone"], body)
+    normalized["status"] = status
+    event_snapshot = {
+        "all_day": normalized["all_day"],
+        "timezone": normalized["timezone"],
+        "all_day_date": normalized["all_day_date"],
+        "start_utc": normalized["start_utc"],
+        "end_utc": normalized["end_utc"],
+    }
+    requested_start, requested_end = _event_time_interval(event_snapshot)
+    conflicts: list[Dict[str, Any]] = []
+    if _is_busy_status(status):
+        conflicts, requested_start, requested_end = _find_conflicts(
+            calendar_id,
+            normalized,
+            exclude_event_id=body.event_id,
+        )
+    return EventConflictPreviewOut(
+        requested_start_utc=iso_utc(requested_start),
+        requested_end_utc=iso_utc(requested_end),
+        timezone=normalized["timezone"],
+        conflicts=[_event_out(item, calendar_id) for item in conflicts],
+    )
+
+
+@router.post("/calendars/{calendar_id}/events/suggestions", response_model=list[OpeningsOut])
+async def suggest_event_slots(
+    calendar_id: str,
+    body: EventSuggestionsIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    meta = _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
+    start_dt = parse_iso_dt(body.start_utc)
+    end_dt = parse_iso_dt(body.end_utc)
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="end_utc must be after start_utc")
+    duration_minutes = body.duration_minutes
+    if duration_minutes is None:
+        duration_minutes = int((end_dt - start_dt).total_seconds() / 60)
+    if duration_minutes <= 0:
+        raise HTTPException(status_code=400, detail="duration_minutes must be positive")
+    window_end = start_dt + timedelta(days=body.window_days or 7)
+    if window_end <= start_dt:
+        raise HTTPException(status_code=400, detail="window_days must be positive")
+    openings = _calendar_openings(meta, start_dt, window_end)
+    suggestions = _suggest_slots(openings, timedelta(minutes=duration_minutes), body.limit or 5)
+    return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in suggestions]
+
+
+@router.post("/calendars/{calendar_id}/events/{event_id}/occurrences/{occurrence_start}/exclude", response_model=EventOut)
+async def exclude_event_occurrence(
+    calendar_id: str,
+    event_id: str,
+    occurrence_start: str,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
+    item = _load_event(calendar_id, event_id)
+    occ_key = iso_utc(parse_iso_dt(occurrence_start))
+    exdates = _normalize_exdates(item.get("exdates_utc") or [], item.get("timezone", "UTC")) or []
+    if occ_key not in exdates:
+        exdates.append(occ_key)
+    updated = {**item, "exdates_utc": sorted(set(exdates))}
+    T.calendar.put_item(Item=updated)
+    return _event_out(updated, calendar_id)
+
+
+@router.post("/calendars/{calendar_id}/events/{event_id}/occurrences/{occurrence_start}/override", response_model=EventOut)
+async def override_event_occurrence(
+    calendar_id: str,
+    event_id: str,
+    occurrence_start: str,
+    body: EventOccurrenceOverrideIn,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
+    item = _load_event(calendar_id, event_id)
+    occ_key = iso_utc(parse_iso_dt(occurrence_start))
+    overrides = item.get("recurrence_overrides") or {}
+    overrides[occ_key] = _normalize_occurrence_override(item.get("timezone", "UTC"), body)
+    updated = {**item, "recurrence_overrides": overrides}
+    T.calendar.put_item(Item=updated)
+    return _event_out(updated, calendar_id)
+
+
+@router.delete("/calendars/{calendar_id}/events/{event_id}/occurrences/{occurrence_start}", response_model=EventOut)
+async def clear_event_occurrence_exception(
+    calendar_id: str,
+    event_id: str,
+    occurrence_start: str,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
+    item = _load_event(calendar_id, event_id)
+    occ_key = iso_utc(parse_iso_dt(occurrence_start))
+    exdates = _normalize_exdates(item.get("exdates_utc") or [], item.get("timezone", "UTC")) or []
+    overrides = item.get("recurrence_overrides") or {}
+    if occ_key in exdates:
+        exdates = [value for value in exdates if value != occ_key]
+    if occ_key in overrides:
+        overrides.pop(occ_key, None)
+    updated = {**item, "exdates_utc": exdates or None, "recurrence_overrides": overrides or None}
+    T.calendar.put_item(Item=updated)
+    return _event_out(updated, calendar_id)
+
+
 @router.post("/calendars/{calendar_id}/events", response_model=EventOut)
 async def create_event(
     calendar_id: str,
@@ -637,12 +1100,14 @@ async def create_event(
     force: bool = Query(False, description="Allow conflicts when true"),
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
-    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    meta = _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
     _validate_booking_settings(body.booking_enabled, body.approval_required)
     status = _normalize_event_status(body.status)
     recurrence_rule = _normalize_recurrence_rule(body.recurrence_rule)
     normalized = _normalize_event_times(meta["timezone"], body)
     normalized["status"] = status
+    exdates = _normalize_exdates(body.exdates_utc, normalized["timezone"])
+    overrides = _normalize_overrides(body.recurrence_overrides, normalized["timezone"])
     if meta.get("conflict_detection") and not force and _is_busy_status(status):
         _ensure_no_conflicts(calendar_id, normalized)
     event_id = uuid.uuid4().hex
@@ -660,6 +1125,8 @@ async def create_event(
         "status": status,
         "category": body.category,
         "recurrence_rule": recurrence_rule.model_dump() if recurrence_rule else None,
+        "exdates_utc": exdates,
+        "recurrence_overrides": overrides,
         "created_at_utc": now,
         **normalized,
     }
@@ -695,6 +1162,8 @@ async def create_event(
         status=status,
         category=body.category,
         recurrence_rule=recurrence_rule,
+        exdates_utc=exdates,
+        recurrence_overrides=overrides,
         created_at_utc=now,
     )
 
@@ -705,7 +1174,7 @@ async def create_booking_link(
     body: BookingLinkCreateIn,
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
-    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    meta = _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
     tz_name = body.timezone or meta.get("timezone", "UTC")
     _validate_timezone(tz_name)
     link_id = uuid.uuid4().hex
@@ -733,6 +1202,31 @@ async def create_booking_link(
     )
 
 
+@router.get("/calendars/{calendar_id}/booking_links", response_model=list[BookingLinkOut])
+async def list_booking_links(
+    calendar_id: str,
+    ctx: Dict[str, str] = Depends(require_ui_session),
+):
+    _load_calendar_access(calendar_id, ctx["user_sub"])
+    response = T.calendar.query(
+        KeyConditionExpression=Key("calendar_id").eq(calendar_id) & Key("sk").begins_with("booking#"),
+        ScanIndexForward=True,
+    )
+    items = response.get("Items", [])
+    return [
+        BookingLinkOut(
+            link_id=item["link_id"],
+            calendar_id=calendar_id,
+            name=item.get("name", ""),
+            duration_minutes=int(item.get("duration_minutes", 0)),
+            timezone=item.get("timezone", "UTC"),
+            created_at_utc=item.get("created_at_utc", ""),
+            public_url=f"/booking/{item['link_id']}",
+        )
+        for item in items
+    ]
+
+
 @router.get("/calendars/{calendar_id}/events", response_model=EventsPageOut)
 async def list_events(
     calendar_id: str,
@@ -748,7 +1242,7 @@ async def list_events(
     cursor: Annotated[str | None, Query(description="Pagination cursor")] = None,
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
-    _load_calendar(calendar_id, ctx["user_sub"])
+    _load_calendar_access(calendar_id, ctx["user_sub"])
     start_dt = parse_iso_dt(start_utc) if start_utc else None
     end_dt = parse_iso_dt(end_utc) if end_utc else None
     items, next_cursor = _list_events(
@@ -775,7 +1269,7 @@ async def update_calendar(
     body: CalendarUpdateIn,
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
-    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    meta = _require_calendar_owner(calendar_id, ctx["user_sub"])
     name = body.name if body.name is not None else meta.get("name", "")
     timezone_name = body.timezone if body.timezone is not None else meta.get("timezone", "UTC")
     if body.timezone is not None:
@@ -828,7 +1322,7 @@ async def update_event(
     body: EventUpdateIn,
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
-    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    meta = _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
     item = _load_event(calendar_id, event_id)
     raw_recurrence = body.recurrence_rule if body.recurrence_rule is not None else item.get("recurrence_rule")
     recurrence_rule = RecurrenceRule(**raw_recurrence) if raw_recurrence else None
@@ -850,12 +1344,18 @@ async def update_event(
         status=body.status if body.status is not None else item.get("status", "busy"),
         category=body.category if body.category is not None else item.get("category"),
         recurrence_rule=recurrence_rule,
+        exdates_utc=body.exdates_utc if body.exdates_utc is not None else item.get("exdates_utc"),
+        recurrence_overrides=(
+            body.recurrence_overrides if body.recurrence_overrides is not None else item.get("recurrence_overrides")
+        ),
     )
     _validate_booking_settings(payload.booking_enabled, payload.approval_required)
     status = _normalize_event_status(payload.status)
     recurrence_rule = _normalize_recurrence_rule(payload.recurrence_rule)
     normalized = _normalize_event_times(meta["timezone"], payload)
     normalized["status"] = status
+    exdates = _normalize_exdates(payload.exdates_utc, normalized["timezone"])
+    overrides = _normalize_overrides(payload.recurrence_overrides, normalized["timezone"])
     if meta.get("conflict_detection") and _is_busy_status(status):
         _ensure_no_conflicts(calendar_id, normalized, exclude_event_id=event_id)
     updated = {
@@ -868,6 +1368,8 @@ async def update_event(
         "status": status,
         "category": payload.category,
         "recurrence_rule": recurrence_rule.model_dump() if recurrence_rule else None,
+        "exdates_utc": exdates,
+        "recurrence_overrides": overrides,
         **normalized,
     }
     T.calendar.put_item(Item=updated)
@@ -895,7 +1397,7 @@ async def delete_event(
     event_id: str,
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
-    _load_calendar(calendar_id, ctx["user_sub"])
+    _load_calendar_access(calendar_id, ctx["user_sub"], write=True)
     item = _load_event(calendar_id, event_id)
     T.calendar.delete_item(Key={"calendar_id": calendar_id, "sk": _event_key(event_id)})
     audit_event(
@@ -918,13 +1420,24 @@ async def delete_event(
 
 @router.delete("/calendars/{calendar_id}")
 async def delete_calendar(calendar_id: str, ctx: Dict[str, str] = Depends(require_ui_session)):
-    _load_calendar(calendar_id, ctx["user_sub"])
+    _require_calendar_owner(calendar_id, ctx["user_sub"])
     events, _ = _list_events(calendar_id)
+    share_response = T.calendar.query(
+        KeyConditionExpression=Key("calendar_id").eq(calendar_id) & Key("sk").begins_with("share#"),
+        ScanIndexForward=True,
+    )
+    shares = share_response.get("Items", [])
     with T.calendar.batch_writer() as batch:
         batch.delete_item(Key={"calendar_id": calendar_id, "sk": "meta"})
         for event in events:
             event_sk = event.get("sk") or _event_key(event["event_id"])
             batch.delete_item(Key={"calendar_id": calendar_id, "sk": event_sk})
+        for share in shares:
+            user_sub = share.get("user_sub")
+            if user_sub:
+                batch.delete_item(Key={"calendar_id": _access_partition(user_sub), "sk": _access_key(calendar_id)})
+            batch.delete_item(Key={"calendar_id": calendar_id, "sk": share.get("sk")})
+        batch.delete_item(Key={"calendar_id": _access_partition(ctx["user_sub"]), "sk": _access_key(calendar_id)})
     return {"ok": True}
 
 
@@ -936,7 +1449,7 @@ async def list_openings(
     ctx: Dict[str, str] = Depends(require_ui_session),
 ):
     window_start, window_end = parse_availability_window(start_utc, end_utc)
-    meta = _load_calendar(calendar_id, ctx["user_sub"])
+    meta = _load_calendar_access(calendar_id, ctx["user_sub"])
     free = _calendar_openings(meta, window_start, window_end)
     return [OpeningsOut(start_utc=iso_utc(s), end_utc=iso_utc(e)) for s, e in free]
 
@@ -948,7 +1461,7 @@ async def list_team_openings(body: TeamAvailabilityIn, ctx: Dict[str, str] = Dep
         raise HTTPException(status_code=400, detail="calendar_ids is required")
     combined: list[tuple[datetime, datetime]] | None = None
     for calendar_id in body.calendar_ids:
-        meta = _load_calendar(calendar_id, ctx["user_sub"])
+        meta = _load_calendar_access(calendar_id, ctx["user_sub"])
         openings = _calendar_openings(meta, window_start, window_end)
         combined = openings if combined is None else _intersect_intervals(combined, openings)
     free = combined or []

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -587,6 +587,29 @@
     <div id="calendarStatus" class="muted" style="margin-top:6px;"></div>
 
     <div class="section" style="margin-top:16px;">
+      <h4 style="margin:0 0 8px 0;">Calendar access</h4>
+      <div class="muted">View calendars you can access and manage sharing for the active calendar.</div>
+      <div class="row-inline" style="margin-top:8px;">
+        <button id="calendarAccessRefreshBtn">Refresh access</button>
+        <span id="calendarAccessStatus" class="muted"></span>
+      </div>
+      <div id="calendarAccessList" class="list" style="margin-top:8px;"></div>
+      <div class="section" style="margin-top:12px;">
+        <h5 style="margin:0 0 6px 0;">Share calendar</h5>
+        <div class="row-inline">
+          <input id="calendarShareUserInput" placeholder="User sub to share with" style="flex:1;"/>
+          <select id="calendarSharePermissionInput" style="width:160px;">
+            <option value="read">Permission: read</option>
+            <option value="write">Permission: write</option>
+          </select>
+          <button id="calendarShareCreateBtn">Share</button>
+        </div>
+        <div id="calendarShareStatus" class="muted" style="margin-top:6px;"></div>
+        <div id="calendarSharesList" class="list" style="margin-top:8px;"></div>
+      </div>
+    </div>
+
+    <div class="section" style="margin-top:16px;">
       <h4 style="margin:0 0 8px 0;">Create event</h4>
       <input id="eventIdInput" type="hidden" />
       <div class="row-inline">
@@ -610,14 +633,105 @@
         <button id="eventCancelEditBtn" class="muted">Cancel edit</button>
       </div>
       <div id="eventCreateStatus" class="muted" style="margin-top:6px;"></div>
+      <div class="section" style="margin-top:12px;">
+        <h5 style="margin:0 0 6px 0;">Recurrence</h5>
+        <div class="row-inline">
+          <select id="eventRecurrenceFreq" style="width:180px;">
+            <option value="">No recurrence</option>
+            <option value="DAILY">Daily</option>
+            <option value="WEEKLY">Weekly</option>
+            <option value="MONTHLY">Monthly</option>
+          </select>
+          <input id="eventRecurrenceInterval" type="number" min="1" placeholder="Interval" style="width:120px;" />
+          <input id="eventRecurrenceCount" type="number" min="1" placeholder="Count" style="width:120px;" />
+          <input id="eventRecurrenceUntil" class="mono" placeholder="Until (ISO-8601 UTC)" style="flex:1;" />
+        </div>
+        <div class="row-inline" style="margin-top:8px; flex-wrap:wrap;">
+          <label class="muted">By day:</label>
+          <label><input type="checkbox" data-day="MO" class="eventRecurrenceByday"/> Mon</label>
+          <label><input type="checkbox" data-day="TU" class="eventRecurrenceByday"/> Tue</label>
+          <label><input type="checkbox" data-day="WE" class="eventRecurrenceByday"/> Wed</label>
+          <label><input type="checkbox" data-day="TH" class="eventRecurrenceByday"/> Thu</label>
+          <label><input type="checkbox" data-day="FR" class="eventRecurrenceByday"/> Fri</label>
+          <label><input type="checkbox" data-day="SA" class="eventRecurrenceByday"/> Sat</label>
+          <label><input type="checkbox" data-day="SU" class="eventRecurrenceByday"/> Sun</label>
+        </div>
+        <div class="row-inline" style="margin-top:8px;">
+          <input id="eventRecurrenceBymonthday" class="mono" placeholder="BYMONTHDAY (e.g. 15,-1)" style="flex:1;" />
+          <input id="eventRecurrenceBysetpos" class="mono" placeholder="BYSETPOS (e.g. 2,-1)" style="flex:1;" />
+        </div>
+        <div class="muted" style="margin-top:6px;">BYSETPOS works with BYDAY for monthly rules (e.g., 2nd Tuesday).</div>
+        <div class="row-inline" style="margin-top:8px;">
+          <textarea id="eventRecurrenceExdates" rows="2" class="mono" placeholder="EXDATEs (ISO-8601 UTC, one per line)" style="flex:1;"></textarea>
+        </div>
+      </div>
+      <div class="section" style="margin-top:12px;">
+        <h5 style="margin:0 0 6px 0;">Conflict preview</h5>
+        <div class="row-inline">
+          <button id="eventPreviewConflictsBtn">Preview conflicts</button>
+          <button id="eventSuggestSlotsBtn" class="muted">Suggest alternate slots</button>
+          <span id="eventConflictStatus" class="muted"></span>
+        </div>
+        <div id="eventConflictsList" class="list" style="margin-top:8px;"></div>
+        <div id="eventSuggestionsList" class="list" style="margin-top:8px;"></div>
+      </div>
     </div>
 
     <div class="section" style="margin-top:16px;">
       <h4 style="margin:0 0 8px 0;">Events</h4>
+      <div class="muted">Use a start and end window to expand recurring events.</div>
       <div class="row-inline">
+        <input id="eventsStartInput" class="mono" placeholder="Start window (ISO-8601 UTC)" style="flex:1;"/>
+        <input id="eventsEndInput" class="mono" placeholder="End window (ISO-8601 UTC)" style="flex:1;"/>
         <button id="eventsRefreshBtn">Refresh events</button>
+        <button id="eventsClearFiltersBtn" class="muted">Clear filters</button>
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="eventsStartPicker" type="datetime-local" style="flex:1;" />
+        <input id="eventsEndPicker" type="datetime-local" style="flex:1;" />
+        <select id="eventsLimitSelect" style="width:160px;">
+          <option value="">Limit: default</option>
+          <option value="25">Limit: 25</option>
+          <option value="50">Limit: 50</option>
+          <option value="100">Limit: 100</option>
+          <option value="200">Limit: 200</option>
+        </select>
+      </div>
+      <div class="row-inline" style="margin-top:8px;">
+        <button id="eventsPrevBtn" class="muted">Prev page</button>
+        <button id="eventsNextBtn" class="muted">Next page</button>
+        <span id="eventsStatus" class="muted"></span>
       </div>
       <div id="calendarEventsList" class="list" style="margin-top:8px;"></div>
+    </div>
+
+    <div class="section" style="margin-top:16px;">
+      <h4 style="margin:0 0 8px 0;">Booking links</h4>
+      <div class="muted">Create shareable booking links and preview openings.</div>
+      <div class="row-inline" style="margin-top:8px;">
+        <input id="bookingLinkNameInput" placeholder="Link name" style="flex:1;"/>
+        <input id="bookingLinkDurationInput" type="number" min="5" max="1440" placeholder="Duration (minutes)" style="width:200px;"/>
+        <input id="bookingLinkTimezoneInput" placeholder="Timezone (optional)" style="width:220px;"/>
+        <button id="bookingLinkCreateBtn" class="primary">Create link</button>
+      </div>
+      <div id="bookingLinkStatus" class="muted" style="margin-top:6px;"></div>
+      <div id="bookingLinksList" class="list" style="margin-top:8px;"></div>
+      <div class="section" style="margin-top:12px;">
+        <h5 style="margin:0 0 6px 0;">Preview openings</h5>
+        <div class="row-inline">
+          <select id="bookingLinkSelect" style="flex:1;"></select>
+          <input id="bookingOpeningsStartInput" class="mono" placeholder="Start window (ISO-8601 UTC)" style="flex:1;"/>
+          <input id="bookingOpeningsEndInput" class="mono" placeholder="End window (ISO-8601 UTC)" style="flex:1;"/>
+          <button id="bookingOpeningsLoadBtn">Load openings</button>
+        </div>
+        <div class="row-inline" style="margin-top:8px;">
+          <input id="bookingOpeningsStartPicker" type="datetime-local" style="flex:1;" />
+          <input id="bookingOpeningsEndPicker" type="datetime-local" style="flex:1;" />
+          <input id="bookingOpeningsLimitInput" type="number" min="1" max="200" placeholder="Limit" style="width:120px;"/>
+        </div>
+        <div id="bookingOpeningsStatus" class="muted" style="margin-top:6px;"></div>
+        <div id="bookingOpeningsList" class="list" style="margin-top:8px;"></div>
+      </div>
     </div>
 
     <div class="section" style="margin-top:16px;">

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -2507,6 +2507,8 @@ async function refreshAll() {
       refreshAddresses(),
       refreshShoppingCart(),
       billingRefreshAll(),
+      refreshCalendarAccess(),
+      refreshCalendarShares(),
       refreshCalendarEvents(),
     ]);
     await pollToastsOnce();
@@ -2621,6 +2623,17 @@ function setCalendarStatus(msg) {
   if (el) el.textContent = msg || "";
 }
 
+const eventsPagination = {
+  currentCursor: null,
+  nextCursor: null,
+  prevStack: [],
+  lastQueryKey: "",
+};
+
+let calendarAccessItems = [];
+let calendarShares = [];
+let bookingLinks = [];
+
 function renderCalendarEvents(events) {
   const wrap = document.getElementById("calendarEventsList");
   if (!wrap) return;
@@ -2635,11 +2648,21 @@ function renderCalendarEvents(events) {
     const when = evt.all_day
       ? `All day ${escapeHtml(evt.all_day_date || "")}`
       : `${escapeHtml(evt.start_utc || "")} → ${escapeHtml(evt.end_utc || "")}`;
+    const recurrenceButtons = evt.recurrence_rule && evt.start_utc
+      ? `
+      <div class="row-inline" style="margin-top:6px;">
+        <button data-action="exclude" data-id="${escapeHtml(evt.event_id || "")}" data-start="${escapeHtml(evt.start_utc || "")}">Exclude occurrence</button>
+        <button data-action="override" data-id="${escapeHtml(evt.event_id || "")}" data-start="${escapeHtml(evt.start_utc || "")}">Edit occurrence</button>
+        <button class="muted" data-action="clear" data-id="${escapeHtml(evt.event_id || "")}" data-start="${escapeHtml(evt.start_utc || "")}">Clear exception</button>
+      </div>
+      `
+      : "";
     const buttons = `
       <div class="row-inline" style="margin-top:6px;">
         <button data-action="edit" data-id="${escapeHtml(evt.event_id || "")}">Edit</button>
         <button class="danger" data-action="delete" data-id="${escapeHtml(evt.event_id || "")}">Delete</button>
       </div>
+      ${recurrenceButtons}
     `;
     row.innerHTML = `
       <div class="row">
@@ -2656,6 +2679,17 @@ function renderCalendarEvents(events) {
     row.querySelector('[data-action="delete"]').onclick = async () => {
       await deleteCalendarEvent(evt.event_id);
     };
+    if (recurrenceButtons) {
+      row.querySelector('[data-action="exclude"]').onclick = async (ev) => {
+        await excludeEventOccurrence(ev.target.getAttribute("data-id"), ev.target.getAttribute("data-start"));
+      };
+      row.querySelector('[data-action="override"]').onclick = async (ev) => {
+        await overrideEventOccurrence(ev.target.getAttribute("data-id"), ev.target.getAttribute("data-start"), evt);
+      };
+      row.querySelector('[data-action="clear"]').onclick = async (ev) => {
+        await clearEventOccurrenceException(ev.target.getAttribute("data-id"), ev.target.getAttribute("data-start"));
+      };
+    }
     wrap.appendChild(row);
   });
 }
@@ -2692,6 +2726,216 @@ function renderTeamOpenings(openings) {
   });
 }
 
+function renderEventConflicts(conflicts) {
+  const wrap = document.getElementById("eventConflictsList");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  if (!conflicts || conflicts.length === 0) {
+    wrap.innerHTML = '<div class="muted">No conflicts found.</div>';
+    return;
+  }
+  conflicts.forEach(evt => {
+    const row = document.createElement("div");
+    row.className = "item";
+    const when = evt.all_day
+      ? `All day ${escapeHtml(evt.all_day_date || "")}`
+      : `${escapeHtml(evt.start_utc || "")} → ${escapeHtml(evt.end_utc || "")}`;
+    row.innerHTML = `
+      <div class="row">
+        <div class="grow"><b>${escapeHtml(evt.name || "")}</b></div>
+        <div class="mono">${escapeHtml(evt.event_id || "")}</div>
+      </div>
+      <div class="muted">${when} (${escapeHtml(evt.timezone || "")})</div>
+    `;
+    wrap.appendChild(row);
+  });
+}
+
+function renderEventSuggestions(suggestions) {
+  const wrap = document.getElementById("eventSuggestionsList");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  if (!suggestions || suggestions.length === 0) {
+    wrap.innerHTML = '<div class="muted">No suggested slots available.</div>';
+    return;
+  }
+  suggestions.forEach(slot => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `
+      <div class="row-inline" style="align-items:center;">
+        <div class="mono grow">${escapeHtml(slot.start_utc)} → ${escapeHtml(slot.end_utc)}</div>
+        <button data-action="apply" data-start="${escapeHtml(slot.start_utc)}" data-end="${escapeHtml(slot.end_utc)}">Use slot</button>
+      </div>
+    `;
+    row.querySelector('[data-action="apply"]').onclick = (ev) => {
+      const start = ev.target.getAttribute("data-start");
+      const end = ev.target.getAttribute("data-end");
+      if (!start || !end) return;
+      document.getElementById("eventAllDayToggle").checked = false;
+      document.getElementById("eventAllDayDateInput").value = "";
+      document.getElementById("eventStartInput").value = start;
+      document.getElementById("eventEndInput").value = end;
+      document.getElementById("eventCreateStatus").textContent = "Applied suggested slot.";
+    };
+    wrap.appendChild(row);
+  });
+}
+
+function renderCalendarAccess(items) {
+  calendarAccessItems = Array.isArray(items) ? items : [];
+  const wrap = document.getElementById("calendarAccessList");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  if (!calendarAccessItems.length) {
+    wrap.innerHTML = '<div class="muted">No accessible calendars yet.</div>';
+    return;
+  }
+  calendarAccessItems.forEach(item => {
+    const row = document.createElement("div");
+    row.className = "item";
+    row.innerHTML = `
+      <div class="row">
+        <div class="grow"><b>${escapeHtml(item.name || "Calendar")}</b></div>
+        <div class="mono">${escapeHtml(item.calendar_id || "")}</div>
+      </div>
+      <div class="muted">Owner: ${escapeHtml(item.owner_user_id || "")} · Permission: ${escapeHtml(item.permission || "read")}</div>
+      <div class="row-inline" style="margin-top:6px;">
+        <button data-action="use" data-id="${escapeHtml(item.calendar_id || "")}">Use calendar</button>
+      </div>
+    `;
+    row.querySelector('[data-action="use"]').onclick = async (ev) => {
+      const calendarId = ev.target.getAttribute("data-id");
+      setCalendarId(calendarId || "");
+      if (calendarId) {
+        setCalendarStatus(`Using calendar ${calendarId}`);
+        resetEventsPagination();
+        await refreshBookingLinks();
+        await refreshCalendarEvents();
+        await refreshCalendarShares();
+      }
+    };
+    wrap.appendChild(row);
+  });
+}
+
+function renderCalendarShares(items) {
+  calendarShares = Array.isArray(items) ? items : [];
+  const wrap = document.getElementById("calendarSharesList");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  if (!calendarShares.length) {
+    wrap.innerHTML = '<div class="muted">No shares for this calendar.</div>';
+    return;
+  }
+  calendarShares.forEach(share => {
+    const row = document.createElement("div");
+    row.className = "item";
+    row.innerHTML = `
+      <div class="row">
+        <div class="grow"><b>${escapeHtml(share.user_sub || "")}</b></div>
+        <div class="mono">${escapeHtml(share.permission || "read")}</div>
+      </div>
+      <div class="muted">Shared at ${escapeHtml(share.created_at_utc || "")}</div>
+      <div class="row-inline" style="margin-top:6px;">
+        <button class="danger" data-action="revoke" data-user="${escapeHtml(share.user_sub || "")}">Revoke</button>
+      </div>
+    `;
+    row.querySelector('[data-action="revoke"]').onclick = async (ev) => {
+      const userSub = ev.target.getAttribute("data-user");
+      if (!userSub) return;
+      await deleteCalendarShare(userSub);
+    };
+    wrap.appendChild(row);
+  });
+}
+
+function renderBookingLinks(links) {
+  bookingLinks = Array.isArray(links) ? links : [];
+  const wrap = document.getElementById("bookingLinksList");
+  if (wrap) {
+    wrap.innerHTML = "";
+    if (!bookingLinks.length) {
+      wrap.innerHTML = '<div class="muted">No booking links yet.</div>';
+    } else {
+      bookingLinks.forEach(link => {
+        const row = document.createElement("div");
+        row.className = "item";
+        const publicUrl = link.public_url || `/booking/${link.link_id}`;
+        row.innerHTML = `
+          <div class="row">
+            <div class="grow"><b>${escapeHtml(link.name || "")}</b></div>
+            <div class="mono">${escapeHtml(link.link_id || "")}</div>
+          </div>
+          <div class="muted">Duration: ${escapeHtml(String(link.duration_minutes || 0))} min · ${escapeHtml(link.timezone || "UTC")}</div>
+          <div class="row-inline" style="margin-top:6px; align-items:center;">
+            <div class="mono grow">${escapeHtml(publicUrl)}</div>
+            <button data-action="copy" data-url="${escapeHtml(publicUrl)}">Copy URL</button>
+            <button data-action="use" data-id="${escapeHtml(link.link_id || "")}">Use for preview</button>
+          </div>
+        `;
+        row.querySelector('[data-action="copy"]').onclick = async (ev) => {
+          const url = ev.target.getAttribute("data-url");
+          if (!url) return;
+          try {
+            await navigator.clipboard.writeText(url);
+            const status = document.getElementById("bookingLinkStatus");
+            if (status) status.textContent = "Copied link URL.";
+          } catch (e) {
+            prompt("Copy booking link URL:", url);
+          }
+        };
+        row.querySelector('[data-action="use"]').onclick = (ev) => {
+          const linkId = ev.target.getAttribute("data-id");
+          const select = document.getElementById("bookingLinkSelect");
+          if (select && linkId) {
+            select.value = linkId;
+          }
+        };
+        wrap.appendChild(row);
+      });
+    }
+  }
+
+  const select = document.getElementById("bookingLinkSelect");
+  if (select) {
+    select.innerHTML = "";
+    if (!bookingLinks.length) {
+      const opt = document.createElement("option");
+      opt.value = "";
+      opt.textContent = "No booking links available";
+      select.appendChild(opt);
+    } else {
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select booking link";
+      select.appendChild(placeholder);
+      bookingLinks.forEach(link => {
+        const opt = document.createElement("option");
+        opt.value = link.link_id || "";
+        opt.textContent = `${link.name || "Booking link"} (${link.duration_minutes || 0} min)`;
+        select.appendChild(opt);
+      });
+    }
+  }
+}
+
+function renderBookingOpenings(openings) {
+  const wrap = document.getElementById("bookingOpeningsList");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  if (!openings || openings.length === 0) {
+    wrap.innerHTML = '<div class="muted">No openings for selected window.</div>';
+    return;
+  }
+  openings.forEach(o => {
+    const row = document.createElement("div");
+    row.className = "list-item";
+    row.innerHTML = `<div class="mono">${escapeHtml(o.start_utc)} → ${escapeHtml(o.end_utc)}</div>`;
+    wrap.appendChild(row);
+  });
+}
+
 function parseTeamCalendarIds(raw) {
   return raw
     .split(/[\n,]+/)
@@ -2707,6 +2951,60 @@ function toIsoUtc(value) {
   return dt.toISOString();
 }
 
+function getEventFilters() {
+  const startPicker = document.getElementById("eventsStartPicker").value.trim();
+  const endPicker = document.getElementById("eventsEndPicker").value.trim();
+  const start = startPicker ? toIsoUtc(startPicker) : document.getElementById("eventsStartInput").value.trim();
+  const end = endPicker ? toIsoUtc(endPicker) : document.getElementById("eventsEndInput").value.trim();
+  const limitRaw = document.getElementById("eventsLimitSelect").value;
+  const limit = limitRaw ? Number.parseInt(limitRaw, 10) : null;
+  return { start, end, limit };
+}
+
+function updateEventsStatus(message) {
+  const status = document.getElementById("eventsStatus");
+  if (status) status.textContent = message || "";
+}
+
+function updateEventsPaginationControls() {
+  const prevBtn = document.getElementById("eventsPrevBtn");
+  const nextBtn = document.getElementById("eventsNextBtn");
+  if (prevBtn) prevBtn.disabled = eventsPagination.prevStack.length === 0;
+  if (nextBtn) nextBtn.disabled = !eventsPagination.nextCursor;
+}
+
+function resetEventsPagination() {
+  eventsPagination.currentCursor = null;
+  eventsPagination.nextCursor = null;
+  eventsPagination.prevStack = [];
+  updateEventsPaginationControls();
+}
+
+function updateBookingLinkStatus(message) {
+  const status = document.getElementById("bookingLinkStatus");
+  if (status) status.textContent = message || "";
+}
+
+function updateBookingOpeningsStatus(message) {
+  const status = document.getElementById("bookingOpeningsStatus");
+  if (status) status.textContent = message || "";
+}
+
+function updateEventConflictStatus(message) {
+  const status = document.getElementById("eventConflictStatus");
+  if (status) status.textContent = message || "";
+}
+
+function updateCalendarAccessStatus(message) {
+  const status = document.getElementById("calendarAccessStatus");
+  if (status) status.textContent = message || "";
+}
+
+function updateCalendarShareStatus(message) {
+  const status = document.getElementById("calendarShareStatus");
+  if (status) status.textContent = message || "";
+}
+
 function setEventEditMode(evt) {
   document.getElementById("eventIdInput").value = evt.event_id || "";
   document.getElementById("eventNameInput").value = evt.name || "";
@@ -2716,6 +3014,17 @@ function setEventEditMode(evt) {
   document.getElementById("eventAllDayDateInput").value = evt.all_day_date || "";
   document.getElementById("eventStartInput").value = evt.start_utc || "";
   document.getElementById("eventEndInput").value = evt.end_utc || "";
+  document.getElementById("eventRecurrenceFreq").value = evt.recurrence_rule?.freq || "";
+  document.getElementById("eventRecurrenceInterval").value = evt.recurrence_rule?.interval || "";
+  document.getElementById("eventRecurrenceCount").value = evt.recurrence_rule?.count || "";
+  document.getElementById("eventRecurrenceUntil").value = evt.recurrence_rule?.until_utc || "";
+  document.getElementById("eventRecurrenceBymonthday").value = (evt.recurrence_rule?.bymonthday || []).join(",");
+  document.getElementById("eventRecurrenceBysetpos").value = (evt.recurrence_rule?.bysetpos || []).join(",");
+  document.getElementById("eventRecurrenceExdates").value = (evt.exdates_utc || []).join("\n");
+  document.querySelectorAll(".eventRecurrenceByday").forEach(box => {
+    const day = box.getAttribute("data-day");
+    box.checked = !!evt.recurrence_rule?.byday?.includes(day);
+  });
   document.getElementById("eventCreateBtn").textContent = "Save event";
   document.getElementById("eventCreateStatus").textContent = `Editing ${evt.event_id}`;
 }
@@ -2729,7 +3038,70 @@ function resetEventForm() {
   document.getElementById("eventAllDayDateInput").value = "";
   document.getElementById("eventStartInput").value = "";
   document.getElementById("eventEndInput").value = "";
+  document.getElementById("eventRecurrenceFreq").value = "";
+  document.getElementById("eventRecurrenceInterval").value = "";
+  document.getElementById("eventRecurrenceCount").value = "";
+  document.getElementById("eventRecurrenceUntil").value = "";
+  document.getElementById("eventRecurrenceBymonthday").value = "";
+  document.getElementById("eventRecurrenceBysetpos").value = "";
+  document.getElementById("eventRecurrenceExdates").value = "";
+  document.querySelectorAll(".eventRecurrenceByday").forEach(box => { box.checked = false; });
   document.getElementById("eventCreateBtn").textContent = "Add event";
+  updateEventConflictStatus("");
+  renderEventConflicts([]);
+  renderEventSuggestions([]);
+}
+
+function parseCsvNumbers(value) {
+  if (!value) return [];
+  return value
+    .split(/[\n,]+/)
+    .map(v => v.trim())
+    .filter(Boolean)
+    .map(v => Number.parseInt(v, 10))
+    .filter(v => !Number.isNaN(v));
+}
+
+function buildRecurrenceRule() {
+  const freq = document.getElementById("eventRecurrenceFreq").value;
+  if (!freq) return null;
+  const intervalRaw = document.getElementById("eventRecurrenceInterval").value.trim();
+  const countRaw = document.getElementById("eventRecurrenceCount").value.trim();
+  const untilRaw = document.getElementById("eventRecurrenceUntil").value.trim();
+  const byday = Array.from(document.querySelectorAll(".eventRecurrenceByday"))
+    .filter(box => box.checked)
+    .map(box => box.getAttribute("data-day"));
+  const bymonthday = parseCsvNumbers(document.getElementById("eventRecurrenceBymonthday").value.trim());
+  const bysetpos = parseCsvNumbers(document.getElementById("eventRecurrenceBysetpos").value.trim());
+  const rule = {
+    freq,
+    interval: intervalRaw ? Number.parseInt(intervalRaw, 10) : 1,
+  };
+  if (countRaw) rule.count = Number.parseInt(countRaw, 10);
+  if (untilRaw) rule.until_utc = toIsoUtc(untilRaw);
+  if (byday.length) rule.byday = byday;
+  if (bymonthday.length) rule.bymonthday = bymonthday;
+  if (bysetpos.length) rule.bysetpos = bysetpos;
+  return rule;
+}
+
+function buildEventPayload() {
+  const exdates = document.getElementById("eventRecurrenceExdates").value
+    .split(/\n+/)
+    .map(value => value.trim())
+    .filter(Boolean)
+    .map(value => toIsoUtc(value));
+  return {
+    name: document.getElementById("eventNameInput").value.trim(),
+    description: document.getElementById("eventDescriptionInput").value.trim(),
+    timezone: document.getElementById("eventTimezoneInput").value.trim() || null,
+    all_day: document.getElementById("eventAllDayToggle").checked,
+    all_day_date: document.getElementById("eventAllDayDateInput").value || null,
+    start_utc: document.getElementById("eventStartInput").value.trim() || null,
+    end_utc: document.getElementById("eventEndInput").value.trim() || null,
+    recurrence_rule: buildRecurrenceRule(),
+    exdates_utc: exdates.length ? exdates : null,
+  };
 }
 
 function buildWorkingHours() {
@@ -2761,9 +3133,151 @@ async function createCalendar() {
     const res = await apiPost("/ui/calendars", { name, timezone });
     setCalendarId(res.calendar_id || "");
     setCalendarStatus(`Created calendar ${res.calendar_id}`);
+    await refreshCalendarAccess();
+    await refreshCalendarShares();
+    await refreshBookingLinks();
     await refreshCalendarEvents();
   } catch (e) {
     setCalendarStatus("Error: " + e.message);
+  }
+}
+
+async function refreshCalendarAccess() {
+  try {
+    await ensureUiSession();
+    updateCalendarAccessStatus("Loading...");
+    const res = await apiGet("/ui/calendars");
+    renderCalendarAccess(res || []);
+    updateCalendarAccessStatus(`Loaded ${Array.isArray(res) ? res.length : 0} calendars.`);
+  } catch (e) {
+    updateCalendarAccessStatus("Error: " + e.message);
+  }
+}
+
+async function refreshCalendarShares() {
+  const calendarId = getCalendarId();
+  if (!calendarId) {
+    renderCalendarShares([]);
+    updateCalendarShareStatus("Set a calendar ID to manage shares.");
+    return;
+  }
+  try {
+    await ensureUiSession();
+    updateCalendarShareStatus("Loading...");
+    const res = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/shares`);
+    renderCalendarShares(res || []);
+    updateCalendarShareStatus(`Loaded ${Array.isArray(res) ? res.length : 0} shares.`);
+  } catch (e) {
+    renderCalendarShares([]);
+    updateCalendarShareStatus("Error: " + e.message);
+  }
+}
+
+async function createCalendarShare() {
+  const calendarId = getCalendarId();
+  if (!calendarId) {
+    updateCalendarShareStatus("Set a calendar ID first.");
+    return;
+  }
+  const userSub = document.getElementById("calendarShareUserInput").value.trim();
+  const permission = document.getElementById("calendarSharePermissionInput").value;
+  if (!userSub) {
+    updateCalendarShareStatus("Enter a user sub to share with.");
+    return;
+  }
+  try {
+    await ensureUiSession();
+    const res = await apiPost(`/ui/calendars/${encodeURIComponent(calendarId)}/shares`, {
+      user_sub: userSub,
+      permission,
+    });
+    updateCalendarShareStatus(`Shared with ${res.user_sub}.`);
+    document.getElementById("calendarShareUserInput").value = "";
+    await refreshCalendarShares();
+    await refreshCalendarAccess();
+  } catch (e) {
+    updateCalendarShareStatus("Error: " + e.message);
+  }
+}
+
+async function deleteCalendarShare(userSub) {
+  const calendarId = getCalendarId();
+  if (!calendarId || !userSub) return;
+  if (!confirm(`Revoke access for ${userSub}?`)) return;
+  try {
+    await ensureUiSession();
+    await apiDelete(`/ui/calendars/${encodeURIComponent(calendarId)}/shares/${encodeURIComponent(userSub)}`);
+    updateCalendarShareStatus(`Revoked access for ${userSub}.`);
+    await refreshCalendarShares();
+    await refreshCalendarAccess();
+  } catch (e) {
+    updateCalendarShareStatus("Error: " + e.message);
+  }
+}
+
+async function refreshBookingLinks() {
+  const calendarId = getCalendarId();
+  if (!calendarId) return;
+  try {
+    await ensureUiSession();
+    const res = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/booking_links`);
+    renderBookingLinks(res || []);
+  } catch (e) {
+    updateBookingLinkStatus("Error: " + e.message);
+  }
+}
+
+async function createBookingLink() {
+  const calendarId = getCalendarId();
+  if (!calendarId) {
+    updateBookingLinkStatus("Set a calendar ID first.");
+    return;
+  }
+  try {
+    await ensureUiSession();
+    const name = document.getElementById("bookingLinkNameInput").value.trim();
+    const duration = document.getElementById("bookingLinkDurationInput").value.trim();
+    const timezone = document.getElementById("bookingLinkTimezoneInput").value.trim() || null;
+    if (!name || !duration) {
+      updateBookingLinkStatus("Enter a name and duration.");
+      return;
+    }
+    const payload = { name, duration_minutes: Number.parseInt(duration, 10), timezone };
+    const res = await apiPost(`/ui/calendars/${encodeURIComponent(calendarId)}/booking_links`, payload);
+    updateBookingLinkStatus(`Created booking link ${res.link_id}`);
+    document.getElementById("bookingLinkNameInput").value = "";
+    document.getElementById("bookingLinkDurationInput").value = "";
+    document.getElementById("bookingLinkTimezoneInput").value = "";
+    await refreshBookingLinks();
+  } catch (e) {
+    updateBookingLinkStatus("Error: " + e.message);
+  }
+}
+
+async function loadBookingLinkOpenings() {
+  const linkId = document.getElementById("bookingLinkSelect").value;
+  if (!linkId) {
+    updateBookingOpeningsStatus("Select a booking link first.");
+    return;
+  }
+  const startPicker = document.getElementById("bookingOpeningsStartPicker").value.trim();
+  const endPicker = document.getElementById("bookingOpeningsEndPicker").value.trim();
+  const start = startPicker ? toIsoUtc(startPicker) : document.getElementById("bookingOpeningsStartInput").value.trim();
+  const end = endPicker ? toIsoUtc(endPicker) : document.getElementById("bookingOpeningsEndInput").value.trim();
+  if (!start || !end) {
+    updateBookingOpeningsStatus("Enter start and end window.");
+    return;
+  }
+  const limitRaw = document.getElementById("bookingOpeningsLimitInput").value.trim();
+  const params = new URLSearchParams({ start_utc: start, end_utc: end });
+  if (limitRaw) params.set("limit", limitRaw);
+  try {
+    updateBookingOpeningsStatus("Loading...");
+    const res = await apiGet(`/booking/${encodeURIComponent(linkId)}/openings?${params.toString()}`);
+    renderBookingOpenings(res || []);
+    updateBookingOpeningsStatus(`Found ${Array.isArray(res) ? res.length : 0} openings.`);
+  } catch (e) {
+    updateBookingOpeningsStatus("Error: " + e.message);
   }
 }
 
@@ -2801,9 +3315,142 @@ async function refreshCalendarEvents() {
   const calendarId = getCalendarId();
   if (!calendarId) return;
   await ensureUiSession();
-  const res = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/events`);
+  const filters = getEventFilters();
+  if ((filters.start && !filters.end) || (!filters.start && filters.end)) {
+    updateEventsStatus("Enter both start and end to filter the event list.");
+    return;
+  }
+  const queryKey = JSON.stringify(filters);
+  if (eventsPagination.lastQueryKey && eventsPagination.lastQueryKey !== queryKey) {
+    resetEventsPagination();
+  }
+  eventsPagination.lastQueryKey = queryKey;
+  const params = new URLSearchParams();
+  if (filters.start) params.set("start_utc", filters.start);
+  if (filters.end) params.set("end_utc", filters.end);
+  if (filters.limit) params.set("limit", String(filters.limit));
+  if (eventsPagination.currentCursor) params.set("cursor", eventsPagination.currentCursor);
+  const qs = params.toString();
+  updateEventsStatus("Loading...");
+  const res = await apiGet(`/ui/calendars/${encodeURIComponent(calendarId)}/events${qs ? `?${qs}` : ""}`);
   const events = Array.isArray(res) ? res : res.events;
   renderCalendarEvents(events || []);
+  eventsPagination.nextCursor = res && !Array.isArray(res) ? res.next_cursor : null;
+  updateEventsPaginationControls();
+  updateEventsStatus(`Loaded ${Array.isArray(events) ? events.length : 0} events.`);
+}
+
+async function previewEventConflicts() {
+  const calendarId = getCalendarId();
+  if (!calendarId) {
+    setCalendarStatus("Set a calendar ID first.");
+    return;
+  }
+  try {
+    await ensureUiSession();
+    updateEventConflictStatus("Checking conflicts...");
+    const eventId = document.getElementById("eventIdInput").value.trim();
+    const payload = buildEventPayload();
+    const res = await apiPost(`/ui/calendars/${encodeURIComponent(calendarId)}/events/conflicts`, {
+      ...payload,
+      event_id: eventId || null,
+    });
+    renderEventConflicts(res?.conflicts || []);
+    renderEventSuggestions([]);
+    const count = Array.isArray(res?.conflicts) ? res.conflicts.length : 0;
+    updateEventConflictStatus(count ? `Found ${count} conflict(s).` : "No conflicts found.");
+  } catch (e) {
+    renderEventConflicts([]);
+    updateEventConflictStatus("Error: " + e.message);
+  }
+}
+
+async function loadEventSuggestions() {
+  const calendarId = getCalendarId();
+  if (!calendarId) {
+    setCalendarStatus("Set a calendar ID first.");
+    return;
+  }
+  const payload = buildEventPayload();
+  if (payload.all_day || !payload.start_utc || !payload.end_utc) {
+    updateEventConflictStatus("Suggestions require start and end times for a timed event.");
+    return;
+  }
+  try {
+    await ensureUiSession();
+    updateEventConflictStatus("Loading suggestions...");
+    const durationMinutes = Math.max(
+      1,
+      Math.round((new Date(payload.end_utc).getTime() - new Date(payload.start_utc).getTime()) / 60000)
+    );
+    const res = await apiPost(`/ui/calendars/${encodeURIComponent(calendarId)}/events/suggestions`, {
+      start_utc: payload.start_utc,
+      end_utc: payload.end_utc,
+      duration_minutes: durationMinutes,
+      limit: 5,
+      window_days: 7,
+    });
+    renderEventSuggestions(res || []);
+    updateEventConflictStatus(`Found ${Array.isArray(res) ? res.length : 0} suggestion(s).`);
+  } catch (e) {
+    renderEventSuggestions([]);
+    updateEventConflictStatus("Error: " + e.message);
+  }
+}
+
+async function excludeEventOccurrence(eventId, occurrenceStart) {
+  const calendarId = getCalendarId();
+  if (!calendarId || !eventId || !occurrenceStart) return;
+  if (!confirm("Exclude this occurrence?")) return;
+  try {
+    await ensureUiSession();
+    await apiPost(
+      `/ui/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/occurrences/${encodeURIComponent(occurrenceStart)}/exclude`,
+      {}
+    );
+    setCalendarStatus("Occurrence excluded.");
+    await refreshCalendarEvents();
+  } catch (e) {
+    setCalendarStatus("Error: " + e.message);
+  }
+}
+
+async function overrideEventOccurrence(eventId, occurrenceStart, evt) {
+  const calendarId = getCalendarId();
+  if (!calendarId || !eventId || !occurrenceStart) return;
+  const defaultStart = evt?.start_utc || occurrenceStart;
+  const defaultEnd = evt?.end_utc || "";
+  const newStart = prompt("New start (ISO-8601 UTC)", defaultStart || "") || "";
+  if (!newStart) return;
+  const newEnd = prompt("New end (ISO-8601 UTC)", defaultEnd || "") || "";
+  if (!newEnd) return;
+  try {
+    await ensureUiSession();
+    await apiPost(
+      `/ui/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/occurrences/${encodeURIComponent(occurrenceStart)}/override`,
+      { start_utc: newStart, end_utc: newEnd }
+    );
+    setCalendarStatus("Occurrence updated.");
+    await refreshCalendarEvents();
+  } catch (e) {
+    setCalendarStatus("Error: " + e.message);
+  }
+}
+
+async function clearEventOccurrenceException(eventId, occurrenceStart) {
+  const calendarId = getCalendarId();
+  if (!calendarId || !eventId || !occurrenceStart) return;
+  if (!confirm("Clear exception for this occurrence?")) return;
+  try {
+    await ensureUiSession();
+    await apiDelete(
+      `/ui/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/occurrences/${encodeURIComponent(occurrenceStart)}`
+    );
+    setCalendarStatus("Occurrence exception cleared.");
+    await refreshCalendarEvents();
+  } catch (e) {
+    setCalendarStatus("Error: " + e.message);
+  }
 }
 
 async function createCalendarEvent() {
@@ -2815,15 +3462,7 @@ async function createCalendarEvent() {
   try {
     await ensureUiSession();
     const eventId = document.getElementById("eventIdInput").value.trim();
-    const payload = {
-      name: document.getElementById("eventNameInput").value.trim(),
-      description: document.getElementById("eventDescriptionInput").value.trim(),
-      timezone: document.getElementById("eventTimezoneInput").value.trim() || null,
-      all_day: document.getElementById("eventAllDayToggle").checked,
-      all_day_date: document.getElementById("eventAllDayDateInput").value || null,
-      start_utc: document.getElementById("eventStartInput").value.trim() || null,
-      end_utc: document.getElementById("eventEndInput").value.trim() || null,
-    };
+    const payload = buildEventPayload();
     const res = eventId
       ? await apiPatch(`/ui/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`, payload)
       : await apiPost(`/ui/calendars/${encodeURIComponent(calendarId)}/events`, payload);
@@ -2833,6 +3472,7 @@ async function createCalendarEvent() {
     } else {
       document.getElementById("eventCreateStatus").textContent = `Added event ${res.event_id}`;
     }
+    resetEventsPagination();
     await refreshCalendarEvents();
   } catch (e) {
     document.getElementById("eventCreateStatus").textContent = "Error: " + e.message;
@@ -2848,6 +3488,7 @@ async function deleteCalendarEvent(eventId) {
     await ensureUiSession();
     await apiDelete(`/ui/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`);
     setCalendarStatus(`Deleted event ${eventId}`);
+    resetEventsPagination();
     await refreshCalendarEvents();
   } catch (e) {
     setCalendarStatus("Error: " + e.message);
@@ -5710,14 +6351,28 @@ document.getElementById("calendarSetBtn").onclick = async () => {
   setCalendarId(calendarId);
   if (calendarId) {
     setCalendarStatus(`Using calendar ${calendarId}`);
+    resetEventsPagination();
+    await refreshCalendarShares();
+    await refreshBookingLinks();
     await refreshCalendarEvents();
   } else {
     setCalendarStatus("Calendar cleared.");
+    renderBookingLinks([]);
+    renderCalendarShares([]);
   }
 };
 
 document.getElementById("calendarCreateBtn").onclick = async () => {
   await createCalendar();
+  resetEventsPagination();
+};
+
+document.getElementById("calendarAccessRefreshBtn").onclick = async () => {
+  await refreshCalendarAccess();
+};
+
+document.getElementById("calendarShareCreateBtn").onclick = async () => {
+  await createCalendarShare();
 };
 
 document.getElementById("eventCreateBtn").onclick = async () => {
@@ -5729,8 +6384,47 @@ document.getElementById("eventCancelEditBtn").onclick = () => {
   document.getElementById("eventCreateStatus").textContent = "Edit canceled.";
 };
 
+document.getElementById("eventPreviewConflictsBtn").onclick = async () => {
+  await previewEventConflicts();
+};
+
+document.getElementById("eventSuggestSlotsBtn").onclick = async () => {
+  await loadEventSuggestions();
+};
+
 document.getElementById("eventsRefreshBtn").onclick = async () => {
   await refreshCalendarEvents();
+};
+
+document.getElementById("eventsClearFiltersBtn").onclick = async () => {
+  document.getElementById("eventsStartInput").value = "";
+  document.getElementById("eventsEndInput").value = "";
+  document.getElementById("eventsStartPicker").value = "";
+  document.getElementById("eventsEndPicker").value = "";
+  document.getElementById("eventsLimitSelect").value = "";
+  resetEventsPagination();
+  await refreshCalendarEvents();
+};
+
+document.getElementById("eventsNextBtn").onclick = async () => {
+  if (!eventsPagination.nextCursor) return;
+  eventsPagination.prevStack.push(eventsPagination.currentCursor);
+  eventsPagination.currentCursor = eventsPagination.nextCursor;
+  await refreshCalendarEvents();
+};
+
+document.getElementById("eventsPrevBtn").onclick = async () => {
+  if (!eventsPagination.prevStack.length) return;
+  eventsPagination.currentCursor = eventsPagination.prevStack.pop();
+  await refreshCalendarEvents();
+};
+
+document.getElementById("bookingLinkCreateBtn").onclick = async () => {
+  await createBookingLink();
+};
+
+document.getElementById("bookingOpeningsLoadBtn").onclick = async () => {
+  await loadBookingLinkOpenings();
 };
 
 document.getElementById("openingsLoadBtn").onclick = async () => {


### PR DESCRIPTION
### Motivation
- Support richer recurrence semantics including BYMONTHDAY/BYSETPOS and allow excluding or overriding individual occurrences (EXDATEs and per-occurrence overrides). 
- Let users preview conflicts and get alternate slot suggestions while avoiding duplication of conflict-checking logic. 
- Expose calendar access/sharing and occurrence exception management in the scheduling UI.

### Description
- Extended models in `app/models.py` to add `EventOccurrenceOverrideIn`, `exdates_utc`, and `recurrence_overrides` on event payloads and to add `bymonthday`/`bysetpos` to `RecurrenceRule`.
- Added normalization and validation helpers in `app/routers/calendar.py` (`_normalize_recurrence_rule`, `_normalize_exdates`, `_normalize_overrides`, `_normalize_occurrence_override`) and extended recurrence expansion to honor `bymonthday`/`bysetpos`, `EXDATE`s, and per-occurrence overrides.
- Implemented new endpoints to manage occurrence exceptions (`POST /ui/calendars/{calendar_id}/events/{event_id}/occurrences/{occurrence_start}/exclude`, `POST .../override`, `DELETE .../{occurrence_start}`), plus conflict preview and suggestions endpoints (`/events/conflicts`, `/events/suggestions`) and calendar access/share APIs (`GET /ui/calendars`, `POST/GET/DELETE /ui/calendars/{calendar_id}/shares`, `GET /ui/calendars/{calendar_id}/booking_links`).
- Persisted `exdates_utc` and normalized `recurrence_overrides` during event create/update flows and updated `_expand_event_occurrences` to apply exceptions/overrides when listing/expanding events.
- Updated the scheduling UI (`app/static/index.html`, `app/static/main.js`) to add recurrence controls (freq/interval/count/until/BYDAY/BYMONTHDAY/BYSETPOS/EXDATEs), conflict preview and suggestion UI, calendar access/share UI, and client handlers for exclude/override/clear actions and suggestions.

### Testing
- Launched a static HTTP server serving `app/static` and ran a Playwright script to load `/index.html` and capture a full-page screenshot; the run completed and produced the artifact `artifacts/recurrence-exceptions-ui.png` indicating the new UI elements rendered successfully.
- The local HTTP server was started during the run and responded to the Playwright probe successfully. 
- No automated unit or integration tests were executed against backend logic; only the UI rendering screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802884467c832b8b935b94ac453ec1)