### PR TITLE
Avoid apt `npm` install; verify npm availability after NodeSource Node.js install

### DIFF
--- a/scripts/update_and_install.sh
+++ b/scripts/update_and_install.sh
@@ -73,6 +73,23 @@ ensure_node_runtime() {
   $SUDO apt-get install -y --no-install-recommends nodejs
 }
 
+ensure_npm_cli() {
+  if command -v npm >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v corepack >/dev/null 2>&1; then
+    corepack enable npm >/dev/null 2>&1 || corepack enable >/dev/null 2>&1 || true
+  fi
+
+  if command -v npm >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "Error: npm is not available after installing Node.js. Verify your Node.js installation and rerun this script." >&2
+  exit 1
+}
+
 if git rev-parse --abbrev-ref --symbolic-full-name "@{u}" >/dev/null 2>&1; then
   git fetch --all --prune
   git pull --ff-only
@@ -90,10 +107,10 @@ $SUDO apt-get install -y --no-install-recommends \
   python3-dev \
   openjdk-17-jre-headless \
   nodejs \
-  npm \
   gnupg
 
 ensure_node_runtime
+ensure_npm_cli
 
 if [[ ! -d ".venv" ]]; then
   run_as_target "cd '$REPO_ROOT' && python3 -m venv .venv"


### PR DESCRIPTION
### Motivation
- Prevent apt `npm` installation which conflicts with NodeSource `nodejs` packages and causes broken-package errors during `scripts/update_and_install.sh` runs.
- Ensure the `npm` CLI is actually usable after installing Node.js from NodeSource and provide a clear failure mode if it is not.

### Description
- Removed `npm` from the `apt-get install` package list in `scripts/update_and_install.sh` to avoid the `nodejs` vs `npm` conflict.
- Added `ensure_npm_cli()` which checks for `npm`, attempts a fallback via `corepack enable npm`, and exits with a clear error if `npm` remains unavailable.
- Invoked `ensure_npm_cli` after `ensure_node_runtime` so the script verifies the frontend tooling is present before continuing.

### Testing
- Ran a syntax check with `bash -n scripts/update_and_install.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992300fb540832b87b4d19267bda9e3)