### PR TITLE
Fix credentialed CORS handling for UI register checks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -43,6 +44,32 @@ from app.services.billing_reconcile import start_billing_reconcile_task
 from app.services.billing_dunning import start_billing_dunning_task
 from app.services.filemanager import start_filemgr_purge_task
 
+
+def _to_bool(value: str, *, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _build_cors_options() -> dict[str, object]:
+    raw_origins = os.environ.get("CORS_ALLOW_ORIGINS", "*")
+    allow_origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+    allow_origin_regex = os.environ.get("CORS_ALLOW_ORIGIN_REGEX")
+
+    # Browsers reject `Access-Control-Allow-Origin: *` when credentials are included.
+    # If wildcard access is desired, use a regex so Starlette echoes the request origin.
+    if "*" in allow_origins:
+        allow_origins = [origin for origin in allow_origins if origin != "*"]
+        allow_origin_regex = allow_origin_regex or ".*"
+
+    return {
+        "allow_origins": allow_origins,
+        "allow_origin_regex": allow_origin_regex,
+        "allow_credentials": _to_bool(os.environ.get("CORS_ALLOW_CREDENTIALS"), default=True),
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }
+
 def create_app() -> FastAPI:
     app = FastAPI(title="Security Backend (refactored)", version="0.1.0")
     static_dir = Path(__file__).resolve().parent / "static"
@@ -53,13 +80,7 @@ def create_app() -> FastAPI:
     async def index():
         return FileResponse(static_dir / "index.html")
 
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    app.add_middleware(CORSMiddleware, **_build_cors_options())
     if METRICS_ENABLED:
         app.middleware("http")(metrics_middleware)
         set_app_info(app.title, app.version)

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from app.main import _build_cors_options
+
+
+class TestCorsConfig(unittest.TestCase):
+    def test_wildcard_is_converted_to_regex_for_credentials_requests(self):
+        with patch.dict(os.environ, {"CORS_ALLOW_ORIGINS": "*"}, clear=False):
+            options = _build_cors_options()
+
+        self.assertEqual(options["allow_origins"], [])
+        self.assertEqual(options["allow_origin_regex"], ".*")
+        self.assertTrue(options["allow_credentials"])
+
+    def test_explicit_origin_list_is_preserved(self):
+        with patch.dict(
+            os.environ,
+            {
+                "CORS_ALLOW_ORIGINS": "http://18.222.237.167:5173,http://localhost:5173",
+                "CORS_ALLOW_CREDENTIALS": "true",
+            },
+            clear=False,
+        ):
+            options = _build_cors_options()
+
+        self.assertEqual(
+            options["allow_origins"],
+            ["http://18.222.237.167:5173", "http://localhost:5173"],
+        )
+        self.assertIsNone(options["allow_origin_regex"])
+        self.assertTrue(options["allow_credentials"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Browsers block credentialed cross-origin requests when the server responds with `Access-Control-Allow-Origin: *`, which caused the frontend `credentials: include` calls to be blocked despite `200` responses. 
- The backend previously used a hardcoded `allow_origins=["*"]` which is incompatible with cookie/session requests and needs to echo the request origin instead.

### Description
- Added helper ` _to_bool` and `_build_cors_options()` in `app/main.py` to build CORS options from environment variables `CORS_ALLOW_ORIGINS`, `CORS_ALLOW_ORIGIN_REGEX`, and `CORS_ALLOW_CREDENTIALS`.
- Implemented logic that converts a wildcard `CORS_ALLOW_ORIGINS='*'` into `allow_origin_regex='.*'` (and clears the literal `*` from `allow_origins`) so Starlette will echo the request origin instead of returning `*` when credentials are enabled.
- Replaced the static middleware call with `app.add_middleware(CORSMiddleware, **_build_cors_options())` in `app/main.py`.
- Added focused unit tests in `tests/test_cors_config.py` that verify wildcard conversion and explicit origin-list behavior.

### Testing
- Ran `python -m pytest tests/test_cors_config.py -q` and the new tests passed (`2 passed`) with warnings from downstream packages. 
- No other automated test suites were modified or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992435c55b4832b8425f7ee9ea50f58)