### PR TITLE
Fix local dev stack initialization failures (registration broken)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,6 +4,17 @@ DEV_MODE=1
 # DynamoDB Local
 DDB_ENDPOINT_URL=http://localhost:8001
 
+# DynamoDB table names (must match local-ddb-init.py defaults)
+DDB_SESSIONS_TABLE=sessions
+DDB_TOTP_TABLE=totp_devices
+DDB_SMS_TABLE=sms_devices
+DDB_RECOVERY_TABLE=recovery_codes
+DDB_EMAIL_TABLE=email_devices
+# Messaging Users table: use a distinct name to avoid a DynamoDB Local SQLite
+# case-collision with the auth `users` table (DynamoDB Local treats table names
+# case-insensitively in its SQLite backend, so "Users" and "users" clash).
+DDB_USERS=ddb_users
+
 # LocalStack (S3 + Cognito)
 AWS_ENDPOINT_URL=http://localhost:4566
 S3_ENDPOINT_URL=http://localhost:4566

--- a/scripts/local-stack-up.sh
+++ b/scripts/local-stack-up.sh
@@ -139,6 +139,15 @@ else
   start_host_stack
 fi
 
+# Load .env.local so init scripts have the endpoint URLs and bucket names they need.
+# run_dev.sh may have already exported these, but source again for direct invocation.
+if [[ -f "${REPO_ROOT}/.env.local" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${REPO_ROOT}/.env.local"
+  set +a
+fi
+
 PYTHONPATH="${REPO_ROOT}" python3 scripts/local-s3-init.py
 PYTHONPATH="${REPO_ROOT}" python3 scripts/local-cognito-init.py
 PYTHONPATH="${REPO_ROOT}" python3 scripts/local-ses-init.py

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -62,6 +62,19 @@ else
 fi
 
 set -a
+# In mock mode, load .env.local first so endpoint URLs and table names are
+# available to the init scripts (local-s3-init.py, local-ddb-init.py, etc.)
+# before run_local_mock_backend.sh sources it for the backend itself.
+if [[ "$backend_mode" == "mock" ]]; then
+  if [[ ! -f ".env.local" ]] && [[ -f ".env.local.example" ]]; then
+    cp .env.local.example ".env.local"
+    echo "Created .env.local from .env.local.example"
+  fi
+  if [[ -f ".env.local" ]]; then
+    # shellcheck disable=SC1091
+    source .env.local
+  fi
+fi
 if [[ -f ".env" ]]; then
   # shellcheck disable=SC1091
   source .env


### PR DESCRIPTION
## Problem

Running `scripts/run_dev.sh` would silently fail to bootstrap DynamoDB tables, causing all registration endpoints to return `ResourceNotFoundException`. Three separate root causes were found and fixed.

### 1. `run_dev.sh` sourced `.env` instead of `.env.local`

`run_dev.sh` tried to load environment variables from `.env`, which doesn't exist — only `.env.local` does. This meant init scripts ran without `DDB_ENDPOINT_URL`, `AWS_ENDPOINT_URL`, `S3_ENDPOINT_URL`, or bucket names set. `local-s3-init.py` then attempted to reach real AWS instead of LocalStack, failed with an auth error, and because `set -euo pipefail` is active, **the entire script aborted before the DDB bootstrap ever ran**.

### 2. `local-stack-up.sh` init scripts also lacked env vars

The same missing-env issue applied to `local-stack-up.sh` — it ran `local-s3-init.py` without bucket name vars, consistently creating 0 S3 buckets on every startup.

### 3. DynamoDB session/MFA table names defaulted to empty string

`Settings.ddb_sessions_table` and the other four auth/MFA table fields default to `""` when their env vars aren't set. This caused `tables.py` to create `ddb.Table("")` for `T.sessions`, `T.totp`, `T.sms`, `T.email`, and `T.recovery` — any operation on these at request time would fail with a DynamoDB validation error.

### 4. DynamoDB Local SQLite case-collision bug

DynamoDB Local treats its internal SQLite table names case-insensitively. The messaging `Users` table (default name `"Users"`) collided with the auth `users` table, producing `InternalFailure` on `CreateTable` for the messaging table — even on a completely fresh database.

## Fix

**`scripts/run_dev.sh`** — In mock mode, source `.env.local` (auto-creating from `.env.local.example` if missing) before running any init scripts. This ensures `DDB_ENDPOINT_URL`, `S3_ENDPOINT_URL`, bucket names, and table names are available when `local-s3-init.py`, `local-ddb-init.py`, and friends run. A `.env` file can still override values afterward.

**`scripts/local-stack-up.sh`** — Source `.env.local` before the Python init scripts for the same reason, and to support direct invocation of the script independent of `run_dev.sh`.

**`.env.local.example`** — Add explicit values for:
- `DDB_SESSIONS_TABLE=sessions`, `DDB_TOTP_TABLE=totp_devices`, `DDB_SMS_TABLE=sms_devices`, `DDB_RECOVERY_TABLE=recovery_codes`, `DDB_EMAIL_TABLE=email_devices` — so `T.sessions` etc. resolve to valid table names instead of `""`
- `DDB_USERS=ddb_users` — avoids the DynamoDB Local SQLite case-insensitivity collision between `Users` and `users`

## Testing

- All 34 DynamoDB tables bootstrap successfully with a clean database
- `POST /ui/register/check` → `{"status":"ok","available":true}` ✅
- `POST /ui/register/start` → reaches endpoint and processes normally (no more `ResourceNotFoundException`) ✅
- S3 buckets (local-uploads, local-chat-images, local-filemgr) created correctly ✅

## Notes

If DynamoDB Local's SQLite data file is ever lost or wiped, force a re-bootstrap with:
```bash
DEV_FORCE_DDB_BOOTSTRAP=1 scripts/run_dev.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)