### PR TITLE
Log email verification codes in dev mode

### DIFF
--- a/app/services/mfa.py
+++ b/app/services/mfa.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import secrets
+import logging
 from typing import Any, Dict, List, Optional, Sequence
 
 from boto3.dynamodb.conditions import Key
@@ -18,6 +19,9 @@ try:
 except Exception:  # pragma: no cover
     pyotp = None  # type: ignore
 
+
+logger = logging.getLogger(__name__)
+
 def _need_pyotp():
     if pyotp is None:
         raise HTTPException(500, "pyotp not installed (required for TOTP features)")
@@ -26,6 +30,8 @@ def gen_numeric_code(n_digits: int = 6) -> str:
     return str(secrets.randbelow(10**n_digits)).zfill(n_digits)
 
 def send_email_code(to_email: str, purpose: str, code: str) -> None:
+    if S.dev_mode:
+        logger.info("DEV MODE email verification code for %s (%s): %s", to_email, purpose, code)
     if not ses:
         raise HTTPException(500, "SES not configured")
     subject = f"Your verification code ({purpose})"

--- a/tests/test_mfa_service.py
+++ b/tests/test_mfa_service.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from app.services import mfa
+
+
+def test_send_email_code_logs_code_in_dev_mode(monkeypatch):
+    ses_mock = Mock()
+    logger_mock = Mock()
+    monkeypatch.setattr(mfa, "S", SimpleNamespace(dev_mode=True, ses_from_email="noreply@example.com"))
+    monkeypatch.setattr(mfa, "ses", ses_mock)
+    monkeypatch.setattr(mfa, "logger", logger_mock)
+
+    mfa.send_email_code("user@example.com", "Registration", "123456")
+
+    logger_mock.info.assert_called_once_with(
+        "DEV MODE email verification code for %s (%s): %s",
+        "user@example.com",
+        "Registration",
+        "123456",
+    )
+    ses_mock.send_email.assert_called_once()


### PR DESCRIPTION
### Motivation
- Make it possible to retrieve email verification codes during local development by emitting them to server logs when `DEV_MODE` is enabled.

### Description
- Add `logging` and a module `logger`, and emit a `logger.info` line in `send_email_code` when `S.dev_mode` is true while keeping the existing SES delivery path unchanged; also add `tests/test_mfa_service.py` to assert the log entry is emitted and SES is still called.

### Testing
- Ran `pytest -q tests/test_mfa_service.py tests/test_register.py` and received all tests passing (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992476af588832b8ede32680aec532d)