### PR TITLE
Prefer public IP detection via checkip in dev runner

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -54,8 +54,15 @@ fi
 set +a
 
 detect_external_ip() {
+  local detected
+
+  detected="$(curl -q -s --max-time 3 https://checkip.amazonaws.com 2>/dev/null | tr -d '[:space:]')"
+  if [[ "${detected}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    echo "${detected}"
+    return 0
+  fi
+
   if command -v ip >/dev/null 2>&1; then
-    local detected
     detected="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}')"
     if [[ -n "${detected}" ]]; then
       echo "${detected}"
@@ -64,7 +71,6 @@ detect_external_ip() {
   fi
 
   if command -v hostname >/dev/null 2>&1; then
-    local detected
     detected="$(hostname -I 2>/dev/null | awk '{print $1}')"
     if [[ -n "${detected}" ]]; then
       echo "${detected}"


### PR DESCRIPTION
### Motivation
- Prefer the machine's external/public IPv4 when auto-configuring `PUBLIC_BASE_URL`/`VITE_API_BASE_URL` for local development so the dev host points to an address reachable from other devices, instead of using a local private interface address.

### Description
- Update `detect_external_ip()` in `scripts/run_dev.sh` to call `curl -s https://checkip.amazonaws.com` first, validate the returned value as an IPv4 address, and fall back to the existing `ip route` and `hostname -I` methods when the external lookup is unavailable.

### Testing
- Verified the script syntax with `bash -n scripts/run_dev.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924224a680832bb6876aecae491dd7)