### PR TITLE
Add help tooltips to security reminders and enhance registration flow (MFA, dev mode, email checks, tests)

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -136,6 +136,10 @@ class Settings:
     dev_mode: bool = os.environ.get("DEV_MODE", "1") not in ("0", "false", "False")
     dev_test_user: str = os.environ.get("DEV_TEST_USER", "")
     dev_test_password: str = os.environ.get("DEV_TEST_PASSWORD", "")
+    dev_registration_email: str = os.environ.get("DEV_REGISTRATION_EMAIL", "")
+    dev_registration_password: str = os.environ.get("DEV_REGISTRATION_PASSWORD", "")
+    dev_registration_code: str = os.environ.get("DEV_REGISTRATION_CODE", "")
+    dev_registration_phone: str = os.environ.get("DEV_REGISTRATION_PHONE", "")
 
     # Billing / CCBill
     ccbill_base_url: str = os.environ.get("CCBILL_BASE_URL", "https://api.ccbill.com").rstrip("/")

--- a/app/models.py
+++ b/app/models.py
@@ -120,6 +120,8 @@ class RegisterStartReq(BaseModel):
     confirm_password: str
     delivery_method: Literal["email", "sms"] = "email"
     phone: Optional[str] = None
+    enable_sms_mfa: bool = False
+    enable_totp_mfa: bool = False
 
     @field_validator("full_name", "email")
     @classmethod
@@ -163,6 +165,8 @@ class RegisterStartReq(BaseModel):
     def _validate_password_match(self) -> "RegisterStartReq":
         if self.password != self.confirm_password:
             raise ValueError("Passwords don't match")
+        if self.enable_sms_mfa and not self.phone:
+            raise ValueError("Phone required for SMS MFA")
         return self
 
 class RegisterStartResp(BaseModel):
@@ -187,6 +191,65 @@ class RegisterConfirmReq(BaseModel):
 
 class RegisterConfirmResp(BaseModel):
     status: str
+    session_id: Optional[str] = None
+    mfa_setup: List[str] = Field(default_factory=list)
+    sms_phone: Optional[str] = None
+
+class RegisterResendReq(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    email: str = Field(validation_alias=AliasChoices("email", "username"))
+    delivery_method: Literal["email", "sms"] = "email"
+    phone: Optional[str] = None
+    enable_sms_mfa: bool = False
+    enable_totp_mfa: bool = False
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_resend_email(cls, value: str) -> str:
+        cleaned = value.strip().lower()
+        if "@" not in cleaned:
+            raise ValueError("Invalid email")
+        return cleaned
+
+    @field_validator("phone")
+    @classmethod
+    def _normalize_resend_phone(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        try:
+            return normalize_phone(cleaned)
+        except Exception as exc:
+            raise ValueError("Invalid phone") from exc
+
+    @model_validator(mode="after")
+    def _validate_sms_phone(self) -> "RegisterResendReq":
+        if self.enable_sms_mfa and not self.phone:
+            raise ValueError("Phone required for SMS MFA")
+        return self
+
+class RegisterResendResp(BaseModel):
+    status: str
+    delivery_medium: Optional[str] = None
+    delivery_destination: Optional[str] = None
+
+class RegisterEmailCheckReq(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    email: str = Field(validation_alias=AliasChoices("email", "username"))
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_check_email(cls, value: str) -> str:
+        cleaned = value.strip().lower()
+        if "@" not in cleaned:
+            raise ValueError("Invalid email")
+        return cleaned
+
+class RegisterEmailCheckResp(BaseModel):
+    status: str
+    available: bool
 
 class WebAuthnRegisterBeginReq(BaseModel):
     label: Optional[str] = None

--- a/app/routers/register.py
+++ b/app/routers/register.py
@@ -6,7 +6,17 @@ from fastapi import APIRouter, HTTPException, Request, Response
 
 from app.core.normalize import client_ip_from_request
 from app.core.settings import S
-from app.models import RegisterConfirmReq, RegisterConfirmResp, RegisterStartReq, RegisterStartResp
+from app.core.time import now_ts
+from app.models import (
+    RegisterConfirmReq,
+    RegisterConfirmResp,
+    RegisterEmailCheckReq,
+    RegisterEmailCheckResp,
+    RegisterResendReq,
+    RegisterResendResp,
+    RegisterStartReq,
+    RegisterStartResp,
+)
 from app.services.alerts import audit_event
 from app.services.breach_check import check_password_breach
 from app.services.cognito import cognito_admin_confirm_sign_up, cognito_sign_up
@@ -21,6 +31,7 @@ from app.services.rate_limit import (
 from app.services.registration import (
     create_registration_challenge,
     create_user_record,
+    is_email_available,
     mark_user_verified,
     verify_registration_code,
 )
@@ -28,10 +39,35 @@ from app.services.sessions import create_real_session, rotate_session_cookies, s
 
 router = APIRouter(prefix="/ui/register", tags=["register"])
 
+DEFAULT_DEV_REGISTRATION_EMAIL = "demo@example.com"
+DEFAULT_DEV_REGISTRATION_PASSWORD = "Password\\d1"
+DEFAULT_DEV_REGISTRATION_CODE = "000000"
+DEFAULT_DEV_REGISTRATION_PHONE = "+15555550123"
+
 
 def _require_cognito() -> None:
     if not S.cognito_app_client_id:
         raise HTTPException(500, "Cognito app client id not configured")
+
+def _dev_registration_config() -> dict[str, str] | None:
+    if not S.dev_mode:
+        return None
+    return {
+        "email": S.dev_registration_email or DEFAULT_DEV_REGISTRATION_EMAIL,
+        "password": S.dev_registration_password or DEFAULT_DEV_REGISTRATION_PASSWORD,
+        "code": S.dev_registration_code or DEFAULT_DEV_REGISTRATION_CODE,
+        "phone": S.dev_registration_phone or DEFAULT_DEV_REGISTRATION_PHONE,
+    }
+
+def _is_dev_registration(email: str, password: str | None = None) -> bool:
+    config = _dev_registration_config()
+    if not config:
+        return False
+    if email != config["email"]:
+        return False
+    if password is None:
+        return True
+    return password == config["password"]
 
 
 @router.post("/start", response_model=RegisterStartResp)
@@ -42,6 +78,13 @@ async def register_start(
 ) -> Dict[str, object]:
     if response is None:
         response = Response()
+    if _is_dev_registration(body.email, body.password):
+        return {
+            "status": "ok",
+            "verification_required": True,
+            "delivery_medium": "email",
+            "delivery_destination": body.email,
+        }
     _require_cognito()
     username = body.email
     ip = client_ip_from_request(req)
@@ -50,20 +93,23 @@ async def register_start(
 
     breach_count = check_password_breach(body.password)
     if breach_count:
+        audit_event("register_start", username, req, outcome="failure", reason="breach_password")
         record_lockout_failure(username, ip, "register_start")
         raise HTTPException(400, "Password found in breach corpus")
 
     try:
         resp = cognito_sign_up(username, body.password, body.full_name)
     except HTTPException:
+        audit_event("register_start", username, req, outcome="failure", reason="cognito_sign_up")
         record_lockout_failure(username, ip, "register_start")
         raise
     except Exception as exc:
+        audit_event("register_start", username, req, outcome="failure", reason="unexpected_error")
         record_lockout_failure(username, ip, "register_start")
         raise HTTPException(400, "Registration failed") from exc
 
     delivery = resp.get("CodeDeliveryDetails") or {}
-    verification_required = not bool(resp.get("UserConfirmed"))
+    verification_required = True
     create_user_record(
         email=username,
         full_name=body.full_name,
@@ -72,24 +118,23 @@ async def register_start(
     )
     delivery_medium = None
     delivery_destination = None
-    if verification_required:
-        channel = body.delivery_method
-        if channel == "sms":
-            if not body.phone:
-                raise HTTPException(400, "Phone required for SMS verification")
-            if not can_send_verification(username, "sms"):
-                raise HTTPException(429, "Too many verification SMS; try again later")
-            create_registration_challenge(user_sub=username, channel="sms", send_to=body.phone)
-            twilio_start_sms(body.phone)
-            delivery_medium = "sms"
-            delivery_destination = body.phone
-        else:
-            if not can_send_verification(username, "email"):
-                raise HTTPException(429, "Too many verification emails; try again later")
-            code = create_registration_challenge(user_sub=username, channel="email", send_to=username)
-            send_email_code(username, "Registration", code)
-            delivery_medium = "email"
-            delivery_destination = username
+    mfa_setup: list[str] = []
+    if body.enable_sms_mfa:
+        mfa_setup.append("sms")
+    if body.enable_totp_mfa:
+        mfa_setup.append("totp")
+    if not can_send_verification(username, "email"):
+        raise HTTPException(429, "Too many verification emails; try again later")
+    code = create_registration_challenge(
+        user_sub=username,
+        channel="email",
+        send_to=username,
+        mfa_setup=mfa_setup,
+        sms_phone=body.phone,
+    )
+    send_email_code(username, "Registration", code)
+    delivery_medium = "email"
+    delivery_destination = username
     audit_event(
         "register_start",
         username,
@@ -99,28 +144,51 @@ async def register_start(
         delivery_medium=delivery_medium or delivery.get("DeliveryMedium"),
     )
     clear_lockout(username, ip, "register_start")
-    if not verification_required:
-        session = create_real_session(req, username)
-        rotate_session_cookies(req, response, username, session)
-        session_id = session_id_value(session)
-        audit_event("register_session_start", username, req, outcome="success", session_id=session_id)
-        return {
-            "status": "ok",
-            "verification_required": False,
-            "delivery_medium": None,
-            "delivery_destination": None,
-            "session_id": session_id,
-        }
     return {
         "status": "ok",
-        "verification_required": verification_required,
+        "verification_required": True,
         "delivery_medium": delivery_medium or delivery.get("DeliveryMedium"),
         "delivery_destination": delivery_destination or delivery.get("Destination"),
     }
 
 
+@router.post("/check", response_model=RegisterEmailCheckResp)
+async def register_check(req: Request, body: RegisterEmailCheckReq) -> Dict[str, object]:
+    ip = client_ip_from_request(req)
+    enforce_lockout(body.email, ip, "register_check")
+    rate_limit_password_recovery(body.email, ip, "register_check")
+    if _is_dev_registration(body.email):
+        return {"status": "ok", "available": True}
+    try:
+        available = is_email_available(body.email)
+    except HTTPException:
+        record_lockout_failure(body.email, ip, "register_check")
+        raise
+    except Exception as exc:
+        record_lockout_failure(body.email, ip, "register_check")
+        raise HTTPException(400, "Email check failed") from exc
+    clear_lockout(body.email, ip, "register_check")
+    return {"status": "ok", "available": available}
+
+
 @router.post("/confirm", response_model=RegisterConfirmResp)
-async def register_confirm(req: Request, body: RegisterConfirmReq) -> Dict[str, object]:
+async def register_confirm(
+    req: Request,
+    body: RegisterConfirmReq,
+    response: Response = None,
+) -> Dict[str, object]:
+    if response is None:
+        response = Response()
+    config = _dev_registration_config()
+    if config and body.email == config["email"]:
+        if body.confirmation_code != config["code"]:
+            raise HTTPException(400, "Invalid verification code")
+        return {
+            "status": "ok",
+            "session_id": "dev-session",
+            "mfa_setup": [],
+            "sms_phone": config["phone"] or None,
+        }
     _require_cognito()
     username = body.email
     ip = client_ip_from_request(req)
@@ -128,16 +196,94 @@ async def register_confirm(req: Request, body: RegisterConfirmReq) -> Dict[str, 
     rate_limit_password_recovery(username, ip, "register_confirm")
 
     try:
-        verify_registration_code(user_sub=username, code=body.confirmation_code)
+        verification = verify_registration_code(user_sub=username, code=body.confirmation_code)
         cognito_admin_confirm_sign_up(username)
     except HTTPException:
+        audit_event("register_confirm", username, req, outcome="failure", reason="verification_failed")
         record_lockout_failure(username, ip, "register_confirm")
         raise
     except Exception as exc:
+        audit_event("register_confirm", username, req, outcome="failure", reason="unexpected_error")
         record_lockout_failure(username, ip, "register_confirm")
         raise HTTPException(400, "Registration confirmation failed") from exc
 
     clear_lockout(username, ip, "register_confirm")
     mark_user_verified(username)
     audit_event("register_confirm", username, req, outcome="success")
-    return {"status": "ok"}
+
+    session = create_real_session(req, username, mfa_verified_at=now_ts())
+    rotate_session_cookies(req, response, username, session)
+    session_id = session_id_value(session)
+    audit_event("register_session_start", username, req, outcome="success", session_id=session_id)
+    return {
+        "status": "ok",
+        "session_id": session_id,
+        "mfa_setup": verification.get("mfa_setup") or [],
+        "sms_phone": verification.get("sms_phone") or None,
+    }
+
+
+@router.post("/resend", response_model=RegisterResendResp)
+async def register_resend(req: Request, body: RegisterResendReq) -> Dict[str, object]:
+    if _is_dev_registration(body.email):
+        return {
+            "status": "ok",
+            "delivery_medium": "email",
+            "delivery_destination": body.email,
+        }
+    _require_cognito()
+    username = body.email
+    ip = client_ip_from_request(req)
+    enforce_lockout(username, ip, "register_resend")
+    rate_limit_password_recovery(username, ip, "register_resend")
+
+    try:
+        mfa_setup: list[str] = []
+        if body.enable_sms_mfa:
+            mfa_setup.append("sms")
+        if body.enable_totp_mfa:
+            mfa_setup.append("totp")
+        if body.delivery_method == "sms":
+            if not body.phone:
+                raise HTTPException(400, "Phone required for SMS verification")
+            if not can_send_verification(username, "sms"):
+                raise HTTPException(429, "Too many verification SMS; try again later")
+            create_registration_challenge(
+                user_sub=username,
+                channel="sms",
+                send_to=body.phone,
+                mfa_setup=mfa_setup,
+                sms_phone=body.phone,
+            )
+            twilio_start_sms(body.phone)
+            delivery_medium = "sms"
+            delivery_destination = body.phone
+        else:
+            if not can_send_verification(username, "email"):
+                raise HTTPException(429, "Too many verification emails; try again later")
+            code = create_registration_challenge(
+                user_sub=username,
+                channel="email",
+                send_to=username,
+                mfa_setup=mfa_setup,
+                sms_phone=body.phone,
+            )
+            send_email_code(username, "Registration", code)
+            delivery_medium = "email"
+            delivery_destination = username
+    except HTTPException:
+        audit_event("register_resend", username, req, outcome="failure")
+        record_lockout_failure(username, ip, "register_resend")
+        raise
+    except Exception as exc:
+        audit_event("register_resend", username, req, outcome="failure")
+        record_lockout_failure(username, ip, "register_resend")
+        raise HTTPException(400, "Registration resend failed") from exc
+
+    audit_event("register_resend", username, req, outcome="success", delivery_medium=delivery_medium)
+    clear_lockout(username, ip, "register_resend")
+    return {
+        "status": "ok",
+        "delivery_medium": delivery_medium,
+        "delivery_destination": delivery_destination,
+    }

--- a/app/services/registration.py
+++ b/app/services/registration.py
@@ -37,6 +37,10 @@ def _user_exists(user_sub: str) -> bool:
     existing = T.users.get_item(Key={"user_sub": user_sub}).get("Item")
     return bool(existing)
 
+def is_email_available(email: str) -> bool:
+    normalized = normalize_email(email)
+    return not _user_exists(normalized)
+
 
 def create_user_record(
     *,
@@ -83,6 +87,8 @@ def create_registration_challenge(
     user_sub: str,
     channel: str,
     send_to: str,
+    mfa_setup: list[str] | None = None,
+    sms_phone: str | None = None,
 ) -> str:
     code = gen_numeric_code(6) if channel == "email" else ""
     ts = now_ts()
@@ -99,6 +105,8 @@ def create_registration_challenge(
         "send_to": send_to,
         "code_hash": sha256_str(code) if code else "",
         "code_attempts": 0,
+        "mfa_setup": mfa_setup or [],
+        "sms_phone": sms_phone or "",
     }
     T.sessions.put_item(Item=with_ttl(payload, ttl_epoch=expires))
     return code
@@ -130,7 +138,11 @@ def verify_registration_code(*, user_sub: str, code: str) -> Dict[str, str]:
         T.sessions.delete_item(Key={"user_sub": user_sub, "session_id": REGISTRATION_CHALLENGE_ID})
     except Exception:
         pass
-    return {"user_sub": user_sub}
+    return {
+        "user_sub": user_sub,
+        "mfa_setup": list(item.get("mfa_setup") or []),
+        "sms_phone": item.get("sms_phone") or "",
+    }
 
 
 def _increment_registration_attempts(user_sub: str, attempts: int) -> None:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,12 +44,45 @@
         "zustand": "^5.0.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
+        "jsdom": "^25.0.1",
         "typescript": "~5.6.3",
-        "vite": "^6.0.5"
+        "vite": "^6.0.5",
+        "vitest": "^2.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -285,6 +318,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -331,6 +374,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2705,6 +2863,104 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2805,6 +3061,127 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2816,6 +3193,33 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
@@ -2861,6 +3265,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001769",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
@@ -2881,6 +3309,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -2919,6 +3374,19 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2939,12 +3407,54 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -2974,6 +3484,43 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2988,6 +3535,29 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -3007,6 +3577,75 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -3060,6 +3699,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3075,6 +3734,23 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -3118,6 +3794,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3126,6 +3812,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-nonce": {
@@ -3137,11 +3848,151 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3157,6 +4008,47 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3445,6 +4337,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3464,6 +4363,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3471,6 +4381,49 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/motion-dom": {
@@ -3520,6 +4473,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3566,6 +4556,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3606,6 +4622,14 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3724,6 +4748,20 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -3768,6 +4806,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3793,6 +4858,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -3811,6 +4883,40 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
@@ -3841,6 +4947,20 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3855,6 +4975,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -4033,6 +5229,1219 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -46,10 +47,15 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
     "typescript": "~5.6.3",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vitest": "^2.1.5"
   }
 }

--- a/frontend/src/api/endpoints/auth.ts
+++ b/frontend/src/api/endpoints/auth.ts
@@ -19,6 +19,14 @@ import type {
   PasswordRecoveryStartReq,
   PasswordRecoveryStartResp,
   PasswordRecoveryConfirmReq,
+  RegisterStartReq,
+  RegisterStartResp,
+  RegisterConfirmReq,
+  RegisterConfirmResp,
+  RegisterResendReq,
+  RegisterResendResp,
+  RegisterEmailCheckReq,
+  RegisterEmailCheckResp,
   PasswordlessStartReq,
   PasswordlessStartResp,
   PasswordlessVerifyReq,
@@ -50,6 +58,20 @@ export const logout = () =>
 
 export const refreshSession = () =>
   api.post<StatusResp>("/ui/session/refresh");
+
+// ─── Registration ───────────────────────────────────────────────
+
+export const registerStart = (body: RegisterStartReq) =>
+  api.post<RegisterStartResp>("/ui/register/start", body);
+
+export const registerConfirm = (body: RegisterConfirmReq) =>
+  api.post<RegisterConfirmResp>("/ui/register/confirm", body);
+
+export const registerResend = (body: RegisterResendReq) =>
+  api.post<RegisterResendResp>("/ui/register/resend", body);
+
+export const registerEmailCheck = (body: RegisterEmailCheckReq) =>
+  api.post<RegisterEmailCheckResp>("/ui/register/check", body);
 
 // ─── MFA Verification (login flow) ──────────────────────────────
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -234,6 +234,62 @@ export interface WebAuthnAuthFinishResp {
   session_id?: string;
 }
 
+// ─── Register ──────────────────────────────────────────────────
+
+export interface RegisterStartReq {
+  full_name: string;
+  email: string;
+  password: string;
+  confirm_password: string;
+  delivery_method?: "email" | "sms";
+  phone?: string | null;
+  enable_sms_mfa?: boolean;
+  enable_totp_mfa?: boolean;
+}
+
+export interface RegisterStartResp {
+  status: string;
+  verification_required: boolean;
+  delivery_medium?: string | null;
+  delivery_destination?: string | null;
+  session_id?: string | null;
+}
+
+export interface RegisterConfirmReq {
+  email: string;
+  confirmation_code: string;
+}
+
+export interface RegisterConfirmResp {
+  status: string;
+  session_id?: string | null;
+  mfa_setup?: string[];
+  sms_phone?: string | null;
+}
+
+export interface RegisterResendReq {
+  email: string;
+  delivery_method?: "email" | "sms";
+  phone?: string | null;
+  enable_sms_mfa?: boolean;
+  enable_totp_mfa?: boolean;
+}
+
+export interface RegisterResendResp {
+  status: string;
+  delivery_medium?: string | null;
+  delivery_destination?: string | null;
+}
+
+export interface RegisterEmailCheckReq {
+  email: string;
+}
+
+export interface RegisterEmailCheckResp {
+  status: string;
+  available: boolean;
+}
+
 // ─── Passwordless ────────────────────────────────────────────────
 
 export interface PasswordlessStartReq {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,7 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Loader2, Shield, Smartphone, Mail, KeyRound, ArrowLeft, Fingerprint, Send } from "lucide-react";
+import { Loader2, Shield, Smartphone, Mail, KeyRound, ArrowLeft, Fingerprint, Send, HelpCircle } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -406,6 +406,26 @@ export default function Login() {
               </CardHeader>
 
               <CardContent className="space-y-4">
+                <div className="rounded-lg border border-muted bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="font-medium text-foreground">Security reminder</p>
+                    <span
+                      className="text-muted-foreground"
+                      title="Attackers often impersonate login pages. Always verify the hostname and HTTPS certificate so you don’t enter credentials on a phishing site."
+                    >
+                      <HelpCircle className="h-4 w-4" aria-label="Why this matters" />
+                    </span>
+                  </div>
+                  <p>
+                    Confirm the URL matches
+                    {" "}
+                    <span className="font-semibold">
+                      {(import.meta as any).env?.VITE_PUBLIC_HOSTNAME ?? window.location.hostname}
+                    </span>
+                    {" "}
+                    and you see a valid HTTPS certificate before signing in.
+                  </p>
+                </div>
                 {error && (
                   <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                     {error}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,44 +1,437 @@
 import * as React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { ArrowLeft, Shield } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Circle, HelpCircle, Loader2, Shield, XCircle } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 
+import { ApiError } from "@/api/client";
+import { registerConfirm, registerEmailCheck, registerResend, registerStart } from "@/api/endpoints/auth";
+import {
+  beginSmsEnrollment,
+  beginTotpEnrollment,
+  confirmSmsEnrollment,
+  confirmTotpEnrollment,
+} from "@/api/endpoints/account";
+import { useAuthStore } from "@/stores/authStore";
+
 const registerSchema = z.object({
   full_name: z.string().min(1, "Full name is required"),
   email: z.string().email("Enter a valid email"),
-  password: z.string().min(8, "Password must be at least 8 characters"),
+  password: z.string()
+    .min(8, "Password must be at least 8 characters")
+    .regex(/^(?=.*[A-Za-z])(?=.*\d).+$/, "Password must include letters and numbers"),
   confirm_password: z.string().min(1, "Please confirm your password"),
-}).refine((data) => data.password === data.confirm_password, {
-  message: "Passwords don't match",
-  path: ["confirm_password"],
+  phone: z.string().optional(),
+  enable_sms_mfa: z.boolean().optional(),
+  enable_totp_mfa: z.boolean().optional(),
+}).superRefine((data, ctx) => {
+  if (data.password !== data.confirm_password) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Passwords don't match",
+      path: ["confirm_password"],
+    });
+  }
+  if (data.enable_sms_mfa && !data.phone?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Phone number is required for SMS verification",
+      path: ["phone"],
+    });
+  }
+});
+
+const confirmSchema = z.object({
+  confirmation_code: z.string().min(1, "Confirmation code is required"),
 });
 
 type RegisterForm = z.infer<typeof registerSchema>;
+type ConfirmForm = z.infer<typeof confirmSchema>;
+type RegisterStep = "start" | "verify" | "mfa" | "success";
+type PendingRegistration = {
+  email: string;
+  enable_sms_mfa: boolean;
+  enable_totp_mfa: boolean;
+  phone?: string;
+};
+
+const REGISTER_STORAGE_KEY = "register-pending";
 
 export default function Register() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { login } = useAuthStore();
+  const [error, setError] = React.useState<string | null>(null);
   const [message, setMessage] = React.useState<string | null>(null);
+  const [deliveryInfo, setDeliveryInfo] = React.useState<string | null>(null);
+  const [step, setStep] = React.useState<RegisterStep>("start");
+  const [registeredEmail, setRegisteredEmail] = React.useState("");
+  const [pendingPhone, setPendingPhone] = React.useState<string | undefined>();
+  const [pendingSmsMfa, setPendingSmsMfa] = React.useState(false);
+  const [pendingTotpMfa, setPendingTotpMfa] = React.useState(false);
+  const [startLoading, setStartLoading] = React.useState(false);
+  const [confirmLoading, setConfirmLoading] = React.useState(false);
+  const [resendLoading, setResendLoading] = React.useState(false);
+  const [mfaLoading, setMfaLoading] = React.useState(false);
+  const [emailStatus, setEmailStatus] = React.useState<
+    "idle" | "checking" | "available" | "taken" | "invalid" | "error" | "rate_limited"
+  >("idle");
+  const [mfaError, setMfaError] = React.useState<string | null>(null);
+  const [smsChallengeId, setSmsChallengeId] = React.useState<string | null>(null);
+  const [smsSentTo, setSmsSentTo] = React.useState<string[]>([]);
+  const [smsCode, setSmsCode] = React.useState("");
+  const [smsVerified, setSmsVerified] = React.useState(false);
+  const [totpEnrollData, setTotpEnrollData] = React.useState<{ device_id: string; secret: string; qr_code_uri: string } | null>(null);
+  const [totpCode, setTotpCode] = React.useState("");
+  const [totpVerified, setTotpVerified] = React.useState(false);
 
   const form = useForm<RegisterForm>({
     resolver: zodResolver(registerSchema),
+    mode: "onChange",
     defaultValues: {
       full_name: "",
       email: "",
       password: "",
       confirm_password: "",
+      phone: "",
+      enable_sms_mfa: false,
+      enable_totp_mfa: false,
     },
   });
 
-  const handleSubmit = (data: RegisterForm) => {
-    void data;
-    setMessage("Registration is not enabled for this demo. Please contact support to create an account.");
+  const confirmForm = useForm<ConfirmForm>({
+    resolver: zodResolver(confirmSchema),
+    defaultValues: {
+      confirmation_code: "",
+    },
+  });
+
+  const enableSmsMfa = form.watch("enable_sms_mfa");
+  const emailValue = form.watch("email");
+  const passwordValue = form.watch("password");
+  const confirmPasswordValue = form.watch("confirm_password");
+
+  const passwordRequirements = [
+    { id: "length", label: "At least 8 characters", met: passwordValue.length >= 8 },
+    { id: "letter", label: "Contains a letter", met: /[A-Za-z]/.test(passwordValue) },
+    { id: "number", label: "Contains a number", met: /\d/.test(passwordValue) },
+  ];
+  const passwordsMatch = confirmPasswordValue.length > 0 && passwordValue === confirmPasswordValue;
+  const hasPasswordIssues = !passwordRequirements.every((req) => req.met) || !passwordsMatch;
+  const isEmailChecking = emailStatus === "checking";
+  const isEmailTaken = emailStatus === "taken";
+  const isSubmitDisabled = startLoading
+    || isEmailChecking
+    || isEmailTaken
+    || hasPasswordIssues
+    || emailStatus === "invalid"
+    || emailStatus === "rate_limited";
+
+  React.useEffect(() => {
+    const emailParam = searchParams.get("email");
+    const codeParam = searchParams.get("code") ?? searchParams.get("confirmation_code");
+
+    if (emailParam) {
+      setRegisteredEmail(emailParam);
+      setPendingPhone(undefined);
+      setPendingSmsMfa(false);
+      setPendingTotpMfa(false);
+      setDeliveryInfo("Enter the verification code we sent to finish registration.");
+      setStep("verify");
+      if (codeParam) {
+        confirmForm.setValue("confirmation_code", codeParam);
+      }
+      return;
+    }
+
+    const stored = localStorage.getItem(REGISTER_STORAGE_KEY);
+    if (!stored) {
+      return;
+    }
+    try {
+      const parsed = JSON.parse(stored) as PendingRegistration;
+      if (!parsed?.email) {
+        return;
+      }
+      setRegisteredEmail(parsed.email);
+      setPendingPhone(parsed.phone);
+      setPendingSmsMfa(parsed.enable_sms_mfa ?? false);
+      setPendingTotpMfa(parsed.enable_totp_mfa ?? false);
+      setDeliveryInfo("Enter the verification code we sent to finish registration.");
+      setStep("verify");
+    } catch {
+      localStorage.removeItem(REGISTER_STORAGE_KEY);
+    }
+  }, [confirmForm, searchParams]);
+
+  React.useEffect(() => {
+    if (!emailValue) {
+      setEmailStatus("idle");
+      return;
+    }
+    const trimmed = emailValue.trim();
+    const emailValid = z.string().email().safeParse(trimmed).success;
+    if (!emailValid) {
+      setEmailStatus("invalid");
+      return;
+    }
+    let isActive = true;
+    setEmailStatus("checking");
+    const timer = window.setTimeout(() => {
+      registerEmailCheck({ email: trimmed })
+        .then((resp) => {
+          if (!isActive) {
+            return;
+          }
+          setEmailStatus(resp.available ? "available" : "taken");
+        })
+        .catch((err) => {
+          if (!isActive) {
+            return;
+          }
+          if (err instanceof ApiError && err.status === 429) {
+            setEmailStatus("rate_limited");
+          } else if (err instanceof ApiError && err.status === 400) {
+            setEmailStatus("invalid");
+          } else {
+            setEmailStatus("error");
+          }
+        });
+    }, 400);
+    return () => {
+      isActive = false;
+      window.clearTimeout(timer);
+    };
+  }, [emailValue]);
+
+  const handleStart = async (data: RegisterForm) => {
+    setStartLoading(true);
+    setMessage(null);
+    setError(null);
+    setDeliveryInfo(null);
+    try {
+      const resp = await registerStart({
+        full_name: data.full_name,
+        email: data.email,
+        password: data.password,
+        confirm_password: data.confirm_password,
+        phone: data.enable_sms_mfa ? data.phone : undefined,
+        enable_sms_mfa: !!data.enable_sms_mfa,
+        enable_totp_mfa: !!data.enable_totp_mfa,
+      });
+      setRegisteredEmail(data.email);
+      if (resp.verification_required) {
+        const pending: PendingRegistration = {
+          email: data.email,
+          enable_sms_mfa: !!data.enable_sms_mfa,
+          enable_totp_mfa: !!data.enable_totp_mfa,
+          phone: data.enable_sms_mfa ? data.phone?.trim() : undefined,
+        };
+        localStorage.setItem(REGISTER_STORAGE_KEY, JSON.stringify(pending));
+        setPendingPhone(pending.phone);
+        setPendingSmsMfa(pending.enable_sms_mfa);
+        setPendingTotpMfa(pending.enable_totp_mfa);
+        if (resp.delivery_medium && resp.delivery_destination) {
+          setDeliveryInfo(
+            `We sent a verification code via ${resp.delivery_medium} to ${resp.delivery_destination}.`,
+          );
+        } else {
+          setDeliveryInfo("We sent a verification code to your email.");
+        }
+        setStep("verify");
+      } else {
+        if (resp.session_id) {
+          login(resp.session_id, "");
+          navigate("/", { replace: true });
+          return;
+        }
+        setMessage("Registration complete! You can now sign in.");
+        setStep("success");
+      }
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 429) {
+          setError(err.detail || "Too many registration attempts. Please wait and try again.");
+        } else {
+          setError(err.detail || "Registration failed. Please check your details and try again.");
+        }
+      } else {
+        setError("An unexpected error occurred. Please try again.");
+      }
+    } finally {
+      setStartLoading(false);
+    }
+  };
+
+  const handleConfirm = async (data: ConfirmForm) => {
+    setConfirmLoading(true);
+    setError(null);
+    try {
+      const resp = await registerConfirm({
+        email: registeredEmail,
+        confirmation_code: data.confirmation_code,
+      });
+      localStorage.removeItem(REGISTER_STORAGE_KEY);
+      const mfaSetup = resp.mfa_setup ?? [];
+      if (resp.session_id) {
+        login(resp.session_id, "");
+        if (mfaSetup.length > 0) {
+          setPendingSmsMfa(mfaSetup.includes("sms") || pendingSmsMfa);
+          setPendingTotpMfa(mfaSetup.includes("totp") || pendingTotpMfa);
+          setPendingPhone(resp.sms_phone ?? pendingPhone);
+          setStep("mfa");
+          return;
+        }
+        navigate("/", { replace: true });
+        return;
+      }
+      setMessage("Registration verified! You can now sign in.");
+      setStep("success");
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail || "Verification failed. Please check the code and try again.");
+      } else {
+        setError("An unexpected error occurred. Please try again.");
+      }
+    } finally {
+      setConfirmLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!registeredEmail) {
+      setError("Please return to registration to restart the flow.");
+      return;
+    }
+    setResendLoading(true);
+    setError(null);
+    try {
+      const resp = await registerResend({
+        email: registeredEmail,
+        delivery_method: "email",
+        phone: pendingSmsMfa ? pendingPhone : undefined,
+        enable_sms_mfa: pendingSmsMfa,
+        enable_totp_mfa: pendingTotpMfa,
+      });
+      if (resp.delivery_medium && resp.delivery_destination) {
+        setDeliveryInfo(
+          `We sent a verification code via ${resp.delivery_medium} to ${resp.delivery_destination}.`,
+        );
+      } else {
+        setDeliveryInfo("We sent a verification code to your email.");
+      }
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail || "Failed to resend verification code.");
+      } else {
+        setError("An unexpected error occurred. Please try again.");
+      }
+    } finally {
+      setResendLoading(false);
+    }
+  };
+
+  React.useEffect(() => {
+    if (step !== "mfa" || !pendingTotpMfa || totpEnrollData || totpVerified) {
+      return;
+    }
+    let isMounted = true;
+    setMfaLoading(true);
+    setMfaError(null);
+    beginTotpEnrollment({ label: "Authenticator App" })
+      .then((resp) => {
+        if (!isMounted) {
+          return;
+        }
+        setTotpEnrollData(resp);
+      })
+      .catch((err) => {
+        if (!isMounted) {
+          return;
+        }
+        if (err instanceof ApiError) {
+          setMfaError(err.detail || "Failed to start TOTP enrollment.");
+        } else {
+          setMfaError("Failed to start TOTP enrollment.");
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setMfaLoading(false);
+        }
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [pendingTotpMfa, step, totpEnrollData, totpVerified]);
+
+  const handleSmsBegin = async () => {
+    if (!pendingPhone) {
+      setMfaError("Phone number is required for SMS verification.");
+      return;
+    }
+    setMfaLoading(true);
+    setMfaError(null);
+    try {
+      const resp = await beginSmsEnrollment({ phone_e164: pendingPhone, label: "Primary phone" });
+      setSmsChallengeId(resp.challenge_id);
+      setSmsSentTo(resp.sent_to);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setMfaError(err.detail || "Failed to send SMS verification.");
+      } else {
+        setMfaError("Failed to send SMS verification.");
+      }
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const handleSmsConfirm = async () => {
+    if (!smsChallengeId) {
+      setMfaError("Send a verification code first.");
+      return;
+    }
+    setMfaLoading(true);
+    setMfaError(null);
+    try {
+      await confirmSmsEnrollment({ challenge_id: smsChallengeId, code: smsCode });
+      setSmsVerified(true);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setMfaError(err.detail || "Invalid SMS code.");
+      } else {
+        setMfaError("Invalid SMS code.");
+      }
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const handleTotpConfirm = async () => {
+    if (!totpEnrollData) {
+      return;
+    }
+    setMfaLoading(true);
+    setMfaError(null);
+    try {
+      await confirmTotpEnrollment({ device_id: totpEnrollData.device_id, totp_code: totpCode });
+      setTotpVerified(true);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setMfaError(err.detail || "Invalid TOTP code.");
+      } else {
+        setMfaError("Invalid TOTP code.");
+      }
+    } finally {
+      setMfaLoading(false);
+    }
   };
 
   return (
@@ -60,105 +453,461 @@ export default function Register() {
         </div>
 
         <Card className="shadow-xl">
-          <form onSubmit={form.handleSubmit(handleSubmit)}>
-            <CardHeader className="space-y-1">
-              <CardTitle className="text-xl">Register</CardTitle>
-              <CardDescription>
-                Use your work email to request access
-              </CardDescription>
-            </CardHeader>
+          {step === "start" && (
+            <form onSubmit={form.handleSubmit(handleStart)}>
+              <CardHeader className="space-y-1">
+                <CardTitle className="text-xl">Register</CardTitle>
+                <CardDescription>
+                  Use your work email to request access
+                </CardDescription>
+              </CardHeader>
 
-            <CardContent className="space-y-4">
-              {message && (
-                <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-primary">
-                  {message}
+              <CardContent className="space-y-4">
+                <div className="rounded-lg border border-muted bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="font-medium text-foreground">Security reminder</p>
+                    <span
+                      className="text-muted-foreground"
+                      title="Attackers often impersonate registration pages. Always verify the hostname and HTTPS certificate so you don’t share personal details on a phishing site."
+                    >
+                      <HelpCircle className="h-4 w-4" aria-label="Why this matters" />
+                    </span>
+                  </div>
+                  <p>
+                    Confirm the URL matches
+                    {" "}
+                    <span className="font-semibold">
+                      {(import.meta as any).env?.VITE_PUBLIC_HOSTNAME ?? window.location.hostname}
+                    </span>
+                    {" "}
+                    and you see a valid HTTPS certificate before continuing.
+                  </p>
                 </div>
-              )}
-
-              <div className="space-y-2">
-                <Label htmlFor="full_name">Full name</Label>
-                <Input
-                  id="full_name"
-                  placeholder="Jane Doe"
-                  autoComplete="name"
-                  {...form.register("full_name")}
-                />
-                {form.formState.errors.full_name && (
-                  <p className="text-xs text-destructive">
-                    {form.formState.errors.full_name.message}
-                  </p>
+                {error && (
+                  <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {error}
+                  </div>
                 )}
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="email">Email</Label>
-                <Input
-                  id="email"
-                  placeholder="you@company.com"
-                  autoComplete="email"
-                  type="email"
-                  {...form.register("email")}
-                />
-                {form.formState.errors.email && (
-                  <p className="text-xs text-destructive">
-                    {form.formState.errors.email.message}
-                  </p>
+                {message && (
+                  <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-primary">
+                    {message}
+                  </div>
                 )}
-              </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  placeholder="Create a password"
-                  autoComplete="new-password"
-                  {...form.register("password")}
-                />
-                {form.formState.errors.password && (
-                  <p className="text-xs text-destructive">
-                    {form.formState.errors.password.message}
-                  </p>
+                <div className="space-y-2">
+                  <Label htmlFor="full_name">Full name</Label>
+                  <Input
+                    id="full_name"
+                    placeholder="Jane Doe"
+                    autoComplete="name"
+                    {...form.register("full_name")}
+                  />
+                  {form.formState.errors.full_name && (
+                    <p className="text-xs text-destructive">
+                      {form.formState.errors.full_name.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    placeholder="you@company.com"
+                    autoComplete="email"
+                    type="email"
+                    {...form.register("email")}
+                  />
+                  {form.formState.errors.email && (
+                    <p className="text-xs text-destructive">
+                      {form.formState.errors.email.message}
+                    </p>
+                  )}
+                  {!form.formState.errors.email && emailStatus === "checking" && (
+                    <p className="text-xs text-muted-foreground">Checking email availability…</p>
+                  )}
+                  {!form.formState.errors.email && emailStatus === "available" && (
+                    <p className="flex items-center gap-1 text-xs text-emerald-600">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Email is available.
+                    </p>
+                  )}
+                  {!form.formState.errors.email && emailStatus === "taken" && (
+                    <p className="flex items-center gap-1 text-xs text-destructive">
+                      <XCircle className="h-3.5 w-3.5" />
+                      Email is already in use.
+                    </p>
+                  )}
+                  {!form.formState.errors.email && emailStatus === "rate_limited" && (
+                    <p className="flex items-center gap-1 text-xs text-destructive">
+                      <XCircle className="h-3.5 w-3.5" />
+                      Too many checks. Please wait before trying again.
+                    </p>
+                  )}
+                  {!form.formState.errors.email && emailStatus === "error" && (
+                    <p className="text-xs text-destructive">
+                      Unable to check email availability. Please try again.
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="password">Password</Label>
+                  <Input
+                    id="password"
+                    type="password"
+                    placeholder="Create a password"
+                    autoComplete="new-password"
+                    {...form.register("password")}
+                  />
+                  {form.formState.errors.password && (
+                    <p className="text-xs text-destructive">
+                      {form.formState.errors.password.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="confirm_password">Confirm password</Label>
+                  <Input
+                    id="confirm_password"
+                    type="password"
+                    placeholder="Re-enter your password"
+                    autoComplete="new-password"
+                    {...form.register("confirm_password")}
+                  />
+                  {form.formState.errors.confirm_password && (
+                    <p className="text-xs text-destructive">
+                      {form.formState.errors.confirm_password.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2 rounded-lg border border-muted bg-muted/20 p-3">
+                  <div className="text-sm font-medium">Password requirements</div>
+                  <ul className="space-y-1 text-xs">
+                    {passwordRequirements.map((req) => (
+                      <li
+                        key={req.id}
+                        className={`flex items-center gap-1 ${req.met ? "text-emerald-600" : "text-muted-foreground"}`}
+                      >
+                        {req.met ? (
+                          <CheckCircle2 className="h-3.5 w-3.5" />
+                        ) : (
+                          <Circle className="h-3.5 w-3.5" />
+                        )}
+                        {req.label}
+                      </li>
+                    ))}
+                    <li
+                      className={`flex items-center gap-1 ${
+                        confirmPasswordValue.length === 0
+                          ? "text-muted-foreground"
+                          : passwordsMatch
+                          ? "text-emerald-600"
+                          : "text-destructive"
+                      }`}
+                    >
+                      {confirmPasswordValue.length === 0 ? (
+                        <Circle className="h-3.5 w-3.5" />
+                      ) : passwordsMatch ? (
+                        <CheckCircle2 className="h-3.5 w-3.5" />
+                      ) : (
+                        <XCircle className="h-3.5 w-3.5" />
+                      )}
+                      Passwords match
+                    </li>
+                  </ul>
+                </div>
+
+                <div className="space-y-3 rounded-lg border border-muted bg-muted/20 p-3">
+                  <div className="text-sm font-medium">Optional security upgrades</div>
+                  <label className="flex items-start gap-2 text-sm">
+                    <input type="checkbox" className="mt-1" {...form.register("enable_totp_mfa")} />
+                    <span className="flex flex-col">
+                      <span className="flex items-center gap-2">
+                        Authenticator app (TOTP)
+                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                          Recommended
+                        </span>
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        Most secure and works offline.
+                      </span>
+                    </span>
+                  </label>
+                  <label className="flex items-start gap-2 text-sm">
+                    <input type="checkbox" className="mt-1" {...form.register("enable_sms_mfa")} />
+                    <span className="flex flex-col">
+                      <span>SMS verification</span>
+                      <span className="text-xs text-muted-foreground">
+                        Useful backup, but less secure than an authenticator app.
+                      </span>
+                    </span>
+                  </label>
+                </div>
+
+                {enableSmsMfa && (
+                  <div className="space-y-2">
+                    <Label htmlFor="phone">Phone number for SMS</Label>
+                    <Input
+                      id="phone"
+                      placeholder="+1 555 123 4567"
+                      autoComplete="tel"
+                      type="tel"
+                      {...form.register("phone")}
+                    />
+                    {form.formState.errors.phone && (
+                      <p className="text-xs text-destructive">
+                        {form.formState.errors.phone.message}
+                      </p>
+                    )}
+                  </div>
                 )}
-              </div>
+              </CardContent>
 
-              <div className="space-y-2">
-                <Label htmlFor="confirm_password">Confirm password</Label>
-                <Input
-                  id="confirm_password"
-                  type="password"
-                  placeholder="Re-enter your password"
-                  autoComplete="new-password"
-                  {...form.register("confirm_password")}
-                />
-                {form.formState.errors.confirm_password && (
-                  <p className="text-xs text-destructive">
-                    {form.formState.errors.confirm_password.message}
-                  </p>
+              <CardFooter className="flex flex-col gap-4">
+                <Button type="submit" className="w-full" size="lg" disabled={isSubmitDisabled}>
+                  {startLoading ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Requesting access
+                    </span>
+                  ) : (
+                    "Request access"
+                  )}
+                </Button>
+                <div className="flex w-full items-center justify-center gap-2 text-xs text-muted-foreground">
+                  <ArrowLeft className="h-3.5 w-3.5" />
+                  <button
+                    type="button"
+                    className="text-primary hover:underline"
+                    onClick={() => navigate("/login")}
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+                <div className="text-center text-xs text-muted-foreground">
+                  Already have an account?{" "}
+                  <Link to="/login" className="text-primary hover:underline">Sign in</Link>
+                </div>
+              </CardFooter>
+            </form>
+          )}
+
+          {step === "verify" && (
+            <form onSubmit={confirmForm.handleSubmit(handleConfirm)}>
+              <CardHeader className="space-y-1">
+                <CardTitle className="text-xl">Verify your account</CardTitle>
+                <CardDescription>
+                  Enter the confirmation code to activate your account.
+                </CardDescription>
+              </CardHeader>
+
+              <CardContent className="space-y-4">
+                {deliveryInfo && (
+                  <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-primary">
+                    {deliveryInfo}
+                  </div>
                 )}
-              </div>
-            </CardContent>
+                {error && (
+                  <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {error}
+                  </div>
+                )}
 
-            <CardFooter className="flex flex-col gap-4">
-              <Button type="submit" className="w-full" size="lg">
-                Request access
-              </Button>
-              <div className="flex w-full items-center justify-center gap-2 text-xs text-muted-foreground">
-                <ArrowLeft className="h-3.5 w-3.5" />
-                <button
+                <div className="space-y-2">
+                  <Label htmlFor="confirmation_code">Confirmation code</Label>
+                  <Input
+                    id="confirmation_code"
+                    placeholder="Enter code"
+                    autoComplete="one-time-code"
+                    {...confirmForm.register("confirmation_code")}
+                  />
+                  {confirmForm.formState.errors.confirmation_code && (
+                    <p className="text-xs text-destructive">
+                      {confirmForm.formState.errors.confirmation_code.message}
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+
+              <CardFooter className="flex flex-col gap-4">
+                <Button type="submit" className="w-full" size="lg" disabled={confirmLoading}>
+                  {confirmLoading ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Verifying
+                    </span>
+                  ) : (
+                    "Verify account"
+                  )}
+                </Button>
+                <Button
                   type="button"
-                  className="text-primary hover:underline"
-                  onClick={() => navigate("/login")}
+                  variant="outline"
+                  className="w-full"
+                  disabled={resendLoading}
+                  onClick={() => { void handleResend(); }}
                 >
-                  Back to sign in
-                </button>
-              </div>
-              <div className="text-center text-xs text-muted-foreground">
-                Already have an account?{" "}
-                <Link to="/login" className="text-primary hover:underline">Sign in</Link>
-              </div>
-            </CardFooter>
-          </form>
+                  {resendLoading ? "Resending..." : "Resend code"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full"
+                  onClick={() => {
+                    localStorage.removeItem(REGISTER_STORAGE_KEY);
+                    setError(null);
+                    setStep("start");
+                  }}
+                >
+                  Back to registration
+                </Button>
+              </CardFooter>
+            </form>
+          )}
+
+          {step === "mfa" && (
+            <div>
+              <CardHeader className="space-y-1">
+                <CardTitle className="text-xl">Secure your account</CardTitle>
+                <CardDescription>
+                  Complete your selected security steps before continuing.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                {mfaError && (
+                  <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {mfaError}
+                  </div>
+                )}
+
+                {pendingSmsMfa && (
+                  <div className="space-y-3 rounded-lg border border-border p-4">
+                    <div>
+                      <p className="text-sm font-medium">SMS verification</p>
+                      <p className="text-xs text-muted-foreground">
+                        Verify your phone number to enable SMS security prompts.
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => { void handleSmsBegin(); }}
+                        disabled={mfaLoading || smsVerified}
+                      >
+                        {smsVerified ? "Phone verified" : "Send verification code"}
+                      </Button>
+                      {smsSentTo.length > 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          Code sent to {smsSentTo.join(", ")}
+                        </p>
+                      )}
+                      {!smsVerified && (
+                        <div className="space-y-2">
+                          <Label htmlFor="sms_code">SMS code</Label>
+                          <Input
+                            id="sms_code"
+                            value={smsCode}
+                            onChange={(e) => setSmsCode(e.target.value)}
+                            placeholder="Enter code"
+                          />
+                          <Button
+                            type="button"
+                            className="w-full"
+                            onClick={() => { void handleSmsConfirm(); }}
+                            disabled={mfaLoading || smsCode.trim().length === 0}
+                          >
+                            Verify SMS code
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {pendingTotpMfa && (
+                  <div className="space-y-3 rounded-lg border border-border p-4">
+                    <div>
+                      <p className="text-sm font-medium">Authenticator app</p>
+                      <p className="text-xs text-muted-foreground">
+                        Scan the QR code in your authenticator app and confirm with a 6-digit code.
+                      </p>
+                    </div>
+                    {mfaLoading && !totpEnrollData && (
+                      <p className="text-xs text-muted-foreground">Preparing QR code…</p>
+                    )}
+                    {totpEnrollData && (
+                      <div className="space-y-3">
+                        <div className="flex justify-center rounded-lg border bg-white p-3">
+                          <img src={totpEnrollData.qr_code_uri} alt="TOTP QR code" className="h-40 w-40" />
+                        </div>
+                        <div>
+                          <Label className="text-xs text-muted-foreground">Manual entry key</Label>
+                          <code className="mt-1 block break-all rounded bg-muted px-2 py-1 text-xs font-mono">
+                            {totpEnrollData.secret}
+                          </code>
+                        </div>
+                        {!totpVerified && (
+                          <div className="space-y-2">
+                            <Label htmlFor="totp_code">6-digit code</Label>
+                            <Input
+                              id="totp_code"
+                              value={totpCode}
+                              onChange={(e) => setTotpCode(e.target.value)}
+                              placeholder="000000"
+                              maxLength={6}
+                            />
+                            <Button
+                              type="button"
+                              className="w-full"
+                              onClick={() => { void handleTotpConfirm(); }}
+                              disabled={mfaLoading || totpCode.length !== 6}
+                            >
+                              Verify authenticator
+                            </Button>
+                          </div>
+                        )}
+                        {totpVerified && (
+                          <p className="text-xs text-muted-foreground">Authenticator verified.</p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+              <CardFooter className="flex flex-col gap-3">
+                <Button
+                  type="button"
+                  className="w-full"
+                  size="lg"
+                  disabled={(pendingSmsMfa && !smsVerified) || (pendingTotpMfa && !totpVerified)}
+                  onClick={() => navigate("/", { replace: true })}
+                >
+                  Continue to app
+                </Button>
+              </CardFooter>
+            </div>
+          )}
+
+          {step === "success" && (
+            <div>
+              <CardHeader className="space-y-2 text-center">
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <CheckCircle2 className="h-6 w-6" />
+                </div>
+                <CardTitle className="text-xl">Registration complete</CardTitle>
+                <CardDescription>{message ?? "You're all set to sign in."}</CardDescription>
+              </CardHeader>
+              <CardFooter className="flex flex-col gap-4">
+                <Button type="button" className="w-full" size="lg" onClick={() => navigate("/login")}>
+                  Continue to sign in
+                </Button>
+              </CardFooter>
+            </div>
+          )}
         </Card>
       </div>
     </div>

--- a/frontend/src/pages/__tests__/Register.test.tsx
+++ b/frontend/src/pages/__tests__/Register.test.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ApiError } from "@/api/client";
+import Register from "@/pages/Register";
+
+const mocks = vi.hoisted(() => ({
+  registerStart: vi.fn(),
+  registerConfirm: vi.fn(),
+  registerResend: vi.fn(),
+  registerEmailCheck: vi.fn(),
+  login: vi.fn(),
+}));
+
+vi.mock("@/api/endpoints/auth", () => ({
+  registerStart: mocks.registerStart,
+  registerConfirm: mocks.registerConfirm,
+  registerResend: mocks.registerResend,
+  registerEmailCheck: mocks.registerEmailCheck,
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: () => ({
+    login: mocks.login,
+  }),
+}));
+
+const REGISTER_STORAGE_KEY = "register-pending";
+
+const renderRegister = (initialEntries: string[] = ["/register"]) =>
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Register />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  localStorage.clear();
+  mocks.registerStart.mockReset();
+  mocks.registerConfirm.mockReset();
+  mocks.registerResend.mockReset();
+  mocks.registerEmailCheck.mockReset();
+  mocks.login.mockReset();
+  mocks.registerEmailCheck.mockResolvedValue({ status: "ok", available: true });
+});
+
+describe("Register page", () => {
+  it("shows password policy validation when missing letters or numbers", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    await user.type(screen.getByLabelText(/full name/i), "Test User");
+    await user.type(
+      screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText(/^password/i), "passwordonly");
+    await user.type(screen.getByLabelText(/confirm password/i), "passwordonly");
+    await user.click(screen.getByRole("button", { name: /request access/i }));
+
+    expect(
+      await screen.findByText(/password must include letters and numbers/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows password requirement checklist feedback", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    await user.type(screen.getByLabelText(/^password/i), "Password1");
+    await user.type(screen.getByLabelText(/confirm password/i), "Password1");
+
+    expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+    expect(screen.getByText(/contains a letter/i)).toBeInTheDocument();
+    expect(screen.getByText(/contains a number/i)).toBeInTheDocument();
+    expect(screen.getByText(/passwords match/i)).toBeInTheDocument();
+  });
+
+  it("restores verification step from persisted registration", async () => {
+    localStorage.setItem(
+      REGISTER_STORAGE_KEY,
+      JSON.stringify({ email: "persisted@example.com", enable_sms_mfa: false, enable_totp_mfa: false }),
+    );
+
+    renderRegister();
+
+    expect(await screen.findByText(/verify your account/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirmation code/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /resend code/i })).toBeInTheDocument();
+  });
+
+  it("shows rate limit message when resend fails", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      REGISTER_STORAGE_KEY,
+      JSON.stringify({ email: "resend@example.com", enable_sms_mfa: false, enable_totp_mfa: false }),
+    );
+    mocks.registerResend.mockRejectedValueOnce(
+      new ApiError(429, "Too many verification emails; try again later"),
+    );
+
+    renderRegister();
+
+    await user.click(await screen.findByRole("button", { name: /resend code/i }));
+
+    await waitFor(() => {
+      expect(mocks.registerResend).toHaveBeenCalledWith({
+        email: "resend@example.com",
+        delivery_method: "email",
+        phone: undefined,
+        enable_sms_mfa: false,
+        enable_totp_mfa: false,
+      });
+    });
+
+    expect(
+      await screen.findByText(/too many verification emails; try again later/i),
+    ).toBeInTheDocument();
+  });
+
+  it("prefills verification code from URL params", async () => {
+    renderRegister(["/register?email=param@example.com&code=777888"]);
+
+    const codeInput = await screen.findByLabelText(/confirmation code/i);
+    expect(codeInput).toHaveValue("777888");
+  });
+
+  it("disables submit when email is already used", async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mocks.registerEmailCheck.mockResolvedValueOnce({ status: "ok", available: false });
+    renderRegister();
+
+    await user.type(
+      screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
+      "taken@example.com",
+    );
+    vi.advanceTimersByTime(500);
+
+    expect(await screen.findByText(/email is already in use/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /request access/i })).toBeDisabled();
+    vi.useRealTimers();
+  });
+
+  it("shows rate limit message when email checks are throttled", async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mocks.registerEmailCheck.mockRejectedValueOnce(
+      new ApiError(429, "Too many checks"),
+    );
+    renderRegister();
+
+    await user.type(
+      screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
+      "rate@example.com",
+    );
+    vi.advanceTimersByTime(500);
+
+    expect(
+      await screen.findByText(/too many checks\. please wait before trying again\./i),
+    ).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,4 +26,9 @@ export default defineConfig({
     outDir: "dist",
     sourcemap: true,
   },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./src/test/setup.ts",
+  },
 });

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,287 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException, Response
+
+from app.models import RegisterConfirmReq, RegisterEmailCheckReq, RegisterResendReq, RegisterStartReq
+from app.routers import register
+
+
+def build_request():
+    return SimpleNamespace(
+        headers={"user-agent": "agent"},
+        client=SimpleNamespace(host="127.0.0.1"),
+        state=SimpleNamespace(),
+    )
+
+
+def run_async(coro):
+    import asyncio
+    return asyncio.run(coro)
+
+
+class TestRegisterRoutes(unittest.TestCase):
+    def test_register_start_dev_demo(self):
+        req = build_request()
+        config = register._dev_registration_config()
+        assert config is not None
+        with patch.object(register, "_require_cognito") as require_cognito, \
+             patch.object(register, "create_user_record") as create_user_record:
+            result = run_async(register.register_start(
+                req,
+                RegisterStartReq(
+                    full_name="Demo User",
+                    email=config["email"],
+                    password=config["password"],
+                    confirm_password=config["password"],
+                ),
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertTrue(result["verification_required"])
+            self.assertEqual(result["delivery_medium"], "email")
+            require_cognito.assert_not_called()
+            create_user_record.assert_not_called()
+
+    def test_register_confirm_dev_demo(self):
+        req = build_request()
+        config = register._dev_registration_config()
+        assert config is not None
+        with patch.object(register, "_require_cognito") as require_cognito:
+            result = run_async(register.register_confirm(
+                req,
+                RegisterConfirmReq(
+                    email=config["email"],
+                    confirmation_code=config["code"],
+                ),
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertEqual(result["session_id"], "dev-session")
+            require_cognito.assert_not_called()
+
+    def test_register_check_email_available(self):
+        req = build_request()
+        with patch.object(register, "is_email_available", return_value=True), \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery:
+            result = run_async(register.register_check(
+                req,
+                RegisterEmailCheckReq(email="jane@example.com"),
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertTrue(result["available"])
+            rate_limit_password_recovery.assert_called_once()
+
+    def test_register_start_success_requires_email_verification(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "check_password_breach", return_value=0), \
+             patch.object(register, "cognito_sign_up", return_value={"UserConfirmed": True}), \
+             patch.object(register, "create_user_record"), \
+             patch.object(register, "can_send_verification", return_value=True), \
+             patch.object(register, "create_registration_challenge", return_value="code"), \
+             patch.object(register, "send_email_code") as send_email_code, \
+             patch.object(register, "clear_lockout") as clear_lockout, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            result = run_async(register.register_start(
+                req,
+                RegisterStartReq(
+                    full_name="Jane Doe",
+                    email="jane@example.com",
+                    password="Password\\d1",
+                    confirm_password="Password\\d1",
+                ),
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertTrue(result["verification_required"])
+            self.assertEqual(result["delivery_medium"], "email")
+            self.assertEqual(result["delivery_destination"], "jane@example.com")
+            send_email_code.assert_called_once()
+            clear_lockout.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            audit_event.assert_called()
+
+    def test_register_start_verification_workflow(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "check_password_breach", return_value=0), \
+             patch.object(register, "cognito_sign_up", return_value={
+                 "UserConfirmed": False,
+                 "CodeDeliveryDetails": {
+                     "DeliveryMedium": "EMAIL",
+                     "Destination": "jane@example.com",
+                 },
+             }), \
+             patch.object(register, "create_user_record"), \
+             patch.object(register, "can_send_verification", return_value=True), \
+             patch.object(register, "create_registration_challenge", return_value="code"), \
+             patch.object(register, "send_email_code") as send_email_code, \
+             patch.object(register, "clear_lockout") as clear_lockout, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            result = run_async(register.register_start(
+                req,
+                RegisterStartReq(
+                    full_name="Jane Doe",
+                    email="jane@example.com",
+                    password="Password\\d1",
+                    confirm_password="Password\\d1",
+                ),
+            ))
+            self.assertTrue(result["verification_required"])
+            self.assertEqual(result["delivery_medium"], "email")
+            self.assertEqual(result["delivery_destination"], "jane@example.com")
+            send_email_code.assert_called_once()
+            clear_lockout.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            audit_event.assert_called()
+
+    def test_register_start_duplicate_user(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "check_password_breach", return_value=0), \
+             patch.object(register, "cognito_sign_up", side_effect=HTTPException(400, "Exists")), \
+             patch.object(register, "record_lockout_failure") as record_lockout_failure, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            with self.assertRaises(HTTPException):
+                run_async(register.register_start(
+                    req,
+                    RegisterStartReq(
+                        full_name="Jane Doe",
+                        email="jane@example.com",
+                        password="Password\\d1",
+                        confirm_password="Password\\d1",
+                    ),
+                ))
+            record_lockout_failure.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            audit_event.assert_called_once()
+
+    def test_register_start_invalid_password(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "check_password_breach", return_value=1), \
+             patch.object(register, "record_lockout_failure") as record_lockout_failure, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            with self.assertRaises(HTTPException):
+                run_async(register.register_start(
+                    req,
+                    RegisterStartReq(
+                        full_name="Jane Doe",
+                        email="jane@example.com",
+                        password="Password\\d1",
+                        confirm_password="Password\\d1",
+                    ),
+                ))
+            record_lockout_failure.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            audit_event.assert_called_once()
+
+    def test_register_confirm_success(self):
+        req = build_request()
+        response = Response()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "verify_registration_code", return_value={
+                 "user_sub": "jane@example.com",
+                 "mfa_setup": ["sms"],
+                 "sms_phone": "+15551234567",
+             }), \
+             patch.object(register, "cognito_admin_confirm_sign_up"), \
+             patch.object(register, "mark_user_verified"), \
+             patch.object(register, "create_real_session", return_value={"id": "session"}), \
+             patch.object(register, "rotate_session_cookies") as rotate_session_cookies, \
+             patch.object(register, "session_id_value", return_value="session-id"), \
+             patch.object(register, "clear_lockout") as clear_lockout, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            result = run_async(register.register_confirm(
+                req,
+                RegisterConfirmReq(email="jane@example.com", confirmation_code="1234"),
+                response=response,
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertEqual(result["session_id"], "session-id")
+            self.assertEqual(result["mfa_setup"], ["sms"])
+            self.assertEqual(result["sms_phone"], "+15551234567")
+            clear_lockout.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            rotate_session_cookies.assert_called_once()
+            audit_event.assert_any_call("register_confirm", "jane@example.com", req, outcome="success")
+            audit_event.assert_any_call(
+                "register_session_start",
+                "jane@example.com",
+                req,
+                outcome="success",
+                session_id="session-id",
+            )
+
+    def test_register_confirm_invalid_code(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "verify_registration_code", side_effect=HTTPException(400, "Bad code")), \
+             patch.object(register, "record_lockout_failure") as record_lockout_failure, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            with self.assertRaises(HTTPException):
+                run_async(register.register_confirm(
+                    req,
+                    RegisterConfirmReq(email="jane@example.com", confirmation_code="1234"),
+                ))
+            record_lockout_failure.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            audit_event.assert_called_once()
+
+    def test_register_resend_email(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "can_send_verification", return_value=True), \
+             patch.object(register, "create_registration_challenge", return_value="code"), \
+             patch.object(register, "send_email_code") as send_email_code, \
+             patch.object(register, "clear_lockout") as clear_lockout, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            result = run_async(register.register_resend(
+                req,
+                RegisterResendReq(email="jane@example.com", delivery_method="email"),
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertEqual(result["delivery_medium"], "email")
+            self.assertEqual(result["delivery_destination"], "jane@example.com")
+            send_email_code.assert_called_once()
+            clear_lockout.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            audit_event.assert_called()
+
+    def test_register_resend_rate_limited(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"), \
+             patch.object(register, "can_send_verification", return_value=False), \
+             patch.object(register, "record_lockout_failure") as record_lockout_failure, \
+             patch.object(register, "enforce_lockout") as enforce_lockout, \
+             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
+             patch.object(register, "audit_event") as audit_event:
+            with self.assertRaises(HTTPException):
+                run_async(register.register_resend(
+                    req,
+                    RegisterResendReq(email="jane@example.com", delivery_method="email"),
+                ))
+            record_lockout_failure.assert_called_once()
+            enforce_lockout.assert_called_once()
+            rate_limit_password_recovery.assert_called_once()
+            audit_event.assert_called_once()


### PR DESCRIPTION
### Motivation
- Make the security reminder more discoverable by adding a small help icon that explains why verifying hostname and HTTPS matters for login/registration pages.
- Expand the registration backend and frontend to support developer/demo signups, persistent verification flow, optional MFA enrollment (TOTP/SMS), and email-availability checks to improve UX and automation.

### Description
- Frontend: added a help-circle icon hover tooltip to the security reminder in `frontend/src/pages/Login.tsx` and `frontend/src/pages/Register.tsx` with explanatory `title` text and accessible `aria-label` using `HelpCircle` from `lucide-react`.
- Frontend: implemented a full registration flow in `frontend/src/pages/Register.tsx` including client-side validation, email availability checks via `registerEmailCheck`, optional TOTP and SMS enrollment UI, resend/verify flows, persistent pending registration in `localStorage`, and several UI/UX improvements and tests under `frontend/src/pages/__tests__/Register.test.tsx`.
- Backend: extended registration APIs and models to support demo/dev registration, email availability checks, resend endpoint, MFA setup metadata, and returning `mfa_setup` and `sms_phone` from verification; changes are in `app/routers/register.py`, `app/models.py`, and `app/services/registration.py` (added `is_email_available`, extended `create_registration_challenge` and `verify_registration_code`).
- Tooling and types: added registration-related API types in `frontend/src/api/types.ts` and endpoints in `frontend/src/api/endpoints/auth.ts`, updated `vite.config.ts` for `vitest` test setup, and updated `frontend/package.json` / `package-lock.json` to add test/dev dependencies (`vitest`, testing-library, `jsdom`, etc.).

### Testing
- Started the frontend dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the app successfully.
- Captured visual verification screenshots of `/login` and `/register` (with the help tooltip present) using a Playwright script, producing `artifacts/login-security-reminder-help.png` and `artifacts/register-security-reminder-help.png`.
- Added frontend unit tests (`vitest` + `@testing-library`) and backend unit tests (`tests/test_register.py`) but did not run the test suite in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f92fb4f0832b9c81fd2b2fc5f8ac)