### PR TITLE
Local Cognito JWKS + shared AWS client factory (local dev wiring)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,26 @@
+AWS_REGION=us-east-1
+DEV_MODE=1
+
+# DynamoDB Local
+DDB_ENDPOINT_URL=http://localhost:8001
+
+# LocalStack (S3 + Cognito)
+AWS_ENDPOINT_URL=http://localhost:4566
+S3_ENDPOINT_URL=http://localhost:4566
+COGNITO_ENDPOINT_URL=http://localhost:4566
+S3_USE_PATH_STYLE=1
+
+# Buckets
+UPLOAD_BUCKET=local-uploads
+S3_BUCKET_IMAGES=local-chat-images
+FILEMGR_BUCKET=local-filemgr
+
+# Cognito (populate after local setup)
+COGNITO_USER_POOL_ID=
+COGNITO_APP_CLIENT_ID=
+COGNITO_REGION=us-east-1
+
+# Stripe mock
+STRIPE_SECRET_KEY=sk_test_local
+STRIPE_PUBLISHABLE_KEY=pk_test_local
+STRIPE_WEBHOOK_SECRET=whsec_local

--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -21,12 +21,14 @@ def _cognito_enabled() -> bool:
 
 
 def _cognito_issuer() -> str:
+    if S.cognito_issuer_url:
+        return S.cognito_issuer_url.rstrip("/")
     region = S.cognito_region or S.aws_region
     return f"https://cognito-idp.{region}.amazonaws.com/{S.cognito_user_pool_id}"
 
 
 def _fetch_cognito_jwks() -> Tuple[Dict[str, Any], float]:
-    url = f"{_cognito_issuer()}/.well-known/jwks.json"
+    url = S.cognito_jwks_url or f"{_cognito_issuer()}/.well-known/jwks.json"
     resp = requests.get(url, timeout=10)
     resp.raise_for_status()
     return resp.json(), time.time()

--- a/app/core/aws.py
+++ b/app/core/aws.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
-import boto3
-
+from app.core.aws_clients import ddb_resource, kms_client, sqs_client as aws_sqs_client
 from .settings import S
 
-_session = boto3.session.Session(region_name=S.aws_region or "us-east-1")
-
-ddb = _session.resource("dynamodb")
-kms = _session.client("kms")
+ddb = ddb_resource()
+kms = kms_client()
 
 # Optional clients - import lazily / guarded so the server can run without extras installed.
-ses = _session.client("ses") if S.ses_from_email else None
+ses = None
+if S.ses_from_email:
+    from boto3 import client as _boto3_client  # lazy import
+
+    ses = _boto3_client(
+        "ses",
+        region_name=S.aws_region or "us-east-1",
+        endpoint_url=S.aws_endpoint_url or None,
+    )
 
 try:
     from twilio.rest import Client as TwilioClient  # type: ignore
@@ -22,4 +27,14 @@ if TwilioClient and S.twilio_account_sid and S.twilio_auth_token:
     twilio = TwilioClient(S.twilio_account_sid, S.twilio_auth_token)
 
 def sns_client():
-    return _session.client("sns")
+    from boto3 import client as _boto3_client  # lazy import
+
+    return _boto3_client(
+        "sns",
+        region_name=S.aws_region or "us-east-1",
+        endpoint_url=S.aws_endpoint_url or None,
+    )
+
+
+def sqs_client():
+    return aws_sqs_client()

--- a/app/core/aws_clients.py
+++ b/app/core/aws_clients.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import boto3
+from botocore.config import Config
+
+from app.core.settings import S
+
+
+def _resolve_endpoint_url(primary: Optional[str], fallback: Optional[str]) -> Optional[str]:
+    if primary:
+        return primary
+    return fallback or None
+
+
+def _aws_region() -> str:
+    return S.aws_region or "us-east-1"
+
+
+def _aws_endpoint_url() -> Optional[str]:
+    return S.aws_endpoint_url or None
+
+
+def _ddb_endpoint_url() -> Optional[str]:
+    return _resolve_endpoint_url(S.ddb_endpoint_url, _aws_endpoint_url())
+
+
+def _s3_endpoint_url() -> Optional[str]:
+    return _resolve_endpoint_url(S.s3_endpoint_url, _aws_endpoint_url())
+
+
+def _cognito_endpoint_url() -> Optional[str]:
+    return _resolve_endpoint_url(S.cognito_endpoint_url, _aws_endpoint_url())
+
+
+def _kms_endpoint_url() -> Optional[str]:
+    return _resolve_endpoint_url(S.kms_endpoint_url, _aws_endpoint_url())
+
+
+def _sqs_endpoint_url() -> Optional[str]:
+    return _resolve_endpoint_url(S.sqs_endpoint_url, _aws_endpoint_url())
+
+
+def _s3_config() -> Config:
+    if S.s3_use_path_style:
+        return Config(s3={"addressing_style": "path"})
+    return Config()
+
+
+def ddb_resource():
+    return boto3.resource("dynamodb", region_name=_aws_region(), endpoint_url=_ddb_endpoint_url())
+
+
+def s3_client():
+    return boto3.client(
+        "s3",
+        region_name=_aws_region(),
+        endpoint_url=_s3_endpoint_url(),
+        config=_s3_config(),
+    )
+
+
+def cognito_client():
+    return boto3.client(
+        "cognito-idp",
+        region_name=_aws_region(),
+        endpoint_url=_cognito_endpoint_url(),
+    )
+
+
+def kms_client():
+    return boto3.client(
+        "kms",
+        region_name=_aws_region(),
+        endpoint_url=_kms_endpoint_url(),
+    )
+
+
+def sqs_client():
+    return boto3.client(
+        "sqs",
+        region_name=_aws_region(),
+        endpoint_url=_sqs_endpoint_url(),
+    )

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -7,11 +7,20 @@ from dataclasses import dataclass
 class Settings:
     # AWS
     aws_region: str = os.environ.get("AWS_REGION", "us-east-1")
+    aws_endpoint_url: str = os.environ.get("AWS_ENDPOINT_URL", "")
+    ddb_endpoint_url: str = os.environ.get("DDB_ENDPOINT_URL", "")
+    s3_endpoint_url: str = os.environ.get("S3_ENDPOINT_URL", "")
+    cognito_endpoint_url: str = os.environ.get("COGNITO_ENDPOINT_URL", "")
+    kms_endpoint_url: str = os.environ.get("KMS_ENDPOINT_URL", "")
+    sqs_endpoint_url: str = os.environ.get("SQS_ENDPOINT_URL", "")
+    s3_use_path_style: bool = os.environ.get("S3_USE_PATH_STYLE", "0") not in ("0", "false", "False")
 
     # Cognito (optional wiring; auth is pluggable)
     cognito_user_pool_id: str = os.environ.get("COGNITO_USER_POOL_ID", "")
     cognito_region: str = os.environ.get("COGNITO_REGION", "")
     cognito_app_client_id: str = os.environ.get("COGNITO_APP_CLIENT_ID", "")
+    cognito_issuer_url: str = os.environ.get("COGNITO_ISSUER_URL", "")
+    cognito_jwks_url: str = os.environ.get("COGNITO_JWKS_URL", "")
     cognito_expected_token_use: str = os.environ.get("COGNITO_EXPECTED_TOKEN_USE", "access")
     cognito_jwks_ttl_seconds: int = int(os.environ.get("COGNITO_JWKS_TTL_SECONDS", "3600"))
 

--- a/app/routers/messaging.py
+++ b/app/routers/messaging.py
@@ -11,7 +11,6 @@ from typing import Annotated, Any, Dict, Iterable, List, Literal, Optional, Sequ
 from urllib.parse import urljoin, urlparse
 
 import anyio
-import boto3
 from boto3.dynamodb.conditions import Attr, Key
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
@@ -25,7 +24,7 @@ from pydantic import BaseModel, Field
 from app.auth.deps import extract_bearer_token, get_authenticated_user_sub
 from app.core.settings import S
 from app.core.aws import ddb
-from app.core.settings import S
+from app.core.aws_clients import s3_client
 from app.services.alerts import audit_event
 from app.services.filemanager import get_node, norm_path
 from app.services.sessions import require_ui_session
@@ -65,7 +64,7 @@ VIEWS_TTL_SEC = int(os.getenv("VIEWS_TTL_SEC", "2592000"))  # 30d
 EDITS_TTL_SEC = int(os.getenv("EDITS_TTL_SEC", "7776000"))  # 90d
 MESSAGE_REVOKE_WINDOW_SEC = int(os.getenv("MESSAGE_REVOKE_WINDOW_SEC", "300"))
 
-s3 = boto3.client("s3", region_name=AWS_REGION)
+s3 = s3_client()
 
 
 tbl_convos = ddb.Table(DDB_CONVERSATIONS)

--- a/app/routers/newsfeed.py
+++ b/app/routers/newsfeed.py
@@ -8,13 +8,13 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional, Set
 
-import boto3
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Header, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from starlette.responses import StreamingResponse
 
 from app.core.aws import ddb
+from app.core.aws_clients import s3_client, sqs_client
 from app.core.cursor import decode_cursor, encode_cursor
 from app.core.settings import S
 from app.services.subscription_access import can_access_creator
@@ -29,8 +29,8 @@ EVENTS_SQS_URL = os.environ.get("EVENTS_SQS_URL")
 
 tbl = ddb.Table(APP_TABLE)
 
-s3 = boto3.client("s3", region_name=AWS_REGION) if UPLOAD_BUCKET else None
-sqs = boto3.client("sqs", region_name=AWS_REGION) if EVENTS_SQS_URL else None
+s3 = s3_client() if UPLOAD_BUCKET else None
+sqs = sqs_client() if EVENTS_SQS_URL else None
 
 router = APIRouter(tags=["newsfeed"])
 

--- a/app/services/cognito.py
+++ b/app/services/cognito.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-import boto3
 from fastapi import HTTPException
 
+from app.core.aws_clients import cognito_client as shared_cognito_client
 from app.core.settings import S
 
 
@@ -28,7 +28,7 @@ def _cognito_user_pool_id() -> str:
 
 
 def cognito_client():
-    return boto3.client("cognito-idp", region_name=_cognito_region())
+    return shared_cognito_client()
 
 
 def cognito_forgot_password(username: str) -> Dict[str, Any]:

--- a/app/services/filemanager.py
+++ b/app/services/filemanager.py
@@ -12,16 +12,16 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
-import boto3
 import zipstream
 from boto3.dynamodb.conditions import Attr, Key
 from botocore.exceptions import ClientError
 from fastapi import HTTPException, UploadFile
 
 from app.core.aws import ddb
+from app.core.aws_clients import s3_client
 from app.core.settings import S
 
-_s3 = boto3.client("s3", region_name=S.aws_region or "us-east-1")
+_s3 = s3_client()
 logger = logging.getLogger(__name__)
 
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,42 @@
+version: "3.9"
+
+services:
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /home/dynamodblocal/data"
+    ports:
+      - "8001:8000"
+    volumes:
+      - dynamodb_data:/home/dynamodblocal/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  localstack:
+    image: localstack/localstack:latest
+    environment:
+      - SERVICES=s3,cognito-idp
+      - AWS_DEFAULT_REGION=${AWS_REGION:-us-east-1}
+      - LOCALSTACK_HOST=localstack
+      - EDGE_PORT=4566
+    ports:
+      - "4566:4566"
+    volumes:
+      - localstack_data:/var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  stripe-mock:
+    image: stripe/stripe-mock:latest
+    ports:
+      - "12111:12111"
+      - "12112:12112"
+
+volumes:
+  dynamodb_data:
+  localstack_data:

--- a/docs/dynamodb.md
+++ b/docs/dynamodb.md
@@ -50,3 +50,4 @@ API keys are stored by user and often rely on a secondary index for user lookup 
 ## Local development tips
 - For local testing, you can use DynamoDB Local and point your AWS SDK config at the local endpoint.
 - Keep table name env vars in the same `.env` used for other secrets.
+- Use `DDB_ENDPOINT_URL` (or `AWS_ENDPOINT_URL`) to force all DynamoDB calls to the local emulator.

--- a/docs/local-dev-stack-plan.md
+++ b/docs/local-dev-stack-plan.md
@@ -1,0 +1,120 @@
+# Local Dev Stack: 10-Ticket Plan
+
+This plan sets up a fully local development stack with local DynamoDB, Cognito, S3, and a mock Stripe flow. Each ticket is scoped to be independently shippable and includes acceptance criteria.
+
+## Ticket 1: Local stack bootstrap (Docker Compose + env template)
+**Goal:** Provide a single command to start the local infra stack.
+
+**Scope**
+- Add `docker-compose.local.yml` with services for DynamoDB Local, LocalStack (S3 + Cognito), and Stripe mock (or Stripe CLI if preferred).
+- Add `.env.local.example` with local service endpoints and credentials.
+- Add `scripts/local-stack-up.sh` + `scripts/local-stack-down.sh` wrappers.
+
+**Acceptance criteria**
+- Running `scripts/local-stack-up.sh` starts all services.
+- `scripts/local-stack-down.sh` stops and removes containers.
+- `.env.local.example` documents required env vars for local stack.
+
+## Ticket 2: Shared AWS client factory w/ endpoint overrides
+**Goal:** Centralize AWS client creation with local endpoint support.
+
+**Scope**
+- Add a module (e.g., `app/core/aws_clients.py`) exposing `ddb_resource()`, `s3_client()`, `cognito_client()`, `kms_client()`, and `sqs_client()`.
+- Support `AWS_ENDPOINT_URL` (global) and per-service overrides (`DDB_ENDPOINT_URL`, `S3_ENDPOINT_URL`, `COGNITO_ENDPOINT_URL`).
+- Add `S3_USE_PATH_STYLE` support for LocalStack/MinIO.
+
+**Acceptance criteria**
+- All AWS clients can target local endpoints when env vars are set.
+- No production endpoint changes when overrides are absent.
+
+## Ticket 3: DynamoDB Local wiring
+**Goal:** Use DynamoDB Local for all DynamoDB access in dev.
+
+**Scope**
+- Update `app/core/aws.py` to use the shared client factory and local endpoint overrides.
+- Ensure all DynamoDB resources (`ddb.Table(...)`) in routers/services use the updated `ddb` resource.
+
+**Acceptance criteria**
+- With `DDB_ENDPOINT_URL` set, all DynamoDB operations target local.
+- Existing production behavior is unchanged without overrides.
+
+## Ticket 4: Local DynamoDB table bootstrap
+**Goal:** Automate creation of all required DynamoDB tables in local dev.
+
+**Scope**
+- Add `scripts/local-ddb-init.py` to create tables from a declarative list.
+- Include required tables from `docs/dynamodb.md` plus optional tables referenced in code (billing, file manager, messaging, etc.).
+- Add `scripts/local-ddb-seed.py` to insert minimal seed data for the UI.
+
+**Acceptance criteria**
+- Running the init script creates all tables in DynamoDB Local.
+- Seed script inserts sample data without errors.
+
+## Ticket 5: S3 local wiring (uploads + presign)
+**Goal:** Use local S3 for file uploads/presigned URLs.
+
+**Scope**
+- Update S3 clients in `messaging`, `newsfeed`, and `filemanager` to use the shared S3 client factory.
+- Ensure presigned URLs are generated correctly against local endpoint with path-style support.
+- Document required buckets in `.env.local.example`.
+
+**Acceptance criteria**
+- Presigned uploads work end-to-end using local S3.
+- File manager endpoints can store and retrieve objects from local buckets.
+
+## Ticket 6: Local S3 bucket bootstrap
+**Goal:** Automatically create required S3 buckets in local dev.
+
+**Scope**
+- Add `scripts/local-s3-init.py` to create and configure buckets (file manager bucket, uploads bucket, chat images bucket).
+- Make `local-stack-up.sh` call this script after containers are healthy.
+
+**Acceptance criteria**
+- Required S3 buckets exist after running the bootstrap.
+- Upload flows succeed without manual bucket creation.
+
+## Ticket 7: Local Cognito wiring (auth + JWKS)
+**Goal:** Support local Cognito issuer/JWKS for JWT validation.
+
+**Scope**
+- Add settings for `COGNITO_ISSUER_URL` and `COGNITO_JWKS_URL` overrides.
+- Update `app/auth/deps.py` to use overrides when present.
+- Update `app/services/cognito.py` to use `COGNITO_ENDPOINT_URL` for local IDP.
+
+**Acceptance criteria**
+- Local JWT validation works with local Cognito JWKS.
+- Production Cognito flow remains unchanged without overrides.
+
+## Ticket 8: Local Cognito bootstrap (user pool + app client)
+**Goal:** Create local Cognito resources automatically.
+
+**Scope**
+- Add `scripts/local-cognito-init.py` to create a user pool and app client in LocalStack.
+- Output configuration to `.env.local` (pool id, client id, issuer/JWKS URLs).
+
+**Acceptance criteria**
+- Local Cognito pool + client exist after init script.
+- `.env.local` includes required Cognito configuration.
+
+## Ticket 9: Stripe mock integration
+**Goal:** Run Stripe flows locally without external Stripe dependency.
+
+**Scope**
+- Add `stripe-mock` (or Stripe CLI) to the local compose stack.
+- Document test keys + webhook signing secret in `.env.local.example`.
+- Add webhook forwarding or configure mock to hit `/api/stripe/webhook`.
+
+**Acceptance criteria**
+- `GET /api/billing/config` works with local Stripe keys.
+- Webhooks can be delivered locally and verified.
+
+## Ticket 10: Local dev playbook + QA checklist
+**Goal:** Provide a single source of truth for running and validating the local stack.
+
+**Scope**
+- Add `docs/local-dev-stack.md` with step-by-step instructions.
+- Include a QA checklist: start stack, init tables/buckets, seed data, create user, validate uploads, run billing flow.
+
+**Acceptance criteria**
+- Developer can follow the doc to run the full stack in <15 minutes.
+- QA checklist covers each local service (DDB, Cognito, S3, Stripe).

--- a/scripts/local-ddb-init.py
+++ b/scripts/local-ddb-init.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from app.core.aws_clients import ddb_resource
+from app.core.settings import S
+
+
+@dataclass(frozen=True)
+class TableDef:
+    name: str
+    partition_key: str
+    sort_key: Optional[str] = None
+    gsi: List[Dict[str, str]] = field(default_factory=list)
+
+
+def _resolve_table_name(name: str, fallback: str) -> str:
+    return name or fallback
+
+
+def _table_defs() -> List[TableDef]:
+    return [
+        TableDef(_resolve_table_name(S.ddb_sessions_table, "sessions"), "user_sub", "session_id"),
+        TableDef(_resolve_table_name(S.ddb_totp_table, "totp_devices"), "user_sub", "device_id"),
+        TableDef(_resolve_table_name(S.ddb_sms_table, "sms_devices"), "user_sub", "sms_device_id"),
+        TableDef(_resolve_table_name(S.ddb_email_table, "email_devices"), "user_sub", "email_device_id"),
+        TableDef(_resolve_table_name(S.ddb_recovery_table, "recovery_codes"), "user_sub", "code_hash"),
+        TableDef(_resolve_table_name(S.users_table_name, "users"), "user_sub"),
+        TableDef(
+            _resolve_table_name(S.api_keys_table_name, "api_keys"),
+            "key_id",
+            gsi=[{"index_name": S.api_keys_user_index, "partition_key": "user_sub"}],
+        ),
+        TableDef(_resolve_table_name(S.alerts_table_name, "alerts"), "user_sub", "alert_id"),
+        TableDef(_resolve_table_name(S.alert_prefs_table_name, "alert_prefs"), "user_sub"),
+        TableDef(_resolve_table_name(S.push_devices_table_name, "push_devices"), "user_sub", "device_id"),
+        TableDef(_resolve_table_name(S.billing_table_name, "billing"), "pk", "sk"),
+        TableDef(_resolve_table_name(S.account_state_table_name, "account_state"), "user_sub"),
+        TableDef(_resolve_table_name(S.profile_table_name, "profiles"), "user_sub"),
+        TableDef(_resolve_table_name(S.addresses_table_name, "addresses"), "user_sub", "address_id"),
+        TableDef(_resolve_table_name(S.calendar_table_name, "calendar"), "calendar_id", "sk"),
+        TableDef(_resolve_table_name(S.purchase_transactions_table_name, "purchase_transactions"), "user_sub", "sk"),
+        TableDef(_resolve_table_name(S.purchase_events_table_name, "purchase_transaction_events"), "pk", "sk"),
+        TableDef(_resolve_table_name(S.shopping_cart_table_name, "shopping_cart"), "PK", "SK"),
+        TableDef(_resolve_table_name(S.catalog_table_name, "shopping_catalog"), "PK", "SK"),
+        TableDef(_resolve_table_name(S.subscriptions_table_name, "subscriptions"), "pk", "sk"),
+        TableDef(_resolve_table_name(S.filemgr_table_name, "file_manager"), "PK", "SK"),
+        TableDef(os.getenv("APP_TABLE", "app_single_table"), "pk", "sk"),
+        TableDef(os.getenv("DDB_CONVERSATIONS", "Conversations"), "conversation_id"),
+        TableDef(
+            os.getenv("DDB_PARTICIPANTS", "Participants"),
+            "user_id",
+            "conversation_id",
+            gsi=[{"index_name": "GSI1", "partition_key": "GSI1PK", "sort_key": "GSI1SK"}],
+        ),
+        TableDef(os.getenv("DDB_MESSAGES", "Messages"), "conversation_id", "message_id"),
+        TableDef(os.getenv("DDB_USER_EVENTS", "UserEvents"), "user_id", "event_id"),
+        TableDef(os.getenv("DDB_USERS", "Users"), "user_id"),
+        TableDef(os.getenv("DDB_USER_SEARCH", "UserSearch"), "token"),
+        TableDef(os.getenv("DDB_MESSAGE_SEARCH", "MessageSearch"), "token", "message_key"),
+        TableDef(os.getenv("DDB_PRESENCE", "UserPresence"), "user_id"),
+        TableDef(os.getenv("DDB_TYPING", "Typing"), "conversation_id", "user_id"),
+        TableDef(os.getenv("DDB_MESSAGE_EDITS", "MessageEdits"), "message_key", "edited_at"),
+        TableDef(os.getenv("DDB_MESSAGE_VIEWS", "MessageViews"), "conversation_id", "message_user"),
+        TableDef(os.getenv("DDB_MESSAGE_RECEIPTS", "MessageReceipts"), "conversation_id", "message_user"),
+    ]
+
+
+def _attribute_definitions(table: TableDef) -> List[Dict[str, str]]:
+    attrs = {table.partition_key: "S"}
+    if table.sort_key:
+        attrs[table.sort_key] = "S"
+    for gsi in table.gsi:
+        attrs[gsi["partition_key"]] = "S"
+        if gsi.get("sort_key"):
+            attrs[gsi["sort_key"]] = "S"
+    return [{"AttributeName": k, "AttributeType": v} for k, v in attrs.items()]
+
+
+def _key_schema(table: TableDef) -> List[Dict[str, str]]:
+    schema = [{"AttributeName": table.partition_key, "KeyType": "HASH"}]
+    if table.sort_key:
+        schema.append({"AttributeName": table.sort_key, "KeyType": "RANGE"})
+    return schema
+
+
+def _global_secondary_indexes(table: TableDef) -> Optional[List[Dict[str, object]]]:
+    if not table.gsi:
+        return None
+    indexes = []
+    for gsi in table.gsi:
+        key_schema = [{"AttributeName": gsi["partition_key"], "KeyType": "HASH"}]
+        if gsi.get("sort_key"):
+            key_schema.append({"AttributeName": gsi["sort_key"], "KeyType": "RANGE"})
+        indexes.append(
+            {
+                "IndexName": gsi["index_name"],
+                "KeySchema": key_schema,
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        )
+    return indexes
+
+
+def _ensure_table(ddb, table: TableDef) -> None:
+    client = ddb.meta.client
+    existing = client.list_tables().get("TableNames", [])
+    if table.name in existing:
+        return
+    kwargs: Dict[str, object] = {
+        "TableName": table.name,
+        "AttributeDefinitions": _attribute_definitions(table),
+        "KeySchema": _key_schema(table),
+        "BillingMode": "PAY_PER_REQUEST",
+    }
+    gsi = _global_secondary_indexes(table)
+    if gsi:
+        kwargs["GlobalSecondaryIndexes"] = gsi
+    client.create_table(**kwargs)
+
+
+def _wait_for_tables(ddb, table_names: Iterable[str]) -> None:
+    client = ddb.meta.client
+    for name in table_names:
+        waiter = client.get_waiter("table_exists")
+        waiter.wait(TableName=name)
+
+
+def main() -> None:
+    ddb = ddb_resource()
+    tables = _table_defs()
+    created = []
+    for table in tables:
+        _ensure_table(ddb, table)
+        created.append(table.name)
+    _wait_for_tables(ddb, created)
+    print(f"Ensured {len(created)} DynamoDB tables exist.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local-ddb-seed.py
+++ b/scripts/local-ddb-seed.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import time
+
+from app.core.aws_clients import ddb_resource
+from app.core.settings import S
+
+
+def _now_ts() -> int:
+    return int(time.time())
+
+
+def _table(ddb, name: str):
+    return ddb.Table(name)
+
+
+def main() -> None:
+    ddb = ddb_resource()
+    ts = _now_ts()
+    user_sub = "dev-user"
+
+    tables = {
+        "sessions": S.ddb_sessions_table,
+        "users": S.users_table_name,
+        "profile": S.profile_table_name,
+        "account_state": S.account_state_table_name,
+        "alert_prefs": S.alert_prefs_table_name,
+        "alerts": S.alerts_table_name,
+    }
+
+    if tables["sessions"]:
+        _table(ddb, tables["sessions"]).put_item(
+            Item={
+                "user_sub": user_sub,
+                "session_id": "dev-session",
+                "created_at": ts,
+                "updated_at": ts,
+                "revoked": False,
+            }
+        )
+
+    if tables["users"]:
+        _table(ddb, tables["users"]).put_item(
+            Item={
+                "user_sub": user_sub,
+                "email": "dev-user@example.com",
+                "created_at": ts,
+                "updated_at": ts,
+            }
+        )
+
+    if tables["profile"]:
+        _table(ddb, tables["profile"]).put_item(
+            Item={
+                "user_sub": user_sub,
+                "profile": {"display_name": "Dev User", "bio": "Local seed user"},
+                "created_at": ts,
+                "updated_at": ts,
+            }
+        )
+
+    if tables["account_state"]:
+        _table(ddb, tables["account_state"]).put_item(
+            Item={
+                "user_sub": user_sub,
+                "status": "active",
+                "reason": "seed",
+                "requested_by": user_sub,
+                "created_at": ts,
+            }
+        )
+
+    if tables["alert_prefs"]:
+        _table(ddb, tables["alert_prefs"]).put_item(
+            Item={
+                "user_sub": user_sub,
+                "email_event_types": [],
+                "sms_event_types": [],
+                "toast_event_types": [],
+                "push_event_types": [],
+                "updated_at": ts,
+            }
+        )
+
+    if tables["alerts"]:
+        _table(ddb, tables["alerts"]).put_item(
+            Item={
+                "user_sub": user_sub,
+                "alert_id": f"{ts:010d}#seed",
+                "event": "seed",
+                "title": "Local seed alert",
+                "created_at": ts,
+            }
+        )
+
+    print("Seeded minimal local data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local-s3-init.py
+++ b/scripts/local-s3-init.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import time
+from typing import Iterable, List
+
+from app.core.aws_clients import s3_client
+from app.core.settings import S
+
+
+def _bucket_names() -> List[str]:
+    names = [
+        os.getenv("UPLOAD_BUCKET", ""),
+        os.getenv("S3_BUCKET_IMAGES", ""),
+        S.filemgr_bucket or os.getenv("FILEMGR_BUCKET", ""),
+    ]
+    return [name for name in names if name]
+
+
+def _ensure_bucket(client, name: str) -> None:
+    existing = {b["Name"] for b in client.list_buckets().get("Buckets", [])}
+    if name in existing:
+        return
+    region = S.aws_region or "us-east-1"
+    if region == "us-east-1":
+        client.create_bucket(Bucket=name)
+    else:
+        client.create_bucket(
+            Bucket=name,
+            CreateBucketConfiguration={"LocationConstraint": region},
+        )
+
+
+def main() -> None:
+    client = s3_client()
+    buckets = _bucket_names()
+    for name in buckets:
+        _ensure_bucket(client, name)
+    print(f"Ensured {len(buckets)} S3 buckets exist.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local-stack-down.sh
+++ b/scripts/local-stack-down.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+docker compose -f docker-compose.local.yml down -v
+
+echo "Local stack stopped and volumes removed."

--- a/scripts/local-stack-up.sh
+++ b/scripts/local-stack-up.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+docker compose -f docker-compose.local.yml up -d
+
+echo "Waiting for local services to be healthy..."
+for _ in {1..40}; do
+  if curl -sf http://localhost:4566/health >/dev/null && curl -sf http://localhost:8001/ >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+python3 scripts/local-s3-init.py
+
+echo ""
+echo "Local stack is starting."
+echo "DynamoDB Local: http://localhost:8001"
+echo "LocalStack:     http://localhost:4566"
+echo "Stripe mock:    http://localhost:12111"


### PR DESCRIPTION
### Motivation
- Enable JWT validation against a local Cognito issuer/JWKS for local development without changing production behavior.
- Centralize AWS client creation so per-service and global endpoint overrides (LocalStack/Local emulators) can be honored consistently.
- Provide local infra bootstrap helpers (compose, init scripts) to make running the local stack and required resources simpler.

### Description
- Add new settings `COGNITO_ISSUER_URL` and `COGNITO_JWKS_URL` (exposed via `S.cognito_issuer_url` and `S.cognito_jwks_url`) and other endpoint overrides in `app/core/settings.py` so local endpoints can be configured.
- Introduce a shared AWS client factory in `app/core/aws_clients.py` that resolves `AWS_ENDPOINT_URL` and per-service overrides and exposes `ddb_resource()`, `s3_client()`, `cognito_client()`, `kms_client()`, and `sqs_client()` for use across the codebase.
- Update auth wiring in `app/auth/deps.py` to use the issuer/JWKS overrides by returning `S.cognito_issuer_url.rstrip('/')` when set and using `S.cognito_jwks_url` when provided to fetch JWKS.
- Route Cognito SDK usage through the shared factory by updating `app/services/cognito.py` to use `cognito_client()` from the shared clients; also update `app/core/aws.py`, `app/routers/messaging.py`, `app/routers/newsfeed.py`, and `app/services/filemanager.py` to consume the shared clients (`ddb`, `s3_client()`, `sqs_client()` etc.).
- Add local development infra files and scripts including `docker-compose.local.yml`, `.env.local.example`, `scripts/local-stack-up.sh`, `scripts/local-stack-down.sh`, `scripts/local-s3-init.py`, `scripts/local-ddb-init.py`, and `scripts/local-ddb-seed.py` to bootstrap LocalStack/DynamoDB/Stripe-mock and required buckets/tables.

### Testing
- No automated tests were executed for these configuration and infra changes.
- Manual validation guidance: the changes are configuration-driven and should be tested by starting the local stack with `scripts/local-stack-up.sh` and verifying JWT validation and AWS client calls target the configured local endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989342fc5c8832bb5747a02fc742d5e)