### PR TITLE
Fix permission errors during dependency install in update script

### DIFF
--- a/scripts/update_and_install.sh
+++ b/scripts/update_and_install.sh
@@ -10,6 +10,20 @@ else
   SUDO=""
 fi
 
+if [[ -n "${SUDO_USER:-}" ]]; then
+  TARGET_USER="$SUDO_USER"
+else
+  TARGET_USER="$(id -un)"
+fi
+
+run_as_target() {
+  if [[ "$(id -un)" == "$TARGET_USER" ]]; then
+    bash -lc "$*"
+  else
+    sudo -u "$TARGET_USER" -H bash -lc "$*"
+  fi
+}
+
 if git rev-parse --abbrev-ref --symbolic-full-name "@{u}" >/dev/null 2>&1; then
   git fetch --all --prune
   git pull --ff-only
@@ -30,16 +44,20 @@ $SUDO apt-get install -y --no-install-recommends \
   npm
 
 if [[ ! -d ".venv" ]]; then
-  python3 -m venv .venv
+  run_as_target "cd '$REPO_ROOT' && python3 -m venv .venv"
+elif [[ "$(id -un)" == "root" ]]; then
+  chown -R "$TARGET_USER:$TARGET_USER" .venv
 fi
 
-source .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -r requirements.txt
-pip uninstall -y multipart >/dev/null 2>&1 || true
-pip install gunicorn
-pip install "moto[server]>=5,<6"
-deactivate
+run_as_target "
+  cd '$REPO_ROOT'
+  source .venv/bin/activate
+  python -m pip install --upgrade pip
+  pip install -r requirements.txt
+  pip uninstall -y multipart >/dev/null 2>&1 || true
+  pip install gunicorn
+  pip install 'moto[server]>=5,<6'
+"
 
 if [[ -f "frontend/package.json" ]]; then
   npm --prefix frontend install


### PR DESCRIPTION
### Motivation

- Ensure `scripts/update_and_install.sh` does not create root-owned virtualenv or site-packages when run via `sudo`, which caused pip failures like `Permission denied: .../.venv/lib/python3.12/site-packages/py_partiql_parser`.

### Description

- Add detection of a non-root `TARGET_USER` (preferring `SUDO_USER`) and introduce a `run_as_target` helper to run commands as that user.
- Create the virtualenv using `run_as_target` and `chown -R` the existing `.venv` to the `TARGET_USER` when the script is run as root.
- Move all pip-related steps into a `run_as_target` invocation so package installation runs as the non-root target user.
- Keep system package installation via `apt` under the original `SUDO` behavior and retain existing frontend `npm` ownership fixes.

### Testing

- Ran `bash -n scripts/update_and_install.sh` to validate syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910aa42f44832b981ed420411bee90)