### PR TITLE
Improve dev setup scripts: Node 20 compatibility, quieter .venv probe, and mock readiness fix

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -71,8 +71,8 @@ mock_component_ready() {
     "dynamodb") probe_http "http://localhost:8001/" ;;
     "cognito") probe_http "http://localhost:4566/health" ;;
     "stripe") probe_http "http://localhost:12111/" ;;
-    "ccbill") probe_http "http://localhost:8000/mock/ccbill/subscriptions/mock-subscription" ;;
-    "ups") probe_http "http://localhost:8000/mock/ups/label" ;;
+    "ccbill") probe_http "http://localhost:8000/openapi.json" ;;
+    "ups") probe_http "http://localhost:8000/openapi.json" ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/update_and_install.sh
+++ b/scripts/update_and_install.sh
@@ -25,7 +25,7 @@ run_as_target() {
 }
 
 ensure_venv_writable() {
-  if run_as_target "cd '$REPO_ROOT' && touch .venv/.codex_write_test && rm -f .venv/.codex_write_test"; then
+  if run_as_target "cd '$REPO_ROOT' && touch .venv/.codex_write_test >/dev/null 2>&1 && rm -f .venv/.codex_write_test"; then
     return 0
   fi
 
@@ -37,7 +37,7 @@ ensure_venv_writable() {
     chown -R "$TARGET_USER:$TARGET_USER" .venv
   fi
 
-  if run_as_target "cd '$REPO_ROOT' && touch .venv/.codex_write_test && rm -f .venv/.codex_write_test"; then
+  if run_as_target "cd '$REPO_ROOT' && touch .venv/.codex_write_test >/dev/null 2>&1 && rm -f .venv/.codex_write_test"; then
     return 0
   fi
 
@@ -50,6 +50,27 @@ ensure_venv_writable() {
   fi
 
   run_as_target "cd '$REPO_ROOT' && python3 -m venv .venv"
+}
+
+ensure_node_runtime() {
+  if ! command -v node >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local node_major
+  node_major="$(node -p "Number(process.versions.node.split('.')[0])" 2>/dev/null || echo 0)"
+  if [[ "$node_major" =~ ^[0-9]+$ ]] && (( node_major >= 20 )); then
+    return 0
+  fi
+
+  echo "Detected Node.js ${node_major}; upgrading to Node.js 20.x for frontend compatibility..."
+  $SUDO install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | $SUDO gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+    | $SUDO tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+  $SUDO apt-get update
+  $SUDO apt-get install -y --no-install-recommends nodejs
 }
 
 if git rev-parse --abbrev-ref --symbolic-full-name "@{u}" >/dev/null 2>&1; then
@@ -69,7 +90,10 @@ $SUDO apt-get install -y --no-install-recommends \
   python3-dev \
   openjdk-17-jre-headless \
   nodejs \
-  npm
+  npm \
+  gnupg
+
+ensure_node_runtime
 
 if [[ ! -d ".venv" ]]; then
   run_as_target "cd '$REPO_ROOT' && python3 -m venv .venv"


### PR DESCRIPTION
### Motivation
- Reduce confusing startup output and frontend engine warnings during local development by improving install/update and mock startup scripts.
- Ensure frontend dependencies (notably `react-router`) run on a supported Node major by detecting and upgrading older Node installations.
- Avoid noisy 404/405 probes against mock business endpoints while waiting for the backend to become reachable.

### Description
- Silence the `.venv` writability probe in `scripts/update_and_install.sh` by redirecting `touch` stderr to `/dev/null` while preserving existing ownership-repair and recreate fallbacks.
- Add `ensure_node_runtime()` to `scripts/update_and_install.sh` which detects Node major version and, if older than 20, configures NodeSource and installs Node.js 20.x; also adds `gnupg` to apt installs to support the keyring step.
- Call `ensure_node_runtime` from the install flow so Node is upgraded when needed.
- Change mock readiness checks in `scripts/run_dev.sh` so CCBill and UPS readiness probes hit `http://localhost:8000/openapi.json` instead of mock business endpoints that return 404/405 during startup.

### Testing
- Verified both scripts are syntactically valid with `bash -n scripts/update_and_install.sh scripts/run_dev.sh` which returned OK.
- Reviewed diffs locally to confirm only the intended modifications were applied and no syntax issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699160819730832bbf3298c807ab3c3a)