### PR TITLE
Start session after registration when verification not required

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -23,6 +23,7 @@ class Settings:
     ddb_email_table: str = os.environ.get("DDB_EMAIL_TABLE", "")
 
     api_keys_table_name: str = os.environ.get("API_KEYS_TABLE_NAME", "api_keys")
+    users_table_name: str = os.environ.get("USERS_TABLE_NAME", "users")
     api_keys_user_index: str = os.environ.get("API_KEYS_USER_INDEX", "user_sub-index")
     api_key_pepper: str = os.environ.get("API_KEY_PEPPER", "")
     api_key_ttl_days: int = int(os.environ.get("API_KEY_TTL_DAYS", "365"))

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -13,6 +13,7 @@ class Tables:
     sms: Any
     recovery: Any
     email: Any
+    users: Any
     api_keys: Any
     alerts: Any
     alert_prefs: Any
@@ -34,6 +35,7 @@ T = Tables(
     sms=ddb.Table(S.ddb_sms_table),
     recovery=ddb.Table(S.ddb_recovery_table),
     email=ddb.Table(S.ddb_email_table),
+    users=ddb.Table(S.users_table_name),
     api_keys=ddb.Table(S.api_keys_table_name),
     alerts=ddb.Table(S.alerts_table_name),
     alert_prefs=ddb.Table(S.alert_prefs_table_name),

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.routers.push import router as push_router
 from app.routers.recovery import router as recovery_router
 from app.routers.password_recovery import router as password_recovery_router
 from app.routers.passwordless import router as passwordless_router
+from app.routers.register import router as register_router
 from app.routers.webauthn import router as webauthn_router
 from app.routers.misc import router as misc_router
 from app.routers.billing_ccbill import router as billing_ccbill_router
@@ -72,6 +73,7 @@ def create_app() -> FastAPI:
     app.include_router(recovery_router)
     app.include_router(password_recovery_router)
     app.include_router(passwordless_router)
+    app.include_router(register_router)
     app.include_router(webauthn_router)
     app.include_router(misc_router)
     app.include_router(billing_ccbill_router)

--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,21 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, conint
+import re
+
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    conint,
+    field_validator,
+    model_validator,
+)
+
+from app.core.normalize import normalize_phone
+
+_PASSWORD_COMPLEXITY = re.compile(r"^(?=.*[A-Za-z])(?=.*\\d).+$")
 
 class UiSessionStartReq(BaseModel):
     # You can include client metadata; auth is handled separately.
@@ -97,6 +111,82 @@ class PasswordlessVerifyResp(BaseModel):
     auth_required: bool = False
     challenge_id: Optional[str] = None
     required_factors: List[str] = Field(default_factory=list)
+
+class RegisterStartReq(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    full_name: str
+    email: str = Field(validation_alias=AliasChoices("email", "username"))
+    password: str
+    confirm_password: str
+    delivery_method: Literal["email", "sms"] = "email"
+    phone: Optional[str] = None
+
+    @field_validator("full_name", "email")
+    @classmethod
+    def _strip_value(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Value required")
+        return cleaned
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_email(cls, value: str) -> str:
+        cleaned = value.strip().lower()
+        if "@" not in cleaned:
+            raise ValueError("Invalid email")
+        return cleaned
+
+    @field_validator("phone")
+    @classmethod
+    def _normalize_phone(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        try:
+            return normalize_phone(cleaned)
+        except Exception as exc:
+            raise ValueError("Invalid phone") from exc
+
+    @field_validator("password")
+    @classmethod
+    def _validate_password(cls, value: str) -> str:
+        if len(value) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if not _PASSWORD_COMPLEXITY.match(value):
+            raise ValueError("Password must include letters and numbers")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_password_match(self) -> "RegisterStartReq":
+        if self.password != self.confirm_password:
+            raise ValueError("Passwords don't match")
+        return self
+
+class RegisterStartResp(BaseModel):
+    status: str
+    verification_required: bool = False
+    delivery_medium: Optional[str] = None
+    delivery_destination: Optional[str] = None
+    session_id: Optional[str] = None
+
+class RegisterConfirmReq(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    email: str = Field(validation_alias=AliasChoices("email", "username"))
+    confirmation_code: str = Field(validation_alias=AliasChoices("confirmation_code", "code"))
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_confirm_email(cls, value: str) -> str:
+        cleaned = value.strip().lower()
+        if "@" not in cleaned:
+            raise ValueError("Invalid email")
+        return cleaned
+
+class RegisterConfirmResp(BaseModel):
+    status: str
 
 class WebAuthnRegisterBeginReq(BaseModel):
     label: Optional[str] = None

--- a/app/routers/register.py
+++ b/app/routers/register.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter, HTTPException, Request, Response
+
+from app.core.normalize import client_ip_from_request
+from app.core.settings import S
+from app.models import RegisterConfirmReq, RegisterConfirmResp, RegisterStartReq, RegisterStartResp
+from app.services.alerts import audit_event
+from app.services.breach_check import check_password_breach
+from app.services.cognito import cognito_admin_confirm_sign_up, cognito_sign_up
+from app.services.mfa import send_email_code, twilio_start_sms
+from app.services.rate_limit import (
+    can_send_verification,
+    enforce_lockout,
+    record_lockout_failure,
+    clear_lockout,
+    rate_limit_password_recovery,
+)
+from app.services.registration import (
+    create_registration_challenge,
+    create_user_record,
+    mark_user_verified,
+    verify_registration_code,
+)
+from app.services.sessions import create_real_session, rotate_session_cookies, session_id_value
+
+router = APIRouter(prefix="/ui/register", tags=["register"])
+
+
+def _require_cognito() -> None:
+    if not S.cognito_app_client_id:
+        raise HTTPException(500, "Cognito app client id not configured")
+
+
+@router.post("/start", response_model=RegisterStartResp)
+async def register_start(
+    req: Request,
+    body: RegisterStartReq,
+    response: Response = None,
+) -> Dict[str, object]:
+    if response is None:
+        response = Response()
+    _require_cognito()
+    username = body.email
+    ip = client_ip_from_request(req)
+    enforce_lockout(username, ip, "register_start")
+    rate_limit_password_recovery(username, ip, "register_start")
+
+    breach_count = check_password_breach(body.password)
+    if breach_count:
+        record_lockout_failure(username, ip, "register_start")
+        raise HTTPException(400, "Password found in breach corpus")
+
+    try:
+        resp = cognito_sign_up(username, body.password, body.full_name)
+    except HTTPException:
+        record_lockout_failure(username, ip, "register_start")
+        raise
+    except Exception as exc:
+        record_lockout_failure(username, ip, "register_start")
+        raise HTTPException(400, "Registration failed") from exc
+
+    delivery = resp.get("CodeDeliveryDetails") or {}
+    verification_required = not bool(resp.get("UserConfirmed"))
+    create_user_record(
+        email=username,
+        full_name=body.full_name,
+        password=body.password,
+        verification_required=verification_required,
+    )
+    delivery_medium = None
+    delivery_destination = None
+    if verification_required:
+        channel = body.delivery_method
+        if channel == "sms":
+            if not body.phone:
+                raise HTTPException(400, "Phone required for SMS verification")
+            if not can_send_verification(username, "sms"):
+                raise HTTPException(429, "Too many verification SMS; try again later")
+            create_registration_challenge(user_sub=username, channel="sms", send_to=body.phone)
+            twilio_start_sms(body.phone)
+            delivery_medium = "sms"
+            delivery_destination = body.phone
+        else:
+            if not can_send_verification(username, "email"):
+                raise HTTPException(429, "Too many verification emails; try again later")
+            code = create_registration_challenge(user_sub=username, channel="email", send_to=username)
+            send_email_code(username, "Registration", code)
+            delivery_medium = "email"
+            delivery_destination = username
+    audit_event(
+        "register_start",
+        username,
+        req,
+        outcome="success",
+        verification_required=verification_required,
+        delivery_medium=delivery_medium or delivery.get("DeliveryMedium"),
+    )
+    clear_lockout(username, ip, "register_start")
+    if not verification_required:
+        session = create_real_session(req, username)
+        rotate_session_cookies(req, response, username, session)
+        session_id = session_id_value(session)
+        audit_event("register_session_start", username, req, outcome="success", session_id=session_id)
+        return {
+            "status": "ok",
+            "verification_required": False,
+            "delivery_medium": None,
+            "delivery_destination": None,
+            "session_id": session_id,
+        }
+    return {
+        "status": "ok",
+        "verification_required": verification_required,
+        "delivery_medium": delivery_medium or delivery.get("DeliveryMedium"),
+        "delivery_destination": delivery_destination or delivery.get("Destination"),
+    }
+
+
+@router.post("/confirm", response_model=RegisterConfirmResp)
+async def register_confirm(req: Request, body: RegisterConfirmReq) -> Dict[str, object]:
+    _require_cognito()
+    username = body.email
+    ip = client_ip_from_request(req)
+    enforce_lockout(username, ip, "register_confirm")
+    rate_limit_password_recovery(username, ip, "register_confirm")
+
+    try:
+        verify_registration_code(user_sub=username, code=body.confirmation_code)
+        cognito_admin_confirm_sign_up(username)
+    except HTTPException:
+        record_lockout_failure(username, ip, "register_confirm")
+        raise
+    except Exception as exc:
+        record_lockout_failure(username, ip, "register_confirm")
+        raise HTTPException(400, "Registration confirmation failed") from exc
+
+    clear_lockout(username, ip, "register_confirm")
+    mark_user_verified(username)
+    audit_event("register_confirm", username, req, outcome="success")
+    return {"status": "ok"}

--- a/app/services/cognito.py
+++ b/app/services/cognito.py
@@ -21,6 +21,12 @@ def _cognito_client_id() -> str:
     return S.cognito_app_client_id
 
 
+def _cognito_user_pool_id() -> str:
+    if not S.cognito_user_pool_id:
+        raise HTTPException(500, "Cognito user pool id not configured")
+    return S.cognito_user_pool_id
+
+
 def cognito_client():
     return boto3.client("cognito-idp", region_name=_cognito_region())
 
@@ -56,3 +62,54 @@ def cognito_refresh_tokens(refresh_token: str) -> Dict[str, Any]:
     if not result:
         raise HTTPException(401, "Refresh token rejected")
     return result
+
+
+def cognito_sign_up(username: str, password: str, full_name: str) -> Dict[str, Any]:
+    client = cognito_client()
+    try:
+        return client.sign_up(
+            ClientId=_cognito_client_id(),
+            Username=username,
+            Password=password,
+            UserAttributes=[
+                {"Name": "email", "Value": username},
+                {"Name": "name", "Value": full_name},
+            ],
+        )
+    except client.exceptions.UsernameExistsException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(409, "User already exists") from exc
+    except client.exceptions.InvalidPasswordException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(400, "Invalid password") from exc
+    except client.exceptions.InvalidParameterException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(400, "Invalid registration parameters") from exc
+
+
+def cognito_confirm_sign_up(username: str, code: str) -> Dict[str, Any]:
+    client = cognito_client()
+    try:
+        return client.confirm_sign_up(
+            ClientId=_cognito_client_id(),
+            Username=username,
+            ConfirmationCode=code,
+        )
+    except client.exceptions.CodeMismatchException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(400, "Invalid confirmation code") from exc
+    except client.exceptions.ExpiredCodeException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(400, "Confirmation code expired") from exc
+    except client.exceptions.NotAuthorizedException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(400, "User already confirmed") from exc
+    except client.exceptions.UserNotFoundException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(404, "User not found") from exc
+
+
+def cognito_admin_confirm_sign_up(username: str) -> Dict[str, Any]:
+    client = cognito_client()
+    try:
+        return client.admin_confirm_sign_up(
+            UserPoolId=_cognito_user_pool_id(),
+            Username=username,
+        )
+    except client.exceptions.UserNotFoundException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(404, "User not found") from exc
+    except client.exceptions.NotAuthorizedException as exc:  # type: ignore[attr-defined]
+        raise HTTPException(403, "Not authorized to confirm user") from exc

--- a/app/services/registration.py
+++ b/app/services/registration.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from typing import Dict
+
+from fastapi import HTTPException
+
+from app.core.normalize import normalize_email
+from app.core.settings import S
+from app.core.tables import T
+from app.core.time import now_ts
+from app.services.account_state import set_account_state
+from app.services.profile import empty_profile, save_profile
+from app.services.ttl import with_ttl
+from app.services.mfa import gen_numeric_code, twilio_check_sms
+from app.core.crypto import sha256_str
+
+PASSWORD_HASH_ITERATIONS = 260_000
+PASSWORD_HASH_ALGO = "pbkdf2_sha256"
+REGISTRATION_CHALLENGE_ID = "register_verify"
+
+
+def _hash_password(password: str) -> Dict[str, str]:
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, PASSWORD_HASH_ITERATIONS)
+    return {
+        "algorithm": PASSWORD_HASH_ALGO,
+        "iterations": str(PASSWORD_HASH_ITERATIONS),
+        "salt_b64": base64.b64encode(salt).decode("ascii"),
+        "hash_b64": base64.b64encode(digest).decode("ascii"),
+    }
+
+
+def _user_exists(user_sub: str) -> bool:
+    existing = T.users.get_item(Key={"user_sub": user_sub}).get("Item")
+    return bool(existing)
+
+
+def create_user_record(
+    *,
+    email: str,
+    full_name: str,
+    password: str,
+    verification_required: bool,
+) -> Dict[str, str]:
+    user_sub = normalize_email(email)
+    if _user_exists(user_sub):
+        raise HTTPException(409, "User already exists")
+
+    password_hash = _hash_password(password)
+    created_at = now_ts()
+    item = {
+        "user_sub": user_sub,
+        "email": user_sub,
+        "full_name": full_name.strip(),
+        "password_hash": password_hash,
+        "created_at": created_at,
+    }
+    try:
+        T.users.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(user_sub)",
+        )
+    except Exception as exc:
+        raise HTTPException(409, "User already exists") from exc
+
+    profile = empty_profile()
+    profile.update({
+        "display_name": full_name.strip() or None,
+        "displayed_email": user_sub,
+    })
+    save_profile(user_sub, profile, audit_entries=[{"event": "register_start", "at": created_at}])
+
+    status = "pending_verification" if verification_required else "active"
+    set_account_state(user_sub, status, reason="initial_registration", requested_by=user_sub)
+    return {"user_sub": user_sub}
+
+
+def create_registration_challenge(
+    *,
+    user_sub: str,
+    channel: str,
+    send_to: str,
+) -> str:
+    code = gen_numeric_code(6) if channel == "email" else ""
+    ts = now_ts()
+    expires = ts + S.session_challenge_ttl_seconds
+    payload = {
+        "user_sub": user_sub,
+        "session_id": REGISTRATION_CHALLENGE_ID,
+        "created_at": ts,
+        "expires_at": expires,
+        "revoked": False,
+        "pending_auth": True,
+        "purpose": "register_verify",
+        "channel": channel,
+        "send_to": send_to,
+        "code_hash": sha256_str(code) if code else "",
+        "code_attempts": 0,
+    }
+    T.sessions.put_item(Item=with_ttl(payload, ttl_epoch=expires))
+    return code
+
+
+def verify_registration_code(*, user_sub: str, code: str) -> Dict[str, str]:
+    item = T.sessions.get_item(
+        Key={"user_sub": user_sub, "session_id": REGISTRATION_CHALLENGE_ID},
+    ).get("Item")
+    if not item:
+        raise HTTPException(400, "Registration verification not found")
+    if int(item.get("expires_at") or 0) < now_ts():
+        raise HTTPException(400, "Verification code expired")
+    channel = item.get("channel") or "email"
+    attempts = int(item.get("code_attempts") or 0)
+    max_attempts = S.sms_code_max_attempts if channel == "sms" else S.email_code_max_attempts
+    if attempts >= max_attempts:
+        raise HTTPException(429, "Too many verification attempts")
+    if channel == "sms":
+        phone = item.get("send_to", "")
+        if not twilio_check_sms(phone, code.strip()):
+            _increment_registration_attempts(user_sub, attempts)
+            raise HTTPException(401, "Invalid verification code")
+    else:
+        if sha256_str(code.strip()) != item.get("code_hash"):
+            _increment_registration_attempts(user_sub, attempts)
+            raise HTTPException(401, "Invalid verification code")
+    try:
+        T.sessions.delete_item(Key={"user_sub": user_sub, "session_id": REGISTRATION_CHALLENGE_ID})
+    except Exception:
+        pass
+    return {"user_sub": user_sub}
+
+
+def _increment_registration_attempts(user_sub: str, attempts: int) -> None:
+    try:
+        T.sessions.update_item(
+            Key={"user_sub": user_sub, "session_id": REGISTRATION_CHALLENGE_ID},
+            UpdateExpression="SET code_attempts = :c, last_failed_at = :t",
+            ExpressionAttributeValues={":c": attempts + 1, ":t": now_ts()},
+        )
+    except Exception:
+        pass
+
+
+def mark_user_verified(user_sub: str) -> Dict[str, str]:
+    normalized = normalize_email(user_sub)
+    if not _user_exists(normalized):
+        raise HTTPException(404, "User not found")
+    set_account_state(normalized, "active", reason="email_verified", requested_by=normalized)
+    return {"user_sub": normalized}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { ErrorPage } from "@/components/shared/ErrorPage";
 
 // ─── Lazy-loaded pages (code-split per route) ───────────────────
 const Login = lazy(() => import("@/pages/Login"));
+const Register = lazy(() => import("@/pages/Register"));
 const PasswordRecovery = lazy(() => import("@/pages/PasswordRecovery"));
 const MagicLinkVerify = lazy(() => import("@/pages/MagicLinkVerify"));
 const Dashboard = lazy(() => import("@/pages/Dashboard"));
@@ -41,6 +42,7 @@ export default function App() {
       <Routes>
         {/* Public routes (no shell) */}
         <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
         <Route path="/password-recovery" element={<PasswordRecovery />} />
         <Route path="/magic-link-verify" element={<MagicLinkVerify />} />
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -487,6 +487,12 @@ export default function Login() {
                     Security key
                   </Button>
                 </div>
+                <div className="text-center text-xs text-muted-foreground">
+                  Don&apos;t have an account?{" "}
+                  <Link to="/register" className="text-primary hover:underline">
+                    Register
+                  </Link>
+                </div>
               </CardFooter>
             </form>
           ) : step === "magic-link" ? (

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,166 @@
+import * as React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ArrowLeft, Shield } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+const registerSchema = z.object({
+  full_name: z.string().min(1, "Full name is required"),
+  email: z.string().email("Enter a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  confirm_password: z.string().min(1, "Please confirm your password"),
+}).refine((data) => data.password === data.confirm_password, {
+  message: "Passwords don't match",
+  path: ["confirm_password"],
+});
+
+type RegisterForm = z.infer<typeof registerSchema>;
+
+export default function Register() {
+  const navigate = useNavigate();
+  const [message, setMessage] = React.useState<string | null>(null);
+
+  const form = useForm<RegisterForm>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: {
+      full_name: "",
+      email: "",
+      password: "",
+      confirm_password: "",
+    },
+  });
+
+  const handleSubmit = (data: RegisterForm) => {
+    void data;
+    setMessage("Registration is not enabled for this demo. Please contact support to create an account.");
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 p-4">
+      <div className="pointer-events-none fixed inset-0 overflow-hidden">
+        <div className="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-primary/5 blur-3xl" />
+        <div className="absolute -bottom-32 -right-32 h-96 w-96 rounded-full bg-primary/10 blur-3xl" />
+      </div>
+
+      <div className="relative w-full max-w-md">
+        <div className="mb-8 text-center">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-lg">
+            <Shield className="h-7 w-7" />
+          </div>
+          <h1 className="text-2xl font-bold tracking-tight">Create your account</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Set up your access details to get started
+          </p>
+        </div>
+
+        <Card className="shadow-xl">
+          <form onSubmit={form.handleSubmit(handleSubmit)}>
+            <CardHeader className="space-y-1">
+              <CardTitle className="text-xl">Register</CardTitle>
+              <CardDescription>
+                Use your work email to request access
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              {message && (
+                <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-primary">
+                  {message}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="full_name">Full name</Label>
+                <Input
+                  id="full_name"
+                  placeholder="Jane Doe"
+                  autoComplete="name"
+                  {...form.register("full_name")}
+                />
+                {form.formState.errors.full_name && (
+                  <p className="text-xs text-destructive">
+                    {form.formState.errors.full_name.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  placeholder="you@company.com"
+                  autoComplete="email"
+                  type="email"
+                  {...form.register("email")}
+                />
+                {form.formState.errors.email && (
+                  <p className="text-xs text-destructive">
+                    {form.formState.errors.email.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="Create a password"
+                  autoComplete="new-password"
+                  {...form.register("password")}
+                />
+                {form.formState.errors.password && (
+                  <p className="text-xs text-destructive">
+                    {form.formState.errors.password.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirm_password">Confirm password</Label>
+                <Input
+                  id="confirm_password"
+                  type="password"
+                  placeholder="Re-enter your password"
+                  autoComplete="new-password"
+                  {...form.register("confirm_password")}
+                />
+                {form.formState.errors.confirm_password && (
+                  <p className="text-xs text-destructive">
+                    {form.formState.errors.confirm_password.message}
+                  </p>
+                )}
+              </div>
+            </CardContent>
+
+            <CardFooter className="flex flex-col gap-4">
+              <Button type="submit" className="w-full" size="lg">
+                Request access
+              </Button>
+              <div className="flex w-full items-center justify-center gap-2 text-xs text-muted-foreground">
+                <ArrowLeft className="h-3.5 w-3.5" />
+                <button
+                  type="button"
+                  className="text-primary hover:underline"
+                  onClick={() => navigate("/login")}
+                >
+                  Back to sign in
+                </button>
+              </div>
+              <div className="text-center text-xs text-muted-foreground">
+                Already have an account?{" "}
+                <Link to="/login" className="text-primary hover:underline">Sign in</Link>
+              </div>
+            </CardFooter>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Allow users to be immediately authenticated after registration when no verification is required by creating a real session and setting cookies server-side using existing session helpers.
- Keep session creation and cookie rotation consistent with other flows by reusing `create_real_session` and `rotate_session_cookies` helpers.
- If verification is required, keep user inactive until the confirm endpoint completes verification and activates the account.

### Description
- Updated `register_start` in `app/routers/register.py` to accept an optional `response: Response`, call `create_real_session(req, username)` when verification is not required, rotate cookies with `rotate_session_cookies`, and return the `session_id` using `session_id_value`.
- Added the `session_id: Optional[str]` field to `RegisterStartResp` in `app/models.py` so the API can return the created session identifier.
- Emitted an audit event `register_session_start` after session creation to record successful immediate login.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988328d9428832b9af1528f09a0f5f7)