### PR TITLE
Allow run_dev.sh to run without .venv and add mock-component wait/status

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -5,6 +5,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 backend_mode="mock"
+MOCK_WAIT_TIMEOUT_SECONDS=60
 
 usage() {
   cat <<'USAGE'
@@ -38,9 +39,11 @@ while (($#)); do
   shift
 done
 
-if [[ ! -d ".venv" ]]; then
-  echo "Missing .venv; run scripts/setup_ubuntu.sh first." >&2
-  exit 1
+if [[ -d ".venv" ]]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+else
+  echo "Warning: .venv not found; using system Python/uvicorn/npm from PATH." >&2
 fi
 
 set -a
@@ -50,7 +53,68 @@ if [[ -f ".env" ]]; then
 fi
 set +a
 
-source .venv/bin/activate
+
+probe_http() {
+  local url="$1"
+  local code
+  code="$(curl -sS -o /dev/null -w "%{http_code}" --max-time 2 "$url" || true)"
+  [[ "$code" != "000" ]]
+}
+
+mock_component_ready() {
+  local component="$1"
+  case "$component" in
+    "twilio")
+      [[ "${DEV_MODE:-1}" == "1" ]]
+      ;;
+    "s3") probe_http "http://localhost:4566/health" ;;
+    "dynamodb") probe_http "http://localhost:8001/" ;;
+    "cognito") probe_http "http://localhost:4566/health" ;;
+    "stripe") probe_http "http://localhost:12111/" ;;
+    "ccbill") probe_http "http://localhost:8000/mock/ccbill/subscriptions/mock-subscription" ;;
+    "ups") probe_http "http://localhost:8000/mock/ups/label" ;;
+    *) return 1 ;;
+  esac
+}
+
+all_mock_components_ready() {
+  local component
+  for component in s3 dynamodb cognito stripe ccbill twilio ups; do
+    if ! mock_component_ready "$component"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+print_mock_component_status() {
+  local label="$1"
+  local component="$2"
+  if mock_component_ready "$component"; then
+    if [[ "$component" == "twilio" ]]; then
+      echo "[mock] ${label}: running (DEV_MODE=1 in-app simulation)"
+    else
+      echo "[mock] ${label}: running"
+    fi
+  else
+    if [[ "$component" == "twilio" ]]; then
+      echo "[mock] ${label}: not enabled (set DEV_MODE=1)"
+    else
+      echo "[mock] ${label}: not reachable"
+    fi
+  fi
+}
+
+wait_for_mock_components() {
+  local deadline=$((SECONDS + MOCK_WAIT_TIMEOUT_SECONDS))
+  while ((SECONDS < deadline)); do
+    if all_mock_components_ready; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
 
 cleanup() {
   if [[ -n "${BACKEND_PID:-}" ]]; then
@@ -67,6 +131,24 @@ else
   echo "Backend running in real mode on http://localhost:8000"
 fi
 BACKEND_PID=$!
+
+if [[ "$backend_mode" == "mock" ]]; then
+  echo "Waiting up to ${MOCK_WAIT_TIMEOUT_SECONDS}s for mock components to come online..."
+  if wait_for_mock_components; then
+    echo "All mock components are up."
+  else
+    echo "Timed out waiting for all mock components; showing current status."
+  fi
+
+  echo "Mock component status:"
+  print_mock_component_status "MinIO/S3 (LocalStack)" "s3"
+  print_mock_component_status "Local DynamoDB" "dynamodb"
+  print_mock_component_status "Local Cognito (LocalStack)" "cognito"
+  print_mock_component_status "Local Stripe mock" "stripe"
+  print_mock_component_status "Local CCBill mock" "ccbill"
+  print_mock_component_status "Local Twilio mock" "twilio"
+  print_mock_component_status "Local UPS mock" "ups"
+fi
 
 if [[ -f "frontend/package.json" ]]; then
   npm --prefix frontend run dev -- --host 0.0.0.0 --port 5173


### PR DESCRIPTION
### Motivation
- Prevent local developer machines from hard-failing when a `.venv` is not present so `scripts/run_dev.sh` can start the backend using system tools from `PATH` and continue mock-mode startup and readiness checks.

### Description
- Change `.venv` handling to conditionally `source .venv/bin/activate` when the directory exists and otherwise print a warning and continue using system `python/uvicorn/npm` from `PATH`.
- Add `MOCK_WAIT_TIMEOUT_SECONDS` and implement `probe_http`, `mock_component_ready`, `all_mock_components_ready`, `wait_for_mock_components`, and `print_mock_component_status` helpers to probe mock services and report status.
- Integrate a wait loop after launching the mock backend to wait up to the configured timeout for mock components, and always print per-component status afterward.
- Preserve existing env-file loading and frontend/backend launch behavior while removing the previous unconditional hard-exit on missing virtualenv.

### Testing
- Ran `bash -n scripts/run_dev.sh` which succeeded with no syntax errors.
- Ran `timeout 8s scripts/run_dev.sh --mock-backend` which confirmed startup proceeds without a `.venv` and the script does not hard-fail (timeout was used to bound validation) and produced readiness/status output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ed74a658832b8002a21d3a20e527)