### PR TITLE
Use explicit local DynamoDB resource in bootstrap to avoid credential lookup

### DIFF
--- a/scripts/local-ddb-init.py
+++ b/scripts/local-ddb-init.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional
 
-from app.core.aws_clients import ddb_resource
+import boto3
 from app.core.settings import S
 
 
@@ -198,8 +198,20 @@ def _wait_for_tables(ddb, table_names: Iterable[str]) -> None:
             table = client.describe_table(TableName=name).get("Table", {})
 
 
+def _ddb_resource_for_local_bootstrap():
+    endpoint = os.getenv("DDB_ENDPOINT_URL") or os.getenv("AWS_ENDPOINT_URL") or "http://localhost:8001"
+    return boto3.resource(
+        "dynamodb",
+        region_name=S.aws_region or "us-east-1",
+        endpoint_url=endpoint,
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", "test"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", "test"),
+        aws_session_token=os.getenv("AWS_SESSION_TOKEN", "test"),
+    )
+
+
 def main() -> None:
-    ddb = ddb_resource()
+    ddb = _ddb_resource_for_local_bootstrap()
     tables = _table_defs()
     created = []
     for table in tables:


### PR DESCRIPTION
### Motivation
- The local DynamoDB bootstrap script failed with `NoCredentialsError` when real AWS credentials were not present, causing dev startup to abort. 
- The bootstrap path needs to target the local emulator and use placeholder credentials so `boto3` does not attempt to resolve real AWS credentials. 

### Description
- Replaced the implicit shared client usage with a dedicated bootstrap resource by adding `_ddb_resource_for_local_bootstrap()` in `scripts/local-ddb-init.py`. 
- The new resource resolves endpoint in order `DDB_ENDPOINT_URL` → `AWS_ENDPOINT_URL` → fallback `http://localhost:8001` and constructs a `boto3.resource('dynamodb', ...)` directly. 
- The bootstrap resource supplies explicit placeholder credentials (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` set to `test` by default) so credential lookup is not attempted during local init. 
- `main()` now uses `_ddb_resource_for_local_bootstrap()` and otherwise preserves the existing table creation and waiter logic. 

### Testing
- Ran `python3 -m py_compile scripts/local-ddb-init.py` which succeeded.  
- Ran `PYTHONPATH=. AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= DDB_ENDPOINT_URL=http://127.0.0.1:9 python3 scripts/local-ddb-init.py` and observed an endpoint connectivity error (connection refused) instead of a `NoCredentialsError`, indicating credentials are no longer required to reach the bootstrap code.  
- No additional test suite changes were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995475182c8832b8579e6fc91caefaa)