### PR TITLE
Add one-command local mock-mode run/test scripts and CCBill/UPS local mocks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,8 +107,18 @@ WS_TOKEN_SECRET=change-me-ws-secret                   # HMAC key for WebSocket t
 # CCBILL_BACKEND_CLIENT_SECRET=
 # CCBILL_CLIENT_ACCNUM=0
 # CCBILL_CLIENT_SUBACC=0
+# CCBILL_WEBHOOK_VERIFY_MODE=ip+sig    # ip+sig (strict), sig_only, local
 # CCBILL_WEBHOOK_SIGNATURE_SECRET=
 # CCBILL_WEBHOOK_IP_ENFORCE=false
+# CCBILL_MOCK_ENABLED=0              # set to 1 for local mock provider endpoints
+# CCBILL_BASE_URL=http://localhost:8000/mock/ccbill
+
+
+# UPS_BASE_URL=https://wwwcie.ups.com/api
+# UPS_AUTH_URL=https://wwwcie.ups.com/security/v1/oauth/token
+# UPS_CLIENT_ID=
+# UPS_CLIENT_SECRET=
+# UPS_WEBHOOK_SECRET=
 
 # ---------------------------------------------------------------------------
 # 11. TWILIO (optional — SMS MFA)

--- a/.env.local.example
+++ b/.env.local.example
@@ -24,3 +24,22 @@ COGNITO_REGION=us-east-1
 STRIPE_SECRET_KEY=sk_test_local
 STRIPE_PUBLISHABLE_KEY=pk_test_local
 STRIPE_WEBHOOK_SECRET=whsec_local
+
+# CCBill local webhook verification
+CCBILL_WEBHOOK_VERIFY_MODE=local
+CCBILL_WEBHOOK_SIGNATURE_SECRET=local-ccbill-webhook-secret
+
+# CCBill local mock provider
+CCBILL_MOCK_ENABLED=1
+CCBILL_BASE_URL=http://localhost:8000/mock/ccbill
+CCBILL_FRONTEND_CLIENT_ID=local_frontend
+CCBILL_FRONTEND_CLIENT_SECRET=local_frontend_secret
+CCBILL_BACKEND_CLIENT_ID=local_backend
+CCBILL_BACKEND_CLIENT_SECRET=local_backend_secret
+
+# UPS local mock provider
+UPS_BASE_URL=http://localhost:8000/mock/ups
+UPS_AUTH_URL=http://localhost:8000/mock/ups/oauth/token
+UPS_CLIENT_ID=local_ups_client
+UPS_CLIENT_SECRET=local_ups_secret
+UPS_WEBHOOK_SECRET=local-ups-webhook-secret

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ session management, MFA, billing, notifications, and a lightweight control panel
 ## Documentation
 - [File reference](docs/file-reference.md)
 - [Run and deploy](docs/run-deploy.md)
+- [Local dev stack](docs/local-dev-stack.md)
 - [Architecture](docs/architecture.md)
 - [DynamoDB setup](docs/dynamodb.md)
 - [AWS services](docs/aws-services.md)
@@ -25,6 +26,13 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload
+```
+
+### Local provider mock mode (fast path)
+```bash
+scripts/run_local_mock_backend.sh
+# in another terminal
+scripts/test_mock_mode.sh
 ```
 
 ## Required environment variables (minimum)

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -167,8 +167,17 @@ class Settings:
     default_currency: str = os.environ.get("DEFAULT_CURRENCY", "usd")
     ccbill_webhook_ip_enforce: bool = os.environ.get("CCBILL_WEBHOOK_IP_ENFORCE", "false").lower() == "true"
     ccbill_webhook_ip_ranges: str = os.environ.get("CCBILL_WEBHOOK_IP_RANGES", "")
+    ccbill_webhook_verify_mode: str = os.environ.get("CCBILL_WEBHOOK_VERIFY_MODE", "")
     ccbill_webhook_signature_secret: str = os.environ.get("CCBILL_WEBHOOK_SIGNATURE_SECRET", "")
     ccbill_webhook_signature_header: str = os.environ.get("CCBILL_WEBHOOK_SIGNATURE_HEADER", "x-ccbill-signature")
+    ccbill_mock_enabled: bool = os.environ.get("CCBILL_MOCK_ENABLED", os.environ.get("DEV_MODE", "1")) not in ("0", "false", "False")
+
+    # UPS
+    ups_base_url: str = os.environ.get("UPS_BASE_URL", "").rstrip("/")
+    ups_auth_url: str = os.environ.get("UPS_AUTH_URL", "").rstrip("/")
+    ups_client_id: str = os.environ.get("UPS_CLIENT_ID", "")
+    ups_client_secret: str = os.environ.get("UPS_CLIENT_SECRET", "")
+    ups_webhook_secret: str = os.environ.get("UPS_WEBHOOK_SECRET", "")
     # Billing / PayPal
     billing_table_name: str = os.environ.get("BILLING_TABLE_NAME", os.environ.get("DDB_TABLE", ""))
     public_base_url: str = os.environ.get("PUBLIC_BASE_URL", "http://localhost:8000").rstrip("/")

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.routers.register import router as register_router
 from app.routers.webauthn import router as webauthn_router
 from app.routers.misc import router as misc_router
 from app.routers.billing_ccbill import router as billing_ccbill_router
+from app.routers.ccbill_mock import router as ccbill_mock_router
 from app.routers.paypal import router as paypal_router
 from app.routers.billing import router as billing_router
 from app.routers.account_state import router as account_state_router
@@ -37,6 +38,7 @@ from app.routers.purchase_history import router as purchase_history_router
 from app.routers.shoppingcart import router as shoppingcart_router
 from app.routers.catalog import router as catalog_router
 from app.routers.subscription_server import router as subscription_server_router
+from app.routers.ups import router as ups_router
 from app.services.billing_reconcile import start_billing_reconcile_task
 from app.services.billing_dunning import start_billing_dunning_task
 from app.services.filemanager import start_filemgr_purge_task
@@ -77,6 +79,7 @@ def create_app() -> FastAPI:
     app.include_router(webauthn_router)
     app.include_router(misc_router)
     app.include_router(billing_ccbill_router)
+    app.include_router(ccbill_mock_router)
     app.include_router(paypal_router)
     app.include_router(billing_router)
     app.include_router(account_state_router)
@@ -95,6 +98,7 @@ def create_app() -> FastAPI:
     app.include_router(shoppingcart_router)
     app.include_router(catalog_router)
     app.include_router(subscription_server_router)
+    app.include_router(ups_router)
     app.add_event_handler("startup", start_billing_reconcile_task)
 
     return app

--- a/app/routers/billing_ccbill.py
+++ b/app/routers/billing_ccbill.py
@@ -41,6 +41,7 @@ from app.services.billing_ccbill import (
     subscribe_monthly,
     update_payment_status,
     upsert_subscription,
+    ccbill_webhook_verify_mode,
     verify_ccbill_webhook_signature,
     webhook_remote_ip_allowed,
     put_payment_record,
@@ -516,7 +517,9 @@ async def ccbill_webhook(req: Request):
         form = await req.form()
         payload = dict(form)
 
-    if not webhook_remote_ip_allowed(remote_ip):
+    verify_mode = ccbill_webhook_verify_mode()
+
+    if verify_mode == "ip+sig" and not webhook_remote_ip_allowed(remote_ip, enforce=True):
         _log_ccbill_webhook_rejection(
             reason="ip_not_allowed",
             remote_ip=remote_ip,
@@ -525,6 +528,7 @@ async def ccbill_webhook(req: Request):
             payload=payload,
             req=req,
             raw_body=raw_body,
+            verify_mode=verify_mode,
         )
         raise HTTPException(403, "Forbidden")
 
@@ -538,6 +542,7 @@ async def ccbill_webhook(req: Request):
             payload=payload,
             req=req,
             raw_body=raw_body,
+            verify_mode=verify_mode,
         )
         raise HTTPException(403, "Invalid webhook signature")
 
@@ -843,6 +848,7 @@ def _log_ccbill_webhook_rejection(
     req: Request,
     raw_body: bytes,
     dedupe_key: Optional[str] = None,
+    verify_mode: Optional[str] = None,
 ) -> None:
     safe_headers = {}
     for key in ("content-type", "user-agent", S.ccbill_webhook_signature_header):
@@ -859,6 +865,7 @@ def _log_ccbill_webhook_rejection(
         "payload": sanitize_ccbill_payload(payload),
         "headers": safe_headers,
         "body_sha256": hashlib.sha256(raw_body).hexdigest(),
+        "verify_mode": verify_mode,
         "created_at": now_ts(),
     })
 

--- a/app/routers/ccbill_mock.py
+++ b/app/routers/ccbill_mock.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from typing import Any, Dict, Optional
+
+import requests
+from fastapi import APIRouter, HTTPException, Request
+
+from app.core.settings import S
+from app.core.time import now_ts
+
+router = APIRouter(tags=["billing", "mock"])
+
+_TOKEN_CACHE: Dict[str, int] = {}
+_SUBSCRIPTIONS: Dict[str, Dict[str, Any]] = {}
+
+
+def _ensure_mock_enabled() -> None:
+    if not S.ccbill_mock_enabled:
+        raise HTTPException(404, "Not found")
+
+
+def _decode_basic_auth(auth_header: str) -> tuple[str, str]:
+    if not auth_header.lower().startswith("basic "):
+        return "", ""
+    raw = auth_header.split(" ", 1)[1].strip()
+    try:
+        decoded = base64.b64decode(raw).decode("utf-8")
+        if ":" not in decoded:
+            return "", ""
+        return decoded.split(":", 1)
+    except Exception:
+        return "", ""
+
+
+def _is_valid_oauth_client(client_id: str, client_secret: str) -> bool:
+    pairs = {
+        (S.ccbill_frontend_client_id, S.ccbill_frontend_client_secret),
+        (S.ccbill_backend_client_id, S.ccbill_backend_client_secret),
+    }
+    # Accept any non-empty credentials when mock creds are not configured.
+    if not any(a and b for a, b in pairs):
+        return bool(client_id and client_secret)
+    return (client_id, client_secret) in pairs
+
+
+def _signature_secret() -> str:
+    if S.ccbill_webhook_signature_secret:
+        return S.ccbill_webhook_signature_secret
+    return "local-ccbill-webhook-secret"
+
+
+@router.post("/mock/ccbill/ccbill-auth/oauth/token")
+async def ccbill_mock_oauth(req: Request) -> Dict[str, Any]:
+    _ensure_mock_enabled()
+    grant_type = req.query_params.get("grant_type", "")
+    if grant_type != "client_credentials":
+        raise HTTPException(400, "Unsupported grant_type")
+
+    client_id, client_secret = _decode_basic_auth(req.headers.get("authorization", ""))
+    if not _is_valid_oauth_client(client_id, client_secret):
+        raise HTTPException(401, "Invalid client credentials")
+
+    token = f"mock_ccbill_{hashlib.sha256(f'{client_id}:{now_ts()}'.encode()).hexdigest()[:20]}"
+    expires_in = 3600
+    _TOKEN_CACHE[token] = now_ts() + expires_in
+    return {"access_token": token, "token_type": "bearer", "expires_in": expires_in}
+
+
+@router.post("/mock/ccbill/transactions/payment-tokens/{payment_token_id}")
+async def ccbill_mock_charge(payment_token_id: str, req: Request) -> Dict[str, Any]:
+    _ensure_mock_enabled()
+
+    auth = req.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        raise HTTPException(401, "Missing bearer token")
+    access_token = auth.split(" ", 1)[1].strip()
+    exp = _TOKEN_CACHE.get(access_token, 0)
+    if exp <= now_ts():
+        raise HTTPException(401, "Invalid or expired token")
+
+    body = await req.json()
+    approved = payment_token_id.lower().startswith("tok_") or bool(body.get("approve", True))
+    if payment_token_id.lower().startswith("fail"):
+        approved = False
+
+    transaction_id = f"txn_{int(time.time() * 1000)}"
+    subscription_id: Optional[str] = None
+    next_renewal_date: Optional[str] = None
+
+    recurring_price = body.get("recurringPrice")
+    recurring_period = body.get("recurringPeriod")
+    if recurring_price is not None and recurring_period is not None and approved:
+        subscription_id = f"sub_{int(time.time() * 1000)}"
+        next_renewal_date = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + 30 * 86400))
+        _SUBSCRIPTIONS[subscription_id] = {
+            "subscriptionId": subscription_id,
+            "status": "Active",
+            "paymentTokenId": payment_token_id,
+            "nextRenewalDate": next_renewal_date,
+            "amount": recurring_price,
+            "currencyCode": body.get("currencyCode"),
+        }
+
+    return {
+        "approved": approved,
+        "responseCode": "200" if approved else "500",
+        "transactionId": transaction_id,
+        "paymentUniqueId": transaction_id,
+        "subscriptionId": subscription_id,
+        "nextRenewalDate": next_renewal_date,
+        "message": "Approved" if approved else "Declined",
+    }
+
+
+@router.get("/mock/ccbill/subscriptions/{subscription_id}")
+def ccbill_mock_get_subscription(subscription_id: str) -> Dict[str, Any]:
+    _ensure_mock_enabled()
+    item = _SUBSCRIPTIONS.get(subscription_id)
+    if not item:
+        raise HTTPException(404, "Subscription not found")
+    return item
+
+
+@router.post("/mock/ccbill/subscriptions/{subscription_id}/cancel")
+def ccbill_mock_cancel_subscription(subscription_id: str) -> Dict[str, Any]:
+    _ensure_mock_enabled()
+    item = _SUBSCRIPTIONS.get(subscription_id)
+    if not item:
+        raise HTTPException(404, "Subscription not found")
+    item["status"] = "Canceled"
+    return {"ok": True, "subscriptionId": subscription_id, "status": item["status"]}
+
+
+@router.post("/emit/ccbill-webhook")
+def emit_ccbill_webhook(body: Dict[str, Any]) -> Dict[str, Any]:
+    _ensure_mock_enabled()
+    event_type = str(body.get("event_type") or body.get("eventType") or "NewSaleSuccess")
+    payload = body.get("payload") or {}
+    if not isinstance(payload, dict):
+        raise HTTPException(400, "payload must be an object")
+
+    target_url = str(body.get("target_url") or f"{S.public_base_url}/api/ccbill/webhook")
+    raw = requests.models.complexjson.dumps(payload).encode("utf-8")
+    sig = hmac.new(_signature_secret().encode("utf-8"), raw, hashlib.sha256).hexdigest()
+
+    resp = requests.post(
+        target_url,
+        params={"eventType": event_type},
+        headers={
+            "content-type": "application/json",
+            S.ccbill_webhook_signature_header: sig,
+            **({"x-forwarded-for": str(body.get("forwarded_for"))} if body.get("forwarded_for") else {}),
+        },
+        data=raw,
+        timeout=10,
+    )
+
+    return {
+        "ok": resp.status_code < 400,
+        "status_code": resp.status_code,
+        "event_type": event_type,
+        "target_url": target_url,
+        "response": resp.text[:2000],
+    }

--- a/app/routers/ups.py
+++ b/app/routers/ups.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from typing import Any, Dict
+
+import requests
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from app.core.settings import S
+from app.core.tables import T
+from app.core.time import now_ts
+from app.services.sessions import require_ui_session
+from app.services.ups import create_label, quote, verify_tracking_webhook_signature
+
+router = APIRouter(tags=["ups", "mock"])
+
+
+def _mock_enabled() -> bool:
+    return S.dev_mode
+
+
+def _ups_sig_secret() -> str:
+    return (S.ups_webhook_secret or "local-ups-webhook-secret").strip()
+
+
+@router.post("/api/ups/quote")
+def ups_quote(body: Dict[str, Any], ctx=Depends(require_ui_session)) -> Dict[str, Any]:
+    _ = ctx["user_sub"]
+    return quote(body)
+
+
+@router.post("/api/ups/label")
+def ups_label(body: Dict[str, Any], ctx=Depends(require_ui_session)) -> Dict[str, Any]:
+    _ = ctx["user_sub"]
+    return create_label(body)
+
+
+@router.post("/api/ups/tracking/webhook")
+async def ups_tracking_webhook(req: Request) -> Dict[str, Any]:
+    raw = await req.body()
+    signature = req.headers.get("x-ups-signature", "")
+    if not verify_tracking_webhook_signature(raw, signature):
+        raise HTTPException(403, "Invalid UPS webhook signature")
+
+    payload = await req.json() if raw else {}
+    tracking_number = payload.get("tracking_number") or payload.get("trackingNumber") or "unknown"
+    T.billing.put_item(
+        Item={
+            "user_sub": "UPS_TRACKING",
+            "sk": f"{now_ts()}#{tracking_number}",
+            "payload": payload,
+            "created_at": now_ts(),
+        }
+    )
+    return {"received": True}
+
+
+def _decode_basic(auth_header: str) -> tuple[str, str]:
+    if not auth_header.lower().startswith("basic "):
+        return "", ""
+    try:
+        raw = base64.b64decode(auth_header.split(" ", 1)[1].strip()).decode("utf-8")
+        return raw.split(":", 1) if ":" in raw else ("", "")
+    except Exception:
+        return "", ""
+
+
+@router.post("/mock/ups/oauth/token")
+def mock_ups_oauth(req: Request) -> Dict[str, Any]:
+    if not _mock_enabled():
+        raise HTTPException(404, "Not found")
+    client_id, client_secret = _decode_basic(req.headers.get("authorization", ""))
+    if S.ups_client_id and S.ups_client_secret and (client_id, client_secret) != (S.ups_client_id, S.ups_client_secret):
+        raise HTTPException(401, "Invalid client credentials")
+    if not client_id or not client_secret:
+        raise HTTPException(401, "Missing client credentials")
+    token = f"mock_ups_{int(time.time()*1000)}"
+    return {"access_token": token, "token_type": "Bearer", "expires_in": 3600}
+
+
+@router.post("/mock/ups/quote")
+async def mock_ups_quote(req: Request) -> Dict[str, Any]:
+    if not _mock_enabled():
+        raise HTTPException(404, "Not found")
+    body = await req.json()
+    weight = float((body.get("package") or {}).get("weight", 1.0))
+    amount = round(max(5.0, 3.5 + weight * 1.2), 2)
+    return {
+        "service": body.get("service", "ground"),
+        "currency": "USD",
+        "amount": amount,
+        "eta_days": 3,
+    }
+
+
+@router.post("/mock/ups/label")
+async def mock_ups_label(req: Request) -> Dict[str, Any]:
+    if not _mock_enabled():
+        raise HTTPException(404, "Not found")
+    body = await req.json()
+    tracking = f"1ZMOCK{int(time.time()*1000)}"
+    return {
+        "tracking_number": tracking,
+        "label_url": f"https://mock-ups.local/labels/{tracking}.pdf",
+        "service": body.get("service", "ground"),
+        "status": "created",
+    }
+
+
+@router.post("/emit/ups-tracking-webhook")
+def emit_ups_tracking_webhook(body: Dict[str, Any]) -> Dict[str, Any]:
+    if not _mock_enabled():
+        raise HTTPException(404, "Not found")
+    payload = body.get("payload") or {"tracking_number": "1ZMOCK", "status": "DELIVERED"}
+    if not isinstance(payload, dict):
+        raise HTTPException(400, "payload must be object")
+    target_url = str(body.get("target_url") or f"{S.public_base_url}/api/ups/tracking/webhook")
+    raw = requests.models.complexjson.dumps(payload).encode("utf-8")
+    sig = hmac.new(_ups_sig_secret().encode("utf-8"), raw, hashlib.sha256).hexdigest()
+    resp = requests.post(
+        target_url,
+        headers={"content-type": "application/json", "x-ups-signature": sig},
+        data=raw,
+        timeout=10,
+    )
+    return {"ok": resp.status_code < 400, "status_code": resp.status_code, "response": resp.text[:1000]}

--- a/app/services/billing_ccbill.py
+++ b/app/services/billing_ccbill.py
@@ -143,9 +143,9 @@ def _ccbill_ip_ranges() -> List[Tuple[ipaddress._BaseAddress, ipaddress._BaseAdd
 
 
 def verify_ccbill_webhook_signature(raw_body: bytes, signature_header: str) -> bool:
-    secret = S.ccbill_webhook_signature_secret
+    secret = _webhook_signature_secret_for_mode(ccbill_webhook_verify_mode())
     if not secret:
-        return True
+        return False
     if not signature_header:
         return False
     sig = signature_header.strip()
@@ -154,6 +154,22 @@ def verify_ccbill_webhook_signature(raw_body: bytes, signature_header: str) -> b
         sig = sig.strip()
     digest = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
     return hmac.compare_digest(digest, sig)
+
+
+def ccbill_webhook_verify_mode() -> str:
+    raw_mode = (S.ccbill_webhook_verify_mode or "").strip().lower()
+    if raw_mode in {"ip+sig", "sig_only", "local"}:
+        return raw_mode
+    return "local" if S.dev_mode else "ip+sig"
+
+
+def _webhook_signature_secret_for_mode(mode: str) -> str:
+    secret = (S.ccbill_webhook_signature_secret or "").strip()
+    if secret:
+        return secret
+    if mode == "local":
+        return "local-ccbill-webhook-secret"
+    return ""
 
 
 def _billing_sk(kind: str, identifier: str) -> str:
@@ -494,8 +510,8 @@ def mark_webhook_processed(dedupe_key: str) -> bool:
         raise
 
 
-def webhook_remote_ip_allowed(ip_str: str) -> bool:
-    if not S.ccbill_webhook_ip_enforce:
+def webhook_remote_ip_allowed(ip_str: str, *, enforce: bool = False) -> bool:
+    if not (enforce or S.ccbill_webhook_ip_enforce):
         return True
     try:
         ip = ipaddress.ip_address(ip_str)

--- a/app/services/ups.py
+++ b/app/services/ups.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Any, Dict
+
+import requests
+from fastapi import HTTPException
+
+from app.core.settings import S
+
+
+_TOKEN_CACHE: Dict[str, str] = {}
+
+
+def _ups_auth_url() -> str:
+    if S.ups_auth_url:
+        return S.ups_auth_url
+    if S.ups_base_url:
+        return f"{S.ups_base_url}/oauth/token"
+    raise HTTPException(500, "UPS base/auth URL not configured")
+
+
+def _ups_api_base() -> str:
+    if not S.ups_base_url:
+        raise HTTPException(500, "UPS base URL not configured")
+    return S.ups_base_url
+
+
+def ups_access_token() -> str:
+    cached = _TOKEN_CACHE.get("access_token")
+    if cached:
+        return cached
+
+    if not S.ups_client_id or not S.ups_client_secret:
+        raise HTTPException(500, "UPS client credentials not configured")
+
+    r = requests.post(
+        _ups_auth_url(),
+        auth=(S.ups_client_id, S.ups_client_secret),
+        data={"grant_type": "client_credentials"},
+        timeout=15,
+    )
+    if r.status_code != 200:
+        raise HTTPException(502, f"UPS auth failed: {r.status_code} {r.text}")
+    token = r.json().get("access_token")
+    if not token:
+        raise HTTPException(502, "UPS auth response missing access_token")
+    _TOKEN_CACHE["access_token"] = str(token)
+    return str(token)
+
+
+def _ups_post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    token = ups_access_token()
+    r = requests.post(
+        f"{_ups_api_base()}/{path.lstrip('/')}",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json=payload,
+        timeout=20,
+    )
+    if r.status_code >= 400:
+        raise HTTPException(502, f"UPS request failed: {r.status_code} {r.text}")
+    return r.json()
+
+
+def quote(shipment: Dict[str, Any]) -> Dict[str, Any]:
+    return _ups_post("quote", shipment)
+
+
+def create_label(shipment: Dict[str, Any]) -> Dict[str, Any]:
+    return _ups_post("label", shipment)
+
+
+def verify_tracking_webhook_signature(raw_body: bytes, signature_header: str) -> bool:
+    secret = (S.ups_webhook_secret or "").strip()
+    if not secret:
+        return True
+    if not signature_header:
+        return False
+    digest = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(digest, signature_header.strip())

--- a/docs/local-dev-stack.md
+++ b/docs/local-dev-stack.md
@@ -1,0 +1,110 @@
+# Local Dev Stack Playbook
+
+This document is the **single source of truth** for running and validating the local provider stack (DynamoDB, LocalStack/Cognito/S3, Stripe mock, CCBill mock, PayPal mock wiring, Twilio local testing, and UPS mock).
+
+## 0) Fast path (mock mode)
+
+For a quick local mock run + validation:
+
+```bash
+scripts/run_local_mock_backend.sh
+```
+
+In another terminal:
+
+```bash
+scripts/test_mock_mode.sh
+```
+
+## 1) Boot local infrastructure
+
+```bash
+scripts/local-stack-up.sh
+python3 scripts/local-ddb-init.py
+python3 scripts/local-ddb-seed.py
+python3 scripts/local-s3-init.py
+python3 scripts/local-cognito-init.py
+```
+
+If `.env.local` does not exist, copy from `.env.local.example` and adjust as needed.
+
+## 2) Start app
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## 3) Provider mock defaults (recommended local)
+
+Use these in `.env.local`:
+
+- `CCBILL_MOCK_ENABLED=1`
+- `CCBILL_BASE_URL=http://localhost:8000/mock/ccbill`
+- `CCBILL_WEBHOOK_VERIFY_MODE=local`
+- `CCBILL_WEBHOOK_SIGNATURE_SECRET=local-ccbill-webhook-secret`
+- `UPS_BASE_URL=http://localhost:8000/mock/ups`
+- `UPS_AUTH_URL=http://localhost:8000/mock/ups/oauth/token`
+- `UPS_CLIENT_ID=local_ups_client`
+- `UPS_CLIENT_SECRET=local_ups_secret`
+- `UPS_WEBHOOK_SECRET=local-ups-webhook-secret`
+
+## 4) QA checklist
+
+Before manual validation, run:
+
+```bash
+scripts/test_mock_mode.sh
+```
+
+### Core stack
+- [ ] UI loads at `/`
+- [ ] DynamoDB tables exist and seeded records are queryable
+- [ ] S3 buckets exist and upload endpoints work
+- [ ] Cognito pool/client exist and `.env.local` has IDs + issuer/JWKS URLs
+
+### Twilio (local validation)
+- [ ] Set `TWILIO_*` vars (or keep disabled)
+- [ ] Run SMS MFA enroll/verify flow from UI
+- [ ] Confirm audit trail/log entries for send + verify
+
+### CCBill
+- [ ] `POST /api/billing/ccbill/frontend-oauth` returns token
+- [ ] Save tokenized payment method via UI
+- [ ] Run `/api/billing/charge-once` and `/api/billing/subscribe-monthly`
+- [ ] Emit webhook: `POST /emit/ccbill-webhook` and verify `/api/ccbill/webhook` reconciliation updates payments/subscriptions
+
+### PayPal
+- [ ] `/api/billing/config` shows PayPal config
+- [ ] Create PayPal setup/payment flow
+- [ ] Trigger/forward PayPal webhook locally and verify billing state transition
+
+### UPS (local mock simulation)
+- [ ] `POST /api/ups/quote` succeeds against local UPS mock
+- [ ] `POST /api/ups/label` returns a mock tracking number + label URL
+- [ ] `POST /emit/ups-tracking-webhook` delivers signed webhook to `/api/ups/tracking/webhook`
+- [ ] Confirm webhook event persisted under `UPS_TRACKING` records in billing table
+
+## 5) Example UPS local simulation
+
+1. Quote:
+```bash
+curl -s -X POST http://localhost:8000/api/ups/quote \
+  -H 'content-type: application/json' \
+  -H 'cookie: ui_session=<session-cookie>' \
+  -d '{"service":"ground","package":{"weight":2.5}}'
+```
+
+2. Label:
+```bash
+curl -s -X POST http://localhost:8000/api/ups/label \
+  -H 'content-type: application/json' \
+  -H 'cookie: ui_session=<session-cookie>' \
+  -d '{"service":"ground","package":{"weight":2.5},"to":{"postal":"10001"}}'
+```
+
+3. Tracking webhook emit:
+```bash
+curl -s -X POST http://localhost:8000/emit/ups-tracking-webhook \
+  -H 'content-type: application/json' \
+  -d '{"payload":{"tracking_number":"1ZMOCK123","status":"DELIVERED"}}'
+```

--- a/docs/ups.md
+++ b/docs/ups.md
@@ -1,22 +1,32 @@
 # UPS Integration
 
-This repository does not currently include first-party UPS API routes. We still document UPS usage here so operators know where to configure credentials and how shipping fits into the broader workflow.
+This service now includes a **minimal UPS integration** for local testing and early provider wiring.
 
-## Current integration status
-- **API routes**: no UPS-specific endpoints are exposed by this service today.
-- **UI**: there is no UPS panel in the control panel UI.
-- **Operational usage**: UPS is typically configured in the shipping or fulfillment system that sits alongside this service.
+## Implemented endpoints
 
-## Recommended configuration checklist
-- Store UPS credentials (client ID/secret, account number, and webhook secrets if used) in your secret manager.
-- Document which downstream service is responsible for:
-  - Rate quoting and label creation.
-  - Tracking updates and webhook handling.
-  - Persisting tracking numbers back to the customer profile or order system.
+### App endpoints
+- `POST /api/ups/quote` — request a shipping quote.
+- `POST /api/ups/label` — create a shipping label.
+- `POST /api/ups/tracking/webhook` — receive tracking updates (HMAC signature optional/configurable).
 
-## Suggested future integration points
-If you plan to add UPS support directly to this service, these are the likely touch points:
-- **Settings**: add UPS configuration fields to `app/core/settings.py`.
-- **Service layer**: create a new module under `app/services/` for UPS API calls.
-- **Routers**: expose routes for rate quoting, label creation, and webhook callbacks.
-- **UI**: add a panel in `app/static/index.html` and supporting logic in `app/static/main.js`.
+### Local mock/provider endpoints
+- `POST /mock/ups/oauth/token`
+- `POST /mock/ups/quote`
+- `POST /mock/ups/label`
+- `POST /emit/ups-tracking-webhook` (helper to emit signed tracking events to the app webhook)
+
+## Configuration
+
+- `UPS_BASE_URL`
+- `UPS_AUTH_URL`
+- `UPS_CLIENT_ID`
+- `UPS_CLIENT_SECRET`
+- `UPS_WEBHOOK_SECRET`
+
+For local usage, point UPS base/auth to the in-app mock endpoints (see `docs/local-dev-stack.md`).
+
+## Notes
+
+- The current implementation is intentionally minimal and aimed at local simulation.
+- Quote/label API payloads are passed through to the configured UPS base URL.
+- Tracking webhook events are stored under `UPS_TRACKING` records in the billing table for verification.

--- a/scripts/local-cognito-init.py
+++ b/scripts/local-cognito-init.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+
+ENV_FILE = Path(".env.local")
+ENV_EXAMPLE_FILE = Path(".env.local.example")
+DEFAULT_POOL_NAME = os.getenv("LOCAL_COGNITO_POOL_NAME", "local-user-pool")
+DEFAULT_CLIENT_NAME = os.getenv("LOCAL_COGNITO_APP_CLIENT_NAME", "local-app-client")
+
+
+def _region() -> str:
+    return os.getenv("COGNITO_REGION") or os.getenv("AWS_REGION", "us-east-1")
+
+
+def _endpoint_base() -> str:
+    endpoint = os.getenv("COGNITO_ENDPOINT_URL") or os.getenv("AWS_ENDPOINT_URL") or "http://localhost:4566"
+    return endpoint.rstrip("/")
+
+
+def _cognito_client():
+    os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+    os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+    return boto3.client(
+        "cognito-idp",
+        region_name=_region(),
+        endpoint_url=_endpoint_base(),
+    )
+
+
+def _find_user_pool_id(client, pool_name: str) -> Optional[str]:
+    next_token: Optional[str] = None
+    while True:
+        kwargs: Dict[str, object] = {"MaxResults": 60}
+        if next_token:
+            kwargs["NextToken"] = next_token
+        response = client.list_user_pools(**kwargs)
+        for pool in response.get("UserPools", []):
+            if pool.get("Name") == pool_name:
+                return pool.get("Id")
+        next_token = response.get("NextToken")
+        if not next_token:
+            return None
+
+
+def _ensure_user_pool(client, pool_name: str) -> str:
+    pool_id = _find_user_pool_id(client, pool_name)
+    if pool_id:
+        return pool_id
+    response = client.create_user_pool(PoolName=pool_name)
+    return response["UserPool"]["Id"]
+
+
+def _find_app_client_id(client, pool_id: str, client_name: str) -> Optional[str]:
+    next_token: Optional[str] = None
+    while True:
+        kwargs: Dict[str, object] = {"UserPoolId": pool_id, "MaxResults": 60}
+        if next_token:
+            kwargs["NextToken"] = next_token
+        response = client.list_user_pool_clients(**kwargs)
+        for app_client in response.get("UserPoolClients", []):
+            if app_client.get("ClientName") == client_name:
+                return app_client.get("ClientId")
+        next_token = response.get("NextToken")
+        if not next_token:
+            return None
+
+
+def _ensure_app_client(client, pool_id: str, client_name: str) -> str:
+    client_id = _find_app_client_id(client, pool_id, client_name)
+    if client_id:
+        return client_id
+
+    response = client.create_user_pool_client(
+        UserPoolId=pool_id,
+        ClientName=client_name,
+        GenerateSecret=False,
+        ExplicitAuthFlows=[
+            "ALLOW_USER_SRP_AUTH",
+            "ALLOW_USER_PASSWORD_AUTH",
+            "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+    )
+    return response["UserPoolClient"]["ClientId"]
+
+
+def _upsert_env_lines(path: Path, key_values: Dict[str, str]) -> None:
+    if not path.exists() and ENV_EXAMPLE_FILE.exists():
+        path.write_text(ENV_EXAMPLE_FILE.read_text())
+
+    lines: List[str] = path.read_text().splitlines() if path.exists() else []
+    pending = dict(key_values)
+    updated: List[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in line:
+            updated.append(line)
+            continue
+
+        key, _ = line.split("=", 1)
+        key = key.strip()
+        if key in pending:
+            updated.append(f"{key}={pending.pop(key)}")
+        else:
+            updated.append(line)
+
+    if pending:
+        if updated and updated[-1].strip():
+            updated.append("")
+        updated.append("# Local Cognito bootstrap")
+        for key, value in pending.items():
+            updated.append(f"{key}={value}")
+
+    path.write_text("\n".join(updated).rstrip() + "\n")
+
+
+def main() -> None:
+    client = _cognito_client()
+    pool_id = _ensure_user_pool(client, DEFAULT_POOL_NAME)
+    app_client_id = _ensure_app_client(client, pool_id, DEFAULT_CLIENT_NAME)
+
+    issuer_url = f"{_endpoint_base()}/{pool_id}"
+    jwks_url = f"{issuer_url}/.well-known/jwks.json"
+
+    _upsert_env_lines(
+        ENV_FILE,
+        {
+            "COGNITO_USER_POOL_ID": pool_id,
+            "COGNITO_APP_CLIENT_ID": app_client_id,
+            "COGNITO_REGION": _region(),
+            "COGNITO_ISSUER_URL": issuer_url,
+            "COGNITO_JWKS_URL": jwks_url,
+        },
+    )
+
+    print("Ensured local Cognito resources exist.")
+    print(f"User pool id: {pool_id}")
+    print(f"App client id: {app_client_id}")
+    print(f"Wrote config to {ENV_FILE}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ClientError, BotoCoreError) as exc:
+        raise SystemExit(f"Failed to initialize local Cognito: {exc}")

--- a/scripts/run_local_mock_backend.sh
+++ b/scripts/run_local_mock_backend.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ENV_FILE=".env.local"
+if [[ ! -f "$ENV_FILE" ]]; then
+  cp .env.local.example "$ENV_FILE"
+  echo "Created $ENV_FILE from .env.local.example"
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+# Force local mock-friendly defaults unless caller explicitly overrides.
+: "${DEV_MODE:=1}"
+: "${CCBILL_MOCK_ENABLED:=1}"
+: "${CCBILL_BASE_URL:=http://localhost:8000/mock/ccbill}"
+: "${CCBILL_WEBHOOK_VERIFY_MODE:=local}"
+: "${CCBILL_WEBHOOK_SIGNATURE_SECRET:=local-ccbill-webhook-secret}"
+: "${UPS_BASE_URL:=http://localhost:8000/mock/ups}"
+: "${UPS_AUTH_URL:=http://localhost:8000/mock/ups/oauth/token}"
+: "${UPS_CLIENT_ID:=local_ups_client}"
+: "${UPS_CLIENT_SECRET:=local_ups_secret}"
+: "${UPS_WEBHOOK_SECRET:=local-ups-webhook-secret}"
+: "${AWS_ACCESS_KEY_ID:=test}"
+: "${AWS_SECRET_ACCESS_KEY:=test}"
+: "${AWS_REGION:=us-east-1}"
+set +a
+
+if [[ -d .venv ]]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi
+
+echo "Starting backend in local mock mode on http://localhost:8000"
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload

--- a/scripts/test_mock_mode.sh
+++ b/scripts/test_mock_mode.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -d .venv ]]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi
+
+echo "Running mock-mode backend tests..."
+python3 -m unittest \
+  tests.test_ccbill_mock \
+  tests.test_ups \
+  tests.test_billing_ccbill \
+  tests.test_billing_routes
+
+echo "Mock-mode tests passed."

--- a/tests/test_billing_ccbill.py
+++ b/tests/test_billing_ccbill.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from app.services import billing_ccbill as bc
 
@@ -25,6 +26,20 @@ class BillingCcbillTests(unittest.TestCase):
     def test_webhook_remote_ip_allowed_by_default(self) -> None:
         # Defaults to disabled IP enforcement, so any IP should pass.
         self.assertTrue(bc.webhook_remote_ip_allowed("203.0.113.10"))
+
+
+    def test_verify_mode_defaults_to_local_in_dev(self) -> None:
+        with mock.patch("app.services.billing_ccbill.S", new=type("Stub", (), {"ccbill_webhook_verify_mode":"", "dev_mode":True})()):
+            self.assertEqual(bc.ccbill_webhook_verify_mode(), "local")
+
+    def test_verify_mode_defaults_to_strict_outside_dev(self) -> None:
+        with mock.patch("app.services.billing_ccbill.S", new=type("Stub", (), {"ccbill_webhook_verify_mode":"", "dev_mode":False})()):
+            self.assertEqual(bc.ccbill_webhook_verify_mode(), "ip+sig")
+
+    def test_signature_required_when_secret_missing_in_strict_mode(self) -> None:
+        with mock.patch("app.services.billing_ccbill.ccbill_webhook_verify_mode", return_value="ip+sig"), \
+             mock.patch("app.services.billing_ccbill._webhook_signature_secret_for_mode", return_value=""):
+            self.assertFalse(bc.verify_ccbill_webhook_signature(b"{}", "anything"))
 
 
 if __name__ == "__main__":

--- a/tests/test_billing_routes.py
+++ b/tests/test_billing_routes.py
@@ -71,15 +71,15 @@ class FakeBillingTable:
         return {"Items": items}
 
 
-def build_request(path: str, *, method: str = "POST", query_string: str = "", json_body: bytes | None = None) -> Request:
-    headers = [
-        (b"content-type", b"application/json"),
-    ]
+def build_request(path: str, *, method: str = "POST", query_string: str = "", json_body: bytes | None = None, headers: dict[str, str] | None = None) -> Request:
+    encoded_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        encoded_headers.append((key.lower().encode(), value.encode()))
     scope = {
         "type": "http",
         "method": method,
         "path": path,
-        "headers": headers,
+        "headers": encoded_headers,
         "query_string": query_string.encode(),
         "client": ("127.0.0.1", 1234),
     }
@@ -98,11 +98,14 @@ class BillingRoutesTests(unittest.TestCase):
         self.services_tables_patcher = patch("app.services.billing_ccbill.T", tables_stub)
         self.tables_patcher.start()
         self.services_tables_patcher.start()
+        self.dunning_patcher = patch("app.routers.billing_ccbill.bump_dunning_after_payment_method_update", return_value=None)
+        self.dunning_patcher.start()
         self.ctx = {"user_sub": "user_123", "session_id": "sess_123"}
 
     def tearDown(self) -> None:
         self.tables_patcher.stop()
         self.services_tables_patcher.stop()
+        self.dunning_patcher.stop()
 
     def test_config_endpoint(self) -> None:
         body = routes.billing_config()
@@ -209,7 +212,8 @@ class BillingRoutesTests(unittest.TestCase):
         self.assertEqual(len(resp["items"]), 1)
 
     def test_webhook_unmatched_payload(self) -> None:
-        with patch("app.services.billing_ccbill.mark_webhook_processed", return_value=True):
+        with patch("app.services.billing_ccbill.mark_webhook_processed", return_value=True), \
+             patch("app.routers.billing_ccbill.verify_ccbill_webhook_signature", return_value=True):
             req = build_request("/api/ccbill/webhook", query_string="eventType=NewSaleSuccess", json_body=b"{}")
             resp = asyncio.run(routes.ccbill_webhook(req))
         self.assertTrue(resp["unmatched"])
@@ -250,7 +254,8 @@ class BillingRoutesTests(unittest.TestCase):
         })
 
         payload = b'{"X-app_user_id":"user_123","transactionId":"txn_1","subscriptionId":"sub_1"}'
-        with patch("app.services.billing_ccbill.mark_webhook_processed", return_value=True):
+        with patch("app.services.billing_ccbill.mark_webhook_processed", return_value=True), \
+             patch("app.routers.billing_ccbill.verify_ccbill_webhook_signature", return_value=True):
             req = build_request("/api/ccbill/webhook", query_string="eventType=NewSaleSuccess", json_body=payload)
             resp = asyncio.run(routes.ccbill_webhook(req))
         self.assertTrue(resp["received"])
@@ -277,13 +282,32 @@ class BillingRoutesTests(unittest.TestCase):
         self.assertEqual(ctx.exception.status_code, 404)
 
     def test_webhook_deduped_returns_flag(self) -> None:
-        with patch("app.routers.billing_ccbill.mark_webhook_processed", return_value=False):
+        with patch("app.routers.billing_ccbill.mark_webhook_processed", return_value=False), \
+             patch("app.routers.billing_ccbill.verify_ccbill_webhook_signature", return_value=True):
             req = build_request("/api/ccbill/webhook", query_string="eventType=NewSaleSuccess", json_body=b"{}")
             resp = asyncio.run(routes.ccbill_webhook(req))
         self.assertTrue(resp["deduped"])
 
+
+    def test_webhook_local_mode_skips_ip_check_with_valid_signature(self) -> None:
+        payload = b'{"X-app_user_id":"user_123","transactionId":"txn_1"}'
+        with patch("app.routers.billing_ccbill.ccbill_webhook_verify_mode", return_value="local"), \
+             patch("app.routers.billing_ccbill.mark_webhook_processed", return_value=True), \
+             patch("app.routers.billing_ccbill.verify_ccbill_webhook_signature", return_value=True):
+            sig = "unused"
+            req = build_request(
+                "/api/ccbill/webhook",
+                query_string="eventType=NewSaleSuccess",
+                json_body=payload,
+                headers={"x-ccbill-signature": sig},
+            )
+            resp = asyncio.run(routes.ccbill_webhook(req))
+        self.assertTrue(resp["received"])
+
     def test_webhook_rejects_disallowed_ip(self) -> None:
-        with patch("app.routers.billing_ccbill.webhook_remote_ip_allowed", return_value=False):
+        with patch("app.routers.billing_ccbill.ccbill_webhook_verify_mode", return_value="ip+sig"), \
+             patch("app.routers.billing_ccbill.webhook_remote_ip_allowed", return_value=False), \
+             patch("app.routers.billing_ccbill.verify_ccbill_webhook_signature", return_value=True):
             req = build_request("/api/ccbill/webhook", query_string="eventType=NewSaleSuccess", json_body=b"{}")
             with self.assertRaises(HTTPException) as ctx:
                 asyncio.run(routes.ccbill_webhook(req))

--- a/tests/test_ccbill_mock.py
+++ b/tests/test_ccbill_mock.py
@@ -1,0 +1,110 @@
+import asyncio
+import base64
+import json
+import unittest
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.routers import ccbill_mock
+
+
+def build_request(path: str, *, method: str = "POST", query_string: str = "", headers: dict[str, str] | None = None, body: bytes = b"") -> Request:
+    encoded = []
+    for k, v in (headers or {}).items():
+        encoded.append((k.lower().encode(), v.encode()))
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": encoded,
+        "query_string": query_string.encode(),
+        "client": ("127.0.0.1", 9999),
+    }
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+class CcbillMockTests(unittest.TestCase):
+    def setUp(self) -> None:
+        ccbill_mock._TOKEN_CACHE.clear()
+        ccbill_mock._SUBSCRIPTIONS.clear()
+        self.settings = type(
+            "StubSettings",
+            (),
+            {
+                "ccbill_mock_enabled": True,
+                "ccbill_frontend_client_id": "front",
+                "ccbill_frontend_client_secret": "front-secret",
+                "ccbill_backend_client_id": "back",
+                "ccbill_backend_client_secret": "back-secret",
+                "ccbill_webhook_signature_secret": "local-ccbill-webhook-secret",
+                "ccbill_webhook_signature_header": "x-ccbill-signature",
+                "public_base_url": "http://localhost:8000",
+            },
+        )()
+
+    def _auth(self, username: str, password: str) -> str:
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        return f"Basic {token}"
+
+    def test_oauth_and_charge_subscription_success(self) -> None:
+        with patch("app.routers.ccbill_mock.S", new=self.settings):
+            oauth_req = build_request(
+                "/mock/ccbill/ccbill-auth/oauth/token",
+                query_string="grant_type=client_credentials",
+                headers={"authorization": self._auth("back", "back-secret")},
+            )
+            oauth = asyncio.run(ccbill_mock.ccbill_mock_oauth(oauth_req))
+            self.assertIn("access_token", oauth)
+
+            charge_payload = json.dumps({"recurringPrice": 9.99, "recurringPeriod": 30, "currencyCode": 840}).encode()
+            charge_req = build_request(
+                "/mock/ccbill/transactions/payment-tokens/tok_123",
+                headers={
+                    "authorization": f"Bearer {oauth['access_token']}",
+                    "content-type": "application/json",
+                },
+                body=charge_payload,
+            )
+            charge = asyncio.run(ccbill_mock.ccbill_mock_charge("tok_123", charge_req))
+            self.assertTrue(charge["approved"])
+            self.assertTrue(charge["subscriptionId"].startswith("sub_"))
+
+    def test_oauth_rejects_bad_credentials(self) -> None:
+        with patch("app.routers.ccbill_mock.S", new=self.settings):
+            oauth_req = build_request(
+                "/mock/ccbill/ccbill-auth/oauth/token",
+                query_string="grant_type=client_credentials",
+                headers={"authorization": self._auth("bad", "bad")},
+            )
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(ccbill_mock.ccbill_mock_oauth(oauth_req))
+            self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_emit_webhook_signs_and_posts(self) -> None:
+        with patch("app.routers.ccbill_mock.S", new=self.settings), patch("app.routers.ccbill_mock.requests.post") as post_mock:
+            post_mock.return_value.status_code = 200
+            post_mock.return_value.text = '{"received": true}'
+
+            result = ccbill_mock.emit_ccbill_webhook(
+                {
+                    "event_type": "NewSaleSuccess",
+                    "payload": {"X-app_user_id": "dev-user", "transactionId": "txn_1"},
+                    "target_url": "http://localhost:8000/api/ccbill/webhook",
+                }
+            )
+
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["status_code"], 200)
+            _, kwargs = post_mock.call_args
+            self.assertEqual(kwargs["params"]["eventType"], "NewSaleSuccess")
+            self.assertIn("x-ccbill-signature", kwargs["headers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ups.py
+++ b/tests/test_ups.py
@@ -1,0 +1,96 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import unittest
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.routers import ups as ups_router
+from app.services import ups as ups_service
+
+
+class FakeBillingTable:
+    def __init__(self) -> None:
+        self.items = []
+
+    def put_item(self, Item, **kwargs):
+        self.items.append(Item)
+        return {}
+
+
+def build_request(path: str, *, headers: dict[str, str] | None = None, body: bytes = b"", query: str = "") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+        "query_string": query.encode(),
+        "client": ("127.0.0.1", 1234),
+    }
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+class UpsTests(unittest.TestCase):
+    def test_verify_tracking_webhook_signature(self) -> None:
+        body = b'{"tracking_number":"1Z1"}'
+        with patch("app.services.ups.S", new=type("S", (), {"ups_webhook_secret": "abc"})()):
+            sig = hmac.new(b"abc", body, hashlib.sha256).hexdigest()
+            self.assertTrue(ups_service.verify_tracking_webhook_signature(body, sig))
+            self.assertFalse(ups_service.verify_tracking_webhook_signature(body, "bad"))
+
+    def test_mock_oauth_quote_label(self) -> None:
+        settings = type(
+            "S", (),
+            {"dev_mode": True, "ups_client_id": "id", "ups_client_secret": "sec", "ups_webhook_secret": "x", "public_base_url": "http://localhost:8000"},
+        )()
+        with patch("app.routers.ups.S", new=settings):
+            basic = base64.b64encode(b"id:sec").decode()
+            oauth_req = build_request("/mock/ups/oauth/token", headers={"authorization": f"Basic {basic}"})
+            oauth = ups_router.mock_ups_oauth(oauth_req)
+            self.assertIn("access_token", oauth)
+
+            quote_req = build_request("/mock/ups/quote", headers={"content-type": "application/json"}, body=json.dumps({"package": {"weight": 2}}).encode())
+            quote = asyncio.run(ups_router.mock_ups_quote(quote_req))
+            self.assertIn("amount", quote)
+
+            label_req = build_request("/mock/ups/label", headers={"content-type": "application/json"}, body=json.dumps({"service": "ground"}).encode())
+            label = asyncio.run(ups_router.mock_ups_label(label_req))
+            self.assertTrue(label["tracking_number"].startswith("1ZMOCK"))
+
+    def test_emit_tracking_webhook(self) -> None:
+        settings = type(
+            "S", (),
+            {"dev_mode": True, "ups_webhook_secret": "local-ups-webhook-secret", "public_base_url": "http://localhost:8000"},
+        )()
+        with patch("app.routers.ups.S", new=settings), patch("app.routers.ups.requests.post") as post_mock:
+            post_mock.return_value.status_code = 200
+            post_mock.return_value.text = '{"received": true}'
+            out = ups_router.emit_ups_tracking_webhook({"payload": {"tracking_number": "1ZMOCK1", "status": "DELIVERED"}})
+            self.assertTrue(out["ok"])
+            _, kwargs = post_mock.call_args
+            self.assertIn("x-ups-signature", kwargs["headers"])
+
+    def test_tracking_webhook_persists(self) -> None:
+        table = FakeBillingTable()
+        tables = type("T", (), {"billing": table})()
+        settings = type("S", (), {"ups_webhook_secret": "abc"})()
+        body = b'{"tracking_number":"1Z111","status":"IN_TRANSIT"}'
+        sig = hmac.new(b"abc", body, hashlib.sha256).hexdigest()
+        req = build_request("/api/ups/tracking/webhook", headers={"x-ups-signature": sig, "content-type": "application/json"}, body=body)
+
+        with patch("app.routers.ups.T", tables), patch("app.routers.ups.S", settings):
+            resp = asyncio.run(ups_router.ups_tracking_webhook(req))
+        self.assertTrue(resp["received"])
+        self.assertEqual(len(table.items), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make it trivial to run the full backend in a local mock provider mode and validate core billing/shipping flows with one command. 
- Provide first-class in-app provider mocks (CCBill and UPS) so developers can exercise OAuth, quote/label, and webhook flows without external services. 
- Surface UPS and CCBill mock-friendly configuration in settings and the local dev playbook so wiring is explicit and repeatable. 

### Description
- Add `scripts/run_local_mock_backend.sh` to start the backend with `.env.local` seeded and mock-friendly defaults for CCBill, UPS, and local AWS credentials. 
- Add `scripts/test_mock_mode.sh` to run the key mock-mode unit tests in one command (`tests.test_ccbill_mock`, `tests.test_ups`, `tests.test_billing_ccbill`, `tests.test_billing_routes`). 
- Implement in-app CCBill mock router `app/routers/ccbill_mock.py` and UPS router `app/routers/ups.py`, plus a minimal UPS service `app/services/ups.py`. 
- Expose UPS/CCBill configuration in `app/core/settings.py` and wire the mock routers into the app in `app/main.py`, plus add local Cognito bootstrap script and documentation updates (`docs/local-dev-stack.md`, `README.md`, `docs/ups.md`). 
- Adjust billing webhook verification plumbing in `app/services/billing_ccbill.py` and `app/routers/billing_ccbill.py` to support mode-aware verification (`local`, `sig_only`, `ip+sig`) and make signature enforcement explicit for stricter environments. 

### Testing
- Compiled modified modules with `python3 -m py_compile app/services/ups.py app/routers/ups.py app/routers/ccbill_mock.py app/services/billing_ccbill.py app/routers/billing_ccbill.py tests/test_ups.py tests/test_ccbill_mock.py` and compilation succeeded. 
- Ran the consolidated mock-mode test runner `scripts/test_mock_mode.sh`, which executed the test suites `tests.test_ccbill_mock`, `tests.test_ups`, `tests.test_billing_ccbill`, and `tests.test_billing_routes` (32 tests total) and completed with `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f922e3fdc832b80a094e51f234977)