### PR TITLE
Improve dev logging output and registration failure diagnostics

### DIFF
--- a/app/routers/register.py
+++ b/app/routers/register.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Dict
 
 from fastapi import APIRouter, HTTPException, Request, Response
@@ -42,6 +43,7 @@ from app.services.sessions import create_real_session, rotate_session_cookies, s
 router = APIRouter(prefix="/ui/register", tags=["register"])
 
 REGISTER_CHECK_TIMEOUT_SECONDS = 5
+logger = logging.getLogger(__name__)
 
 
 def _require_cognito() -> None:
@@ -84,11 +86,16 @@ async def register_start(
     if use_cognito:
         try:
             cognito_sign_up(username, body.password, body.full_name)
-        except HTTPException:
+        except HTTPException as exc:
+            logger.warning(
+                "register_start cognito_sign_up rejected",
+                extra={"email": username, "status_code": exc.status_code, "detail": exc.detail},
+            )
             audit_event("register_start", username, req, outcome="failure", reason="cognito_sign_up")
             record_lockout_failure(username, ip, "register_start")
             return generic_response
         except Exception:
+            logger.exception("register_start unexpected error during cognito_sign_up", extra={"email": username})
             audit_event("register_start", username, req, outcome="failure", reason="unexpected_error")
             record_lockout_failure(username, ip, "register_start")
             return generic_response
@@ -145,14 +152,20 @@ async def register_check(req: Request, body: RegisterEmailCheckReq) -> Dict[str,
             timeout=REGISTER_CHECK_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
+        logger.warning("register_check timed out", extra={"email": body.email, "timeout_seconds": REGISTER_CHECK_TIMEOUT_SECONDS})
         audit_event("register_check", body.email, req, outcome="failure", reason="check_timeout")
         record_lockout_failure(body.email, ip, "register_check")
         return generic_response
-    except HTTPException:
+    except HTTPException as exc:
+        logger.warning(
+            "register_check failed with HTTP exception",
+            extra={"email": body.email, "status_code": exc.status_code, "detail": exc.detail},
+        )
         audit_event("register_check", body.email, req, outcome="failure", reason="check_error")
         record_lockout_failure(body.email, ip, "register_check")
         return generic_response
     except Exception:
+        logger.exception("register_check unexpected error", extra={"email": body.email})
         audit_event("register_check", body.email, req, outcome="failure", reason="unexpected_error")
         record_lockout_failure(body.email, ip, "register_check")
         return generic_response

--- a/app/services/cognito.py
+++ b/app/services/cognito.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict
+import logging
 
 from fastapi import HTTPException
 
 from app.core.aws_clients import cognito_client as shared_cognito_client
 from app.core.settings import S
+
+logger = logging.getLogger(__name__)
 
 
 def _cognito_region() -> str:
@@ -77,11 +80,17 @@ def cognito_sign_up(username: str, password: str, full_name: str) -> Dict[str, A
             ],
         )
     except client.exceptions.UsernameExistsException as exc:  # type: ignore[attr-defined]
+        logger.info("cognito sign_up user already exists", extra={"username": username})
         raise HTTPException(409, "User already exists") from exc
     except client.exceptions.InvalidPasswordException as exc:  # type: ignore[attr-defined]
+        logger.warning("cognito sign_up invalid password", extra={"username": username})
         raise HTTPException(400, "Invalid password") from exc
     except client.exceptions.InvalidParameterException as exc:  # type: ignore[attr-defined]
+        logger.warning("cognito sign_up invalid parameters", extra={"username": username, "error": str(exc)})
         raise HTTPException(400, "Invalid registration parameters") from exc
+    except Exception:
+        logger.exception("cognito sign_up unexpected exception", extra={"username": username})
+        raise
 
 
 def cognito_confirm_sign_up(username: str, code: str) -> Dict[str, Any]:

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -6,6 +6,9 @@ cd "$REPO_ROOT"
 
 backend_mode="mock"
 MOCK_WAIT_TIMEOUT_SECONDS=60
+DEV_LOG_DIR="${DEV_LOG_DIR:-$REPO_ROOT/.logs/dev}"
+BACKEND_LOG_PATH="${DEV_BACKEND_LOG_PATH:-$DEV_LOG_DIR/backend.log}"
+FRONTEND_LOG_PATH="${DEV_FRONTEND_LOG_PATH:-$DEV_LOG_DIR/frontend.log}"
 
 usage() {
   cat <<'USAGE'
@@ -38,6 +41,13 @@ while (($#)); do
   esac
   shift
 done
+
+mkdir -p "$(dirname "$BACKEND_LOG_PATH")" "$(dirname "$FRONTEND_LOG_PATH")"
+touch "$BACKEND_LOG_PATH" "$FRONTEND_LOG_PATH"
+
+echo "Dev logs will be written to:"
+echo "  backend : $BACKEND_LOG_PATH"
+echo "  frontend: $FRONTEND_LOG_PATH"
 
 if [[ -d ".venv" ]]; then
   # shellcheck disable=SC1091
@@ -185,10 +195,10 @@ trap cleanup EXIT
 
 if [[ "$backend_mode" == "mock" ]]; then
   ensure_local_mock_infra
-  scripts/run_local_mock_backend.sh &
+  scripts/run_local_mock_backend.sh >>"$BACKEND_LOG_PATH" 2>&1 &
   echo "Backend running in mock mode on http://localhost:8000"
 else
-  uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 &
+  uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 >>"$BACKEND_LOG_PATH" 2>&1 &
   echo "Backend running in real mode on http://localhost:8000"
 fi
 BACKEND_PID=$!
@@ -212,7 +222,7 @@ if [[ "$backend_mode" == "mock" ]]; then
 fi
 
 if [[ -f "frontend/package.json" ]]; then
-  npm --prefix frontend run dev -- --host 0.0.0.0 --port 5173
+  npm --prefix frontend run dev -- --host 0.0.0.0 --port 5173 >>"$FRONTEND_LOG_PATH" 2>&1
 else
   wait "$BACKEND_PID"
 fi


### PR DESCRIPTION
### Motivation
- Ensure developer-run backend and frontend output is captured to durable local files for easier debugging in dev runs.
- Add actionable logging around registration/Cognito flows where audit payloads were previously the only observable output, to aid root-cause analysis of silent failures.

### Description
- Update `scripts/run_dev.sh` to create a local dev log directory and default paths `./.logs/dev/backend.log` and `./.logs/dev/frontend.log`, with overrides via `DEV_LOG_DIR`, `DEV_BACKEND_LOG_PATH`, and `DEV_FRONTEND_LOG_PATH`, and print the chosen paths at startup.
- Redirect backend process output (both mock starter and direct `uvicorn` path) into the backend log file and redirect the frontend `npm` dev server output into the frontend log file.
- Add structured `logging` statements to `app/routers/register.py` for `register_start` and `register_check` branches to log Cognito rejections, HTTP exceptions, timeouts, and unexpected errors alongside existing audit events.
- Add `logging` and extra log lines in `app/services/cognito.py` to record known Cognito sign-up failure cases and unexpected exceptions for improved diagnostics.

### Testing
- Ran unit tests: `pytest -q tests/test_register.py tests/test_auth_cognito.py` which completed successfully (`20 passed`).
- Performed basic validation: `bash -n scripts/run_dev.sh && python -m py_compile app/routers/register.py app/services/cognito.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699255e66c88832b8d2e24db2e7c9980)