### PR TITLE
Handle local AWS endpoints without configured credentials

### DIFF
--- a/app/core/aws_clients.py
+++ b/app/core/aws_clients.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from urllib.parse import urlparse
 from typing import Optional
 
 import boto3
@@ -20,6 +22,25 @@ def _aws_region() -> str:
 
 def _aws_endpoint_url() -> Optional[str]:
     return S.aws_endpoint_url or None
+
+
+def _is_local_endpoint(endpoint_url: Optional[str]) -> bool:
+    if not endpoint_url:
+        return False
+    host = (urlparse(endpoint_url).hostname or "").lower()
+    return host in {"localhost", "127.0.0.1", "0.0.0.0"}
+
+
+def _local_credentials_kwargs(endpoint_url: Optional[str]) -> dict:
+    if not _is_local_endpoint(endpoint_url):
+        return {}
+    if os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"):
+        return {}
+    return {
+        "aws_access_key_id": "test",
+        "aws_secret_access_key": "test",
+        "aws_session_token": os.getenv("AWS_SESSION_TOKEN", "test"),
+    }
 
 
 def _ddb_endpoint_url() -> Optional[str]:
@@ -49,37 +70,51 @@ def _s3_config() -> Config:
 
 
 def ddb_resource():
-    return boto3.resource("dynamodb", region_name=_aws_region(), endpoint_url=_ddb_endpoint_url())
+    endpoint_url = _ddb_endpoint_url()
+    return boto3.resource(
+        "dynamodb",
+        region_name=_aws_region(),
+        endpoint_url=endpoint_url,
+        **_local_credentials_kwargs(endpoint_url),
+    )
 
 
 def s3_client():
+    endpoint_url = _s3_endpoint_url()
     return boto3.client(
         "s3",
         region_name=_aws_region(),
-        endpoint_url=_s3_endpoint_url(),
+        endpoint_url=endpoint_url,
         config=_s3_config(),
+        **_local_credentials_kwargs(endpoint_url),
     )
 
 
 def cognito_client():
+    endpoint_url = _cognito_endpoint_url()
     return boto3.client(
         "cognito-idp",
         region_name=_aws_region(),
-        endpoint_url=_cognito_endpoint_url(),
+        endpoint_url=endpoint_url,
+        **_local_credentials_kwargs(endpoint_url),
     )
 
 
 def kms_client():
+    endpoint_url = _kms_endpoint_url()
     return boto3.client(
         "kms",
         region_name=_aws_region(),
-        endpoint_url=_kms_endpoint_url(),
+        endpoint_url=endpoint_url,
+        **_local_credentials_kwargs(endpoint_url),
     )
 
 
 def sqs_client():
+    endpoint_url = _sqs_endpoint_url()
     return boto3.client(
         "sqs",
         region_name=_aws_region(),
-        endpoint_url=_sqs_endpoint_url(),
+        endpoint_url=endpoint_url,
+        **_local_credentials_kwargs(endpoint_url),
     )


### PR DESCRIPTION
### Motivation
- Local dev bootstrap can run host-mode mocks (DynamoDB Local / moto) before environment AWS creds are set, which caused `NoCredentialsError` when the init script attempted to call DynamoDB at `http://localhost:8001`.

### Description
- Add local-endpoint detection in `app/core/aws_clients.py` to recognize `localhost`, `127.0.0.1`, and `0.0.0.0` endpoints.
- Add `_local_credentials_kwargs` helper that injects fallback test credentials (`aws_access_key_id`/`aws_secret_access_key`/`aws_session_token`) only when using a local endpoint and no explicit `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are present.
- Apply the endpoint-aware credential kwargs to the DynamoDB resource and S3, Cognito, KMS, and SQS client constructors so local mocks are callable without real AWS credentials.

### Testing
- Ran `./scripts/local-stack-up.sh` to exercise the host-mode bootstrap flow and confirm the stack startup sequence reached initialization (succeeded).
- Ran a targeted Python validation with `PYTHONPATH=/workspace/testlogon` and `DDB_ENDPOINT_URL=http://localhost:8001` that uses `ddb_resource()` and `botocore.stub.Stubber` to call `list_tables`, and verified the client signs requests and `client._request_signer._credentials` is present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954240233c832bb1c293d290749e0a)