### PR TITLE
Add password strength meter (UI) and bound register email check with timeouts (backend + frontend)

### DIFF
--- a/app/routers/register.py
+++ b/app/routers/register.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Dict
 
 from fastapi import APIRouter, HTTPException, Request, Response
+from starlette.concurrency import run_in_threadpool
 
 from app.core.normalize import client_ip_from_request
 from app.core.settings import S
@@ -43,6 +45,7 @@ DEFAULT_DEV_REGISTRATION_EMAIL = "demo@example.com"
 DEFAULT_DEV_REGISTRATION_PASSWORD = "CloudRiver789!"
 DEFAULT_DEV_REGISTRATION_CODE = "000000"
 DEFAULT_DEV_REGISTRATION_PHONE = "+15555550123"
+REGISTER_CHECK_TIMEOUT_SECONDS = 5
 
 
 def _require_cognito() -> None:
@@ -160,7 +163,14 @@ async def register_check(req: Request, body: RegisterEmailCheckReq) -> Dict[str,
         audit_event("register_check", body.email, req, outcome="success", mode="dev")
         return generic_response
     try:
-        available = is_email_available(body.email)
+        available = await asyncio.wait_for(
+            run_in_threadpool(is_email_available, body.email),
+            timeout=REGISTER_CHECK_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        audit_event("register_check", body.email, req, outcome="failure", reason="check_timeout")
+        record_lockout_failure(body.email, ip, "register_check")
+        return generic_response
     except HTTPException:
         audit_event("register_check", body.email, req, outcome="failure", reason="check_error")
         record_lockout_failure(body.email, ip, "register_check")

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -63,6 +63,7 @@ type PendingRegistration = {
 };
 
 const REGISTER_STORAGE_KEY = "register-pending";
+const EMAIL_CHECK_TIMEOUT_MS = 8000;
 
 export default function Register() {
   const navigate = useNavigate();
@@ -126,6 +127,28 @@ export default function Register() {
     { id: "max", label: "No more than 128 characters", met: passwordValue.length <= 128 },
     { id: "variety", label: "Use a varied passphrase", met: new Set(passwordValue).size >= 4 },
   ];
+  const passwordClassesUsed = [
+    /[a-z]/.test(passwordValue),
+    /[A-Z]/.test(passwordValue),
+    /\d/.test(passwordValue),
+    /[^A-Za-z0-9]/.test(passwordValue),
+  ].filter(Boolean).length;
+  const passwordStrengthScore = Math.min(
+    5,
+    (passwordValue.length >= 8 ? 1 : 0)
+      + (passwordValue.length >= 12 ? 1 : 0)
+      + (passwordValue.length >= 16 ? 1 : 0)
+      + (passwordClassesUsed >= 2 ? 1 : 0)
+      + (passwordClassesUsed >= 3 ? 1 : 0),
+  );
+  const passwordStrengthLevels = [
+    { label: "Very weak", colorClass: "bg-red-500" },
+    { label: "Weak", colorClass: "bg-orange-500" },
+    { label: "Fair", colorClass: "bg-yellow-400" },
+    { label: "Good", colorClass: "bg-lime-500" },
+    { label: "Strong", colorClass: "bg-green-600" },
+  ];
+  const activePasswordStrength = passwordStrengthLevels[Math.max(passwordStrengthScore - 1, 0)];
   const passwordsMatch = confirmPasswordValue.length > 0 && passwordValue === confirmPasswordValue;
   const hasPasswordIssues = !passwordRequirements.every((req) => req.met) || !passwordsMatch;
   const isFullNameValid = fullNameValue.trim().length > 0 && !form.formState.errors.full_name;
@@ -186,17 +209,28 @@ export default function Register() {
       return;
     }
     let isActive = true;
+    let didTimeout = false;
     setEmailStatus("checking");
     const timer = window.setTimeout(() => {
+      const timeoutTimer = window.setTimeout(() => {
+        didTimeout = true;
+        if (!isActive) {
+          return;
+        }
+        setEmailStatus("error");
+      }, EMAIL_CHECK_TIMEOUT_MS);
+
       registerEmailCheck({ email: trimmed })
         .then(() => {
-          if (!isActive) {
+          window.clearTimeout(timeoutTimer);
+          if (!isActive || didTimeout) {
             return;
           }
           setEmailStatus("available");
         })
         .catch((err) => {
-          if (!isActive) {
+          window.clearTimeout(timeoutTimer);
+          if (!isActive || didTimeout) {
             return;
           }
           if (err instanceof ApiError && err.status === 429) {
@@ -628,6 +662,16 @@ export default function Register() {
                 </div>
 
                 <div className="space-y-2 rounded-lg border border-muted bg-muted/20 p-3">
+                  <div className="flex items-center justify-between gap-2 text-sm font-medium">
+                    <span>Password strength</span>
+                    <span className="text-xs text-muted-foreground">{activePasswordStrength.label}</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className={`h-full transition-all ${activePasswordStrength.colorClass}`}
+                      style={{ width: passwordValue.length === 0 ? "0%" : `${Math.max(passwordStrengthScore, 1) * 20}%` }}
+                    />
+                  </div>
                   <div className="text-sm font-medium">Password requirements</div>
                   <ul className="space-y-1 text-xs">
                     {passwordRequirements.map((req) => (

--- a/frontend/src/pages/__tests__/Register.test.tsx
+++ b/frontend/src/pages/__tests__/Register.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ApiError } from "@/api/client";
@@ -123,6 +123,22 @@ describe("Register page", () => {
     ).toBeInTheDocument();
   });
 
+
+  it("shows password strength meter progression", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    expect(screen.getByText(/password strength/i)).toBeInTheDocument();
+    expect(screen.getByText(/^very weak$/i)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/^password/i), "short");
+    expect(screen.getByText(/^very weak$/i)).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/^password/i));
+    await user.type(screen.getByLabelText(/^password/i), "StrongPassphrase42!");
+    expect(screen.getByText(/^strong$/i)).toBeInTheDocument();
+  });
+
   it("shows password requirement checklist feedback", async () => {
     const user = userEvent.setup();
     renderRegister();
@@ -214,5 +230,29 @@ describe("Register page", () => {
     expect(
       await screen.findByText(/too many checks\. please wait before trying again\./i),
     ).toBeInTheDocument();
+  });
+
+  it("recovers when email check never resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.registerEmailCheck.mockImplementationOnce(() => new Promise(() => {}));
+      renderRegister();
+
+      fireEvent.change(screen.getByLabelText(/email/i, { selector: "input[type='email']" }), {
+        target: { value: "stuck@example.com" },
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+      });
+      expect(screen.getByText(/checking email availability/i)).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(8000);
+      });
+      expect(screen.getByText(/unable to check email availability\. please try again\./i)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -312,6 +313,24 @@ class TestRegisterRoutes(unittest.TestCase):
             unavailable = run_async(register.register_check(req, RegisterEmailCheckReq(email="jane@example.com")))
         self.assertEqual(available, unavailable)
         self.assertEqual(available, {"status": "ok", "available": True})
+
+    def test_register_check_times_out_without_hanging(self):
+        req = build_request()
+
+        async def slow_run_in_threadpool(*_args, **_kwargs):
+            await asyncio.sleep(0.02)
+            return True
+
+        with patch.object(register, "run_in_threadpool", new=slow_run_in_threadpool), \
+             patch.object(register, "REGISTER_CHECK_TIMEOUT_SECONDS", 0.001), \
+             patch.object(register, "record_lockout_failure") as record_lockout_failure, \
+             patch.object(register, "audit_event") as audit_event:
+            result = run_async(register.register_check(req, RegisterEmailCheckReq(email="jane@example.com")))
+
+        self.assertEqual(result, {"status": "ok", "available": True})
+        record_lockout_failure.assert_called_once()
+        self.assertTrue(any(call.kwargs.get("reason") == "check_timeout" for call in audit_event.mock_calls))
+
 
     def test_register_start_is_generic_on_signup_failure(self):
         req = build_request()


### PR DESCRIPTION
### Motivation
- Prevent the register email-availability flow from hanging the server or leaving the UI stuck when a storage/backend check never responds. 
- Improve UX by showing password strength feedback on the register form so users can see how safe their password is while creating an account.

### Description
- Backend: run the synchronous `is_email_available` lookup off the event loop using `run_in_threadpool(...)` and bound it with `await asyncio.wait_for(..., timeout=REGISTER_CHECK_TIMEOUT_SECONDS)` to avoid indefinite blocking, and emit an audit event and record a lockout failure on timeout while returning the same generic anti-enumeration payload (`app/routers/register.py`).
- Frontend: add a 5-level password scoring model and UI block with a colored progress bar and label (levels: `Very weak`, `Weak`, `Fair`, `Good`, `Strong`, colors red → orange → yellow → light green → green) above the existing requirements checklist (`frontend/src/pages/Register.tsx`).
- Frontend: add client-side email-check timeout handling with `EMAIL_CHECK_TIMEOUT_MS` and guard against stale promise resolutions so the UI recovers if the email-check promise never resolves (`frontend/src/pages/Register.tsx`).
- Tests: add a backend test to simulate a slow lookup and assert the route times out without hanging, and add frontend tests that verify password strength label progression and recovery when email-check never resolves (`tests/test_register.py`, `frontend/src/pages/__tests__/Register.test.tsx`).

### Testing
- Ran frontend unit tests with `cd frontend && npx vitest run src/pages/__tests__/Register.test.tsx` and observed success: `1 file, 13 tests passed`.
- Ran backend unit tests with `python -m pytest -q tests/test_register.py` and observed success: `16 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ecc58e9c832b8fd9ac113c0aa061)