### PR TITLE
Fix security reminder tooltips on login and registration pages

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { OtpInput } from "@/components/ui/otp-input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import { useAuthStore } from "@/stores/authStore";
 import { ApiError } from "@/api/client";
@@ -409,12 +410,21 @@ export default function Login() {
                 <div className="rounded-lg border border-muted bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
                   <div className="flex items-start justify-between gap-3">
                     <p className="font-medium text-foreground">Security reminder</p>
-                    <span
-                      className="text-muted-foreground"
-                      title="Attackers often impersonate login pages. Always verify the hostname and HTTPS certificate so you don’t enter credentials on a phishing site."
-                    >
-                      <HelpCircle className="h-4 w-4" aria-label="Why this matters" />
-                    </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-muted-foreground transition-colors hover:text-foreground"
+                          aria-label="Why this matters"
+                        >
+                          <HelpCircle className="h-4 w-4" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs text-pretty">
+                        Attackers often impersonate login pages. Always verify the hostname and HTTPS certificate so you
+                        don’t enter credentials on a phishing site.
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                   <p>
                     Confirm the URL matches

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import { ApiError } from "@/api/client";
 import { registerConfirm, registerEmailCheck, registerResend, registerStart } from "@/api/endpoints/auth";
@@ -466,12 +467,21 @@ export default function Register() {
                 <div className="rounded-lg border border-muted bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
                   <div className="flex items-start justify-between gap-3">
                     <p className="font-medium text-foreground">Security reminder</p>
-                    <span
-                      className="text-muted-foreground"
-                      title="Attackers often impersonate registration pages. Always verify the hostname and HTTPS certificate so you don’t share personal details on a phishing site."
-                    >
-                      <HelpCircle className="h-4 w-4" aria-label="Why this matters" />
-                    </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-muted-foreground transition-colors hover:text-foreground"
+                          aria-label="Why this matters"
+                        >
+                          <HelpCircle className="h-4 w-4" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs text-pretty">
+                        Attackers often impersonate registration pages. Always verify the hostname and HTTPS
+                        certificate so you don’t share personal details on a phishing site.
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                   <p>
                     Confirm the URL matches


### PR DESCRIPTION
### Motivation
- The small help icon used a `title` on a plain element which produced unreliable hover behavior and poor accessibility for the security reminder on auth pages.

### Description
- Replaced the title-based hint with the shared Radix tooltip by importing `Tooltip`, `TooltipTrigger`, and `TooltipContent` into `frontend/src/pages/Login.tsx` and `frontend/src/pages/Register.tsx`.
- Wrapped the help icon in a `TooltipTrigger asChild` and used an accessible `button` with `aria-label` as the trigger so the tooltip works on hover and is keyboard-focusable.
- Added concise tooltip copy via `TooltipContent` and minor styling classes to constrain width.
- Changes affect `frontend/src/pages/Login.tsx` and `frontend/src/pages/Register.tsx` and reuse the existing tooltip implementation in `frontend/src/components/ui/tooltip.tsx`.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which started successfully. 
- Ran a Playwright script that visits `/login` and `/register`, hovers `button[aria-label="Why this matters"]`, and captured screenshots at `artifacts/login-tooltip.png` and `artifacts/register-tooltip.png`; the script completed and artifacts were produced. All automated checks ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698925c7ce18832ba67e205e251cf44a)