### PR TITLE
HB-009: Add feature-flagged auto-claim on first helpdesk agent reply

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -249,6 +249,17 @@ USAGE_METERING_PIPELINE_LATENCY = Histogram(
     ["stage"],
     buckets=(0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5),
 )
+HELPDESK_ALERTS_SENT = Counter(
+    "helpdesk_alerts_sent_total",
+    "Helpdesk alerted-agent fanout outcomes",
+    ["outcome"],
+)
+HELPDESK_CLAIMS_TOTAL = Counter(
+    "helpdesk_claims_total",
+    "Helpdesk claim outcomes",
+    ["outcome"],
+)
+
 ADMIN_SCOPE_DENIED = Counter(
     "admin_scope_denied_total",
     "Denied admin scope authorization checks by route, required scope, and profile type",
@@ -398,6 +409,14 @@ def record_api_usage_snapshot_finalize(outcome: str) -> None:
 
 def record_api_usage_reconciliation_drift(*, area: str, rows: int) -> None:
     API_USAGE_RECONCILIATION_DRIFT.labels(area=(area or "unknown").lower()).set(float(max(0, int(rows))))
+
+
+def record_helpdesk_alert_sent(outcome: str) -> None:
+    HELPDESK_ALERTS_SENT.labels(outcome=(outcome or "unknown").lower()).inc()
+
+
+def record_helpdesk_claim(outcome: str) -> None:
+    HELPDESK_CLAIMS_TOTAL.labels(outcome=(outcome or "unknown").lower()).inc()
 
 
 def record_admin_scope_denied(*, route: str, required_scope: str, admin_profile_type: str) -> None:

--- a/app/routers/messaging.py
+++ b/app/routers/messaging.py
@@ -27,10 +27,17 @@ from pydantic import BaseModel, Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from app.auth.deps import extract_bearer_token, get_authenticated_user_sub
+from app.metrics import record_helpdesk_alert_sent, record_helpdesk_claim
 from app.core.settings import S
 from app.core.aws import ddb
 from app.core.aws_clients import s3_client
 from app.services.alerts import audit_event
+from app.services.messaging_routing import (
+    RoutingTransitionError,
+    RoutingTransitionInput,
+    build_routing_event_item,
+    transition_helpdesk_routing,
+)
 from app.services.filemanager import get_node, get_usage_summary, norm_path
 from app.services.sessions import require_ui_session
 from app.services.subscription_access import require_subscription_access
@@ -49,6 +56,7 @@ DDB_CONVERSATIONS = os.getenv("DDB_CONVERSATIONS", "Conversations")
 DDB_PARTICIPANTS = os.getenv("DDB_PARTICIPANTS", "Participants")
 DDB_MESSAGES = os.getenv("DDB_MESSAGES", "Messages")
 DDB_USER_EVENTS = os.getenv("DDB_USER_EVENTS", "UserEvents")
+DDB_CONVERSATION_ROUTING_EVENTS = os.getenv("DDB_CONVERSATION_ROUTING_EVENTS", "ConversationRoutingEvents")
 
 DDB_USERS = os.getenv("DDB_USERS", "Users")
 DDB_USER_SEARCH = os.getenv("DDB_USER_SEARCH", "UserSearch")
@@ -73,6 +81,7 @@ TYPING_TTL_SEC = int(os.getenv("TYPING_TTL_SEC", "10"))
 VIEWS_TTL_SEC = int(os.getenv("VIEWS_TTL_SEC", "2592000"))  # 30d
 EDITS_TTL_SEC = int(os.getenv("EDITS_TTL_SEC", "7776000"))  # 90d
 MESSAGE_REVOKE_WINDOW_SEC = int(os.getenv("MESSAGE_REVOKE_WINDOW_SEC", "300"))
+HELPDESK_GROUP_MEMBERS_JSON = os.getenv("HELPDESK_GROUP_MEMBERS_JSON", "").strip()
 
 s3 = s3_client()
 
@@ -81,6 +90,7 @@ tbl_convos = ddb.Table(DDB_CONVERSATIONS)
 tbl_parts = ddb.Table(DDB_PARTICIPANTS)
 tbl_msgs = ddb.Table(DDB_MESSAGES)
 tbl_events = ddb.Table(DDB_USER_EVENTS)
+tbl_routing_events = ddb.Table(DDB_CONVERSATION_ROUTING_EVENTS)
 tbl_users = ddb.Table(DDB_USERS)
 tbl_search = ddb.Table(DDB_USER_SEARCH)
 tbl_msg_search = ddb.Table(DDB_MESSAGE_SEARCH)
@@ -97,6 +107,9 @@ logger = logging.getLogger(__name__)
 MESSAGE_TEXT_MAX_CHARS = 4000
 ENCRYPTED_CIPHERTEXT_MAX_BYTES = 8192
 ENCRYPTED_EDIT_ERROR_CODE = "encrypted_message_edit_unsupported"
+NO_AGENTS_ONLINE_NOTICE_TEXT = "No helpdesk agents are online right now. Please try again later."
+NO_AGENTS_NOTICE_THROTTLE_SEC = int(os.getenv("NO_AGENTS_NOTICE_THROTTLE_SEC", "600"))
+HELPDESK_AUTO_CLAIM_ON_REPLY_ENABLED = os.getenv("HELPDESK_AUTO_CLAIM_ON_REPLY_ENABLED", "0").strip().lower() in {"1", "true", "yes", "on"}
 
 
 # -------------------------
@@ -332,6 +345,12 @@ async def get_messaging_user_id(
     return get_current_user_id(authorization)
 
 
+def _helpdesk_virtual_participant_id(group_id: str) -> str:
+    return f"helpdesk_group:{group_id}"
+
+
+
+
 # -------------------------
 # Models
 # -------------------------
@@ -341,7 +360,7 @@ class Contact(BaseModel):
 
 
 class StartConversationIn(BaseModel):
-    participant_ids: List[str] = Field(min_length=1)
+    participant_ids: List[str] = Field(default_factory=list)
     participant_id: Optional[str] = None
     type: Literal["dm", "group"] = "dm"
     title: Optional[str] = None
@@ -349,6 +368,8 @@ class StartConversationIn(BaseModel):
     icon: Optional[str] = Field(default=None, max_length=500)
     topic: Optional[str] = Field(default=None, max_length=200)
     retention_days: Optional[int] = Field(default=None, ge=1, le=3650)
+    routing_mode: Literal["standard", "helpdesk_bridge"] = "standard"
+    helpdesk_group_id: Optional[str] = Field(default=None, max_length=128)
 
     @model_validator(mode="before")
     @classmethod
@@ -360,6 +381,26 @@ class StartConversationIn(BaseModel):
             payload["participant_ids"] = [payload["participant_id"]]
             logger.warning("messaging.start_conversation legacy payload used: participant_id")
         return payload
+
+    @model_validator(mode="after")
+    def _validate_helpdesk_routing(self):
+        if self.routing_mode == "helpdesk_bridge":
+            if not self.helpdesk_group_id:
+                raise PydanticCustomError(
+                    "helpdesk_group_required",
+                    "helpdesk_group_id is required when routing_mode=helpdesk_bridge",
+                )
+            if self.type != "dm":
+                raise PydanticCustomError(
+                    "helpdesk_type_invalid",
+                    "helpdesk_bridge conversations must use type=dm",
+                )
+        elif not self.participant_ids:
+            raise PydanticCustomError(
+                "participant_ids_required",
+                "participant_ids must include at least one participant for standard conversations",
+            )
+        return self
 
 
 class StartGroupConversationIn(BaseModel):
@@ -388,6 +429,29 @@ class ConversationOut(BaseModel):
     muted_until: int = 0
     last_read_at: int = 0
     unread_count: int = 0
+
+
+class RoutingEventOut(BaseModel):
+    conversation_id: str
+    event_id: str
+    event_type: str
+    actor_user_id: str
+    from_state: str
+    to_state: str
+    created_at: int
+    assignment_version: int = 0
+    routing_group_id: str = ""
+    active_agent_user_id: str = ""
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class HelpdeskClaimOut(BaseModel):
+    ok: bool
+    conversation_id: str
+    state: str
+    assigned_agent_user_id: str
+    assignment_version: int
+    idempotent: bool = False
 
 
 class LinkPreviewIn(BaseModel):
@@ -579,7 +643,7 @@ class UpdateConversationIn(BaseModel):
 
 
 class AddParticipantsIn(BaseModel):
-    participant_ids: List[str] = Field(min_length=1)
+    participant_ids: List[str] = Field(default_factory=list)
 
 
 class UpdateParticipantRoleIn(BaseModel):
@@ -1149,6 +1213,52 @@ def _get_conversation_or_404(conversation_id: str) -> dict:
     return convo
 
 
+def _routing_event_id(ts: int) -> str:
+    return f"{int(ts):010d}#{new_id()}"
+
+
+def _apply_helpdesk_routing_transition(
+    *,
+    conversation_id: str,
+    cmd: RoutingTransitionInput,
+    actor_user_id: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> dict:
+    convo = _get_conversation_or_404(conversation_id)
+    result = transition_helpdesk_routing(convo, cmd)
+
+    if result.changed:
+        current_version = int(convo.get("assignment_version") or 0)
+        update_expr_parts = []
+        expr_values: Dict[str, Any] = {":expected_version": current_version, ":zero": 0}
+        for idx, (key, value) in enumerate(result.patch.items()):
+            token = f":v{idx}"
+            update_expr_parts.append(f"{key} = {token}")
+            expr_values[token] = value
+        tbl_convos.update_item(
+            Key={"conversation_id": conversation_id},
+            UpdateExpression="SET " + ", ".join(update_expr_parts),
+            ConditionExpression=(
+                "(attribute_not_exists(assignment_version) AND :expected_version = :zero) "
+                "OR assignment_version = :expected_version"
+            ),
+            ExpressionAttributeValues=expr_values,
+        )
+        convo = {**convo, **result.patch}
+
+    event_created_at = int(cmd.now_ts)
+    event_item = build_routing_event_item(
+        conversation=convo,
+        transition=result,
+        actor_user_id=actor_user_id,
+        created_at=event_created_at,
+        event_id=_routing_event_id(event_created_at),
+        metadata=metadata or {},
+    )
+    tbl_routing_events.put_item(Item=event_item, ConditionExpression="attribute_not_exists(event_id)")
+    return {"transition": result, "event": event_item, "conversation": convo}
+
+
 def _message_retention_ttl(conversation: dict, created_at: int) -> Optional[int]:
     retention_days = conversation.get("retention_days")
     if retention_days is None:
@@ -1377,6 +1487,173 @@ def _event_id() -> str:
     return f"e_{now_ts()}_{uuid.uuid4().hex}"
 
 
+def _helpdesk_alert_event_id(conversation_id: str, target_user_id: str) -> str:
+    return f"helpdesk_alert#{conversation_id}#{target_user_id}"
+
+
+def _resolve_helpdesk_group_members(group_id: str) -> list[str]:
+    gid = (group_id or "").strip()
+    if not gid:
+        return []
+
+    members: list[str] = []
+    if HELPDESK_GROUP_MEMBERS_JSON:
+        try:
+            raw = json.loads(HELPDESK_GROUP_MEMBERS_JSON)
+            if isinstance(raw, dict):
+                values = raw.get(gid, [])
+                if isinstance(values, list):
+                    members.extend(str(v).strip() for v in values if str(v).strip())
+        except Exception:
+            logger.exception("failed to parse HELPDESK_GROUP_MEMBERS_JSON")
+
+    if members:
+        return list(dict.fromkeys(members))
+
+    # Fallback: allow user records to self-declare helpdesk groups.
+    items = []
+    try:
+        resp = tbl_users.scan(FilterExpression=Attr("helpdesk_groups").contains(gid), ProjectionExpression="user_id")
+        items.extend(resp.get("Items", []))
+        while resp.get("LastEvaluatedKey"):
+            resp = tbl_users.scan(
+                FilterExpression=Attr("helpdesk_groups").contains(gid),
+                ProjectionExpression="user_id",
+                ExclusiveStartKey=resp["LastEvaluatedKey"],
+            )
+            items.extend(resp.get("Items", []))
+    except Exception:
+        return []
+
+    return list(dict.fromkeys(str(it.get("user_id") or "").strip() for it in items if str(it.get("user_id") or "").strip()))
+
+
+def _is_helpdesk_group_member(group_id: str, user_id: str) -> bool:
+    uid = (user_id or "").strip()
+    if not uid:
+        return False
+    return uid in set(_resolve_helpdesk_group_members(group_id))
+
+
+def _is_user_online_available(user_id: str, ts: int) -> bool:
+    try:
+        item = tbl_presence.get_item(Key={"user_id": user_id}).get("Item") or {}
+    except Exception:
+        return False
+    last_seen = int(item.get("last_seen_at", 0) or 0)
+    status = str(item.get("status") or "online").lower()
+    return bool(last_seen and (ts - last_seen) <= ONLINE_WINDOW_SEC and status in {"online", "available"})
+
+
+def _resolve_online_helpdesk_members(group_id: str, ts: int) -> list[str]:
+    members = _resolve_helpdesk_group_members(group_id)
+    if not members:
+        return []
+    keys = [{"user_id": uid} for uid in members]
+    try:
+        resp = ddb.meta.client.batch_get_item(RequestItems={DDB_PRESENCE: {"Keys": keys}})
+    except Exception:
+        return []
+    presence_items = {it.get("user_id"): it for it in resp.get("Responses", {}).get(DDB_PRESENCE, [])}
+    out: list[str] = []
+    for uid in members:
+        it = presence_items.get(uid) or {}
+        last_seen = int(it.get("last_seen_at", 0) or 0)
+        status = str(it.get("status") or "online").lower()
+        if last_seen and (ts - last_seen) <= ONLINE_WINDOW_SEC and status in {"online", "available"}:
+            out.append(uid)
+    return out
+
+
+def fanout_helpdesk_alert(conversation_id: str, group_id: str, created_by: str) -> int:
+    ts = now_ts()
+    online_members = _resolve_online_helpdesk_members(group_id, ts)
+    if not online_members:
+        return 0
+
+    ttl = ts + 7 * 24 * 3600
+    delivered = 0
+    for uid in online_members:
+        event_item = {
+            "user_id": uid,
+            "event_id": _helpdesk_alert_event_id(conversation_id, uid),
+            "type": "helpdesk.conversation.alerted",
+            "created_at": ts,
+            "conversation_id": conversation_id,
+            "payload": {
+                "conversation_id": conversation_id,
+                "group_id": group_id,
+                "created_by": created_by,
+                "routing_state": "awaiting_agent",
+            },
+            "ttl": ttl,
+        }
+        try:
+            tbl_events.put_item(Item=event_item, ConditionExpression="attribute_not_exists(event_id)")
+            delivered += 1
+            record_helpdesk_alert_sent("delivered")
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                record_helpdesk_alert_sent("duplicate")
+                continue
+            record_helpdesk_alert_sent("error")
+            logger.exception("failed to write helpdesk alert event", extra={"conversation_id": conversation_id, "target_user_id": uid})
+        except Exception:
+            record_helpdesk_alert_sent("error")
+            logger.exception("failed to write helpdesk alert event", extra={"conversation_id": conversation_id, "target_user_id": uid})
+    return delivered
+
+
+def _emit_no_agents_online_notice(*, conversation_id: str, user_id: str, now: int) -> bool:
+    convo = _get_conversation_or_404(conversation_id)
+    last_notice_at = int(convo.get("no_agents_notice_sent_at", 0) or 0)
+    if last_notice_at and (now - last_notice_at) < NO_AGENTS_NOTICE_THROTTLE_SEC:
+        return False
+
+    try:
+        _apply_helpdesk_routing_transition(
+            conversation_id=conversation_id,
+            cmd=RoutingTransitionInput(action="pause_no_agents", now_ts=now),
+            actor_user_id=user_id,
+            metadata={"reason": "no_agents_online_creation"},
+        )
+    except RoutingTransitionError as exc:
+        if exc.code != "routing_pause_invalid_state":
+            raise
+
+    message_id = "sys_no_agents_online"
+    try:
+        tbl_msgs.put_item(
+            Item={
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+                "sender_id": "system",
+                "created_at": now,
+                "kind": "text",
+                "text": NO_AGENTS_ONLINE_NOTICE_TEXT,
+            },
+            ConditionExpression="attribute_not_exists(message_id)",
+        )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
+            raise
+
+    tbl_convos.update_item(
+        Key={"conversation_id": conversation_id},
+        UpdateExpression=(
+            "SET last_message_at=:ts, last_message_preview=:preview, "
+            "no_agents_notice_sent_at=:ts"
+        ),
+        ExpressionAttributeValues={
+            ":ts": now,
+            ":preview": NO_AGENTS_ONLINE_NOTICE_TEXT,
+        },
+    )
+    return True
+
+
+
+
 def fanout_event_to_conversation(
     conversation_id: str,
     sender_id: str,
@@ -1530,16 +1807,23 @@ def start_conversation(
     cid = "c_" + new_id()
     created_at = now_ts()
 
-    participant_ids = list(dict.fromkeys([user_id] + inp.participant_ids))
+    routing_mode = inp.routing_mode
+    routing_state = "awaiting_agent" if routing_mode == "helpdesk_bridge" else "none"
+    group_id = inp.helpdesk_group_id if routing_mode == "helpdesk_bridge" else ""
+
+    if routing_mode == "helpdesk_bridge":
+        participant_ids = [user_id, _helpdesk_virtual_participant_id(group_id)]
+    else:
+        participant_ids = list(dict.fromkeys([user_id] + inp.participant_ids))
+
     if inp.type == "dm" and len(participant_ids) != 2:
         raise HTTPException(400, "dm conversation must have exactly 2 unique participants")
     if inp.type == "group" and len(participant_ids) < 3:
         raise HTTPException(400, "group conversation must have at least 3 unique participants")
     for pid in participant_ids:
-        if pid == user_id:
+        if pid == user_id or pid.startswith("helpdesk_group:"):
             continue
         require_subscription_access(user_id, pid)
-
     convo_item = {
         "conversation_id": cid,
         "created_at": created_at,
@@ -1553,6 +1837,16 @@ def start_conversation(
         "participant_count": len(participant_ids),
         "last_message_at": 0,
         "last_message_preview": "",
+        "routing_mode": routing_mode,
+        "routing_group_id": group_id,
+        "routing_state": routing_state,
+        "active_agent_user_id": "",
+        "active_agent_claimed_at": 0,
+        "last_failover_at": 0,
+        "assignment_version": 0,
+        "no_agents_notice_sent_at": 0,
+        "routing_state_group_pk": f"{routing_state}#{group_id}",
+        "routing_state_group_sk": cid,
     }
     tbl_convos.put_item(Item=convo_item, ConditionExpression="attribute_not_exists(conversation_id)")
 
@@ -1573,6 +1867,11 @@ def start_conversation(
                 "GSI1SK": pid,
             }
         )
+
+    if routing_mode == "helpdesk_bridge":
+        delivered = fanout_helpdesk_alert(conversation_id=cid, group_id=group_id, created_by=user_id)
+        if delivered == 0:
+            _emit_no_agents_online_notice(conversation_id=cid, user_id=user_id, now=created_at)
 
     convo = ConversationOut(
         conversation_id=cid,
@@ -1974,6 +2273,157 @@ def delete_conversation_if_last(conversation_id: str, req: Request = None, user_
     return {"ok": True, "deleted": True}
 
 
+def _claim_helpdesk_conversation_internal(
+    *,
+    conversation_id: str,
+    user_id: str,
+    req: Optional[Request] = None,
+) -> HelpdeskClaimOut:
+    def _idempotent_success(latest: dict) -> HelpdeskClaimOut:
+        record_helpdesk_claim("idempotent")
+        return HelpdeskClaimOut(
+            ok=True,
+            conversation_id=conversation_id,
+            state="assigned",
+            assigned_agent_user_id=user_id,
+            assignment_version=int(latest.get("assignment_version") or 0),
+            idempotent=True,
+        )
+
+    convo = _get_conversation_or_404(conversation_id)
+    if str(convo.get("routing_mode") or "") != "helpdesk_bridge":
+        raise HTTPException(400, detail={"code": "helpdesk_claim_invalid_mode", "message": "conversation is not helpdesk-routed"})
+
+    group_id = str(convo.get("routing_group_id") or "")
+    if not _is_helpdesk_group_member(group_id, user_id):
+        raise HTTPException(403, detail={"code": "helpdesk_claim_not_group_member", "message": "user is not a helpdesk group member"})
+
+    ts = now_ts()
+    if not _is_user_online_available(user_id, ts):
+        raise HTTPException(403, detail={"code": "helpdesk_claim_not_available", "message": "user is not currently online/available"})
+
+    current_state = str(convo.get("routing_state") or "none")
+    current_agent = str(convo.get("active_agent_user_id") or "")
+    current_version = int(convo.get("assignment_version") or 0)
+
+    if current_state == "assigned":
+        if current_agent == user_id:
+            return _idempotent_success(convo)
+        record_helpdesk_claim("conflict")
+        raise HTTPException(409, detail={"code": "helpdesk_claim_already_assigned", "message": "conversation already assigned"})
+
+    if current_state != "awaiting_agent":
+        record_helpdesk_claim("conflict")
+        raise HTTPException(409, detail={"code": "helpdesk_claim_invalid_state", "message": f"cannot claim from state: {current_state}"})
+
+    try:
+        result = _apply_helpdesk_routing_transition(
+            conversation_id=conversation_id,
+            cmd=RoutingTransitionInput(
+                action="assign_agent",
+                now_ts=ts,
+                agent_user_id=user_id,
+                expected_assignment_version=current_version,
+            ),
+            actor_user_id=user_id,
+            metadata={"reason": "claim"},
+        )
+    except RoutingTransitionError as exc:
+        if exc.code in {"routing_assign_invalid_state", "routing_assignment_version_conflict"}:
+            latest = _get_conversation_or_404(conversation_id)
+            if str(latest.get("routing_state") or "") == "assigned" and str(latest.get("active_agent_user_id") or "") == user_id:
+                return _idempotent_success(latest)
+            record_helpdesk_claim("conflict")
+            raise HTTPException(409, detail={"code": "helpdesk_claim_conflict", "message": "conversation claim conflict"})
+        raise HTTPException(400, detail={"code": exc.code, "message": exc.message})
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            latest = _get_conversation_or_404(conversation_id)
+            if str(latest.get("routing_state") or "") == "assigned" and str(latest.get("active_agent_user_id") or "") == user_id:
+                return _idempotent_success(latest)
+            record_helpdesk_claim("conflict")
+            raise HTTPException(409, detail={"code": "helpdesk_claim_conflict", "message": "conversation claim conflict"})
+        raise
+
+    updated = result.get("conversation", {}) if isinstance(result, dict) else {}
+    audit_event(
+        "messaging_helpdesk_conversation_claimed",
+        user_id,
+        req,
+        outcome="success",
+        conversation_id=conversation_id,
+        routing_group_id=group_id,
+    )
+    record_helpdesk_claim("success")
+    return HelpdeskClaimOut(
+        ok=True,
+        conversation_id=conversation_id,
+        state=str(updated.get("routing_state") or "assigned"),
+        assigned_agent_user_id=str(updated.get("active_agent_user_id") or user_id),
+        assignment_version=int(updated.get("assignment_version") or (current_version + 1)),
+        idempotent=False,
+    )
+
+
+@router.post("/helpdesk/conversations/{conversation_id}/claim", response_model=HelpdeskClaimOut)
+def claim_helpdesk_conversation(
+    conversation_id: str,
+    req: Request = None,
+    user_id: str = Depends(get_messaging_user_id),
+):
+    return _claim_helpdesk_conversation_internal(conversation_id=conversation_id, user_id=user_id, req=req)
+
+
+def _auto_claim_helpdesk_on_first_reply(*, conversation_id: str, convo: dict, user_id: str, req: Optional[Request] = None) -> None:
+    if str(convo.get("routing_mode") or "") != "helpdesk_bridge":
+        return
+    group_id = str(convo.get("routing_group_id") or "")
+    if not group_id or not _is_helpdesk_group_member(group_id, user_id):
+        return
+
+    state = str(convo.get("routing_state") or "none")
+    assigned_agent = str(convo.get("active_agent_user_id") or "")
+    if state == "assigned" and assigned_agent and assigned_agent != user_id:
+        raise HTTPException(409, detail={"code": "helpdesk_claim_already_assigned", "message": "conversation already assigned"})
+    if state != "awaiting_agent":
+        return
+    if not HELPDESK_AUTO_CLAIM_ON_REPLY_ENABLED:
+        raise HTTPException(409, detail={"code": "helpdesk_claim_required", "message": "explicit claim required before replying"})
+
+    _claim_helpdesk_conversation_internal(conversation_id=conversation_id, user_id=user_id, req=req)
+
+
+@router.get("/conversations/{conversation_id}/routing-events", response_model=List[RoutingEventOut])
+def list_conversation_routing_events(
+    conversation_id: str,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    user_id: str = Depends(get_messaging_user_id),
+):
+    require_participant_role(user_id, conversation_id, {"admin"})
+    resp = tbl_routing_events.query(
+        KeyConditionExpression=Key("conversation_id").eq(conversation_id),
+        ScanIndexForward=False,
+        Limit=limit,
+    )
+    items = resp.get("Items", [])
+    return [
+        RoutingEventOut(
+            conversation_id=item.get("conversation_id", conversation_id),
+            event_id=item.get("event_id", ""),
+            event_type=item.get("event_type", ""),
+            actor_user_id=item.get("actor_user_id", ""),
+            from_state=item.get("from_state", ""),
+            to_state=item.get("to_state", ""),
+            created_at=int(item.get("created_at", 0) or 0),
+            assignment_version=int(item.get("assignment_version", 0) or 0),
+            routing_group_id=item.get("routing_group_id", ""),
+            active_agent_user_id=item.get("active_agent_user_id", ""),
+            metadata=item.get("metadata", {}) if isinstance(item.get("metadata"), dict) else {},
+        )
+        for item in items
+    ]
+
+
 @router.get("/conversations/{conversation_id}/participants", response_model=List[ParticipantOut])
 def list_participants(conversation_id: str, user_id: str = Depends(get_messaging_user_id)):
     part = get_participant_any(user_id, conversation_id)
@@ -2230,6 +2680,7 @@ def send_text_message(
     if inp.encryption and not _encrypted_messages_enabled():
         raise HTTPException(status_code=403, detail="Encrypted messaging is disabled")
     convo = _get_conversation_or_404(conversation_id)
+    _auto_claim_helpdesk_on_first_reply(conversation_id=conversation_id, convo=convo, user_id=user_id, req=req)
     try:
         resp = tbl_parts.query(IndexName="GSI1", KeyConditionExpression=Key("GSI1PK").eq(conversation_id))
         participants = resp.get("Items", [])

--- a/app/services/messaging_routing.py
+++ b/app/services/messaging_routing.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Mapping, Optional
+
+RoutingMode = Literal["standard", "helpdesk_bridge"]
+RoutingState = Literal["none", "awaiting_agent", "assigned", "paused_no_agents_online", "closed"]
+RoutingAction = Literal["assign_agent", "release_agent", "pause_no_agents", "resume_awaiting", "close"]
+
+
+@dataclass(frozen=True)
+class RoutingTransitionError(Exception):
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class RoutingTransitionResult:
+    from_state: RoutingState
+    to_state: RoutingState
+    changed: bool
+    event_type: str
+    patch: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RoutingTransitionInput:
+    action: RoutingAction
+    now_ts: int
+    agent_user_id: Optional[str] = None
+    expected_assignment_version: Optional[int] = None
+
+
+def _state(item: Mapping[str, Any]) -> RoutingState:
+    return str(item.get("routing_state") or "none")  # type: ignore[return-value]
+
+
+def _mode(item: Mapping[str, Any]) -> RoutingMode:
+    return str(item.get("routing_mode") or "standard")  # type: ignore[return-value]
+
+
+def _assignment_version(item: Mapping[str, Any]) -> int:
+    try:
+        return int(item.get("assignment_version") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _state_group_pk(next_state: RoutingState, group_id: str) -> str:
+    return f"{next_state}#{group_id}"
+
+
+def build_routing_event_item(
+    *,
+    conversation: Mapping[str, Any],
+    transition: RoutingTransitionResult,
+    actor_user_id: str,
+    created_at: int,
+    event_id: str,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "conversation_id": str(conversation.get("conversation_id") or ""),
+        "event_id": event_id,
+        "event_type": transition.event_type,
+        "actor_user_id": actor_user_id,
+        "from_state": transition.from_state,
+        "to_state": transition.to_state,
+        "created_at": int(created_at),
+        "assignment_version": int(transition.patch.get("assignment_version") or conversation.get("assignment_version") or 0),
+        "routing_group_id": str(conversation.get("routing_group_id") or ""),
+        "active_agent_user_id": str(transition.patch.get("active_agent_user_id") or ""),
+        "metadata": dict(metadata or {}),
+    }
+
+
+def transition_helpdesk_routing(
+    conversation: Mapping[str, Any],
+    cmd: RoutingTransitionInput,
+) -> RoutingTransitionResult:
+    mode = _mode(conversation)
+    if mode != "helpdesk_bridge":
+        raise RoutingTransitionError(
+            code="routing_mode_not_helpdesk_bridge",
+            message="routing transitions are only valid for helpdesk bridge conversations",
+        )
+
+    from_state = _state(conversation)
+    if from_state == "closed" and cmd.action != "close":
+        raise RoutingTransitionError(
+            code="routing_conversation_closed",
+            message="conversation routing is closed",
+        )
+
+    current_version = _assignment_version(conversation)
+    if cmd.expected_assignment_version is not None and cmd.expected_assignment_version != current_version:
+        raise RoutingTransitionError(
+            code="routing_assignment_version_conflict",
+            message="assignment version mismatch",
+        )
+
+    group_id = str(conversation.get("routing_group_id") or "")
+    base_patch: Dict[str, Any] = {
+        "routing_mode": "helpdesk_bridge",
+        "routing_group_id": group_id,
+    }
+
+    if cmd.action == "assign_agent":
+        if from_state != "awaiting_agent":
+            raise RoutingTransitionError(
+                code="routing_assign_invalid_state",
+                message="agent can only be assigned from awaiting_agent state",
+            )
+        if not cmd.agent_user_id:
+            raise RoutingTransitionError(code="routing_assign_agent_required", message="agent_user_id is required")
+        to_state: RoutingState = "assigned"
+        return RoutingTransitionResult(
+            from_state=from_state,
+            to_state=to_state,
+            changed=True,
+            event_type="helpdesk.conversation.assigned",
+            patch={
+                **base_patch,
+                "routing_state": to_state,
+                "active_agent_user_id": cmd.agent_user_id,
+                "active_agent_claimed_at": int(cmd.now_ts),
+                "assignment_version": current_version + 1,
+                "routing_state_group_pk": _state_group_pk(to_state, group_id),
+                "routing_state_group_sk": str(conversation.get("conversation_id") or ""),
+            },
+        )
+
+    if cmd.action == "release_agent":
+        if from_state != "assigned":
+            raise RoutingTransitionError(
+                code="routing_release_invalid_state",
+                message="agent can only be released from assigned state",
+            )
+        current_agent = str(conversation.get("active_agent_user_id") or "")
+        if cmd.agent_user_id and current_agent and cmd.agent_user_id != current_agent:
+            raise RoutingTransitionError(
+                code="routing_release_agent_mismatch",
+                message="agent_user_id does not match active agent",
+            )
+        to_state = "awaiting_agent"
+        return RoutingTransitionResult(
+            from_state=from_state,
+            to_state=to_state,
+            changed=True,
+            event_type="helpdesk.conversation.released",
+            patch={
+                **base_patch,
+                "routing_state": to_state,
+                "active_agent_user_id": "",
+                "last_failover_at": int(cmd.now_ts),
+                "assignment_version": current_version + 1,
+                "routing_state_group_pk": _state_group_pk(to_state, group_id),
+                "routing_state_group_sk": str(conversation.get("conversation_id") or ""),
+            },
+        )
+
+    if cmd.action == "pause_no_agents":
+        if from_state not in {"awaiting_agent", "assigned"}:
+            raise RoutingTransitionError(
+                code="routing_pause_invalid_state",
+                message="conversation can only be paused from awaiting_agent or assigned state",
+            )
+        to_state = "paused_no_agents_online"
+        return RoutingTransitionResult(
+            from_state=from_state,
+            to_state=to_state,
+            changed=True,
+            event_type="helpdesk.conversation.no_agents_online",
+            patch={
+                **base_patch,
+                "routing_state": to_state,
+                "active_agent_user_id": "",
+                "no_agents_notice_sent_at": int(cmd.now_ts),
+                "assignment_version": current_version + 1,
+                "routing_state_group_pk": _state_group_pk(to_state, group_id),
+                "routing_state_group_sk": str(conversation.get("conversation_id") or ""),
+            },
+        )
+
+    if cmd.action == "resume_awaiting":
+        if from_state != "paused_no_agents_online":
+            raise RoutingTransitionError(
+                code="routing_resume_invalid_state",
+                message="conversation can only resume from paused_no_agents_online state",
+            )
+        to_state = "awaiting_agent"
+        return RoutingTransitionResult(
+            from_state=from_state,
+            to_state=to_state,
+            changed=True,
+            event_type="helpdesk.conversation.alerted",
+            patch={
+                **base_patch,
+                "routing_state": to_state,
+                "routing_state_group_pk": _state_group_pk(to_state, group_id),
+                "routing_state_group_sk": str(conversation.get("conversation_id") or ""),
+            },
+        )
+
+    if cmd.action == "close":
+        if from_state == "closed":
+            return RoutingTransitionResult(
+                from_state=from_state,
+                to_state="closed",
+                changed=False,
+                event_type="helpdesk.conversation.closed",
+                patch={},
+            )
+        to_state = "closed"
+        return RoutingTransitionResult(
+            from_state=from_state,
+            to_state=to_state,
+            changed=True,
+            event_type="helpdesk.conversation.closed",
+            patch={
+                **base_patch,
+                "routing_state": to_state,
+                "active_agent_user_id": "",
+                "assignment_version": current_version + 1,
+                "routing_state_group_pk": _state_group_pk(to_state, group_id),
+                "routing_state_group_sk": str(conversation.get("conversation_id") or ""),
+            },
+        )
+
+    raise RoutingTransitionError(code="routing_action_not_supported", message=f"unsupported action: {cmd.action}")

--- a/docs/helpdesk-bridge-conversation-plan.md
+++ b/docs/helpdesk-bridge-conversation-plan.md
@@ -1,0 +1,273 @@
+# Helpdesk Bridge Conversation Mode — Implementation Plan
+
+## Goals
+
+Implement a special messaging mode where an end user chats with a **Helpdesk** identity while the system dynamically routes the conversation to an available helpdesk agent.
+
+Behavior required:
+
+1. User starts a conversation addressed to the Helpdesk identity.
+2. All online members of the helpdesk group are alerted.
+3. First agent to accept/respond becomes the active responder in a temporary 1:1 bridge.
+4. End user always sees the responder as the Helpdesk identity (agent identity hidden).
+5. If active agent goes offline/disconnects while conversation is still open, routing returns to group-available mode.
+6. If no helpdesk agents are online when routing is needed, show a deterministic system message telling user nobody is online and to try again later.
+
+---
+
+## Solution outline
+
+Treat this as a **stateful routed conversation** with a virtual participant (`helpdesk_group`) and an optional live assignee (`agent_user_id`).
+
+### Conversation states
+
+- `awaiting_agent`: no live assignee; group members may claim.
+- `assigned`: exactly one active assignee is handling replies.
+- `paused_no_agents_online`: no available agents; user is informed and conversation waits for availability.
+- `closed` (optional, existing lifecycle).
+
+### Key principles
+
+- **Identity masking**: user-facing events and payloads render sender as `Helpdesk` for all agent messages.
+- **Single active assignee**: only one agent can own an assigned conversation at a time.
+- **Fast failover**: loss of active assignee transitions back to `awaiting_agent` and re-alerts online group members.
+- **Deterministic system messaging**: standardized event/message when nobody is online.
+
+---
+
+## Data model changes
+
+Add or extend `conversation_routing` metadata (same record or sibling table):
+
+- `conversation_id`
+- `routing_mode` = `helpdesk_bridge`
+- `group_id` (helpdesk group)
+- `state` (`awaiting_agent|assigned|paused_no_agents_online|closed`)
+- `active_agent_user_id` (nullable)
+- `active_agent_claimed_at` (nullable)
+- `last_failover_at` (nullable)
+- `assignment_version` (integer for optimistic concurrency)
+- `no_agents_notice_sent_at` (nullable; throttle duplicate notices)
+
+Optional audit table (`conversation_routing_events`):
+
+- `event_id`, `conversation_id`, `event_type`, `actor_user_id`, `from_state`, `to_state`, `created_at`, `metadata`
+
+This helps compliance/debugging without exposing agent identity to end users.
+
+---
+
+## API and service changes
+
+## 1) Conversation creation
+
+When user starts a helpdesk chat:
+
+- Create conversation with `routing_mode=helpdesk_bridge`, `state=awaiting_agent`.
+- Publish alert event to all currently online users in `group_id`.
+- If no one online at creation time:
+  - set `state=paused_no_agents_online`
+  - inject user-visible system message: "No helpdesk agents are online right now. Please try again later."
+
+## 2) Agent claim/accept endpoint
+
+Add endpoint (or command) for helpdesk members:
+
+- `POST /v1/messaging/helpdesk/conversations/{id}/claim`
+
+Server behavior:
+
+- Validate caller in helpdesk group and online/available.
+- Atomic compare-and-set from `awaiting_agent -> assigned`.
+- Set `active_agent_user_id`, timestamps, increment `assignment_version`.
+- Return idempotent success if caller already assignee.
+- Return conflict if already assigned to another agent.
+
+## 3) Sending messages
+
+For assigned conversations:
+
+- Agent reply is stored with true sender internally.
+- User-facing render path maps sender display to Helpdesk virtual identity.
+- Agent identity is only available to authorized internal/admin/audit paths.
+
+For unassigned conversations:
+
+- Block outbound agent send unless first claiming (or auto-claim on first reply with same CAS logic).
+
+## 4) Presence and failover
+
+Subscribe routing service to presence changes (`online/offline/unavailable`):
+
+- If active assignee goes offline/unavailable:
+  - transition `assigned -> awaiting_agent`
+  - clear `active_agent_user_id`
+  - publish group re-alert event
+  - if no online agents exist, set `paused_no_agents_online` and emit the offline notice (throttled)
+
+- If in `paused_no_agents_online` and any agent comes online:
+  - transition to `awaiting_agent`
+  - alert group members
+
+## 5) Read/list APIs
+
+User view:
+
+- Participants include user + `Helpdesk` virtual user.
+- Messages from any agent appear as from `Helpdesk`.
+
+Agent view:
+
+- Show assignment status and ownership metadata needed for operations.
+- Optionally include "claimed by you / another agent" indicators.
+
+---
+
+## Realtime/eventing changes
+
+Add events:
+
+- `helpdesk.conversation.alerted`
+- `helpdesk.conversation.assigned`
+- `helpdesk.conversation.released`
+- `helpdesk.conversation.no_agents_online`
+
+Channel strategy:
+
+- User channel receives masked message/user events only.
+- Helpdesk group channel receives claim/release/alert events with actual agent IDs where authorized.
+
+Ensure websocket payload serializer applies identity masking consistently (API and realtime parity).
+
+---
+
+## Concurrency and correctness
+
+Use optimistic locking (`assignment_version`) or transactional conditional writes to prevent dual assignment.
+
+Critical race scenarios to cover:
+
+1. Two agents claim simultaneously.
+2. Agent sends first reply at same instant another agent claims.
+3. Agent disconnect event races with outbound send.
+4. Presence flapping causing repeated no-agent notices.
+
+Mitigations:
+
+- CAS for claim and auto-claim.
+- Idempotency keys for claim requests.
+- Notice throttling window (for example 5–10 minutes).
+- Ordered event processing by conversation key where possible.
+
+---
+
+## UX behaviors
+
+### End user
+
+- Starts chat with "Helpdesk".
+- Sees continuous thread from Helpdesk identity.
+- If no one available, sees explicit system notice and optional CTA (retry later, leave message if supported).
+
+### Helpdesk agent
+
+- Receives incoming alert with "Claim conversation" action.
+- Once claimed, sees locked ownership status.
+- If disconnected, ownership is released automatically.
+
+---
+
+## Security and privacy
+
+- Enforce that only helpdesk-group members can claim/respond.
+- Do not leak `active_agent_user_id` in user-facing APIs/events.
+- Audit all claim/release transitions.
+- Add tests for serialization redaction.
+
+---
+
+## Implementation phases
+
+## Phase 1 — Foundation
+
+1. Add routing metadata schema + migrations.
+2. Introduce state machine and transition guards in messaging service.
+3. Add masked sender projection for helpdesk mode.
+
+## Phase 2 — Assignment flow
+
+1. Implement claim endpoint/command with CAS.
+2. Add helpdesk alert event on new unassigned conversation.
+3. Support auto-claim on first agent response (optional but recommended).
+
+## Phase 3 — Presence failover
+
+1. Wire presence events to routing transitions.
+2. Implement release/re-alert/no-agent notice flow.
+3. Add throttling for repeated no-agent notices.
+
+## Phase 4 — UI integration
+
+1. End-user thread labeling and no-agent system message UX.
+2. Agent inbox alert + claim controls + ownership indicators.
+3. Realtime updates for assignment changes.
+
+## Phase 5 — Hardening
+
+1. Concurrency and race-condition tests.
+2. Load test for bursty helpdesk conversations.
+3. Audit logging and observability dashboards.
+
+---
+
+## Test plan
+
+### Unit tests
+
+- State transitions valid/invalid paths.
+- Masking logic for message serialization.
+- Claim CAS behavior and idempotency.
+
+### Integration tests
+
+- Create helpdesk conversation with online agents -> alerts emitted.
+- Claim conflict between two agents -> only one winner.
+- Assignee disconnect -> conversation released and re-alerted.
+- No agents online -> user gets deterministic notice.
+
+### E2E tests
+
+- User chats continuously while assignee changes; user only sees Helpdesk identity.
+- Conversation recovers when agent logs off mid-thread.
+
+### Observability checks
+
+Track metrics:
+
+- `helpdesk_alerts_sent_total`
+- `helpdesk_claim_success_total`
+- `helpdesk_claim_conflict_total`
+- `helpdesk_failover_total`
+- `helpdesk_no_agents_notice_total`
+- `helpdesk_time_to_first_claim_ms`
+
+---
+
+## Rollout plan
+
+1. Feature flag: `helpdesk_bridge_mode`.
+2. Internal pilot with limited helpdesk group.
+3. Monitor claim conflicts, failovers, and no-agent rates.
+4. Gradual rollout by tenant/group.
+5. Define rollback: disable flag and keep existing conversation behavior.
+
+---
+
+## Open product decisions
+
+1. Should first agent reply auto-claim if unassigned, or require explicit claim always?
+2. Should users be able to leave offline messages when no agents are online?
+3. Maximum idle timeout before auto-release of assigned conversation?
+4. Can supervisors force-reassign an active conversation?
+5. SLA targets for first response and failover time?
+

--- a/docs/helpdesk-bridge-implementation-tickets.md
+++ b/docs/helpdesk-bridge-implementation-tickets.md
@@ -1,0 +1,320 @@
+# Helpdesk Bridge Conversation Mode — Implementation Ticket Backlog
+
+This backlog translates `docs/helpdesk-bridge-conversation-plan.md` into actionable engineering tickets.
+
+## Epic A — Routing model and state machine foundation
+
+### HB-001: Add helpdesk routing metadata schema
+**Goal**: Persist routing state for helpdesk bridge conversations.
+
+**Scope**
+- Add `conversation_routing` fields needed for helpdesk mode:
+  - `routing_mode`, `group_id`, `state`, `active_agent_user_id`, `active_agent_claimed_at`
+  - `last_failover_at`, `assignment_version`, `no_agents_notice_sent_at`
+- Add migration/backfill defaults for existing conversations.
+- Add indexes for state-driven lookups (for example `state + group_id`).
+
+**Acceptance criteria**
+- New helpdesk conversations persist routing metadata successfully.
+- Existing conversations are unaffected and continue to load without null-handling regressions.
+- Versioned conditional writes are supported by persistence layer.
+
+---
+
+### HB-002: Implement routing state machine with guarded transitions
+**Goal**: Centralize valid transitions between `awaiting_agent`, `assigned`, and `paused_no_agents_online`.
+
+**Scope**
+- Add routing service/domain module with explicit transition API.
+- Enforce transition guards and terminal/error behavior.
+- Emit typed transition outcomes for API/realtime layers.
+
+**Acceptance criteria**
+- Invalid transitions fail with deterministic error codes.
+- State transitions are covered by unit tests (happy and failure paths).
+- Service can be reused by claim, send, and presence flows.
+
+---
+
+### HB-003: Add routing event audit log
+**Goal**: Make assignment/failover transitions reviewable.
+
+**Scope**
+- Introduce `conversation_routing_events` store/table.
+- Record claim/release/failover/no-agents transitions with actor and metadata.
+- Add query support for operational debugging.
+
+**Acceptance criteria**
+- Every routing transition creates an immutable audit record.
+- Logs include enough metadata to reconstruct assignment timeline.
+
+---
+
+## Epic B — Conversation creation and alert fanout
+
+### HB-004: Add helpdesk conversation creation mode
+**Goal**: Allow users to start a helpdesk-routed conversation.
+
+**Scope**
+- Extend create-conversation API/command with `routing_mode=helpdesk_bridge`.
+- Ensure virtual helpdesk participant model is set on create.
+- Initialize routing state to `awaiting_agent`.
+
+**Acceptance criteria**
+- New helpdesk conversation can be created from supported clients.
+- Newly created conversation is discoverable in helpdesk agent queue.
+
+---
+
+### HB-005: Alert online helpdesk group members on new unassigned conversation
+**Goal**: Notify available agents immediately.
+
+**Scope**
+- Resolve online users in configured helpdesk group.
+- Emit `helpdesk.conversation.alerted` event with conversation context.
+- Track alert emission metrics.
+
+**Acceptance criteria**
+- Online helpdesk members receive alert event in realtime channel.
+- Alert is emitted once per creation event (idempotent under retries).
+
+---
+
+### HB-006: Emit deterministic no-agents-online user notice at creation time
+**Goal**: Provide immediate user feedback when no helpdesk agent is online.
+
+**Scope**
+- Detect zero online agents during conversation creation.
+- Transition to `paused_no_agents_online`.
+- Inject standardized system message: nobody online, try again later.
+
+**Acceptance criteria**
+- User sees consistent no-agents-online message in thread.
+- Duplicate notices are suppressed according to throttling policy.
+
+---
+
+## Epic C — Claiming and assignment ownership
+
+### HB-007: Implement claim endpoint for helpdesk agents
+**Goal**: Let one agent claim ownership of a waiting conversation.
+
+**Scope**
+- Add `POST /v1/messaging/helpdesk/conversations/{id}/claim`.
+- Validate caller is in helpdesk group and currently available.
+- Return conflict semantics when already assigned to another agent.
+
+**Acceptance criteria**
+- Eligible agents can successfully claim `awaiting_agent` conversations.
+- Ineligible callers get authorization/validation failures.
+- Conflict behavior is deterministic and client-safe.
+
+---
+
+### HB-008: Add optimistic concurrency + idempotency for claims
+**Goal**: Prevent dual assignment under race conditions.
+
+**Scope**
+- Use `assignment_version` conditional write/CAS in claim path.
+- Support idempotent claim retry behavior for same agent/request.
+- Instrument claim success/conflict metrics.
+
+**Acceptance criteria**
+- Concurrent claims yield exactly one winner.
+- Retried claim from winning agent returns idempotent success.
+- Claim conflict rate is observable via metrics.
+
+---
+
+### HB-009: Support auto-claim on first agent reply (feature-flagged)
+**Goal**: Reduce operational friction while preserving exclusivity.
+
+**Scope**
+- Add optional auto-claim path in send-message flow.
+- Reuse same CAS/locking semantics as explicit claim.
+- Gate behavior behind config/feature flag.
+
+**Acceptance criteria**
+- First reply can atomically claim when flag is enabled.
+- Disabled flag enforces explicit claim-only behavior.
+
+---
+
+## Epic D — Identity masking and read/write behavior
+
+### HB-010: Implement masked sender projection for user-facing APIs
+**Goal**: Hide agent identity from end users.
+
+**Scope**
+- Update message serializer/projection in helpdesk mode.
+- Render agent-authored messages as virtual `Helpdesk` identity.
+- Preserve true sender internally for authorized admin/audit use.
+
+**Acceptance criteria**
+- End user never sees individual agent identifiers in helpdesk thread.
+- Internal privileged views retain true sender metadata.
+
+---
+
+### HB-011: Enforce send constraints for unassigned conversations
+**Goal**: Ensure only active assignee can respond as Helpdesk.
+
+**Scope**
+- Reject agent send attempts when conversation is unassigned unless auto-claim succeeds.
+- Reject non-assignee send attempts while assigned.
+- Return clear error codes for client handling.
+
+**Acceptance criteria**
+- Only assignee (or successful auto-claimer) can send.
+- Error codes are stable and mapped in client UX.
+
+---
+
+### HB-012: Split participant/read models for end user vs helpdesk agents
+**Goal**: Expose the right metadata per audience.
+
+**Scope**
+- User read/list APIs show participant = user + `Helpdesk`.
+- Agent read/list APIs expose assignment state and ownership info.
+- Keep response shape backward-compatible where required.
+
+**Acceptance criteria**
+- User payloads remain masked and minimal.
+- Agent payloads include operational assignment fields.
+
+---
+
+## Epic E — Presence-driven release and failover
+
+### HB-013: Subscribe routing service to presence events
+**Goal**: Drive assignment lifecycle from agent availability.
+
+**Scope**
+- Consume `online/offline/unavailable` events for helpdesk agents.
+- Correlate active assignee presence with assigned conversations.
+- Trigger transition commands in routing state machine.
+
+**Acceptance criteria**
+- Assignee offline/unavailable event is detected within target SLA.
+- Presence pipeline integration is observable and retry-safe.
+
+---
+
+### HB-014: Implement automatic release and re-alert flow on assignee disconnect
+**Goal**: Keep conversations serviceable without manual intervention.
+
+**Scope**
+- Transition `assigned -> awaiting_agent` on assignee loss.
+- Clear assignee metadata and stamp `last_failover_at`.
+- Emit `helpdesk.conversation.released` + `helpdesk.conversation.alerted`.
+
+**Acceptance criteria**
+- Conversation ownership is automatically released on disconnect.
+- Online group members are re-alerted immediately after release.
+
+---
+
+### HB-015: Handle no-agents-available during failover and recovery back to awaiting
+**Goal**: Provide deterministic fallback when nobody can take over.
+
+**Scope**
+- If no online agents after release, set `paused_no_agents_online` and emit no-agent notice.
+- When any eligible agent comes online, transition back to `awaiting_agent` and alert group.
+- Throttle repeated no-agent notices.
+
+**Acceptance criteria**
+- Failover with zero agents results in exactly one throttled user notice window.
+- Returning agent availability automatically reopens assignment flow.
+
+---
+
+## Epic F — Realtime and delivery guarantees
+
+### HB-016: Add helpdesk routing realtime event contract
+**Goal**: Provide consistent assignment lifecycle events to clients.
+
+**Scope**
+- Add event types:
+  - `helpdesk.conversation.alerted`
+  - `helpdesk.conversation.assigned`
+  - `helpdesk.conversation.released`
+  - `helpdesk.conversation.no_agents_online`
+- Define payload schemas and compatibility rules.
+
+**Acceptance criteria**
+- Event schemas are documented and validated in tests.
+- Clients can subscribe and react to all four lifecycle events.
+
+---
+
+### HB-017: Enforce channel-level data segregation for masked vs internal events
+**Goal**: Prevent accidental identity leakage across channels.
+
+**Scope**
+- Ensure user channel only receives masked sender and user-safe routing data.
+- Ensure helpdesk/internal channel can carry assignee IDs for authorized consumers.
+- Add serializer guard tests.
+
+**Acceptance criteria**
+- No user-channel payload contains `active_agent_user_id` or true sender IDs.
+- Authorized internal channels retain required operational details.
+
+---
+
+## Epic G — Testing, observability, rollout
+
+### HB-018: Implement unit/integration/E2E coverage for assignment and masking flows
+**Goal**: Validate correctness under normal and race conditions.
+
+**Scope**
+- Unit tests for state transitions, masking, and claim CAS/idempotency.
+- Integration tests for create-alert-claim-release/no-agent flows.
+- E2E test for mid-thread assignee change while user sees continuous Helpdesk identity.
+
+**Acceptance criteria**
+- Race-condition scenarios are reproducible and asserted in CI.
+- Regression suite blocks identity leakage and dual assignment bugs.
+
+---
+
+### HB-019: Add operational metrics and dashboards for helpdesk routing health
+**Goal**: Monitor responsiveness and reliability in production.
+
+**Scope**
+- Emit metrics:
+  - `helpdesk_alerts_sent_total`
+  - `helpdesk_claim_success_total`
+  - `helpdesk_claim_conflict_total`
+  - `helpdesk_failover_total`
+  - `helpdesk_no_agents_notice_total`
+  - `helpdesk_time_to_first_claim_ms`
+- Build dashboard panels and alert thresholds.
+
+**Acceptance criteria**
+- Metrics are emitted in staging and production.
+- On-call dashboard shows claim latency, failover count, and no-agent rate trends.
+
+---
+
+### HB-020: Roll out via feature flag with staged tenant/group enablement
+**Goal**: Reduce rollout risk and support quick rollback.
+
+**Scope**
+- Add `helpdesk_bridge_mode` feature flag controls.
+- Pilot with internal helpdesk group, then expand by tenant/group.
+- Document rollback procedure to disable routing mode safely.
+
+**Acceptance criteria**
+- Feature can be enabled/disabled without deploy.
+- Rollback path is tested and documented in runbook.
+
+---
+
+## Suggested implementation order (critical path)
+
+1. HB-001, HB-002, HB-004 (schema + core state machine + creation mode)
+2. HB-005, HB-006 (alerting + no-agent notice)
+3. HB-007, HB-008, HB-010, HB-011 (claiming + masking + send guards)
+4. HB-013, HB-014, HB-015 (presence failover)
+5. HB-016, HB-017 (realtime contract + channel segregation)
+6. HB-018, HB-019, HB-020 (hardening + observability + rollout)

--- a/scripts/backfill_helpdesk_routing_metadata.py
+++ b/scripts/backfill_helpdesk_routing_metadata.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+
+from app.core.aws import ddb
+
+DDB_CONVERSATIONS = os.getenv("DDB_CONVERSATIONS", "Conversations")
+
+
+def _coerce_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def main() -> None:
+    table = ddb.Table(DDB_CONVERSATIONS)
+    scanned = 0
+    updated = 0
+    last_key = None
+
+    while True:
+        kwargs = {}
+        if last_key is not None:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = table.scan(**kwargs)
+        items = resp.get("Items", [])
+        scanned += len(items)
+
+        for item in items:
+            conversation_id = item.get("conversation_id")
+            if not conversation_id:
+                continue
+
+            routing_mode = item.get("routing_mode") or "standard"
+            routing_state = item.get("routing_state") or ("awaiting_agent" if routing_mode == "helpdesk_bridge" else "none")
+            group_id = item.get("routing_group_id") or ""
+            active_agent_user_id = item.get("active_agent_user_id") or ""
+            active_agent_claimed_at = _coerce_int(item.get("active_agent_claimed_at"), 0)
+            last_failover_at = _coerce_int(item.get("last_failover_at"), 0)
+            assignment_version = _coerce_int(item.get("assignment_version"), 0)
+            no_agents_notice_sent_at = _coerce_int(item.get("no_agents_notice_sent_at"), 0)
+            state_group_pk = item.get("routing_state_group_pk") or f"{routing_state}#{group_id}"
+            state_group_sk = item.get("routing_state_group_sk") or conversation_id
+
+            expected = {
+                "routing_mode": routing_mode,
+                "routing_group_id": group_id,
+                "routing_state": routing_state,
+                "active_agent_user_id": active_agent_user_id,
+                "active_agent_claimed_at": active_agent_claimed_at,
+                "last_failover_at": last_failover_at,
+                "assignment_version": assignment_version,
+                "no_agents_notice_sent_at": no_agents_notice_sent_at,
+                "routing_state_group_pk": state_group_pk,
+                "routing_state_group_sk": state_group_sk,
+            }
+
+            needs_update = any(item.get(k) != v for k, v in expected.items())
+            if not needs_update:
+                continue
+
+            table.update_item(
+                Key={"conversation_id": conversation_id},
+                UpdateExpression=(
+                    "SET routing_mode=:rm, routing_group_id=:gid, routing_state=:rs, "
+                    "active_agent_user_id=:auid, active_agent_claimed_at=:ac, "
+                    "last_failover_at=:lf, assignment_version=:av, "
+                    "no_agents_notice_sent_at=:na, routing_state_group_pk=:sgpk, "
+                    "routing_state_group_sk=:sgsk"
+                ),
+                ExpressionAttributeValues={
+                    ":rm": routing_mode,
+                    ":gid": group_id,
+                    ":rs": routing_state,
+                    ":auid": active_agent_user_id,
+                    ":ac": active_agent_claimed_at,
+                    ":lf": last_failover_at,
+                    ":av": assignment_version,
+                    ":na": no_agents_notice_sent_at,
+                    ":sgpk": state_group_pk,
+                    ":sgsk": state_group_sk,
+                },
+            )
+            updated += 1
+
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+    print(f"scanned={scanned} updated={updated}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local-ddb-init.py
+++ b/scripts/local-ddb-init.py
@@ -83,7 +83,17 @@ def _table_defs() -> List[TableDef]:
                 {"index_name": "GSI3", "partition_key": "GSI3PK", "sort_key": "GSI3SK"},
             ],
         ),
-        TableDef(os.getenv("DDB_CONVERSATIONS", "Conversations"), "conversation_id"),
+        TableDef(
+            os.getenv("DDB_CONVERSATIONS", "Conversations"),
+            "conversation_id",
+            gsi=[
+                {
+                    "index_name": "RoutingStateGroupIndex",
+                    "partition_key": "routing_state_group_pk",
+                    "sort_key": "routing_state_group_sk",
+                }
+            ],
+        ),
         TableDef(
             os.getenv("DDB_PARTICIPANTS", "Participants"),
             "user_id",
@@ -100,6 +110,7 @@ def _table_defs() -> List[TableDef]:
         TableDef(os.getenv("DDB_MESSAGE_EDITS", "MessageEdits"), "message_key", "edited_at"),
         TableDef(os.getenv("DDB_MESSAGE_VIEWS", "MessageViews"), "conversation_id", "message_user"),
         TableDef(os.getenv("DDB_MESSAGE_RECEIPTS", "MessageReceipts"), "conversation_id", "message_user"),
+        TableDef(os.getenv("DDB_CONVERSATION_ROUTING_EVENTS", "ConversationRoutingEvents"), "conversation_id", "event_id"),
     ]
 
 

--- a/tests/test_messaging_routes.py
+++ b/tests/test_messaging_routes.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
+from pydantic import ValidationError
 
 from app.routers import messaging
 
@@ -51,11 +52,59 @@ class TestMessagingRoutes(unittest.TestCase):
             )
 
         tbl_convos.put_item.assert_called_once()
+        convo_item = tbl_convos.put_item.call_args.kwargs["Item"]
+        self.assertEqual(convo_item["routing_mode"], "standard")
+        self.assertEqual(convo_item["routing_state"], "none")
+        self.assertEqual(convo_item["assignment_version"], 0)
         self.assertEqual(tbl_parts.put_item.call_count, 2)
         self.assertEqual(resp.conversation_id, "c_abc")
         self.assertEqual(resp.created_at, 123)
         self.assertEqual(resp.participant_count, 2)
         self.assertEqual(resp.status, "active")
+
+    def test_start_conversation_helpdesk_routing_metadata(self):
+        with (
+            patch.object(messaging, "now_ts", return_value=123),
+            patch.object(messaging, "new_id", return_value="abc"),
+            patch.object(messaging, "tbl_convos") as tbl_convos,
+            patch.object(messaging, "tbl_parts") as tbl_parts,
+        ):
+            messaging.start_conversation(
+                messaging.StartConversationIn(
+                    participant_ids=[],
+                    type="dm",
+                    routing_mode="helpdesk_bridge",
+                    helpdesk_group_id="helpdesk-l1",
+                ),
+                user_id="user-1",
+            )
+
+        self.assertEqual(tbl_parts.put_item.call_count, 2)
+        participant_items = [c.kwargs["Item"] for c in tbl_parts.put_item.call_args_list]
+        self.assertIn("helpdesk_group:helpdesk-l1", {i["user_id"] for i in participant_items})
+        convo_item = tbl_convos.put_item.call_args.kwargs["Item"]
+        self.assertEqual(convo_item["routing_mode"], "helpdesk_bridge")
+        self.assertEqual(convo_item["routing_group_id"], "helpdesk-l1")
+        self.assertEqual(convo_item["routing_state"], "awaiting_agent")
+        self.assertEqual(convo_item["routing_state_group_pk"], "awaiting_agent#helpdesk-l1")
+        self.assertEqual(convo_item["routing_state_group_sk"], "c_abc")
+
+
+    def test_start_conversation_standard_requires_participant(self):
+        with self.assertRaises(ValidationError):
+            messaging.StartConversationIn(
+                participant_ids=[],
+                type="dm",
+                routing_mode="standard",
+            )
+
+    def test_start_conversation_helpdesk_requires_group(self):
+        with self.assertRaises(ValidationError):
+            messaging.StartConversationIn(
+                participant_ids=["user-2"],
+                type="dm",
+                routing_mode="helpdesk_bridge",
+            )
 
     def test_list_messages_filters_deleted_and_sets_reactions(self):
         tbl_parts = Mock()
@@ -109,6 +158,8 @@ class TestMessagingRoutes(unittest.TestCase):
             patch.object(messaging, "new_id", return_value="xyz"),
             patch.object(messaging, "require_participant_active"),
             patch.object(messaging, "_enforce_message_send_quota_precheck"),
+            patch.object(messaging, "fanout_event_to_conversation"),
+            patch.object(messaging, "audit_event"),
             patch.object(messaging, "tbl_msgs", tbl_msgs),
             patch.object(messaging, "tbl_convos", tbl_convos),
         ):
@@ -181,6 +232,43 @@ class TestMessagingRoutes(unittest.TestCase):
         self.assertEqual(payload["message"]["message_id"], "m_xyz")
         self.assertEqual(payload["message"]["text"], "Hello world")
         self.assertNotIn("encryption", payload["message"])
+
+
+    def test_send_text_message_helpdesk_auto_claim_on_first_reply_when_enabled(self):
+        tbl_msgs = Mock()
+        tbl_convos = Mock()
+        with (
+            patch.object(messaging, "HELPDESK_AUTO_CLAIM_ON_REPLY_ENABLED", True),
+            patch.object(messaging, "now_ts", return_value=55),
+            patch.object(messaging, "new_id", return_value="xyz"),
+            patch.object(messaging, "require_participant_active"),
+            patch.object(messaging, "_enforce_message_send_quota_precheck"),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "_claim_helpdesk_conversation_internal") as claim_internal,
+            patch.object(messaging, "_get_conversation_or_404", return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1", "routing_state": "awaiting_agent"}),
+            patch.object(messaging, "fanout_event_to_conversation"),
+            patch.object(messaging, "_meter_message_send"),
+            patch.object(messaging, "audit_event"),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+            patch.object(messaging, "tbl_convos", tbl_convos),
+        ):
+            messaging.send_text_message("c1", messaging.SendTextMessageIn(text="Hello world"), user_id="agent-1")
+
+        claim_internal.assert_called_once_with(conversation_id="c1", user_id="agent-1", req=None)
+
+    def test_send_text_message_helpdesk_requires_explicit_claim_when_auto_claim_disabled(self):
+        with (
+            patch.object(messaging, "HELPDESK_AUTO_CLAIM_ON_REPLY_ENABLED", False),
+            patch.object(messaging, "require_participant_active"),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "_get_conversation_or_404", return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1", "routing_state": "awaiting_agent"}),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                messaging.send_text_message("c1", messaging.SendTextMessageIn(text="Hello world"), user_id="agent-1")
+
+        self.assertEqual(ctx.exception.status_code, 409)
+        self.assertEqual(ctx.exception.detail["code"], "helpdesk_claim_required")
+
 
 
 
@@ -1406,3 +1494,325 @@ class TestMessagingRoutes(unittest.TestCase):
             resp = messaging.mute_conversation("c1", messaging.MuteIn(muted=False), user_id="u1")
         self.assertEqual(resp["muted_until"], 0)
         tbl_parts.update_item.assert_called_once()
+
+
+    def test_list_conversation_routing_events_returns_items(self):
+        tbl_events = Mock()
+        tbl_events.query.return_value = {
+            "Items": [
+                {
+                    "conversation_id": "c1",
+                    "event_id": "00001#e1",
+                    "event_type": "helpdesk.conversation.assigned",
+                    "actor_user_id": "agent-1",
+                    "from_state": "awaiting_agent",
+                    "to_state": "assigned",
+                    "created_at": 1,
+                    "assignment_version": 1,
+                    "routing_group_id": "helpdesk-l1",
+                    "active_agent_user_id": "agent-1",
+                    "metadata": {"source": "claim"},
+                }
+            ]
+        }
+        with (
+            patch.object(messaging, "require_participant_role"),
+            patch.object(messaging, "tbl_routing_events", tbl_events),
+        ):
+            out = messaging.list_conversation_routing_events("c1", user_id="u1")
+
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].event_type, "helpdesk.conversation.assigned")
+        self.assertEqual(out[0].metadata["source"], "claim")
+
+    def test_apply_helpdesk_routing_transition_writes_event(self):
+        tbl_convos = Mock()
+        tbl_events = Mock()
+        tbl_convos.get_item.return_value = {
+            "Item": {
+                "conversation_id": "c1",
+                "routing_mode": "helpdesk_bridge",
+                "routing_group_id": "helpdesk-l1",
+                "routing_state": "awaiting_agent",
+                "assignment_version": 0,
+            }
+        }
+        with (
+            patch.object(messaging, "tbl_convos", tbl_convos),
+            patch.object(messaging, "tbl_routing_events", tbl_events),
+            patch.object(messaging, "new_id", return_value="evt1"),
+        ):
+            result = messaging._apply_helpdesk_routing_transition(
+                conversation_id="c1",
+                cmd=messaging.RoutingTransitionInput(action="assign_agent", now_ts=10, agent_user_id="a1"),
+                actor_user_id="a1",
+                metadata={"reason": "claim"},
+            )
+
+        tbl_convos.update_item.assert_called_once()
+        tbl_events.put_item.assert_called_once()
+        self.assertEqual(result["event"]["event_type"], "helpdesk.conversation.assigned")
+        self.assertEqual(result["event"]["metadata"]["reason"], "claim")
+
+
+    def test_fanout_helpdesk_alert_targets_online_group_members(self):
+        tbl_events = Mock()
+        ddb = Mock()
+        ddb.meta.client.batch_get_item.return_value = {
+            "Responses": {
+                messaging.DDB_PRESENCE: [
+                    {"user_id": "a1", "last_seen_at": 100, "status": "online"},
+                    {"user_id": "a2", "last_seen_at": 20, "status": "online"},
+                    {"user_id": "a3", "last_seen_at": 100, "status": "offline"},
+                ]
+            }
+        }
+        with (
+            patch.object(messaging, "_resolve_helpdesk_group_members", return_value=["a1", "a2", "a3"]),
+            patch.object(messaging, "tbl_events", tbl_events),
+            patch.object(messaging, "ddb", ddb),
+            patch.object(messaging, "now_ts", return_value=110),
+            patch.object(messaging, "record_helpdesk_alert_sent") as rec_metric,
+        ):
+            delivered = messaging.fanout_helpdesk_alert("c1", "helpdesk-l1", "u1")
+
+        self.assertEqual(delivered, 1)
+        tbl_events.put_item.assert_called_once()
+        rec_metric.assert_called_once_with("delivered")
+
+    def test_start_conversation_helpdesk_fanout_called(self):
+        with (
+            patch.object(messaging, "now_ts", return_value=123),
+            patch.object(messaging, "new_id", return_value="abc"),
+            patch.object(messaging, "tbl_convos") as tbl_convos,
+            patch.object(messaging, "tbl_parts") as tbl_parts,
+            patch.object(messaging, "fanout_helpdesk_alert") as fanout,
+        ):
+            messaging.start_conversation(
+                messaging.StartConversationIn(
+                    participant_ids=[],
+                    type="dm",
+                    routing_mode="helpdesk_bridge",
+                    helpdesk_group_id="helpdesk-l1",
+                ),
+                user_id="user-1",
+            )
+
+        tbl_convos.put_item.assert_called_once()
+        self.assertEqual(tbl_parts.put_item.call_count, 2)
+        fanout.assert_called_once_with(conversation_id="c_abc", group_id="helpdesk-l1", created_by="user-1")
+
+
+    def test_start_conversation_helpdesk_no_agents_emits_notice(self):
+        with (
+            patch.object(messaging, "now_ts", return_value=123),
+            patch.object(messaging, "new_id", return_value="abc"),
+            patch.object(messaging, "tbl_convos") as tbl_convos,
+            patch.object(messaging, "tbl_parts") as tbl_parts,
+            patch.object(messaging, "fanout_helpdesk_alert", return_value=0),
+            patch.object(messaging, "_emit_no_agents_online_notice") as emit_notice,
+        ):
+            messaging.start_conversation(
+                messaging.StartConversationIn(
+                    participant_ids=[],
+                    type="dm",
+                    routing_mode="helpdesk_bridge",
+                    helpdesk_group_id="helpdesk-l1",
+                ),
+                user_id="user-1",
+            )
+
+        tbl_convos.put_item.assert_called_once()
+        self.assertEqual(tbl_parts.put_item.call_count, 2)
+        emit_notice.assert_called_once_with(conversation_id="c_abc", user_id="user-1", now=123)
+
+    def test_emit_no_agents_online_notice_throttled(self):
+        with (
+            patch.object(messaging, "_get_conversation_or_404", return_value={"no_agents_notice_sent_at": 100}),
+            patch.object(messaging, "NO_AGENTS_NOTICE_THROTTLE_SEC", 600),
+        ):
+            out = messaging._emit_no_agents_online_notice(conversation_id="c1", user_id="u1", now=200)
+        self.assertFalse(out)
+
+    def test_emit_no_agents_online_notice_writes_message_and_updates_convo(self):
+        tbl_msgs = Mock()
+        tbl_convos = Mock()
+        with (
+            patch.object(messaging, "_get_conversation_or_404", return_value={"no_agents_notice_sent_at": 0}),
+            patch.object(messaging, "_apply_helpdesk_routing_transition"),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+            patch.object(messaging, "tbl_convos", tbl_convos),
+        ):
+            out = messaging._emit_no_agents_online_notice(conversation_id="c1", user_id="u1", now=200)
+
+        self.assertTrue(out)
+        tbl_msgs.put_item.assert_called_once()
+        tbl_convos.update_item.assert_called_once()
+
+
+    def test_claim_helpdesk_conversation_success(self):
+        with (
+            patch.object(messaging, "_get_conversation_or_404", return_value={
+                "conversation_id": "c1",
+                "routing_mode": "helpdesk_bridge",
+                "routing_group_id": "helpdesk-l1",
+                "routing_state": "awaiting_agent",
+                "assignment_version": 2,
+            }),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "_is_user_online_available", return_value=True),
+            patch.object(messaging, "now_ts", return_value=50),
+            patch.object(messaging, "_apply_helpdesk_routing_transition", return_value={
+                "conversation": {"routing_state": "assigned", "active_agent_user_id": "a1", "assignment_version": 3}
+            }),
+            patch.object(messaging, "audit_event"),
+            patch.object(messaging, "record_helpdesk_claim") as record_claim,
+        ):
+            out = messaging.claim_helpdesk_conversation("c1", user_id="a1")
+
+        self.assertTrue(out.ok)
+        self.assertEqual(out.state, "assigned")
+        self.assertEqual(out.assigned_agent_user_id, "a1")
+        self.assertEqual(out.assignment_version, 3)
+        record_claim.assert_called_once_with("success")
+
+    def test_claim_helpdesk_conversation_rejects_non_member(self):
+        with (
+            patch.object(messaging, "_get_conversation_or_404", return_value={
+                "conversation_id": "c1",
+                "routing_mode": "helpdesk_bridge",
+                "routing_group_id": "helpdesk-l1",
+                "routing_state": "awaiting_agent",
+                "assignment_version": 0,
+            }),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=False),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                messaging.claim_helpdesk_conversation("c1", user_id="a1")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_claim_helpdesk_conversation_rejects_unavailable(self):
+        with (
+            patch.object(messaging, "_get_conversation_or_404", return_value={
+                "conversation_id": "c1",
+                "routing_mode": "helpdesk_bridge",
+                "routing_group_id": "helpdesk-l1",
+                "routing_state": "awaiting_agent",
+                "assignment_version": 0,
+            }),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "now_ts", return_value=50),
+            patch.object(messaging, "_is_user_online_available", return_value=False),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                messaging.claim_helpdesk_conversation("c1", user_id="a1")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_claim_helpdesk_conversation_conflict_when_assigned_to_other(self):
+        with (
+            patch.object(messaging, "_get_conversation_or_404", return_value={
+                "conversation_id": "c1",
+                "routing_mode": "helpdesk_bridge",
+                "routing_group_id": "helpdesk-l1",
+                "routing_state": "assigned",
+                "active_agent_user_id": "a2",
+                "assignment_version": 4,
+            }),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "now_ts", return_value=50),
+            patch.object(messaging, "_is_user_online_available", return_value=True),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                messaging.claim_helpdesk_conversation("c1", user_id="a1")
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    def test_claim_helpdesk_conversation_idempotent_for_same_agent(self):
+        with (
+            patch.object(messaging, "_get_conversation_or_404", return_value={
+                "conversation_id": "c1",
+                "routing_mode": "helpdesk_bridge",
+                "routing_group_id": "helpdesk-l1",
+                "routing_state": "assigned",
+                "active_agent_user_id": "a1",
+                "assignment_version": 4,
+            }),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "now_ts", return_value=50),
+            patch.object(messaging, "_is_user_online_available", return_value=True),
+            patch.object(messaging, "record_helpdesk_claim") as record_claim,
+        ):
+            out = messaging.claim_helpdesk_conversation("c1", user_id="a1")
+        self.assertTrue(out.idempotent)
+        self.assertEqual(out.assignment_version, 4)
+        record_claim.assert_called_once_with("idempotent")
+
+    def test_claim_helpdesk_conversation_cas_conflict_returns_idempotent_for_winner_retry(self):
+        with (
+            patch.object(
+                messaging,
+                "_get_conversation_or_404",
+                side_effect=[
+                    {
+                        "conversation_id": "c1",
+                        "routing_mode": "helpdesk_bridge",
+                        "routing_group_id": "helpdesk-l1",
+                        "routing_state": "awaiting_agent",
+                        "assignment_version": 2,
+                    },
+                    {
+                        "conversation_id": "c1",
+                        "routing_mode": "helpdesk_bridge",
+                        "routing_group_id": "helpdesk-l1",
+                        "routing_state": "assigned",
+                        "active_agent_user_id": "a1",
+                        "assignment_version": 3,
+                    },
+                ],
+            ),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "_is_user_online_available", return_value=True),
+            patch.object(messaging, "now_ts", return_value=50),
+            patch.object(messaging, "_apply_helpdesk_routing_transition", side_effect=messaging.RoutingTransitionError(code="routing_assignment_version_conflict", message="stale")),
+            patch.object(messaging, "record_helpdesk_claim") as record_claim,
+        ):
+            out = messaging.claim_helpdesk_conversation("c1", user_id="a1")
+
+        self.assertTrue(out.ok)
+        self.assertTrue(out.idempotent)
+        self.assertEqual(out.assignment_version, 3)
+        record_claim.assert_called_once_with("idempotent")
+
+    def test_claim_helpdesk_conversation_cas_conflict_records_conflict_metric(self):
+        with (
+            patch.object(
+                messaging,
+                "_get_conversation_or_404",
+                side_effect=[
+                    {
+                        "conversation_id": "c1",
+                        "routing_mode": "helpdesk_bridge",
+                        "routing_group_id": "helpdesk-l1",
+                        "routing_state": "awaiting_agent",
+                        "assignment_version": 2,
+                    },
+                    {
+                        "conversation_id": "c1",
+                        "routing_mode": "helpdesk_bridge",
+                        "routing_group_id": "helpdesk-l1",
+                        "routing_state": "assigned",
+                        "active_agent_user_id": "a2",
+                        "assignment_version": 3,
+                    },
+                ],
+            ),
+            patch.object(messaging, "_is_helpdesk_group_member", return_value=True),
+            patch.object(messaging, "_is_user_online_available", return_value=True),
+            patch.object(messaging, "now_ts", return_value=50),
+            patch.object(messaging, "_apply_helpdesk_routing_transition", side_effect=messaging.RoutingTransitionError(code="routing_assignment_version_conflict", message="stale")),
+            patch.object(messaging, "record_helpdesk_claim") as record_claim,
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                messaging.claim_helpdesk_conversation("c1", user_id="a1")
+
+        self.assertEqual(ctx.exception.status_code, 409)
+        record_claim.assert_called_once_with("conflict")

--- a/tests/test_messaging_routing.py
+++ b/tests/test_messaging_routing.py
@@ -1,0 +1,155 @@
+from app.services.messaging_routing import (
+    RoutingTransitionError,
+    RoutingTransitionInput,
+    transition_helpdesk_routing,
+    build_routing_event_item,
+)
+
+
+def _base_conversation(**overrides):
+    base = {
+        "conversation_id": "c1",
+        "routing_mode": "helpdesk_bridge",
+        "routing_group_id": "helpdesk-l1",
+        "routing_state": "awaiting_agent",
+        "assignment_version": 0,
+        "active_agent_user_id": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_assign_agent_success():
+    out = transition_helpdesk_routing(
+        _base_conversation(),
+        RoutingTransitionInput(action="assign_agent", now_ts=101, agent_user_id="agent-1", expected_assignment_version=0),
+    )
+    assert out.from_state == "awaiting_agent"
+    assert out.to_state == "assigned"
+    assert out.event_type == "helpdesk.conversation.assigned"
+    assert out.patch["active_agent_user_id"] == "agent-1"
+    assert out.patch["assignment_version"] == 1
+
+
+def test_assign_agent_requires_agent_id():
+    try:
+        transition_helpdesk_routing(
+            _base_conversation(),
+            RoutingTransitionInput(action="assign_agent", now_ts=101),
+        )
+        assert False, "expected RoutingTransitionError"
+    except RoutingTransitionError as exc:
+        assert exc.code == "routing_assign_agent_required"
+
+
+def test_assign_agent_invalid_state_fails():
+    try:
+        transition_helpdesk_routing(
+            _base_conversation(routing_state="paused_no_agents_online"),
+            RoutingTransitionInput(action="assign_agent", now_ts=101, agent_user_id="agent-1"),
+        )
+        assert False, "expected RoutingTransitionError"
+    except RoutingTransitionError as exc:
+        assert exc.code == "routing_assign_invalid_state"
+
+
+def test_release_agent_success():
+    out = transition_helpdesk_routing(
+        _base_conversation(routing_state="assigned", active_agent_user_id="agent-1", assignment_version=3),
+        RoutingTransitionInput(action="release_agent", now_ts=202, agent_user_id="agent-1", expected_assignment_version=3),
+    )
+    assert out.to_state == "awaiting_agent"
+    assert out.event_type == "helpdesk.conversation.released"
+    assert out.patch["active_agent_user_id"] == ""
+    assert out.patch["last_failover_at"] == 202
+    assert out.patch["assignment_version"] == 4
+
+
+def test_release_agent_mismatch_fails():
+    try:
+        transition_helpdesk_routing(
+            _base_conversation(routing_state="assigned", active_agent_user_id="agent-1"),
+            RoutingTransitionInput(action="release_agent", now_ts=202, agent_user_id="agent-2"),
+        )
+        assert False, "expected RoutingTransitionError"
+    except RoutingTransitionError as exc:
+        assert exc.code == "routing_release_agent_mismatch"
+
+
+def test_pause_resume_success_path():
+    paused = transition_helpdesk_routing(
+        _base_conversation(routing_state="awaiting_agent", assignment_version=1),
+        RoutingTransitionInput(action="pause_no_agents", now_ts=333, expected_assignment_version=1),
+    )
+    assert paused.to_state == "paused_no_agents_online"
+    assert paused.event_type == "helpdesk.conversation.no_agents_online"
+    assert paused.patch["no_agents_notice_sent_at"] == 333
+
+    resumed = transition_helpdesk_routing(
+        _base_conversation(routing_state="paused_no_agents_online", assignment_version=2),
+        RoutingTransitionInput(action="resume_awaiting", now_ts=444),
+    )
+    assert resumed.to_state == "awaiting_agent"
+    assert resumed.event_type == "helpdesk.conversation.alerted"
+
+
+def test_version_conflict_fails():
+    try:
+        transition_helpdesk_routing(
+            _base_conversation(assignment_version=5),
+            RoutingTransitionInput(action="assign_agent", now_ts=1, agent_user_id="a1", expected_assignment_version=4),
+        )
+        assert False, "expected RoutingTransitionError"
+    except RoutingTransitionError as exc:
+        assert exc.code == "routing_assignment_version_conflict"
+
+
+def test_non_helpdesk_conversation_fails():
+    try:
+        transition_helpdesk_routing(
+            _base_conversation(routing_mode="standard", routing_state="none"),
+            RoutingTransitionInput(action="assign_agent", now_ts=1, agent_user_id="a1"),
+        )
+        assert False, "expected RoutingTransitionError"
+    except RoutingTransitionError as exc:
+        assert exc.code == "routing_mode_not_helpdesk_bridge"
+
+
+def test_closed_is_terminal():
+    try:
+        transition_helpdesk_routing(
+            _base_conversation(routing_state="closed"),
+            RoutingTransitionInput(action="assign_agent", now_ts=1, agent_user_id="a1"),
+        )
+        assert False, "expected RoutingTransitionError"
+    except RoutingTransitionError as exc:
+        assert exc.code == "routing_conversation_closed"
+
+
+def test_close_idempotent_when_already_closed():
+    out = transition_helpdesk_routing(
+        _base_conversation(routing_state="closed"),
+        RoutingTransitionInput(action="close", now_ts=10),
+    )
+    assert out.changed is False
+    assert out.to_state == "closed"
+
+
+def test_build_routing_event_item_contains_timeline_fields():
+    transition = transition_helpdesk_routing(
+        _base_conversation(),
+        RoutingTransitionInput(action="assign_agent", now_ts=101, agent_user_id="agent-1"),
+    )
+    event = build_routing_event_item(
+        conversation=_base_conversation(),
+        transition=transition,
+        actor_user_id="agent-1",
+        created_at=101,
+        event_id="0000000101#evt",
+        metadata={"source": "claim"},
+    )
+    assert event["conversation_id"] == "c1"
+    assert event["from_state"] == "awaiting_agent"
+    assert event["to_state"] == "assigned"
+    assert event["assignment_version"] == 1
+    assert event["metadata"]["source"] == "claim"


### PR DESCRIPTION
### Motivation
- Reduce operational friction by allowing a helpdesk agent's first reply to atomically claim an unassigned conversation while preserving single-assignee exclusivity via CAS semantics. 
- Reuse the same claim idempotency and conditional-write semantics used by explicit claim flows to avoid duplication of race-handling logic. 
- Gate the behavior behind a runtime feature flag so teams can opt into auto-claim or require explicit claims only. 

### Description
- Added a feature flag `HELPDESK_AUTO_CLAIM_ON_REPLY_ENABLED` and integrated it into the send flow so first replies can trigger auto-claim when enabled via `HELPDESK_AUTO_CLAIM_ON_REPLY_ENABLED`. 
- Refactored explicit claim handling into a shared helper ` _claim_helpdesk_conversation_internal ` and kept the HTTP claim endpoint as a thin wrapper to ensure both explicit claims and auto-claims share the same CAS/idempotency/conflict behavior. 
- Implemented ` _auto_claim_helpdesk_on_first_reply ` and invoked it at the start of `send_text_message` to enforce helpdesk-only send constraints, return `409 helpdesk_claim_required` when the flag is disabled, and deterministically reject replies from a different assigned agent. 
- Added/updated tests and small helpers to exercise the send/claim flows, and wired metrics/emission points so claim outcomes remain observable. 

### Testing
- Ran targeted send/claim tests with `pytest -q tests/test_messaging_routes.py -k "send_text_message or claim_helpdesk_conversation"` which passed (`13 passed, 74 deselected`). 
- Ran focused auto-claim tests with `pytest -q tests/test_messaging_routes.py -k "send_text_message_helpdesk_auto_claim or helpdesk_claim_required or claim_helpdesk_conversation"` which passed after test fixes (`8 passed, 79 deselected`). 
- Verified syntax/compilation with `python -m py_compile app/routers/messaging.py tests/test_messaging_routes.py app/metrics.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69963d6914a4832bb0a6df96bd95d9e5)