### PR TITLE
Add DEV_TEST_USER dev login and fix frontend setup permissions

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -10,6 +10,8 @@ cp .env.example .env          # copy and edit with your values
 
 The app runs in **DEV_MODE** by default — Cognito auth is bypassed and you can
 authenticate with any `Authorization: Bearer <user_id>` header.
+If you want a simple dev login in the UI, set `DEV_TEST_USER` and
+`DEV_TEST_PASSWORD` to allow those credentials to start a session in dev mode.
 
 ---
 
@@ -326,6 +328,10 @@ WS_TOKEN_SECRET=local-ws-secret
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=fakeMyKeyId
 AWS_SECRET_ACCESS_KEY=fakeSecretAccessKey
+
+# Optional: allow UI login with dev credentials
+DEV_TEST_USER=test-user-1
+DEV_TEST_PASSWORD=change-me
 ```
 
 > This boots the app in dev mode. Most API calls will fail with DynamoDB

--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -10,6 +10,7 @@ import requests
 from fastapi import HTTPException, Request
 
 from app.core.settings import S
+from app.models import UiSessionStartReq
 
 _JWKS_CACHE: Optional[Dict[str, Any]] = None
 _JWKS_FETCHED_AT: float = 0.0
@@ -134,3 +135,16 @@ async def get_authenticated_user_sub(request: Request) -> str:
     auth = request.headers.get("authorization", "")
     token = extract_bearer_token(auth)
     return _decode_jwt_sub(token) or token
+
+
+async def resolve_dev_or_authenticated_user_sub(
+    request: Request,
+    body: UiSessionStartReq,
+) -> str:
+    if S.dev_mode and S.dev_test_user and S.dev_test_password:
+        context = body.challenge_context or {}
+        username = context.get("username")
+        password = context.get("password")
+        if username == S.dev_test_user and password == S.dev_test_password:
+            return S.dev_test_user
+    return await get_authenticated_user_sub(request)

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -133,6 +133,8 @@ class Settings:
 
     audit_log_enabled: bool = os.environ.get("AUDIT_LOG_ENABLED", "1") not in ("0","false","False")
     dev_mode: bool = os.environ.get("DEV_MODE", "1") not in ("0", "false", "False")
+    dev_test_user: str = os.environ.get("DEV_TEST_USER", "")
+    dev_test_password: str = os.environ.get("DEV_TEST_PASSWORD", "")
 
     # Billing / CCBill
     ccbill_base_url: str = os.environ.get("CCBILL_BASE_URL", "https://api.ccbill.com").rstrip("/")

--- a/app/routers/ui_session.py
+++ b/app/routers/ui_session.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from boto3.dynamodb.conditions import Key
 
-from app.auth.deps import get_authenticated_user_sub
+from app.auth.deps import get_authenticated_user_sub, resolve_dev_or_authenticated_user_sub
 from app.models import UiSessionFinalizeReq, UiSessionStartReq, UiSessionStartResp
 from app.core.normalize import client_ip_from_request
 from app.core.settings import S
@@ -38,7 +38,7 @@ async def ui_session_start(
     req: Request,
     body: UiSessionStartReq,
     response: Response = None,
-    user_sub: str = Depends(get_authenticated_user_sub),
+    user_sub: str = Depends(resolve_dev_or_authenticated_user_sub),
 ):
     if response is None:
         response = Response()

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -34,6 +34,11 @@ deactivate
 
 if [[ -f "frontend/package.json" ]]; then
   npm --prefix frontend install
+  if [[ -n "${SUDO_USER:-}" ]]; then
+    chown -R "${SUDO_USER}:${SUDO_USER}" frontend/node_modules frontend/package-lock.json 2>/dev/null || true
+    chown -R "${SUDO_USER}:${SUDO_USER}" frontend 2>/dev/null || true
+  fi
+  chmod -R u+rwX frontend/node_modules 2>/dev/null || true
 fi
 
 echo "Setup complete. Configure env vars (see docs/run-deploy.md) and run scripts/run_dev.sh."


### PR DESCRIPTION
### Motivation
- Provide a simple dev UI login using test credentials so developers can start a session in `DEV_MODE` without Cognito.
- Fix permission issues seen when running the Ubuntu setup script with `sudo` that left `frontend/node_modules` owned by root and unreadable by the developer user.

### Description
- Add `DEV_TEST_USER` and `DEV_TEST_PASSWORD` settings to `app/core/settings.py` to make dev credentials configurable via environment variables.
- Implement `resolve_dev_or_authenticated_user_sub` in `app/auth/deps.py` to accept dev credentials from the `UiSessionStartReq.challenge_context` when `DEV_MODE` and test creds are configured, and fall back to existing authentication logic.
- Wire the new resolver into the UI session start endpoint by changing the dependency in `app/routers/ui_session.py` to `resolve_dev_or_authenticated_user_sub`.
- Document the new `DEV_TEST_USER`/`DEV_TEST_PASSWORD` options in `DEPLOYMENT.md` (quick start and minimal `.env` example).
- Update `scripts/setup_ubuntu.sh` to `chown` the frontend artifacts back to the invoking user (`$SUDO_USER`) after `npm` install and to `chmod -R u+rwX frontend/node_modules` to ensure writable permissions.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988312c2f2c832b8413ced60b65642a)