### PR TITLE
AP-018: Add authorization regression matrix and scoped-admin enforcement (policies, metrics, UI)

### DIFF
--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -10,7 +10,7 @@ import jwt
 import requests
 from fastapi import HTTPException, Request
 
-from app.auth.roles import Role, normalize_role
+from app.auth.roles import AdminProfile, Role, normalize_admin_profile, normalize_role
 from app.auth.root_invariant import enforce_root_role_invariant
 from app.core.settings import S
 from app.models import UiSessionStartReq
@@ -123,6 +123,7 @@ def _extract_role_from_claims(claims: Dict[str, Any]) -> Role:
 class AuthenticatedUser:
     sub: str
     role: Role = Role.USER
+    admin_profile: AdminProfile = AdminProfile()
 
 
 def extract_bearer_token(auth_header: Optional[str]) -> str:
@@ -144,6 +145,10 @@ async def get_authenticated_user_role(request: Request) -> Role:
     return user.role
 
 
+def _extract_admin_profile_from_claims(claims: Dict[str, Any]) -> AdminProfile:
+    return normalize_admin_profile(claims.get("admin_profile"))
+
+
 async def get_authenticated_user(request: Request) -> AuthenticatedUser:
     """
     Wire this into your real authentication (Cognito JWT validation, cookies, etc.)
@@ -161,7 +166,8 @@ async def get_authenticated_user(request: Request) -> AuthenticatedUser:
             raise HTTPException(401, "Token missing subject")
         role = _extract_role_from_claims(payload)
         role = enforce_root_role_invariant(user_sub=str(user_sub), role=role)
-        return AuthenticatedUser(sub=str(user_sub), role=role)
+        admin_profile = _extract_admin_profile_from_claims(payload)
+        return AuthenticatedUser(sub=str(user_sub), role=role, admin_profile=admin_profile)
 
     if not S.dev_mode:
         raise HTTPException(401, "Authentication not configured")
@@ -170,7 +176,8 @@ async def get_authenticated_user(request: Request) -> AuthenticatedUser:
     if fallback_user:
         fallback_role = normalize_role(request.headers.get("x-user-role"))
         fallback_role = enforce_root_role_invariant(user_sub=fallback_user, role=fallback_role)
-        return AuthenticatedUser(sub=fallback_user, role=fallback_role)
+        fallback_admin_profile = normalize_admin_profile(request.headers.get("x-user-admin-profile"))
+        return AuthenticatedUser(sub=fallback_user, role=fallback_role, admin_profile=fallback_admin_profile)
 
     auth = request.headers.get("authorization", "")
     token = extract_bearer_token(auth)
@@ -178,7 +185,8 @@ async def get_authenticated_user(request: Request) -> AuthenticatedUser:
     sub = payload.get("sub") if isinstance(payload.get("sub"), str) and payload.get("sub").strip() else token
     role = _extract_role_from_claims(payload)
     role = enforce_root_role_invariant(user_sub=sub, role=role)
-    return AuthenticatedUser(sub=sub, role=role)
+    admin_profile = _extract_admin_profile_from_claims(payload)
+    return AuthenticatedUser(sub=sub, role=role, admin_profile=admin_profile)
 
 
 async def resolve_dev_or_authenticated_user_sub(

--- a/app/auth/policy.py
+++ b/app/auth/policy.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Callable, Iterable
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Request
 
 from app.auth.deps import AuthenticatedUser, get_authenticated_user
-from app.auth.roles import Role, normalize_role
+from app.auth.roles import AdminProfileType, AdminScope, Role, admin_profile_has_scope, normalize_admin_profile, normalize_admin_scope, normalize_role
+from app.metrics import record_admin_scope_denied
+from app.services.alerts import audit_event
 
 
 def role_required_error(*, required: Iterable[Role], actual: Role) -> HTTPException:
@@ -16,6 +18,30 @@ def role_required_error(*, required: Iterable[Role], actual: Role) -> HTTPExcept
             "code": "role_required",
             "required_roles": required_values,
             "actual_role": actual.value,
+        },
+    )
+
+
+def role_required_scope_error(*, required_scope: AdminScope, user: AuthenticatedUser) -> HTTPException:
+    return HTTPException(
+        status_code=403,
+        detail={
+            "code": "role_required_scope",
+            "required_scope": required_scope.value,
+            "actual_role": normalize_role(user.role).value,
+            "actual_admin_profile": normalize_admin_profile(getattr(user, "admin_profile", None)).to_dict(),
+        },
+    )
+
+
+def role_required_admin_profile_type_error(*, required_profile_type: AdminProfileType, user: AuthenticatedUser) -> HTTPException:
+    return HTTPException(
+        status_code=403,
+        detail={
+            "code": "role_required_admin_profile_type",
+            "required_admin_profile_type": required_profile_type.value,
+            "actual_role": normalize_role(user.role).value,
+            "actual_admin_profile": normalize_admin_profile(getattr(user, "admin_profile", None)).to_dict(),
         },
     )
 
@@ -40,6 +66,69 @@ async def require_root(user: AuthenticatedUser = Depends(get_authenticated_user)
 
 async def require_admin_or_root(user: AuthenticatedUser = Depends(get_authenticated_user)) -> AuthenticatedUser:
     return require_roles(user, {Role.ADMIN, Role.ROOT})
+
+
+async def require_general_admin_or_root(user: AuthenticatedUser = Depends(get_authenticated_user)) -> AuthenticatedUser:
+    role = normalize_role(user.role)
+    if role is Role.ROOT:
+        return user
+    if role is not Role.ADMIN:
+        raise role_required_error(required={Role.ADMIN, Role.ROOT}, actual=role)
+
+    profile = normalize_admin_profile(getattr(user, "admin_profile", None))
+    if profile.type is not AdminProfileType.GENERAL:
+        raise role_required_admin_profile_type_error(required_profile_type=AdminProfileType.GENERAL, user=user)
+    return user
+
+
+def require_admin_scope(scope: AdminScope | str) -> Callable[..., AuthenticatedUser]:
+    normalized_scope = normalize_admin_scope(scope)
+    if normalized_scope is None:
+        raise ValueError(f"Unknown admin scope: {scope}")
+
+    async def _require_admin_scope(
+        request: Request,
+        user: AuthenticatedUser = Depends(get_authenticated_user),
+    ) -> AuthenticatedUser:
+        role = normalize_role(user.role)
+        if role is Role.ROOT:
+            return user
+        if role is not Role.ADMIN:
+            raise role_required_error(required={Role.ADMIN, Role.ROOT}, actual=role)
+
+        profile = normalize_admin_profile(getattr(user, "admin_profile", None))
+        if not admin_profile_has_scope(profile, normalized_scope):
+            route = "unknown"
+            request_scope = getattr(request, "scope", None)
+            if isinstance(request_scope, dict):
+                route_obj = request_scope.get("route")
+                route_path = getattr(route_obj, "path", None)
+                if isinstance(route_path, str) and route_path:
+                    route = route_path
+            if route == "unknown":
+                request_url = getattr(request, "url", None)
+                url_path = getattr(request_url, "path", None)
+                if isinstance(url_path, str) and url_path:
+                    route = url_path
+            record_admin_scope_denied(
+                route=route,
+                required_scope=normalized_scope.value,
+                admin_profile_type=profile.type.value,
+            )
+            audit_event(
+                "admin_scope_denied",
+                user.sub,
+                request,
+                outcome="error",
+                status_code=403,
+                required_scope=normalized_scope.value,
+                actual_role=role.value,
+                actual_admin_profile=profile.to_dict(),
+            )
+            raise role_required_scope_error(required_scope=normalized_scope, user=user)
+        return user
+
+    return _require_admin_scope
 
 
 def require_self_or_admin(*, actor: AuthenticatedUser, target_user_sub: str) -> AuthenticatedUser:

--- a/app/auth/roles.py
+++ b/app/auth/roles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
@@ -8,6 +9,38 @@ class Role(str, Enum):
     ROOT = "root"
     ADMIN = "admin"
     USER = "user"
+
+
+class AdminScope(str, Enum):
+    AUTH_SUPPORT = "auth_support"
+    BILLING_SUPPORT = "billing_support"
+    CONTENT_MODERATION = "content_moderation"
+
+
+class AdminProfileType(str, Enum):
+    GENERAL = "general"
+    SCOPED = "scoped"
+
+
+CANONICAL_ADMIN_SCOPES: tuple[AdminScope, ...] = (
+    AdminScope.AUTH_SUPPORT,
+    AdminScope.BILLING_SUPPORT,
+    AdminScope.CONTENT_MODERATION,
+)
+
+
+@dataclass(frozen=True)
+class AdminProfile:
+    type: AdminProfileType = AdminProfileType.GENERAL
+    scopes: tuple[AdminScope, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.type is AdminProfileType.GENERAL:
+            return {"type": AdminProfileType.GENERAL.value}
+        return {
+            "type": AdminProfileType.SCOPED.value,
+            "scopes": [scope.value for scope in self.scopes],
+        }
 
 
 def normalize_role(value: Any) -> Role:
@@ -24,3 +57,66 @@ def normalize_role(value: Any) -> Role:
 
 def role_allows_admin_features(role: Role) -> bool:
     return role in {Role.ADMIN, Role.ROOT}
+
+
+def normalize_admin_scope(value: Any) -> AdminScope | None:
+    if isinstance(value, AdminScope):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        for scope in CANONICAL_ADMIN_SCOPES:
+            if normalized == scope.value:
+                return scope
+    return None
+
+
+def normalize_admin_profile(value: Any) -> AdminProfile:
+    """
+    Return canonical admin profile.
+
+    Fallback is always `general` to preserve current broad-admin behavior when
+    data is missing/malformed.
+    """
+    if isinstance(value, AdminProfile):
+        if value.type is AdminProfileType.GENERAL:
+            return AdminProfile(type=AdminProfileType.GENERAL)
+        scopes = sorted(set(value.scopes), key=lambda item: item.value)
+        if not scopes:
+            return AdminProfile(type=AdminProfileType.GENERAL)
+        return AdminProfile(type=AdminProfileType.SCOPED, scopes=tuple(scopes))
+
+    if not isinstance(value, dict):
+        return AdminProfile(type=AdminProfileType.GENERAL)
+
+    profile_type_raw = value.get("type")
+    profile_type = None
+    if isinstance(profile_type_raw, AdminProfileType):
+        profile_type = profile_type_raw
+    elif isinstance(profile_type_raw, str):
+        normalized_type = profile_type_raw.strip().lower()
+        for candidate in AdminProfileType:
+            if candidate.value == normalized_type:
+                profile_type = candidate
+                break
+
+    if profile_type is not AdminProfileType.SCOPED:
+        return AdminProfile(type=AdminProfileType.GENERAL)
+
+    raw_scopes = value.get("scopes")
+    if not isinstance(raw_scopes, list):
+        return AdminProfile(type=AdminProfileType.GENERAL)
+
+    normalized_scopes = [normalize_admin_scope(scope) for scope in raw_scopes]
+    scoped = sorted({scope for scope in normalized_scopes if scope is not None}, key=lambda item: item.value)
+    if not scoped:
+        return AdminProfile(type=AdminProfileType.GENERAL)
+    return AdminProfile(type=AdminProfileType.SCOPED, scopes=tuple(scoped))
+
+
+def admin_profile_has_scope(profile: AdminProfile, scope: AdminScope | str) -> bool:
+    normalized = normalize_admin_scope(scope)
+    if normalized is None:
+        return False
+    if profile.type is AdminProfileType.GENERAL:
+        return True
+    return normalized in profile.scopes

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -76,6 +76,11 @@ class Settings:
     impersonation_max_ttl_seconds: int = int(os.environ.get("IMPERSONATION_MAX_TTL_SECONDS", "3600"))
     impersonation_allow_privileged_targets: bool = os.environ.get("IMPERSONATION_ALLOW_PRIVILEGED_TARGETS", "false").lower() in ("1", "true", "yes", "on")
 
+    # Admin scope enforcement feature flags (AP-016)
+    admin_scope_enforce_auth_support: bool = os.environ.get("ADMIN_SCOPE_ENFORCE_AUTH_SUPPORT", "1") not in ("0", "false", "False")
+    admin_scope_enforce_billing_support: bool = os.environ.get("ADMIN_SCOPE_ENFORCE_BILLING_SUPPORT", "1") not in ("0", "false", "False")
+    admin_scope_enforce_content_moderation: bool = os.environ.get("ADMIN_SCOPE_ENFORCE_CONTENT_MODERATION", "1") not in ("0", "false", "False")
+
     # MFA rate limiting
     mfa_send_min_interval_seconds: int = int(os.environ.get("MFA_SEND_MIN_INTERVAL_SECONDS", "30"))
     mfa_send_max_per_hour: int = int(os.environ.get("MFA_SEND_MAX_PER_HOUR", "20"))

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -203,6 +203,11 @@ USAGE_METERING_PIPELINE_LATENCY = Histogram(
     ["stage"],
     buckets=(0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5),
 )
+ADMIN_SCOPE_DENIED = Counter(
+    "admin_scope_denied_total",
+    "Denied admin scope authorization checks by route, required scope, and profile type",
+    ["route", "required_scope", "admin_profile_type"],
+)
 
 _START_TIME = time.monotonic()
 _ACTIVE_SESSIONS_BY_USER: dict[str, int] = {}
@@ -302,6 +307,14 @@ def record_usage_metering_pipeline_error(stage: str) -> None:
 
 def record_usage_metering_pipeline_latency(stage: str, elapsed_seconds: float) -> None:
     USAGE_METERING_PIPELINE_LATENCY.labels(stage=stage).observe(max(0.0, float(elapsed_seconds)))
+
+
+def record_admin_scope_denied(*, route: str, required_scope: str, admin_profile_type: str) -> None:
+    ADMIN_SCOPE_DENIED.labels(
+        route=route or "unknown",
+        required_scope=required_scope or "unknown",
+        admin_profile_type=admin_profile_type or "unknown",
+    ).inc()
 
 def set_app_info(name: str, version: str) -> None:
     APP_INFO.info({"name": name, "version": version})

--- a/app/routers/admin_impersonation.py
+++ b/app/routers/admin_impersonation.py
@@ -9,8 +9,8 @@ import jwt
 from boto3.dynamodb.conditions import Key
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 
-from app.auth.deps import AuthenticatedUser
-from app.auth.policy import require_admin_or_root
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.policy import require_admin_scope, require_general_admin_or_root, require_role_value
 from app.auth.roles import Role, normalize_role
 from app.core.settings import S
 from app.core.tables import T
@@ -22,6 +22,14 @@ from app.services.ttl import with_ttl
 
 router = APIRouter(prefix="/admin/impersonation", tags=["admin-impersonation"])
 
+require_auth_support_admin = require_admin_scope("auth_support")
+
+
+async def require_impersonation_operator(user: AuthenticatedUser = Depends(get_authenticated_user), request: Request = None) -> AuthenticatedUser:
+    if bool(getattr(S, "admin_scope_enforce_auth_support", True)):
+        return await require_auth_support_admin(request=request, user=user)
+    require_role_value(normalize_role(user.role).value, {Role.ADMIN, Role.ROOT})
+    return user
 
 
 def _encode_cursor(cursor: Dict[str, Any] | None) -> str | None:
@@ -62,7 +70,7 @@ def start_impersonation(
     req: Request,
     body: Dict[str, Any] = Body(default={}),
     _ctx: Dict[str, str] = Depends(require_ui_session),
-    actor: AuthenticatedUser = Depends(require_admin_or_root),
+    actor: AuthenticatedUser = Depends(require_impersonation_operator),
 ):
     rate_limit_admin_action(actor.sub, "impersonation_start")
     target_user_sub = str((body or {}).get("target_user_sub") or "").strip()
@@ -146,7 +154,7 @@ def stop_impersonation(
     req: Request,
     body: Dict[str, Any] = Body(default={}),
     _ctx: Dict[str, str] = Depends(require_ui_session),
-    actor: AuthenticatedUser = Depends(require_admin_or_root),
+    actor: AuthenticatedUser = Depends(require_impersonation_operator),
 ):
     rate_limit_admin_action(actor.sub, "impersonation_stop")
     impersonation_id = str((body or {}).get("impersonation_id") or "").strip()
@@ -189,7 +197,7 @@ def impersonation_audit(
     limit: int = Query(default=50, ge=1, le=200),
     cursor: str | None = Query(default=None),
     _ctx: Dict[str, str] = Depends(require_ui_session),
-    _actor: AuthenticatedUser = Depends(require_admin_or_root),
+    _actor: AuthenticatedUser = Depends(require_impersonation_operator),
 ):
     end = int(end_ts or now_ts())
     if start_ts > end:

--- a/app/routers/admin_roles.py
+++ b/app/routers/admin_roles.py
@@ -10,8 +10,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from app.auth.deps import AuthenticatedUser
-from app.auth.policy import require_assignable_role, require_root
-from app.auth.roles import Role, normalize_role
+from app.auth.policy import require_assignable_role, require_roles, require_root
+from app.auth.roles import AdminProfileType, AdminScope, Role, normalize_admin_profile, normalize_admin_scope, normalize_role
 from app.core.normalize import client_ip_from_request
 from app.core.settings import S
 from app.core.tables import T
@@ -27,6 +27,8 @@ class RoleGrantReq(BaseModel):
     target_user_sub: str = Field(..., min_length=1)
     role: str = Field(default="admin")
     reason: str = Field(default="", max_length=500)
+    admin_profile_type: str = Field(default=AdminProfileType.GENERAL.value)
+    admin_scopes: list[str] = Field(default_factory=list)
 
 
 class RoleRevokeReq(BaseModel):
@@ -35,11 +37,105 @@ class RoleRevokeReq(BaseModel):
     reason: str = Field(default="", max_length=500)
 
 
+class RoleUpdateProfileReq(BaseModel):
+    target_user_sub: str = Field(..., min_length=1)
+    admin_profile_type: str = Field(default=AdminProfileType.GENERAL.value)
+    admin_scopes: list[str] = Field(default_factory=list)
+    reason: str = Field(default="", max_length=500)
+
+
+def _normalize_admin_profile_type(value: str | None) -> AdminProfileType | None:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        for profile_type in AdminProfileType:
+            if profile_type.value == normalized:
+                return profile_type
+    return None
+
+
+def _validate_admin_profile_input(*, admin_profile_type: str | None, admin_scopes: list[str] | None) -> Dict[str, Any]:
+    profile_type = _normalize_admin_profile_type(admin_profile_type)
+    if profile_type is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_admin_profile_type",
+                "allowed_profile_types": sorted([item.value for item in AdminProfileType]),
+            },
+        )
+
+    raw_scopes = admin_scopes or []
+    if profile_type is AdminProfileType.GENERAL:
+        if raw_scopes:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "invalid_admin_scopes",
+                    "reason": "general_profile_disallows_scopes",
+                },
+            )
+        return {"type": AdminProfileType.GENERAL.value}
+
+    normalized_scopes: list[AdminScope] = []
+    seen: set[AdminScope] = set()
+    duplicate_scopes: set[str] = set()
+    invalid_scopes: set[str] = set()
+
+    for raw_scope in raw_scopes:
+        scope = normalize_admin_scope(raw_scope)
+        if scope is None:
+            invalid_scopes.add(str(raw_scope).strip())
+            continue
+        if scope in seen:
+            duplicate_scopes.add(scope.value)
+            continue
+        seen.add(scope)
+        normalized_scopes.append(scope)
+
+    if invalid_scopes:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_admin_scopes",
+                "reason": "unknown_scope_values",
+                "invalid_scopes": sorted(s for s in invalid_scopes if s),
+                "allowed_scopes": sorted([scope.value for scope in AdminScope]),
+            },
+        )
+
+    if duplicate_scopes:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_admin_scopes",
+                "reason": "duplicate_scope_values",
+                "duplicate_scopes": sorted(duplicate_scopes),
+            },
+        )
+
+    if not normalized_scopes:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_admin_scopes",
+                "reason": "scoped_profile_requires_non_empty_scopes",
+            },
+        )
+
+    return {"type": AdminProfileType.SCOPED.value, "scopes": sorted([scope.value for scope in normalized_scopes])}
+
+
 def _load_user_or_404(user_sub: str) -> Dict[str, Any]:
     item = T.users.get_item(Key={"user_sub": user_sub}).get("Item")
     if not item:
         raise HTTPException(status_code=404, detail="target user not found")
     return item
+
+
+
+
+def _normalized_user_admin_profile(user_item: Dict[str, Any]) -> Dict[str, Any]:
+    return normalize_admin_profile(user_item.get("admin_profile")).to_dict()
 
 
 def _encode_cursor(last_key: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -70,6 +166,8 @@ def _persist_role_assignment_event(
     action: str,
     previous_role: Role,
     new_role: Role,
+    previous_admin_profile: Dict[str, Any] | None,
+    new_admin_profile: Dict[str, Any] | None,
     reason: str,
 ) -> Dict[str, Any]:
     ts = now_ts()
@@ -85,6 +183,8 @@ def _persist_role_assignment_event(
         "target_user_sub": target_user_sub,
         "previous_role": previous_role.value,
         "new_role": new_role.value,
+        "previous_admin_profile": previous_admin_profile,
+        "new_admin_profile": new_admin_profile,
         "reason": reason,
         "ip": client_ip_from_request(req),
         "request_id": request_id,
@@ -109,12 +209,19 @@ def grant_role(
         raise HTTPException(status_code=400, detail="only admin role is assignable via this endpoint")
 
     try:
+        admin_profile = _validate_admin_profile_input(admin_profile_type=body.admin_profile_type, admin_scopes=body.admin_scopes)
+    except HTTPException as exc:
+        audit_event("admin_role_grant_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="invalid_admin_profile", status_code=exc.status_code)
+        raise
+
+    try:
         user = _load_user_or_404(target)
     except HTTPException as exc:
         audit_event("admin_role_grant_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="target_not_found", status_code=exc.status_code)
         raise
 
     current = normalize_role(user.get("role"))
+    previous_admin_profile = _normalized_user_admin_profile(user)
     if current is Role.ROOT or target == (S.root_user_sub or "").strip():
         audit_event("admin_role_grant_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="root_immutable", status_code=409)
         raise HTTPException(status_code=409, detail="cannot modify root role through admin grant API")
@@ -125,10 +232,11 @@ def grant_role(
     reason = (body.reason or "").strip()
     T.users.update_item(
         Key={"user_sub": target},
-        UpdateExpression="SET #role=:role, role_updated_at=:ts, role_updated_by=:by, role_reason=:reason",
+        UpdateExpression="SET #role=:role, admin_profile=:admin_profile, role_updated_at=:ts, role_updated_by=:by, role_reason=:reason",
         ExpressionAttributeNames={"#role": "role"},
         ExpressionAttributeValues={
             ":role": Role.ADMIN.value,
+            ":admin_profile": admin_profile,
             ":ts": now_ts(),
             ":by": actor.sub,
             ":reason": reason,
@@ -141,6 +249,8 @@ def grant_role(
         action="grant",
         previous_role=current,
         new_role=Role.ADMIN,
+        previous_admin_profile=previous_admin_profile,
+        new_admin_profile=admin_profile,
         reason=reason,
     )
     audit_event(
@@ -153,9 +263,80 @@ def grant_role(
         role=Role.ADMIN.value,
         previous_role=current.value,
         reason=reason,
+        admin_profile=admin_profile,
         role_audit_event_id=event["event_id"],
     )
-    return {"ok": True, "target_user_sub": target, "role": Role.ADMIN.value, "event_id": event["event_id"]}
+    return {"ok": True, "target_user_sub": target, "role": Role.ADMIN.value, "admin_profile": admin_profile, "event_id": event["event_id"]}
+
+
+@router.post("/update-profile")
+def update_role_profile(
+    body: RoleUpdateProfileReq,
+    req: Request,
+    _ctx: Dict[str, str] = Depends(require_ui_session),
+    actor: AuthenticatedUser = Depends(require_root),
+):
+    require_roles(actor, {Role.ROOT})
+    rate_limit_admin_action(actor.sub, "role_update_profile")
+    target = body.target_user_sub.strip()
+
+    try:
+        admin_profile = _validate_admin_profile_input(admin_profile_type=body.admin_profile_type, admin_scopes=body.admin_scopes)
+    except HTTPException as exc:
+        audit_event("admin_role_profile_update_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="invalid_admin_profile", status_code=exc.status_code)
+        raise
+
+    try:
+        user = _load_user_or_404(target)
+    except HTTPException as exc:
+        audit_event("admin_role_profile_update_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="target_not_found", status_code=exc.status_code)
+        raise
+
+    current = normalize_role(user.get("role"))
+    previous_admin_profile = _normalized_user_admin_profile(user)
+    if current is Role.ROOT or target == (S.root_user_sub or "").strip():
+        audit_event("admin_role_profile_update_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="root_immutable", status_code=409)
+        raise HTTPException(status_code=409, detail="cannot modify root role through admin profile API")
+    if current is not Role.ADMIN:
+        audit_event("admin_role_profile_update_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="target_not_admin", status_code=409)
+        raise HTTPException(status_code=409, detail="target user is not admin")
+
+    reason = (body.reason or "").strip()
+    T.users.update_item(
+        Key={"user_sub": target},
+        UpdateExpression="SET admin_profile=:admin_profile, role_updated_at=:ts, role_updated_by=:by, role_reason=:reason",
+        ExpressionAttributeValues={
+            ":admin_profile": admin_profile,
+            ":ts": now_ts(),
+            ":by": actor.sub,
+            ":reason": reason,
+        },
+    )
+    event = _persist_role_assignment_event(
+        req=req,
+        actor_sub=actor.sub,
+        target_user_sub=target,
+        action="update_profile",
+        previous_role=Role.ADMIN,
+        new_role=Role.ADMIN,
+        previous_admin_profile=previous_admin_profile,
+        new_admin_profile=admin_profile,
+        reason=reason,
+    )
+
+    audit_event(
+        "admin_role_profile_updated",
+        actor.sub,
+        req,
+        outcome="success",
+        target_user_sub=target,
+        actor_sub=actor.sub,
+        role=Role.ADMIN.value,
+        reason=reason,
+        admin_profile=admin_profile,
+        role_audit_event_id=event["event_id"],
+    )
+    return {"ok": True, "target_user_sub": target, "role": Role.ADMIN.value, "admin_profile": admin_profile, "event_id": event["event_id"]}
 
 
 @router.post("/revoke")
@@ -179,6 +360,7 @@ def revoke_role(
         raise
 
     current = normalize_role(user.get("role"))
+    previous_admin_profile = _normalized_user_admin_profile(user)
     if current is Role.ROOT or target == (S.root_user_sub or "").strip():
         audit_event("admin_role_revoke_failed", actor.sub, req, outcome="error", target_user_sub=target, reason="root_immutable", status_code=409)
         raise HTTPException(status_code=409, detail="cannot modify root role through admin revoke API")
@@ -189,7 +371,7 @@ def revoke_role(
     reason = (body.reason or "").strip()
     T.users.update_item(
         Key={"user_sub": target},
-        UpdateExpression="SET #role=:role, role_updated_at=:ts, role_updated_by=:by, role_reason=:reason",
+        UpdateExpression="SET #role=:role, role_updated_at=:ts, role_updated_by=:by, role_reason=:reason REMOVE admin_profile",
         ExpressionAttributeNames={"#role": "role"},
         ExpressionAttributeValues={
             ":role": Role.USER.value,
@@ -205,6 +387,8 @@ def revoke_role(
         action="revoke",
         previous_role=current,
         new_role=Role.USER,
+        previous_admin_profile=previous_admin_profile,
+        new_admin_profile=None,
         reason=reason,
     )
     audit_event(
@@ -268,6 +452,8 @@ def list_role_audit(
             "target_user_sub": it.get("target_user_sub"),
             "previous_role": it.get("previous_role"),
             "new_role": it.get("new_role"),
+            "previous_admin_profile": it.get("previous_admin_profile"),
+            "new_admin_profile": it.get("new_admin_profile"),
             "reason": it.get("reason"),
             "ip": it.get("ip"),
             "request_id": it.get("request_id"),

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -15,8 +15,9 @@ else:  # pragma: no cover
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from app.auth.policy import require_role_value
-from app.auth.roles import Role
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.policy import require_admin_scope, require_role_value
+from app.auth.roles import AdminScope, Role, admin_profile_has_scope, normalize_role
 from app.core.settings import S
 from app.core.tables import T
 from app.core.time import now_ts
@@ -61,26 +62,62 @@ router = APIRouter(tags=["billing"])
 logger = logging.getLogger(__name__)
 
 
-def require_admin_or_root_session(ctx=Depends(require_ui_session)) -> Dict[str, Any]:
-    require_role_value(ctx.get("role"), {Role.ADMIN, Role.ROOT})
-    return ctx
+require_billing_support_admin = require_admin_scope("billing_support")
 
 
-def _billing_read_user_sub(ctx: Dict[str, Any], target_user_sub: Optional[str]) -> str:
+async def require_billing_admin_operator(user: AuthenticatedUser = Depends(get_authenticated_user), request: Request = None) -> AuthenticatedUser:
+    if bool(getattr(S, "admin_scope_enforce_billing_support", True)):
+        return await require_billing_support_admin(request=request, user=user)
+    require_role_value(normalize_role(user.role).value, {Role.ADMIN, Role.ROOT})
+    return user
+
+
+def _resolve_actor_from_context(ctx: Dict[str, Any], actor: AuthenticatedUser | Any) -> AuthenticatedUser:
+    if isinstance(actor, AuthenticatedUser):
+        return actor
+    role = normalize_role((ctx or {}).get("role"))
+    return AuthenticatedUser(sub=str((ctx or {}).get("user_sub") or ""), role=role)
+
+
+def _require_billing_support_actor(actor: AuthenticatedUser) -> None:
+    if not bool(getattr(S, "admin_scope_enforce_billing_support", True)):
+        require_role_value(normalize_role(actor.role).value, {Role.ADMIN, Role.ROOT})
+        return
+    role = normalize_role(actor.role)
+    if role is Role.ROOT:
+        return
+    if role is Role.ADMIN:
+        if admin_profile_has_scope(actor.admin_profile, AdminScope.BILLING_SUPPORT):
+            return
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "role_required_scope",
+                "required_scope": AdminScope.BILLING_SUPPORT.value,
+                "actual_role": role.value,
+                "actual_admin_profile": actor.admin_profile.to_dict(),
+            },
+        )
+    require_role_value(role.value, {Role.ADMIN, Role.ROOT})
+
+
+def _billing_read_user_sub(ctx: Dict[str, Any], target_user_sub: Optional[str], actor: AuthenticatedUser | Any = None) -> str:
     requested = (target_user_sub or "").strip()
+    resolved_actor = _resolve_actor_from_context(ctx, actor)
     if requested and requested != ctx["user_sub"]:
-        require_role_value(ctx.get("role"), {Role.ADMIN, Role.ROOT})
+        _require_billing_support_actor(resolved_actor)
         return requested
     return ctx["user_sub"]
 
 
-def _billing_write_user_context(ctx: Dict[str, Any], target_user_sub: Optional[str]) -> tuple[str, Dict[str, Any]]:
+def _billing_write_user_context(ctx: Dict[str, Any], target_user_sub: Optional[str], actor: AuthenticatedUser | Any = None) -> tuple[str, Dict[str, Any]]:
     requested = (target_user_sub or "").strip()
-    actor_sub = str(ctx.get("actor_sub") or ctx["user_sub"])
+    resolved_actor = _resolve_actor_from_context(ctx, actor)
+    actor_sub = str(ctx.get("actor_sub") or resolved_actor.sub or ctx["user_sub"])
     effective_sub = ctx["user_sub"]
     tags: Dict[str, Any] = {}
     if requested and requested != ctx["user_sub"]:
-        require_role_value(ctx.get("role"), {Role.ADMIN, Role.ROOT})
+        _require_billing_support_actor(resolved_actor)
         effective_sub = requested
         tags = {
             "viewed_as_admin": True,
@@ -287,16 +324,16 @@ def billing_config() -> Dict[str, str]:
 
 
 @dual_route("GET", "/billing/settings")
-def get_settings(ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, Any]:
-    user_id = _billing_read_user_sub(ctx, user_sub)
+def get_settings(ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, Any]:
+    user_id = _billing_read_user_sub(ctx, user_sub, actor)
     pk = user_pk(user_id)
     settings = ddb_get(T.billing, pk, "BILLING") or {"autopay_enabled": False, "currency": "usd", "default_payment_method_id": None}
     return settings
 
 
 @dual_route("POST", "/billing/autopay")
-def set_autopay(body: SetAutopayReq, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, bool]:
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+def set_autopay(body: SetAutopayReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, bool]:
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
     if not ddb_get(T.billing, pk, "BILLING"):
         ddb_put(T.billing, {"pk": pk, "sk": "BILLING", "autopay_enabled": False, "currency": "usd", "default_payment_method_id": None})
@@ -308,8 +345,8 @@ def set_autopay(body: SetAutopayReq, req: Request = None, ctx=Depends(require_ui
 
 
 @dual_route("GET", "/billing/balance")
-def get_balance(ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, Any]:
-    user_id = _billing_read_user_sub(ctx, user_sub)
+def get_balance(ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, Any]:
+    user_id = _billing_read_user_sub(ctx, user_sub, actor)
     pk = user_pk(user_id)
     ensure_balance_row(T.billing, pk, S.stripe_default_currency or "usd")
     bal = ddb_get(T.billing, pk, "BALANCE") or {}
@@ -390,8 +427,8 @@ def list_payment_methods(ctx=Depends(require_ui_session)) -> List[StripePaymentM
 
 
 @dual_route("POST", "/billing/payment-methods/priority")
-def set_priority(body: SetPriorityReq, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, bool]:
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+def set_priority(body: SetPriorityReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, bool]:
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
     sk = pm_sk(body.payment_method_id)
     if not ddb_get(T.billing, pk, sk):
@@ -402,9 +439,9 @@ def set_priority(body: SetPriorityReq, req: Request = None, ctx=Depends(require_
 
 
 @dual_route("POST", "/billing/payment-methods/default")
-def set_default(body: SetDefaultReq, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, bool]:
+def set_default(body: SetDefaultReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, bool]:
     ensure_stripe_configured()
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
     if not ddb_get(T.billing, pk, pm_sk(body.payment_method_id)):
         raise HTTPException(404, "Payment method not found")
@@ -418,9 +455,9 @@ def set_default(body: SetDefaultReq, req: Request = None, ctx=Depends(require_ui
 
 
 @dual_route("DELETE", "/billing/payment-methods/{payment_method_id}")
-def remove_payment_method(payment_method_id: str, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, bool]:
+def remove_payment_method(payment_method_id: str, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, bool]:
     ensure_stripe_configured()
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
     sk = pm_sk(payment_method_id)
     if not ddb_get(T.billing, pk, sk):
@@ -456,9 +493,9 @@ def remove_payment_method(payment_method_id: str, req: Request = None, ctx=Depen
 
 
 @dual_route("POST", "/billing/pay-balance")
-def pay_balance(body: PayBalanceReq, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, str]:
+def pay_balance(body: PayBalanceReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, str]:
     ensure_stripe_configured()
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
 
     ensure_balance_row(T.billing, pk, S.stripe_default_currency or "usd")
@@ -556,9 +593,9 @@ def pay_balance(body: PayBalanceReq, req: Request = None, ctx=Depends(require_ui
 
 
 @dual_route("POST", "/billing/charge-once")
-def charge_once(body: StripeChargeReq, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, Any]:
+def charge_once(body: StripeChargeReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, Any]:
     ensure_stripe_configured()
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
 
     ensure_balance_row(T.billing, pk, S.stripe_default_currency or "usd")
@@ -655,9 +692,9 @@ def charge_once(body: StripeChargeReq, req: Request = None, ctx=Depends(require_
 
 
 @dual_route("POST", "/billing/refund")
-def refund_payment(body: StripeRefundReq, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, Any]:
+def refund_payment(body: StripeRefundReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, Any]:
     ensure_stripe_configured()
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
 
     pay = ddb_get(T.billing, pk, pay_sk(body.payment_intent_id))
@@ -716,9 +753,9 @@ def refund_payment(body: StripeRefundReq, req: Request = None, ctx=Depends(requi
 
 
 @dual_route("POST", "/billing/checkout_session")
-def create_checkout_session(body: BillingCheckoutReq, req: Request = None, ctx=Depends(require_ui_session), user_sub: Optional[str] = None) -> Dict[str, str]:
+def create_checkout_session(body: BillingCheckoutReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), user_sub: Optional[str] = None) -> Dict[str, str]:
     ensure_stripe_configured()
-    target_user_sub, admin_tags = _billing_write_user_context(ctx, user_sub)
+    target_user_sub, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     if body.amount_cents <= 0:
         raise HTTPException(400, "amount_cents must be greater than zero")
     currency = (body.currency or S.stripe_default_currency or "usd").lower()
@@ -1059,8 +1096,8 @@ async def stripe_webhook(req: Request) -> Dict[str, Any]:
 
 
 @dual_route("POST", "/billing/_dev/add-charge")
-def dev_add_charge(body: AddChargeReq, req: Request = None, ctx=Depends(require_admin_or_root_session), user_sub: Optional[str] = None) -> Dict[str, Any]:
-    user_id, admin_tags = _billing_write_user_context(ctx, user_sub)
+def dev_add_charge(body: AddChargeReq, req: Request = None, ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(require_billing_admin_operator), user_sub: Optional[str] = None) -> Dict[str, Any]:
+    user_id, admin_tags = _billing_write_user_context(ctx, user_sub, actor)
     pk = user_pk(user_id)
     ensure_balance_row(T.billing, pk, S.stripe_default_currency or "usd")
 
@@ -1095,8 +1132,8 @@ def dev_add_charge(body: AddChargeReq, req: Request = None, ctx=Depends(require_
 
 
 @dual_route("GET", "/billing/ledger")
-def list_ledger(ctx=Depends(require_ui_session), limit: int = 50, user_sub: Optional[str] = None) -> Dict[str, Any]:
-    user_id = _billing_read_user_sub(ctx, user_sub)
+def list_ledger(ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), limit: int = 50, user_sub: Optional[str] = None) -> Dict[str, Any]:
+    user_id = _billing_read_user_sub(ctx, user_sub, actor)
     items = ddb_query_pk(T.billing, user_pk(user_id))
     led = [it for it in items if it["sk"].startswith("LEDGER#")]
     led.sort(key=lambda x: x.get("ts", 0), reverse=True)
@@ -1104,17 +1141,17 @@ def list_ledger(ctx=Depends(require_ui_session), limit: int = 50, user_sub: Opti
 
 
 @dual_route("GET", "/billing/payments")
-def list_payments(ctx=Depends(require_ui_session), limit: int = 50, user_sub: Optional[str] = None) -> Dict[str, Any]:
-    user_id = _billing_read_user_sub(ctx, user_sub)
+def list_payments(ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), limit: int = 50, user_sub: Optional[str] = None) -> Dict[str, Any]:
+    user_id = _billing_read_user_sub(ctx, user_sub, actor)
     pays = list_payment_records_ddb(user_id)
     pays.sort(key=lambda x: x.get("created_at", 0), reverse=True)
     return {"items": pays[: max(1, min(limit, 200))]}
 
 
 @dual_route("GET", "/billing/subscriptions")
-def list_subscriptions(ctx=Depends(require_ui_session), limit: int = 50, user_sub: Optional[str] = None) -> Dict[str, Any]:
+def list_subscriptions(ctx=Depends(require_ui_session), actor: AuthenticatedUser = Depends(get_authenticated_user), limit: int = 50, user_sub: Optional[str] = None) -> Dict[str, Any]:
     ensure_stripe_configured()
-    user_id = _billing_read_user_sub(ctx, user_sub)
+    user_id = _billing_read_user_sub(ctx, user_sub, actor)
     customer_id = get_or_create_customer(user_id)
     capped_limit = max(1, min(limit, 200))
     resp = stripe.Subscription.list(customer=customer_id, limit=capped_limit)

--- a/app/routers/filemanager.py
+++ b/app/routers/filemanager.py
@@ -10,8 +10,9 @@ from fastapi import APIRouter, Depends, File, Query, UploadFile, Body, Request, 
 from pydantic import BaseModel, Field
 from fastapi.responses import StreamingResponse
 
-from app.auth.policy import require_role_value
-from app.auth.roles import Role
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.policy import require_admin_scope, require_role_value
+from app.auth.roles import AdminScope, Role, admin_profile_has_scope, normalize_role
 from app.core.tables import T
 from app.core.settings import S
 from app.services.filemanager import (
@@ -88,8 +89,48 @@ def _current_user(ctx=Depends(require_ui_session)) -> str:
     return ctx["user_sub"]
 
 
-def _admin_or_root_ctx(ctx=Depends(require_ui_session)) -> Dict[str, Any]:
-    require_role_value(ctx.get("role"), {Role.ADMIN, Role.ROOT})
+require_content_moderation_admin = require_admin_scope("content_moderation")
+
+
+async def require_content_moderation_operator(user: AuthenticatedUser = Depends(get_authenticated_user), request: Request = None) -> AuthenticatedUser:
+    if bool(getattr(S, "admin_scope_enforce_content_moderation", True)):
+        return await require_content_moderation_admin(request=request, user=user)
+    require_role_value(normalize_role(user.role).value, {Role.ADMIN, Role.ROOT})
+    return user
+
+
+def _resolve_actor_from_context(ctx: Dict[str, Any], actor: AuthenticatedUser | Any) -> AuthenticatedUser:
+    if isinstance(actor, AuthenticatedUser):
+        return actor
+    role = normalize_role((ctx or {}).get("role"))
+    return AuthenticatedUser(sub=str((ctx or {}).get("user_sub") or ""), role=role)
+
+
+def _require_content_moderation_actor(actor: AuthenticatedUser) -> None:
+    if not bool(getattr(S, "admin_scope_enforce_content_moderation", True)):
+        require_role_value(normalize_role(actor.role).value, {Role.ADMIN, Role.ROOT})
+        return
+    role = normalize_role(actor.role)
+    if role is Role.ROOT:
+        return
+    if role is Role.ADMIN:
+        if admin_profile_has_scope(actor.admin_profile, AdminScope.CONTENT_MODERATION):
+            return
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "role_required_scope",
+                "required_scope": AdminScope.CONTENT_MODERATION.value,
+                "actual_role": role.value,
+                "actual_admin_profile": actor.admin_profile.to_dict(),
+            },
+        )
+    require_role_value(role.value, {Role.ADMIN, Role.ROOT})
+
+
+def _admin_or_root_ctx(ctx=Depends(require_ui_session), actor: AuthenticatedUser | Any = Depends(require_content_moderation_operator)) -> Dict[str, Any]:
+    resolved_actor = _resolve_actor_from_context(ctx, actor)
+    _require_content_moderation_actor(resolved_actor)
     return ctx
 
 

--- a/docs/admin-endpoint-scope-authorization-matrix.md
+++ b/docs/admin-endpoint-scope-authorization-matrix.md
@@ -1,0 +1,56 @@
+# AP-007 Endpoint-to-scope authorization matrix
+
+This matrix inventories all currently admin-gated API routes and classifies each route to one of:
+
+- `auth_support`
+- `billing_support`
+- `content_moderation`
+- `general_admin_only`
+
+Routes that are not safely classifiable to a domain scope are explicitly marked as deferred for security review.
+
+## Scope mapping decisions
+
+- **`auth_support`**: login/session/account-access support actions.
+- **`billing_support`**: payment, charge, and account-balance support actions.
+- **`content_moderation`**: user-generated content review/moderation enforcement actions.
+- **`general_admin_only`**: privileged cross-domain or governance actions not limited to one support domain.
+
+## Admin-gated route inventory
+
+| Method | Route | Current guard | Classified scope | Owner | Status | Notes |
+|---|---|---|---|---|---|---|
+| POST | `/admin/impersonation/start` | `require_admin_or_root` | `auth_support` | Auth Platform | Classified | Account access troubleshooting; root-only target guardrails remain in handler. |
+| POST | `/admin/impersonation/stop` | `require_admin_or_root` | `auth_support` | Auth Platform | Classified | Ends support impersonation sessions. |
+| GET | `/admin/impersonation/audit` | `require_admin_or_root` | `general_admin_only` | Security Operations | Deferred (security review) | Audit visibility is cross-domain and may require narrower read policy than action policy. |
+| POST | `/admin/roles/grant` | `require_root` | `general_admin_only` | Identity & Access Management | Classified | Governance-critical role assignment; root-only preserved. |
+| POST | `/admin/roles/revoke` | `require_root` | `general_admin_only` | Identity & Access Management | Classified | Governance-critical role revocation; root-only preserved. |
+| POST | `/admin/roles/update-profile` | `require_root` | `general_admin_only` | Identity & Access Management | Classified | Capability-profile governance; root-only preserved. |
+| GET | `/admin/roles/audit` | `require_root` | `general_admin_only` | Identity & Access Management | Classified | Role governance audit stream. |
+| POST | `/api/billing/_dev/add-charge` | `require_admin_or_root_session` | `billing_support` | Billing Platform | Classified | Billing-only mutation for support/testing flows. |
+| POST | `/ui/billing/_dev/add-charge` | `require_admin_or_root_session` | `billing_support` | Billing Platform | Classified | UI alias for same billing support mutation. |
+| GET | `/v1/fs/admin/list` | `_admin_or_root_ctx` | `content_moderation` | Trust & Safety | Deferred (security review) | File inventory may be moderation-related, but ownership/privacy constraints require review. |
+| GET | `/v1/fs/admin/search` | `_admin_or_root_ctx` | `content_moderation` | Trust & Safety | Deferred (security review) | Metadata search can be moderation tooling or support tooling depending on intent. |
+| GET | `/v1/fs/admin/read` | `_admin_or_root_ctx` | `content_moderation` | Trust & Safety | Deferred (security review) | Potential content access; existing feature flag allows root-only content read in some tiers. |
+| GET | `/v1/fs/admin/audit` | `_admin_or_root_ctx` | `general_admin_only` | Security Operations | Deferred (security review) | Cross-domain telemetry; needs decision on least-privilege read audience. |
+| POST | `/v1/fs/purge-deleted` | `_admin_or_root_ctx` | `general_admin_only` | Storage Platform | Deferred (security review) | Destructive operation without domain ownership encoded in route. |
+
+## Explicitly unresolved/ambiguous routes for review
+
+The following routes are intentionally deferred and require security sign-off before AP-008+ enforcement migrations:
+
+1. `GET /admin/impersonation/audit`
+2. `GET /v1/fs/admin/list`
+3. `GET /v1/fs/admin/search`
+4. `GET /v1/fs/admin/read`
+5. `GET /v1/fs/admin/audit`
+6. `POST /v1/fs/purge-deleted`
+
+## Coverage check
+
+All currently admin-gated routes identified via broad admin/root checks are included above:
+
+- `require_admin_or_root` routes in `app/routers/admin_impersonation.py`
+- root-governed role routes in `app/routers/admin_roles.py`
+- `require_admin_or_root_session` route aliases in `app/routers/billing.py`
+- `_admin_or_root_ctx` routes in `app/routers/filemanager.py`

--- a/docs/admin-permissions-model-extension-plan.md
+++ b/docs/admin-permissions-model-extension-plan.md
@@ -1,0 +1,154 @@
+# Admin permissions model extension plan
+
+## Goal
+Introduce scoped admin roles so support staff can be limited to specific operational domains:
+
+- **Login & account recovery admins** can help with sign-in, MFA, passwordless, and recovery actions only.
+- **Billing admins** can handle billing, payments, subscriptions, invoices, and refunds only.
+- **Content moderation admins** can review and moderate user-generated content only.
+- **General admins** keep broad admin access (non-root), while **root** remains the highest-privilege role.
+
+## Current-state constraints
+
+- Authorization is currently coarse-grained (`root`, `admin`, `user`) via `Role` enum and policy helpers.
+- Role management APIs only grant/revoke the single `admin` role.
+- Existing admin checks are endpoint-level (for example `require_admin_or_root`) and do not model domain scopes.
+
+## Proposed authorization model
+
+### 1) Split identity role from admin capability scope
+Keep top-level identity roles:
+
+- `root`
+- `admin`
+- `user`
+
+Add a separate **admin capability profile** persisted on user records, for users where `role=admin`.
+
+Example shape:
+
+```json
+{
+  "role": "admin",
+  "admin_profile": {
+    "type": "scoped",
+    "scopes": ["auth_support", "billing_support"]
+  }
+}
+```
+
+Alternative for general admins:
+
+```json
+{
+  "role": "admin",
+  "admin_profile": {
+    "type": "general"
+  }
+}
+```
+
+### 2) Define capability vocabulary
+Use stable scope keys:
+
+- `auth_support` (login/account recovery/MFA/passwordless/device trust)
+- `billing_support` (billing, subscriptions, payment methods, reconciliation assist tools)
+- `content_moderation` (newsfeed moderation, abuse actions, moderation queue)
+- `admin_general` (optional synthetic scope if you prefer explicit broad capability)
+
+Rules:
+
+- `root` bypasses scope checks.
+- `admin` with `type=general` is allowed in all admin-gated domains.
+- `admin` with `type=scoped` must have the required scope(s) for each domain action.
+- `user` has no admin privileges.
+
+## Implementation phases
+
+### Phase 1 — Data model and policy primitives
+1. Add an admin capability model in auth layer (`app/auth/roles.py` or a new `app/auth/admin_scopes.py`):
+   - enum/constants for scopes
+   - parser/normalizer for stored `admin_profile`
+   - helper: `admin_has_scope(user, required_scope)`
+2. Add policy dependencies in `app/auth/policy.py`:
+   - `require_admin_scope(scope)`
+   - `require_general_admin_or_root()` (for endpoints needing broad powers)
+3. Keep `require_admin_or_root()` temporarily for backward compatibility while migrating endpoints.
+
+**Deliverable:** policy helpers compiled and unit-tested without endpoint migration.
+
+### Phase 2 — Role assignment API evolution
+1. Extend admin role APIs (`app/routers/admin_roles.py`) to support profile assignment when granting admin:
+   - grant payload accepts either `general` or `scoped` + scope list
+   - validate allowed scopes, reject empty scoped set
+2. Add targeted endpoint for updating scope/profile of existing admins (root-only):
+   - `POST /admin/roles/update-profile`
+3. Expand role audit event schema to include profile transitions:
+   - `previous_admin_profile`, `new_admin_profile`
+
+**Deliverable:** root can create any of the 4 admin types and audit changes.
+
+### Phase 3 — Endpoint permission migration (backend)
+Migrate routes by domain and replace broad checks with scope-aware dependencies.
+
+1. **Auth support domain**
+   - likely routers: `password_recovery`, `recovery`, `passwordless`, `mfa_devices`, `ui_mfa`, `device_trust`, session-security actions.
+   - enforce `require_admin_scope("auth_support")` where admin intervention occurs.
+2. **Billing domain**
+   - likely routers: `billing`, `billing_ccbill`, `paypal`, `subscription_server`, receipts/reconcile utilities.
+   - enforce `require_admin_scope("billing_support")`.
+3. **Content moderation domain**
+   - moderation/admin actions in content routers (for example newsfeed or messaging moderation endpoints).
+   - enforce `require_admin_scope("content_moderation")`.
+4. Keep sensitive cross-domain controls as general-admin/root only:
+   - impersonation, role management, system-wide policy toggles, destructive global operations.
+
+**Deliverable:** endpoint matrix mapped to scopes; deprecated broad checks minimized.
+
+### Phase 4 — Frontend and operator UX
+1. Update admin role management UI (`frontend/src/pages/admin/RootRoleManagementPage.tsx` + API client):
+   - assign admin type: auth support / billing support / content moderation / general
+   - edit scopes for scoped admins
+2. Gate frontend admin features by returned capability profile to reduce accidental access attempts.
+3. Improve error UX for scope denial (`403 role_required_scope`) with actionable messaging.
+
+**Deliverable:** root can assign scoped/general admins from UI; scoped admins see only permitted controls.
+
+### Phase 5 — Testing and migration hardening
+1. Unit tests:
+   - scope parsing and default behavior
+   - policy dependency behavior for root/general/scoped/no-scope cases
+2. Route tests:
+   - domain-admin positive/negative authorization tests
+3. Regression tests:
+   - existing root behavior unchanged
+   - existing general admin behavior remains broad
+4. Data migration:
+   - backfill existing `role=admin` users to `admin_profile.type=general`
+   - idempotent migration script + rollback notes
+
+**Deliverable:** deterministic migration with full auth regression coverage.
+
+## Rollout strategy
+
+1. **Release A:** ship policy/data model + compatibility mode (no endpoint behavior change yet).
+2. **Release B:** enable scope-aware checks on low-risk endpoints behind a feature flag.
+3. **Release C:** migrate remaining admin endpoints and enforce profile requirements in role assignment.
+4. **Release D:** remove legacy broad checks where no longer needed.
+
+## Security and operational safeguards
+
+- Default-deny for scoped admins on unclassified endpoints until explicitly mapped.
+- Root-only control for creating/updating admin profiles.
+- Full audit trail for role/profile/scope changes.
+- Add metrics for denied scope checks by route to catch misclassification quickly.
+- Document incident break-glass process for temporary general-admin elevation.
+
+## Suggested acceptance criteria
+
+- Root can create all four admin categories.
+- Login support admin can perform recovery/login actions but cannot access billing or moderation admin actions.
+- Billing admin can perform billing actions but cannot access login support or moderation admin actions.
+- Content moderation admin can perform moderation actions but cannot access login support or billing admin actions.
+- General admin can access all non-root admin functions.
+- All denied actions return a structured 403 with missing scope detail and are audit logged.

--- a/docs/admin-permissions-model-extension-tickets.md
+++ b/docs/admin-permissions-model-extension-tickets.md
@@ -1,0 +1,313 @@
+# Admin permissions model extension — Implementation tickets
+
+This backlog translates `docs/admin-permissions-model-extension-plan.md` into implementation-ready tickets.
+
+## Delivery assumptions
+- Keep existing top-level roles (`root`, `admin`, `user`) and add scoped admin capabilities via `admin_profile`.
+- Ship with backward compatibility first; tighten enforcement in phased rollout.
+- Root remains the only actor that can create/modify admin capability profiles.
+
+---
+
+## Epic AP-1 — Authorization model foundation
+
+### AP-001: Define admin scope constants and profile schema
+**Goal**: Introduce a canonical scope vocabulary and normalized admin profile structure.
+
+**Scope**
+- Add canonical scope keys and profile type enums/constants (`general`, `scoped`).
+- Add parser/normalizer for persisted `admin_profile` values.
+- Define deterministic fallback behavior for malformed/missing profile data.
+
+**Acceptance criteria**
+- Scope names are centralized and imported from one source of truth.
+- Profile normalization is deterministic for valid/invalid input.
+- Unit tests cover schema normalization and fallback behavior.
+
+**Dependencies**: None.
+
+---
+
+### AP-002: Add policy helpers for scope-based authorization
+**Goal**: Extend auth policy with reusable dependencies for scoped admin checks.
+
+**Scope**
+- Add `require_admin_scope(scope)` policy dependency.
+- Add `require_general_admin_or_root()` policy dependency.
+- Preserve `require_admin_or_root()` temporarily for compatibility while migration is in progress.
+
+**Acceptance criteria**
+- Root always passes scoped checks.
+- General admins pass all admin-domain checks.
+- Scoped admins are denied when required scope is missing with structured `403` payload.
+- Unit tests cover root/general/scoped/user allow-deny matrix.
+
+**Dependencies**: AP-001.
+
+---
+
+### AP-003: Add structured authorization denial contract for missing scopes
+**Goal**: Standardize API error shape for scope-denied requests.
+
+**Scope**
+- Add/extend error payload to include fields like `code`, `required_scope`, and `actual_admin_profile` summary.
+- Ensure denied scope checks are auditable.
+
+**Acceptance criteria**
+- All scope-denied responses use one canonical error contract.
+- Tests assert response schema and status code consistency.
+
+**Dependencies**: AP-002.
+
+---
+
+## Epic AP-2 — Role/profile lifecycle APIs and auditing
+
+### AP-004: Extend admin grant API to accept capability profile
+**Goal**: Allow root to create either general admins or scoped admins.
+
+**Scope**
+- Extend grant request payload with profile mode (`general` or `scoped`) and optional `scopes` list.
+- Validate: allowed scope values, no duplicates, non-empty set for scoped mode.
+- Preserve existing root-only guardrails and root immutability behavior.
+
+**Acceptance criteria**
+- Root can grant admin with `general` profile.
+- Root can grant admin with `scoped` profile for any supported scope set.
+- Invalid profile payloads fail with deterministic `400` errors.
+
+**Dependencies**: AP-001, AP-002.
+
+---
+
+### AP-005: Add profile update endpoint for existing admins
+**Goal**: Support changing admin capability profile after role grant.
+
+**Scope**
+- Add root-only endpoint: `POST /admin/roles/update-profile`.
+- Enforce target eligibility (`role=admin`, not root, existing user).
+- Support transitions: `general -> scoped`, `scoped -> general`, `scoped -> scoped`.
+
+**Acceptance criteria**
+- Root can update profile transitions safely.
+- Non-root actors receive `403`.
+- Invalid transitions or targets return explicit errors.
+
+**Dependencies**: AP-004.
+
+---
+
+### AP-006: Expand role audit events to include profile transitions
+**Goal**: Preserve a complete immutable audit trail for profile changes.
+
+**Scope**
+- Add profile fields to relevant audit events (`previous_admin_profile`, `new_admin_profile`).
+- Apply to grant/revoke/update-profile events.
+- Keep actor/target/request metadata intact.
+
+**Acceptance criteria**
+- Every role/profile mutation writes immutable event(s) with old/new profile values.
+- Audit query endpoint returns profile transition data.
+
+**Dependencies**: AP-004, AP-005.
+
+---
+
+## Epic AP-3 — Backend endpoint migration by domain
+
+### AP-007: Build endpoint-to-scope authorization matrix
+**Goal**: Classify all admin-gated routes before enforcing scoped checks.
+
+**Scope**
+- Inventory endpoints currently using broad admin checks.
+- Map each endpoint to one of: `auth_support`, `billing_support`, `content_moderation`, or `general_admin_only`.
+- Mark unresolved/ambiguous routes for security review.
+
+**Acceptance criteria**
+- Published matrix includes route, method, scope, and owner.
+- All current admin-gated routes are classified or explicitly deferred.
+
+**Dependencies**: AP-002.
+
+---
+
+### AP-008: Migrate auth-support routes to `auth_support` scope
+**Goal**: Restrict admin intervention in login/recovery domains to appropriate admins.
+
+**Scope**
+- Apply `require_admin_scope("auth_support")` to designated auth-support endpoints.
+- Keep root bypass behavior.
+- Add positive/negative tests for scope-specific access.
+
+**Acceptance criteria**
+- Auth-support scoped admins can perform allowed auth-support actions.
+- Billing/moderation scoped admins are denied on auth-support routes.
+
+**Dependencies**: AP-007.
+
+---
+
+### AP-009: Migrate billing routes to `billing_support` scope
+**Goal**: Restrict billing operations to billing-capable admins.
+
+**Scope**
+- Apply `require_admin_scope("billing_support")` to billing endpoints/services.
+- Ensure shared billing helpers use consistent authorization paths.
+- Add positive/negative tests.
+
+**Acceptance criteria**
+- Billing scoped admins can perform allowed billing actions.
+- Auth/moderation scoped admins are denied on billing routes.
+
+**Dependencies**: AP-007.
+
+---
+
+### AP-010: Migrate moderation routes to `content_moderation` scope
+**Goal**: Restrict moderation controls to moderation-capable admins.
+
+**Scope**
+- Apply `require_admin_scope("content_moderation")` to moderation/admin content controls.
+- Add tests for allow/deny behavior.
+
+**Acceptance criteria**
+- Moderation scoped admins can perform moderation actions.
+- Non-moderation scoped admins are denied.
+
+**Dependencies**: AP-007.
+
+---
+
+### AP-011: Enforce general-admin-or-root checks for cross-domain sensitive controls
+**Goal**: Keep high-risk controls limited to broad admins/root.
+
+**Scope**
+- Replace broad legacy checks on designated sensitive endpoints with `require_general_admin_or_root()`.
+- Candidate domains include impersonation controls, role management, and global policy toggles.
+
+**Acceptance criteria**
+- Scoped admins cannot access general-admin-only controls.
+- General admins and root continue to access those controls.
+
+**Dependencies**: AP-002, AP-007.
+
+---
+
+## Epic AP-4 — Frontend and operator workflows
+
+### AP-012: Update root admin role management UI for profile assignment
+**Goal**: Allow root operators to create/edit scoped or general admins from UI.
+
+**Scope**
+- Add profile mode selector and scope multi-select in role management page.
+- Wire API request/response contracts for profile fields.
+- Add form validation and clear operator guidance text.
+
+**Acceptance criteria**
+- Root can assign each of the 4 requested admin categories via UI.
+- Invalid combinations are blocked client-side and handled server-side.
+
+**Dependencies**: AP-004, AP-005.
+
+---
+
+### AP-013: Gate admin frontend surfaces by capability profile
+**Goal**: Reduce accidental unauthorized actions and noisy 403s.
+
+**Scope**
+- Hide/disable admin controls not permitted by current profile.
+- Keep server as source of truth (frontend gating is UX optimization, not security boundary).
+
+**Acceptance criteria**
+- Scoped admins only see relevant admin UI sections by default.
+- General admins keep broad admin UI access.
+
+**Dependencies**: AP-001, AP-012.
+
+---
+
+### AP-014: Add user-facing scope-denied error UX
+**Goal**: Provide actionable denial messages for support operators.
+
+**Scope**
+- Map scope-denied API responses to human-readable explanations.
+- Include recommended escalation path (for example request temporary elevation).
+
+**Acceptance criteria**
+- Scope-denied interactions show consistent actionable messaging.
+- No raw/unparsed backend error payloads leak into UI.
+
+**Dependencies**: AP-003, AP-013.
+
+---
+
+## Epic AP-5 — Migration, release controls, and observability
+
+### AP-015: Backfill existing admins to `admin_profile.type=general`
+**Goal**: Preserve existing admin capabilities during rollout.
+
+**Scope**
+- Create idempotent migration job/script for existing `role=admin` users.
+- Add dry-run/report mode and rollback notes.
+
+**Acceptance criteria**
+- Migration can run repeatedly without duplicate/inconsistent writes.
+- Existing admins retain broad access post-migration.
+
+**Dependencies**: AP-001.
+
+---
+
+### AP-016: Add feature flags for phased enforcement
+**Goal**: De-risk production rollout.
+
+**Scope**
+- Add flags to control per-domain scope enforcement activation.
+- Add operational runbook for progressive enablement.
+
+**Acceptance criteria**
+- Teams can independently enable auth, billing, and moderation scope checks.
+- Rollback is possible by toggling flags without data rollback.
+
+**Dependencies**: AP-008, AP-009, AP-010.
+
+---
+
+### AP-017: Add metrics and alerts for denied scope checks
+**Goal**: Detect misclassification and support friction early.
+
+**Scope**
+- Emit metrics for `scope_denied` by route/scope/profile type.
+- Add alert thresholds for spikes post-rollout.
+
+**Acceptance criteria**
+- Dashboards show denial trends by endpoint and scope.
+- Alerting triggers on abnormal denial spikes.
+
+**Dependencies**: AP-003.
+
+---
+
+### AP-018: Build end-to-end authorization regression suite
+**Goal**: Prevent permission regressions as route coverage expands.
+
+**Scope**
+- Add test matrix for user, scoped-admin variants, general admin, and root.
+- Cover all migrated domains and general-admin-only controls.
+- Verify audit event emission on denied and allowed privileged operations where applicable.
+
+**Acceptance criteria**
+- CI includes permission matrix tests for scoped/admin/root behavior.
+- Regressions in scope enforcement block merge.
+
+**Dependencies**: AP-008, AP-009, AP-010, AP-011.
+
+---
+
+## Requested admin categories mapping
+
+- **Login/account recovery admin** = `role=admin`, `admin_profile.type=scoped`, `scopes=["auth_support"]`
+- **Billing admin** = `role=admin`, `admin_profile.type=scoped`, `scopes=["billing_support"]`
+- **Content moderation admin** = `role=admin`, `admin_profile.type=scoped`, `scopes=["content_moderation"]`
+- **General admin** = `role=admin`, `admin_profile.type=general`
+

--- a/docs/admin-profile-backfill-ap015.md
+++ b/docs/admin-profile-backfill-ap015.md
@@ -1,0 +1,54 @@
+# AP-015 admin profile backfill runbook
+
+## Goal
+Backfill existing `role=admin` users to explicit `admin_profile.type=general` so they retain broad admin capabilities during scoped-admin rollout.
+
+## Script
+Use:
+
+- `scripts/backfill_admin_profiles_general.py`
+
+## Behavior
+
+- **Idempotent**:
+  - skips non-admin users,
+  - skips admins already set to `{"type":"general"}`,
+  - skips admins already explicitly scoped,
+  - only targets admins with missing/malformed profile payloads that normalize to `general`.
+- Supports **dry-run by default**.
+- Supports JSON **report output** for review/audit.
+
+## Commands
+
+### 1) Dry-run with report (recommended first)
+
+```bash
+python scripts/backfill_admin_profiles_general.py --report-file ap015-dry-run.json
+```
+
+### 2) Apply migration
+
+```bash
+python scripts/backfill_admin_profiles_general.py --apply --report-file ap015-apply.json
+```
+
+### 3) Re-run safely
+
+Re-running is safe and should produce zero or reduced candidates once migration is complete.
+
+```bash
+python scripts/backfill_admin_profiles_general.py --apply --report-file ap015-rerun.json
+```
+
+## Rollback notes
+
+This migration only writes explicit general profile state for legacy admin users. Existing scoped admins are not modified.
+
+If rollback is needed:
+
+1. Use `ap015-apply.json` candidate list to identify touched users.
+2. For each touched user, either:
+   - remove `admin_profile` to restore pre-backfill implicit behavior, or
+   - set a corrected explicit profile (`general`/`scoped`) via root role-management API/UI.
+
+Because runtime normalization already treats missing/malformed admin profile as `general`, rollback risk is low for access continuity.

--- a/docs/admin-scope-enforcement-feature-flags-runbook.md
+++ b/docs/admin-scope-enforcement-feature-flags-runbook.md
@@ -1,0 +1,82 @@
+# Admin Scope Enforcement Feature Flags Runbook (AP-016)
+
+## Purpose
+Use these feature flags to enable scoped-admin authorization checks by domain in controlled phases. Flags can be toggled independently for auth-support, billing, and moderation without reverting role/profile data.
+
+## Flags
+- `ADMIN_SCOPE_ENFORCE_AUTH_SUPPORT` (default: `1`)
+  - `1`: enforce `auth_support` scoped checks for auth-support admin controls.
+  - `0`: fallback to legacy broad `admin/root` behavior for those controls.
+- `ADMIN_SCOPE_ENFORCE_BILLING_SUPPORT` (default: `1`)
+  - `1`: enforce `billing_support` scoped checks on billing admin operations.
+  - `0`: fallback to legacy broad `admin/root` behavior.
+- `ADMIN_SCOPE_ENFORCE_CONTENT_MODERATION` (default: `1`)
+  - `1`: enforce `content_moderation` scoped checks for moderation controls.
+  - `0`: fallback to legacy broad `admin/root` behavior.
+
+## Recommended progressive enablement
+1. **Pre-checks**
+   - Ensure AP-015 backfill completed for existing admins (`admin_profile.type=general`).
+   - Verify API metrics/logs for `403 role_required_scope` are observable.
+2. **Auth-support rollout**
+   - Set only `ADMIN_SCOPE_ENFORCE_AUTH_SUPPORT=1` in target environment.
+   - Keep billing/moderation flags at current desired state.
+   - Validate auth-support scoped admins can access auth-support endpoints.
+3. **Billing rollout**
+   - Set `ADMIN_SCOPE_ENFORCE_BILLING_SUPPORT=1`.
+   - Validate billing scoped admins can perform billing actions; non-billing scoped admins are denied.
+4. **Moderation rollout**
+   - Set `ADMIN_SCOPE_ENFORCE_CONTENT_MODERATION=1`.
+   - Validate moderation scoped admins can perform moderation actions; non-moderation scoped admins are denied.
+
+## Verification checklist
+- Root retains access across all admin domains.
+- General admins retain broad access.
+- Scoped admins are granted only their assigned domain permissions.
+- Denials return structured scope error payloads (`code=role_required_scope`) for operator UX mapping.
+
+## Rollback
+If a domain rollout causes operational issues:
+1. Toggle the domain flag to `0`.
+2. Redeploy/reload configuration.
+3. Confirm legacy broad `admin/root` behavior restored for that domain.
+
+No role-data rollback is required; admin profile records remain valid and can be re-used when the flag is turned back on.
+
+## Scope-denied metrics and alerts (AP-017)
+
+### Metric emitted
+- `admin_scope_denied_total{route,required_scope,admin_profile_type}`
+  - emitted whenever `require_admin_scope(...)` denies an admin request with `403 code=role_required_scope`.
+  - dimensions:
+    - `route`: normalized FastAPI route path (for example `/api/billing/_dev/add-charge`).
+    - `required_scope`: one of `auth_support`, `billing_support`, `content_moderation`.
+    - `admin_profile_type`: effective profile type of caller (`general` or `scoped`).
+
+### Dashboard panels
+Add these panels to the admin-scope rollout dashboard:
+1. **Total scope denials (all domains)**
+   - `sum(increase(admin_scope_denied_total[15m]))`
+2. **Denials by route**
+   - `topk(10, sum by (route) (increase(admin_scope_denied_total[15m])))`
+3. **Denials by required scope**
+   - `sum by (required_scope) (increase(admin_scope_denied_total[15m]))`
+4. **Denials by profile type**
+   - `sum by (admin_profile_type) (increase(admin_scope_denied_total[15m]))`
+
+### Alert thresholds
+Start with conservative rollout thresholds and tune per environment:
+- **Warning: domain denial spike**
+  - Trigger when any scope exceeds 20 denials in 15 minutes.
+  - PromQL example:
+    - `sum by (required_scope) (increase(admin_scope_denied_total[15m])) > 20`
+- **Critical: endpoint denial spike**
+  - Trigger when any single endpoint exceeds 30 denials in 10 minutes.
+  - PromQL example:
+    - `sum by (route, required_scope) (increase(admin_scope_denied_total[10m])) > 30`
+
+### Alert response guidance
+- Correlate spike scope/route with recent flag toggles (`ADMIN_SCOPE_ENFORCE_*`) and role-profile updates.
+- If misclassification is suspected, disable only the impacted domain flag as an immediate rollback.
+- Open a security review ticket for repeated spikes on the same route/scope pair.
+

--- a/frontend/src/api/client.errorMapping.test.ts
+++ b/frontend/src/api/client.errorMapping.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeErrorDetail } from "./client";
+
+describe("normalizeErrorDetail authorization mapping", () => {
+  it("maps scope-denied payload to actionable guidance", () => {
+    const msg = normalizeErrorDetail(
+      {
+        code: "role_required_scope",
+        required_scope: "billing_support",
+        actual_role: "admin",
+      },
+      "Permission denied",
+    );
+
+    expect(msg).toContain("billing support");
+    expect(msg).toContain("Request temporary elevation");
+  });
+
+  it("maps general-admin-required payload to actionable guidance", () => {
+    const msg = normalizeErrorDetail(
+      {
+        code: "role_required_admin_profile_type",
+        required_admin_profile_type: "general",
+        actual_role: "admin",
+      },
+      "Permission denied",
+    );
+
+    expect(msg).toContain("general admin access");
+    expect(msg).toContain("Request temporary elevation");
+  });
+
+  it("does not leak raw object payload for unknown structures", () => {
+    const msg = normalizeErrorDetail({ code: "unknown_code", foo: "bar" }, "Permission denied");
+    expect(msg).toBe("Permission denied");
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,7 +18,35 @@ function getCookie(name: string): string | null {
   return match ? decodeURIComponent(match[1]!) : null;
 }
 
-function normalizeErrorDetail(detail: unknown, fallback: string): string {
+function humanizeScope(scope: unknown): string {
+  if (typeof scope !== "string" || !scope.trim()) return "required scope";
+  if (scope === "auth_support") return "authentication support";
+  if (scope === "billing_support") return "billing support";
+  if (scope === "content_moderation") return "content moderation";
+  return scope.replace(/_/g, " ");
+}
+
+function mapAuthorizationError(detail: Record<string, unknown>): string | null {
+  const code = typeof detail.code === "string" ? detail.code : null;
+  if (!code) return null;
+
+  if (code === "role_required_scope") {
+    const scope = humanizeScope(detail.required_scope);
+    return `You don't currently have ${scope} permission for this action. Request temporary elevation or ask a general admin/root operator to perform it.`;
+  }
+
+  if (code === "role_required_admin_profile_type") {
+    return "This action requires general admin access. Request temporary elevation or ask a general admin/root operator to perform it.";
+  }
+
+  if (code === "role_required") {
+    return "You don't currently have permission for this action. Request temporary elevation or contact a general admin/root operator.";
+  }
+
+  return null;
+}
+
+export function normalizeErrorDetail(detail: unknown, fallback: string): string {
   if (typeof detail === "string") {
     return detail;
   }
@@ -39,6 +67,12 @@ function normalizeErrorDetail(detail: unknown, fallback: string): string {
       .filter(Boolean);
     if (messages.length > 0) {
       return messages.join(", ");
+    }
+  }
+  if (detail && typeof detail === "object") {
+    const mapped = mapAuthorizationError(detail as Record<string, unknown>);
+    if (mapped) {
+      return mapped;
     }
   }
   if (detail && typeof detail === "object" && "msg" in detail) {

--- a/frontend/src/api/endpoints/adminRoles.ts
+++ b/frontend/src/api/endpoints/adminRoles.ts
@@ -1,9 +1,26 @@
 import { api } from "@/api/client";
 
-export interface RoleGrantRevokeReq {
+export type AdminProfileType = "general" | "scoped";
+export type AdminScope = "auth_support" | "billing_support" | "content_moderation";
+
+export interface AdminProfile {
+  type: AdminProfileType;
+  scopes?: AdminScope[];
+}
+
+export interface RoleGrantReq {
   target_user_sub: string;
   role: "admin";
   reason: string;
+  admin_profile_type?: AdminProfileType;
+  admin_scopes?: AdminScope[];
+}
+
+export interface RoleUpdateProfileReq {
+  target_user_sub: string;
+  reason: string;
+  admin_profile_type: AdminProfileType;
+  admin_scopes?: AdminScope[];
 }
 
 export interface RoleGrantRevokeResp {
@@ -11,16 +28,19 @@ export interface RoleGrantRevokeResp {
   target_user_sub: string;
   role: "admin" | "user";
   event_id: string;
+  admin_profile?: AdminProfile;
 }
 
 export interface RoleAuditItem {
   event_id: string;
-  action: "grant" | "revoke" | string;
+  action: "grant" | "revoke" | "update_profile" | string;
   actor_sub: string;
   target_user_sub: string;
   previous_role: string;
   new_role: string;
   reason: string;
+  previous_admin_profile?: AdminProfile | null;
+  new_admin_profile?: AdminProfile | null;
   ip?: string;
   request_id?: string;
   ts: number;
@@ -31,11 +51,15 @@ export interface RoleAuditResp {
   cursor?: string | null;
 }
 
-export function grantAdminRole(body: RoleGrantRevokeReq) {
+export function grantAdminRole(body: RoleGrantReq) {
   return api.post<RoleGrantRevokeResp>("/admin/roles/grant", body);
 }
 
-export function revokeAdminRole(body: RoleGrantRevokeReq) {
+export function updateAdminProfile(body: RoleUpdateProfileReq) {
+  return api.post<RoleGrantRevokeResp>("/admin/roles/update-profile", body);
+}
+
+export function revokeAdminRole(body: Pick<RoleGrantReq, "target_user_sub" | "role" | "reason">) {
   return api.post<RoleGrantRevokeResp>("/admin/roles/revoke", body);
 }
 

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -80,6 +80,8 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Separator } from "@/components/ui/separator";
+import { useAuthStore } from "@/stores/authStore";
+import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 
 const MOBILE_NAV_GROUPS = [
   {
@@ -121,6 +123,8 @@ const MOBILE_NAV_GROUPS = [
 
 function MobileSidebar({ onNavigate }: { onNavigate: () => void }) {
   const location = useLocation();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const showRootRoleManagement = canSeeRootRoleManagement(accessToken);
 
   const isActive = (path: string) => {
     if (path === "/") return location.pathname === "/";
@@ -141,14 +145,17 @@ function MobileSidebar({ onNavigate }: { onNavigate: () => void }) {
 
       {/* Nav */}
       <nav className="flex-1 overflow-y-auto px-2 py-3">
-        {MOBILE_NAV_GROUPS.map((group, gi) => (
+        {MOBILE_NAV_GROUPS.map((group, gi) => {
+          const items = group.items.filter((item) => item.path !== "/root/roles" || showRootRoleManagement);
+          if (items.length === 0) return null;
+          return (
           <div key={group.title}>
             {gi > 0 && <Separator className="my-2" />}
             <span className="mb-1 block px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
               {group.title}
             </span>
             <ul className="space-y-0.5">
-              {group.items.map((item) => {
+              {items.map((item) => {
                 const active = isActive(item.path);
                 return (
                   <li key={item.path}>
@@ -170,7 +177,8 @@ function MobileSidebar({ onNavigate }: { onNavigate: () => void }) {
               })}
             </ul>
           </div>
-        ))}
+          );
+        })}
       </nav>
     </div>
   );

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -25,6 +25,8 @@ import {
 } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { useAuthStore } from "@/stores/authStore";
+import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 
 // ─── Tab config ─────────────────────────────────────────────────
 
@@ -52,6 +54,10 @@ const MORE_LINKS = [
 export default function MobileNav() {
   const [moreOpen, setMoreOpen] = React.useState(false);
   const navigate = useNavigate();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const showRootRoleManagement = canSeeRootRoleManagement(accessToken);
+
+  const moreLinks = MORE_LINKS.filter((item) => item.path !== "/root/roles" || showRootRoleManagement);
 
   return (
     <>
@@ -91,7 +97,7 @@ export default function MobileNav() {
           </SheetHeader>
           <Separator className="my-3" />
           <div className="grid grid-cols-4 gap-4 pb-4">
-            {MORE_LINKS.map((link) => (
+            {moreLinks.map((link) => (
               <Button
                 key={link.path}
                 variant="ghost"

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -23,6 +23,8 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Separator } from "@/components/ui/separator";
 import { useUiStore } from "@/stores/uiStore";
+import { useAuthStore } from "@/stores/authStore";
+import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 
 // ─── Navigation Config ──────────────────────────────────────────
 
@@ -82,6 +84,8 @@ export default function Sidebar() {
   const collapsed = useUiStore((s) => s.sidebarCollapsed);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const location = useLocation();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const showRootRoleManagement = canSeeRootRoleManagement(accessToken);
 
   const isActive = (path: string) => {
     if (path === "/") return location.pathname === "/";
@@ -113,7 +117,10 @@ export default function Sidebar() {
 
       {/* Navigation */}
       <nav className="flex-1 overflow-y-auto px-2 py-3">
-        {NAV_GROUPS.map((group, gi) => (
+        {NAV_GROUPS.map((group, gi) => {
+          const items = group.items.filter((item) => item.path !== "/root/roles" || showRootRoleManagement);
+          if (items.length === 0) return null;
+          return (
           <div key={group.title}>
             {gi > 0 && <Separator className="my-2" />}
             {!collapsed && (
@@ -122,7 +129,7 @@ export default function Sidebar() {
               </span>
             )}
             <ul className="space-y-0.5">
-              {group.items.map((item) => {
+              {items.map((item) => {
                 const active = isActive(item.path);
                 const link = (
                   <NavLink
@@ -167,7 +174,8 @@ export default function Sidebar() {
               })}
             </ul>
           </div>
-        ))}
+          );
+        })}
       </nav>
 
       {/* Collapse toggle */}

--- a/frontend/src/components/shared/ImpersonationBanner.tsx
+++ b/frontend/src/components/shared/ImpersonationBanner.tsx
@@ -8,19 +8,11 @@ import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { useAuthStore } from "@/stores/authStore";
+import { canAccessGeneralAdminControls } from "@/lib/adminCapabilities";
 import { useImpersonationStore } from "@/stores/impersonationStore";
 import { startImpersonation, stopImpersonation } from "@/api/endpoints/adminImpersonation";
 import { ApiError } from "@/api/client";
 
-function accessTokenRole(token: string | null): string | null {
-  if (!token || token.split(".").length < 2) return null;
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]!));
-    return typeof payload?.role === "string" ? payload.role : null;
-  } catch {
-    return null;
-  }
-}
 
 function formatExpiry(epoch?: number | null) {
   if (!epoch) return "-";
@@ -29,8 +21,7 @@ function formatExpiry(epoch?: number | null) {
 
 export default function ImpersonationBanner() {
   const accessToken = useAuthStore((s) => s.accessToken);
-  const role = accessTokenRole(accessToken);
-  const canImpersonate = role === "admin" || role === "root";
+  const canImpersonate = canAccessGeneralAdminControls(accessToken);
 
   const imp = useImpersonationStore();
   const active = imp.isActive();
@@ -90,7 +81,7 @@ export default function ImpersonationBanner() {
               {imp.actorSub ? <> (actor: {imp.actorSub})</> : null} • expires {formatExpiry(imp.expiresAt)}
             </span>
           ) : (
-            <span className="truncate">Admin/root impersonation controls available.</span>
+            <span className="truncate">General admin/root impersonation controls available.</span>
           )}
         </div>
 

--- a/frontend/src/lib/adminCapabilities.test.ts
+++ b/frontend/src/lib/adminCapabilities.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canAccessGeneralAdminControls,
+  canSeeRootRoleManagement,
+  getAdminProfileFromAccessToken,
+  getRoleFromAccessToken,
+} from "./adminCapabilities";
+
+function tokenFor(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+describe("adminCapabilities", () => {
+  it("parses role from token", () => {
+    expect(getRoleFromAccessToken(tokenFor({ role: "admin" }))).toBe("admin");
+    expect(getRoleFromAccessToken(tokenFor({ role: "root" }))).toBe("root");
+    expect(getRoleFromAccessToken("bad")).toBeNull();
+  });
+
+  it("normalizes admin profile from token", () => {
+    expect(getAdminProfileFromAccessToken(tokenFor({ role: "admin" }))).toEqual({ type: "general", scopes: [] });
+    expect(
+      getAdminProfileFromAccessToken(
+        tokenFor({ role: "admin", admin_profile: { type: "scoped", scopes: ["auth_support", "auth_support"] } }),
+      ),
+    ).toEqual({ type: "scoped", scopes: ["auth_support"] });
+    expect(
+      getAdminProfileFromAccessToken(
+        tokenFor({ role: "admin", admin_profile: { type: "scoped", scopes: ["unknown_scope"] } }),
+      ),
+    ).toEqual({ type: "general", scopes: [] });
+  });
+
+  it("gates general admin controls", () => {
+    expect(canAccessGeneralAdminControls(tokenFor({ role: "root" }))).toBe(true);
+    expect(canAccessGeneralAdminControls(tokenFor({ role: "admin" }))).toBe(true);
+    expect(
+      canAccessGeneralAdminControls(
+        tokenFor({ role: "admin", admin_profile: { type: "scoped", scopes: ["billing_support"] } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("gates root-only role management visibility", () => {
+    expect(canSeeRootRoleManagement(tokenFor({ role: "root" }))).toBe(true);
+    expect(canSeeRootRoleManagement(tokenFor({ role: "admin" }))).toBe(false);
+    expect(canSeeRootRoleManagement(tokenFor({ role: "user" }))).toBe(false);
+  });
+});

--- a/frontend/src/lib/adminCapabilities.ts
+++ b/frontend/src/lib/adminCapabilities.ts
@@ -1,0 +1,56 @@
+import type { AdminProfileType, AdminScope } from "@/api/endpoints/adminRoles";
+
+interface JwtAdminProfile {
+  type?: AdminProfileType | string;
+  scopes?: string[];
+}
+
+interface JwtClaims {
+  role?: string;
+  admin_profile?: JwtAdminProfile;
+}
+
+function parseJwtClaims(token: string | null): JwtClaims | null {
+  if (!token || token.split(".").length < 2) return null;
+  try {
+    return JSON.parse(atob(token.split(".")[1]!));
+  } catch {
+    return null;
+  }
+}
+
+export function getRoleFromAccessToken(token: string | null): string | null {
+  const claims = parseJwtClaims(token);
+  return typeof claims?.role === "string" ? claims.role : null;
+}
+
+export function getAdminProfileFromAccessToken(token: string | null): { type: AdminProfileType; scopes: AdminScope[] } | null {
+  const claims = parseJwtClaims(token);
+  if (!claims || claims.role !== "admin") return null;
+
+  const raw = claims.admin_profile;
+  if (!raw || raw.type !== "scoped") {
+    return { type: "general", scopes: [] };
+  }
+
+  const scopes = Array.isArray(raw.scopes)
+    ? (raw.scopes.filter((s): s is AdminScope => s === "auth_support" || s === "billing_support" || s === "content_moderation"))
+    : [];
+
+  if (scopes.length === 0) {
+    return { type: "general", scopes: [] };
+  }
+
+  return { type: "scoped", scopes: Array.from(new Set(scopes)) };
+}
+
+export function canAccessGeneralAdminControls(token: string | null): boolean {
+  const role = getRoleFromAccessToken(token);
+  if (role === "root") return true;
+  if (role !== "admin") return false;
+  return getAdminProfileFromAccessToken(token)?.type === "general";
+}
+
+export function canSeeRootRoleManagement(token: string | null): boolean {
+  return getRoleFromAccessToken(token) === "root";
+}

--- a/frontend/src/pages/admin/RootRoleManagementPage.tsx
+++ b/frontend/src/pages/admin/RootRoleManagementPage.tsx
@@ -7,6 +7,9 @@ import {
   grantAdminRole,
   listRoleAudit,
   revokeAdminRole,
+  updateAdminProfile,
+  type AdminProfileType,
+  type AdminScope,
   type RoleAuditItem,
 } from "@/api/endpoints/adminRoles";
 import { ApiError } from "@/api/client";
@@ -18,16 +21,25 @@ import { Label } from "@/components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { ErrorPage } from "@/components/shared/ErrorPage";
+import { getRoleFromAccessToken } from "@/lib/adminCapabilities";
 
-function accessTokenRole(token: string | null): string | null {
-  if (!token || token.split(".").length < 2) return null;
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]!));
-    const role = payload?.role;
-    return typeof role === "string" ? role : null;
-  } catch {
+const ADMIN_SCOPE_OPTIONS: Array<{ value: AdminScope; label: string; guidance: string }> = [
+  { value: "auth_support", label: "Auth support", guidance: "Login, session, and account recovery support" },
+  { value: "billing_support", label: "Billing support", guidance: "Payments, charges, and billing account support" },
+  { value: "content_moderation", label: "Content moderation", guidance: "Content review and moderation controls" },
+];
+
+export function validateAdminProfileInput(profileType: AdminProfileType, scopes: AdminScope[]): string | null {
+  if (profileType === "general") {
+    if (scopes.length > 0) {
+      return "General admins cannot have scoped permissions selected.";
+    }
     return null;
   }
+  if (scopes.length === 0) {
+    return "Scoped admins must include at least one scope.";
+  }
+  return null;
 }
 
 function formatTs(ts?: number): string {
@@ -35,19 +47,35 @@ function formatTs(ts?: number): string {
   return new Date(ts * 1000).toLocaleString();
 }
 
-function RoleActionForm({
-  type,
+function formatProfile(profile?: { type: string; scopes?: string[] } | null): string {
+  if (!profile) return "-";
+  if (profile.type === "general") return "general";
+  const scopes = (profile.scopes ?? []).join(", ");
+  return scopes ? `scoped (${scopes})` : "scoped";
+}
+
+function GrantAdminForm({
   onSubmit,
   loading,
 }: {
-  type: "grant" | "revoke";
-  onSubmit: (payload: { target_user_sub: string; reason: string }) => void;
+  onSubmit: (payload: {
+    target_user_sub: string;
+    reason: string;
+    admin_profile_type: AdminProfileType;
+    admin_scopes?: AdminScope[];
+  }) => void;
   loading: boolean;
 }) {
   const [targetUserSub, setTargetUserSub] = React.useState("");
   const [reason, setReason] = React.useState("");
+  const [profileType, setProfileType] = React.useState<AdminProfileType>("general");
+  const [selectedScopes, setSelectedScopes] = React.useState<AdminScope[]>([]);
 
-  const actionLabel = type === "grant" ? "Grant admin" : "Revoke admin";
+  const validationError = validateAdminProfileInput(profileType, selectedScopes);
+
+  const toggleScope = (scope: AdminScope) => {
+    setSelectedScopes((prev) => (prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]));
+  };
 
   return (
     <form
@@ -56,39 +84,198 @@ function RoleActionForm({
         e.preventDefault();
         const target = targetUserSub.trim();
         const why = reason.trim();
-        if (!target) {
-          toast.error("Target user_sub is required");
-          return;
-        }
-        if (!why) {
-          toast.error("Reason is required");
-          return;
-        }
+        if (!target) return toast.error("Target user_sub is required");
+        if (!why) return toast.error("Reason is required");
+        if (validationError) return toast.error(validationError);
+
+        onSubmit({
+          target_user_sub: target,
+          reason: why,
+          admin_profile_type: profileType,
+          admin_scopes: profileType === "scoped" ? selectedScopes : undefined,
+        });
+      }}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="grant-target">Target user_sub</Label>
+        <Input id="grant-target" value={targetUserSub} onChange={(e) => setTargetUserSub(e.target.value)} placeholder="user_123" />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="grant-reason">Reason</Label>
+        <Input id="grant-reason" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Required for audit trail" />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="grant-profile-type">Admin profile mode</Label>
+        <select
+          id="grant-profile-type"
+          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+          value={profileType}
+          onChange={(e) => {
+            const nextType = e.target.value as AdminProfileType;
+            setProfileType(nextType);
+            if (nextType === "general") setSelectedScopes([]);
+          }}
+        >
+          <option value="general">General admin (all admin domains)</option>
+          <option value="scoped">Scoped admin (selected domains only)</option>
+        </select>
+      </div>
+
+      <div className="space-y-2 rounded-md border p-3">
+        <Label>Scoped permissions</Label>
+        <p className="text-xs text-muted-foreground">
+          Select at least one scope for scoped admins. Leave all unchecked for general admins.
+        </p>
+        <div className="space-y-2">
+          {ADMIN_SCOPE_OPTIONS.map((scope) => (
+            <label key={scope.value} className="flex items-start gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={selectedScopes.includes(scope.value)}
+                onChange={() => toggleScope(scope.value)}
+                disabled={profileType === "general"}
+              />
+              <span>
+                <span className="font-medium">{scope.label}</span>
+                <span className="block text-xs text-muted-foreground">{scope.guidance}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+        {validationError ? <p className="text-xs text-destructive">{validationError}</p> : null}
+      </div>
+
+      <Button type="submit" disabled={loading}>
+        {loading ? "Submitting..." : "Grant admin"}
+      </Button>
+    </form>
+  );
+}
+
+function RevokeAdminForm({
+  onSubmit,
+  loading,
+}: {
+  onSubmit: (payload: { target_user_sub: string; reason: string }) => void;
+  loading: boolean;
+}) {
+  const [targetUserSub, setTargetUserSub] = React.useState("");
+  const [reason, setReason] = React.useState("");
+
+  return (
+    <form
+      className="space-y-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const target = targetUserSub.trim();
+        const why = reason.trim();
+        if (!target) return toast.error("Target user_sub is required");
+        if (!why) return toast.error("Reason is required");
         onSubmit({ target_user_sub: target, reason: why });
       }}
     >
       <div className="space-y-1.5">
-        <Label htmlFor={`${type}-target`}>Target user_sub</Label>
-        <Input
-          id={`${type}-target`}
-          value={targetUserSub}
-          onChange={(e) => setTargetUserSub(e.target.value)}
-          placeholder="user_123"
-        />
+        <Label htmlFor="revoke-target">Target user_sub</Label>
+        <Input id="revoke-target" value={targetUserSub} onChange={(e) => setTargetUserSub(e.target.value)} placeholder="user_123" />
       </div>
-
       <div className="space-y-1.5">
-        <Label htmlFor={`${type}-reason`}>Reason</Label>
-        <Input
-          id={`${type}-reason`}
-          value={reason}
-          onChange={(e) => setReason(e.target.value)}
-          placeholder="Required for audit trail"
-        />
+        <Label htmlFor="revoke-reason">Reason</Label>
+        <Input id="revoke-reason" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Required for audit trail" />
+      </div>
+      <Button type="submit" disabled={loading} variant="destructive">
+        {loading ? "Submitting..." : "Revoke admin"}
+      </Button>
+    </form>
+  );
+}
+
+function UpdateProfileForm({
+  onSubmit,
+  loading,
+}: {
+  onSubmit: (payload: {
+    target_user_sub: string;
+    reason: string;
+    admin_profile_type: AdminProfileType;
+    admin_scopes?: AdminScope[];
+  }) => void;
+  loading: boolean;
+}) {
+  const [targetUserSub, setTargetUserSub] = React.useState("");
+  const [reason, setReason] = React.useState("");
+  const [profileType, setProfileType] = React.useState<AdminProfileType>("general");
+  const [selectedScopes, setSelectedScopes] = React.useState<AdminScope[]>([]);
+  const validationError = validateAdminProfileInput(profileType, selectedScopes);
+
+  const toggleScope = (scope: AdminScope) => {
+    setSelectedScopes((prev) => (prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]));
+  };
+
+  return (
+    <form
+      className="space-y-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const target = targetUserSub.trim();
+        const why = reason.trim();
+        if (!target) return toast.error("Target user_sub is required");
+        if (!why) return toast.error("Reason is required");
+        if (validationError) return toast.error(validationError);
+        onSubmit({
+          target_user_sub: target,
+          reason: why,
+          admin_profile_type: profileType,
+          admin_scopes: profileType === "scoped" ? selectedScopes : undefined,
+        });
+      }}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="profile-target">Target admin user_sub</Label>
+        <Input id="profile-target" value={targetUserSub} onChange={(e) => setTargetUserSub(e.target.value)} placeholder="admin_123" />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="profile-reason">Reason</Label>
+        <Input id="profile-reason" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Why this profile change is needed" />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="update-profile-type">Admin profile mode</Label>
+        <select
+          id="update-profile-type"
+          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+          value={profileType}
+          onChange={(e) => {
+            const nextType = e.target.value as AdminProfileType;
+            setProfileType(nextType);
+            if (nextType === "general") setSelectedScopes([]);
+          }}
+        >
+          <option value="general">General admin (all admin domains)</option>
+          <option value="scoped">Scoped admin (selected domains only)</option>
+        </select>
       </div>
 
-      <Button type="submit" disabled={loading} variant={type === "grant" ? "default" : "destructive"}>
-        {loading ? "Submitting..." : actionLabel}
+      <div className="space-y-2 rounded-md border p-3">
+        <Label>Scoped permissions</Label>
+        <div className="space-y-2">
+          {ADMIN_SCOPE_OPTIONS.map((scope) => (
+            <label key={scope.value} className="flex items-start gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={selectedScopes.includes(scope.value)}
+                onChange={() => toggleScope(scope.value)}
+                disabled={profileType === "general"}
+              />
+              <span>{scope.label}</span>
+            </label>
+          ))}
+        </div>
+        {validationError ? <p className="text-xs text-destructive">{validationError}</p> : null}
+      </div>
+
+      <Button type="submit" disabled={loading} variant="secondary">
+        {loading ? "Submitting..." : "Update admin profile"}
       </Button>
     </form>
   );
@@ -97,7 +284,7 @@ function RoleActionForm({
 export default function RootRoleManagementPage() {
   const qc = useQueryClient();
   const accessToken = useAuthStore((s) => s.accessToken);
-  const role = accessTokenRole(accessToken);
+  const role = getRoleFromAccessToken(accessToken);
 
   const [actorFilter, setActorFilter] = React.useState("");
   const [startTs, setStartTs] = React.useState("");
@@ -115,14 +302,35 @@ export default function RootRoleManagementPage() {
   });
 
   const grantMut = useMutation({
-    mutationFn: ({ target_user_sub, reason }: { target_user_sub: string; reason: string }) =>
-      grantAdminRole({ target_user_sub, role: "admin", reason }),
+    mutationFn: (payload: {
+      target_user_sub: string;
+      reason: string;
+      admin_profile_type: AdminProfileType;
+      admin_scopes?: AdminScope[];
+    }) => grantAdminRole({ ...payload, role: "admin" }),
     onSuccess: () => {
       toast.success("Admin role granted");
       qc.invalidateQueries({ queryKey: ["root-role-audit"] });
     },
     onError: (err: unknown) => {
       const msg = err instanceof ApiError ? err.detail : "Grant failed";
+      toast.error(msg);
+    },
+  });
+
+  const updateProfileMut = useMutation({
+    mutationFn: (payload: {
+      target_user_sub: string;
+      reason: string;
+      admin_profile_type: AdminProfileType;
+      admin_scopes?: AdminScope[];
+    }) => updateAdminProfile(payload),
+    onSuccess: () => {
+      toast.success("Admin profile updated");
+      qc.invalidateQueries({ queryKey: ["root-role-audit"] });
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof ApiError ? err.detail : "Profile update failed";
       toast.error(msg);
     },
   });
@@ -149,21 +357,37 @@ export default function RootRoleManagementPage() {
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Root Role Management</h1>
-          <p className="text-sm text-muted-foreground">Grant/revoke admin access and review immutable role audit history.</p>
+          <p className="text-sm text-muted-foreground">
+            Assign general or scoped admins, update admin capability profiles, and review immutable role/profile audit history.
+          </p>
         </div>
         <Badge variant="secondary" className="inline-flex gap-1">
           <ShieldCheck className="h-3.5 w-3.5" /> Root only
         </Badge>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader>
             <CardTitle>Grant admin role</CardTitle>
-            <CardDescription>Assign admin role to an existing user. Reason is required.</CardDescription>
+            <CardDescription>
+              Choose one category: General, Auth support, Billing support, or Content moderation. Reason is required.
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            <RoleActionForm type="grant" onSubmit={(payload) => grantMut.mutate(payload)} loading={grantMut.isPending} />
+            <GrantAdminForm onSubmit={(payload) => grantMut.mutate(payload)} loading={grantMut.isPending} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Update admin profile</CardTitle>
+            <CardDescription>
+              Convert existing admins between general/scoped profiles or update scoped permissions.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <UpdateProfileForm onSubmit={(payload) => updateProfileMut.mutate(payload)} loading={updateProfileMut.isPending} />
           </CardContent>
         </Card>
 
@@ -173,7 +397,7 @@ export default function RootRoleManagementPage() {
             <CardDescription>Remove admin role and return user to standard role. Reason is required.</CardDescription>
           </CardHeader>
           <CardContent>
-            <RoleActionForm type="revoke" onSubmit={(payload) => revokeMut.mutate(payload)} loading={revokeMut.isPending} />
+            <RevokeAdminForm onSubmit={(payload) => revokeMut.mutate(payload)} loading={revokeMut.isPending} />
           </CardContent>
         </Card>
       </div>
@@ -183,7 +407,7 @@ export default function RootRoleManagementPage() {
           <div className="flex items-center justify-between gap-2">
             <div>
               <CardTitle>Role assignment audit timeline</CardTitle>
-              <CardDescription>Review grant/revoke events with actor metadata and reasons.</CardDescription>
+              <CardDescription>Review grant/revoke/profile-update events with profile transitions and actor metadata.</CardDescription>
             </div>
             <Button variant="outline" size="sm" onClick={() => auditQuery.refetch()}>
               <RefreshCw className="mr-1 h-4 w-4" /> Refresh
@@ -210,9 +434,9 @@ export default function RootRoleManagementPage() {
                     <TableHead>Action</TableHead>
                     <TableHead>Actor</TableHead>
                     <TableHead>Target</TableHead>
-                    <TableHead>Transition</TableHead>
+                    <TableHead>Role transition</TableHead>
+                    <TableHead>Profile transition</TableHead>
                     <TableHead>Reason</TableHead>
-                    <TableHead>Metadata</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -220,16 +444,15 @@ export default function RootRoleManagementPage() {
                     <TableRow key={row.event_id}>
                       <TableCell className="whitespace-nowrap text-xs">{formatTs(row.ts)}</TableCell>
                       <TableCell>
-                        <Badge variant={row.action === "grant" ? "default" : "destructive"}>{row.action}</Badge>
+                        <Badge variant={row.action === "revoke" ? "destructive" : "default"}>{row.action}</Badge>
                       </TableCell>
                       <TableCell className="font-mono text-xs">{row.actor_sub}</TableCell>
                       <TableCell className="font-mono text-xs">{row.target_user_sub}</TableCell>
                       <TableCell className="text-xs">{row.previous_role} → {row.new_role}</TableCell>
-                      <TableCell className="max-w-[280px] whitespace-normal break-words text-xs">{row.reason || "-"}</TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        <div>ip: {row.ip || "-"}</div>
-                        <div className="font-mono">req: {row.request_id || "-"}</div>
+                      <TableCell className="max-w-[260px] whitespace-normal break-words text-xs">
+                        {formatProfile(row.previous_admin_profile)} → {formatProfile(row.new_admin_profile)}
                       </TableCell>
+                      <TableCell className="max-w-[240px] whitespace-normal break-words text-xs">{row.reason || "-"}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>

--- a/frontend/src/pages/admin/__tests__/RootRoleManagementPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/RootRoleManagementPage.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import RootRoleManagementPage, { validateAdminProfileInput } from "../RootRoleManagementPage";
+
+const grantAdminRole = vi.fn();
+const revokeAdminRole = vi.fn();
+const updateAdminProfile = vi.fn();
+const listRoleAudit = vi.fn();
+
+vi.mock("@/api/endpoints/adminRoles", () => ({
+  grantAdminRole: (...args: unknown[]) => grantAdminRole(...args),
+  revokeAdminRole: (...args: unknown[]) => revokeAdminRole(...args),
+  updateAdminProfile: (...args: unknown[]) => updateAdminProfile(...args),
+  listRoleAudit: (...args: unknown[]) => listRoleAudit(...args),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (selector: (s: { accessToken: string | null }) => unknown) => selector({ accessToken: null }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RootRoleManagementPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("RootRoleManagementPage profile validation", () => {
+  it("validates general/scoped profile combinations", () => {
+    expect(validateAdminProfileInput("general", [])).toBeNull();
+    expect(validateAdminProfileInput("general", ["auth_support"]))
+      .toContain("General admins cannot have scoped permissions");
+    expect(validateAdminProfileInput("scoped", [])).toContain("Scoped admins must include at least one scope");
+    expect(validateAdminProfileInput("scoped", ["billing_support"]))
+      .toBeNull();
+  });
+});
+
+describe("RootRoleManagementPage grant admin payloads", () => {
+  beforeEach(() => {
+    grantAdminRole.mockResolvedValue({ ok: true, target_user_sub: "u1", role: "admin", event_id: "evt1" });
+    revokeAdminRole.mockResolvedValue({ ok: true, target_user_sub: "u1", role: "user", event_id: "evt2" });
+    updateAdminProfile.mockResolvedValue({ ok: true, target_user_sub: "u1", role: "admin", event_id: "evt3" });
+    listRoleAudit.mockResolvedValue({ items: [] });
+    grantAdminRole.mockClear();
+  });
+
+  it.each([
+    {
+      label: "general admin",
+      setup: () => {},
+      expected: {
+        target_user_sub: "target_1",
+        role: "admin",
+        reason: "ops",
+        admin_profile_type: "general",
+        admin_scopes: undefined,
+      },
+    },
+    {
+      label: "auth-support scoped admin",
+      setup: () => {
+        const grantCard = screen.getByText("Grant admin role").closest("div")?.parentElement?.parentElement as HTMLElement;
+        const q = within(grantCard);
+        fireEvent.change(q.getByLabelText("Admin profile mode"), { target: { value: "scoped" } });
+        fireEvent.click(q.getByLabelText(/Auth support/i));
+      },
+      expected: {
+        target_user_sub: "target_1",
+        role: "admin",
+        reason: "ops",
+        admin_profile_type: "scoped",
+        admin_scopes: ["auth_support"],
+      },
+    },
+    {
+      label: "billing scoped admin",
+      setup: () => {
+        const grantCard = screen.getByText("Grant admin role").closest("div")?.parentElement?.parentElement as HTMLElement;
+        const q = within(grantCard);
+        fireEvent.change(q.getByLabelText("Admin profile mode"), { target: { value: "scoped" } });
+        fireEvent.click(q.getByLabelText(/Billing support/i));
+      },
+      expected: {
+        target_user_sub: "target_1",
+        role: "admin",
+        reason: "ops",
+        admin_profile_type: "scoped",
+        admin_scopes: ["billing_support"],
+      },
+    },
+    {
+      label: "content moderation scoped admin",
+      setup: () => {
+        const grantCard = screen.getByText("Grant admin role").closest("div")?.parentElement?.parentElement as HTMLElement;
+        const q = within(grantCard);
+        fireEvent.change(q.getByLabelText("Admin profile mode"), { target: { value: "scoped" } });
+        fireEvent.click(q.getByLabelText(/Content moderation/i));
+      },
+      expected: {
+        target_user_sub: "target_1",
+        role: "admin",
+        reason: "ops",
+        admin_profile_type: "scoped",
+        admin_scopes: ["content_moderation"],
+      },
+    },
+  ])("submits $label", async ({ setup, expected }) => {
+    renderPage();
+
+    const grantCard = screen.getByText("Grant admin role").closest("div")?.parentElement?.parentElement as HTMLElement;
+    const q = within(grantCard);
+
+    fireEvent.change(q.getByLabelText("Target user_sub"), { target: { value: "target_1" } });
+    fireEvent.change(q.getByLabelText("Reason"), { target: { value: "ops" } });
+    setup();
+
+    fireEvent.click(q.getByRole("button", { name: "Grant admin" }));
+
+    await waitFor(() => {
+      expect(grantAdminRole).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  it("blocks invalid client-side combination for scoped mode without scopes", async () => {
+    renderPage();
+    const grantCard = screen.getByText("Grant admin role").closest("div")?.parentElement?.parentElement as HTMLElement;
+    const q = within(grantCard);
+    fireEvent.change(q.getByLabelText("Target user_sub"), { target: { value: "target_1" } });
+    fireEvent.change(q.getByLabelText("Reason"), { target: { value: "ops" } });
+    fireEvent.change(q.getByLabelText("Admin profile mode"), { target: { value: "scoped" } });
+
+    fireEvent.click(q.getByRole("button", { name: "Grant admin" }));
+
+    await waitFor(() => {
+      expect(grantAdminRole).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/scripts/backfill_admin_profiles_general.py
+++ b/scripts/backfill_admin_profiles_general.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.auth.roles import AdminProfileType, Role, normalize_admin_profile, normalize_role
+from app.core.aws import ddb
+from app.core.settings import S
+
+
+@dataclass
+class BackfillStats:
+    scanned: int = 0
+    admin_users_seen: int = 0
+    candidates: int = 0
+    updated: int = 0
+    skipped_already_general: int = 0
+    skipped_non_admin: int = 0
+
+
+@dataclass
+class Candidate:
+    user_sub: str
+    current_admin_profile: Dict[str, Any]
+    desired_admin_profile: Dict[str, Any]
+    reason: str
+
+
+def _users_table():
+    if not S.users_table_name:
+        raise RuntimeError("USERS_TABLE_NAME is not configured")
+    return ddb.Table(S.users_table_name)
+
+
+def _should_backfill(item: Dict[str, Any]) -> tuple[bool, str, Dict[str, Any], Dict[str, Any]]:
+    role = normalize_role(item.get("role"))
+    normalized = normalize_admin_profile(item.get("admin_profile"))
+    current_profile = normalized.to_dict()
+    desired_profile = {"type": AdminProfileType.GENERAL.value}
+
+    if role is not Role.ADMIN:
+        return False, "non_admin", current_profile, desired_profile
+
+    if normalized.type is AdminProfileType.SCOPED:
+        return False, "already_scoped", current_profile, desired_profile
+
+    raw_profile = item.get("admin_profile")
+    if isinstance(raw_profile, dict) and raw_profile.get("type") == AdminProfileType.GENERAL.value:
+        return False, "already_general", current_profile, desired_profile
+
+    return True, "missing_or_malformed_profile", current_profile, desired_profile
+
+
+def run_backfill(*, scan_limit: int, dry_run: bool, report_file: Optional[str]) -> Dict[str, Any]:
+    table = _users_table()
+    stats = BackfillStats()
+    candidates: List[Candidate] = []
+    last_evaluated_key = None
+
+    while True:
+        kwargs: Dict[str, Any] = {
+            "Limit": max(1, min(scan_limit, 1000)),
+            "ProjectionExpression": "user_sub, #role, admin_profile",
+            "ExpressionAttributeNames": {"#role": "role"},
+        }
+        if last_evaluated_key is not None:
+            kwargs["ExclusiveStartKey"] = last_evaluated_key
+
+        resp = table.scan(**kwargs)
+        items = resp.get("Items", [])
+        stats.scanned += len(items)
+
+        for item in items:
+            should_update, reason, current_profile, desired_profile = _should_backfill(item)
+            if reason == "non_admin":
+                stats.skipped_non_admin += 1
+                continue
+
+            stats.admin_users_seen += 1
+            if not should_update:
+                if reason == "already_general":
+                    stats.skipped_already_general += 1
+                continue
+
+            candidate = Candidate(
+                user_sub=str(item.get("user_sub") or ""),
+                current_admin_profile=current_profile,
+                desired_admin_profile=desired_profile,
+                reason=reason,
+            )
+            candidates.append(candidate)
+            stats.candidates += 1
+
+            if dry_run:
+                continue
+
+            table.update_item(
+                Key={"user_sub": candidate.user_sub},
+                UpdateExpression="SET admin_profile=:profile, role_updated_at=:ts, role_reason=:reason",
+                ConditionExpression="#role=:admin_role",
+                ExpressionAttributeNames={"#role": "role"},
+                ExpressionAttributeValues={
+                    ":profile": desired_profile,
+                    ":admin_role": Role.ADMIN.value,
+                    ":ts": int(datetime.now(timezone.utc).timestamp()),
+                    ":reason": "ap015_admin_profile_general_backfill",
+                },
+            )
+            stats.updated += 1
+
+        last_evaluated_key = resp.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+
+    report = {
+        "dry_run": dry_run,
+        "stats": asdict(stats),
+        "candidates": [asdict(c) for c in candidates],
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    if report_file:
+        with open(report_file, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, sort_keys=True)
+
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="AP-015 backfill: set admin_profile.type=general for existing admin users missing/malformed profiles.",
+    )
+    parser.add_argument("--scan-limit", type=int, default=500, help="DynamoDB scan page size")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply writes. If omitted, script runs in dry-run mode.",
+    )
+    parser.add_argument("--report-file", default=None, help="Optional path to write JSON report")
+    args = parser.parse_args()
+
+    report = run_backfill(scan_limit=args.scan_limit, dry_run=not args.apply, report_file=args.report_file)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_admin_impersonation.py
+++ b/tests/test_admin_impersonation.py
@@ -5,9 +5,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import HTTPException
+from fastapi.routing import APIRoute
 
 from app.auth.deps import AuthenticatedUser
-from app.auth.roles import Role
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
 from app.routers import admin_impersonation
 
 
@@ -17,6 +18,59 @@ def _req():
 
 def _tables(users: Mock, sessions: Mock) -> SimpleNamespace:
     return SimpleNamespace(users=users, sessions=sessions)
+
+
+def _mock_policy_request() -> SimpleNamespace:
+    return SimpleNamespace(headers={"user-agent": "pytest"}, client=SimpleNamespace(host="127.0.0.1"), state=SimpleNamespace())
+
+
+def _enforce_general_admin_or_root(actor: AuthenticatedUser) -> None:
+    import asyncio
+
+    asyncio.run(admin_impersonation.require_general_admin_or_root(user=actor))
+
+
+def test_impersonation_mutation_routes_use_feature_flag_operator_dependency() -> None:
+    scoped_paths = {"/admin/impersonation/start", "/admin/impersonation/stop"}
+    route_deps = {
+        route.path: {dep.call for dep in route.dependant.dependencies}
+        for route in admin_impersonation.router.routes
+        if isinstance(route, APIRoute) and route.path in scoped_paths
+    }
+    assert route_deps["/admin/impersonation/start"] >= {admin_impersonation.require_impersonation_operator}
+    assert route_deps["/admin/impersonation/stop"] >= {admin_impersonation.require_impersonation_operator}
+
+
+
+def test_require_impersonation_operator_falls_back_to_general_admin_when_flag_disabled() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+    )
+    with patch.object(admin_impersonation, "S", SimpleNamespace(admin_scope_enforce_auth_support=False)):
+        out = asyncio.run(admin_impersonation.require_impersonation_operator(user=actor, request=_mock_policy_request()))
+
+    assert out is actor
+
+
+def test_require_impersonation_operator_enforces_auth_support_when_flag_enabled() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+    )
+    with patch.object(admin_impersonation, "S", SimpleNamespace(admin_scope_enforce_auth_support=True)):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(admin_impersonation.require_impersonation_operator(user=actor, request=_mock_policy_request()))
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_scope"
+    assert exc.value.detail["required_scope"] == "auth_support"
 
 
 def test_start_impersonation_rejects_missing_target() -> None:
@@ -225,3 +279,57 @@ def test_impersonation_audit_reconstructs_timeline_with_filters() -> None:
 
     assert [x["impersonation_id"] for x in resp["items"]] == ["imp_1", "imp_2"]
     assert resp["items"][0]["actor_sub"] == "admin"
+
+
+def test_start_impersonation_allows_general_admin() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "target", "role": "user"}}
+    sessions = Mock()
+    fake_settings = SimpleNamespace(
+        impersonation_ttl_seconds=600,
+        impersonation_max_ttl_seconds=3600,
+        impersonation_allow_privileged_targets=False,
+        ui_access_token_secret="secret",
+    )
+    actor = AuthenticatedUser(
+        sub="admin-general",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.GENERAL),
+    )
+
+    _enforce_general_admin_or_root(actor)
+
+    with patch.object(admin_impersonation, "T", _tables(users, sessions)), patch.object(
+        admin_impersonation, "S", fake_settings
+    ), patch.object(admin_impersonation, "now_ts", return_value=1000), patch.object(
+        admin_impersonation, "with_ttl", side_effect=lambda item, ttl_epoch: {**item, "ttl_epoch": ttl_epoch}
+    ), patch.object(admin_impersonation, "audit_event"):
+        resp = admin_impersonation.start_impersonation(
+            _req(),
+            body={"target_user_sub": "target", "reason": "support"},
+            _ctx={"user_sub": "admin-general", "session_id": "sid", "role": "admin"},
+            actor=actor,
+        )
+
+    assert resp["ok"] is True
+    assert resp["effective_sub"] == "target"
+
+
+@pytest.mark.parametrize("scope", [AdminScope.BILLING_SUPPORT, AdminScope.CONTENT_MODERATION])
+def test_general_admin_or_root_denies_scoped_admins(scope: AdminScope) -> None:
+    actor = AuthenticatedUser(
+        sub="admin-other-scope",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(scope,)),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _enforce_general_admin_or_root(actor)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == {
+        "code": "role_required_admin_profile_type",
+        "required_admin_profile_type": "general",
+        "actual_role": "admin",
+        "actual_admin_profile": {"type": "scoped", "scopes": [scope.value]},
+    }

--- a/tests/test_admin_profile_backfill_script.py
+++ b/tests/test_admin_profile_backfill_script.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from scripts.backfill_admin_profiles_general import _should_backfill
+
+
+def test_should_backfill_non_admin_is_skipped() -> None:
+    should_update, reason, current, desired = _should_backfill({"user_sub": "u1", "role": "user"})
+    assert should_update is False
+    assert reason == "non_admin"
+    assert current == {"type": "general"}
+    assert desired == {"type": "general"}
+
+
+def test_should_backfill_admin_with_missing_profile() -> None:
+    should_update, reason, current, desired = _should_backfill({"user_sub": "a1", "role": "admin"})
+    assert should_update is True
+    assert reason == "missing_or_malformed_profile"
+    assert current == {"type": "general"}
+    assert desired == {"type": "general"}
+
+
+def test_should_backfill_admin_with_malformed_profile() -> None:
+    should_update, reason, current, desired = _should_backfill(
+        {"user_sub": "a1", "role": "admin", "admin_profile": {"type": "scoped", "scopes": ["unknown"]}}
+    )
+    assert should_update is True
+    assert reason == "missing_or_malformed_profile"
+    assert current == {"type": "general"}
+    assert desired == {"type": "general"}
+
+
+def test_should_backfill_admin_with_general_profile_is_idempotent() -> None:
+    should_update, reason, current, desired = _should_backfill(
+        {"user_sub": "a1", "role": "admin", "admin_profile": {"type": "general"}}
+    )
+    assert should_update is False
+    assert reason == "already_general"
+    assert current == {"type": "general"}
+    assert desired == {"type": "general"}
+
+
+def test_should_backfill_admin_with_scoped_profile_is_preserved() -> None:
+    should_update, reason, current, desired = _should_backfill(
+        {"user_sub": "a1", "role": "admin", "admin_profile": {"type": "scoped", "scopes": ["billing_support"]}}
+    )
+    assert should_update is False
+    assert reason == "already_scoped"
+    assert current == {"type": "scoped", "scopes": ["billing_support"]}
+    assert desired == {"type": "general"}

--- a/tests/test_admin_roles.py
+++ b/tests/test_admin_roles.py
@@ -68,10 +68,14 @@ def test_grant_role_root_only_success_updates_user_and_writes_immutable_audit() 
         )
     assert resp["ok"] is True
     assert resp["role"] == "admin"
+    assert resp["admin_profile"] == {"type": "general"}
     assert resp["event_id"]
     users.update_item.assert_called_once()
     role_audit.put_item.assert_called_once()
     assert role_audit.put_item.call_args.kwargs["ConditionExpression"] == "attribute_not_exists(event_id)"
+    audit_item = role_audit.put_item.call_args.kwargs["Item"]
+    assert audit_item["previous_admin_profile"] == {"type": "general"}
+    assert audit_item["new_admin_profile"] == {"type": "general"}
     assert audit.called
     assert any(call.kwargs.get("target_user_sub") == "u1" and call.kwargs.get("actor_sub") == "root" for call in audit.call_args_list)
 
@@ -111,6 +115,9 @@ def test_revoke_role_success_updates_user_and_writes_immutable_audit() -> None:
     users.update_item.assert_called_once()
     role_audit.put_item.assert_called_once()
     assert role_audit.put_item.call_args.kwargs["ConditionExpression"] == "attribute_not_exists(event_id)"
+    audit_item = role_audit.put_item.call_args.kwargs["Item"]
+    assert audit_item["previous_admin_profile"] == {"type": "general"}
+    assert audit_item["new_admin_profile"] is None
 
 
 def test_role_mutations_apply_admin_action_rate_limit() -> None:
@@ -141,6 +148,8 @@ def test_list_role_audit_queries_by_actor_and_date_range_with_cursor() -> None:
                 "target_user_sub": "u1",
                 "previous_role": "user",
                 "new_role": "admin",
+                "previous_admin_profile": {"type": "general"},
+                "new_admin_profile": {"type": "scoped", "scopes": ["billing_support"]},
                 "reason": "ops",
                 "ip": "127.0.0.1",
                 "request_id": "rid",
@@ -164,6 +173,8 @@ def test_list_role_audit_queries_by_actor_and_date_range_with_cursor() -> None:
     role_audit.query.assert_called_once()
     assert len(resp["items"]) == 1
     assert resp["items"][0]["actor_sub"] == "root"
+    assert resp["items"][0]["previous_admin_profile"] == {"type": "general"}
+    assert resp["items"][0]["new_admin_profile"] == {"type": "scoped", "scopes": ["billing_support"]}
     assert resp["cursor"]
 
 
@@ -190,3 +201,261 @@ def test_list_role_audit_scan_without_actor_and_sorts_desc() -> None:
 
     role_audit.scan.assert_called_once()
     assert [it["event_id"] for it in resp["items"]] == ["e2", "e1"]
+
+
+def test_grant_role_supports_scoped_admin_profile() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u2", "role": "user"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)), patch.object(admin_roles, "audit_event"), patch.object(
+        admin_roles, "now_ts", return_value=1000
+    ):
+        resp = admin_roles.grant_role(
+            admin_roles.RoleGrantReq(
+                target_user_sub="u2",
+                role="admin",
+                reason="billing",
+                admin_profile_type="scoped",
+                admin_scopes=["billing_support", "auth_support"],
+            ),
+            _req("rid-125"),
+            _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+            actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+        )
+
+    assert resp["ok"] is True
+    assert resp["admin_profile"] == {"type": "scoped", "scopes": ["auth_support", "billing_support"]}
+    expr_vals = users.update_item.call_args.kwargs["ExpressionAttributeValues"]
+    assert expr_vals[":admin_profile"] == {"type": "scoped", "scopes": ["auth_support", "billing_support"]}
+
+
+def test_grant_role_rejects_invalid_admin_profile_type() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "user"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.grant_role(
+                admin_roles.RoleGrantReq(target_user_sub="u1", role="admin", reason="ops", admin_profile_type="bad"),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "invalid_admin_profile_type"
+
+
+def test_grant_role_rejects_scoped_admin_profile_with_empty_scopes() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "user"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.grant_role(
+                admin_roles.RoleGrantReq(target_user_sub="u1", role="admin", reason="ops", admin_profile_type="scoped", admin_scopes=[]),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {"code": "invalid_admin_scopes", "reason": "scoped_profile_requires_non_empty_scopes"}
+
+
+def test_grant_role_rejects_duplicate_admin_scopes() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "user"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.grant_role(
+                admin_roles.RoleGrantReq(
+                    target_user_sub="u1",
+                    role="admin",
+                    reason="ops",
+                    admin_profile_type="scoped",
+                    admin_scopes=["billing_support", "billing_support"],
+                ),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "code": "invalid_admin_scopes",
+        "reason": "duplicate_scope_values",
+        "duplicate_scopes": ["billing_support"],
+    }
+
+
+def test_grant_role_rejects_unknown_admin_scope_values() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "user"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.grant_role(
+                admin_roles.RoleGrantReq(
+                    target_user_sub="u1",
+                    role="admin",
+                    reason="ops",
+                    admin_profile_type="scoped",
+                    admin_scopes=["nope"],
+                ),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "code": "invalid_admin_scopes",
+        "reason": "unknown_scope_values",
+        "invalid_scopes": ["nope"],
+        "allowed_scopes": ["auth_support", "billing_support", "content_moderation"],
+    }
+
+
+def test_grant_role_rejects_scopes_for_general_profile() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "user"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.grant_role(
+                admin_roles.RoleGrantReq(
+                    target_user_sub="u1",
+                    role="admin",
+                    reason="ops",
+                    admin_profile_type="general",
+                    admin_scopes=["auth_support"],
+                ),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {"code": "invalid_admin_scopes", "reason": "general_profile_disallows_scopes"}
+
+
+def test_update_role_profile_updates_admin_to_scoped_profile() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "admin"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)), patch.object(admin_roles, "audit_event") as audit, patch.object(
+        admin_roles, "now_ts", return_value=1002
+    ):
+        resp = admin_roles.update_role_profile(
+            admin_roles.RoleUpdateProfileReq(
+                target_user_sub="u1",
+                admin_profile_type="scoped",
+                admin_scopes=["content_moderation", "auth_support"],
+                reason="team shift",
+            ),
+            _req("rid-126"),
+            _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+            actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+        )
+
+    assert resp["ok"] is True
+    assert resp["target_user_sub"] == "u1"
+    assert resp["role"] == "admin"
+    assert resp["admin_profile"] == {"type": "scoped", "scopes": ["auth_support", "content_moderation"]}
+    assert resp["event_id"]
+    users.update_item.assert_called_once()
+    role_audit.put_item.assert_called_once()
+    update_audit_item = role_audit.put_item.call_args.kwargs["Item"]
+    assert update_audit_item["action"] == "update_profile"
+    assert update_audit_item["previous_admin_profile"] == {"type": "general"}
+    assert update_audit_item["new_admin_profile"] == {"type": "scoped", "scopes": ["auth_support", "content_moderation"]}
+    assert users.update_item.call_args.kwargs["ExpressionAttributeValues"][":admin_profile"] == {
+        "type": "scoped",
+        "scopes": ["auth_support", "content_moderation"],
+    }
+    assert any(call.args[0] == "admin_role_profile_updated" for call in audit.call_args_list)
+
+
+def test_update_role_profile_supports_scoped_to_general_transition() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "admin", "admin_profile": {"type": "scoped", "scopes": ["billing_support"]}}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)), patch.object(admin_roles, "audit_event"):
+        resp = admin_roles.update_role_profile(
+            admin_roles.RoleUpdateProfileReq(target_user_sub="u1", admin_profile_type="general", admin_scopes=[], reason="promoted"),
+            _req("rid-127"),
+            _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+            actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+        )
+
+    assert resp["admin_profile"] == {"type": "general"}
+
+
+def test_update_role_profile_rejects_non_root_actor() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "admin"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.update_role_profile(
+                admin_roles.RoleUpdateProfileReq(target_user_sub="u1", admin_profile_type="general", admin_scopes=[]),
+                _req(),
+                _ctx={"user_sub": "admin", "session_id": "sid", "role": "admin"},
+                actor=AuthenticatedUser(sub="admin", role=Role.ADMIN),
+            )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required"
+
+
+def test_update_role_profile_rejects_non_admin_target() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "user"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.update_role_profile(
+                admin_roles.RoleUpdateProfileReq(target_user_sub="u1", admin_profile_type="general", admin_scopes=[]),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 409
+    assert "not admin" in str(exc.value.detail)
+
+
+def test_update_role_profile_rejects_root_target() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "root-user", "role": "root"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)), patch.object(admin_roles, "S", SimpleNamespace(root_user_sub="root-user")):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.update_role_profile(
+                admin_roles.RoleUpdateProfileReq(target_user_sub="root-user", admin_profile_type="general", admin_scopes=[]),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 409
+    assert "cannot modify root" in str(exc.value.detail)
+
+
+def test_update_role_profile_rejects_invalid_profile_payload() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "u1", "role": "admin"}}
+    role_audit = Mock()
+    with patch.object(admin_roles, "T", _tables(users, role_audit)):
+        with pytest.raises(HTTPException) as exc:
+            admin_roles.update_role_profile(
+                admin_roles.RoleUpdateProfileReq(target_user_sub="u1", admin_profile_type="scoped", admin_scopes=[]),
+                _req(),
+                _ctx={"user_sub": "root", "session_id": "sid", "role": "root"},
+                actor=AuthenticatedUser(sub="root", role=Role.ROOT),
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {"code": "invalid_admin_scopes", "reason": "scoped_profile_requires_non_empty_scopes"}

--- a/tests/test_auth_policy.py
+++ b/tests/test_auth_policy.py
@@ -1,11 +1,33 @@
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 
 from app.auth.deps import AuthenticatedUser
-from app.auth.policy import require_role_value, require_roles, require_self_or_admin
-from app.auth.roles import Role
+from app.auth.policy import (
+    require_admin_scope,
+    require_general_admin_or_root,
+    require_role_value,
+    require_roles,
+    require_self_or_admin,
+)
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def _mock_request(path: str = "/_test") -> SimpleNamespace:
+    return SimpleNamespace(
+        headers={"user-agent": "pytest"},
+        state=SimpleNamespace(),
+        scope={"route": SimpleNamespace(path=path)},
+        url=SimpleNamespace(path=path),
+    )
 
 
 def test_require_roles_allows_admin() -> None:
@@ -41,5 +63,113 @@ def test_require_self_or_admin_denies_non_admin_other_user() -> None:
     actor = AuthenticatedUser(sub="u1", role=Role.USER)
     with pytest.raises(HTTPException) as exc:
         require_self_or_admin(actor=actor, target_user_sub="u2")
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required"
+
+
+def test_require_general_admin_or_root_allows_root() -> None:
+    user = AuthenticatedUser(sub="root", role=Role.ROOT)
+    out = run_async(require_general_admin_or_root(user=user))
+    assert out is user
+
+
+def test_require_general_admin_or_root_allows_general_admin() -> None:
+    user = AuthenticatedUser(sub="a1", role=Role.ADMIN, admin_profile=AdminProfile(type=AdminProfileType.GENERAL))
+    out = run_async(require_general_admin_or_root(user=user))
+    assert out is user
+
+
+def test_require_general_admin_or_root_denies_scoped_admin() -> None:
+    user = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,)),
+    )
+    with pytest.raises(HTTPException) as exc:
+        run_async(require_general_admin_or_root(user=user))
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_admin_profile_type"
+
+
+def test_require_admin_scope_allows_root() -> None:
+    dep = require_admin_scope(AdminScope.BILLING_SUPPORT)
+    user = AuthenticatedUser(sub="root", role=Role.ROOT)
+    out = run_async(dep(request=_mock_request(), user=user))
+    assert out is user
+
+
+def test_require_admin_scope_allows_general_admin() -> None:
+    dep = require_admin_scope(AdminScope.BILLING_SUPPORT)
+    user = AuthenticatedUser(sub="a1", role=Role.ADMIN, admin_profile=AdminProfile(type=AdminProfileType.GENERAL))
+    out = run_async(dep(request=_mock_request(), user=user))
+    assert out is user
+
+
+def test_require_admin_scope_allows_scoped_admin_with_scope() -> None:
+    dep = require_admin_scope(AdminScope.AUTH_SUPPORT)
+    user = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,)),
+    )
+    out = run_async(dep(request=_mock_request(), user=user))
+    assert out is user
+
+
+def test_require_admin_scope_denies_scoped_admin_missing_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    events = []
+    metric_events = []
+
+    def _capture(event: str, user_sub: str, request=None, **fields):
+        events.append({"event": event, "user_sub": user_sub, "fields": fields})
+
+    def _capture_metric(*, route: str, required_scope: str, admin_profile_type: str):
+        metric_events.append(
+            {
+                "route": route,
+                "required_scope": required_scope,
+                "admin_profile_type": admin_profile_type,
+            }
+        )
+
+    monkeypatch.setattr("app.auth.policy.audit_event", _capture)
+    monkeypatch.setattr("app.auth.policy.record_admin_scope_denied", _capture_metric)
+
+    dep = require_admin_scope(AdminScope.BILLING_SUPPORT)
+    user = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,)),
+    )
+    with pytest.raises(HTTPException) as exc:
+        run_async(dep(request=_mock_request(path="/api/billing/_dev/add-charge"), user=user))
+    assert exc.value.status_code == 403
+    assert exc.value.detail == {
+        "code": "role_required_scope",
+        "required_scope": "billing_support",
+        "actual_role": "admin",
+        "actual_admin_profile": {"type": "scoped", "scopes": ["auth_support"]},
+    }
+
+    assert len(events) == 1
+    assert events[0]["event"] == "admin_scope_denied"
+    assert events[0]["user_sub"] == "a1"
+    assert events[0]["fields"]["required_scope"] == "billing_support"
+    assert events[0]["fields"]["status_code"] == 403
+
+    assert metric_events == [
+        {
+            "route": "/api/billing/_dev/add-charge",
+            "required_scope": "billing_support",
+            "admin_profile_type": "scoped",
+        }
+    ]
+
+
+def test_require_admin_scope_denies_non_admin_user() -> None:
+    dep = require_admin_scope(AdminScope.BILLING_SUPPORT)
+    user = AuthenticatedUser(sub="u1", role=Role.USER)
+    with pytest.raises(HTTPException) as exc:
+        run_async(dep(request=_mock_request(), user=user))
     assert exc.value.status_code == 403
     assert exc.value.detail["code"] == "role_required"

--- a/tests/test_auth_roles.py
+++ b/tests/test_auth_roles.py
@@ -6,7 +6,15 @@ import json
 from types import SimpleNamespace
 
 from app.auth import deps
-from app.auth.roles import Role, normalize_role
+from app.auth.roles import (
+    AdminProfile,
+    AdminProfileType,
+    AdminScope,
+    Role,
+    admin_profile_has_scope,
+    normalize_admin_profile,
+    normalize_role,
+)
 from app.core.settings import S
 
 
@@ -68,3 +76,48 @@ def test_get_authenticated_user_role_prefers_highest_privilege_in_roles_claim() 
     token = _encode_payload({"sub": "user-1", "roles": ["user", "admin"]})
     req = SimpleNamespace(headers={"authorization": f"Bearer {token}"})
     assert run_async(deps.get_authenticated_user_role(req)) == Role.ADMIN
+
+
+def test_normalize_admin_profile_defaults_to_general_for_missing_or_malformed() -> None:
+    assert normalize_admin_profile(None) == AdminProfile(type=AdminProfileType.GENERAL)
+    assert normalize_admin_profile("bad") == AdminProfile(type=AdminProfileType.GENERAL)
+    assert normalize_admin_profile({"type": "scoped", "scopes": []}) == AdminProfile(type=AdminProfileType.GENERAL)
+    assert normalize_admin_profile({"type": "scoped", "scopes": ["unknown"]}) == AdminProfile(type=AdminProfileType.GENERAL)
+
+
+def test_normalize_admin_profile_canonicalizes_scopes_deterministically() -> None:
+    profile = normalize_admin_profile(
+        {
+            "type": "SCOPED",
+            "scopes": ["billing_support", "auth_support", "billing_support", " content_moderation "],
+        }
+    )
+
+    assert profile == AdminProfile(
+        type=AdminProfileType.SCOPED,
+        scopes=(
+            AdminScope.AUTH_SUPPORT,
+            AdminScope.BILLING_SUPPORT,
+            AdminScope.CONTENT_MODERATION,
+        ),
+    )
+
+
+def test_normalize_admin_profile_accepts_admin_profile_instance_and_dedupes() -> None:
+    profile = normalize_admin_profile(
+        AdminProfile(
+            type=AdminProfileType.SCOPED,
+            scopes=(AdminScope.BILLING_SUPPORT, AdminScope.AUTH_SUPPORT, AdminScope.BILLING_SUPPORT),
+        )
+    )
+    assert profile.scopes == (AdminScope.AUTH_SUPPORT, AdminScope.BILLING_SUPPORT)
+
+
+def test_admin_profile_has_scope_supports_general_and_scoped_profiles() -> None:
+    general = AdminProfile(type=AdminProfileType.GENERAL)
+    scoped = AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,))
+
+    assert admin_profile_has_scope(general, AdminScope.BILLING_SUPPORT)
+    assert admin_profile_has_scope(scoped, "auth_support")
+    assert not admin_profile_has_scope(scoped, AdminScope.BILLING_SUPPORT)
+    assert not admin_profile_has_scope(scoped, "not-a-scope")

--- a/tests/test_authorization_regression_matrix.py
+++ b/tests/test_authorization_regression_matrix.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.deps import AuthenticatedUser
+from app.auth.policy import require_general_admin_or_root
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
+from app.routers import admin_impersonation, billing, filemanager
+
+
+def _actor(role: Role, scope: AdminScope | None = None) -> AuthenticatedUser:
+    if role is Role.ADMIN and scope is not None:
+        return AuthenticatedUser(
+            sub=f"admin-{scope.value}",
+            role=Role.ADMIN,
+            admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(scope,)),
+        )
+    if role is Role.ADMIN:
+        return AuthenticatedUser(
+            sub="admin-general",
+            role=Role.ADMIN,
+            admin_profile=AdminProfile(type=AdminProfileType.GENERAL),
+        )
+    return AuthenticatedUser(sub=role.value, role=role)
+
+
+def _policy_request(path: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        headers={"user-agent": "pytest"},
+        client=SimpleNamespace(host="127.0.0.1"),
+        state=SimpleNamespace(),
+        scope={"route": SimpleNamespace(path=path)},
+        url=SimpleNamespace(path=path),
+    )
+
+
+@pytest.mark.parametrize(
+    "label,dep,module,flag_name,path,actor,allowed,expected_code,expected_required_scope",
+    [
+        (
+            "auth_scope_allows_auth_admin",
+            admin_impersonation.require_impersonation_operator,
+            admin_impersonation,
+            "admin_scope_enforce_auth_support",
+            "/admin/impersonation/start",
+            _actor(Role.ADMIN, AdminScope.AUTH_SUPPORT),
+            True,
+            None,
+            None,
+        ),
+        (
+            "auth_scope_denies_billing_admin",
+            admin_impersonation.require_impersonation_operator,
+            admin_impersonation,
+            "admin_scope_enforce_auth_support",
+            "/admin/impersonation/start",
+            _actor(Role.ADMIN, AdminScope.BILLING_SUPPORT),
+            False,
+            "role_required_scope",
+            "auth_support",
+        ),
+        (
+            "billing_scope_allows_billing_admin",
+            billing.require_billing_admin_operator,
+            billing,
+            "admin_scope_enforce_billing_support",
+            "/api/billing/_dev/add-charge",
+            _actor(Role.ADMIN, AdminScope.BILLING_SUPPORT),
+            True,
+            None,
+            None,
+        ),
+        (
+            "billing_scope_denies_moderation_admin",
+            billing.require_billing_admin_operator,
+            billing,
+            "admin_scope_enforce_billing_support",
+            "/api/billing/_dev/add-charge",
+            _actor(Role.ADMIN, AdminScope.CONTENT_MODERATION),
+            False,
+            "role_required_scope",
+            "billing_support",
+        ),
+        (
+            "moderation_scope_allows_moderation_admin",
+            filemanager.require_content_moderation_operator,
+            filemanager,
+            "admin_scope_enforce_content_moderation",
+            "/v1/fs/admin/read",
+            _actor(Role.ADMIN, AdminScope.CONTENT_MODERATION),
+            True,
+            None,
+            None,
+        ),
+        (
+            "moderation_scope_denies_auth_admin",
+            filemanager.require_content_moderation_operator,
+            filemanager,
+            "admin_scope_enforce_content_moderation",
+            "/v1/fs/admin/read",
+            _actor(Role.ADMIN, AdminScope.AUTH_SUPPORT),
+            False,
+            "role_required_scope",
+            "content_moderation",
+        ),
+        (
+            "general_admin_allowed_across_scoped_domains",
+            billing.require_billing_admin_operator,
+            billing,
+            "admin_scope_enforce_billing_support",
+            "/api/billing/_dev/add-charge",
+            _actor(Role.ADMIN),
+            True,
+            None,
+            None,
+        ),
+        (
+            "root_allowed_across_scoped_domains",
+            filemanager.require_content_moderation_operator,
+            filemanager,
+            "admin_scope_enforce_content_moderation",
+            "/v1/fs/admin/read",
+            _actor(Role.ROOT),
+            True,
+            None,
+            None,
+        ),
+        (
+            "user_denied_scoped_domain",
+            billing.require_billing_admin_operator,
+            billing,
+            "admin_scope_enforce_billing_support",
+            "/api/billing/_dev/add-charge",
+            _actor(Role.USER),
+            False,
+            "role_required",
+            None,
+        ),
+    ],
+)
+def test_authorization_regression_matrix_scoped_domains(
+    label: str,
+    dep,
+    module,
+    flag_name: str,
+    path: str,
+    actor: AuthenticatedUser,
+    allowed: bool,
+    expected_code: str | None,
+    expected_required_scope: str | None,
+) -> None:
+    req = _policy_request(path)
+    with patch.object(module, "S", SimpleNamespace(**{flag_name: True})):
+        if allowed:
+            out = asyncio.run(dep(user=actor, request=req))
+            assert out is actor, label
+        else:
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(dep(user=actor, request=req))
+            assert exc.value.status_code == 403, label
+            assert exc.value.detail["code"] == expected_code, label
+            if expected_required_scope:
+                assert exc.value.detail["required_scope"] == expected_required_scope, label
+
+
+@pytest.mark.parametrize(
+    "actor,allowed",
+    [
+        (_actor(Role.USER), False),
+        (_actor(Role.ADMIN, AdminScope.AUTH_SUPPORT), False),
+        (_actor(Role.ADMIN, AdminScope.BILLING_SUPPORT), False),
+        (_actor(Role.ADMIN, AdminScope.CONTENT_MODERATION), False),
+        (_actor(Role.ADMIN), True),
+        (_actor(Role.ROOT), True),
+    ],
+)
+def test_authorization_regression_matrix_general_admin_or_root_control(actor: AuthenticatedUser, allowed: bool) -> None:
+    if allowed:
+        out = asyncio.run(require_general_admin_or_root(user=actor))
+        assert out is actor
+    else:
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(require_general_admin_or_root(user=actor))
+        assert exc.value.status_code == 403
+        assert exc.value.detail["code"] in {"role_required", "role_required_admin_profile_type"}
+
+
+@pytest.mark.parametrize(
+    "dep,module,flag_name,path,required_scope",
+    [
+        (
+            admin_impersonation.require_impersonation_operator,
+            admin_impersonation,
+            "admin_scope_enforce_auth_support",
+            "/admin/impersonation/start",
+            "auth_support",
+        ),
+        (
+            billing.require_billing_admin_operator,
+            billing,
+            "admin_scope_enforce_billing_support",
+            "/api/billing/_dev/add-charge",
+            "billing_support",
+        ),
+        (
+            filemanager.require_content_moderation_operator,
+            filemanager,
+            "admin_scope_enforce_content_moderation",
+            "/v1/fs/admin/read",
+            "content_moderation",
+        ),
+    ],
+)
+def test_authorization_regression_matrix_denials_emit_scope_audit_event(dep, module, flag_name: str, path: str, required_scope: str) -> None:
+    actor = _actor(Role.ADMIN, AdminScope.AUTH_SUPPORT)
+    if required_scope == "auth_support":
+        actor = _actor(Role.ADMIN, AdminScope.BILLING_SUPPORT)
+
+    events: list[dict] = []
+
+    def _capture(event: str, user_sub: str, request=None, **fields):
+        events.append({"event": event, "user_sub": user_sub, "fields": fields})
+
+    with patch.object(module, "S", SimpleNamespace(**{flag_name: True})), patch("app.auth.policy.audit_event", side_effect=_capture):
+        with pytest.raises(HTTPException):
+            asyncio.run(dep(user=actor, request=_policy_request(path)))
+
+    assert len(events) == 1
+    assert events[0]["event"] == "admin_scope_denied"
+    assert events[0]["fields"]["required_scope"] == required_scope
+    assert events[0]["fields"]["status_code"] == 403
+
+
+def test_authorization_regression_matrix_impersonation_success_emits_audit_event() -> None:
+    users = Mock()
+    users.get_item.return_value = {"Item": {"user_sub": "target", "role": "user"}}
+    sessions = Mock()
+
+    fake_settings = SimpleNamespace(
+        impersonation_ttl_seconds=600,
+        impersonation_max_ttl_seconds=3600,
+        impersonation_allow_privileged_targets=False,
+        ui_access_token_secret="secret",
+    )
+
+    with patch.object(admin_impersonation, "T", SimpleNamespace(users=users, sessions=sessions)), patch.object(
+        admin_impersonation, "S", fake_settings
+    ), patch.object(admin_impersonation, "now_ts", return_value=1000), patch.object(
+        admin_impersonation, "with_ttl", side_effect=lambda item, ttl_epoch: {**item, "ttl_epoch": ttl_epoch}
+    ), patch.object(admin_impersonation, "audit_event") as audit_mock:
+        resp = admin_impersonation.start_impersonation(
+            req=_policy_request("/admin/impersonation/start"),
+            body={"target_user_sub": "target", "reason": "support"},
+            _ctx={"user_sub": "admin-auth", "session_id": "sid", "role": "admin"},
+            actor=_actor(Role.ADMIN, AdminScope.AUTH_SUPPORT),
+        )
+
+    assert resp["ok"] is True
+    assert audit_mock.call_count == 1
+    assert audit_mock.call_args.args[0] == "admin_impersonation_start"
+    assert audit_mock.call_args.kwargs["outcome"] == "success"

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 from unittest.mock import MagicMock
 
+import pytest
+
 from starlette.requests import Request
 from fastapi import HTTPException
 
@@ -15,6 +17,8 @@ if str(ROOT) not in sys.path:
 
 sys.modules.setdefault("stripe", MagicMock())
 
+from app.auth.deps import AuthenticatedUser
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
 from app.core.settings import S
 from app.core.tables import T
 from app.routers import billing as billing_router
@@ -110,6 +114,27 @@ def build_request(
 
     return Request(scope, receive)
 
+
+
+
+def _user_actor(sub: str = "user-123") -> AuthenticatedUser:
+    return AuthenticatedUser(sub=sub, role=Role.USER)
+
+
+def _billing_admin_actor(sub: str = "admin-1") -> AuthenticatedUser:
+    return AuthenticatedUser(
+        sub=sub,
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+    )
+
+
+def _scoped_admin_actor(sub: str, scope: AdminScope) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        sub=sub,
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(scope,)),
+    )
 
 def setup_table(fake_table: FakeTable) -> None:
     object.__setattr__(T, "billing", fake_table)
@@ -304,19 +329,19 @@ def test_billing_read_surfaces_allow_admin_target_override(monkeypatch) -> None:
     fake_table.put_item(Item={"pk": "USER#target-1", "sk": "PAY#pi_target", "payment_intent_id": "pi_target", "created_at": 1})
 
     admin_ctx = {"user_sub": "admin-1", "role": "admin"}
-    settings = billing_router.get_settings(ctx=admin_ctx, user_sub="target-1")
+    settings = billing_router.get_settings(ctx=admin_ctx, actor=_billing_admin_actor(), user_sub="target-1")
     assert settings["autopay_enabled"] is True
 
-    balance = billing_router.get_balance(ctx=admin_ctx, user_sub="target-1")
+    balance = billing_router.get_balance(ctx=admin_ctx, actor=_billing_admin_actor(), user_sub="target-1")
     assert balance["owed_settled_cents"] == 42
 
-    ledger = billing_router.list_ledger(ctx=admin_ctx, user_sub="target-1")
+    ledger = billing_router.list_ledger(ctx=admin_ctx, actor=_billing_admin_actor(), user_sub="target-1")
     assert ledger["items"][0]["sk"] == "LEDGER#10#A"
 
-    payments = billing_router.list_payments(ctx=admin_ctx, user_sub="target-1")
+    payments = billing_router.list_payments(ctx=admin_ctx, actor=_billing_admin_actor(), user_sub="target-1")
     assert payments["items"][0]["payment_intent_id"] == "pi_target"
 
-    subs = billing_router.list_subscriptions(ctx=admin_ctx, user_sub="target-1")
+    subs = billing_router.list_subscriptions(ctx=admin_ctx, actor=_billing_admin_actor(), user_sub="target-1")
     assert subs["items"][0]["id"] == "sub_123"
 
 
@@ -328,7 +353,7 @@ def test_billing_read_surfaces_keep_user_scoped(monkeypatch) -> None:
     user_ctx = {"user_sub": "user-123", "role": "user"}
 
     try:
-        billing_router.get_balance(ctx=user_ctx, user_sub="target-1")
+        billing_router.get_balance(ctx=user_ctx, actor=_user_actor(), user_sub="target-1")
     except HTTPException as exc:
         assert exc.status_code == 403
         assert exc.detail["code"] == "role_required"
@@ -341,7 +366,7 @@ def test_billing_dev_add_charge(monkeypatch) -> None:
     setup_table(fake_table)
     setup_stripe_mocks(monkeypatch)
 
-    resp = billing_router.dev_add_charge(body=AddChargeReq(amount_cents=500, state="pending", reason="usage"), ctx={"user_sub": "user-123"})
+    resp = billing_router.dev_add_charge(body=AddChargeReq(amount_cents=500, state="pending", reason="usage"), ctx={"user_sub": "user-123"}, actor=_billing_admin_actor("user-123"))
     assert resp["ok"] is True
 
 
@@ -362,6 +387,7 @@ def test_admin_can_write_billing_for_target_with_audit_tags(monkeypatch) -> None
         body=SetDefaultReq(payment_method_id="pm_123"),
         req=build_request(),
         ctx={"user_sub": "admin-1", "role": "admin"},
+        actor=_billing_admin_actor(),
         user_sub="target-1",
     )
     assert resp["ok"] is True
@@ -385,6 +411,7 @@ def test_non_privileged_user_cannot_write_other_users_billing(monkeypatch) -> No
             body=PayBalanceReq(),
             req=build_request(),
             ctx={"user_sub": "user-123", "role": "user"},
+            actor=_user_actor(),
             user_sub="target-1",
         )
     except HTTPException as exc:
@@ -411,6 +438,7 @@ def test_admin_checkout_session_and_dev_add_charge_targeted(monkeypatch) -> None
         body=BillingCheckoutReq(amount_cents=1200),
         req=req,
         ctx={"user_sub": "admin-1", "role": "admin"},
+        actor=_billing_admin_actor(),
         user_sub="target-1",
     )
     assert data["session_id"] == "cs_123"
@@ -419,6 +447,7 @@ def test_admin_checkout_session_and_dev_add_charge_targeted(monkeypatch) -> None
         body=AddChargeReq(amount_cents=500, state="pending", reason="ops"),
         req=req,
         ctx={"user_sub": "admin-1", "role": "admin"},
+        actor=_billing_admin_actor(),
         user_sub="target-1",
     )
     assert resp["ok"] is True
@@ -610,3 +639,20 @@ def test_billing_webhook_allows_missing_signature(monkeypatch) -> None:
     req = build_request(body=b"{}")
     resp = run_async(billing_router.stripe_webhook(req))
     assert resp["received"] is True
+
+
+def test_billing_scoped_admin_denied_for_cross_user_with_non_billing_scope(monkeypatch) -> None:
+    fake_table = FakeTable()
+    setup_table(fake_table)
+    setup_stripe_mocks(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc:
+        billing_router.get_balance(
+            ctx={"user_sub": "admin-auth", "role": "admin"},
+            actor=_scoped_admin_actor("admin-auth", AdminScope.AUTH_SUPPORT),
+            user_sub="target-1",
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_scope"
+    assert exc.value.detail["required_scope"] == "billing_support"

--- a/tests/test_policy_matrix.py
+++ b/tests/test_policy_matrix.py
@@ -5,10 +5,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import HTTPException
+from fastapi.routing import APIRoute
 
 from app.auth.deps import AuthenticatedUser
 from app.auth.policy import require_admin_or_root, require_root, require_self_or_admin
-from app.auth.roles import Role
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
 from app.routers import admin_impersonation, billing, filemanager, root_auth
 
 
@@ -64,39 +65,79 @@ def test_policy_matrix_root_vs_admin_guards(role: Role, requires_root_ok: bool, 
 
 
 @pytest.mark.parametrize(
-    "ctx,target,allowed",
+    "ctx,actor,target,allowed",
     [
-        ({"user_sub": "u1", "role": "user"}, None, True),
-        ({"user_sub": "u1", "role": "user"}, "u1", True),
-        ({"user_sub": "u1", "role": "user"}, "u2", False),
-        ({"user_sub": "a1", "role": "admin"}, "u2", True),
-        ({"user_sub": "r1", "role": "root"}, "u2", True),
+        ({"user_sub": "u1", "role": "user"}, AuthenticatedUser(sub="u1", role=Role.USER), None, True),
+        ({"user_sub": "u1", "role": "user"}, AuthenticatedUser(sub="u1", role=Role.USER), "u1", True),
+        ({"user_sub": "u1", "role": "user"}, AuthenticatedUser(sub="u1", role=Role.USER), "u2", False),
+        (
+            {"user_sub": "a1", "role": "admin"},
+            AuthenticatedUser(
+                sub="a1",
+                role=Role.ADMIN,
+                admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+            ),
+            "u2",
+            True,
+        ),
+        (
+            {"user_sub": "a1", "role": "admin"},
+            AuthenticatedUser(
+                sub="a1",
+                role=Role.ADMIN,
+                admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,)),
+            ),
+            "u2",
+            False,
+        ),
+        ({"user_sub": "r1", "role": "root"}, AuthenticatedUser(sub="r1", role=Role.ROOT), "u2", True),
     ],
 )
-def test_policy_matrix_billing_read_scope(ctx: dict, target: str | None, allowed: bool) -> None:
+def test_policy_matrix_billing_read_scope(ctx: dict, actor: AuthenticatedUser, target: str | None, allowed: bool) -> None:
     if allowed:
-        out = billing._billing_read_user_sub(ctx, target)
+        out = billing._billing_read_user_sub(ctx, target, actor)
         assert out == (target or ctx["user_sub"])
     else:
         with pytest.raises(HTTPException) as exc:
-            billing._billing_read_user_sub(ctx, target)
+            billing._billing_read_user_sub(ctx, target, actor)
         assert exc.value.status_code == 403
-        assert exc.value.detail["code"] == "role_required"
+        assert exc.value.detail["code"] in {"role_required", "role_required_scope"}
 
 
 @pytest.mark.parametrize(
-    "ctx,target,allowed,expected_target",
+    "ctx,actor,target,allowed,expected_target",
     [
-        ({"user_sub": "u1", "role": "user"}, None, True, "u1"),
-        ({"user_sub": "u1", "role": "user"}, "u1", True, "u1"),
-        ({"user_sub": "u1", "role": "user"}, "u2", False, None),
-        ({"user_sub": "a1", "role": "admin"}, "u2", True, "u2"),
-        ({"user_sub": "r1", "role": "root"}, "u2", True, "u2"),
+        ({"user_sub": "u1", "role": "user"}, AuthenticatedUser(sub="u1", role=Role.USER), None, True, "u1"),
+        ({"user_sub": "u1", "role": "user"}, AuthenticatedUser(sub="u1", role=Role.USER), "u1", True, "u1"),
+        ({"user_sub": "u1", "role": "user"}, AuthenticatedUser(sub="u1", role=Role.USER), "u2", False, None),
+        (
+            {"user_sub": "a1", "role": "admin"},
+            AuthenticatedUser(
+                sub="a1",
+                role=Role.ADMIN,
+                admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+            ),
+            "u2",
+            True,
+            "u2",
+        ),
+        (
+            {"user_sub": "a1", "role": "admin"},
+            AuthenticatedUser(
+                sub="a1",
+                role=Role.ADMIN,
+                admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+            ),
+            "u2",
+            False,
+            None,
+        ),
+        ({"user_sub": "r1", "role": "root"}, AuthenticatedUser(sub="r1", role=Role.ROOT), "u2", True, "u2"),
     ],
 )
-def test_policy_matrix_billing_write_scope(ctx: dict, target: str | None, allowed: bool, expected_target: str | None) -> None:
+def test_policy_matrix_billing_write_scope(ctx: dict, actor: AuthenticatedUser, target: str | None, allowed: bool, expected_target: str | None) -> None:
     if allowed:
-        user_sub, tags = billing._billing_write_user_context(ctx, target)
+        user_sub, tags = billing._billing_write_user_context(ctx, target, actor)
         assert user_sub == expected_target
         if target and target != ctx["user_sub"]:
             assert tags["viewed_as_admin"] is True
@@ -105,14 +146,31 @@ def test_policy_matrix_billing_write_scope(ctx: dict, target: str | None, allowe
             assert tags == {}
     else:
         with pytest.raises(HTTPException):
-            billing._billing_write_user_context(ctx, target)
+            billing._billing_write_user_context(ctx, target, actor)
 
 
 def test_policy_matrix_file_admin_ctx_guard() -> None:
-    assert filemanager._admin_or_root_ctx({"user_sub": "a1", "role": "admin"})["role"] == "admin"
-    assert filemanager._admin_or_root_ctx({"user_sub": "r1", "role": "root"})["role"] == "root"
+    moderation_admin = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    non_moderation_admin = AuthenticatedUser(
+        sub="a2",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,)),
+    )
+
+    assert filemanager._admin_or_root_ctx({"user_sub": "a1", "role": "admin"}, moderation_admin)["role"] == "admin"
+    assert filemanager._admin_or_root_ctx({"user_sub": "r1", "role": "root"}, AuthenticatedUser(sub="r1", role=Role.ROOT))["role"] == "root"
+    with pytest.raises(HTTPException) as exc:
+        filemanager._admin_or_root_ctx({"user_sub": "a2", "role": "admin"}, non_moderation_admin)
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_scope"
+    assert exc.value.detail["required_scope"] == "content_moderation"
+
     with pytest.raises(HTTPException):
-        filemanager._admin_or_root_ctx({"user_sub": "u1", "role": "user"})
+        filemanager._admin_or_root_ctx({"user_sub": "u1", "role": "user"}, AuthenticatedUser(sub="u1", role=Role.USER))
 
 
 @pytest.mark.parametrize(
@@ -194,3 +252,154 @@ def test_policy_matrix_impersonation_restrictions(target_role: str, actor_role: 
                 )
             assert exc.value.status_code == 403
             assert exc.value.detail == "impersonation_not_allowed"
+
+
+def test_policy_matrix_billing_dev_add_charge_route_uses_billing_scope_dependency() -> None:
+    route = next(
+        r for r in billing.router.routes
+        if isinstance(r, APIRoute) and r.path == "/api/billing/_dev/add-charge" and "POST" in r.methods
+    )
+    deps = {dep.call for dep in route.dependant.dependencies}
+    assert billing.require_billing_admin_operator in deps
+
+
+@pytest.mark.parametrize("scope", [AdminScope.AUTH_SUPPORT, AdminScope.CONTENT_MODERATION])
+def test_policy_matrix_billing_scope_dependency_denies_non_billing_scoped_admin(scope: AdminScope) -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(scope,)),
+    )
+    req = SimpleNamespace(headers={"user-agent": "pytest"}, client=SimpleNamespace(host="127.0.0.1"), state=SimpleNamespace())
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(billing.require_billing_support_admin(request=req, user=actor))
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_scope"
+    assert exc.value.detail["required_scope"] == "billing_support"
+
+
+def test_policy_matrix_billing_scope_dependency_allows_billing_scoped_admin() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+    )
+    req = SimpleNamespace(headers={"user-agent": "pytest"}, client=SimpleNamespace(host="127.0.0.1"), state=SimpleNamespace())
+
+    out = asyncio.run(billing.require_billing_support_admin(request=req, user=actor))
+    assert out is actor
+
+
+
+def test_policy_matrix_file_admin_route_uses_content_moderation_scope_dependency() -> None:
+    route = next(
+        r for r in filemanager.router.routes
+        if isinstance(r, APIRoute) and r.path == "/v1/fs/admin/read" and "GET" in r.methods
+    )
+    deps = {dep.call for dep in route.dependant.dependencies}
+    assert filemanager._admin_or_root_ctx in deps
+
+
+@pytest.mark.parametrize("scope", [AdminScope.AUTH_SUPPORT, AdminScope.BILLING_SUPPORT])
+def test_policy_matrix_content_moderation_scope_dependency_denies_non_moderation_scoped_admin(scope: AdminScope) -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(scope,)),
+    )
+    req = SimpleNamespace(headers={"user-agent": "pytest"}, client=SimpleNamespace(host="127.0.0.1"), state=SimpleNamespace())
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(filemanager.require_content_moderation_admin(request=req, user=actor))
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_scope"
+    assert exc.value.detail["required_scope"] == "content_moderation"
+
+
+def test_policy_matrix_content_moderation_scope_dependency_allows_moderation_scoped_admin() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    req = SimpleNamespace(headers={"user-agent": "pytest"}, client=SimpleNamespace(host="127.0.0.1"), state=SimpleNamespace())
+
+    out = asyncio.run(filemanager.require_content_moderation_admin(request=req, user=actor))
+    assert out is actor
+
+
+def test_policy_matrix_billing_operator_falls_back_to_admin_or_root_when_flag_disabled() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,)),
+    )
+    with patch.object(billing, "S", SimpleNamespace(admin_scope_enforce_billing_support=False)):
+        out = asyncio.run(billing.require_billing_admin_operator(user=actor, request=SimpleNamespace()))
+
+    assert out is actor
+
+
+def test_policy_matrix_billing_operator_enforces_scope_when_flag_enabled() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.AUTH_SUPPORT,)),
+    )
+    req = SimpleNamespace(headers={"user-agent": "pytest"}, client=SimpleNamespace(host="127.0.0.1"), state=SimpleNamespace())
+
+    with patch.object(billing, "S", SimpleNamespace(admin_scope_enforce_billing_support=True)):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(billing.require_billing_admin_operator(user=actor, request=req))
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_scope"
+    assert exc.value.detail["required_scope"] == "billing_support"
+
+
+def test_policy_matrix_content_moderation_operator_falls_back_to_admin_or_root_when_flag_disabled() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+    )
+    with patch.object(filemanager, "S", SimpleNamespace(admin_scope_enforce_content_moderation=False)):
+        out = asyncio.run(filemanager.require_content_moderation_operator(user=actor, request=SimpleNamespace()))
+
+    assert out is actor
+
+
+def test_policy_matrix_content_moderation_operator_enforces_scope_when_flag_enabled() -> None:
+    import asyncio
+
+    actor = AuthenticatedUser(
+        sub="a1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.BILLING_SUPPORT,)),
+    )
+    req = SimpleNamespace(headers={"user-agent": "pytest"}, client=SimpleNamespace(host="127.0.0.1"), state=SimpleNamespace())
+
+    with patch.object(filemanager, "S", SimpleNamespace(admin_scope_enforce_content_moderation=True)):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(filemanager.require_content_moderation_operator(user=actor, request=req))
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "role_required_scope"
+    assert exc.value.detail["required_scope"] == "content_moderation"


### PR DESCRIPTION
### Motivation
- Prevent permission regressions as scoped-admin route coverage expands by adding an end-to-end regression suite that exercises user, scoped-admin variants, general admin, and root behaviors.  
- Introduce a deterministic admin capability model so scoped admin checks can be enforced per-domain while preserving `root` and `general admin` semantics.  
- Make scope-denials observable and auditable so misclassifications are detectable during phased rollout.

### Description
- Add scoped-admin model and helpers in `app/auth/roles.py`: `AdminScope`, `AdminProfileType`, `AdminProfile`, `normalize_admin_profile`, `normalize_admin_scope`, and `admin_profile_has_scope`.  
- Extend authentication `AuthenticatedUser` in `app/auth/deps.py` to carry an `admin_profile` and extract/normalize it from JWT and dev fallbacks.  
- Add policy primitives in `app/auth/policy.py`: `require_admin_scope(...)` for per-scope checks and `require_general_admin_or_root()` for general-admin-only controls; emit structured audit events and call the new metrics helper on scope denials.  
- Add feature flags in `app/core/settings.py` to toggle enforcement per domain (`ADMIN_SCOPE_ENFORCE_AUTH_SUPPORT`, `ADMIN_SCOPE_ENFORCE_BILLING_SUPPORT`, `ADMIN_SCOPE_ENFORCE_CONTENT_MODERATION`).  
- Emit a Prometheus counter `admin_scope_denied_total{route,required_scope,admin_profile_type}` and helper `record_admin_scope_denied(...)` in `app/metrics.py`.  
- Migrate several server routes to scope-aware dependencies and operator helpers: `app/routers/admin_impersonation.py`, `app/routers/billing.py`, and `app/routers/filemanager.py` now use the `require_admin_scope` pattern or feature-flagged operator wrappers; billing/filemanager helpers were refactored to accept resolved `actor` values.  
- Extend `app/routers/admin_roles.py` to accept and validate `admin_profile` on grant, add `update-profile` endpoint, include profile fields in role-audit events, and validate/normalize scope inputs.  
- Add a backfill script `scripts/backfill_admin_profiles_general.py` and runbook docs for rollout (`docs/*`), plus UI/client changes to support profile payloads and better UX mapping of scope-denied errors (`frontend/src/*`).  
- Add a new end-to-end regression test file `tests/test_authorization_regression_matrix.py` and extend/adjust many unit tests to cover scoped/general/root behavior and audit/metric emission.

### Testing
- Ran `pytest -q tests/test_authorization_regression_matrix.py tests/test_auth_policy.py tests/test_policy_matrix.py` and observed all tests pass (`76 passed`).  
- Performed static validation with `python -m py_compile tests/test_authorization_regression_matrix.py` which succeeded.  
- New regression suite `tests/test_authorization_regression_matrix.py` exercises allow/deny matrices across domains, asserts canonical error contracts (`role_required`, `role_required_scope`, `role_required_admin_profile_type`), and asserts audit emission for both denied and allowed privileged operations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f2721f84832bb54532adf0c16504)