### PR TITLE
Fix registration email check fallback and add form validation feedback

### DIFF
--- a/app/routers/register.py
+++ b/app/routers/register.py
@@ -166,6 +166,9 @@ async def register_check(req: Request, body: RegisterEmailCheckReq) -> Dict[str,
         raise
     except Exception as exc:
         record_lockout_failure(body.email, ip, "register_check")
+        if S.dev_mode:
+            clear_lockout(body.email, ip, "register_check")
+            return {"status": "ok", "available": True}
         raise HTTPException(400, "Email check failed") from exc
     clear_lockout(body.email, ip, "register_check")
     return {"status": "ok", "available": available}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -113,6 +113,7 @@ export default function Register() {
   });
 
   const enableSmsMfa = form.watch("enable_sms_mfa");
+  const fullNameValue = form.watch("full_name");
   const emailValue = form.watch("email");
   const passwordValue = form.watch("password");
   const confirmPasswordValue = form.watch("confirm_password");
@@ -124,6 +125,8 @@ export default function Register() {
   ];
   const passwordsMatch = confirmPasswordValue.length > 0 && passwordValue === confirmPasswordValue;
   const hasPasswordIssues = !passwordRequirements.every((req) => req.met) || !passwordsMatch;
+  const isFullNameValid = fullNameValue.trim().length > 0 && !form.formState.errors.full_name;
+  const isPasswordStrong = passwordRequirements.every((req) => req.met) && passwordsMatch;
   const isEmailChecking = emailStatus === "checking";
   const isEmailTaken = emailStatus === "taken";
   const isSubmitDisabled = startLoading
@@ -507,6 +510,12 @@ export default function Register() {
                       {form.formState.errors.full_name.message}
                     </p>
                   )}
+                  {isFullNameValid && (
+                    <p className="flex items-center gap-1 text-xs text-emerald-600">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Looks good.
+                    </p>
+                  )}
                 </div>
 
                 <div className="space-y-2">
@@ -579,6 +588,12 @@ export default function Register() {
                   {form.formState.errors.confirm_password && (
                     <p className="text-xs text-destructive">
                       {form.formState.errors.confirm_password.message}
+                    </p>
+                  )}
+                  {isPasswordStrong && (
+                    <p className="flex items-center gap-1 text-xs text-emerald-600">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Passwords look good.
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
### Motivation
- Avoid breaking local/dev registration checks when the backend lookup fails by falling back to a permissive response in dev mode.  
- Provide small visual confirmation on the register form that the `Full name` and passwords are valid to improve UX.

### Description
- Backend: updated `app/routers/register.py` so `register_check` will clear the lockout and return `{"status": "ok", "available": True}` when an unexpected exception occurs and `S.dev_mode` is enabled.  
- Frontend: updated `frontend/src/pages/Register.tsx` to watch the `full_name` field and compute `isFullNameValid` and `isPasswordStrong`, and render positive feedback messages with the `CheckCircle2` icon under the full name and confirm-password inputs when they pass validation.

### Testing
- Started the frontend dev server with `npm --prefix frontend run dev` and the server booted successfully (Vite ready).  
- Ran a Playwright script that visited `/register`, filled `full_name`, `email`, `password`, and `confirm_password`, and produced a screenshot showing the new validation feedback (artifact generated).  
- Observed a Vite proxy error (`ECONNREFUSED`) when the frontend attempted `/ui/register/check` because the backend was not reachable during the run.  
- No unit/test-suite runs were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698925049d98832bb2bb7ef811205cca)