### PR TITLE
Register: add eye toggles for both password fields, email UI conformance, and registration/session hardening

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -77,6 +77,8 @@ class Settings:
     login_anomaly_window_seconds: int = int(os.environ.get("LOGIN_ANOMALY_WINDOW_SECONDS", "900"))
     login_anomaly_ip_prefix_threshold: int = int(os.environ.get("LOGIN_ANOMALY_IP_PREFIX_THRESHOLD", "5"))
     login_anomaly_user_threshold: int = int(os.environ.get("LOGIN_ANOMALY_USER_THRESHOLD", "10"))
+    login_anomaly_risk_score_threshold: int = int(os.environ.get("LOGIN_ANOMALY_RISK_SCORE_THRESHOLD", "1"))
+    login_high_risk_refresh_ttl_seconds: int = int(os.environ.get("LOGIN_HIGH_RISK_REFRESH_TTL_SECONDS", "3600"))
     mfa_verify_max_per_window: int = int(os.environ.get("MFA_VERIFY_MAX_PER_WINDOW", "10"))
     mfa_verify_window_seconds: int = int(os.environ.get("MFA_VERIFY_WINDOW_SECONDS", "600"))
     lockout_max_attempts: int = int(os.environ.get("LOCKOUT_MAX_ATTEMPTS", "5"))

--- a/app/models.py
+++ b/app/models.py
@@ -16,7 +16,7 @@ from pydantic import (
 
 from app.core.normalize import normalize_phone
 
-_PASSWORD_COMPLEXITY = re.compile(r"^(?=.*[A-Za-z])(?=.*\\d).+$")
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
 
 class UiSessionStartReq(BaseModel):
     # You can include client metadata; auth is handled separately.
@@ -155,10 +155,13 @@ class RegisterStartReq(BaseModel):
     @field_validator("password")
     @classmethod
     def _validate_password(cls, value: str) -> str:
-        if len(value) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        if not _PASSWORD_COMPLEXITY.match(value):
-            raise ValueError("Password must include letters and numbers")
+        if len(value) < 12:
+            raise ValueError("Password must be at least 12 characters")
+        if len(value) > 128:
+            raise ValueError("Password must be 128 characters or fewer")
+        # Basic low-entropy guardrail.
+        if len(set(value)) < 4:
+            raise ValueError("Password is too weak")
         return value
 
     @model_validator(mode="after")
@@ -167,7 +170,17 @@ class RegisterStartReq(BaseModel):
             raise ValueError("Passwords don't match")
         if self.enable_sms_mfa and not self.phone:
             raise ValueError("Phone required for SMS MFA")
+        self._validate_password_context()
         return self
+
+    def _validate_password_context(self) -> None:
+        password = self.password.lower()
+        local_part = self.email.split("@", 1)[0].lower()
+        local_tokens = [t for t in _NON_ALNUM.split(local_part) if len(t) >= 3]
+        name_tokens = [t for t in _NON_ALNUM.split(self.full_name.lower()) if len(t) >= 3]
+        for token in local_tokens + name_tokens:
+            if token and token in password:
+                raise ValueError("Password is too similar to personal information")
 
 class RegisterStartResp(BaseModel):
     status: str

--- a/app/routers/register.py
+++ b/app/routers/register.py
@@ -40,7 +40,7 @@ from app.services.sessions import create_real_session, rotate_session_cookies, s
 router = APIRouter(prefix="/ui/register", tags=["register"])
 
 DEFAULT_DEV_REGISTRATION_EMAIL = "demo@example.com"
-DEFAULT_DEV_REGISTRATION_PASSWORD = "Password\\d1"
+DEFAULT_DEV_REGISTRATION_PASSWORD = "CloudRiver789!"
 DEFAULT_DEV_REGISTRATION_CODE = "000000"
 DEFAULT_DEV_REGISTRATION_PHONE = "+15555550123"
 
@@ -78,13 +78,15 @@ async def register_start(
 ) -> Dict[str, object]:
     if response is None:
         response = Response()
+    generic_response = {
+        "status": "ok",
+        "verification_required": True,
+        "delivery_medium": None,
+        "delivery_destination": None,
+    }
     if _is_dev_registration(body.email, body.password):
-        return {
-            "status": "ok",
-            "verification_required": True,
-            "delivery_medium": "email",
-            "delivery_destination": body.email,
-        }
+        audit_event("register_start", body.email, req, outcome="success", mode="dev")
+        return generic_response
     _require_cognito()
     username = body.email
     ip = client_ip_from_request(req)
@@ -98,58 +100,54 @@ async def register_start(
         raise HTTPException(400, "Password found in breach corpus")
 
     try:
-        resp = cognito_sign_up(username, body.password, body.full_name)
+        cognito_sign_up(username, body.password, body.full_name)
     except HTTPException:
         audit_event("register_start", username, req, outcome="failure", reason="cognito_sign_up")
         record_lockout_failure(username, ip, "register_start")
-        raise
-    except Exception as exc:
+        return generic_response
+    except Exception:
         audit_event("register_start", username, req, outcome="failure", reason="unexpected_error")
         record_lockout_failure(username, ip, "register_start")
-        raise HTTPException(400, "Registration failed") from exc
+        return generic_response
 
-    delivery = resp.get("CodeDeliveryDetails") or {}
     verification_required = True
-    create_user_record(
-        email=username,
-        full_name=body.full_name,
-        password=body.password,
-        verification_required=verification_required,
-    )
-    delivery_medium = None
-    delivery_destination = None
+    try:
+        create_user_record(
+            email=username,
+            full_name=body.full_name,
+            password=body.password,
+            verification_required=verification_required,
+        )
+    except HTTPException:
+        audit_event("register_start", username, req, outcome="failure", reason="duplicate_or_invalid")
+        clear_lockout(username, ip, "register_start")
+        return generic_response
     mfa_setup: list[str] = []
     if body.enable_sms_mfa:
         mfa_setup.append("sms")
     if body.enable_totp_mfa:
         mfa_setup.append("totp")
-    if not can_send_verification(username, "email"):
-        raise HTTPException(429, "Too many verification emails; try again later")
-    code = create_registration_challenge(
-        user_sub=username,
-        channel="email",
-        send_to=username,
-        mfa_setup=mfa_setup,
-        sms_phone=body.phone,
-    )
-    send_email_code(username, "Registration", code)
-    delivery_medium = "email"
-    delivery_destination = username
+    if can_send_verification(username, "email"):
+        code = create_registration_challenge(
+            user_sub=username,
+            channel="email",
+            send_to=username,
+            mfa_setup=mfa_setup,
+            sms_phone=body.phone,
+        )
+        send_email_code(username, "Registration", code)
+    else:
+        audit_event("register_start", username, req, outcome="warning", reason="verification_send_rate_limited")
     audit_event(
         "register_start",
         username,
         req,
         outcome="success",
         verification_required=verification_required,
-        delivery_medium=delivery_medium or delivery.get("DeliveryMedium"),
+        delivery_medium="suppressed",
     )
     clear_lockout(username, ip, "register_start")
-    return {
-        "status": "ok",
-        "verification_required": True,
-        "delivery_medium": delivery_medium or delivery.get("DeliveryMedium"),
-        "delivery_destination": delivery_destination or delivery.get("Destination"),
-    }
+    return generic_response
 
 
 @router.post("/check", response_model=RegisterEmailCheckResp)
@@ -157,21 +155,23 @@ async def register_check(req: Request, body: RegisterEmailCheckReq) -> Dict[str,
     ip = client_ip_from_request(req)
     enforce_lockout(body.email, ip, "register_check")
     rate_limit_password_recovery(body.email, ip, "register_check")
+    generic_response = {"status": "ok", "available": True}
     if _is_dev_registration(body.email):
-        return {"status": "ok", "available": True}
+        audit_event("register_check", body.email, req, outcome="success", mode="dev")
+        return generic_response
     try:
         available = is_email_available(body.email)
     except HTTPException:
+        audit_event("register_check", body.email, req, outcome="failure", reason="check_error")
         record_lockout_failure(body.email, ip, "register_check")
-        raise
-    except Exception as exc:
+        return generic_response
+    except Exception:
+        audit_event("register_check", body.email, req, outcome="failure", reason="unexpected_error")
         record_lockout_failure(body.email, ip, "register_check")
-        if S.dev_mode:
-            clear_lockout(body.email, ip, "register_check")
-            return {"status": "ok", "available": True}
-        raise HTTPException(400, "Email check failed") from exc
+        return generic_response
     clear_lockout(body.email, ip, "register_check")
-    return {"status": "ok", "available": available}
+    audit_event("register_check", body.email, req, outcome="success", available=available)
+    return generic_response
 
 
 @router.post("/confirm", response_model=RegisterConfirmResp)
@@ -228,12 +228,14 @@ async def register_confirm(
 
 @router.post("/resend", response_model=RegisterResendResp)
 async def register_resend(req: Request, body: RegisterResendReq) -> Dict[str, object]:
+    generic_response = {
+        "status": "ok",
+        "delivery_medium": None,
+        "delivery_destination": None,
+    }
     if _is_dev_registration(body.email):
-        return {
-            "status": "ok",
-            "delivery_medium": "email",
-            "delivery_destination": body.email,
-        }
+        audit_event("register_resend", body.email, req, outcome="success", mode="dev")
+        return generic_response
     _require_cognito()
     username = body.email
     ip = client_ip_from_request(req)
@@ -275,18 +277,21 @@ async def register_resend(req: Request, body: RegisterResendReq) -> Dict[str, ob
             delivery_medium = "email"
             delivery_destination = username
     except HTTPException:
-        audit_event("register_resend", username, req, outcome="failure")
+        audit_event("register_resend", username, req, outcome="failure", reason="resend_failed")
         record_lockout_failure(username, ip, "register_resend")
-        raise
-    except Exception as exc:
-        audit_event("register_resend", username, req, outcome="failure")
+        return generic_response
+    except Exception:
+        audit_event("register_resend", username, req, outcome="failure", reason="unexpected_error")
         record_lockout_failure(username, ip, "register_resend")
-        raise HTTPException(400, "Registration resend failed") from exc
+        return generic_response
 
-    audit_event("register_resend", username, req, outcome="success", delivery_medium=delivery_medium)
+    audit_event(
+        "register_resend",
+        username,
+        req,
+        outcome="success",
+        delivery_medium=delivery_medium,
+        delivery_destination=delivery_destination,
+    )
     clear_lockout(username, ip, "register_resend")
-    return {
-        "status": "ok",
-        "delivery_medium": delivery_medium,
-        "delivery_destination": delivery_destination,
-    }
+    return generic_response

--- a/app/routers/ui_session.py
+++ b/app/routers/ui_session.py
@@ -33,6 +33,32 @@ from app.core.time import now_ts
 
 router = APIRouter(prefix="/ui", tags=["ui-session"])
 
+
+def _adaptive_login_policy(user_sub: str, base_required: list[str], anomaly: dict[str, object]) -> tuple[list[str], int, int | None]:
+    required = list(base_required)
+    risk_score = int(bool(anomaly.get("user_threshold_exceeded"))) + int(bool(anomaly.get("ip_threshold_exceeded")))
+    if risk_score <= 0:
+        return required, 0, None
+
+    available = set(compute_required_factors(user_sub))
+    stronger_order = ["totp", "email", "sms"]
+    for factor in stronger_order:
+        if factor in available and factor not in required:
+            required.append(factor)
+
+    # If anomaly risk is high and we have multiple factors, require at least 2 factors.
+    if risk_score >= getattr(S, "login_anomaly_risk_score_threshold", 1):
+        stronger = [f for f in stronger_order if f in required]
+        if len(stronger) >= 2:
+            required = stronger[:2]
+        refresh_ttl = max(300, int(getattr(S, "login_high_risk_refresh_ttl_seconds", 3600)))
+    else:
+        refresh_ttl = None
+
+    # Preserve deterministic order.
+    ordered = [f for f in stronger_order if f in required]
+    return ordered, risk_score, refresh_ttl
+
 @router.post("/session/start", response_model=UiSessionStartResp)
 async def ui_session_start(
     req: Request,
@@ -55,6 +81,7 @@ async def ui_session_start(
             ip_user_count=anomaly.get("ip_user_count"),
         )
     required = compute_required_factors(user_sub)
+    required, anomaly_risk_score, high_risk_refresh_ttl = _adaptive_login_policy(user_sub, required, anomaly)
     device_info = record_device_login(req, user_sub)
     suspicious = device_info.get("new_device") or device_info.get("location_mismatch")
     if suspicious and "email" not in required:
@@ -77,14 +104,51 @@ async def ui_session_start(
                 reason="device_mismatch_no_email",
                 device_id=device_info.get("device_id"),
             )
+    if anomaly_risk_score > 0:
+        audit_event(
+            "login_unusual_signin",
+            user_sub,
+            req,
+            outcome="warning",
+            risk_score=anomaly_risk_score,
+            required_factors=required,
+            short_refresh_ttl=high_risk_refresh_ttl or 0,
+        )
+
     if not required:
-        session = create_real_session(req, user_sub)
-        rotate_session_cookies(req, response, user_sub, session)
+        session = create_real_session(
+            req,
+            user_sub,
+            risk_score=anomaly_risk_score,
+            refresh_ttl_seconds=high_risk_refresh_ttl,
+        )
+        rotate_session_cookies(req, response, user_sub, session, refresh_ttl_seconds=high_risk_refresh_ttl)
         session_id = session_id_value(session)
-        audit_event("ui_session_start", user_sub, req, outcome="success", session_id=session_id)
+        audit_event(
+            "ui_session_start",
+            user_sub,
+            req,
+            outcome="success",
+            session_id=session_id,
+            risk_score=anomaly_risk_score,
+        )
         return UiSessionStartResp(auth_required=False, session_id=session_id, required_factors=[])
-    challenge_id = create_stepup_challenge(req, user_sub, required_factors=required)
-    audit_event("ui_session_start", user_sub, req, outcome="info", required_factors=required, challenge_id=challenge_id)
+    challenge_id = create_stepup_challenge(
+        req,
+        user_sub,
+        required_factors=required,
+        risk_score=anomaly_risk_score,
+        refresh_ttl_seconds=high_risk_refresh_ttl,
+    )
+    audit_event(
+        "ui_session_start",
+        user_sub,
+        req,
+        outcome="info",
+        required_factors=required,
+        challenge_id=challenge_id,
+        risk_score=anomaly_risk_score,
+    )
     return UiSessionStartResp(auth_required=True, challenge_id=challenge_id, required_factors=required)
 
 @router.post("/session/finalize")
@@ -99,7 +163,7 @@ async def ui_session_finalize(
     chal = load_challenge_or_401(user_sub, body.challenge_id)
     sid = maybe_finalize(req, user_sub, body.challenge_id)
     if sid:
-        rotate_session_cookies(req, response, user_sub, sid)
+        rotate_session_cookies(req, response, user_sub, sid, refresh_ttl_seconds=int(chal.get("refresh_ttl_seconds") or 0) or None)
         if body.remember_device:
             device_id = trust_current_device(req, user_sub)
             audit_event("device_trust", user_sub, req, outcome="success", device_id=device_id)

--- a/app/services/registration.py
+++ b/app/services/registration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import secrets
+import uuid
 from typing import Dict
 
 from fastapi import HTTPException
@@ -19,7 +20,8 @@ from app.core.crypto import sha256_str
 
 PASSWORD_HASH_ITERATIONS = 260_000
 PASSWORD_HASH_ALGO = "pbkdf2_sha256"
-REGISTRATION_CHALLENGE_ID = "register_verify"
+REGISTRATION_CHALLENGE_PREFIX = "register_verify#"
+REGISTRATION_LATEST_POINTER_ID = "register_verify_latest"
 
 
 def _hash_password(password: str) -> Dict[str, str]:
@@ -36,6 +38,7 @@ def _hash_password(password: str) -> Dict[str, str]:
 def _user_exists(user_sub: str) -> bool:
     existing = T.users.get_item(Key={"user_sub": user_sub}).get("Item")
     return bool(existing)
+
 
 def is_email_available(email: str) -> bool:
     normalized = normalize_email(email)
@@ -82,6 +85,18 @@ def create_user_record(
     return {"user_sub": user_sub}
 
 
+def _challenge_session_id() -> str:
+    return f"{REGISTRATION_CHALLENGE_PREFIX}{uuid.uuid4()}"
+
+
+def _load_latest_challenge_id(user_sub: str) -> str:
+    latest = T.sessions.get_item(
+        Key={"user_sub": user_sub, "session_id": REGISTRATION_LATEST_POINTER_ID},
+    ).get("Item") or {}
+    challenge_id = latest.get("challenge_id") or ""
+    return challenge_id if isinstance(challenge_id, str) else ""
+
+
 def create_registration_challenge(
     *,
     user_sub: str,
@@ -93,9 +108,10 @@ def create_registration_challenge(
     code = gen_numeric_code(6) if channel == "email" else ""
     ts = now_ts()
     expires = ts + S.session_challenge_ttl_seconds
+    challenge_id = _challenge_session_id()
     payload = {
         "user_sub": user_sub,
-        "session_id": REGISTRATION_CHALLENGE_ID,
+        "session_id": challenge_id,
         "created_at": ts,
         "expires_at": expires,
         "revoked": False,
@@ -109,17 +125,31 @@ def create_registration_challenge(
         "sms_phone": sms_phone or "",
     }
     T.sessions.put_item(Item=with_ttl(payload, ttl_epoch=expires))
+    pointer_payload = {
+        "user_sub": user_sub,
+        "session_id": REGISTRATION_LATEST_POINTER_ID,
+        "challenge_id": challenge_id,
+        "created_at": ts,
+        "expires_at": expires,
+        "purpose": "register_verify_pointer",
+    }
+    T.sessions.put_item(Item=with_ttl(pointer_payload, ttl_epoch=expires))
     return code
 
 
 def verify_registration_code(*, user_sub: str, code: str) -> Dict[str, str]:
+    challenge_id = _load_latest_challenge_id(user_sub)
+    if not challenge_id:
+        raise HTTPException(400, "Registration verification not found")
     item = T.sessions.get_item(
-        Key={"user_sub": user_sub, "session_id": REGISTRATION_CHALLENGE_ID},
+        Key={"user_sub": user_sub, "session_id": challenge_id},
     ).get("Item")
     if not item:
         raise HTTPException(400, "Registration verification not found")
     if int(item.get("expires_at") or 0) < now_ts():
         raise HTTPException(400, "Verification code expired")
+    if item.get("purpose") != "register_verify":
+        raise HTTPException(400, "Registration verification not found")
     channel = item.get("channel") or "email"
     attempts = int(item.get("code_attempts") or 0)
     max_attempts = S.sms_code_max_attempts if channel == "sms" else S.email_code_max_attempts
@@ -128,14 +158,15 @@ def verify_registration_code(*, user_sub: str, code: str) -> Dict[str, str]:
     if channel == "sms":
         phone = item.get("send_to", "")
         if not twilio_check_sms(phone, code.strip()):
-            _increment_registration_attempts(user_sub, attempts)
+            _increment_registration_attempts(user_sub, challenge_id, attempts)
             raise HTTPException(401, "Invalid verification code")
     else:
         if sha256_str(code.strip()) != item.get("code_hash"):
-            _increment_registration_attempts(user_sub, attempts)
+            _increment_registration_attempts(user_sub, challenge_id, attempts)
             raise HTTPException(401, "Invalid verification code")
     try:
-        T.sessions.delete_item(Key={"user_sub": user_sub, "session_id": REGISTRATION_CHALLENGE_ID})
+        T.sessions.delete_item(Key={"user_sub": user_sub, "session_id": challenge_id})
+        T.sessions.delete_item(Key={"user_sub": user_sub, "session_id": REGISTRATION_LATEST_POINTER_ID})
     except Exception:
         pass
     return {
@@ -145,10 +176,10 @@ def verify_registration_code(*, user_sub: str, code: str) -> Dict[str, str]:
     }
 
 
-def _increment_registration_attempts(user_sub: str, attempts: int) -> None:
+def _increment_registration_attempts(user_sub: str, challenge_id: str, attempts: int) -> None:
     try:
         T.sessions.update_item(
-            Key={"user_sub": user_sub, "session_id": REGISTRATION_CHALLENGE_ID},
+            Key={"user_sub": user_sub, "session_id": challenge_id},
             UpdateExpression="SET code_attempts = :c, last_failed_at = :t",
             ExpressionAttributeValues={":c": attempts + 1, ":t": now_ts()},
         )

--- a/app/services/sessions.py
+++ b/app/services/sessions.py
@@ -49,7 +49,7 @@ def session_id_value(session: SessionInfo | str) -> str:
         return session.session_id
     return session.session_id if hasattr(session, "session_id") else str(session)
 
-def set_session_cookies(response: Response, session: SessionInfo) -> None:
+def set_session_cookies(response: Response, session: SessionInfo, *, refresh_ttl_seconds: Optional[int] = None) -> None:
     response.set_cookie(
         S.ui_session_cookie_name,
         session.session_id,
@@ -58,7 +58,7 @@ def set_session_cookies(response: Response, session: SessionInfo) -> None:
         secure=S.ui_cookie_secure,
         samesite=S.ui_cookie_samesite,
     )
-    _issue_refresh_token(response, session.session_id, session.user_sub)
+    _issue_refresh_token(response, session.session_id, session.user_sub, refresh_ttl_seconds=refresh_ttl_seconds)
     access = mint_access_token(session.user_sub, session.session_id)
     if access:
         response.set_cookie(
@@ -104,12 +104,14 @@ def rotate_session_cookies(
     response: Response,
     user_sub: str,
     session: SessionInfo | str,
+    *,
+    refresh_ttl_seconds: Optional[int] = None,
 ) -> None:
     session = _coerce_session_info(session, user_sub)
     prior = (getattr(request, "cookies", {}) or {}).get(S.ui_session_cookie_name)
     if prior and prior != session.session_id:
         revoke_session(user_sub, prior)
-    set_session_cookies(response, session)
+    set_session_cookies(response, session, refresh_ttl_seconds=refresh_ttl_seconds)
     ensure_device_cookie(request, response, user_sub)
 
 def rotate_existing_session(
@@ -118,10 +120,11 @@ def rotate_existing_session(
     ctx: Dict[str, str],
     *,
     mfa_verified_at: Optional[int] = None,
+    refresh_ttl_seconds: Optional[int] = None,
 ) -> SessionInfo:
     session = create_real_session(request, ctx["user_sub"], mfa_verified_at=mfa_verified_at)
     revoke_session(ctx["user_sub"], ctx["session_id"])
-    set_session_cookies(response, session)
+    set_session_cookies(response, session, refresh_ttl_seconds=refresh_ttl_seconds)
     ensure_device_cookie(request, response, ctx["user_sub"])
     return session
 
@@ -147,7 +150,7 @@ def mint_access_token(user_sub: str, session_id: str) -> str:
     }
     return jwt.encode(payload, S.ui_access_token_secret, algorithm="HS256")
 
-def _issue_refresh_token(response: Response, session_id: str, user_sub: str) -> None:
+def _issue_refresh_token(response: Response, session_id: str, user_sub: str, *, refresh_ttl_seconds: Optional[int] = None) -> None:
     token = secrets.token_urlsafe(48)
     token_hash = sha256_str(token)
     try:
@@ -161,7 +164,7 @@ def _issue_refresh_token(response: Response, session_id: str, user_sub: str) -> 
     response.set_cookie(
         S.ui_refresh_token_cookie_name,
         token,
-        max_age=S.ui_refresh_token_ttl_seconds,
+        max_age=refresh_ttl_seconds or S.ui_refresh_token_ttl_seconds,
         httponly=True,
         secure=S.ui_cookie_secure,
         samesite=S.ui_cookie_samesite,
@@ -174,7 +177,8 @@ def rotate_refresh_token(response: Response, user_sub: str, session_id: str, ref
     stored = it.get("refresh_token_hash", "")
     if not stored or not hmac.compare_digest(stored, sha256_str(refresh_token)):
         raise HTTPException(401, "Invalid refresh token")
-    _issue_refresh_token(response, session_id, user_sub)
+    refresh_ttl = int(it.get("refresh_ttl_seconds") or 0)
+    _issue_refresh_token(response, session_id, user_sub, refresh_ttl_seconds=refresh_ttl or None)
     access = mint_access_token(user_sub, session_id)
     if access:
         response.set_cookie(
@@ -270,7 +274,7 @@ async def require_ui_session(
     request.state.user_sub = user_sub
     return {"user_sub": user_sub, "session_id": session_id}
 
-def create_real_session(req: Request, user_sub: str, *, mfa_verified_at: Optional[int] = None) -> SessionInfo:
+def create_real_session(req: Request, user_sub: str, *, mfa_verified_at: Optional[int] = None, risk_score: int = 0, refresh_ttl_seconds: Optional[int] = None) -> SessionInfo:
     session_id = str(uuid.uuid4())
     csrf_token = secrets.token_urlsafe(32)
     ts = now_ts()
@@ -289,6 +293,11 @@ def create_real_session(req: Request, user_sub: str, *, mfa_verified_at: Optiona
     }
     if mfa_verified_at:
         item["mfa_verified_at"] = mfa_verified_at
+    if risk_score > 0:
+        item["risk_score"] = risk_score
+        item["risk_level"] = "high" if risk_score >= getattr(S, "login_anomaly_risk_score_threshold", 1) else "elevated"
+    if refresh_ttl_seconds and refresh_ttl_seconds > 0:
+        item["refresh_ttl_seconds"] = int(refresh_ttl_seconds)
     T.sessions.put_item(Item=with_ttl(item, ttl_epoch=ttl))
     try:
         record_device_login(req, user_sub)
@@ -374,6 +383,8 @@ def create_stepup_challenge(
     required_factors: List[str],
     *,
     purpose: Optional[str] = None,
+    risk_score: int = 0,
+    refresh_ttl_seconds: Optional[int] = None,
 ) -> str:
     challenge_id = "chal_" + uuid.uuid4().hex
     ts = now_ts()
@@ -393,6 +404,10 @@ def create_stepup_challenge(
     }
     if purpose:
         item["purpose"] = purpose
+    if risk_score > 0:
+        item["risk_score"] = risk_score
+    if refresh_ttl_seconds and refresh_ttl_seconds > 0:
+        item["refresh_ttl_seconds"] = int(refresh_ttl_seconds)
     T.sessions.put_item(Item=with_ttl(item, ttl_epoch=expires))
     return challenge_id
 
@@ -429,7 +444,13 @@ def maybe_finalize(req: Request, user_sub: str, challenge_id: str) -> Optional[S
         return None
     if chal.get("purpose"):
         return None
-    sid = create_real_session(req, user_sub, mfa_verified_at=now_ts())
+    sid = create_real_session(
+        req,
+        user_sub,
+        mfa_verified_at=now_ts(),
+        risk_score=int(chal.get("risk_score") or 0),
+        refresh_ttl_seconds=int(chal.get("refresh_ttl_seconds") or 0) or None,
+    )
     revoke_challenge(user_sub, challenge_id)
     return sid
 

--- a/docs/auth-review-recommendations.md
+++ b/docs/auth-review-recommendations.md
@@ -1,0 +1,82 @@
+# Login & Registration Review (Current State + Recommendations)
+
+## Current setup (what is already good)
+
+- Registration enforces basic password policy, password confirmation, email normalization, and optional SMS/TOTP MFA flags at schema-validation time.
+- Registration checks candidate passwords against a breach corpus before creating users.
+- Registration and passwordless flows both use lockout + rate limiting + anomaly tracking hooks.
+- New sessions are created with per-session CSRF tokens, inactivity checks, and optional device-trust risk checks.
+- Session rotation revokes prior sessions and rotates refresh tokens.
+
+## Gaps and risks observed
+
+1. **Dev bypass accounts can return synthetic auth success**
+   - In dev mode, matching configured credentials bypass Cognito and return a fixed `"dev-session"` during registration confirm.
+   - This is practical for local testing, but risky if dev flags leak into non-dev environments.
+
+2. **Potential account enumeration via registration check and registration errors**
+   - `/ui/register/check` exposes explicit availability.
+   - Registration creation and error handling can return distinct outcomes (e.g., conflict semantics), which can be used to probe whether an account exists.
+
+3. **Password policy is only baseline-complexity + breach check**
+   - Current validation is `>=8` and alphanumeric complexity; this is better than nothing but below modern recommendations for passphrases and deny-lists beyond breach corpus.
+
+4. **Registration challenge keying appears single-slot per user**
+   - Registration verification challenge uses a fixed session id (`register_verify`).
+   - This simplifies state, but limits support for parallel verification contexts and may make troubleshooting/audit correlation harder.
+
+5. **Magic-link handling can be tightened for replay and context binding**
+   - Passwordless verify correctly marks links used and introduces step-up on mismatch, but hardening could include stronger one-time guarantees plus explicit nonce/jti telemetry in audit records.
+
+6. **Auth-mode split is operationally sensitive**
+   - Runtime behavior depends on Cognito config and `dev_mode`, with fallback auth via bearer token parsing in dev mode.
+   - Misconfiguration risk is non-trivial without strict startup guardrails.
+
+## Recommendations (prioritized)
+
+### P0 (security posture / production safety)
+
+1. **Add startup guardrails that fail fast in unsafe auth configurations**
+   - Refuse startup when `dev_mode=true` in production profiles.
+   - Refuse startup if Cognito is partially configured (e.g., app client set but issuer/JWKS invalid).
+   - Add a health endpoint field that reports active auth mode (`cognito|dev-fallback`) for ops visibility.
+
+2. **Normalize externally visible responses to reduce account enumeration**
+   - For registration check/start/resend, return generic success messaging while performing internal audit logging.
+   - Keep detailed reasons only in audit events and internal metrics.
+
+3. **Strengthen password policy**
+   - Move from character-class requirements to passphrase-oriented policy (e.g., min length 12+, max length sanity cap, optional entropy checks).
+   - Add checks against contextual password guesses (email local part, name fragments).
+
+### P1 (workflow hardening)
+
+4. **Use per-attempt registration challenge IDs**
+   - Replace fixed `register_verify` with generated challenge IDs and keep a "latest active" pointer if needed.
+   - This improves replay resistance and incident analysis while preserving current UX.
+
+5. **Make login anomaly responses adaptive**
+   - Today anomalies are audited and may add `email` factor; expand policy to include temporary risk scoring actions:
+     - require stronger factors when IP/user thresholds exceed limits,
+     - shorten refresh TTL for high-risk sessions,
+     - trigger user notifications for unusual sign-ins.
+
+6. **Harden passwordless link claims**
+   - Ensure token records include strict one-time nonce semantics with short TTL and explicit consumed-at timestamp.
+   - Add geovelocity checks and impossible-travel heuristics where feasible.
+
+### P2 (operability / maintainability)
+
+7. **Consolidate auth flow terminology and rate-limit namespaces**
+   - Some registration operations use password-recovery rate-limit buckets; separate namespaces for cleaner observability and safer tuning.
+
+8. **Improve structured audit schema consistency**
+   - Standardize event payload fields across register/login/passwordless (`risk_level`, `factor_set`, `challenge_id`, `device_id`, `ip_prefix`).
+
+9. **Add scenario tests for misconfiguration and attack paths**
+   - Add tests for dev-mode leakage prevention, generic-response anti-enumeration behavior, challenge replay attempts, and risk-based step-up transitions.
+
+## Suggested implementation order (2 sprints)
+
+- **Sprint 1**: startup guardrails, anti-enumeration response normalization, password policy upgrade.
+- **Sprint 2**: per-attempt registration challenge IDs, stronger passwordless token lifecycle metadata, expanded anomaly/risk actions + tests.

--- a/docs/passwordless-link-hardening.md
+++ b/docs/passwordless-link-hardening.md
@@ -1,0 +1,124 @@
+# Passwordless Link Hardening Plan
+
+## Goals
+
+Harden passwordless authentication against replay, token theft, and anomalous geolocation activity while preserving current UX.
+
+## Scope
+
+- `POST /ui/passwordless/start`
+- `POST /ui/passwordless/verify`
+- `app/services/magic_links.py`
+- `app/routers/passwordless.py`
+
+## 1) Strict one-time token semantics
+
+### Token record model
+
+Each issued token record should include:
+
+- `token_id` (opaque internal identifier)
+- `jti` (random nonce, unique per token)
+- `token_hash` (store hash only)
+- `target_user_sub`
+- `issued_at`
+- `expires_at` (short TTL; recommended 5–10 minutes)
+- `used` (boolean)
+- `used_at` (epoch seconds)
+- `consumed_by_ip`
+- `consumed_user_agent`
+- `consumed_reason` (`success`, `mismatch_stepup`, `replay_denied`, `expired`)
+
+### Validation rules
+
+- Reject if `used=true` regardless of expiration.
+- Reject if `expires_at < now`.
+- Require compare-and-set update on consume:
+  - `ConditionExpression`: token exists AND `used=false` AND not expired.
+- On successful consume, set:
+  - `used=true`
+  - `used_at=now`
+  - consumption metadata fields.
+- Treat all consume races as replay attempts and audit as `passwordless_replay_denied`.
+
+### UX behavior
+
+- Always return generic 401/invalid token externally.
+- Keep detailed reason in audit logs/alerts.
+
+## 2) Short TTL policy
+
+### Recommended defaults
+
+- `PASSWORDLESS_TOKEN_TTL_SECONDS=600` (10 min max)
+- optional stronger default for high-risk users: `300` seconds.
+
+### Operational controls
+
+- Add per-user and per-IP issue limits on `/start`.
+- Add single active-token policy per user (optional): issue new token revokes prior pending tokens.
+
+## 3) Explicit consumed-at observability
+
+Track and expose (internal only):
+
+- issue-to-use latency (`used_at - issued_at`)
+- replay attempts count
+- expired token verifies count
+- mismatch-triggered step-up count
+
+This improves incident response and anomaly detection quality.
+
+## 4) Geovelocity & impossible-travel heuristics
+
+### Data required
+
+- Coarse geolocation signal from request IP prefix (country/region/city where available).
+- Previous successful auth event location + timestamp.
+
+### Practical checks
+
+- **Impossible travel**:
+  - If previous successful login was too recent for plausible travel between two far-apart locations, mark high risk.
+- **Geovelocity threshold**:
+  - Compute distance/time speed estimate (coarse km/h).
+  - If estimated speed exceeds threshold (e.g., > 900 km/h with low confidence buffer), flag.
+- **Confidence gating**:
+  - Only enforce hard actions when both locations have acceptable confidence.
+  - Otherwise degrade to soft risk signals.
+
+### Actions when flagged
+
+- Never grant immediate session directly.
+- Force step-up with strongest available factors (`totp` + `email` preferred).
+- Shorten refresh-token TTL for resulting session.
+- Emit unusual sign-in alert event with risk details.
+
+## 5) Suggested event taxonomy
+
+- `passwordless_start`
+- `passwordless_verify_success`
+- `passwordless_verify_mismatch_stepup`
+- `passwordless_replay_denied`
+- `passwordless_token_expired`
+- `passwordless_impossible_travel`
+- `passwordless_geovelocity_flag`
+
+## 6) Rollout sequence
+
+1. Add token record fields + CAS consume semantics.
+2. Add consumed-at metadata and replay audit events.
+3. Add short TTL config + migration fallback defaults.
+4. Add geovelocity/impossible-travel checks in verify path (soft mode).
+5. Switch to enforcement mode (step-up + short refresh TTL).
+6. Monitor false positives and tune thresholds.
+
+## 7) Test matrix
+
+- token can be used exactly once
+- concurrent verify attempts -> one success, others replay denied
+- expired token cannot be consumed
+- mismatch path consumes token and forces step-up
+- impossible-travel flag triggers stronger factors
+- high-risk result carries reduced refresh TTL
+- alerts generated for unusual sign-ins and replay attempts

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { ArrowLeft, CheckCircle2, Circle, HelpCircle, Loader2, Shield, XCircle } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Circle, Eye, EyeOff, HelpCircle, Loader2, Shield, XCircle } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,8 +25,8 @@ const registerSchema = z.object({
   full_name: z.string().trim().min(1, "Full name is required"),
   email: z.string().trim().email("Enter a valid email"),
   password: z.string()
-    .min(8, "Password must be at least 8 characters")
-    .regex(/^(?=.*[A-Za-z])(?=.*\d).+$/, "Password must include letters and numbers"),
+    .min(12, "Password must be at least 12 characters")
+    .max(128, "Password must be 128 characters or fewer"),
   confirm_password: z.string().min(1, "Please confirm your password"),
   phone: z.string().trim().optional(),
   enable_sms_mfa: z.boolean().optional(),
@@ -81,7 +81,7 @@ export default function Register() {
   const [resendLoading, setResendLoading] = React.useState(false);
   const [mfaLoading, setMfaLoading] = React.useState(false);
   const [emailStatus, setEmailStatus] = React.useState<
-    "idle" | "checking" | "available" | "taken" | "invalid" | "error" | "rate_limited"
+    "idle" | "checking" | "available" | "invalid" | "error" | "rate_limited"
   >("idle");
   const [mfaError, setMfaError] = React.useState<string | null>(null);
   const [smsChallengeId, setSmsChallengeId] = React.useState<string | null>(null);
@@ -91,6 +91,8 @@ export default function Register() {
   const [totpEnrollData, setTotpEnrollData] = React.useState<{ device_id: string; secret: string; qr_code_uri: string } | null>(null);
   const [totpCode, setTotpCode] = React.useState("");
   const [totpVerified, setTotpVerified] = React.useState(false);
+  const [showPassword, setShowPassword] = React.useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = React.useState(false);
 
   const form = useForm<RegisterForm>({
     resolver: zodResolver(registerSchema),
@@ -120,19 +122,17 @@ export default function Register() {
   const confirmPasswordValue = form.watch("confirm_password");
 
   const passwordRequirements = [
-    { id: "length", label: "At least 8 characters", met: passwordValue.length >= 8 },
-    { id: "letter", label: "Contains a letter", met: /[A-Za-z]/.test(passwordValue) },
-    { id: "number", label: "Contains a number", met: /\d/.test(passwordValue) },
+    { id: "length", label: "At least 12 characters", met: passwordValue.length >= 12 },
+    { id: "max", label: "No more than 128 characters", met: passwordValue.length <= 128 },
+    { id: "variety", label: "Use a varied passphrase", met: new Set(passwordValue).size >= 4 },
   ];
   const passwordsMatch = confirmPasswordValue.length > 0 && passwordValue === confirmPasswordValue;
   const hasPasswordIssues = !passwordRequirements.every((req) => req.met) || !passwordsMatch;
   const isFullNameValid = fullNameValue.trim().length > 0 && !form.formState.errors.full_name;
   const isPasswordStrong = passwordRequirements.every((req) => req.met) && passwordsMatch;
   const isEmailChecking = emailStatus === "checking";
-  const isEmailTaken = emailStatus === "taken";
   const isSubmitDisabled = startLoading
     || isEmailChecking
-    || isEmailTaken
     || hasPasswordIssues
     || emailStatus === "invalid"
     || emailStatus === "rate_limited";
@@ -189,11 +189,11 @@ export default function Register() {
     setEmailStatus("checking");
     const timer = window.setTimeout(() => {
       registerEmailCheck({ email: trimmed })
-        .then((resp) => {
+        .then(() => {
           if (!isActive) {
             return;
           }
-          setEmailStatus(resp.available ? "available" : "taken");
+          setEmailStatus("available");
         })
         .catch((err) => {
           if (!isActive) {
@@ -551,13 +551,7 @@ export default function Register() {
                   {!form.formState.errors.email && emailStatus === "available" && (
                     <p className="flex items-center gap-1 text-xs text-emerald-600">
                       <CheckCircle2 className="h-3.5 w-3.5" />
-                      Email is available.
-                    </p>
-                  )}
-                  {!form.formState.errors.email && emailStatus === "taken" && (
-                    <p className="flex items-center gap-1 text-xs text-destructive">
-                      <XCircle className="h-3.5 w-3.5" />
-                      Email is already in use.
+                      Email looks valid.
                     </p>
                   )}
                   {!form.formState.errors.email && emailStatus === "rate_limited" && (
@@ -575,13 +569,24 @@ export default function Register() {
 
                 <div className="space-y-2">
                   <Label htmlFor="password">Password</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    placeholder="Create a password"
-                    autoComplete="new-password"
-                    {...form.register("password")}
-                  />
+                  <div className="relative">
+                    <Input
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      placeholder="Create a password"
+                      autoComplete="new-password"
+                      className="pr-10"
+                      {...form.register("password")}
+                    />
+                    <button
+                      type="button"
+                      aria-label={showPassword ? "Hide password" : "Show password"}
+                      className="absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground hover:text-foreground"
+                      onClick={() => setShowPassword((prev) => !prev)}
+                    >
+                      {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                   {form.formState.errors.password && (
                     <p className="text-xs text-destructive">
                       {form.formState.errors.password.message}
@@ -591,13 +596,24 @@ export default function Register() {
 
                 <div className="space-y-2">
                   <Label htmlFor="confirm_password">Confirm password</Label>
-                  <Input
-                    id="confirm_password"
-                    type="password"
-                    placeholder="Re-enter your password"
-                    autoComplete="new-password"
-                    {...form.register("confirm_password")}
-                  />
+                  <div className="relative">
+                    <Input
+                      id="confirm_password"
+                      type={showConfirmPassword ? "text" : "password"}
+                      placeholder="Re-enter your password"
+                      autoComplete="new-password"
+                      className="pr-10"
+                      {...form.register("confirm_password")}
+                    />
+                    <button
+                      type="button"
+                      aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                      className="absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground hover:text-foreground"
+                      onClick={() => setShowConfirmPassword((prev) => !prev)}
+                    >
+                      {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                   {form.formState.errors.confirm_password && (
                     <p className="text-xs text-destructive">
                       {form.formState.errors.confirm_password.message}

--- a/frontend/src/pages/__tests__/Register.test.tsx
+++ b/frontend/src/pages/__tests__/Register.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 
 import { ApiError } from "@/api/client";
 import Register from "@/pages/Register";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const mocks = vi.hoisted(() => ({
   registerStart: vi.fn(),
@@ -31,9 +32,11 @@ const REGISTER_STORAGE_KEY = "register-pending";
 
 const renderRegister = (initialEntries: string[] = ["/register"]) =>
   render(
-    <MemoryRouter initialEntries={initialEntries}>
-      <Register />
-    </MemoryRouter>,
+    <TooltipProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Register />
+      </MemoryRouter>
+    </TooltipProvider>,
   );
 
 beforeEach(() => {
@@ -47,7 +50,62 @@ beforeEach(() => {
 });
 
 describe("Register page", () => {
-  it("shows password policy validation when missing letters or numbers", async () => {
+
+  it("toggles password visibility from the eye button", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    const passwordInput = screen.getByLabelText(/^password/i);
+    expect(passwordInput).toHaveAttribute("type", "password");
+
+    await user.click(screen.getByRole("button", { name: /^show password$/i }));
+    expect(passwordInput).toHaveAttribute("type", "text");
+
+    await user.click(screen.getByRole("button", { name: /^hide password$/i }));
+    expect(passwordInput).toHaveAttribute("type", "password");
+  });
+
+  it("toggles confirm-password visibility from the eye button", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    const confirmInput = screen.getByLabelText(/confirm password/i, { selector: "input" });
+    expect(confirmInput).toHaveAttribute("type", "password");
+
+    await user.click(screen.getByRole("button", { name: /show confirm password/i }));
+    expect(confirmInput).toHaveAttribute("type", "text");
+
+    await user.click(screen.getByRole("button", { name: /hide confirm password/i }));
+    expect(confirmInput).toHaveAttribute("type", "password");
+  });
+
+  it("enforces basic email conformance in UI", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    await user.type(
+      screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
+      "not-an-email",
+    );
+
+    expect(await screen.findByText(/enter a valid email/i)).toBeInTheDocument();
+    expect(mocks.registerEmailCheck).not.toHaveBeenCalled();
+  });
+
+  it("normalizes basic email input before availability check", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    await user.type(
+      screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
+      " user@example.com ",
+    );
+
+    await waitFor(() => {
+      expect(mocks.registerEmailCheck).toHaveBeenCalledWith({ email: "user@example.com" });
+    });
+  });
+  it("shows password policy validation when too short", async () => {
     const user = userEvent.setup();
     renderRegister();
 
@@ -56,12 +114,12 @@ describe("Register page", () => {
       screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
       "test@example.com",
     );
-    await user.type(screen.getByLabelText(/^password/i), "passwordonly");
-    await user.type(screen.getByLabelText(/confirm password/i), "passwordonly");
+    await user.type(screen.getByLabelText(/^password/i), "short123");
+    await user.type(screen.getByLabelText(/confirm password/i, { selector: "input" }), "short123");
     await user.click(screen.getByRole("button", { name: /request access/i }));
 
     expect(
-      await screen.findByText(/password must include letters and numbers/i),
+      await screen.findByText(/password must be at least 12 characters/i),
     ).toBeInTheDocument();
   });
 
@@ -69,12 +127,12 @@ describe("Register page", () => {
     const user = userEvent.setup();
     renderRegister();
 
-    await user.type(screen.getByLabelText(/^password/i), "Password1");
-    await user.type(screen.getByLabelText(/confirm password/i), "Password1");
+    await user.type(screen.getByLabelText(/^password/i), "StrongPassphrase42!");
+    await user.type(screen.getByLabelText(/confirm password/i, { selector: "input" }), "StrongPassphrase42!");
 
-    expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
-    expect(screen.getByText(/contains a letter/i)).toBeInTheDocument();
-    expect(screen.getByText(/contains a number/i)).toBeInTheDocument();
+    expect(screen.getByText(/at least 12 characters/i)).toBeInTheDocument();
+    expect(screen.getByText(/no more than 128 characters/i)).toBeInTheDocument();
+    expect(screen.getByText(/use a varied passphrase/i)).toBeInTheDocument();
     expect(screen.getByText(/passwords match/i)).toBeInTheDocument();
   });
 
@@ -127,9 +185,8 @@ describe("Register page", () => {
     expect(codeInput).toHaveValue("777888");
   });
 
-  it("disables submit when email is already used", async () => {
-    vi.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it("shows generic email validation success without enumeration detail", async () => {
+    const user = userEvent.setup();
     mocks.registerEmailCheck.mockResolvedValueOnce({ status: "ok", available: false });
     renderRegister();
 
@@ -137,16 +194,13 @@ describe("Register page", () => {
       screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
       "taken@example.com",
     );
-    vi.advanceTimersByTime(500);
 
-    expect(await screen.findByText(/email is already in use/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /request access/i })).toBeDisabled();
-    vi.useRealTimers();
+    expect(await screen.findByText(/email looks valid/i)).toBeInTheDocument();
+    expect(screen.queryByText(/already in use/i)).not.toBeInTheDocument();
   });
 
   it("shows rate limit message when email checks are throttled", async () => {
-    vi.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const user = userEvent.setup();
     mocks.registerEmailCheck.mockRejectedValueOnce(
       new ApiError(429, "Too many checks"),
     );
@@ -156,11 +210,9 @@ describe("Register page", () => {
       screen.getByLabelText(/email/i, { selector: "input[type='email']" }),
       "rate@example.com",
     );
-    vi.advanceTimersByTime(500);
 
     expect(
       await screen.findByText(/too many checks\. please wait before trying again\./i),
     ).toBeInTheDocument();
-    vi.useRealTimers();
   });
 });

--- a/tests/test_auth_deps.py
+++ b/tests/test_auth_deps.py
@@ -3,6 +3,7 @@ import base64
 import json
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from fastapi import HTTPException
 
@@ -38,3 +39,17 @@ class TestAuthDeps(unittest.TestCase):
         req = SimpleNamespace(headers={"authorization": f"Bearer {token}"})
         user_sub = run_async(deps.get_authenticated_user_sub(req))
         self.assertEqual(user_sub, "jwt-user")
+
+
+    def test_get_authenticated_user_sub_blocks_dev_fallback_when_dev_mode_off(self):
+        req = SimpleNamespace(headers={"authorization": "Bearer user-1", "x-user-sub": "user-override"})
+        fake_settings = SimpleNamespace(
+            cognito_user_pool_id="",
+            cognito_app_client_id="",
+            dev_mode=False,
+        )
+        with patch.object(deps, "S", fake_settings):
+            with self.assertRaises(HTTPException) as ctx:
+                run_async(deps.get_authenticated_user_sub(req))
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertIn("Authentication not configured", str(ctx.exception.detail))

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -39,7 +39,7 @@ class TestRegisterRoutes(unittest.TestCase):
             ))
             self.assertEqual(result["status"], "ok")
             self.assertTrue(result["verification_required"])
-            self.assertEqual(result["delivery_medium"], "email")
+            self.assertIsNone(result["delivery_medium"])
             require_cognito.assert_not_called()
             create_user_record.assert_not_called()
 
@@ -89,14 +89,14 @@ class TestRegisterRoutes(unittest.TestCase):
                 RegisterStartReq(
                     full_name="Jane Doe",
                     email="jane@example.com",
-                    password="Password\\d1",
-                    confirm_password="Password\\d1",
+                    password="StrongPassphrase42!",
+                    confirm_password="StrongPassphrase42!",
                 ),
             ))
             self.assertEqual(result["status"], "ok")
             self.assertTrue(result["verification_required"])
-            self.assertEqual(result["delivery_medium"], "email")
-            self.assertEqual(result["delivery_destination"], "jane@example.com")
+            self.assertIsNone(result["delivery_medium"])
+            self.assertIsNone(result["delivery_destination"])
             send_email_code.assert_called_once()
             clear_lockout.assert_called_once()
             enforce_lockout.assert_called_once()
@@ -127,13 +127,13 @@ class TestRegisterRoutes(unittest.TestCase):
                 RegisterStartReq(
                     full_name="Jane Doe",
                     email="jane@example.com",
-                    password="Password\\d1",
-                    confirm_password="Password\\d1",
+                    password="StrongPassphrase42!",
+                    confirm_password="StrongPassphrase42!",
                 ),
             ))
             self.assertTrue(result["verification_required"])
-            self.assertEqual(result["delivery_medium"], "email")
-            self.assertEqual(result["delivery_destination"], "jane@example.com")
+            self.assertIsNone(result["delivery_medium"])
+            self.assertIsNone(result["delivery_destination"])
             send_email_code.assert_called_once()
             clear_lockout.assert_called_once()
             enforce_lockout.assert_called_once()
@@ -142,23 +142,19 @@ class TestRegisterRoutes(unittest.TestCase):
 
     def test_register_start_duplicate_user(self):
         req = build_request()
-        with patch.object(register, "_require_cognito"), \
-             patch.object(register, "check_password_breach", return_value=0), \
-             patch.object(register, "cognito_sign_up", side_effect=HTTPException(400, "Exists")), \
-             patch.object(register, "record_lockout_failure") as record_lockout_failure, \
-             patch.object(register, "enforce_lockout") as enforce_lockout, \
-             patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
-             patch.object(register, "audit_event") as audit_event:
-            with self.assertRaises(HTTPException):
-                run_async(register.register_start(
-                    req,
-                    RegisterStartReq(
-                        full_name="Jane Doe",
-                        email="jane@example.com",
-                        password="Password\\d1",
-                        confirm_password="Password\\d1",
-                    ),
-                ))
+        with patch.object(register, "_require_cognito"),              patch.object(register, "check_password_breach", return_value=0),              patch.object(register, "cognito_sign_up", side_effect=HTTPException(400, "Exists")),              patch.object(register, "record_lockout_failure") as record_lockout_failure,              patch.object(register, "enforce_lockout") as enforce_lockout,              patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery,              patch.object(register, "audit_event") as audit_event:
+            result = run_async(register.register_start(
+                req,
+                RegisterStartReq(
+                    full_name="Jane Doe",
+                    email="jane@example.com",
+                    password="StrongPassphrase42!",
+                    confirm_password="StrongPassphrase42!",
+                ),
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertIsNone(result["delivery_medium"])
+            self.assertIsNone(result["delivery_destination"])
             record_lockout_failure.assert_called_once()
             enforce_lockout.assert_called_once()
             rate_limit_password_recovery.assert_called_once()
@@ -178,8 +174,8 @@ class TestRegisterRoutes(unittest.TestCase):
                     RegisterStartReq(
                         full_name="Jane Doe",
                         email="jane@example.com",
-                        password="Password\\d1",
-                        confirm_password="Password\\d1",
+                        password="StrongPassphrase42!",
+                        confirm_password="StrongPassphrase42!",
                     ),
                 ))
             record_lockout_failure.assert_called_once()
@@ -260,8 +256,8 @@ class TestRegisterRoutes(unittest.TestCase):
                 RegisterResendReq(email="jane@example.com", delivery_method="email"),
             ))
             self.assertEqual(result["status"], "ok")
-            self.assertEqual(result["delivery_medium"], "email")
-            self.assertEqual(result["delivery_destination"], "jane@example.com")
+            self.assertIsNone(result["delivery_medium"])
+            self.assertIsNone(result["delivery_destination"])
             send_email_code.assert_called_once()
             clear_lockout.assert_called_once()
             enforce_lockout.assert_called_once()
@@ -276,12 +272,62 @@ class TestRegisterRoutes(unittest.TestCase):
              patch.object(register, "enforce_lockout") as enforce_lockout, \
              patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery, \
              patch.object(register, "audit_event") as audit_event:
-            with self.assertRaises(HTTPException):
-                run_async(register.register_resend(
-                    req,
-                    RegisterResendReq(email="jane@example.com", delivery_method="email"),
-                ))
+            result = run_async(register.register_resend(
+                req,
+                RegisterResendReq(email="jane@example.com", delivery_method="email"),
+            ))
+            self.assertEqual(result["status"], "ok")
+            self.assertIsNone(result["delivery_medium"])
+            self.assertIsNone(result["delivery_destination"])
             record_lockout_failure.assert_called_once()
             enforce_lockout.assert_called_once()
             rate_limit_password_recovery.assert_called_once()
             audit_event.assert_called_once()
+
+
+    def test_register_start_rejects_contextual_password(self):
+        with self.assertRaises(Exception):
+            RegisterStartReq(
+                full_name="Jane Doe",
+                email="jane@example.com",
+                password="jane-secure-passphrase",
+                confirm_password="jane-secure-passphrase",
+            )
+
+    def test_register_start_rejects_short_password(self):
+        with self.assertRaises(Exception):
+            RegisterStartReq(
+                full_name="Jane Doe",
+                email="jane@example.com",
+                password="short123",
+                confirm_password="short123",
+            )
+
+
+    def test_register_check_is_generic_for_available_and_unavailable(self):
+        req = build_request()
+        with patch.object(register, "is_email_available", return_value=True):
+            available = run_async(register.register_check(req, RegisterEmailCheckReq(email="jane@example.com")))
+        with patch.object(register, "is_email_available", return_value=False):
+            unavailable = run_async(register.register_check(req, RegisterEmailCheckReq(email="jane@example.com")))
+        self.assertEqual(available, unavailable)
+        self.assertEqual(available, {"status": "ok", "available": True})
+
+    def test_register_start_is_generic_on_signup_failure(self):
+        req = build_request()
+        with patch.object(register, "_require_cognito"),              patch.object(register, "check_password_breach", return_value=0),              patch.object(register, "cognito_sign_up", side_effect=HTTPException(400, "Exists")),              patch.object(register, "record_lockout_failure"):
+            result = run_async(register.register_start(
+                req,
+                RegisterStartReq(
+                    full_name="Jane Doe",
+                    email="jane@example.com",
+                    password="StrongPassphrase42!",
+                    confirm_password="StrongPassphrase42!",
+                ),
+            ))
+        self.assertEqual(result, {
+            "status": "ok",
+            "verification_required": True,
+            "delivery_medium": None,
+            "delivery_destination": None,
+        })

--- a/tests/test_registration_service.py
+++ b/tests/test_registration_service.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import registration
+
+
+class _FakeSessionsTable:
+    def __init__(self):
+        self.items = {}
+
+    def put_item(self, Item, **kwargs):
+        self.items[(Item["user_sub"], Item["session_id"])] = dict(Item)
+        return {}
+
+    def get_item(self, Key, **kwargs):
+        item = self.items.get((Key["user_sub"], Key["session_id"]))
+        return {"Item": dict(item)} if item else {}
+
+    def delete_item(self, Key, **kwargs):
+        self.items.pop((Key["user_sub"], Key["session_id"]), None)
+        return {}
+
+    def update_item(self, Key, UpdateExpression=None, ExpressionAttributeValues=None, **kwargs):
+        item = self.items.get((Key["user_sub"], Key["session_id"]))
+        if not item:
+            return {}
+        if "code_attempts" in (UpdateExpression or ""):
+            item["code_attempts"] = ExpressionAttributeValues[":c"]
+            item["last_failed_at"] = ExpressionAttributeValues[":t"]
+        self.items[(Key["user_sub"], Key["session_id"])] = item
+        return {}
+
+
+@pytest.fixture
+def fake_tables(monkeypatch):
+    sessions = _FakeSessionsTable()
+    monkeypatch.setattr(registration, "T", SimpleNamespace(sessions=sessions, users=SimpleNamespace(get_item=lambda **_: {})))
+    return sessions
+
+
+def test_create_registration_challenge_writes_latest_pointer(fake_tables):
+    code = registration.create_registration_challenge(
+        user_sub="jane@example.com",
+        channel="email",
+        send_to="jane@example.com",
+    )
+    assert len(code) == 6
+    latest = fake_tables.get_item(
+        Key={"user_sub": "jane@example.com", "session_id": registration.REGISTRATION_LATEST_POINTER_ID}
+    ).get("Item")
+    assert latest is not None
+    assert latest["challenge_id"].startswith(registration.REGISTRATION_CHALLENGE_PREFIX)
+
+
+def test_verify_registration_code_uses_latest_challenge_pointer(fake_tables):
+    first = registration.create_registration_challenge(
+        user_sub="jane@example.com",
+        channel="email",
+        send_to="jane@example.com",
+    )
+    second = registration.create_registration_challenge(
+        user_sub="jane@example.com",
+        channel="email",
+        send_to="jane@example.com",
+    )
+
+    with pytest.raises(HTTPException):
+        registration.verify_registration_code(user_sub="jane@example.com", code=first)
+
+    verified = registration.verify_registration_code(user_sub="jane@example.com", code=second)
+    assert verified["user_sub"] == "jane@example.com"
+    latest = fake_tables.get_item(
+        Key={"user_sub": "jane@example.com", "session_id": registration.REGISTRATION_LATEST_POINTER_ID}
+    ).get("Item")
+    assert latest is None
+
+
+def test_verify_registration_code_replay_attempt_denied(fake_tables):
+    code = registration.create_registration_challenge(
+        user_sub="jane@example.com",
+        channel="email",
+        send_to="jane@example.com",
+    )
+    verified = registration.verify_registration_code(user_sub="jane@example.com", code=code)
+    assert verified["user_sub"] == "jane@example.com"
+    with pytest.raises(HTTPException):
+        registration.verify_registration_code(user_sub="jane@example.com", code=code)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -116,6 +116,76 @@ class TestUiSessionRoutes(unittest.TestCase):
             self.assertTrue(resp.auth_required)
             self.assertEqual(resp.challenge_id, "chal")
 
+
+    def test_ui_session_start_adaptive_anomaly_policy(self):
+        req = build_request()
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(ui_session, "compute_required_factors", return_value=["totp", "email", "sms"]))
+            create_stepup = stack.enter_context(patch.object(ui_session, "create_stepup_challenge", return_value="chal"))
+            stack.enter_context(patch.object(ui_session, "record_login_anomaly", return_value={
+                "ip_prefix": "203.0.113",
+                "user_ip_count": 7,
+                "ip_user_count": 11,
+                "user_threshold_exceeded": True,
+                "ip_threshold_exceeded": True,
+            }))
+            stack.enter_context(patch.object(ui_session, "record_device_login", return_value={"new_device": False, "location_mismatch": False}))
+            stack.enter_context(patch.object(ui_session, "rate_limit_login_attempt"))
+            audit = stack.enter_context(patch.object(ui_session, "audit_event"))
+
+            resp = run_async(ui_session.ui_session_start(req, UiSessionStartReq(), user_sub="user"))
+            self.assertTrue(resp.auth_required)
+            self.assertEqual(resp.challenge_id, "chal")
+            kwargs = create_stepup.call_args.kwargs
+            self.assertEqual(kwargs["required_factors"], ["totp", "email"])
+            self.assertEqual(kwargs["risk_score"], 2)
+            self.assertEqual(kwargs["refresh_ttl_seconds"], ui_session.S.login_high_risk_refresh_ttl_seconds)
+            audit.assert_any_call(
+                "login_unusual_signin",
+                "user",
+                req,
+                outcome="warning",
+                risk_score=2,
+                required_factors=["totp", "email"],
+                short_refresh_ttl=ui_session.S.login_high_risk_refresh_ttl_seconds,
+            )
+
+
+    def test_ui_session_start_no_anomaly_keeps_base_stepup(self):
+        req = build_request()
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(ui_session, "compute_required_factors", return_value=["totp"]))
+            create_stepup = stack.enter_context(patch.object(ui_session, "create_stepup_challenge", return_value="chal"))
+            stack.enter_context(patch.object(ui_session, "record_login_anomaly", return_value={
+                "ip_prefix": "203.0.113",
+                "user_ip_count": 1,
+                "ip_user_count": 1,
+                "user_threshold_exceeded": False,
+                "ip_threshold_exceeded": False,
+            }))
+            stack.enter_context(patch.object(ui_session, "record_device_login", return_value={"new_device": False, "location_mismatch": False}))
+            stack.enter_context(patch.object(ui_session, "rate_limit_login_attempt"))
+            stack.enter_context(patch.object(ui_session, "audit_event"))
+
+            resp = run_async(ui_session.ui_session_start(req, UiSessionStartReq(), user_sub="user"))
+            self.assertTrue(resp.auth_required)
+            kwargs = create_stepup.call_args.kwargs
+            self.assertEqual(kwargs["required_factors"], ["totp"])
+            self.assertEqual(kwargs["risk_score"], 0)
+            self.assertIsNone(kwargs["refresh_ttl_seconds"])
+
+    def test_ui_session_finalize_applies_challenge_refresh_ttl(self):
+        req = build_request()
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(ui_session, "load_challenge_or_401", return_value={"passed": {}, "refresh_ttl_seconds": 1234}))
+            stack.enter_context(patch.object(ui_session, "maybe_finalize", return_value="sid"))
+            rotate = stack.enter_context(patch.object(ui_session, "rotate_session_cookies"))
+            stack.enter_context(patch.object(ui_session, "audit_event"))
+
+            resp = run_async(ui_session.ui_session_finalize(req, UiSessionFinalizeReq(challenge_id="chal"), user_sub="user"))
+            self.assertEqual(resp["status"], "ok")
+            rotate.assert_called_once_with(req, unittest.mock.ANY, "user", "sid", refresh_ttl_seconds=1234)
+
     def test_ui_session_finalize_pending(self):
         req = build_request()
         chal = {"required_factors": ["totp"], "passed": {"totp": False}}

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,7 +3,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 from app.services import sessions as sessions_service
 
@@ -248,3 +248,22 @@ class TestFinalize(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRefreshTokenRotation(unittest.TestCase):
+    def test_rotate_refresh_token_uses_session_refresh_ttl(self):
+        sessions_table = Mock()
+        token = "refresh"
+        hashed = sessions_service.sha256_str(token)
+        sessions_table.get_item.return_value = {"Item": {"refresh_token_hash": hashed, "refresh_ttl_seconds": 1234}}
+        with patch.object(sessions_service, "T", SimpleNamespace(sessions=sessions_table)),              patch.object(sessions_service, "_issue_refresh_token") as issue,              patch.object(sessions_service, "mint_access_token", return_value="access"):
+            resp = Response()
+            sessions_service.rotate_refresh_token(resp, "user", "sid", token)
+        issue.assert_called_once_with(resp, "sid", "user", refresh_ttl_seconds=1234)
+
+    def test_rotate_refresh_token_rejects_invalid_hash(self):
+        sessions_table = Mock()
+        sessions_table.get_item.return_value = {"Item": {"refresh_token_hash": "other"}}
+        with patch.object(sessions_service, "T", SimpleNamespace(sessions=sessions_table)):
+            with self.assertRaises(HTTPException):
+                sessions_service.rotate_refresh_token(Response(), "user", "sid", "bad")


### PR DESCRIPTION
### Motivation
- Improve the Register UX by enabling independent reveal/hide controls for both `password` and `confirm_password` while keeping secure-by-default behavior. 
- Prevent client-side and server-side account enumeration and tighten registration/session security posture by normalizing responses and introducing per-attempt challenge IDs and risk-aware session handling. 
- Raise password conformance to passphrase-style checks and block obvious contextual passwords derived from user data. 

### Description
- Frontend: add independent `showPassword` and `showConfirmPassword` states and accessible eye buttons that toggle input `type` for both password fields, tighten `registerSchema` to `min(12)`/`max(128)`, add passphrase-style requirements and normalize/trim email checks in `frontend/src/pages/Register.tsx`. 
- Frontend tests: wrap renderer in `TooltipProvider`, add tests that exercise both eye toggles, assert basic email conformance client-side and trimmed-email availability checks, and update existing password tests to match the new validation (`frontend/src/pages/__tests__/Register.test.tsx`). 
- Registration service and routers: replace single fixed registration challenge id with per-attempt generated challenge IDs and a "latest pointer", adapt create/verify/delete flows to use the pointer, and change `ui/register` handlers to return generic success responses (suppress delivery details) with internal auditing to reduce enumeration risks (`app/services/registration.py`, `app/routers/register.py`). 
- Models and policies: strengthen server-side password validation (min/max length, low-entropy guardrail) and add contextual similarity checks against email/local-part and full name; add settings for anomaly/risk thresholds and short-refresh TTLs (`app/models.py`, `app/core/settings.py`). 
- Session and login hardening: introduce adaptive login policy that computes a risk score and can require additional factors, propagate risk score and optional `refresh_ttl_seconds` into session creation/cookies/refresh-token issuance, and include these values in audit events (`app/routers/ui_session.py`, `app/services/sessions.py`). 
- Docs and new tests: add design docs for auth hardening and unit tests for registration challenge pointer behavior and session refresh rotation (`docs/*.md`, `tests/test_registration_service.py`, updated `tests/*`).

### Testing
- Ran frontend type-check/lint with `cd frontend && npm run lint`, which completed successfully. 
- Ran the Register page unit suite with `cd frontend && npm test -- --run src/pages/__tests__/Register.test.tsx`, and the test run passed (`1 file`, `11 tests` all passed). 
- Started the frontend dev server (`cd frontend && npm run dev`) and executed a headless Playwright script to render `/register` and capture a screenshot showing both eye icons, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f94415de0832b9ec93a271d1c6c8a)