### PR TITLE
Refine local credential fallback for dev AWS mocks

### DIFF
--- a/app/core/aws_clients.py
+++ b/app/core/aws_clients.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import os
 from urllib.parse import urlparse
 from typing import Optional
@@ -31,8 +32,35 @@ def _is_local_endpoint(endpoint_url: Optional[str]) -> bool:
     return host in {"localhost", "127.0.0.1", "0.0.0.0"}
 
 
+def _is_non_aws_localish_endpoint(endpoint_url: Optional[str]) -> bool:
+    if not endpoint_url:
+        return False
+
+    host = (urlparse(endpoint_url).hostname or "").lower()
+    if not host:
+        return False
+
+    if host.endswith("amazonaws.com"):
+        return False
+
+    if S.dev_mode:
+        return True
+
+    if host in {"host.docker.internal", "localstack", "minio"}:
+        return True
+
+    if host.endswith(".local") or host.endswith(".internal"):
+        return True
+
+    try:
+        ip = ipaddress.ip_address(host)
+        return ip.is_private or ip.is_loopback or ip.is_link_local
+    except ValueError:
+        return False
+
+
 def _local_credentials_kwargs(endpoint_url: Optional[str]) -> dict:
-    if not _is_local_endpoint(endpoint_url):
+    if not (_is_local_endpoint(endpoint_url) or _is_non_aws_localish_endpoint(endpoint_url)):
         return {}
     if os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"):
         return {}

--- a/tests/test_aws_clients.py
+++ b/tests/test_aws_clients.py
@@ -1,0 +1,50 @@
+from app.core.aws_clients import _local_credentials_kwargs
+
+
+def test_local_credentials_added_for_localhost_endpoint(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    creds = _local_credentials_kwargs("http://localhost:8001")
+
+    assert creds["aws_access_key_id"] == "test"
+    assert creds["aws_secret_access_key"] == "test"
+
+
+def test_local_credentials_added_for_private_ip_endpoint(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    creds = _local_credentials_kwargs("http://192.168.1.10:8001")
+
+    assert creds["aws_access_key_id"] == "test"
+    assert creds["aws_secret_access_key"] == "test"
+
+
+def test_local_credentials_added_for_host_internal_endpoint(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    creds = _local_credentials_kwargs("http://host.docker.internal:8001")
+
+    assert creds["aws_access_key_id"] == "test"
+    assert creds["aws_secret_access_key"] == "test"
+
+
+def test_no_local_credentials_for_aws_endpoint(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    creds = _local_credentials_kwargs("https://dynamodb.us-east-1.amazonaws.com")
+
+    assert creds == {}
+
+
+def test_local_credentials_for_public_non_aws_endpoint_in_dev_mode(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    creds = _local_credentials_kwargs("http://18.222.237.167:8001")
+
+    assert creds["aws_access_key_id"] == "test"
+    assert creds["aws_secret_access_key"] == "test"


### PR DESCRIPTION
### Motivation
- Ensure local/mock AWS services (for example local DynamoDB or S3 mocks reachable via hostnames or IPs) receive fallback credentials when no AWS credentials are configured. 
- Avoid injecting test credentials when the endpoint is a real AWS service by explicitly excluding `*.amazonaws.com` hosts. 
- Make behavior sensible for development mode so dev environments that expose services on non-`localhost` hosts or public IPs can still be used without manual credential wiring.

### Description
- Added an `ipaddress` import and a new helper `_is_non_aws_localish_endpoint` that classifies endpoints as local/mock by checking `S.dev_mode`, known dev hostnames (`host.docker.internal`, `localstack`, `minio`), `.local`/`.internal` suffixes, and private/loopback/link-local IPs, while explicitly excluding `amazonaws.com` hosts. 
- Updated `_local_credentials_kwargs` to use the new helper (together with the existing `_is_local_endpoint`) before returning fallback `aws_*` test credentials, and preserved the guard that avoids overriding explicitly provided AWS environment credentials. 
- Replaced/added `tests/test_aws_clients.py` with unit tests that cover localhost, private IP, `host.docker.internal`, AWS endpoint exclusion, and public non-AWS host behavior in dev mode.

### Testing
- Ran `pytest -q tests/test_aws_clients.py` and all tests passed successfully. 
- Test suite result: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699544868564832b8b1e5ee8f2dad38d)