### PR TITLE
Fix local dev stack: projects layer, test isolation, dev-mode regressions

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -265,6 +265,7 @@ class Settings:
 
     # File manager
     filemgr_table_name: str = os.environ.get("FILEMGR_TABLE", "")
+    projects_table_name: str = os.environ.get("PROJECTS_TABLE_NAME", "projects")
     filemgr_bucket: str = os.environ.get("FILEMGR_BUCKET", "")
     filemgr_retention_days: int = int(os.environ.get("FILEMGR_RETENTION_DAYS", "30"))
     filemgr_purge_scan_limit: int = int(os.environ.get("FILEMGR_PURGE_SCAN_LIMIT", "200"))
@@ -272,6 +273,16 @@ class Settings:
     filemgr_purge_interval_seconds: int = int(os.environ.get("FILEMGR_PURGE_INTERVAL_SECONDS", "900"))
     filemgr_admin_content_access_tier: str = os.environ.get("FILEMGR_ADMIN_CONTENT_ACCESS_TIER", "none")
     filemgr_purge_index_name: str = os.environ.get("FILEMGR_PURGE_INDEX_NAME", "GSI_PURGE")
+    projects_reconcile_enabled: bool = os.environ.get("PROJECTS_RECONCILE_ENABLED", "false").lower() == "true"
+    projects_reconcile_interval_seconds: int = int(os.environ.get("PROJECTS_RECONCILE_INTERVAL_SECONDS", "900"))
+    projects_reconcile_scan_limit: int = int(os.environ.get("PROJECTS_RECONCILE_SCAN_LIMIT", "200"))
+    projects_reconcile_max_attempts: int = int(os.environ.get("PROJECTS_RECONCILE_MAX_ATTEMPTS", "3"))
+    projects_reconcile_backoff_seconds: float = float(os.environ.get("PROJECTS_RECONCILE_BACKOFF_SECONDS", "0.2"))
+    projects_provider_failure_alert_threshold: int = int(
+        os.environ.get("PROJECTS_PROVIDER_FAILURE_ALERT_THRESHOLD", "5")
+    )
+    github_api_base_url: str = os.environ.get("GITHUB_API_BASE_URL", "https://api.github.com").rstrip("/")
+    gitlab_api_base_url: str = os.environ.get("GITLAB_API_BASE_URL", "https://gitlab.com/api/v4").rstrip("/")
     filemgr_zip_max_entries: int = int(os.environ.get("FILEMGR_ZIP_MAX_ENTRIES", "1000"))
     filemgr_zip_max_total_uncompressed_bytes: int = int(
         os.environ.get("FILEMGR_ZIP_MAX_TOTAL_UNCOMPRESSED_BYTES", "524288000")

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -29,6 +29,7 @@ class Tables:
     shopping_cart: Any
     catalog: Any
     subscriptions: Any
+    projects: Any
 
 T = Tables(
     sessions=ddb.Table(S.ddb_sessions_table),
@@ -52,4 +53,5 @@ T = Tables(
     shopping_cart=ddb.Table(S.shopping_cart_table_name),
     catalog=ddb.Table(S.catalog_table_name),
     subscriptions=ddb.Table(S.subscriptions_table_name),
+    projects=ddb.Table(S.projects_table_name),
 )

--- a/app/main.py
+++ b/app/main.py
@@ -51,12 +51,14 @@ from app.routers.catalog import router as catalog_router
 from app.routers.subscription_server import router as subscription_server_router
 from app.routers.admin_usage import router as admin_usage_router
 from app.routers.ups import router as ups_router
+from app.routers.projects import router as projects_router
 from app.services.billing_reconcile import start_billing_reconcile_task
 from app.services.billing_dunning import start_billing_dunning_task
 from app.services.filemanager import start_filemgr_purge_task
 from app.services.api_usage_metering import record_api_usage_from_response, enforce_account_quota_pre_request
 from app.services.api_metering_policy import build_limit_denial_headers
 from app.routers.messaging import start_scheduled_messages_task
+from app.services.projects_reconcile import start_projects_reconcile_task
 
 
 def _api_usage_metering_middleware():
@@ -182,7 +184,9 @@ def create_app() -> FastAPI:
     app.include_router(subscription_server_router)
     app.include_router(admin_usage_router)
     app.include_router(ups_router)
+    app.include_router(projects_router)
     app.add_event_handler("startup", start_billing_reconcile_task)
+    app.add_event_handler("startup", start_projects_reconcile_task)
 
     return app
 

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -363,10 +363,41 @@ ONCE_MEDIA_CONFLICT_EVENTS = Counter(
     "Once-media consume conflict/race outcomes by media kind/cohort",
     ["media_kind", "cohort"],
 )
+PROJECT_COUNT = Gauge(
+    "project_count",
+    "Estimated project count in this process",
+)
+TRACKED_FILE_COUNT = Gauge(
+    "tracked_file_count",
+    "Estimated tracked file count in this process",
+)
+RECONCILE_FAILURES = Counter(
+    "reconcile_failures_total",
+    "Tracked file reconciliation failures",
+    ["provider", "reason"],
+)
+PROVIDER_LATENCY = Histogram(
+    "provider_latency_seconds",
+    "Provider operation latency in seconds",
+    ["provider", "operation"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+)
+PROVIDER_FAILURE_STREAK = Gauge(
+    "provider_failure_streak",
+    "Current consecutive provider failures",
+    ["provider"],
+)
+PROVIDER_FAILURE_ALERTS = Counter(
+    "provider_failure_alerts_total",
+    "Provider repeated-failure alert triggers",
+    ["provider"],
+)
 
 _START_TIME = time.monotonic()
 _ACTIVE_SESSIONS_BY_USER: dict[str, int] = {}
 _ACTIVE_SESSIONS_COUNT = 0
+_PROJECT_COUNT_ESTIMATE = 0
+_TRACKED_FILE_COUNT_ESTIMATE = 0
 
 
 def _route_path(request: Request) -> str:
@@ -725,6 +756,8 @@ def record_filemgr_preview_queue_depth_delta(delta: int) -> None:
     if delta == 0:
         return
     FILEMGR_PREVIEW_QUEUE_DEPTH.inc(float(delta))
+
+
 def record_messaging_gallery_request(*, gallery_type: str, outcome: str) -> None:
     MESSAGING_GALLERY_REQUESTS.labels(
         type=(gallery_type or "unknown").lower(),
@@ -743,6 +776,39 @@ def record_messaging_gallery_cursor_page_depth(*, gallery_type: str, depth: int)
         max(0.0, float(depth))
     )
 
+
+def record_project_count_delta(delta: int) -> None:
+    global _PROJECT_COUNT_ESTIMATE
+    _PROJECT_COUNT_ESTIMATE = max(0, _PROJECT_COUNT_ESTIMATE + int(delta))
+    PROJECT_COUNT.set(float(_PROJECT_COUNT_ESTIMATE))
+
+
+def record_tracked_file_count_delta(delta: int) -> None:
+    global _TRACKED_FILE_COUNT_ESTIMATE
+    _TRACKED_FILE_COUNT_ESTIMATE = max(0, _TRACKED_FILE_COUNT_ESTIMATE + int(delta))
+    TRACKED_FILE_COUNT.set(float(_TRACKED_FILE_COUNT_ESTIMATE))
+
+
+def record_reconcile_failure(provider: str, reason: str) -> None:
+    RECONCILE_FAILURES.labels(
+        provider=(provider or "unknown").lower(),
+        reason=(reason or "unknown").lower(),
+    ).inc()
+
+
+def record_provider_latency(provider: str, operation: str, elapsed_seconds: float) -> None:
+    PROVIDER_LATENCY.labels(
+        provider=(provider or "unknown").lower(),
+        operation=(operation or "unknown").lower(),
+    ).observe(max(0.0, float(elapsed_seconds)))
+
+
+def record_provider_failure_streak(provider: str, streak: int) -> None:
+    PROVIDER_FAILURE_STREAK.labels(provider=(provider or "unknown").lower()).set(float(max(0, int(streak))))
+
+
+def record_provider_failure_alert(provider: str) -> None:
+    PROVIDER_FAILURE_ALERTS.labels(provider=(provider or "unknown").lower()).inc()
 
 def metrics_endpoint() -> Response:
     UPTIME_SECONDS.set(time.monotonic() - _START_TIME)

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional
 
 import re
+from datetime import datetime, timezone
 
 from pydantic import (
     AliasChoices,
@@ -1080,3 +1081,181 @@ class AddChargeReq(BaseModel):
 
 class AccountStatusReq(BaseModel):
     reason: Optional[str] = None
+
+
+class ProjectModel(BaseModel):
+    id: str = Field(min_length=1, max_length=128)
+    owner: str = Field(min_length=1, max_length=256)
+    name: str = Field(min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=2000)
+    tags: List[str] = Field(default_factory=list)
+    settings: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+    @field_validator("id", "owner", "name")
+    @classmethod
+    def _strip_required(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Value required")
+        return cleaned
+
+    @field_validator("description")
+    @classmethod
+    def _strip_optional_description(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+    @field_validator("tags")
+    @classmethod
+    def _normalize_tags(cls, value: List[str]) -> List[str]:
+        out: List[str] = []
+        seen = set()
+        for tag in value or []:
+            normalized = (tag or "").strip().lower()
+            if not normalized:
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            out.append(normalized)
+        return out
+
+    @field_validator("created_at", "updated_at")
+    @classmethod
+    def _validate_iso(cls, value: str) -> str:
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            raise ValueError("timestamp must include timezone")
+        return value
+
+
+class TrackedFileModel(BaseModel):
+    id: str = Field(min_length=1, max_length=128)
+    project_id: str = Field(min_length=1, max_length=128)
+    owner: str = Field(min_length=1, max_length=256)
+    provider: str = Field(min_length=1, max_length=32)
+    provider_ref: str = Field(min_length=1, max_length=2048)
+    display_path: str = Field(min_length=1, max_length=2048)
+    status: Literal["active", "missing", "archived"] = "active"
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+    last_seen_at: Optional[str] = None
+    archived_at: Optional[str] = None
+
+    @field_validator("id", "project_id", "owner", "provider", "provider_ref", "display_path")
+    @classmethod
+    def _strip_required(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Value required")
+        return cleaned
+
+    @field_validator("provider")
+    @classmethod
+    def _normalize_provider(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not re.fullmatch(r"[a-z][a-z0-9_-]{0,31}", normalized):
+            raise ValueError("invalid provider")
+        return normalized
+
+    @field_validator("provider_ref")
+    @classmethod
+    def _normalize_provider_ref(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("provider_ref required")
+        return cleaned
+
+    @field_validator("created_at", "updated_at", "last_seen_at", "archived_at")
+    @classmethod
+    def _validate_optional_iso(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            raise ValueError("timestamp must include timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_archive_consistency(self) -> "TrackedFileModel":
+        if self.status == "archived" and not self.archived_at:
+            self.archived_at = datetime.now(timezone.utc).isoformat()
+        if self.status != "archived":
+            self.archived_at = None
+        return self
+
+
+class ProjectEventModel(BaseModel):
+    id: str = Field(min_length=1, max_length=128)
+    project_id: str = Field(min_length=1, max_length=128)
+    owner: str = Field(min_length=1, max_length=256)
+    event_type: Literal["file_added", "file_removed", "sync_ran", "provider_error"]
+    tracked_file_id: Optional[str] = Field(default=None, max_length=128)
+    provider: Optional[str] = Field(default=None, max_length=32)
+    provider_ref: Optional[str] = Field(default=None, max_length=2048)
+    message: Optional[str] = Field(default=None, max_length=1024)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+
+    @field_validator("id", "project_id", "owner", "tracked_file_id", "provider", "provider_ref", "message")
+    @classmethod
+    def _strip_optional(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+    @field_validator("created_at")
+    @classmethod
+    def _validate_iso(cls, value: str) -> str:
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            raise ValueError("timestamp must include timezone")
+        return value
+
+
+class ProviderCredentialModel(BaseModel):
+    owner: str = Field(min_length=1, max_length=256)
+    provider: Literal["github", "gitlab"]
+    org: Optional[str] = Field(default=None, max_length=256)
+    token_ct_b64: str = Field(min_length=1)
+    scopes: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+    @field_validator("owner", "org", "token_ct_b64")
+    @classmethod
+    def _strip_optional_text(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        return cleaned
+
+    @field_validator("scopes")
+    @classmethod
+    def _normalize_scopes(cls, value: List[str]) -> List[str]:
+        out: List[str] = []
+        seen = set()
+        for raw in value or []:
+            normalized = (raw or "").strip().lower()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            out.append(normalized)
+        return out
+
+    @field_validator("created_at", "updated_at")
+    @classmethod
+    def _validate_iso(cls, value: str) -> str:
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            raise ValueError("timestamp must include timezone")
+        return value

--- a/app/routers/projects.py
+++ b/app/routers/projects.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.services.projects_store import (
+    add_tracked_file,
+    create_project,
+    delete_project,
+    get_project,
+    get_project_detail,
+    list_projects,
+    list_project_events,
+    list_tracked_files,
+    remove_tracked_file,
+    update_project,
+)
+from app.services.provider_credentials import (
+    delete_provider_credential,
+    get_provider_credential,
+    upsert_provider_credential,
+)
+from app.services.sessions import require_ui_session
+
+router = APIRouter(prefix="/v1/projects", tags=["projects"])
+
+
+class ProjectCreateIn(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=2000)
+    tags: List[str] = Field(default_factory=list)
+    settings: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ProjectUpdateIn(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=2000)
+    tags: Optional[List[str]] = None
+    settings: Optional[Dict[str, Any]] = None
+
+
+class ProjectOut(BaseModel):
+    id: str
+    owner: str
+    name: str
+    description: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    settings: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+
+class ProjectListOut(BaseModel):
+    items: List[ProjectOut] = Field(default_factory=list)
+    cursor: Optional[str] = None
+
+
+class DeleteProjectOut(BaseModel):
+    ok: bool
+
+
+class TrackedFileCreateIn(BaseModel):
+    provider: str = Field(default="local", min_length=1, max_length=32)
+    provider_ref: str = Field(..., min_length=1, max_length=2048)
+    display_path: Optional[str] = Field(default=None, max_length=2048)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TrackedFileOut(BaseModel):
+    id: str
+    project_id: str
+    owner: str
+    provider: str
+    provider_ref: str
+    display_path: str
+    status: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+    last_seen_at: Optional[str] = None
+    archived_at: Optional[str] = None
+
+
+class TrackedFileListOut(BaseModel):
+    items: List[TrackedFileOut] = Field(default_factory=list)
+    cursor: Optional[str] = None
+
+
+class DeleteTrackedFileOut(BaseModel):
+    ok: bool
+    deleted: bool
+
+
+class ProjectDetailOut(BaseModel):
+    project: ProjectOut
+    files: List[TrackedFileOut] = Field(default_factory=list)
+    cursor: Optional[str] = None
+
+
+class ProjectEventOut(BaseModel):
+    id: str
+    project_id: str
+    owner: str
+    event_type: str
+    tracked_file_id: Optional[str] = None
+    provider: Optional[str] = None
+    provider_ref: Optional[str] = None
+    message: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+
+
+class ProjectEventListOut(BaseModel):
+    items: List[ProjectEventOut] = Field(default_factory=list)
+    cursor: Optional[str] = None
+
+
+class ProviderCredentialUpsertIn(BaseModel):
+    token: str = Field(..., min_length=1, max_length=8192)
+    org: Optional[str] = Field(default=None, max_length=256)
+    api_base_url: Optional[str] = Field(default=None, max_length=2048)
+    required_scopes: List[str] = Field(default_factory=list)
+
+
+class ProviderCredentialOut(BaseModel):
+    provider: str
+    org: Optional[str] = None
+    scopes: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+
+class DeleteProviderCredentialOut(BaseModel):
+    ok: bool
+    deleted: bool
+
+
+def _current_user(ctx=Depends(require_ui_session)) -> str:
+    return ctx["user_sub"]
+
+
+def _encode_cursor(cursor: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not cursor:
+        return None
+    payload = json.dumps(cursor).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("utf-8")
+
+
+def _decode_cursor(cursor: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not cursor:
+        return None
+    try:
+        payload = base64.urlsafe_b64decode(cursor.encode("utf-8"))
+        value = json.loads(payload.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise HTTPException(status_code=400, detail="invalid cursor") from exc
+    if not isinstance(value, dict):
+        raise HTTPException(status_code=400, detail="invalid cursor")
+    return value
+
+
+@router.post("", response_model=ProjectOut)
+def create_project_route(body: ProjectCreateIn, user: str = Depends(_current_user)):
+    project = create_project(
+        user,
+        body.name,
+        description=body.description,
+        tags=body.tags,
+        settings=body.settings,
+    )
+    return ProjectOut(**project.model_dump())
+
+
+@router.get("/{project_id}", response_model=ProjectOut)
+def get_project_route(project_id: str, user: str = Depends(_current_user)):
+    project = get_project(user, project_id)
+    return ProjectOut(**project.model_dump())
+
+
+@router.get("", response_model=ProjectListOut)
+def list_projects_route(
+    limit: int = Query(50, ge=1, le=200),
+    cursor: Optional[str] = Query(default=None),
+    tag: Optional[str] = Query(default=None),
+    name_query: Optional[str] = Query(default=None),
+    user: str = Depends(_current_user),
+):
+    payload = _decode_cursor(cursor)
+    result = list_projects(user, limit=limit, cursor=payload, tag=tag, name_query=name_query)
+    items = [ProjectOut(**item.model_dump()) for item in result["items"]]
+    return ProjectListOut(items=items, cursor=_encode_cursor(result.get("cursor")))
+
+
+@router.patch("/{project_id}", response_model=ProjectOut)
+def update_project_route(project_id: str, body: ProjectUpdateIn, user: str = Depends(_current_user)):
+    project = update_project(
+        user,
+        project_id,
+        name=body.name,
+        description=body.description,
+        tags=body.tags,
+        settings=body.settings,
+    )
+    return ProjectOut(**project.model_dump())
+
+
+@router.delete("/{project_id}", response_model=DeleteProjectOut)
+def delete_project_route(project_id: str, user: str = Depends(_current_user)):
+    result = delete_project(user, project_id)
+    return DeleteProjectOut(**result)
+
+
+@router.post("/{project_id}/files", response_model=TrackedFileOut)
+def add_tracked_file_route(project_id: str, body: TrackedFileCreateIn, user: str = Depends(_current_user)):
+    tracked = add_tracked_file(
+        user,
+        project_id,
+        provider=body.provider,
+        provider_ref=body.provider_ref,
+        display_path=body.display_path,
+        metadata=body.metadata,
+    )
+    return TrackedFileOut(**tracked.model_dump())
+
+
+@router.get("/{project_id}/files", response_model=TrackedFileListOut)
+def list_tracked_files_route(
+    project_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    cursor: Optional[str] = Query(default=None),
+    status: Optional[str] = Query(default=None),
+    provider: Optional[str] = Query(default=None),
+    user: str = Depends(_current_user),
+):
+    payload = _decode_cursor(cursor)
+    result = list_tracked_files(user, project_id, limit=limit, cursor=payload, status=status, provider=provider)
+    items = [TrackedFileOut(**item.model_dump()) for item in result["items"]]
+    return TrackedFileListOut(items=items, cursor=_encode_cursor(result.get("cursor")))
+
+
+@router.delete("/{project_id}/files/{tracked_file_id}", response_model=DeleteTrackedFileOut)
+def remove_tracked_file_route(project_id: str, tracked_file_id: str, user: str = Depends(_current_user)):
+    result = remove_tracked_file(user, project_id, tracked_file_id)
+    return DeleteTrackedFileOut(**result)
+
+
+@router.get("/{project_id}/detail", response_model=ProjectDetailOut)
+def get_project_detail_route(
+    project_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    cursor: Optional[str] = Query(default=None),
+    status: Optional[str] = Query(default=None),
+    provider: Optional[str] = Query(default=None),
+    user: str = Depends(_current_user),
+):
+    payload = _decode_cursor(cursor)
+    result = get_project_detail(
+        user,
+        project_id,
+        limit=limit,
+        cursor=payload,
+        status=status,
+        provider=provider,
+    )
+    project = ProjectOut(**result["project"].model_dump())
+    files = [TrackedFileOut(**item) for item in result["files"]]
+    return ProjectDetailOut(project=project, files=files, cursor=_encode_cursor(result.get("cursor")))
+
+
+@router.get("/{project_id}/events", response_model=ProjectEventListOut)
+def list_project_events_route(
+    project_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    cursor: Optional[str] = Query(default=None),
+    user: str = Depends(_current_user),
+):
+    payload = _decode_cursor(cursor)
+    result = list_project_events(user, project_id, limit=limit, cursor=payload)
+    items = [ProjectEventOut(**item.model_dump()) for item in result["items"]]
+    return ProjectEventListOut(items=items, cursor=_encode_cursor(result.get("cursor")))
+
+
+@router.put("/providers/{provider}/credentials", response_model=ProviderCredentialOut)
+def upsert_provider_credential_route(provider: str, body: ProviderCredentialUpsertIn, user: str = Depends(_current_user)):
+    out = upsert_provider_credential(
+        user,
+        provider,
+        body.token,
+        org=body.org,
+        required_scopes=body.required_scopes,
+        api_base_url=body.api_base_url,
+    )
+    return ProviderCredentialOut(
+        provider=out.provider,
+        org=out.org,
+        scopes=out.scopes,
+        metadata=out.metadata,
+        created_at=out.created_at,
+        updated_at=out.updated_at,
+    )
+
+
+@router.get("/providers/{provider}/credentials", response_model=ProviderCredentialOut)
+def get_provider_credential_route(provider: str, org: Optional[str] = Query(default=None), user: str = Depends(_current_user)):
+    out = get_provider_credential(user, provider, org=org)
+    return ProviderCredentialOut(
+        provider=out.provider,
+        org=out.org,
+        scopes=out.scopes,
+        metadata=out.metadata,
+        created_at=out.created_at,
+        updated_at=out.updated_at,
+    )
+
+
+@router.delete("/providers/{provider}/credentials", response_model=DeleteProviderCredentialOut)
+def delete_provider_credential_route(provider: str, org: Optional[str] = Query(default=None), user: str = Depends(_current_user)):
+    return DeleteProviderCredentialOut(**delete_provider_credential(user, provider, org=org))

--- a/app/services/api_metering_contract.py
+++ b/app/services/api_metering_contract.py
@@ -12,6 +12,7 @@ _EXCLUDED_PATH_PREFIXES: tuple[str, ...] = (
     "/docs",
     "/redoc",
     "/static",
+    "/mock",
 )
 _EXCLUDED_EXACT_PATHS: Set[str] = {
     "/",

--- a/app/services/file_providers.py
+++ b/app/services/file_providers.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs
+from urllib.parse import quote
+from typing import Any, Dict, List, Optional, Protocol
+
+import requests
+from fastapi import HTTPException
+
+from app.core.settings import S
+from app.services import filemanager
+from app.services.provider_credentials import (
+    get_provider_auth_context,
+    normalize_github_api_base_url,
+    normalize_gitlab_api_base_url,
+)
+
+
+class FileProvider(Protocol):
+    provider_name: str
+
+    def resolve(self, ref: str) -> str:
+        ...
+
+    def exists(self, canonical_ref: str) -> bool:
+        ...
+
+    def get_metadata(self, canonical_ref: str) -> Dict[str, Any]:
+        ...
+
+    def list_children(self, canonical_ref: str) -> List[str]:
+        ...
+
+
+class LocalFileProvider:
+    provider_name = "local"
+
+    def __init__(self, owner: str):
+        self.owner = owner
+
+    def resolve(self, ref: str) -> str:
+        return filemanager.norm_path(ref, is_folder=None)
+
+    def exists(self, canonical_ref: str) -> bool:
+        try:
+            filemanager.get_node(self.owner, canonical_ref)
+            return True
+        except HTTPException as exc:
+            if exc.status_code == 404:
+                return False
+            raise
+
+    def get_metadata(self, canonical_ref: str) -> Dict[str, Any]:
+        node = filemanager.get_node(self.owner, canonical_ref)
+        return {
+            "path": node.get("path"),
+            "type": node.get("type"),
+            "name": node.get("name"),
+            "size": node.get("size"),
+            "content_type": node.get("content_type"),
+            "updated_at": node.get("updated_at"),
+            "last_download_at": node.get("last_download_at"),
+            "is_encrypted": node.get("is_encrypted", False),
+        }
+
+    def list_children(self, canonical_ref: str) -> List[str]:
+        folder = filemanager.norm_path(canonical_ref, is_folder=True)
+        children = filemanager.list_children(self.owner, folder)
+        out: List[str] = []
+        for item in children:
+            path = item.get("path")
+            if isinstance(path, str) and path:
+                out.append(path)
+        return out
+
+
+class GitHubProvider:
+    provider_name = "github"
+
+    def __init__(self, owner: str):
+        self.owner = owner
+
+    def _parse_ref(self, ref: str) -> Dict[str, str]:
+        raw = (ref or "").strip()
+        if raw.startswith("github://"):
+            raw = raw[len("github://") :]
+
+        query: Dict[str, List[str]] = {}
+        if "?" in raw:
+            path_part, query_string = raw.split("?", 1)
+            raw = path_part
+            query = parse_qs(query_string, keep_blank_values=False)
+
+        pieces = [p for p in raw.split("/") if p]
+        if len(pieces) < 3:
+            raise HTTPException(
+                status_code=400,
+                detail="invalid github ref; expected owner/repo/path?ref=<branch-or-sha>",
+            )
+
+        repo_owner, repo, *path_parts = pieces
+        file_path = "/".join(path_parts)
+        if not file_path:
+            raise HTTPException(status_code=400, detail="github ref path is required")
+
+        ref_value = (query.get("ref") or ["HEAD"])[0].strip() or "HEAD"
+        return {
+            "repo_owner": repo_owner,
+            "repo": repo,
+            "path": file_path,
+            "ref": ref_value,
+        }
+
+    def resolve(self, ref: str) -> str:
+        parsed = self._parse_ref(ref)
+        return f"github://{parsed['repo_owner']}/{parsed['repo']}/{parsed['path']}?ref={parsed['ref']}"
+
+    def _request(self, canonical_ref: str) -> requests.Response:
+        parsed = self._parse_ref(canonical_ref)
+        auth = get_provider_auth_context(self.owner, "github")
+        token = auth["token"]
+        metadata = auth.get("metadata") if isinstance(auth, dict) else {}
+        api_base_url = normalize_github_api_base_url((metadata or {}).get("api_base_url") if isinstance(metadata, dict) else S.github_api_base_url)
+        url = f"{api_base_url}/repos/{parsed['repo_owner']}/{parsed['repo']}/contents/{parsed['path']}"
+        response = requests.get(
+            url,
+            params={"ref": parsed["ref"]},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=10,
+        )
+        return response
+
+    def _raise_for_error(self, response: requests.Response) -> None:
+        if response.status_code < 400:
+            return
+        if response.status_code == 404:
+            raise HTTPException(status_code=404, detail="github path not found")
+        if response.status_code in (401, 403):
+            remaining = response.headers.get("X-RateLimit-Remaining", "")
+            if remaining == "0":
+                reset = response.headers.get("X-RateLimit-Reset", "unknown")
+                raise HTTPException(status_code=429, detail=f"github rate limit exceeded; retry after reset={reset}")
+            raise HTTPException(status_code=401, detail="github credential invalid or access denied")
+        raise HTTPException(status_code=502, detail=f"github api error ({response.status_code})")
+
+    def exists(self, canonical_ref: str) -> bool:
+        try:
+            response = self._request(canonical_ref)
+        except requests.RequestException as exc:
+            raise HTTPException(status_code=502, detail="github api request failed") from exc
+
+        if response.status_code == 404:
+            return False
+        self._raise_for_error(response)
+        return True
+
+    def get_metadata(self, canonical_ref: str) -> Dict[str, Any]:
+        try:
+            response = self._request(canonical_ref)
+        except requests.RequestException as exc:
+            raise HTTPException(status_code=502, detail="github api request failed") from exc
+        self._raise_for_error(response)
+
+        body = response.json() if response.content else {}
+        if isinstance(body, list):
+            return {
+                "type": "dir",
+                "entry_count": len(body),
+                "path": canonical_ref,
+            }
+        return {
+            "type": body.get("type"),
+            "size": body.get("size"),
+            "sha": body.get("sha"),
+            "name": body.get("name"),
+            "path": body.get("path"),
+            "html_url": body.get("html_url"),
+            "download_url": body.get("download_url"),
+        }
+
+    def list_children(self, canonical_ref: str) -> List[str]:
+        try:
+            response = self._request(canonical_ref)
+        except requests.RequestException as exc:
+            raise HTTPException(status_code=502, detail="github api request failed") from exc
+        self._raise_for_error(response)
+
+        body = response.json() if response.content else []
+        if not isinstance(body, list):
+            raise HTTPException(status_code=400, detail="github ref is not a directory")
+
+        out: List[str] = []
+        for child in body:
+            path = child.get("path")
+            if not isinstance(path, str) or not path:
+                continue
+            parsed = self._parse_ref(canonical_ref)
+            out.append(f"github://{parsed['repo_owner']}/{parsed['repo']}/{path}?ref={parsed['ref']}")
+        return out
+
+
+class GitLabProvider:
+    provider_name = "gitlab"
+
+    def __init__(self, owner: str):
+        self.owner = owner
+
+    def _parse_ref(self, ref: str) -> Dict[str, str]:
+        raw = (ref or "").strip()
+        if raw.startswith("gitlab://"):
+            raw = raw[len("gitlab://") :]
+
+        query: Dict[str, List[str]] = {}
+        if "?" in raw:
+            path_part, query_string = raw.split("?", 1)
+            raw = path_part
+            query = parse_qs(query_string, keep_blank_values=False)
+
+        if "//" in raw:
+            project_path, file_path = raw.split("//", 1)
+            if not project_path or not file_path:
+                raise HTTPException(status_code=400, detail="invalid gitlab ref; expected <project>//<path>?ref=<branch-or-sha>")
+        else:
+            parts = [p for p in raw.split("/") if p]
+            if len(parts) < 3:
+                raise HTTPException(
+                    status_code=400,
+                    detail="invalid gitlab ref; expected namespace/project/path or namespace/project//path",
+                )
+            project_path = "/".join(parts[:2])
+            file_path = "/".join(parts[2:])
+
+        ref_value = (query.get("ref") or ["HEAD"])[0].strip() or "HEAD"
+        return {
+            "project_path": project_path,
+            "path": file_path,
+            "ref": ref_value,
+        }
+
+    def resolve(self, ref: str) -> str:
+        parsed = self._parse_ref(ref)
+        return f"gitlab://{parsed['project_path']}//{parsed['path']}?ref={parsed['ref']}"
+
+    def _request_file(self, canonical_ref: str) -> requests.Response:
+        parsed = self._parse_ref(canonical_ref)
+        auth = get_provider_auth_context(self.owner, "gitlab")
+        token = auth["token"]
+        metadata = auth.get("metadata") if isinstance(auth, dict) else {}
+        api_base_url = normalize_gitlab_api_base_url((metadata or {}).get("api_base_url") if isinstance(metadata, dict) else S.gitlab_api_base_url)
+        project = quote(parsed["project_path"], safe="")
+        file_path = quote(parsed["path"], safe="")
+        url = f"{api_base_url}/projects/{project}/repository/files/{file_path}"
+        return requests.get(
+            url,
+            params={"ref": parsed["ref"]},
+            headers={"PRIVATE-TOKEN": token},
+            timeout=10,
+        )
+
+    def _request_tree(self, canonical_ref: str) -> requests.Response:
+        parsed = self._parse_ref(canonical_ref)
+        auth = get_provider_auth_context(self.owner, "gitlab")
+        token = auth["token"]
+        metadata = auth.get("metadata") if isinstance(auth, dict) else {}
+        api_base_url = normalize_gitlab_api_base_url((metadata or {}).get("api_base_url") if isinstance(metadata, dict) else S.gitlab_api_base_url)
+        project = quote(parsed["project_path"], safe="")
+        url = f"{api_base_url}/projects/{project}/repository/tree"
+        return requests.get(
+            url,
+            params={"path": parsed["path"], "ref": parsed["ref"]},
+            headers={"PRIVATE-TOKEN": token},
+            timeout=10,
+        )
+
+    def _raise_for_error(self, response: requests.Response) -> None:
+        if response.status_code < 400:
+            return
+        if response.status_code == 404:
+            raise HTTPException(status_code=404, detail="gitlab path not found")
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After", "unknown")
+            raise HTTPException(status_code=429, detail=f"gitlab rate limit exceeded; retry_after={retry_after}")
+        if response.status_code in (401, 403):
+            remaining = response.headers.get("RateLimit-Remaining", "")
+            if remaining == "0":
+                reset = response.headers.get("RateLimit-Reset", "unknown")
+                raise HTTPException(status_code=429, detail=f"gitlab rate limit exceeded; reset={reset}")
+            raise HTTPException(status_code=401, detail="gitlab credential invalid or access denied")
+        raise HTTPException(status_code=502, detail=f"gitlab api error ({response.status_code})")
+
+    def exists(self, canonical_ref: str) -> bool:
+        try:
+            response = self._request_file(canonical_ref)
+        except requests.RequestException as exc:
+            raise HTTPException(status_code=502, detail="gitlab api request failed") from exc
+
+        if response.status_code == 404:
+            return False
+        self._raise_for_error(response)
+        return True
+
+    def get_metadata(self, canonical_ref: str) -> Dict[str, Any]:
+        try:
+            response = self._request_file(canonical_ref)
+        except requests.RequestException as exc:
+            raise HTTPException(status_code=502, detail="gitlab api request failed") from exc
+        self._raise_for_error(response)
+
+        body = response.json() if response.content else {}
+        return {
+            "type": "file",
+            "size": body.get("size"),
+            "blob_id": body.get("blob_id"),
+            "commit_id": body.get("commit_id"),
+            "last_commit_id": body.get("last_commit_id"),
+            "file_name": body.get("file_name"),
+            "file_path": body.get("file_path"),
+            "content_sha256": body.get("content_sha256"),
+            "encoding": body.get("encoding"),
+            "ref": body.get("ref"),
+        }
+
+    def list_children(self, canonical_ref: str) -> List[str]:
+        try:
+            response = self._request_tree(canonical_ref)
+        except requests.RequestException as exc:
+            raise HTTPException(status_code=502, detail="gitlab api request failed") from exc
+        self._raise_for_error(response)
+
+        body = response.json() if response.content else []
+        if not isinstance(body, list):
+            raise HTTPException(status_code=400, detail="gitlab ref is not a directory")
+
+        parsed = self._parse_ref(canonical_ref)
+        out: List[str] = []
+        for child in body:
+            path = child.get("path")
+            if not isinstance(path, str) or not path:
+                continue
+            out.append(f"gitlab://{parsed['project_path']}//{path}?ref={parsed['ref']}")
+        return out
+
+
+@dataclass
+class ProviderRegistry:
+    _factories: Dict[str, Any] = field(default_factory=dict)
+
+    def register(self, name: str, factory: Any) -> None:
+        normalized = (name or "").strip().lower()
+        if not normalized:
+            raise HTTPException(status_code=400, detail="provider is required")
+        self._factories[normalized] = factory
+
+    def get(self, owner: str, name: str) -> FileProvider:
+        normalized = (name or "").strip().lower()
+        factory = self._factories.get(normalized)
+        if not factory:
+            raise HTTPException(status_code=400, detail="unsupported provider")
+        return factory(owner)
+
+
+_DEFAULT_REGISTRY: Optional[ProviderRegistry] = None
+
+
+def default_provider_registry() -> ProviderRegistry:
+    global _DEFAULT_REGISTRY
+    if _DEFAULT_REGISTRY is None:
+        registry = ProviderRegistry()
+        registry.register("local", lambda owner: LocalFileProvider(owner))
+        registry.register("github", lambda owner: GitHubProvider(owner))
+        registry.register("gitlab", lambda owner: GitLabProvider(owner))
+        _DEFAULT_REGISTRY = registry
+    return _DEFAULT_REGISTRY

--- a/app/services/projects_reconcile.py
+++ b/app/services/projects_reconcile.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from botocore.exceptions import ClientError
+from fastapi import HTTPException
+
+from app.core.settings import Settings
+from app.core.tables import T
+from app.metrics import (
+    record_provider_failure_alert,
+    record_provider_failure_streak,
+    record_provider_latency,
+    record_reconcile_failure,
+)
+from app.models import TrackedFileModel
+from app.services.file_providers import ProviderRegistry, default_provider_registry
+from app.services.projects_store import emit_project_event, now_iso, tracked_file_from_item, tracked_file_to_item
+
+logger = logging.getLogger(__name__)
+S = Settings()
+_PROVIDER_FAILURE_STREAKS: Dict[str, int] = {}
+
+_TRANSIENT_CLIENT_ERRORS = {
+    "ProvisionedThroughputExceededException",
+    "ThrottlingException",
+    "RequestLimitExceeded",
+    "InternalServerError",
+    "ServiceUnavailable",
+}
+
+
+def _is_transient_error(exc: Exception) -> bool:
+    if isinstance(exc, HTTPException):
+        return exc.status_code in {429, 500, 502, 503, 504}
+    if isinstance(exc, ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        return code in _TRANSIENT_CLIENT_ERRORS
+    return isinstance(exc, (TimeoutError, ConnectionError, OSError))
+
+
+def _with_retry(
+    fn: Callable[[], Any],
+    *,
+    max_attempts: int,
+    base_backoff_seconds: float,
+    sleep_fn: Callable[[float], None],
+) -> Any:
+    attempts = max(1, max_attempts)
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001
+            if (not _is_transient_error(exc)) or attempt >= attempts:
+                raise
+            delay = base_backoff_seconds * (2 ** (attempt - 1))
+            sleep_fn(delay)
+
+
+def _scan_tracked_file_items(*, limit: int, cursor: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    kwargs: Dict[str, Any] = {"Limit": max(1, limit)}
+    if cursor:
+        kwargs["ExclusiveStartKey"] = cursor
+    return T.projects.scan(**kwargs)
+
+
+def _project_exists_for_owner(owner: str, project_id: str) -> bool:
+    resp = T.projects.get_item(
+        Key={"PK": f"OWNER#{owner}", "SK": f"PROJECT#{project_id}"},
+        ConsistentRead=True,
+    )
+    item = resp.get("Item")
+    if not item:
+        return False
+    if item.get("entity_type") != "project":
+        return False
+    return item.get("owner") == owner and item.get("id") == project_id
+
+
+def reconcile_tracked_files_batch(
+    *,
+    limit: Optional[int] = None,
+    cursor: Optional[Dict[str, Any]] = None,
+    registry: Optional[ProviderRegistry] = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    max_attempts: Optional[int] = None,
+    base_backoff_seconds: Optional[float] = None,
+) -> Dict[str, Any]:
+    scan_limit = int(limit or S.projects_reconcile_scan_limit)
+    attempts = int(max_attempts or S.projects_reconcile_max_attempts)
+    backoff = float(base_backoff_seconds or S.projects_reconcile_backoff_seconds)
+
+    page = _scan_tracked_file_items(limit=scan_limit, cursor=cursor)
+    provider_registry = registry or default_provider_registry()
+    alert_threshold = max(1, int(S.projects_provider_failure_alert_threshold))
+
+    checked = 0
+    updated = 0
+    missing = 0
+    skipped = 0
+    errors = 0
+
+    for raw in page.get("Items", []):
+        if raw.get("entity_type") != "tracked_file":
+            continue
+
+        checked += 1
+        tracked = tracked_file_from_item(raw)
+
+        if tracked.status == "archived":
+            skipped += 1
+            continue
+
+        if not _project_exists_for_owner(tracked.owner, tracked.project_id):
+            logger.warning(
+                "Skipping tracked file reconcile due to project ownership mismatch",
+                extra={"tracked_file_id": tracked.id, "project_id": tracked.project_id, "owner": tracked.owner},
+            )
+            skipped += 1
+            continue
+
+        provider = provider_registry.get(tracked.owner, tracked.provider)
+        provider_name = (tracked.provider or "unknown").lower()
+
+        def _probe() -> Tuple[bool, Dict[str, Any], str]:
+            canonical_ref = provider.resolve(tracked.provider_ref)
+            exists = provider.exists(canonical_ref)
+            if not exists:
+                return False, {}, canonical_ref
+            metadata = provider.get_metadata(canonical_ref)
+            return True, metadata, canonical_ref
+
+        started = time.perf_counter()
+        try:
+            exists, fresh_metadata, canonical_ref = _with_retry(
+                _probe,
+                max_attempts=attempts,
+                base_backoff_seconds=backoff,
+                sleep_fn=sleep_fn,
+            )
+            record_provider_latency(provider_name, "reconcile", time.perf_counter() - started)
+        except HTTPException as exc:
+            record_provider_latency(provider_name, "reconcile", time.perf_counter() - started)
+            if exc.status_code == 404:
+                exists = False
+                fresh_metadata = {}
+                canonical_ref = tracked.provider_ref
+            else:
+                record_reconcile_failure(provider_name, "provider_http_error")
+                streak = _PROVIDER_FAILURE_STREAKS.get(provider_name, 0) + 1
+                _PROVIDER_FAILURE_STREAKS[provider_name] = streak
+                record_provider_failure_streak(provider_name, streak)
+                if streak >= alert_threshold and streak % alert_threshold == 0:
+                    logger.warning("Provider repeated failures exceeded threshold", extra={"provider": provider_name, "streak": streak})
+                    record_provider_failure_alert(provider_name)
+                emit_project_event(
+                    tracked.owner,
+                    tracked.project_id,
+                    "provider_error",
+                    tracked_file_id=tracked.id,
+                    provider=tracked.provider,
+                    provider_ref=tracked.provider_ref,
+                    message=str(exc.detail),
+                )
+                logger.exception("Tracked file reconcile failed", extra={"tracked_file_id": tracked.id})
+                errors += 1
+                continue
+        except Exception as exc:  # noqa: BLE001
+            record_provider_latency(provider_name, "reconcile", time.perf_counter() - started)
+            record_reconcile_failure(provider_name, "provider_error")
+            streak = _PROVIDER_FAILURE_STREAKS.get(provider_name, 0) + 1
+            _PROVIDER_FAILURE_STREAKS[provider_name] = streak
+            record_provider_failure_streak(provider_name, streak)
+            if streak >= alert_threshold and streak % alert_threshold == 0:
+                logger.warning("Provider repeated failures exceeded threshold", extra={"provider": provider_name, "streak": streak})
+                record_provider_failure_alert(provider_name)
+            emit_project_event(
+                tracked.owner,
+                tracked.project_id,
+                "provider_error",
+                tracked_file_id=tracked.id,
+                provider=tracked.provider,
+                provider_ref=tracked.provider_ref,
+                message=str(exc),
+            )
+            logger.exception("Tracked file reconcile failed", extra={"tracked_file_id": tracked.id})
+            errors += 1
+            continue
+
+        _PROVIDER_FAILURE_STREAKS[provider_name] = 0
+        record_provider_failure_streak(provider_name, 0)
+
+        ts = now_iso()
+        if exists:
+            merged = tracked.model_copy(
+                update={
+                    "provider_ref": canonical_ref,
+                    "display_path": tracked.display_path or canonical_ref,
+                    "status": "active",
+                    "metadata": {**(tracked.metadata or {}), **fresh_metadata},
+                    "updated_at": ts,
+                    "last_seen_at": ts,
+                }
+            )
+            updated += 1
+        else:
+            merged = tracked.model_copy(
+                update={
+                    "status": "missing",
+                    "updated_at": ts,
+                }
+            )
+            missing += 1
+
+        T.projects.put_item(Item=tracked_file_to_item(merged))
+        emit_project_event(
+            tracked.owner,
+            tracked.project_id,
+            "sync_ran",
+            tracked_file_id=tracked.id,
+            provider=tracked.provider,
+            provider_ref=canonical_ref if exists else tracked.provider_ref,
+            metadata={"status": merged.status},
+        )
+
+    return {
+        "checked": checked,
+        "updated": updated,
+        "missing": missing,
+        "skipped": skipped,
+        "errors": errors,
+        "cursor": page.get("LastEvaluatedKey"),
+    }
+
+
+async def projects_reconcile_loop() -> None:
+    interval = max(30, int(S.projects_reconcile_interval_seconds))
+    while True:
+        cursor: Optional[Dict[str, Any]] = None
+        try:
+            while True:
+                result = reconcile_tracked_files_batch(cursor=cursor)
+                cursor = result.get("cursor")
+                if not cursor:
+                    break
+        except Exception:  # noqa: BLE001
+            logger.exception("Projects reconciliation loop failed")
+        await asyncio.sleep(interval)
+
+
+def start_projects_reconcile_task() -> None:
+    if not S.projects_reconcile_enabled:
+        logger.info("Projects reconciliation disabled")
+        return
+    asyncio.create_task(projects_reconcile_loop())

--- a/app/services/projects_store.py
+++ b/app/services/projects_store.py
@@ -1,0 +1,604 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.core.tables import T
+from app.metrics import record_project_count_delta, record_tracked_file_count_delta
+from app.models import ProjectEventModel, ProjectModel, TrackedFileModel
+from app.services.file_providers import ProviderRegistry, default_provider_registry
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _project_pk(owner: str) -> str:
+    return f"OWNER#{owner}"
+
+
+def _project_sk(project_id: str) -> str:
+    return f"PROJECT#{project_id}"
+
+
+def _tracked_file_sk(tracked_file_id: str) -> str:
+    return f"TRACKED_FILE#{tracked_file_id}"
+
+
+def _event_sk(created_at: str, event_id: str) -> str:
+    return f"EVENT#{created_at}#{event_id}"
+
+
+def _tracked_file_unique_key(provider: str, provider_ref: str) -> str:
+    return f"{provider.lower()}#{provider_ref.strip()}"
+
+
+def project_to_item(project: ProjectModel) -> Dict[str, Any]:
+    return {
+        "PK": _project_pk(project.owner),
+        "SK": _project_sk(project.id),
+        "entity_type": "project",
+        "id": project.id,
+        "owner": project.owner,
+        "name": project.name,
+        "description": project.description,
+        "tags": project.tags,
+        "settings": project.settings,
+        "created_at": project.created_at,
+        "updated_at": project.updated_at,
+        "GSI1PK": f"PROJECT#{project.id}",
+        "GSI1SK": f"OWNER#{project.owner}",
+    }
+
+
+def project_from_item(item: Dict[str, Any]) -> ProjectModel:
+    return ProjectModel(
+        id=item["id"],
+        owner=item["owner"],
+        name=item["name"],
+        description=item.get("description"),
+        tags=item.get("tags") or [],
+        settings=item.get("settings") or {},
+        created_at=item["created_at"],
+        updated_at=item["updated_at"],
+    )
+
+
+def _coerce_project(*, project_id: str, owner: str, name: str, description: Optional[str], tags: Optional[List[str]], settings: Optional[Dict[str, Any]], created_at: str, updated_at: str) -> ProjectModel:
+    try:
+        return ProjectModel(
+            id=project_id,
+            owner=owner,
+            name=name,
+            description=description,
+            tags=tags or [],
+            settings=settings or {},
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="invalid project payload") from exc
+
+
+def create_project(
+    owner: str,
+    name: str,
+    description: Optional[str] = None,
+    *,
+    tags: Optional[List[str]] = None,
+    settings: Optional[Dict[str, Any]] = None,
+) -> ProjectModel:
+    ts = now_iso()
+    project = _coerce_project(
+        project_id=str(uuid4()),
+        owner=owner,
+        name=name,
+        description=description,
+        tags=tags,
+        settings=settings,
+        created_at=ts,
+        updated_at=ts,
+    )
+    T.projects.put_item(
+        Item=project_to_item(project),
+        ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+    )
+    record_project_count_delta(1)
+    return project
+
+
+def get_project(owner: str, project_id: str) -> ProjectModel:
+    if not owner or not project_id:
+        raise HTTPException(status_code=400, detail="owner and project_id are required")
+    resp = T.projects.get_item(Key={"PK": _project_pk(owner), "SK": _project_sk(project_id)}, ConsistentRead=True)
+    item = resp.get("Item")
+    if not item or item.get("entity_type") != "project":
+        raise HTTPException(status_code=404, detail="project not found")
+    return project_from_item(item)
+
+
+def list_projects(
+    owner: str,
+    *,
+    limit: int = 50,
+    cursor: Optional[Dict[str, Any]] = None,
+    tag: Optional[str] = None,
+    name_query: Optional[str] = None,
+) -> Dict[str, Any]:
+    if not owner:
+        raise HTTPException(status_code=400, detail="owner is required")
+    if not isinstance(limit, int) or limit < 1 or limit > 200:
+        raise HTTPException(status_code=400, detail="invalid limit")
+    if cursor is not None and not isinstance(cursor, dict):
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+    normalized_tag = (tag or "").strip().lower() or None
+    normalized_query = (name_query or "").strip().lower() or None
+
+    items: List[ProjectModel] = []
+    last_key = cursor
+    while len(items) < limit:
+        kwargs: Dict[str, Any] = {
+            "KeyConditionExpression": Key("PK").eq(_project_pk(owner)) & Key("SK").begins_with("PROJECT#"),
+            "Limit": max(limit, 25),
+            "ScanIndexForward": False,
+        }
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = T.projects.query(**kwargs)
+
+        for raw in resp.get("Items", []):
+            if raw.get("entity_type") != "project":
+                continue
+            project = project_from_item(raw)
+            if normalized_tag and normalized_tag not in project.tags:
+                continue
+            if normalized_query and normalized_query not in project.name.lower():
+                continue
+            items.append(project)
+            if len(items) >= limit:
+                break
+
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+    return {
+        "items": items,
+        "cursor": last_key,
+    }
+
+
+def update_project(
+    owner: str,
+    project_id: str,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    settings: Optional[Dict[str, Any]] = None,
+) -> ProjectModel:
+    existing = get_project(owner, project_id)
+
+    merged = _coerce_project(
+        project_id=existing.id,
+        owner=existing.owner,
+        name=existing.name if name is None else name,
+        description=existing.description if description is None else description,
+        tags=existing.tags if tags is None else tags,
+        settings=existing.settings if settings is None else settings,
+        created_at=existing.created_at,
+        updated_at=now_iso(),
+    )
+
+    T.projects.put_item(
+        Item=project_to_item(merged),
+        ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+    )
+    return merged
+
+
+def delete_project(owner: str, project_id: str) -> Dict[str, bool]:
+    try:
+        T.projects.delete_item(
+            Key={"PK": _project_pk(owner), "SK": _project_sk(project_id)},
+            ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+        )
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "ConditionalCheckFailedException":
+            raise HTTPException(status_code=404, detail="project not found") from exc
+        raise
+    record_project_count_delta(-1)
+    return {"ok": True}
+
+
+def tracked_file_to_item(tracked: TrackedFileModel) -> Dict[str, Any]:
+    unique_key = _tracked_file_unique_key(tracked.provider, tracked.provider_ref)
+    return {
+        "PK": f"PROJECT#{tracked.project_id}",
+        "SK": _tracked_file_sk(tracked.id),
+        "entity_type": "tracked_file",
+        "id": tracked.id,
+        "project_id": tracked.project_id,
+        "owner": tracked.owner,
+        "provider": tracked.provider,
+        "provider_ref": tracked.provider_ref,
+        "provider_ref_key": unique_key,
+        "display_path": tracked.display_path,
+        "status": tracked.status,
+        "metadata": tracked.metadata,
+        "created_at": tracked.created_at,
+        "updated_at": tracked.updated_at,
+        "last_seen_at": tracked.last_seen_at,
+        "archived_at": tracked.archived_at,
+        "GSI1PK": f"PROJECT#{tracked.project_id}",
+        "GSI1SK": f"PROVIDER_REF#{unique_key}",
+        "GSI2PK": f"OWNER#{tracked.owner}",
+        "GSI2SK": f"PROJECT#{tracked.project_id}#TRACKED_FILE#{tracked.id}",
+    }
+
+
+def project_event_to_item(event: ProjectEventModel) -> Dict[str, Any]:
+    return {
+        "PK": f"PROJECT#{event.project_id}",
+        "SK": _event_sk(event.created_at, event.id),
+        "entity_type": "project_event",
+        "id": event.id,
+        "project_id": event.project_id,
+        "owner": event.owner,
+        "event_type": event.event_type,
+        "tracked_file_id": event.tracked_file_id,
+        "provider": event.provider,
+        "provider_ref": event.provider_ref,
+        "message": event.message,
+        "metadata": event.metadata,
+        "created_at": event.created_at,
+        "GSI2PK": f"OWNER#{event.owner}",
+        "GSI2SK": f"PROJECT#{event.project_id}#EVENT#{event.created_at}#{event.id}",
+    }
+
+
+def project_event_from_item(item: Dict[str, Any]) -> ProjectEventModel:
+    return ProjectEventModel(
+        id=item["id"],
+        project_id=item["project_id"],
+        owner=item["owner"],
+        event_type=item["event_type"],
+        tracked_file_id=item.get("tracked_file_id"),
+        provider=item.get("provider"),
+        provider_ref=item.get("provider_ref"),
+        message=item.get("message"),
+        metadata=item.get("metadata") or {},
+        created_at=item["created_at"],
+    )
+
+
+def emit_project_event(
+    owner: str,
+    project_id: str,
+    event_type: str,
+    *,
+    tracked_file_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    provider_ref: Optional[str] = None,
+    message: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> ProjectEventModel:
+    event = ProjectEventModel(
+        id=str(uuid4()),
+        project_id=project_id,
+        owner=owner,
+        event_type=event_type,
+        tracked_file_id=tracked_file_id,
+        provider=provider,
+        provider_ref=provider_ref,
+        message=message,
+        metadata=metadata or {},
+        created_at=now_iso(),
+    )
+    T.projects.put_item(Item=project_event_to_item(event))
+    return event
+
+
+def tracked_file_from_item(item: Dict[str, Any]) -> TrackedFileModel:
+    return TrackedFileModel(
+        id=item["id"],
+        project_id=item["project_id"],
+        owner=item["owner"],
+        provider=item["provider"],
+        provider_ref=item["provider_ref"],
+        display_path=item["display_path"],
+        status=item.get("status", "active"),
+        metadata=item.get("metadata") or {},
+        created_at=item["created_at"],
+        updated_at=item["updated_at"],
+        last_seen_at=item.get("last_seen_at"),
+        archived_at=item.get("archived_at"),
+    )
+
+
+def put_tracked_file(
+    tracked_file: TrackedFileModel,
+    *,
+    registry: Optional[ProviderRegistry] = None,
+) -> TrackedFileModel:
+    provider_registry = registry or default_provider_registry()
+    provider = provider_registry.get(tracked_file.owner, tracked_file.provider)
+
+    canonical_ref = provider.resolve(tracked_file.provider_ref)
+    if not provider.exists(canonical_ref):
+        raise HTTPException(status_code=404, detail="tracked file target not found")
+
+    metadata = provider.get_metadata(canonical_ref)
+    display_path = (tracked_file.display_path or "").strip() or canonical_ref
+    tracked = tracked_file.model_copy(
+        update={
+            "provider": tracked_file.provider.lower(),
+            "provider_ref": canonical_ref,
+            "display_path": display_path,
+            "metadata": {**metadata, **(tracked_file.metadata or {})},
+            "updated_at": tracked_file.updated_at or now_iso(),
+            "last_seen_at": tracked_file.last_seen_at or now_iso(),
+        }
+    )
+
+    existing = T.projects.query(
+        IndexName="GSI1",
+        KeyConditionExpression=Key("GSI1PK").eq(f"PROJECT#{tracked.project_id}")
+        & Key("GSI1SK").eq(f"PROVIDER_REF#{_tracked_file_unique_key(tracked.provider, tracked.provider_ref)}"),
+        Limit=1,
+    )
+    if existing.get("Items"):
+        raise HTTPException(status_code=409, detail="tracked file already exists for provider_ref")
+
+    try:
+        T.projects.put_item(
+            Item=tracked_file_to_item(tracked),
+            ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+        )
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "ConditionalCheckFailedException":
+            raise HTTPException(status_code=409, detail="tracked file id already exists") from exc
+        raise
+    return tracked
+
+
+def add_tracked_file(
+    owner: str,
+    project_id: str,
+    *,
+    provider: str,
+    provider_ref: str,
+    display_path: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    registry: Optional[ProviderRegistry] = None,
+) -> TrackedFileModel:
+    # Authorization/project scope check
+    get_project(owner, project_id)
+
+    ts = now_iso()
+    tracked = TrackedFileModel(
+        id=str(uuid4()),
+        project_id=project_id,
+        owner=owner,
+        provider=provider,
+        provider_ref=provider_ref,
+        display_path=(display_path or provider_ref or "").strip(),
+        status="active",
+        metadata=metadata or {},
+        created_at=ts,
+        updated_at=ts,
+        last_seen_at=ts,
+    )
+    stored = put_tracked_file(tracked, registry=registry)
+    record_tracked_file_count_delta(1)
+    emit_project_event(
+        owner,
+        project_id,
+        "file_added",
+        tracked_file_id=stored.id,
+        provider=stored.provider,
+        provider_ref=stored.provider_ref,
+        metadata={"display_path": stored.display_path},
+    )
+    return stored
+
+
+def list_tracked_files(
+    owner: str,
+    project_id: str,
+    *,
+    limit: int = 50,
+    cursor: Optional[Dict[str, Any]] = None,
+    status: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> Dict[str, Any]:
+    get_project(owner, project_id)
+
+    if not isinstance(limit, int) or limit < 1 or limit > 200:
+        raise HTTPException(status_code=400, detail="invalid limit")
+    if cursor is not None and not isinstance(cursor, dict):
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+    normalized_provider = (provider or "").strip().lower() or None
+    normalized_status = (status or "").strip().lower() or None
+
+    items: List[TrackedFileModel] = []
+    last_key = cursor
+    while len(items) < limit:
+        kwargs: Dict[str, Any] = {
+            "KeyConditionExpression": Key("PK").eq(f"PROJECT#{project_id}") & Key("SK").begins_with("TRACKED_FILE#"),
+            "Limit": max(limit, 25),
+            "ScanIndexForward": False,
+        }
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = T.projects.query(**kwargs)
+
+        for raw in resp.get("Items", []):
+            if raw.get("entity_type") != "tracked_file":
+                continue
+            if raw.get("owner") != owner:
+                continue
+            tracked = tracked_file_from_item(raw)
+            if normalized_provider and tracked.provider.lower() != normalized_provider:
+                continue
+            if normalized_status and (tracked.status or "").lower() != normalized_status:
+                continue
+            items.append(tracked)
+            if len(items) >= limit:
+                break
+
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+    return {"items": items, "cursor": last_key}
+
+
+def remove_tracked_file(owner: str, project_id: str, tracked_file_id: str) -> Dict[str, bool]:
+    # authorization/project scope check
+    get_project(owner, project_id)
+
+    key = {"PK": f"PROJECT#{project_id}", "SK": _tracked_file_sk(tracked_file_id)}
+    resp = T.projects.get_item(Key=key, ConsistentRead=True)
+    item = resp.get("Item")
+    if not item:
+        return {"ok": True, "deleted": False}
+    if item.get("entity_type") != "tracked_file" or item.get("owner") != owner:
+        raise HTTPException(status_code=404, detail="tracked file not found")
+
+    model = tracked_file_from_item(item)
+    if model.status == "archived":
+        return {"ok": True, "deleted": False}
+
+    archived = model.model_copy(update={"status": "archived", "updated_at": now_iso(), "archived_at": now_iso()})
+    T.projects.put_item(Item=tracked_file_to_item(archived))
+    record_tracked_file_count_delta(-1)
+    emit_project_event(
+        owner,
+        project_id,
+        "file_removed",
+        tracked_file_id=archived.id,
+        provider=archived.provider,
+        provider_ref=archived.provider_ref,
+        metadata={"display_path": archived.display_path},
+    )
+    return {"ok": True, "deleted": True}
+
+
+def list_project_events(
+    owner: str,
+    project_id: str,
+    *,
+    limit: int = 50,
+    cursor: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    get_project(owner, project_id)
+
+    if not isinstance(limit, int) or limit < 1 or limit > 200:
+        raise HTTPException(status_code=400, detail="invalid limit")
+    if cursor is not None and not isinstance(cursor, dict):
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+    kwargs: Dict[str, Any] = {
+        "KeyConditionExpression": Key("PK").eq(f"PROJECT#{project_id}") & Key("SK").begins_with("EVENT#"),
+        "Limit": limit,
+        "ScanIndexForward": False,
+    }
+    if cursor:
+        kwargs["ExclusiveStartKey"] = cursor
+
+    resp = T.projects.query(**kwargs)
+    items: List[ProjectEventModel] = []
+    for raw in resp.get("Items", []):
+        if raw.get("entity_type") != "project_event":
+            continue
+        if raw.get("owner") != owner:
+            continue
+        items.append(project_event_from_item(raw))
+    return {"items": items, "cursor": resp.get("LastEvaluatedKey")}
+
+
+def get_project_detail(
+    owner: str,
+    project_id: str,
+    *,
+    limit: int = 50,
+    cursor: Optional[Dict[str, Any]] = None,
+    status: Optional[str] = None,
+    provider: Optional[str] = None,
+    registry: Optional[ProviderRegistry] = None,
+) -> Dict[str, Any]:
+    project = get_project(owner, project_id)
+    tracked_page = list_tracked_files(
+        owner,
+        project_id,
+        limit=limit,
+        cursor=cursor,
+        status=status,
+        provider=provider,
+    )
+
+    provider_registry = registry or default_provider_registry()
+    rows: List[Dict[str, Any]] = []
+    for tracked in tracked_page["items"]:
+        provider_client = provider_registry.get(owner, tracked.provider)
+        canonical_ref = provider_client.resolve(tracked.provider_ref)
+
+        row_status = tracked.status
+        hydrated_meta = dict(tracked.metadata or {})
+        try:
+            exists = provider_client.exists(canonical_ref)
+            if exists:
+                fresh_meta = provider_client.get_metadata(canonical_ref)
+                hydrated_meta = {**hydrated_meta, **fresh_meta}
+                row_status = "active" if tracked.status != "archived" else "archived"
+            elif tracked.status != "archived":
+                row_status = "missing"
+        except HTTPException as exc:
+            if exc.status_code == 404 and tracked.status != "archived":
+                row_status = "missing"
+            else:
+                raise
+
+        rows.append(
+            {
+                "id": tracked.id,
+                "project_id": tracked.project_id,
+                "provider": tracked.provider,
+                "provider_ref": canonical_ref,
+                "display_path": (tracked.display_path or canonical_ref),
+                "status": row_status,
+                "last_seen_at": tracked.last_seen_at,
+                "updated_at": tracked.updated_at,
+                "metadata": hydrated_meta,
+            }
+        )
+
+    return {
+        "project": project,
+        "files": rows,
+        "cursor": tracked_page.get("cursor"),
+    }
+
+
+def archive_tracked_file(project_id: str, tracked_file_id: str) -> TrackedFileModel:
+    key = {"PK": f"PROJECT#{project_id}", "SK": _tracked_file_sk(tracked_file_id)}
+    resp = T.projects.get_item(Key=key, ConsistentRead=True)
+    item = resp.get("Item")
+    if not item:
+        raise HTTPException(status_code=404, detail="tracked file not found")
+
+    model = tracked_file_from_item(item)
+    model = model.model_copy(update={"status": "archived", "updated_at": now_iso(), "archived_at": now_iso()})
+    T.projects.put_item(Item=tracked_file_to_item(model))
+    return model

--- a/app/services/provider_credentials.py
+++ b/app/services/provider_credentials.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+from fastapi import HTTPException
+
+from app.core.crypto import kms_decrypt, kms_encrypt
+from app.core.settings import S
+from app.core.tables import T
+from app.models import ProviderCredentialModel
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _credential_pk(owner: str) -> str:
+    return f"OWNER#{owner}"
+
+
+def _credential_sk(provider: str, org: Optional[str]) -> str:
+    suffix = (org or "self").strip().lower()
+    return f"PROVIDER_CRED#{provider.strip().lower()}#{suffix}"
+
+
+def _credential_to_item(model: ProviderCredentialModel) -> Dict[str, Any]:
+    return {
+        "PK": _credential_pk(model.owner),
+        "SK": _credential_sk(model.provider, model.org),
+        "entity_type": "provider_credential",
+        "owner": model.owner,
+        "provider": model.provider,
+        "org": model.org,
+        "token_ct_b64": model.token_ct_b64,
+        "scopes": model.scopes,
+        "metadata": model.metadata,
+        "created_at": model.created_at,
+        "updated_at": model.updated_at,
+    }
+
+
+def _credential_from_item(item: Dict[str, Any]) -> ProviderCredentialModel:
+    return ProviderCredentialModel(
+        owner=item["owner"],
+        provider=item["provider"],
+        org=item.get("org"),
+        token_ct_b64=item["token_ct_b64"],
+        scopes=item.get("scopes") or [],
+        metadata=item.get("metadata") or {},
+        created_at=item["created_at"],
+        updated_at=item["updated_at"],
+    )
+
+
+def _parse_github_scopes(header_value: Optional[str]) -> List[str]:
+    if not header_value:
+        return []
+    out: List[str] = []
+    seen = set()
+    for raw in header_value.split(","):
+        normalized = raw.strip().lower()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        out.append(normalized)
+    return out
+
+
+def _normalize_api_base_url(value: Optional[str], *, default: str, provider: str) -> str:
+    candidate = (value or default).strip().rstrip("/")
+    if not candidate.startswith("http://") and not candidate.startswith("https://"):
+        raise HTTPException(status_code=400, detail=f"{provider} api_base_url must start with http:// or https://")
+    return candidate
+
+
+def normalize_github_api_base_url(value: Optional[str]) -> str:
+    return _normalize_api_base_url(
+        value,
+        default=(S.github_api_base_url or "https://api.github.com"),
+        provider="github",
+    )
+
+
+def normalize_gitlab_api_base_url(value: Optional[str]) -> str:
+    return _normalize_api_base_url(
+        value,
+        default=(S.gitlab_api_base_url or "https://gitlab.com/api/v4"),
+        provider="gitlab",
+    )
+
+
+def _validate_github_token(token: str, api_base_url: Optional[str] = None) -> Dict[str, Any]:
+    normalized_base_url = normalize_github_api_base_url(api_base_url)
+    r = requests.get(
+        f"{normalized_base_url}/user",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+        timeout=10,
+    )
+    if r.status_code in (401, 403):
+        raise HTTPException(status_code=401, detail="github token invalid or expired; refresh token and retry")
+    if r.status_code >= 400:
+        raise HTTPException(status_code=502, detail=f"github token validation failed ({r.status_code})")
+    body = r.json() if r.content else {}
+    return {
+        "scopes": _parse_github_scopes(r.headers.get("X-OAuth-Scopes")),
+        "metadata": {
+            "login": body.get("login"),
+            "id": body.get("id"),
+            "api_base_url": normalized_base_url,
+        },
+    }
+
+
+def _validate_gitlab_token(token: str, api_base_url: Optional[str] = None) -> Dict[str, Any]:
+    normalized_base_url = normalize_gitlab_api_base_url(api_base_url)
+    r = requests.get(
+        f"{normalized_base_url}/personal_access_tokens/self",
+        headers={"PRIVATE-TOKEN": token},
+        timeout=10,
+    )
+    if r.status_code in (401, 403):
+        raise HTTPException(status_code=401, detail="gitlab token invalid/expired or missing api scope")
+    if r.status_code >= 400:
+        raise HTTPException(status_code=502, detail=f"gitlab token validation failed ({r.status_code})")
+    body = r.json() if r.content else {}
+    scopes = [str(scope).strip().lower() for scope in (body.get("scopes") or []) if str(scope).strip()]
+    return {
+        "scopes": scopes,
+        "metadata": {
+            "token_id": body.get("id"),
+            "active": body.get("active"),
+            "expires_at": body.get("expires_at"),
+            "api_base_url": normalized_base_url,
+        },
+    }
+
+
+def validate_provider_token(
+    provider: str,
+    token: str,
+    required_scopes: Optional[List[str]] = None,
+    *,
+    api_base_url: Optional[str] = None,
+) -> Dict[str, Any]:
+    normalized_provider = (provider or "").strip().lower()
+    if not token or not token.strip():
+        raise HTTPException(status_code=400, detail="token is required")
+
+    if normalized_provider == "github":
+        result = _validate_github_token(token.strip(), api_base_url=api_base_url)
+    elif normalized_provider == "gitlab":
+        result = _validate_gitlab_token(token.strip(), api_base_url=api_base_url)
+    else:
+        raise HTTPException(status_code=400, detail="unsupported provider")
+
+    required = [s.strip().lower() for s in (required_scopes or []) if s and s.strip()]
+    granted = result.get("scopes") or []
+    missing = [scope for scope in required if scope not in granted]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"provider token missing required scopes: {', '.join(missing)}",
+        )
+
+    return result
+
+
+def upsert_provider_credential(
+    owner: str,
+    provider: str,
+    token: str,
+    *,
+    org: Optional[str] = None,
+    required_scopes: Optional[List[str]] = None,
+    api_base_url: Optional[str] = None,
+) -> ProviderCredentialModel:
+    validated = validate_provider_token(
+        provider,
+        token,
+        required_scopes=required_scopes,
+        api_base_url=api_base_url,
+    )
+
+    try:
+        token_ct_b64 = kms_encrypt(token.strip())
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail="credential encryption is not configured") from exc
+
+    ts = now_iso()
+    existing = get_provider_credential(owner, provider, org=org, allow_missing=True)
+    model = ProviderCredentialModel(
+        owner=owner,
+        provider=provider.strip().lower(),
+        org=(org or None),
+        token_ct_b64=token_ct_b64,
+        scopes=validated.get("scopes") or [],
+        metadata=validated.get("metadata") or {},
+        created_at=existing.created_at if existing else ts,
+        updated_at=ts,
+    )
+    T.projects.put_item(Item=_credential_to_item(model))
+    return model
+
+
+def get_provider_credential(
+    owner: str,
+    provider: str,
+    *,
+    org: Optional[str] = None,
+    allow_missing: bool = False,
+) -> Optional[ProviderCredentialModel]:
+    resp = T.projects.get_item(
+        Key={
+            "PK": _credential_pk(owner),
+            "SK": _credential_sk(provider, org),
+        },
+        ConsistentRead=True,
+    )
+    item = resp.get("Item")
+    if not item or item.get("entity_type") != "provider_credential":
+        if allow_missing:
+            return None
+        raise HTTPException(status_code=404, detail="provider credential not found")
+    return _credential_from_item(item)
+
+
+def get_provider_token(
+    owner: str,
+    provider: str,
+    *,
+    org: Optional[str] = None,
+    required_scopes: Optional[List[str]] = None,
+) -> str:
+    cred = get_provider_credential(owner, provider, org=org)
+    granted = cred.scopes or []
+    required = [s.strip().lower() for s in (required_scopes or []) if s and s.strip()]
+    missing = [scope for scope in required if scope not in granted]
+    if missing:
+        raise HTTPException(status_code=400, detail=f"stored token missing scopes: {', '.join(missing)}")
+
+    try:
+        return kms_decrypt(cred.token_ct_b64).decode("utf-8")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail="credential decryption is not configured") from exc
+
+
+def get_provider_auth_context(
+    owner: str,
+    provider: str,
+    *,
+    org: Optional[str] = None,
+    required_scopes: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    cred = get_provider_credential(owner, provider, org=org)
+    granted = cred.scopes or []
+    required = [s.strip().lower() for s in (required_scopes or []) if s and s.strip()]
+    missing = [scope for scope in required if scope not in granted]
+    if missing:
+        raise HTTPException(status_code=400, detail=f"stored token missing scopes: {', '.join(missing)}")
+
+    try:
+        token = kms_decrypt(cred.token_ct_b64).decode("utf-8")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail="credential decryption is not configured") from exc
+
+    return {
+        "token": token,
+        "provider": cred.provider,
+        "org": cred.org,
+        "scopes": list(cred.scopes or []),
+        "metadata": dict(cred.metadata or {}),
+    }
+
+
+def delete_provider_credential(owner: str, provider: str, *, org: Optional[str] = None) -> Dict[str, bool]:
+    key = {"PK": _credential_pk(owner), "SK": _credential_sk(provider, org)}
+    resp = T.projects.get_item(Key=key, ConsistentRead=True)
+    item = resp.get("Item")
+    if not item:
+        return {"ok": True, "deleted": False}
+    if item.get("entity_type") != "provider_credential" or item.get("owner") != owner:
+        raise HTTPException(status_code=404, detail="provider credential not found")
+    T.projects.delete_item(Key=key)
+    return {"ok": True, "deleted": True}

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -110,22 +110,6 @@
         "operationId": "ui_me_ui_me_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -189,22 +173,6 @@
         "operationId": "ui_sessions_ui_sessions_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -267,22 +235,6 @@
         "summary": "Ui Sessions Revoke",
         "operationId": "ui_sessions_revoke_ui_sessions_revoke_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -357,22 +309,6 @@
         "summary": "Ui Session Logout",
         "operationId": "ui_session_logout_ui_session_logout_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -455,22 +391,6 @@
         "summary": "Ui Sessions Revoke Others",
         "operationId": "ui_sessions_revoke_others_ui_sessions_revoke_others_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -780,22 +700,6 @@
         "operationId": "totp_devices_ui_mfa_totp_devices_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -858,22 +762,6 @@
         "summary": "Totp Devices Begin",
         "operationId": "totp_devices_begin_ui_mfa_totp_devices_begin_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -947,22 +835,6 @@
         "summary": "Totp Devices Confirm",
         "operationId": "totp_devices_confirm_ui_mfa_totp_devices_confirm_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -1046,22 +918,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -1135,22 +991,6 @@
         "operationId": "sms_devices_ui_mfa_sms_devices_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -1213,22 +1053,6 @@
         "summary": "Sms Devices Begin",
         "operationId": "sms_devices_begin_ui_mfa_sms_devices_begin_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -1302,22 +1126,6 @@
         "summary": "Sms Devices Confirm",
         "operationId": "sms_devices_confirm_ui_mfa_sms_devices_confirm_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -1401,22 +1209,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -1479,22 +1271,6 @@
         "summary": "Sms Devices Remove Confirm",
         "operationId": "sms_devices_remove_confirm_ui_mfa_sms_devices_remove_confirm_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -1569,22 +1345,6 @@
         "operationId": "email_devices_ui_mfa_email_devices_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -1647,22 +1407,6 @@
         "summary": "Email Devices Begin",
         "operationId": "email_devices_begin_ui_mfa_email_devices_begin_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -1736,22 +1480,6 @@
         "summary": "Email Devices Confirm",
         "operationId": "email_devices_confirm_ui_mfa_email_devices_confirm_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -1835,22 +1563,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -1913,22 +1625,6 @@
         "summary": "Email Devices Remove Confirm",
         "operationId": "email_devices_remove_confirm_ui_mfa_email_devices_remove_confirm_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -2003,22 +1699,6 @@
         "operationId": "ui_list_api_keys_ui_api_keys_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -2079,22 +1759,6 @@
         "summary": "Ui Create Api Key",
         "operationId": "ui_create_api_key_ui_api_keys_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -2169,22 +1833,6 @@
         "operationId": "ui_revoke_api_key_ui_api_keys_revoke_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -2258,22 +1906,6 @@
         "operationId": "ui_set_api_key_ip_rules_ui_api_keys_ip_rules_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -2338,16 +1970,353 @@
         }
       }
     },
-    "/ui/alerts/types": {
-      "get": {
+    "/ui/api_keys/self_limits": {
+      "post": {
         "tags": [
-          "alerts"
+          "api-keys"
         ],
-        "summary": "Alert Types",
-        "operationId": "alert_types_ui_alerts_types_get",
+        "summary": "Ui Set Api Key Self Limits",
+        "operationId": "ui_set_api_key_self_limits_ui_api_keys_self_limits_post",
         "parameters": [
           {
-            "name": "user_sub",
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeySelfLimitsReq"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/api_keys/{key_id}/limits": {
+      "patch": {
+        "tags": [
+          "api-keys"
+        ],
+        "summary": "Ui Patch Api Key Limits",
+        "operationId": "ui_patch_api_key_limits_ui_api_keys__key_id__limits_patch",
+        "parameters": [
+          {
+            "name": "key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeyLimitsPatchReq"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/api_keys/{key_id}/usage": {
+      "get": {
+        "tags": [
+          "api-keys"
+        ],
+        "summary": "Ui Get Api Key Usage",
+        "operationId": "ui_get_api_key_usage_ui_api_keys__key_id__usage_get",
+        "parameters": [
+          {
+            "name": "key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Period"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/api-usage/summary": {
+      "get": {
+        "tags": [
+          "api-usage"
+        ],
+        "summary": "Ui Api Usage Summary",
+        "operationId": "ui_api_usage_summary_ui_api_usage_summary_get",
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Period"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/api-usage/routes": {
+      "get": {
+        "tags": [
+          "api-usage"
+        ],
+        "summary": "Ui Api Usage Routes",
+        "operationId": "ui_api_usage_routes_ui_api_usage_routes_get",
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Period"
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "cost_subtotal_micros",
+              "title": "Sort By"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "title": "Order"
+            }
+          },
+          {
+            "name": "search",
             "in": "query",
             "required": false,
             "schema": {
@@ -2359,9 +2328,236 @@
                   "type": "null"
                 }
               ],
-              "title": "User Sub"
+              "title": "Search"
             }
           },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/api-usage/keys": {
+      "get": {
+        "tags": [
+          "api-usage"
+        ],
+        "summary": "Ui Api Usage Keys",
+        "operationId": "ui_api_usage_keys_ui_api_usage_keys_get",
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Period"
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "cost_subtotal_micros",
+              "title": "Sort By"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "title": "Order"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/alerts/types": {
+      "get": {
+        "tags": [
+          "alerts"
+        ],
+        "summary": "Alert Types",
+        "operationId": "alert_types_ui_alerts_types_get",
+        "parameters": [
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -2459,22 +2655,6 @@
               "type": "integer",
               "default": 0,
               "title": "Unread Only"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -2579,22 +2759,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -2657,22 +2821,6 @@
         "summary": "Mark Read",
         "operationId": "mark_read_ui_alerts_mark_read_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -2747,22 +2895,6 @@
         "operationId": "get_email_prefs_ui_alerts_email_prefs_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -2823,22 +2955,6 @@
         "summary": "Set Email Prefs",
         "operationId": "set_email_prefs_ui_alerts_email_prefs_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -2913,22 +3029,6 @@
         "operationId": "get_sms_prefs_ui_alerts_sms_prefs_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -2989,22 +3089,6 @@
         "summary": "Set Sms Prefs",
         "operationId": "set_sms_prefs_ui_alerts_sms_prefs_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -3079,22 +3163,6 @@
         "operationId": "get_toast_prefs_ui_alerts_toast_prefs_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -3155,22 +3223,6 @@
         "summary": "Set Toast Prefs",
         "operationId": "set_toast_prefs_ui_alerts_toast_prefs_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -3245,22 +3297,6 @@
         "operationId": "set_push_prefs_ui_alerts_push_prefs_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -3334,22 +3370,6 @@
         "operationId": "get_webhook_prefs_ui_alerts_webhook_prefs_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -3410,22 +3430,6 @@
         "summary": "Set Webhook Prefs",
         "operationId": "set_webhook_prefs_ui_alerts_webhook_prefs_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -3499,22 +3503,6 @@
         "summary": "Mark Toast Delivered",
         "operationId": "mark_toast_delivered_ui_alerts_mark_toast_delivered_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -3590,22 +3578,6 @@
         "operationId": "alert_sms_add_begin_ui_alerts_sms_begin_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -3678,22 +3650,6 @@
         "summary": "Alert Sms Add Confirm",
         "operationId": "alert_sms_add_confirm_ui_alerts_sms_confirm_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -3768,22 +3724,6 @@
         "operationId": "alert_sms_remove_ui_alerts_sms_remove_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -3856,22 +3796,6 @@
         "summary": "Alert Email Add Begin",
         "operationId": "alert_email_add_begin_ui_alerts_emails_begin_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -3946,22 +3870,6 @@
         "operationId": "alert_email_add_confirm_ui_alerts_emails_confirm_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -4034,22 +3942,6 @@
         "summary": "Alert Email Remove",
         "operationId": "alert_email_remove_ui_alerts_emails_remove_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -4124,22 +4016,6 @@
         "operationId": "alerts_stream_ui_alerts_stream_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -4203,22 +4079,6 @@
         "operationId": "account_closure_start_ui_account_closure_start_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -4281,22 +4141,6 @@
         "summary": "Account Closure Finalize",
         "operationId": "account_closure_finalize_ui_account_closure_finalize_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -4371,22 +4215,6 @@
         "operationId": "ui_list_push_devices_ui_push_devices_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -4449,22 +4277,6 @@
         "summary": "Ui Register Push",
         "operationId": "ui_register_push_ui_push_register_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -4539,22 +4351,6 @@
         "operationId": "ui_revoke_push_ui_push_revoke_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -4627,22 +4423,6 @@
         "summary": "Ui Push Test",
         "operationId": "ui_push_test_ui_push_test_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -5456,22 +5236,6 @@
         "operationId": "webauthn_register_begin_ui_webauthn_register_begin_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -5546,22 +5310,6 @@
         "summary": "Webauthn Register Finish",
         "operationId": "webauthn_register_finish_ui_webauthn_register_finish_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -5761,22 +5509,6 @@
         "operationId": "grant_role_admin_roles_grant_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -5850,22 +5582,6 @@
         "operationId": "update_role_profile_admin_roles_update_profile_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -5938,22 +5654,6 @@
         "summary": "Revoke Role",
         "operationId": "revoke_role_admin_roles_revoke_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -6100,22 +5800,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -6178,22 +5862,6 @@
         "summary": "Start Impersonation",
         "operationId": "start_impersonation_admin_impersonation_start_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -6268,22 +5936,6 @@
         "summary": "Stop Impersonation",
         "operationId": "stop_impersonation_admin_impersonation_stop_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -6431,22 +6083,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -6509,22 +6145,6 @@
         "summary": "Ui Ws Token",
         "operationId": "ui_ws_token_ui_ws_token_get",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -6694,22 +6314,6 @@
         "summary": "Get Frontend Oauth",
         "operationId": "get_frontend_oauth_api_billing_ccbill_frontend_oauth_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -7033,22 +6637,6 @@
         "operationId": "save_payment_token_api_billing_payment_methods_ccbill_token_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -7121,22 +6709,6 @@
         "summary": "List Payment Methods",
         "operationId": "list_payment_methods_api_billing_payment_methods_get",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -8376,6 +7948,548 @@
         }
       }
     },
+    "/mock/paypal/v1/oauth2/token": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Oauth",
+        "operationId": "mock_oauth_mock_paypal_v1_oauth2_token_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Mock Oauth Mock Paypal V1 Oauth2 Token Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v3/vault/setup-tokens": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Create Setup Token",
+        "operationId": "mock_create_setup_token_mock_paypal_v3_vault_setup_tokens_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Mock Create Setup Token Mock Paypal V3 Vault Setup Tokens Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v3/vault/payment-tokens": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Exchange Setup Token",
+        "operationId": "mock_exchange_setup_token_mock_paypal_v3_vault_payment_tokens_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Mock Exchange Setup Token Mock Paypal V3 Vault Payment Tokens Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v3/vault/payment-tokens/{payment_token_id}": {
+      "delete": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Delete Payment Token",
+        "operationId": "mock_delete_payment_token_mock_paypal_v3_vault_payment_tokens__payment_token_id__delete",
+        "parameters": [
+          {
+            "name": "payment_token_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Payment Token Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v2/checkout/orders": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Create Order",
+        "operationId": "mock_create_order_mock_paypal_v2_checkout_orders_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Mock Create Order Mock Paypal V2 Checkout Orders Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v2/checkout/orders/{order_id}/capture": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Capture Order",
+        "operationId": "mock_capture_order_mock_paypal_v2_checkout_orders__order_id__capture_post",
+        "parameters": [
+          {
+            "name": "order_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Order Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Mock Capture Order Mock Paypal V2 Checkout Orders  Order Id  Capture Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v1/billing/subscriptions": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Create Subscription",
+        "operationId": "mock_create_subscription_mock_paypal_v1_billing_subscriptions_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Mock Create Subscription Mock Paypal V1 Billing Subscriptions Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v1/billing/subscriptions/{subscription_id}/cancel": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Cancel Subscription",
+        "operationId": "mock_cancel_subscription_mock_paypal_v1_billing_subscriptions__subscription_id__cancel_post",
+        "parameters": [
+          {
+            "name": "subscription_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Subscription Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/paypal/v1/notifications/verify-webhook-signature": {
+      "post": {
+        "tags": [
+          "mock"
+        ],
+        "summary": "Mock Verify Webhook",
+        "operationId": "mock_verify_webhook_mock_paypal_v1_notifications_verify_webhook_signature_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Mock Verify Webhook Mock Paypal V1 Notifications Verify Webhook Signature Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/s3/": {
+      "get": {
+        "tags": [
+          "s3_mock"
+        ],
+        "summary": "List Buckets Slash",
+        "operationId": "list_buckets_slash_mock_s3__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/s3/{bucket}": {
+      "put": {
+        "tags": [
+          "s3_mock"
+        ],
+        "summary": "Create Bucket",
+        "operationId": "create_bucket_mock_s3__bucket__put",
+        "parameters": [
+          {
+            "name": "bucket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Bucket"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "s3_mock"
+        ],
+        "summary": "List Objects",
+        "operationId": "list_objects_mock_s3__bucket__get",
+        "parameters": [
+          {
+            "name": "bucket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Bucket"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mock/s3/{bucket}/{key}": {
+      "put": {
+        "tags": [
+          "s3_mock"
+        ],
+        "summary": "Put Object",
+        "operationId": "put_object_mock_s3__bucket___key__put",
+        "parameters": [
+          {
+            "name": "bucket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Bucket"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "s3_mock"
+        ],
+        "summary": "Get Object",
+        "operationId": "get_object_mock_s3__bucket___key__get",
+        "parameters": [
+          {
+            "name": "bucket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Bucket"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "s3_mock"
+        ],
+        "summary": "Head Object",
+        "operationId": "head_object_mock_s3__bucket___key__head",
+        "parameters": [
+          {
+            "name": "bucket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Bucket"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "s3_mock"
+        ],
+        "summary": "Delete Object",
+        "operationId": "delete_object_mock_s3__bucket___key__delete",
+        "parameters": [
+          {
+            "name": "bucket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Bucket"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/billing/payment-methods/paypal/setup-token": {
       "post": {
         "tags": [
@@ -8916,22 +9030,6 @@
         "operationId": "create_card_setup_intent_api_billing_setup_intent_card_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -9000,22 +9098,6 @@
         "summary": "Create Card Setup Intent",
         "operationId": "create_card_setup_intent_ui_billing_setup_intent_card_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -9086,22 +9168,6 @@
         "operationId": "create_us_bank_setup_intent_api_billing_setup_intent_us_bank_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -9171,22 +9237,6 @@
         "operationId": "create_us_bank_setup_intent_ui_billing_setup_intent_us_bank_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -9255,22 +9305,6 @@
         "summary": "Verify Microdeposits",
         "operationId": "verify_microdeposits_api_billing_us_bank_verify_microdeposits_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -9351,22 +9385,6 @@
         "operationId": "verify_microdeposits_ui_billing_us_bank_verify_microdeposits_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -9445,22 +9463,6 @@
         "summary": "List Payment Methods",
         "operationId": "list_payment_methods_ui_billing_payment_methods_get",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -10768,22 +10770,6 @@
         "operationId": "account_status_ui_account_status_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -10846,22 +10832,6 @@
         "summary": "Account Suspend",
         "operationId": "account_suspend_ui_account_suspend_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -10936,22 +10906,6 @@
         "operationId": "account_reactivate_ui_account_reactivate_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -11025,22 +10979,6 @@
         "operationId": "ui_get_profile_ui_profile_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -11101,22 +11039,6 @@
         "summary": "Ui Patch Profile",
         "operationId": "ui_patch_profile_ui_profile_patch",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -11188,22 +11110,6 @@
         "summary": "Ui Put Profile",
         "operationId": "ui_put_profile_ui_profile_put",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -11278,22 +11184,6 @@
         "operationId": "ui_get_profile_audit_ui_profile_audit_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -11363,22 +11253,6 @@
             "schema": {
               "type": "string",
               "title": "Kind"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -12502,6 +12376,170 @@
         }
       }
     },
+    "/messaging/helpdesk/conversations/{conversation_id}/claim": {
+      "post": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "Claim Helpdesk Conversation",
+        "operationId": "claim_helpdesk_conversation_messaging_helpdesk_conversations__conversation_id__claim_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HelpdeskClaimOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messaging/conversations/{conversation_id}/routing-events": {
+      "get": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "List Conversation Routing Events",
+        "operationId": "list_conversation_routing_events_messaging_conversations__conversation_id__routing_events_get",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoutingEventOut"
+                  },
+                  "title": "Response List Conversation Routing Events Messaging Conversations  Conversation Id  Routing Events Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/messaging/conversations/{conversation_id}/messages": {
       "get": {
         "tags": [
@@ -13356,6 +13394,192 @@
         }
       }
     },
+    "/messaging/conversations/{conversation_id}/messages/{message_id}/attachment/grant": {
+      "post": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "Create Once Media Attachment Grant",
+        "operationId": "create_once_media_attachment_grant_messaging_conversations__conversation_id__messages__message_id__attachment_grant_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Message Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentGrantOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messaging/conversations/{conversation_id}/messages/{message_id}/attachment/consume": {
+      "post": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "Consume Once Media Attachment",
+        "operationId": "consume_once_media_attachment_messaging_conversations__conversation_id__messages__message_id__attachment_consume_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Message Id"
+            }
+          },
+          {
+            "name": "grant_token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 16,
+              "title": "Grant Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsumeAttachmentIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumeAttachmentOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/messaging/conversations/{conversation_id}/messages/{message_id}/attachment": {
       "get": {
         "tags": [
@@ -13380,6 +13604,22 @@
             "schema": {
               "type": "string",
               "title": "Message Id"
+            }
+          },
+          {
+            "name": "grant_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Grant Token"
             }
           },
           {
@@ -14847,6 +15087,358 @@
         }
       }
     },
+    "/messaging/conversations/{conversation_id}/messages/scheduled": {
+      "get": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "List Scheduled Messages",
+        "description": "Return the caller's pending scheduled messages in a conversation.",
+        "operationId": "list_scheduled_messages_messaging_conversations__conversation_id__messages_scheduled_get",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MessageOut"
+                  },
+                  "title": "Response List Scheduled Messages Messaging Conversations  Conversation Id  Messages Scheduled Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messaging/conversations/{conversation_id}/messages/{message_id}/schedule": {
+      "delete": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "Cancel Scheduled Message",
+        "description": "Cancel a scheduled message (only the sender can cancel).",
+        "operationId": "cancel_scheduled_message_messaging_conversations__conversation_id__messages__message_id__schedule_delete",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Message Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Cancel Scheduled Message Messaging Conversations  Conversation Id  Messages  Message Id  Schedule Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messaging/conversations/{conversation_id}/messages/{message_id}/tip": {
+      "post": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "Send Message Tip",
+        "description": "Send a monetary tip attached to a message.",
+        "operationId": "send_message_tip_messaging_conversations__conversation_id__messages__message_id__tip_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Message Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendTipIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messaging/conversations/{conversation_id}/messages/{message_id}/unlock": {
+      "post": {
+        "tags": [
+          "messaging"
+        ],
+        "summary": "Unlock Message",
+        "description": "Pay to unlock a locked (PPV) message.",
+        "operationId": "unlock_message_messaging_conversations__conversation_id__messages__message_id__unlock_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Message Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnlockMessageIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnlockOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/fs/list": {
       "get": {
         "tags": [
@@ -14915,22 +15507,6 @@
               "pattern": "^(asc|desc)$",
               "default": "asc",
               "title": "Sort Dir"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -15003,22 +15579,6 @@
             "schema": {
               "type": "string",
               "title": "Path"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -15108,22 +15668,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -15207,22 +15751,6 @@
               "minimum": 1,
               "default": 200,
               "title": "Limit"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -15328,22 +15856,6 @@
               "minimum": 1,
               "default": 200,
               "title": "Limit"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -15476,22 +15988,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -15587,22 +16083,6 @@
               "title": "Include Content"
             },
             "description": "Whether to return file content stream"
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
           },
           {
             "name": "X-SESSION-ID",
@@ -15776,22 +16256,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -15854,22 +16318,6 @@
         "summary": "Create Folder",
         "operationId": "create_folder_v1_fs_folder_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -15948,22 +16396,6 @@
             "schema": {
               "type": "string",
               "title": "Path"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -16069,22 +16501,6 @@
             "description": "JSON encryption metadata"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -16157,22 +16573,6 @@
         "summary": "Presign Fs Upload",
         "operationId": "presign_fs_upload_v1_fs_presign_upload_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -16248,22 +16648,6 @@
         "summary": "Complete Fs Upload",
         "operationId": "complete_fs_upload_v1_fs_complete_upload_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -16347,22 +16731,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -16432,22 +16800,6 @@
             "schema": {
               "type": "string",
               "title": "Path"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -16523,22 +16875,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -16611,22 +16947,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -16689,22 +17009,6 @@
         "summary": "Move Fs Node",
         "operationId": "move_fs_node_v1_fs_move_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -16779,22 +17083,6 @@
         "operationId": "resume_fs_move_v1_fs_move_resume_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -16867,22 +17155,6 @@
         "summary": "Rollback Fs Move",
         "operationId": "rollback_fs_move_v1_fs_move_rollback_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -16957,22 +17229,6 @@
         "operationId": "rename_file_v1_fs_rename_file_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -17046,22 +17302,6 @@
         "operationId": "rename_folder_v1_fs_rename_folder_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -17134,22 +17374,6 @@
         "summary": "Download Multiple As Zip",
         "operationId": "download_multiple_as_zip_v1_fs_download_zip_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -17240,22 +17464,6 @@
             "description": "Folder to extract into"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -17341,22 +17549,6 @@
             "description": "Folder to extract into"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -17430,22 +17622,6 @@
         "operationId": "share_fs_node_v1_fs_share_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -17518,22 +17694,6 @@
         "summary": "Unshare Fs Node",
         "operationId": "unshare_fs_node_v1_fs_unshare_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -17617,22 +17777,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -17695,22 +17839,6 @@
         "summary": "List Shared Me",
         "operationId": "list_shared_me_v1_fs_shared_with_me_get",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -17846,22 +17974,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -17940,22 +18052,6 @@
             "schema": {
               "type": "string",
               "title": "Path"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -18040,22 +18136,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -18134,22 +18214,6 @@
             "schema": {
               "type": "string",
               "title": "Path"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -18234,22 +18298,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -18328,22 +18376,6 @@
             "schema": {
               "type": "string",
               "title": "Path"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -18428,22 +18460,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -18511,22 +18527,6 @@
             "schema": {
               "type": "string",
               "title": "Owner"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -18612,22 +18612,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -18710,22 +18694,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -18805,22 +18773,6 @@
             "schema": {
               "type": "string",
               "title": "Owner"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -18945,22 +18897,6 @@
             "description": "JSON encryption metadata"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -19033,22 +18969,6 @@
         "summary": "File Crypto Client Telemetry",
         "operationId": "file_crypto_client_telemetry_v1_fs_client_telemetry_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -19141,22 +19061,6 @@
               "title": "Dest Folder"
             },
             "description": "Destination folder"
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
           },
           {
             "name": "X-SESSION-ID",
@@ -19252,22 +19156,6 @@
             "description": "Destination folder"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -19347,22 +19235,6 @@
             "schema": {
               "type": "string",
               "title": "Owner"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -19459,22 +19331,6 @@
               "title": "Period"
             },
             "description": "Billing period YYYY-MM in UTC"
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
           },
           {
             "name": "X-SESSION-ID",
@@ -19576,22 +19432,6 @@
             "description": "End date YYYY-MM-DD UTC"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -19667,22 +19507,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -19746,22 +19570,6 @@
         "operationId": "purge_deleted_v1_fs_purge_deleted_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -19824,22 +19632,6 @@
         "summary": "Ui List Addresses",
         "operationId": "ui_list_addresses_ui_addresses_get",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -19907,22 +19699,6 @@
         "summary": "Ui Create Address",
         "operationId": "ui_create_address_ui_addresses_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -20008,22 +19784,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -20106,22 +19866,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -20184,22 +19928,6 @@
         "summary": "Ui Search Addresses",
         "operationId": "ui_search_addresses_ui_addresses_search_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -20276,22 +20004,6 @@
         "operationId": "ui_set_primary_address_ui_addresses_primary_put",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -20367,22 +20079,6 @@
         "operationId": "create_calendar_ui_calendars_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -20455,22 +20151,6 @@
         "summary": "List Calendars",
         "operationId": "list_calendars_ui_calendars_get",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -20547,22 +20227,6 @@
             "schema": {
               "type": "string",
               "title": "Calendar Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -20648,22 +20312,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -20746,14 +20394,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "type": "string",
               "title": "User Sub"
             }
           },
@@ -20827,22 +20468,6 @@
             "schema": {
               "type": "string",
               "title": "Calendar Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -20927,22 +20552,6 @@
             "schema": {
               "type": "string",
               "title": "Calendar Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -21052,22 +20661,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -21157,22 +20750,6 @@
             "schema": {
               "type": "string",
               "title": "Occurrence Start"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -21278,22 +20855,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -21378,22 +20939,6 @@
               "title": "Force"
             },
             "description": "Allow conflicts when true"
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
           },
           {
             "name": "X-SESSION-ID",
@@ -21550,22 +21095,6 @@
             "description": "Pagination cursor"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -21637,22 +21166,6 @@
             "schema": {
               "type": "string",
               "title": "Calendar Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -21738,22 +21251,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -21829,22 +21326,6 @@
             "schema": {
               "type": "string",
               "title": "Calendar Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -21930,22 +21411,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -22024,22 +21489,6 @@
             "schema": {
               "type": "string",
               "title": "Event Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -22131,22 +21580,6 @@
             "schema": {
               "type": "string",
               "title": "Event Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -22244,22 +21677,6 @@
             "description": "End window in ISO-8601 UTC"
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -22328,22 +21745,6 @@
         "summary": "List Team Openings",
         "operationId": "list_team_openings_ui_calendars_availability_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -22604,22 +22005,6 @@
         "operationId": "ui_devices_ui_devices_get",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -22694,22 +22079,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -22779,22 +22148,6 @@
             "schema": {
               "type": "string",
               "title": "Device Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -23889,22 +23242,6 @@
         "operationId": "ui_create_transaction_ui_purchase_history_transactions_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24006,22 +23343,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24113,22 +23434,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24207,22 +23512,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24294,22 +23583,6 @@
             "schema": {
               "type": "string",
               "title": "Txn Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -24397,22 +23670,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24494,22 +23751,6 @@
             "schema": {
               "type": "string",
               "title": "Txn Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -24597,22 +23838,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24694,22 +23919,6 @@
             "schema": {
               "type": "string",
               "title": "Txn Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -24809,22 +24018,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24897,22 +24090,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -24977,22 +24154,6 @@
         "summary": "Ui List Carts",
         "operationId": "ui_list_carts_ui_shoppingcart_carts_get",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -25060,22 +24221,6 @@
         "summary": "Ui Start Cart",
         "operationId": "ui_start_cart_ui_shoppingcart_carts_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -25151,22 +24296,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -25239,22 +24368,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -25324,22 +24437,6 @@
             "schema": {
               "type": "string",
               "title": "Cart Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -25440,22 +24537,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -25525,22 +24606,6 @@
             "schema": {
               "type": "string",
               "title": "Cart Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -25634,22 +24699,6 @@
             "schema": {
               "type": "string",
               "title": "Sku"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -25763,22 +24812,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -25848,22 +24881,6 @@
             "schema": {
               "type": "string",
               "title": "Cart Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -25941,22 +24958,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -26021,22 +25022,6 @@
         "summary": "Create Category",
         "operationId": "create_category_ui_catalog_categories_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -26139,22 +25124,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -26241,22 +25210,6 @@
             "description": "Delete items in the category before removing it."
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -26326,22 +25279,6 @@
             "schema": {
               "type": "string",
               "title": "Category Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -26455,22 +25392,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -26575,22 +25496,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -26665,22 +25570,6 @@
               "title": "Path"
             },
             "description": "Catalog image path"
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
           },
           {
             "name": "X-SESSION-ID",
@@ -26761,22 +25650,6 @@
             "schema": {
               "type": "string",
               "title": "Item Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -26883,22 +25756,6 @@
             "description": "Delete item reviews before removing item."
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -26977,22 +25834,6 @@
             "schema": {
               "type": "string",
               "title": "Item Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -27108,22 +25949,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -27193,22 +26018,6 @@
             "schema": {
               "type": "string",
               "title": "Item Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -27302,22 +26111,6 @@
             "schema": {
               "type": "string",
               "title": "Review Id"
-            }
-          },
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
             }
           },
           {
@@ -29079,22 +27872,6 @@
         "operationId": "finalize_billing_period_v1_admin_billing_finalize_period_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -29167,22 +27944,6 @@
         "summary": "Recompute Usage",
         "operationId": "recompute_usage_v1_admin_usage_recompute_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -29318,22 +28079,6 @@
             }
           },
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -29396,22 +28141,6 @@
         "summary": "Generate Invoice Lines",
         "operationId": "generate_invoice_lines_v1_admin_billing_generate_invoice_lines_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -29486,22 +28215,6 @@
         "operationId": "create_billing_adjustment_v1_admin_billing_adjustments_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
-          {
             "name": "X-SESSION-ID",
             "in": "header",
             "required": false,
@@ -29566,18 +28279,17 @@
         }
       }
     },
-    "/api/ups/quote": {
+    "/v1/admin/api-usage/billing/generate-invoice-lines": {
       "post": {
         "tags": [
-          "ups",
-          "mock"
+          "admin-usage"
         ],
-        "summary": "Ups Quote",
-        "operationId": "ups_quote_api_ups_quote_post",
+        "summary": "Generate Api Usage Invoice Lines",
+        "operationId": "generate_api_usage_invoice_lines_v1_admin_api_usage_billing_generate_invoice_lines_post",
         "parameters": [
           {
-            "name": "user_sub",
-            "in": "query",
+            "name": "X-SESSION-ID",
+            "in": "header",
             "required": false,
             "schema": {
               "anyOf": [
@@ -29588,9 +28300,376 @@
                   "type": "null"
                 }
               ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateApiInvoiceLinesIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/api-usage/billing/adjustments": {
+      "post": {
+        "tags": [
+          "admin-usage"
+        ],
+        "summary": "Create Api Usage Billing Adjustment",
+        "operationId": "create_api_usage_billing_adjustment_v1_admin_api_usage_billing_adjustments_post",
+        "parameters": [
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApiBillingAdjustmentIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/api-usage/billing/reconciliation": {
+      "get": {
+        "tags": [
+          "admin-usage"
+        ],
+        "summary": "Export Api Usage Reconciliation",
+        "operationId": "export_api_usage_reconciliation_v1_admin_api_usage_billing_reconciliation_get",
+        "parameters": [
+          {
+            "name": "user_sub",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
               "title": "User Sub"
             }
           },
+          {
+            "name": "period_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Period Id"
+            }
+          },
+          {
+            "name": "snapshot_version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Snapshot Version"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/api-usage/billing/shadow-validation": {
+      "post": {
+        "tags": [
+          "admin-usage"
+        ],
+        "summary": "Run Api Usage Shadow Validation",
+        "operationId": "run_api_usage_shadow_validation_v1_admin_api_usage_billing_shadow_validation_post",
+        "parameters": [
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunApiBillingShadowValidationIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/api-usage/billing/cutover-signoff": {
+      "post": {
+        "tags": [
+          "admin-usage"
+        ],
+        "summary": "Create Api Usage Cutover Signoff",
+        "operationId": "create_api_usage_cutover_signoff_v1_admin_api_usage_billing_cutover_signoff_post",
+        "parameters": [
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiBillingCutoverSignoffIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ups/quote": {
+      "post": {
+        "tags": [
+          "ups",
+          "mock"
+        ],
+        "summary": "Ups Quote",
+        "operationId": "ups_quote_api_ups_quote_post",
+        "parameters": [
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -29669,22 +28748,6 @@
         "summary": "Ups Label",
         "operationId": "ups_label_api_ups_label_post",
         "parameters": [
-          {
-            "name": "user_sub",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Sub"
-            }
-          },
           {
             "name": "X-SESSION-ID",
             "in": "header",
@@ -29889,6 +28952,1227 @@
           }
         }
       }
+    },
+    "/v1/projects": {
+      "post": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Create Project Route",
+        "operationId": "create_project_route_v1_projects_post",
+        "parameters": [
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List Projects Route",
+        "operationId": "list_projects_route_v1_projects_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tag"
+            }
+          },
+          {
+            "name": "name_query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name Query"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Get Project Route",
+        "operationId": "get_project_route_v1_projects__project_id__get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Update Project Route",
+        "operationId": "update_project_route_v1_projects__project_id__patch",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectUpdateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Delete Project Route",
+        "operationId": "delete_project_route_v1_projects__project_id__delete",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteProjectOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}/files": {
+      "post": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Add Tracked File Route",
+        "operationId": "add_tracked_file_route_v1_projects__project_id__files_post",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackedFileCreateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackedFileOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List Tracked Files Route",
+        "operationId": "list_tracked_files_route_v1_projects__project_id__files_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Provider"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackedFileListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}/files/{tracked_file_id}": {
+      "delete": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Remove Tracked File Route",
+        "operationId": "remove_tracked_file_route_v1_projects__project_id__files__tracked_file_id__delete",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "tracked_file_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tracked File Id"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteTrackedFileOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}/detail": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Get Project Detail Route",
+        "operationId": "get_project_detail_route_v1_projects__project_id__detail_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Provider"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDetailOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}/events": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List Project Events Route",
+        "operationId": "list_project_events_route_v1_projects__project_id__events_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectEventListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/providers/{provider}/credentials": {
+      "put": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Upsert Provider Credential Route",
+        "operationId": "upsert_provider_credential_route_v1_projects_providers__provider__credentials_put",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderCredentialUpsertIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderCredentialOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Get Provider Credential Route",
+        "operationId": "get_provider_credential_route_v1_projects_providers__provider__credentials_get",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider"
+            }
+          },
+          {
+            "name": "org",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Org"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderCredentialOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Delete Provider Credential Route",
+        "operationId": "delete_provider_credential_route_v1_projects_providers__provider__credentials_delete",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider"
+            }
+          },
+          {
+            "name": "org",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Org"
+            }
+          },
+          {
+            "name": "X-SESSION-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Id"
+            }
+          },
+          {
+            "name": "X-IMPERSONATION-TOKEN",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Impersonation-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteProviderCredentialOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -29980,14 +30264,10 @@
               "type": "string"
             },
             "type": "array",
-            "minItems": 1,
             "title": "Participant Ids"
           }
         },
         "type": "object",
-        "required": [
-          "participant_ids"
-        ],
         "title": "AddParticipantsIn"
       },
       "AddressIn": {
@@ -30429,6 +30709,60 @@
         "type": "object",
         "title": "AlertWebhookPrefsReq"
       },
+      "ApiBillingCutoverSignoffIn": {
+        "properties": {
+          "user_sub": {
+            "type": "string",
+            "title": "User Sub"
+          },
+          "period_id": {
+            "type": "string",
+            "title": "Period Id"
+          },
+          "snapshot_version": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Snapshot Version"
+          },
+          "shadow_report_sk": {
+            "type": "string",
+            "title": "Shadow Report Sk"
+          },
+          "product_approved_by": {
+            "type": "string",
+            "title": "Product Approved By"
+          },
+          "finance_approved_by": {
+            "type": "string",
+            "title": "Finance Approved By"
+          },
+          "engineering_approved_by": {
+            "type": "string",
+            "title": "Engineering Approved By"
+          },
+          "cutover_criteria": {
+            "type": "string",
+            "title": "Cutover Criteria"
+          },
+          "rollback_criteria": {
+            "type": "string",
+            "title": "Rollback Criteria"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_sub",
+          "period_id",
+          "snapshot_version",
+          "shadow_report_sk",
+          "product_approved_by",
+          "finance_approved_by",
+          "engineering_approved_by",
+          "cutover_criteria",
+          "rollback_criteria"
+        ],
+        "title": "ApiBillingCutoverSignoffIn"
+      },
       "ApiKeyIpRulesReq": {
         "properties": {
           "key_id": {
@@ -30455,6 +30789,81 @@
           "key_id"
         ],
         "title": "ApiKeyIpRulesReq"
+      },
+      "ApiKeyLimitsPatchReq": {
+        "properties": {
+          "monthly_calls_cap": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Monthly Calls Cap",
+            "default": 0
+          },
+          "monthly_spend_cap_micros": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Monthly Spend Cap Micros",
+            "default": 0
+          },
+          "route_caps": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ApiKeyRouteCapReq"
+            },
+            "type": "object",
+            "title": "Route Caps"
+          }
+        },
+        "type": "object",
+        "title": "ApiKeyLimitsPatchReq"
+      },
+      "ApiKeyRouteCapReq": {
+        "properties": {
+          "monthly_calls_cap": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Monthly Calls Cap",
+            "default": 0
+          },
+          "monthly_spend_cap_micros": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Monthly Spend Cap Micros",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "ApiKeyRouteCapReq"
+      },
+      "ApiKeySelfLimitsReq": {
+        "properties": {
+          "key_id": {
+            "type": "string",
+            "title": "Key Id"
+          },
+          "monthly_calls_cap": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Monthly Calls Cap",
+            "default": 0
+          },
+          "monthly_spend_cap_micros": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Monthly Spend Cap Micros",
+            "default": 0
+          },
+          "route_caps": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ApiKeyRouteCapReq"
+            },
+            "type": "object",
+            "title": "Route Caps"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key_id"
+        ],
+        "title": "ApiKeySelfLimitsReq"
       },
       "Attachment": {
         "properties": {
@@ -30505,6 +30914,34 @@
           "s3_key"
         ],
         "title": "Attachment"
+      },
+      "AttachmentGrantOut": {
+        "properties": {
+          "grant_token": {
+            "type": "string",
+            "title": "Grant Token"
+          },
+          "expires_at": {
+            "type": "integer",
+            "title": "Expires At"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "grant_token",
+          "expires_at",
+          "conversation_id",
+          "message_id"
+        ],
+        "title": "AttachmentGrantOut"
       },
       "BillingCheckoutReq": {
         "properties": {
@@ -31975,6 +32412,80 @@
         ],
         "title": "CompleteUploadIn"
       },
+      "ConsumeAttachmentIn": {
+        "properties": {
+          "consumption_attempt_id": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Consumption Attempt Id"
+          },
+          "trigger": {
+            "type": "string",
+            "enum": [
+              "open",
+              "play"
+            ],
+            "title": "Trigger"
+          },
+          "playback_seconds": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Playback Seconds"
+          }
+        },
+        "type": "object",
+        "required": [
+          "consumption_attempt_id",
+          "trigger"
+        ],
+        "title": "ConsumeAttachmentIn"
+      },
+      "ConsumeAttachmentOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          },
+          "consumption_state": {
+            "const": "consumed",
+            "title": "Consumption State"
+          },
+          "consumed_at": {
+            "type": "integer",
+            "title": "Consumed At"
+          },
+          "consumption_attempt_id": {
+            "type": "string",
+            "title": "Consumption Attempt Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok",
+          "conversation_id",
+          "message_id",
+          "consumption_state",
+          "consumed_at",
+          "consumption_attempt_id"
+        ],
+        "title": "ConsumeAttachmentOut"
+      },
       "Contact": {
         "properties": {
           "user_id": {
@@ -32110,6 +32621,72 @@
             "type": "integer",
             "title": "Unread Count",
             "default": 0
+          },
+          "routing_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routing Mode"
+          },
+          "routing_group_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routing Group Id"
+          },
+          "routing_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routing State"
+          },
+          "active_agent_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Agent User Id"
+          },
+          "active_agent_claimed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Agent Claimed At"
+          },
+          "assignment_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assignment Version"
           }
         },
         "type": "object",
@@ -32122,6 +32699,61 @@
           "status"
         ],
         "title": "ConversationOut"
+      },
+      "CreateApiBillingAdjustmentIn": {
+        "properties": {
+          "user_sub": {
+            "type": "string",
+            "title": "User Sub"
+          },
+          "period_id": {
+            "type": "string",
+            "title": "Period Id"
+          },
+          "snapshot_version": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Snapshot Version"
+          },
+          "adjustment_type": {
+            "type": "string",
+            "enum": [
+              "credit",
+              "debit"
+            ],
+            "title": "Adjustment Type"
+          },
+          "amount_micros": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Amount Micros"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_sub",
+          "period_id",
+          "snapshot_version",
+          "adjustment_type",
+          "amount_micros",
+          "reason"
+        ],
+        "title": "CreateApiBillingAdjustmentIn"
       },
       "CreateApiKeyReq": {
         "properties": {
@@ -32266,6 +32898,16 @@
                 "type": "null"
               }
             ]
+          },
+          "consumption_policy": {
+            "type": "string",
+            "enum": [
+              "none",
+              "view_once",
+              "listen_once"
+            ],
+            "title": "Consumption Policy",
+            "default": "none"
           }
         },
         "type": "object",
@@ -32321,6 +32963,58 @@
               }
             ],
             "title": "Reply To Message Id"
+          },
+          "consumption_policy": {
+            "type": "string",
+            "enum": [
+              "none",
+              "view_once"
+            ],
+            "title": "Consumption Policy",
+            "default": "none"
+          },
+          "expires_in_seconds": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 604800.0,
+                "minimum": 10.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires In Seconds"
+          },
+          "view_once": {
+            "type": "boolean",
+            "title": "View Once",
+            "default": false
+          },
+          "lock_price_cents": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 100000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lock Price Cents"
+          },
+          "lock_description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lock Description"
           }
         },
         "type": "object",
@@ -32412,6 +33106,55 @@
         },
         "type": "object",
         "title": "CreatorSubscriberActionIn"
+      },
+      "DeleteProjectOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok"
+        ],
+        "title": "DeleteProjectOut"
+      },
+      "DeleteProviderCredentialOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok",
+          "deleted"
+        ],
+        "title": "DeleteProviderCredentialOut"
+      },
+      "DeleteTrackedFileOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok",
+          "deleted"
+        ],
+        "title": "DeleteTrackedFileOut"
       },
       "DeviceTrustListOut": {
         "properties": {
@@ -33780,7 +34523,7 @@
         "properties": {
           "event": {
             "type": "string",
-            "pattern": "^(decrypt_failure|remembered_password_used)$",
+            "pattern": "^(decrypt_failure|remembered_password_used|hover_play_start|hover_play_failure)$",
             "title": "Event"
           },
           "path": {
@@ -33798,7 +34541,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "pattern": "^(wrong_password|corrupted_metadata|crypto_error)?$"
+                "pattern": "^(wrong_password|corrupted_metadata|crypto_error|playback_error|autoplay_blocked|unsupported_capability|unknown)?$"
               },
               {
                 "type": "null"
@@ -34011,6 +34754,35 @@
         ],
         "title": "GalleryPageOut"
       },
+      "GenerateApiInvoiceLinesIn": {
+        "properties": {
+          "user_sub": {
+            "type": "string",
+            "title": "User Sub"
+          },
+          "period_id": {
+            "type": "string",
+            "title": "Period Id"
+          },
+          "snapshot_version": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Snapshot Version"
+          },
+          "include_key_sublines": {
+            "type": "boolean",
+            "title": "Include Key Sublines",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_sub",
+          "period_id",
+          "snapshot_version"
+        ],
+        "title": "GenerateApiInvoiceLinesIn"
+      },
       "GenerateInvoiceLinesIn": {
         "properties": {
           "user_id": {
@@ -34058,6 +34830,44 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "HelpdeskClaimOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          },
+          "assigned_agent_user_id": {
+            "type": "string",
+            "title": "Assigned Agent User Id"
+          },
+          "assignment_version": {
+            "type": "integer",
+            "title": "Assignment Version"
+          },
+          "idempotent": {
+            "type": "boolean",
+            "title": "Idempotent",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok",
+          "conversation_id",
+          "state",
+          "assigned_agent_user_id",
+          "assignment_version"
+        ],
+        "title": "HelpdeskClaimOut"
       },
       "HidePostRequest": {
         "properties": {
@@ -34656,6 +35466,168 @@
                 "type": "null"
               }
             ]
+          },
+          "consumption_policy": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "view_once",
+                  "listen_once"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consumption Policy"
+          },
+          "media_kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "image",
+                  "video",
+                  "audio"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Media Kind"
+          },
+          "consumption_state": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "consumed",
+                  "expired",
+                  "failed"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consumption State"
+          },
+          "consumed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consumed At"
+          },
+          "scheduled": {
+            "type": "boolean",
+            "title": "Scheduled",
+            "default": false
+          },
+          "deliver_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deliver At"
+          },
+          "tip_amount_cents": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tip Amount Cents"
+          },
+          "tip_currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tip Currency"
+          },
+          "tip_payment_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tip Payment Id"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "view_once": {
+            "type": "boolean",
+            "title": "View Once",
+            "default": false
+          },
+          "expired": {
+            "type": "boolean",
+            "title": "Expired",
+            "default": false
+          },
+          "locked": {
+            "type": "boolean",
+            "title": "Locked",
+            "default": false
+          },
+          "lock_price_cents": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lock Price Cents"
+          },
+          "lock_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lock Description"
+          },
+          "is_unlocked": {
+            "type": "boolean",
+            "title": "Is Unlocked",
+            "default": false
           }
         },
         "type": "object",
@@ -34696,11 +35668,16 @@
           "messaging_encrypted_messages_enabled": {
             "type": "boolean",
             "title": "Messaging Encrypted Messages Enabled"
+          },
+          "messaging_gallery_enabled": {
+            "type": "boolean",
+            "title": "Messaging Gallery Enabled"
           }
         },
         "type": "object",
         "required": [
-          "messaging_encrypted_messages_enabled"
+          "messaging_encrypted_messages_enabled",
+          "messaging_gallery_enabled"
         ],
         "title": "MessagingConfigOut"
       },
@@ -34838,6 +35815,39 @@
             "type": "integer",
             "title": "Left At",
             "default": 0
+          },
+          "assignment_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assignment State"
+          },
+          "assignment_owner_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assignment Owner User Id"
+          },
+          "is_assignment_owner": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Assignment Owner"
           }
         },
         "type": "object",
@@ -36238,6 +37248,405 @@
         "type": "object",
         "title": "ProfilePutReq"
       },
+      "ProjectCreateIn": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "settings": {
+            "type": "object",
+            "title": "Settings"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "ProjectCreateIn"
+      },
+      "ProjectDetailOut": {
+        "properties": {
+          "project": {
+            "$ref": "#/components/schemas/ProjectOut"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/TrackedFileOut"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project"
+        ],
+        "title": "ProjectDetailOut"
+      },
+      "ProjectEventListOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectEventOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cursor"
+          }
+        },
+        "type": "object",
+        "title": "ProjectEventListOut"
+      },
+      "ProjectEventOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner"
+          },
+          "event_type": {
+            "type": "string",
+            "title": "Event Type"
+          },
+          "tracked_file_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tracked File Id"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "provider_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Ref"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "owner",
+          "event_type",
+          "created_at"
+        ],
+        "title": "ProjectEventOut"
+      },
+      "ProjectListOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cursor"
+          }
+        },
+        "type": "object",
+        "title": "ProjectListOut"
+      },
+      "ProjectOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "settings": {
+            "type": "object",
+            "title": "Settings"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "owner",
+          "name",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ProjectOut"
+      },
+      "ProjectUpdateIn": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 120,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "settings": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Settings"
+          }
+        },
+        "type": "object",
+        "title": "ProjectUpdateIn"
+      },
+      "ProviderCredentialOut": {
+        "properties": {
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "org": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Org"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes"
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "provider",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ProviderCredentialOut"
+      },
+      "ProviderCredentialUpsertIn": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "maxLength": 8192,
+            "minLength": 1,
+            "title": "Token"
+          },
+          "org": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 256
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Org"
+          },
+          "api_base_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2048
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Base Url"
+          },
+          "required_scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Required Scopes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token"
+        ],
+        "title": "ProviderCredentialUpsertIn"
+      },
       "PurchaseCancelReq": {
         "properties": {
           "reason": {
@@ -37418,6 +38827,127 @@
         ],
         "title": "RoleUpdateProfileReq"
       },
+      "RoutingEventOut": {
+        "properties": {
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "event_id": {
+            "type": "string",
+            "title": "Event Id"
+          },
+          "event_type": {
+            "type": "string",
+            "title": "Event Type"
+          },
+          "actor_user_id": {
+            "type": "string",
+            "title": "Actor User Id"
+          },
+          "from_state": {
+            "type": "string",
+            "title": "From State"
+          },
+          "to_state": {
+            "type": "string",
+            "title": "To State"
+          },
+          "created_at": {
+            "type": "integer",
+            "title": "Created At"
+          },
+          "assignment_version": {
+            "type": "integer",
+            "title": "Assignment Version",
+            "default": 0
+          },
+          "routing_group_id": {
+            "type": "string",
+            "title": "Routing Group Id",
+            "default": ""
+          },
+          "active_agent_user_id": {
+            "type": "string",
+            "title": "Active Agent User Id",
+            "default": ""
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "conversation_id",
+          "event_id",
+          "event_type",
+          "actor_user_id",
+          "from_state",
+          "to_state",
+          "created_at"
+        ],
+        "title": "RoutingEventOut"
+      },
+      "RunApiBillingShadowValidationIn": {
+        "properties": {
+          "user_sub": {
+            "type": "string",
+            "title": "User Sub"
+          },
+          "period_id": {
+            "type": "string",
+            "title": "Period Id"
+          },
+          "snapshot_version": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Snapshot Version"
+          },
+          "expected_total_micros": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Total Micros"
+          },
+          "variance_threshold_micros": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Variance Threshold Micros",
+            "default": 0
+          },
+          "sample_expected_by_route": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Sample Expected By Route"
+          },
+          "cycle_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cycle Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_sub",
+          "period_id",
+          "snapshot_version"
+        ],
+        "title": "RunApiBillingShadowValidationIn"
+      },
       "SavePaymentTokenIn": {
         "properties": {
           "payment_token_id": {
@@ -37519,10 +39049,109 @@
                 "type": "null"
               }
             ]
+          },
+          "send_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Send At"
+          },
+          "tip_amount_cents": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 100000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tip Amount Cents"
+          },
+          "expires_in_seconds": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 604800.0,
+                "minimum": 10.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires In Seconds"
+          },
+          "view_once": {
+            "type": "boolean",
+            "title": "View Once",
+            "default": false
+          },
+          "lock_price_cents": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 100000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lock Price Cents"
+          },
+          "lock_description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lock Description"
           }
         },
         "type": "object",
         "title": "SendTextMessageIn"
+      },
+      "SendTipIn": {
+        "properties": {
+          "amount_cents": {
+            "type": "integer",
+            "maximum": 100000.0,
+            "minimum": 1.0,
+            "title": "Amount Cents"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency",
+            "default": "USD"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          }
+        },
+        "type": "object",
+        "required": [
+          "amount_cents"
+        ],
+        "title": "SendTipIn"
       },
       "SetAutopayIn": {
         "properties": {
@@ -38030,7 +39659,6 @@
               "type": "string"
             },
             "type": "array",
-            "minItems": 1,
             "title": "Participant Ids"
           },
           "participant_id": {
@@ -38112,12 +39740,30 @@
               }
             ],
             "title": "Retention Days"
+          },
+          "routing_mode": {
+            "type": "string",
+            "enum": [
+              "standard",
+              "helpdesk_bridge"
+            ],
+            "title": "Routing Mode",
+            "default": "standard"
+          },
+          "helpdesk_group_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Helpdesk Group Id"
           }
         },
         "type": "object",
-        "required": [
-          "participant_ids"
-        ],
         "title": "StartConversationIn"
       },
       "StartGroupConversationIn": {
@@ -38918,6 +40564,44 @@
         ],
         "title": "TeamAvailabilityIn"
       },
+      "TipOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          },
+          "tip_payment_id": {
+            "type": "string",
+            "title": "Tip Payment Id"
+          },
+          "amount_cents": {
+            "type": "integer",
+            "title": "Amount Cents"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok",
+          "conversation_id",
+          "message_id",
+          "tip_payment_id",
+          "amount_cents",
+          "currency"
+        ],
+        "title": "TipOut"
+      },
       "TipRequest": {
         "properties": {
           "amount_cents": {
@@ -39051,6 +40735,147 @@
         ],
         "title": "TotpVerifyReq"
       },
+      "TrackedFileCreateIn": {
+        "properties": {
+          "provider": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Provider",
+            "default": "local"
+          },
+          "provider_ref": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Provider Ref"
+          },
+          "display_path": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2048
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Path"
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "provider_ref"
+        ],
+        "title": "TrackedFileCreateIn"
+      },
+      "TrackedFileListOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TrackedFileOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cursor"
+          }
+        },
+        "type": "object",
+        "title": "TrackedFileListOut"
+      },
+      "TrackedFileOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "provider_ref": {
+            "type": "string",
+            "title": "Provider Ref"
+          },
+          "display_path": {
+            "type": "string",
+            "title": "Display Path"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          },
+          "last_seen_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen At"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "owner",
+          "provider",
+          "provider_ref",
+          "display_path",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "TrackedFileOut"
+      },
       "TypingIn": {
         "properties": {
           "is_typing": {
@@ -39162,6 +40987,44 @@
           "target_user_id"
         ],
         "title": "UnfollowRequest"
+      },
+      "UnlockMessageIn": {
+        "properties": {},
+        "type": "object",
+        "title": "UnlockMessageIn"
+      },
+      "UnlockOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          },
+          "unlock_payment_id": {
+            "type": "string",
+            "title": "Unlock Payment Id"
+          },
+          "amount_cents": {
+            "type": "integer",
+            "title": "Amount Cents"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok",
+          "conversation_id",
+          "message_id",
+          "unlock_payment_id",
+          "amount_cents"
+        ],
+        "title": "UnlockOut"
       },
       "UnlockPostRequest": {
         "properties": {

--- a/tests/test_admin_usage_routes.py
+++ b/tests/test_admin_usage_routes.py
@@ -174,7 +174,7 @@ class TestAdminUsageRoutes(unittest.TestCase):
             patch.object(admin_usage, "_api_usage_table", return_value="tbl"),
             patch.object(admin_usage, "export_api_billing_reconciliation_report", return_value={"variance_vs_snapshot_micros": 0}) as fn,
         ):
-            resp = admin_usage.export_api_usage_reconciliation(user_sub="u1", period_id="2026-02", snapshot_version=1, admin_user="admin")
+            resp = admin_usage.export_api_usage_reconciliation(target_user_sub="u1", period_id="2026-02", snapshot_version=1, admin_user="admin")
         self.assertEqual(resp["variance_vs_snapshot_micros"], 0)
         fn.assert_called_once_with("tbl", user_sub="u1", period_id="2026-02", snapshot_version=1)
 

--- a/tests/test_auth_cognito.py
+++ b/tests/test_auth_cognito.py
@@ -42,8 +42,15 @@ def enable_cognito() -> None:
     object.__setattr__(S, "cognito_region", "us-east-1")
 
 
-def test_auth_fallback_allows_x_user_sub() -> None:
+@pytest.fixture(autouse=True)
+def reset_cognito():
+    """Ensure Cognito settings are disabled before and after each test."""
     disable_cognito()
+    yield
+    disable_cognito()
+
+
+def test_auth_fallback_allows_x_user_sub() -> None:
     req = build_request(headers={"x-user-sub": "user-123"})
     assert run_async(deps.get_authenticated_user_sub(req)) == "user-123"
 

--- a/tests/test_auth_roles.py
+++ b/tests/test_auth_roles.py
@@ -51,25 +51,33 @@ def test_get_authenticated_user_role_reads_dev_header() -> None:
 
 
 def test_get_authenticated_user_role_reads_jwt_role_claim() -> None:
-    object.__setattr__(S, "root_user_sub", "user-1")
-    token = _encode_payload({"sub": "user-1", "role": "root"})
-    req = SimpleNamespace(headers={"authorization": f"Bearer {token}"})
-    assert run_async(deps.get_authenticated_user_role(req)) == Role.ROOT
+    original = S.root_user_sub
+    try:
+        object.__setattr__(S, "root_user_sub", "user-1")
+        token = _encode_payload({"sub": "user-1", "role": "root"})
+        req = SimpleNamespace(headers={"authorization": f"Bearer {token}"})
+        assert run_async(deps.get_authenticated_user_role(req)) == Role.ROOT
+    finally:
+        object.__setattr__(S, "root_user_sub", original)
 
 
 def test_get_authenticated_user_role_rejects_root_claim_for_other_subject() -> None:
-    object.__setattr__(S, "root_user_sub", "actual-root")
-    token = _encode_payload({"sub": "user-1", "role": "root"})
-    req = SimpleNamespace(headers={"authorization": f"Bearer {token}"})
+    original = S.root_user_sub
     try:
-        run_async(deps.get_authenticated_user_role(req))
-        assert False, "expected exception"
-    except Exception as exc:
-        from fastapi import HTTPException
+        object.__setattr__(S, "root_user_sub", "actual-root")
+        token = _encode_payload({"sub": "user-1", "role": "root"})
+        req = SimpleNamespace(headers={"authorization": f"Bearer {token}"})
+        try:
+            run_async(deps.get_authenticated_user_role(req))
+            assert False, "expected exception"
+        except Exception as exc:
+            from fastapi import HTTPException
 
-        assert isinstance(exc, HTTPException)
-        assert exc.status_code == 403
-        assert exc.detail["code"] == "role_required"
+            assert isinstance(exc, HTTPException)
+            assert exc.status_code == 403
+            assert exc.detail["code"] == "role_required"
+    finally:
+        object.__setattr__(S, "root_user_sub", original)
 
 
 def test_get_authenticated_user_role_prefers_highest_privilege_in_roles_claim() -> None:

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -315,6 +315,9 @@ def test_billing_payments_and_subscriptions(monkeypatch) -> None:
     payments = billing_router.list_payments(ctx={"user_sub": "user-123"})
     assert payments["items"][0]["payment_intent_id"] == "pi_123"
 
+    monkeypatch.setattr(billing_router, "S", type("S", (), {
+        "dev_mode": False, "stripe_secret_key": "sk_test", "stripe_api_base": None,
+    })())
     subs = billing_router.list_subscriptions(ctx={"user_sub": "user-123"})
     assert subs["items"][0]["id"] == "sub_123"
 
@@ -341,6 +344,9 @@ def test_billing_read_surfaces_allow_admin_target_override(monkeypatch) -> None:
     payments = billing_router.list_payments(ctx=admin_ctx, actor=_billing_admin_actor(), user_sub="target-1")
     assert payments["items"][0]["payment_intent_id"] == "pi_target"
 
+    monkeypatch.setattr(billing_router, "S", type("S", (), {
+        "dev_mode": False, "stripe_secret_key": "sk_test", "stripe_api_base": None,
+    })())
     subs = billing_router.list_subscriptions(ctx=admin_ctx, actor=_billing_admin_actor(), user_sub="target-1")
     assert subs["items"][0]["id"] == "sub_123"
 

--- a/tests/test_billing_routes.py
+++ b/tests/test_billing_routes.py
@@ -14,14 +14,14 @@ class FakeBillingTable:
         self._items: Dict[tuple[str, str], Dict[str, Any]] = {}
 
     def get_item(self, Key: Dict[str, str]) -> Dict[str, Any]:
-        return {"Item": self._items.get((Key["user_sub"], Key["sk"]))}
+        return {"Item": self._items.get((Key["pk"], Key["sk"]))}
 
     def put_item(self, Item: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
-        self._items[(Item["user_sub"], Item["sk"])] = Item
+        self._items[(Item["pk"], Item["sk"])] = Item
         return {}
 
     def delete_item(self, Key: Dict[str, str]) -> Dict[str, Any]:
-        self._items.pop((Key["user_sub"], Key["sk"]), None)
+        self._items.pop((Key["pk"], Key["sk"]), None)
         return {}
 
     def update_item(
@@ -32,7 +32,7 @@ class FakeBillingTable:
         ExpressionAttributeNames: Dict[str, str] | None = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        item = self._items.setdefault((Key["user_sub"], Key["sk"]), {"user_sub": Key["user_sub"], "sk": Key["sk"]})
+        item = self._items.setdefault((Key["pk"], Key["sk"]), {"pk": Key["pk"], "sk": Key["sk"]})
         expr = UpdateExpression.replace("SET", "").strip()
         parts = []
         depth = 0
@@ -58,7 +58,7 @@ class FakeBillingTable:
                 lhs = ExpressionAttributeNames[lhs]
             if rhs.startswith(":"):
                 item[lhs] = ExpressionAttributeValues[rhs]
-        self._items[(Key["user_sub"], Key["sk"])] = item
+        self._items[(Key["pk"], Key["sk"])] = item
         return {}
 
     def query(self, ExpressionAttributeValues: Dict[str, Any], **kwargs: Any) -> Dict[str, List[Dict[str, Any]]]:
@@ -193,13 +193,13 @@ class BillingRoutesTests(unittest.TestCase):
 
     def test_list_payments_and_subscriptions(self) -> None:
         self.table.put_item(Item={
-            "user_sub": "user_123",
+            "pk": "user_123",
             "sk": "PAY#txn_1",
             "transaction_id": "txn_1",
             "created_at": 2,
         })
         self.table.put_item(Item={
-            "user_sub": "user_123",
+            "pk": "user_123",
             "sk": "SUB#sub_1",
             "subscription_id": "sub_1",
             "created_at": 3,
@@ -239,13 +239,13 @@ class BillingRoutesTests(unittest.TestCase):
     def test_webhook_new_sale_success_updates_records(self) -> None:
         ledger_sk = "LEDGER#1#abc"
         self.table.put_item(Item={
-            "user_sub": "user_123",
+            "pk": "user_123",
             "sk": ledger_sk,
             "state": "pending",
             "amount_cents": 999,
         })
         self.table.put_item(Item={
-            "user_sub": "user_123",
+            "pk": "user_123",
             "sk": "PAY#txn_1",
             "transaction_id": "txn_1",
             "status": "pending",
@@ -260,10 +260,10 @@ class BillingRoutesTests(unittest.TestCase):
             resp = asyncio.run(routes.ccbill_webhook(req))
         self.assertTrue(resp["received"])
 
-        ledger = self.table.get_item(Key={"user_sub": "user_123", "sk": ledger_sk})["Item"]
+        ledger = self.table.get_item(Key={"pk": "user_123", "sk": ledger_sk})["Item"]
         self.assertEqual(ledger["state"], "settled")
 
-        payment = self.table.get_item(Key={"user_sub": "user_123", "sk": "PAY#txn_1"})["Item"]
+        payment = self.table.get_item(Key={"pk": "user_123", "sk": "PAY#txn_1"})["Item"]
         self.assertEqual(payment["status"], "succeeded")
 
     def test_set_default_missing_payment_method_rejected(self) -> None:

--- a/tests/test_file_providers.py
+++ b/tests/test_file_providers.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.services.file_providers import (
+    GitHubProvider,
+    GitLabProvider,
+    LocalFileProvider,
+    ProviderRegistry,
+    default_provider_registry,
+)
+
+
+class TestLocalFileProvider(unittest.TestCase):
+    def test_resolve_canonicalizes_path(self):
+        provider = LocalFileProvider("user-1")
+        with patch("app.services.file_providers.filemanager.norm_path", return_value="/docs/a.txt") as norm_path:
+            out = provider.resolve("docs//a.txt")
+        self.assertEqual(out, "/docs/a.txt")
+        norm_path.assert_called_once_with("docs//a.txt", is_folder=None)
+
+    def test_exists_returns_false_for_missing_file(self):
+        provider = LocalFileProvider("user-1")
+        with patch(
+            "app.services.file_providers.filemanager.get_node",
+            side_effect=HTTPException(status_code=404, detail="not found"),
+        ):
+            self.assertFalse(provider.exists("/docs/missing.txt"))
+
+    def test_get_metadata_reads_from_filemanager(self):
+        provider = LocalFileProvider("user-1")
+        node = {
+            "path": "/docs/a.txt",
+            "type": "file",
+            "name": "a.txt",
+            "size": 12,
+            "content_type": "text/plain",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }
+        with patch("app.services.file_providers.filemanager.get_node", return_value=node):
+            out = provider.get_metadata("/docs/a.txt")
+        self.assertEqual(out["path"], "/docs/a.txt")
+        self.assertEqual(out["type"], "file")
+        self.assertEqual(out["size"], 12)
+
+
+class TestProviderRegistry(unittest.TestCase):
+    def test_default_registry_returns_local_provider(self):
+        registry = default_provider_registry()
+        provider = registry.get("user-1", "LOCAL")
+        self.assertEqual(provider.provider_name, "local")
+
+    def test_default_registry_returns_github_provider(self):
+        registry = default_provider_registry()
+        provider = registry.get("user-1", "github")
+        self.assertEqual(provider.provider_name, "github")
+
+    def test_default_registry_returns_gitlab_provider(self):
+        registry = default_provider_registry()
+        provider = registry.get("user-1", "gitlab")
+        self.assertEqual(provider.provider_name, "gitlab")
+
+    def test_registry_rejects_unknown_provider(self):
+        registry = ProviderRegistry()
+        with self.assertRaises(HTTPException) as ctx:
+            registry.get("user-1", "github")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+class TestGitHubProvider(unittest.TestCase):
+    def test_resolve_canonicalizes_ref(self):
+        provider = GitHubProvider("user-1")
+        out = provider.resolve("octocat/hello-world/src/main.py?ref=main")
+        self.assertEqual(out, "github://octocat/hello-world/src/main.py?ref=main")
+
+    def test_exists_returns_false_on_404(self):
+        provider = GitHubProvider("user-1")
+        response = SimpleNamespace(status_code=404, headers={}, content=b"")
+        with (
+            patch("app.services.file_providers.get_provider_auth_context", return_value={"token": "token", "metadata": {}}),
+            patch("app.services.file_providers.requests.get", return_value=response),
+        ):
+            self.assertFalse(provider.exists("github://octocat/hello-world/README.md?ref=main"))
+
+    def test_get_metadata_handles_rate_limit(self):
+        provider = GitHubProvider("user-1")
+        response = SimpleNamespace(
+            status_code=403,
+            headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"},
+            content=b"1",
+            json=lambda: {},
+        )
+        with (
+            patch("app.services.file_providers.get_provider_auth_context", return_value={"token": "token", "metadata": {}}),
+            patch("app.services.file_providers.requests.get", return_value=response),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                provider.get_metadata("github://octocat/hello-world/README.md?ref=main")
+        self.assertEqual(ctx.exception.status_code, 429)
+        self.assertIn("rate limit", ctx.exception.detail)
+
+    def test_get_metadata_parses_payload(self):
+        provider = GitHubProvider("user-1")
+        response = SimpleNamespace(
+            status_code=200,
+            headers={},
+            content=b"1",
+            json=lambda: {
+                "type": "file",
+                "size": 10,
+                "sha": "abc",
+                "name": "README.md",
+                "path": "README.md",
+                "html_url": "https://github.com/octocat/hello-world/blob/main/README.md",
+                "download_url": "https://raw.githubusercontent.com/...",
+            },
+        )
+        with (
+            patch("app.services.file_providers.get_provider_auth_context", return_value={"token": "token", "metadata": {}}),
+            patch("app.services.file_providers.requests.get", return_value=response),
+        ):
+            out = provider.get_metadata("github://octocat/hello-world/README.md?ref=main")
+        self.assertEqual(out["type"], "file")
+        self.assertEqual(out["size"], 10)
+
+    def test_get_metadata_uses_enterprise_api_base_url_from_credential_metadata(self):
+        provider = GitHubProvider("user-1")
+        response = SimpleNamespace(
+            status_code=200,
+            headers={},
+            content=b"1",
+            json=lambda: {"type": "file", "size": 10, "path": "README.md"},
+        )
+        with (
+            patch(
+                "app.services.file_providers.get_provider_auth_context",
+                return_value={"token": "token", "metadata": {"api_base_url": "https://ghe.local/api/v3"}},
+            ),
+            patch("app.services.file_providers.requests.get", return_value=response) as requests_get,
+        ):
+            provider.get_metadata("github://octocat/hello-world/README.md?ref=main")
+        self.assertTrue(requests_get.call_args.args[0].startswith("https://ghe.local/api/v3"))
+
+
+class TestGitLabProvider(unittest.TestCase):
+    def test_resolve_canonicalizes_ref(self):
+        provider = GitLabProvider("user-1")
+        out = provider.resolve("group/project//src/main.py?ref=main")
+        self.assertEqual(out, "gitlab://group/project//src/main.py?ref=main")
+
+    def test_exists_returns_false_on_404(self):
+        provider = GitLabProvider("user-1")
+        response = SimpleNamespace(status_code=404, headers={}, content=b"")
+        with (
+            patch("app.services.file_providers.get_provider_auth_context", return_value={"token": "token", "metadata": {}}),
+            patch("app.services.file_providers.requests.get", return_value=response),
+        ):
+            self.assertFalse(provider.exists("gitlab://group/project//README.md?ref=main"))
+
+    def test_get_metadata_handles_rate_limit(self):
+        provider = GitLabProvider("user-1")
+        response = SimpleNamespace(
+            status_code=429,
+            headers={"Retry-After": "30"},
+            content=b"1",
+            json=lambda: {},
+        )
+        with (
+            patch("app.services.file_providers.get_provider_auth_context", return_value={"token": "token", "metadata": {}}),
+            patch("app.services.file_providers.requests.get", return_value=response),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                provider.get_metadata("gitlab://group/project//README.md?ref=main")
+        self.assertEqual(ctx.exception.status_code, 429)
+        self.assertIn("rate limit", ctx.exception.detail)
+
+    def test_get_metadata_parses_payload(self):
+        provider = GitLabProvider("user-1")
+        response = SimpleNamespace(
+            status_code=200,
+            headers={},
+            content=b"1",
+            json=lambda: {
+                "file_name": "README.md",
+                "file_path": "README.md",
+                "size": 5,
+                "blob_id": "abc",
+                "commit_id": "def",
+                "last_commit_id": "ghi",
+                "content_sha256": "zzz",
+                "encoding": "base64",
+                "ref": "main",
+            },
+        )
+        with (
+            patch("app.services.file_providers.get_provider_auth_context", return_value={"token": "token", "metadata": {}}),
+            patch("app.services.file_providers.requests.get", return_value=response),
+        ):
+            out = provider.get_metadata("gitlab://group/project//README.md?ref=main")
+        self.assertEqual(out["type"], "file")
+        self.assertEqual(out["size"], 5)
+
+    def test_get_metadata_uses_self_hosted_api_base_url_from_credential_metadata(self):
+        provider = GitLabProvider("user-1")
+        response = SimpleNamespace(
+            status_code=200,
+            headers={},
+            content=b"1",
+            json=lambda: {"file_name": "README.md", "file_path": "README.md", "size": 5},
+        )
+        with (
+            patch(
+                "app.services.file_providers.get_provider_auth_context",
+                return_value={"token": "token", "metadata": {"api_base_url": "https://gitlab.local/api/v4"}},
+            ),
+            patch("app.services.file_providers.requests.get", return_value=response) as requests_get,
+        ):
+            provider.get_metadata("gitlab://group/project//README.md?ref=main")
+        self.assertTrue(requests_get.call_args.args[0].startswith("https://gitlab.local/api/v4"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_filemanager_projects.py
+++ b/tests/test_filemanager_projects.py
@@ -1,0 +1,989 @@
+"""
+Extended tests for project-layer services:
+- projects_store:   archive_tracked_file, event serialization, update/list edge cases
+- provider_credentials: get_provider_credential, get_provider_auth_context,
+                        delete_provider_credential, scope parsing, URL normalisation
+- projects_reconcile:   _is_transient_error, start_projects_reconcile_task,
+                        projects_reconcile_loop pagination/error-swallow
+- file_providers:   list_children for Local/GitHub/GitLab, _parse_ref edge cases,
+                    _raise_for_error branches, ProviderRegistry.register
+- projects router:  list_tracked_files_route happy path
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from botocore.exceptions import ClientError
+from fastapi import HTTPException
+
+from app.services import projects_reconcile, projects_store, provider_credentials
+from app.services.file_providers import (
+    GitHubProvider,
+    GitLabProvider,
+    LocalFileProvider,
+    ProviderRegistry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": "boom"}}, "Op")
+
+
+def _tracked_item(**overrides):
+    base = {
+        "entity_type": "tracked_file",
+        "id": "tf-1",
+        "project_id": "p-1",
+        "owner": "user-1",
+        "provider": "local",
+        "provider_ref": "/docs/a.txt",
+        "display_path": "/docs/a.txt",
+        "status": "active",
+        "metadata": {},
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "last_seen_at": "2026-01-01T00:00:00+00:00",
+        "archived_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _credential_item(**overrides):
+    base = {
+        "entity_type": "provider_credential",
+        "owner": "user-1",
+        "provider": "github",
+        "org": None,
+        "token_ct_b64": "cipher",
+        "scopes": ["repo"],
+        "metadata": {"api_base_url": "https://api.github.com"},
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_response(status: int, body=None, headers=None, content=b"1"):
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    r.content = content
+    r.json.return_value = body or {}
+    return r
+
+
+# ===========================================================================
+# projects_store – archive_tracked_file
+# ===========================================================================
+
+class TestArchiveTrackedFile(unittest.TestCase):
+    def test_archive_tracked_file_sets_status_and_timestamps(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": _tracked_item(status="active")}
+
+        with (
+            patch.object(projects_store, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_store, "now_iso", return_value="2026-06-01T00:00:00+00:00"),
+        ):
+            out = projects_store.archive_tracked_file("p-1", "tf-1")
+
+        self.assertEqual(out.status, "archived")
+        self.assertEqual(out.archived_at, "2026-06-01T00:00:00+00:00")
+        self.assertEqual(out.updated_at, "2026-06-01T00:00:00+00:00")
+        table.put_item.assert_called_once()
+        stored = table.put_item.call_args.kwargs["Item"]
+        self.assertEqual(stored["status"], "archived")
+
+    def test_archive_tracked_file_not_found_raises_404(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.archive_tracked_file("p-1", "missing")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+# ===========================================================================
+# projects_store – project_event serialization
+# ===========================================================================
+
+class TestProjectEventSerialization(unittest.TestCase):
+    def test_project_event_round_trip(self):
+        from app.models import ProjectEventModel
+
+        event = ProjectEventModel(
+            id="ev-1",
+            project_id="p-1",
+            owner="user-1",
+            event_type="file_added",
+            tracked_file_id="tf-1",
+            provider="github",
+            provider_ref="github://owner/repo/README.md?ref=main",
+            message="file tracked",
+            metadata={"extra": "info"},
+            created_at="2026-01-01T00:00:00+00:00",
+        )
+        item = projects_store.project_event_to_item(event)
+        self.assertEqual(item["entity_type"], "project_event")
+        self.assertEqual(item["PK"], "PROJECT#p-1")
+        self.assertEqual(item["GSI2PK"], "OWNER#user-1")
+        self.assertIn("PROJECT#p-1#EVENT#", item["GSI2SK"])
+
+        restored = projects_store.project_event_from_item(item)
+        self.assertEqual(restored.id, "ev-1")
+        self.assertEqual(restored.event_type, "file_added")
+        self.assertEqual(restored.metadata, {"extra": "info"})
+        self.assertEqual(restored.provider, "github")
+
+    def test_project_event_optional_fields_default_to_none(self):
+        from app.models import ProjectEventModel
+
+        event = ProjectEventModel(
+            id="ev-2",
+            project_id="p-2",
+            owner="user-2",
+            event_type="sync_ran",
+            metadata={},
+            created_at="2026-02-01T00:00:00+00:00",
+        )
+        item = projects_store.project_event_to_item(event)
+        self.assertIsNone(item["tracked_file_id"])
+        self.assertIsNone(item["provider"])
+        self.assertIsNone(item["message"])
+
+        restored = projects_store.project_event_from_item(item)
+        self.assertIsNone(restored.tracked_file_id)
+        self.assertIsNone(restored.provider)
+        self.assertEqual(restored.metadata, {})
+
+
+# ===========================================================================
+# projects_store – update_project edge cases
+# ===========================================================================
+
+class TestUpdateProjectEdgeCases(unittest.TestCase):
+    def _project_item(self):
+        return {
+            "entity_type": "project",
+            "id": "p-1",
+            "owner": "user-1",
+            "name": "Original Name",
+            "description": "original desc",
+            "tags": ["alpha"],
+            "settings": {"k": "v"},
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }
+
+    def test_update_project_only_name_leaves_other_fields_unchanged(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": self._project_item()}
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.update_project("user-1", "p-1", name="New Name")
+
+        self.assertEqual(out.name, "New Name")
+        self.assertEqual(out.description, "original desc")
+        self.assertEqual(out.tags, ["alpha"])
+        self.assertEqual(out.settings, {"k": "v"})
+
+    def test_update_project_clears_description(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": self._project_item()}
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.update_project("user-1", "p-1", description=None)
+
+        # When description passed as None explicitly it stays None (no change)
+        # but tags/settings remain
+        self.assertEqual(out.tags, ["alpha"])
+
+
+# ===========================================================================
+# projects_store – list_projects edge cases
+# ===========================================================================
+
+class TestListProjectsEdgeCases(unittest.TestCase):
+    def test_list_projects_returns_empty_when_no_matches(self):
+        table = MagicMock()
+        table.query.return_value = {"Items": [], "LastEvaluatedKey": None}
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            result = projects_store.list_projects("user-1", tag="nonexistent-tag")
+
+        self.assertEqual(result["items"], [])
+        self.assertIsNone(result["cursor"])
+
+    def test_list_projects_name_query_is_case_insensitive(self):
+        table = MagicMock()
+        table.query.return_value = {
+            "Items": [
+                {
+                    "entity_type": "project",
+                    "id": "p-1",
+                    "owner": "user-1",
+                    "name": "Project Alpha",
+                    "description": None,
+                    "tags": [],
+                    "settings": {},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            ]
+        }
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            result = projects_store.list_projects("user-1", name_query="ALPHA")
+
+        self.assertEqual(len(result["items"]), 1)
+        self.assertEqual(result["items"][0].name, "Project Alpha")
+
+    def test_list_projects_name_query_filters_non_matching(self):
+        table = MagicMock()
+        table.query.return_value = {
+            "Items": [
+                {
+                    "entity_type": "project",
+                    "id": "p-1",
+                    "owner": "user-1",
+                    "name": "Security Audit",
+                    "description": None,
+                    "tags": [],
+                    "settings": {},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            ]
+        }
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            result = projects_store.list_projects("user-1", name_query="alpha")
+
+        self.assertEqual(result["items"], [])
+
+    def test_list_projects_invalid_limit_raises_400(self):
+        table = MagicMock()
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.list_projects("user-1", limit=0)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+# ===========================================================================
+# projects_store – delete_project edge cases
+# ===========================================================================
+
+class TestDeleteProjectEdgeCases(unittest.TestCase):
+    def test_delete_project_conditional_check_failed_raises_404(self):
+        table = MagicMock()
+        table.delete_item.side_effect = _make_client_error("ConditionalCheckFailedException")
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.delete_project("user-1", "ghost-project")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertIn("not found", ctx.exception.detail)
+
+    def test_delete_project_other_client_error_propagates(self):
+        table = MagicMock()
+        table.delete_item.side_effect = _make_client_error("ProvisionedThroughputExceededException")
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(ClientError):
+                projects_store.delete_project("user-1", "p-1")
+
+
+# ===========================================================================
+# provider_credentials – get_provider_credential
+# ===========================================================================
+
+class TestGetProviderCredential(unittest.TestCase):
+    def test_get_provider_credential_happy_path(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": _credential_item()}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            cred = provider_credentials.get_provider_credential("user-1", "github")
+
+        self.assertEqual(cred.provider, "github")
+        self.assertEqual(cred.scopes, ["repo"])
+
+    def test_get_provider_credential_not_found_raises_404(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                provider_credentials.get_provider_credential("user-1", "github")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_get_provider_credential_allow_missing_returns_none(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            result = provider_credentials.get_provider_credential("user-1", "github", allow_missing=True)
+
+        self.assertIsNone(result)
+
+    def test_get_provider_credential_wrong_entity_type_raises_404(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": _credential_item(entity_type="project")}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                provider_credentials.get_provider_credential("user-1", "github")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+# ===========================================================================
+# provider_credentials – get_provider_auth_context
+# ===========================================================================
+
+class TestGetProviderAuthContext(unittest.TestCase):
+    def test_get_provider_auth_context_returns_token_and_scopes(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": _credential_item(scopes=["repo", "read:user"])}
+
+        with (
+            patch.object(provider_credentials, "T", SimpleNamespace(projects=table)),
+            patch.object(provider_credentials, "kms_decrypt", return_value=b"cleartoken"),
+        ):
+            ctx = provider_credentials.get_provider_auth_context("user-1", "github")
+
+        self.assertEqual(ctx["token"], "cleartoken")
+        self.assertEqual(ctx["provider"], "github")
+        self.assertIn("repo", ctx["scopes"])
+        self.assertIn("read:user", ctx["scopes"])
+        self.assertEqual(ctx["metadata"]["api_base_url"], "https://api.github.com")
+
+    def test_get_provider_auth_context_missing_scope_raises_400(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": _credential_item(scopes=["read:user"])}
+
+        with (
+            patch.object(provider_credentials, "T", SimpleNamespace(projects=table)),
+            patch.object(provider_credentials, "kms_decrypt", return_value=b"cleartoken"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                provider_credentials.get_provider_auth_context(
+                    "user-1", "github", required_scopes=["repo"]
+                )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("repo", ctx.exception.detail)
+
+    def test_get_provider_auth_context_credential_not_found_raises_404(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                provider_credentials.get_provider_auth_context("user-1", "github")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+# ===========================================================================
+# provider_credentials – delete_provider_credential
+# ===========================================================================
+
+class TestDeleteProviderCredential(unittest.TestCase):
+    def test_delete_returns_deleted_true_when_present(self):
+        table = MagicMock()
+        table.get_item.return_value = {"Item": _credential_item()}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            result = provider_credentials.delete_provider_credential("user-1", "github")
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["deleted"])
+        table.delete_item.assert_called_once()
+
+    def test_delete_returns_deleted_false_when_absent(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            result = provider_credentials.delete_provider_credential("user-1", "github")
+
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["deleted"])
+        table.delete_item.assert_not_called()
+
+    def test_delete_wrong_owner_raises_404(self):
+        table = MagicMock()
+        # item exists but belongs to a different owner
+        table.get_item.return_value = {"Item": _credential_item(owner="attacker")}
+
+        with patch.object(provider_credentials, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                provider_credentials.delete_provider_credential("user-1", "github")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+# ===========================================================================
+# provider_credentials – scope parsing & URL normalisation
+# ===========================================================================
+
+class TestParseGithubScopes(unittest.TestCase):
+    def test_none_returns_empty_list(self):
+        self.assertEqual(provider_credentials._parse_github_scopes(None), [])
+
+    def test_empty_string_returns_empty_list(self):
+        self.assertEqual(provider_credentials._parse_github_scopes(""), [])
+
+    def test_deduplicates_and_normalises(self):
+        result = provider_credentials._parse_github_scopes("REPO, repo, read:user,  READ:USER")
+        self.assertEqual(result, ["repo", "read:user"])
+
+    def test_single_scope(self):
+        result = provider_credentials._parse_github_scopes("read:org")
+        self.assertEqual(result, ["read:org"])
+
+    def test_whitespace_only_entries_skipped(self):
+        result = provider_credentials._parse_github_scopes("repo,  , read:user")
+        self.assertEqual(result, ["repo", "read:user"])
+
+
+class TestNormalizeApiBaseUrl(unittest.TestCase):
+    def test_github_default_when_none(self):
+        url = provider_credentials.normalize_github_api_base_url(None)
+        self.assertTrue(url.startswith("https://"))
+        self.assertNotIn("//", url.replace("https://", "").replace("http://", ""))
+
+    def test_gitlab_default_when_none(self):
+        url = provider_credentials.normalize_gitlab_api_base_url(None)
+        self.assertTrue(url.startswith("https://"))
+
+    def test_strips_trailing_slash(self):
+        url = provider_credentials.normalize_github_api_base_url("https://ghe.local/api/v3/")
+        self.assertFalse(url.endswith("/"))
+
+    def test_rejects_missing_protocol(self):
+        with self.assertRaises(HTTPException) as ctx:
+            provider_credentials.normalize_github_api_base_url("ghe.local/api/v3")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_rejects_empty_after_strip(self):
+        # Empty string falls back to default (which is valid https://)
+        url = provider_credentials.normalize_github_api_base_url("")
+        self.assertTrue(url.startswith("https://"))
+
+
+# ===========================================================================
+# projects_reconcile – _is_transient_error
+# ===========================================================================
+
+class TestIsTransientError(unittest.TestCase):
+    def test_http_transient_codes(self):
+        for code in (429, 500, 502, 503, 504):
+            self.assertTrue(
+                projects_reconcile._is_transient_error(HTTPException(status_code=code)),
+                f"expected 429/500/502/503/504 to be transient, got False for {code}",
+            )
+
+    def test_http_non_transient_codes(self):
+        for code in (400, 401, 403, 404, 422):
+            self.assertFalse(
+                projects_reconcile._is_transient_error(HTTPException(status_code=code)),
+                f"expected {code} to be non-transient",
+            )
+
+    def test_client_error_transient(self):
+        for code in ("ProvisionedThroughputExceededException", "ThrottlingException", "InternalServerError"):
+            self.assertTrue(
+                projects_reconcile._is_transient_error(_make_client_error(code)),
+                f"expected {code} to be transient",
+            )
+
+    def test_client_error_non_transient(self):
+        self.assertFalse(
+            projects_reconcile._is_transient_error(_make_client_error("ConditionalCheckFailedException"))
+        )
+
+    def test_os_error_types_are_transient(self):
+        self.assertTrue(projects_reconcile._is_transient_error(TimeoutError()))
+        self.assertTrue(projects_reconcile._is_transient_error(ConnectionError()))
+        self.assertTrue(projects_reconcile._is_transient_error(OSError()))
+
+    def test_generic_value_error_is_not_transient(self):
+        self.assertFalse(projects_reconcile._is_transient_error(ValueError("bad value")))
+
+
+# ===========================================================================
+# projects_reconcile – start_projects_reconcile_task
+# ===========================================================================
+
+class TestStartProjectsReconcileTask(unittest.TestCase):
+    def test_disabled_flag_skips_task_creation(self):
+        with (
+            patch.object(
+                projects_reconcile, "S",
+                SimpleNamespace(projects_reconcile_enabled=False, projects_reconcile_interval_seconds=60),
+            ),
+            patch("asyncio.create_task") as create_task,
+        ):
+            projects_reconcile.start_projects_reconcile_task()
+
+        create_task.assert_not_called()
+
+    def test_enabled_flag_creates_task(self):
+        with (
+            patch.object(
+                projects_reconcile, "S",
+                SimpleNamespace(projects_reconcile_enabled=True, projects_reconcile_interval_seconds=60),
+            ),
+            patch("asyncio.create_task") as create_task,
+        ):
+            projects_reconcile.start_projects_reconcile_task()
+
+        create_task.assert_called_once()
+
+
+# ===========================================================================
+# projects_reconcile – projects_reconcile_loop
+# ===========================================================================
+
+class TestProjectsReconcileLoop(unittest.TestCase):
+    def test_loop_single_batch_with_no_cursor_exits(self):
+        async def _run():
+            with (
+                patch.object(
+                    projects_reconcile, "S",
+                    SimpleNamespace(projects_reconcile_enabled=True, projects_reconcile_interval_seconds=0),
+                ),
+                patch.object(
+                    projects_reconcile,
+                    "reconcile_tracked_files_batch",
+                    return_value={"cursor": None, "checked": 1, "missing": 0, "errors": 0},
+                ) as reconcile_batch,
+                patch("asyncio.sleep", new=AsyncMock(side_effect=asyncio.CancelledError)),
+            ):
+                with self.assertRaises(asyncio.CancelledError):
+                    await projects_reconcile.projects_reconcile_loop()
+
+            # Batch called once, then sleep raised to break infinite loop
+            reconcile_batch.assert_called_once()
+
+        asyncio.run(_run())
+
+    def test_loop_paginates_until_cursor_exhausted(self):
+        batches = [
+            {"cursor": {"PK": "x", "SK": "y"}, "checked": 10, "missing": 0, "errors": 0},
+            {"cursor": None, "checked": 5, "missing": 0, "errors": 0},
+        ]
+        call_count = 0
+
+        def fake_reconcile(*, cursor=None, **_kwargs):
+            nonlocal call_count
+            result = batches[call_count]
+            call_count += 1
+            return result
+
+        async def _run():
+            with (
+                patch.object(
+                    projects_reconcile, "S",
+                    SimpleNamespace(projects_reconcile_enabled=True, projects_reconcile_interval_seconds=0),
+                ),
+                patch.object(projects_reconcile, "reconcile_tracked_files_batch", side_effect=fake_reconcile),
+                patch("asyncio.sleep", new=AsyncMock(side_effect=asyncio.CancelledError)),
+            ):
+                with self.assertRaises(asyncio.CancelledError):
+                    await projects_reconcile.projects_reconcile_loop()
+
+        asyncio.run(_run())
+        self.assertEqual(call_count, 2)
+
+    def test_loop_swallows_exceptions_and_sleeps(self):
+        async def fake_sleep(_):
+            raise asyncio.CancelledError
+
+        async def _run():
+            with (
+                patch.object(
+                    projects_reconcile, "S",
+                    SimpleNamespace(projects_reconcile_enabled=True, projects_reconcile_interval_seconds=0),
+                ),
+                patch.object(
+                    projects_reconcile,
+                    "reconcile_tracked_files_batch",
+                    side_effect=RuntimeError("database down"),
+                ),
+                patch("asyncio.sleep", new=fake_sleep),
+            ):
+                with self.assertRaises(asyncio.CancelledError):
+                    await projects_reconcile.projects_reconcile_loop()
+
+        asyncio.run(_run())  # RuntimeError from reconcile should be swallowed
+
+
+# ===========================================================================
+# file_providers – LocalFileProvider.list_children
+# ===========================================================================
+
+class TestLocalFileProviderListChildren(unittest.TestCase):
+    def test_list_children_returns_paths(self):
+        provider = LocalFileProvider("user-1")
+        with (
+            patch("app.services.file_providers.filemanager.norm_path", return_value="/docs/"),
+            patch(
+                "app.services.file_providers.filemanager.list_children",
+                return_value=[
+                    {"path": "/docs/a.txt"},
+                    {"path": "/docs/b.txt"},
+                    {"path": ""},  # empty path should be skipped
+                ],
+            ),
+        ):
+            result = provider.list_children("/docs/")
+
+        self.assertEqual(result, ["/docs/a.txt", "/docs/b.txt"])
+
+    def test_list_children_empty_folder_returns_empty_list(self):
+        provider = LocalFileProvider("user-1")
+        with (
+            patch("app.services.file_providers.filemanager.norm_path", return_value="/empty/"),
+            patch("app.services.file_providers.filemanager.list_children", return_value=[]),
+        ):
+            result = provider.list_children("/empty/")
+
+        self.assertEqual(result, [])
+
+
+# ===========================================================================
+# file_providers – GitHubProvider._parse_ref
+# ===========================================================================
+
+class TestGitHubParseRef(unittest.TestCase):
+    def setUp(self):
+        self.p = GitHubProvider("user-1")
+
+    def test_minimal_ref_defaults_ref_to_HEAD(self):
+        out = self.p._parse_ref("owner/repo/README.md")
+        self.assertEqual(out["repo_owner"], "owner")
+        self.assertEqual(out["repo"], "repo")
+        self.assertEqual(out["path"], "README.md")
+        self.assertEqual(out["ref"], "HEAD")
+
+    def test_explicit_ref_param(self):
+        out = self.p._parse_ref("owner/repo/src/main.py?ref=main")
+        self.assertEqual(out["path"], "src/main.py")
+        self.assertEqual(out["ref"], "main")
+
+    def test_github_scheme_prefix_stripped(self):
+        out = self.p._parse_ref("github://owner/repo/README.md?ref=abc123")
+        self.assertEqual(out["repo_owner"], "owner")
+        self.assertEqual(out["ref"], "abc123")
+
+    def test_too_few_components_raises_400(self):
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._parse_ref("owner/repo")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_no_file_path_raises_400(self):
+        # owner/repo/ — trailing slash but no file
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._parse_ref("owner/repo/")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_deep_path_joined_correctly(self):
+        out = self.p._parse_ref("owner/repo/src/utils/helpers.py")
+        self.assertEqual(out["path"], "src/utils/helpers.py")
+
+
+# ===========================================================================
+# file_providers – GitHubProvider._raise_for_error
+# ===========================================================================
+
+class TestGitHubRaiseForError(unittest.TestCase):
+    def setUp(self):
+        self.p = GitHubProvider("user-1")
+
+    def test_2xx_does_not_raise(self):
+        self.p._raise_for_error(_make_response(200))  # no exception
+
+    def test_404_raises_404(self):
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(_make_response(404))
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_401_rate_limited_raises_429(self):
+        r = _make_response(401, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"})
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(r)
+        self.assertEqual(ctx.exception.status_code, 429)
+        self.assertIn("rate limit", ctx.exception.detail)
+
+    def test_401_not_rate_limited_raises_401(self):
+        r = _make_response(401, headers={"X-RateLimit-Remaining": "59"})
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(r)
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_500_raises_502(self):
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(_make_response(500))
+        self.assertEqual(ctx.exception.status_code, 502)
+
+
+# ===========================================================================
+# file_providers – GitHubProvider.list_children
+# ===========================================================================
+
+class TestGitHubListChildren(unittest.TestCase):
+    def setUp(self):
+        self.p = GitHubProvider("user-1")
+
+    def test_list_children_returns_canonical_refs(self):
+        r = _make_response(
+            200,
+            body=[
+                {"path": "src/a.py"},
+                {"path": "src/b.py"},
+                {"path": ""},  # empty path skipped
+            ],
+        )
+        with patch.object(self.p, "_request", return_value=r):
+            result = self.p.list_children("github://owner/repo/src?ref=main")
+
+        self.assertEqual(len(result), 2)
+        self.assertTrue(result[0].startswith("github://owner/repo/src/a.py?ref=main"))
+        self.assertTrue(result[1].startswith("github://owner/repo/src/b.py?ref=main"))
+
+    def test_list_children_non_list_response_raises_400(self):
+        r = _make_response(200, body={"type": "file", "name": "README.md"})
+        with patch.object(self.p, "_request", return_value=r):
+            with self.assertRaises(HTTPException) as ctx:
+                self.p.list_children("github://owner/repo/README.md?ref=main")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_list_children_request_exception_raises_502(self):
+        import requests
+
+        with patch.object(self.p, "_request", side_effect=requests.RequestException("timeout")):
+            with self.assertRaises(HTTPException) as ctx:
+                self.p.list_children("github://owner/repo/src?ref=main")
+        self.assertEqual(ctx.exception.status_code, 502)
+
+
+# ===========================================================================
+# file_providers – GitLabProvider._parse_ref
+# ===========================================================================
+
+class TestGitLabParseRef(unittest.TestCase):
+    def setUp(self):
+        self.p = GitLabProvider("user-1")
+
+    def test_double_slash_separator(self):
+        out = self.p._parse_ref("namespace/project//src/main.py?ref=main")
+        self.assertEqual(out["project_path"], "namespace/project")
+        self.assertEqual(out["path"], "src/main.py")
+        self.assertEqual(out["ref"], "main")
+
+    def test_legacy_slash_based_three_parts(self):
+        out = self.p._parse_ref("ns/proj/README.md")
+        self.assertEqual(out["project_path"], "ns/proj")
+        self.assertEqual(out["path"], "README.md")
+        self.assertEqual(out["ref"], "HEAD")
+
+    def test_with_ref_query_param(self):
+        out = self.p._parse_ref("gitlab://ns/proj//lib/utils.py?ref=develop")
+        self.assertEqual(out["ref"], "develop")
+        self.assertEqual(out["path"], "lib/utils.py")
+
+    def test_too_few_slash_parts_raises_400(self):
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._parse_ref("ns/proj")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_gitlab_scheme_prefix_stripped(self):
+        out = self.p._parse_ref("gitlab://ns/proj/README.md")
+        self.assertEqual(out["project_path"], "ns/proj")
+
+
+# ===========================================================================
+# file_providers – GitLabProvider._raise_for_error
+# ===========================================================================
+
+class TestGitLabRaiseForError(unittest.TestCase):
+    def setUp(self):
+        self.p = GitLabProvider("user-1")
+
+    def test_200_does_not_raise(self):
+        self.p._raise_for_error(_make_response(200))
+
+    def test_404_raises_404(self):
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(_make_response(404))
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_explicit_429_uses_retry_after_header(self):
+        r = _make_response(429, headers={"Retry-After": "30"})
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(r)
+        self.assertEqual(ctx.exception.status_code, 429)
+        self.assertIn("retry_after=30", ctx.exception.detail)
+
+    def test_401_rate_limited_raises_429(self):
+        r = _make_response(401, headers={"RateLimit-Remaining": "0", "RateLimit-Reset": "999"})
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(r)
+        self.assertEqual(ctx.exception.status_code, 429)
+
+    def test_401_auth_failure_raises_401(self):
+        r = _make_response(401, headers={"RateLimit-Remaining": "100"})
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(r)
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_server_error_raises_502(self):
+        with self.assertRaises(HTTPException) as ctx:
+            self.p._raise_for_error(_make_response(500))
+        self.assertEqual(ctx.exception.status_code, 502)
+
+
+# ===========================================================================
+# file_providers – GitLabProvider.list_children
+# ===========================================================================
+
+class TestGitLabListChildren(unittest.TestCase):
+    def setUp(self):
+        self.p = GitLabProvider("user-1")
+
+    def test_list_children_returns_canonical_refs(self):
+        r = _make_response(
+            200,
+            body=[
+                {"path": "src/a.py", "type": "blob"},
+                {"path": "src/utils", "type": "tree"},
+                {"path": "", "type": "blob"},  # empty path skipped
+            ],
+        )
+        with patch.object(self.p, "_request_tree", return_value=r):
+            result = self.p.list_children("gitlab://ns/proj//src?ref=main")
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("gitlab://ns/proj//src/a.py?ref=main", result)
+        self.assertIn("gitlab://ns/proj//src/utils?ref=main", result)
+
+    def test_list_children_request_exception_raises_502(self):
+        import requests
+
+        with patch.object(self.p, "_request_tree", side_effect=requests.RequestException("conn")):
+            with self.assertRaises(HTTPException) as ctx:
+                self.p.list_children("gitlab://ns/proj//src?ref=main")
+        self.assertEqual(ctx.exception.status_code, 502)
+
+    def test_list_children_non_list_response_raises_400(self):
+        r = _make_response(200, body={"unexpected": "dict"})
+        with patch.object(self.p, "_request_tree", return_value=r):
+            with self.assertRaises(HTTPException) as ctx:
+                self.p.list_children("gitlab://ns/proj//src?ref=main")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+# ===========================================================================
+# file_providers – ProviderRegistry.register
+# ===========================================================================
+
+class TestProviderRegistryRegister(unittest.TestCase):
+    def test_register_and_retrieve(self):
+        registry = ProviderRegistry()
+        registry.register("custom", lambda owner: SimpleNamespace(provider_name="custom", owner=owner))
+        provider = registry.get("user-1", "CUSTOM")  # case-insensitive
+        self.assertEqual(provider.provider_name, "custom")
+        self.assertEqual(provider.owner, "user-1")
+
+    def test_register_empty_name_raises_400(self):
+        registry = ProviderRegistry()
+        with self.assertRaises(HTTPException) as ctx:
+            registry.register("", lambda owner: None)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_register_whitespace_only_name_raises_400(self):
+        registry = ProviderRegistry()
+        with self.assertRaises(HTTPException) as ctx:
+            registry.register("   ", lambda owner: None)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+# ===========================================================================
+# projects router – list_tracked_files_route happy path
+# ===========================================================================
+
+class TestListTrackedFilesRoute(unittest.TestCase):
+    def test_list_tracked_files_route_returns_items(self):
+        from app.routers import projects as projects_router
+
+        file_item = {
+            "id": "tf-1",
+            "project_id": "p-1",
+            "owner": "user-1",
+            "provider": "github",
+            "provider_ref": "github://owner/repo/README.md?ref=main",
+            "display_path": "README.md",
+            "status": "active",
+            "metadata": {},
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "last_seen_at": None,
+            "archived_at": None,
+        }
+        from app.models import TrackedFileModel
+
+        with patch.object(
+            projects_router,
+            "list_tracked_files",
+            return_value={"items": [TrackedFileModel(**file_item)], "cursor": None},
+        ) as mock_list:
+            result = projects_router.list_tracked_files_route(
+                "p-1",
+                limit=10,
+                cursor=None,
+                status="active",
+                provider="github",
+                user="user-1",
+            )
+
+        mock_list.assert_called_once_with(
+            "user-1", "p-1", limit=10, cursor=None, status="active", provider="github"
+        )
+        self.assertEqual(len(result.items), 1)
+        self.assertEqual(result.items[0].id, "tf-1")
+        self.assertIsNone(result.cursor)
+
+    def test_list_tracked_files_route_invalid_cursor_raises_400(self):
+        from app.routers import projects as projects_router
+
+        with self.assertRaises(HTTPException) as ctx:
+            projects_router.list_tracked_files_route(
+                "p-1",
+                limit=10,
+                cursor="not-valid-base64!@@",
+                status=None,
+                provider=None,
+                user="user-1",
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("cursor", ctx.exception.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_filemanager_service.py
+++ b/tests/test_filemanager_service.py
@@ -1429,6 +1429,7 @@ class TestFileManagerService(unittest.TestCase):
             patch.object(filemanager, "require_not_exists"),
             patch.object(filemanager, "_table") as table_factory,
             patch.object(filemanager, "_s3") as s3,
+            patch.object(filemanager, "S", SimpleNamespace(dev_mode=False)),
         ):
             table = Mock()
             table_factory.return_value = table

--- a/tests/test_messaging_routes.py
+++ b/tests/test_messaging_routes.py
@@ -228,6 +228,20 @@ class TestMessagingRoutes(unittest.TestCase):
             ]
         }
 
+        with (
+            patch.object(messaging, "tbl_parts", tbl_parts),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+            patch.object(
+                messaging,
+                "_get_conversation_or_404",
+                return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1"},
+            ),
+            patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid == "agent-1"),
+        ):
+            messages = messaging.list_messages("c1", user_id="customer-1")
+
+        self.assertEqual(messages[0].sender_id, messaging.HELPDESK_MASKED_SENDER_ID)
+
     def test_list_conversation_gallery_filters_by_type_and_returns_cursor(self):
         tbl_parts = Mock()
         tbl_msgs = Mock()
@@ -257,57 +271,134 @@ class TestMessagingRoutes(unittest.TestCase):
             {"Items": []},
         ]
 
-with (
-    patch.object(messaging, "tbl_parts", tbl_parts),
-    patch.object(messaging, "tbl_msgs", tbl_msgs),
-    patch.object(
-        messaging,
-        "_get_conversation_or_404",
-        return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1"},
-    ),
-    patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid == "agent-1"),
-):
-    messages = messaging.list_messages("c1", user_id="customer-1")
+        with (
+            patch.object(messaging, "tbl_parts", tbl_parts),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+        ):
+            page = messaging.list_conversation_gallery("c1", type="image", user_id="user-1")
 
-self.assertEqual(messages[0].sender_id, messaging.HELPDESK_MASKED_SENDER_ID)
+        self.assertEqual(len(page.items), 1)
+        self.assertEqual(page.items[0].type, "image")
+        self.assertEqual(page.items[0].message_id, "m3")
+        self.assertIsNone(page.next_cursor)
 
+    def test_e2e_mid_thread_assignee_change_keeps_helpdesk_identity_for_end_user(self):
+        tbl_parts = Mock()
+        tbl_msgs = Mock()
+        tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
+        tbl_parts.query.return_value = {"Items": []}
+        # agent-1 sent early, agent-2 claimed and replied later — end user sees both as "Helpdesk"
+        tbl_msgs.query.return_value = {
+            "Items": [
+                {
+                    "conversation_id": "c1",
+                    "message_id": "m2",
+                    "sender_id": "agent-2",
+                    "created_at": 20,
+                    "kind": "text",
+                    "text": "I can take over from here",
+                    "deleted_for": [],
+                    "reactions": {},
+                },
+                {
+                    "conversation_id": "c1",
+                    "message_id": "m1",
+                    "sender_id": "agent-1",
+                    "created_at": 10,
+                    "kind": "text",
+                    "text": "Hi, I will help you",
+                    "deleted_for": [],
+                    "reactions": {},
+                },
+            ]
+        }
 
-def test_e2e_mid_thread_assignee_change_keeps_helpdesk_identity_for_end_user(self):
-    tbl_parts = Mock()
-    tbl_msgs = Mock()
-    tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
-    tbl_parts.query.return_value = {"Items": []}
-    # ... rest of your test ...
+        with (
+            patch.object(messaging, "tbl_parts", tbl_parts),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+            patch.object(
+                messaging,
+                "_get_conversation_or_404",
+                return_value={
+                    "routing_mode": "helpdesk_bridge",
+                    "routing_group_id": "helpdesk-l1",
+                    "routing_state": "assigned",
+                    "active_agent_user_id": "agent-2",
+                },
+            ),
+            patch.object(
+                messaging,
+                "_is_helpdesk_group_member",
+                side_effect=lambda gid, uid: uid in {"agent-1", "agent-2"},
+            ),
+        ):
+            messages = messaging.list_messages("c1", user_id="customer-1")
 
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].sender_id, messaging.HELPDESK_MASKED_SENDER_ID)
+        self.assertEqual(messages[1].sender_id, messaging.HELPDESK_MASKED_SENDER_ID)
 
-# --- gallery tests from main continue here ---
+    def test_list_conversation_gallery_paginates_across_sparse_matches(self):
+        tbl_parts = Mock()
+        tbl_msgs = Mock()
+        tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
+        tbl_msgs.query.side_effect = [
+            {
+                "Items": [
+                    {
+                        "conversation_id": "c1",
+                        "message_id": "m3",
+                        "sender_id": "user-2",
+                        "created_at": 103,
+                        "kind": "text",
+                        "text": "hello",
+                    },
+                    {
+                        "conversation_id": "c1",
+                        "message_id": "m2",
+                        "sender_id": "user-2",
+                        "created_at": 102,
+                        "kind": "image",
+                        "image": {"url": "https://cdn.example.com/2.jpg"},
+                    },
+                ],
+                "LastEvaluatedKey": {"conversation_id": "c1", "message_id": "m2"},
+            },
+            {
+                "Items": [
+                    {
+                        "conversation_id": "c1",
+                        "message_id": "m1",
+                        "sender_id": "user-3",
+                        "created_at": 101,
+                        "kind": "image",
+                        "image": {"url": "https://cdn.example.com/1.jpg"},
+                    },
+                ]
+            },
+        ]
 
-with (
-    patch.object(messaging, "tbl_parts", tbl_parts),
-    patch.object(messaging, "tbl_msgs", tbl_msgs),
-):
-    page = messaging.list_conversation_gallery("c1", type="image", user_id="user-1")
+        with (
+            patch.object(messaging, "tbl_parts", tbl_parts),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+        ):
+            page = messaging.list_conversation_gallery("c1", type="image", limit=2, user_id="user-1")
 
-self.assertEqual(len(page.items), 1)
-self.assertEqual(page.items[0].type, "image")
-self.assertEqual(page.items[0].message_id, "m3")
-self.assertIsNone(page.next_cursor)
+        self.assertEqual([item.message_id for item in page.items], ["m2", "m1"])
+        self.assertIsNone(page.next_cursor)
 
-
-def test_list_conversation_gallery_paginates_across_sparse_matches(self):
-    tbl_parts = Mock()
-    tbl_msgs = Mock()
-    tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
-    tbl_msgs.query.side_effect = [
-        {
+    def test_list_conversation_gallery_suppresses_revoked_and_deleted(self):
+        tbl_msgs = Mock()
+        tbl_msgs.query.return_value = {
             "Items": [
                 {
                     "conversation_id": "c1",
                     "message_id": "m3",
                     "sender_id": "user-2",
                     "created_at": 103,
-                    "kind": "text",
-                    "text": "hello",
+                    "kind": "image",
+                    "image": {"url": "https://cdn.example.com/3.jpg"},
+                    "revoked_at": 101,
                 },
                 {
                     "conversation_id": "c1",
@@ -316,216 +407,160 @@ def test_list_conversation_gallery_paginates_across_sparse_matches(self):
                     "created_at": 102,
                     "kind": "image",
                     "image": {"url": "https://cdn.example.com/2.jpg"},
+                    "deleted_for": ["user-1"],
                 },
-            ],
-            "LastEvaluatedKey": {"conversation_id": "c1", "message_id": "m2"},
-        },
-        {
-            "Items": [
                 {
                     "conversation_id": "c1",
                     "message_id": "m1",
-                    "sender_id": "user-3",
+                    "sender_id": "user-2",
                     "created_at": 101,
                     "kind": "image",
                     "image": {"url": "https://cdn.example.com/1.jpg"},
                 },
             ]
-        },
-    ]
+        }
 
-    with (
-        patch.object(messaging, "tbl_parts", tbl_parts),
-        patch.object(messaging, "tbl_msgs", tbl_msgs),
-    ):
-        page = messaging.list_conversation_gallery("c1", type="image", limit=2, user_id="user-1")
+        with (
+            patch.object(messaging, "require_participant_active"),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+        ):
+            page = messaging.list_conversation_gallery("c1", type="image", user_id="user-1")
 
-    self.assertEqual([item.message_id for item in page.items], ["m2", "m1"])
-    self.assertIsNone(page.next_cursor)
+        self.assertEqual([item.message_id for item in page.items], ["m1"])
 
+    def test_list_messages_masks_helpdesk_agents_for_end_users(self):
+        tbl_parts = Mock()
+        tbl_msgs = Mock()
+        tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
+        tbl_parts.query.return_value = {"Items": []}
 
-# ... keep all other main gallery tests unchanged ...
-
-
-def test_list_conversation_gallery_suppresses_revoked_and_deleted(self):
-    tbl_msgs = Mock()
-    tbl_msgs.query.return_value = {
-        "Items": [
-            {
-                "conversation_id": "c1",
-                "message_id": "m3",
-                "sender_id": "user-2",
-                "created_at": 103,
-                "kind": "image",
-                "image": {"url": "https://cdn.example.com/3.jpg"},
-                "revoked_at": 101,
-            },
-            {
-                "conversation_id": "c1",
-                "message_id": "m2",
-                "sender_id": "user-2",
-                "created_at": 102,
-                "kind": "image",
-                "image": {"url": "https://cdn.example.com/2.jpg"},
-                "deleted_for": ["user-1"],
-            },
-            {
-                "conversation_id": "c1",
-                "message_id": "m1",
-                "sender_id": "user-2",
-                "created_at": 101,
-                "kind": "image",
-                "image": {"url": "https://cdn.example.com/1.jpg"},
-            },
-        ]
-    }
-
-    with (
-        patch.object(messaging, "require_participant_active"),
-        patch.object(messaging, "tbl_msgs", tbl_msgs),
-    ):
-        page = messaging.list_conversation_gallery("c1", type="image", user_id="user-1")
-
-    self.assertEqual([item.message_id for item in page.items], ["m1"])
-
-
-# --- helpdesk tests from your branch continue here (keep them) ---
-
-def test_list_messages_masks_helpdesk_agents_for_end_users(self):
-    tbl_parts = Mock()
-    tbl_msgs = Mock()
-    tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
-    tbl_parts.query.return_value = {"Items": []}
-
-    tbl_msgs.query.return_value = {
-        "Items": [
-            {
-                "conversation_id": "c1",
-                "message_id": "m2",
-                "sender_id": "agent-2",
-                "created_at": 20,
-                "kind": "text",
-                "text": "I can take over",
-                "deleted_for": [],
-                "reactions": {},
-            },
-            {
-                "conversation_id": "c1",
-                "message_id": "m1",
-                "sender_id": "agent-1",
-                "created_at": 10,
-                "kind": "text",
-                "text": "I will help you",
-                "deleted_for": [],
-                "reactions": {},
-            },
-        ]
-    }
-
-    with (
-        patch.object(messaging, "tbl_parts", tbl_parts),
-        patch.object(messaging, "tbl_msgs", tbl_msgs),
-        patch.object(
-            messaging,
-            "_get_conversation_or_404",
-            return_value={
-                "routing_mode": "helpdesk_bridge",
-                "routing_group_id": "helpdesk-l1",
-                "routing_state": "assigned",
-            },
-        ),
-        patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid in {"agent-1", "agent-2"}),
-    ):
-        messages = messaging.list_messages("c1", user_id="customer-1")
-
-    self.assertEqual(
-        [m.sender_id for m in messages],
-        [messaging.HELPDESK_MASKED_SENDER_ID, messaging.HELPDESK_MASKED_SENDER_ID],
-    )
-
-
-def test_list_messages_retains_helpdesk_agent_sender_for_helpdesk_agents(self):
-    tbl_parts = Mock()
-    tbl_msgs = Mock()
-    tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
-    tbl_parts.query.return_value = {"Items": []}
-
-    tbl_msgs.query.return_value = {
-        "Items": [
-            {
-                "conversation_id": "c1",
-                "message_id": "m1",
-                "sender_id": "agent-1",
-                "created_at": 10,
-                "kind": "text",
-                "text": "hello",
-                "deleted_for": [],
-                "reactions": {},
-            }
-        ]
-    }
-
-    with (
-        patch.object(messaging, "tbl_parts", tbl_parts),
-        patch.object(messaging, "tbl_msgs", tbl_msgs),
-        patch.object(
-            messaging,
-            "_get_conversation_or_404",
-            return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1"},
-        ),
-        patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid in {"agent-1", "agent-2"}),
-    ):
-        messages = messaging.list_messages("c1", user_id="agent-2")
-
-    self.assertEqual(messages[0].sender_id, "agent-1")
-
-
-def test_fetch_events_projects_helpdesk_sender_for_end_users(self):
-    with (
-        patch.object(
-            messaging,
-            "_ddb_fetch_events",
-            return_value=[
+        tbl_msgs.query.return_value = {
+            "Items": [
                 {
-                    "event_id": "e1",
-                    "type": "message:new",
                     "conversation_id": "c1",
-                    "payload": {
-                        "message": {
-                            "conversation_id": "c1",
-                            "message_id": "m1",
-                            "sender_id": "agent-1",
-                        }
-                    },
-                }
-            ],
-        ),
-        patch.object(
-            messaging,
-            "_get_message_or_404",
-            return_value={
-                "conversation_id": "c1",
-                "message_id": "m1",
-                "sender_id": "agent-1",
-                "created_at": 10,
-                "kind": "text",
-                "text": "hello",
-                "reactions": {},
-            },
-        ),
-        patch.object(
-            messaging,
-            "_get_conversation_or_404",
-            return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1"},
-        ),
-        patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid == "agent-1"),
-    ):
-        resp = messaging.fetch_events(user_id="customer-1")
+                    "message_id": "m2",
+                    "sender_id": "agent-2",
+                    "created_at": 20,
+                    "kind": "text",
+                    "text": "I can take over",
+                    "deleted_for": [],
+                    "reactions": {},
+                },
+                {
+                    "conversation_id": "c1",
+                    "message_id": "m1",
+                    "sender_id": "agent-1",
+                    "created_at": 10,
+                    "kind": "text",
+                    "text": "I will help you",
+                    "deleted_for": [],
+                    "reactions": {},
+                },
+            ]
+        }
 
-    self.assertEqual(
-        resp["events"][0]["payload"]["message"]["sender_id"],
-        messaging.HELPDESK_MASKED_SENDER_ID,
-    )
+        with (
+            patch.object(messaging, "tbl_parts", tbl_parts),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+            patch.object(
+                messaging,
+                "_get_conversation_or_404",
+                return_value={
+                    "routing_mode": "helpdesk_bridge",
+                    "routing_group_id": "helpdesk-l1",
+                    "routing_state": "assigned",
+                },
+            ),
+            patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid in {"agent-1", "agent-2"}),
+        ):
+            messages = messaging.list_messages("c1", user_id="customer-1")
+
+        self.assertEqual(
+            [m.sender_id for m in messages],
+            [messaging.HELPDESK_MASKED_SENDER_ID, messaging.HELPDESK_MASKED_SENDER_ID],
+        )
+
+    def test_list_messages_retains_helpdesk_agent_sender_for_helpdesk_agents(self):
+        tbl_parts = Mock()
+        tbl_msgs = Mock()
+        tbl_parts.get_item.return_value = {"Item": {"status": "active"}}
+        tbl_parts.query.return_value = {"Items": []}
+
+        tbl_msgs.query.return_value = {
+            "Items": [
+                {
+                    "conversation_id": "c1",
+                    "message_id": "m1",
+                    "sender_id": "agent-1",
+                    "created_at": 10,
+                    "kind": "text",
+                    "text": "hello",
+                    "deleted_for": [],
+                    "reactions": {},
+                }
+            ]
+        }
+
+        with (
+            patch.object(messaging, "tbl_parts", tbl_parts),
+            patch.object(messaging, "tbl_msgs", tbl_msgs),
+            patch.object(
+                messaging,
+                "_get_conversation_or_404",
+                return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1"},
+            ),
+            patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid in {"agent-1", "agent-2"}),
+        ):
+            messages = messaging.list_messages("c1", user_id="agent-2")
+
+        self.assertEqual(messages[0].sender_id, "agent-1")
+
+    def test_fetch_events_projects_helpdesk_sender_for_end_users(self):
+        with (
+            patch.object(
+                messaging,
+                "_ddb_fetch_events",
+                return_value=[
+                    {
+                        "event_id": "e1",
+                        "type": "message:new",
+                        "conversation_id": "c1",
+                        "payload": {
+                            "message": {
+                                "conversation_id": "c1",
+                                "message_id": "m1",
+                                "sender_id": "agent-1",
+                            }
+                        },
+                    }
+                ],
+            ),
+            patch.object(
+                messaging,
+                "_get_message_or_404",
+                return_value={
+                    "conversation_id": "c1",
+                    "message_id": "m1",
+                    "sender_id": "agent-1",
+                    "created_at": 10,
+                    "kind": "text",
+                    "text": "hello",
+                    "reactions": {},
+                },
+            ),
+            patch.object(
+                messaging,
+                "_get_conversation_or_404",
+                return_value={"routing_mode": "helpdesk_bridge", "routing_group_id": "helpdesk-l1"},
+            ),
+            patch.object(messaging, "_is_helpdesk_group_member", side_effect=lambda gid, uid: uid == "agent-1"),
+        ):
+            resp = messaging.fetch_events(user_id="customer-1")
+
+        self.assertEqual(
+            resp["events"][0]["payload"]["message"]["sender_id"],
+            messaging.HELPDESK_MASKED_SENDER_ID,
+        )
 
 
     def test_send_text_message_success_records_usage_once(self):
@@ -2624,7 +2659,11 @@ def test_fetch_events_projects_helpdesk_sender_for_end_users(self):
         tbl_views = Mock()
         with (
             patch.object(messaging, "require_participant_active"),
-            patch.object(messaging, "_get_message_or_404"),
+            patch.object(
+                messaging,
+                "_get_message_or_404",
+                return_value={"message_id": "m1", "sender_id": "other-user", "kind": "text"},
+            ),
             patch.object(messaging, "tbl_views", tbl_views),
             patch.object(messaging, "fanout_event_to_conversation"),
             patch.object(messaging, "now_ts", return_value=10),

--- a/tests/test_mfa_service.py
+++ b/tests/test_mfa_service.py
@@ -7,9 +7,10 @@ from app.services import mfa
 def test_send_email_code_logs_code_in_dev_mode(monkeypatch):
     ses_mock = Mock()
     logger_mock = Mock()
-    monkeypatch.setattr(mfa, "S", SimpleNamespace(dev_mode=True, ses_from_email="noreply@example.com"))
+    monkeypatch.setattr(mfa, "S", SimpleNamespace(dev_mode=True, ses_from_email="noreply@example.com", dev_email_log=None))
     monkeypatch.setattr(mfa, "ses", ses_mock)
     monkeypatch.setattr(mfa, "logger", logger_mock)
+    monkeypatch.setattr(mfa, "_write_dev_log", lambda *a, **kw: None)
 
     mfa.send_email_code("user@example.com", "Registration", "123456")
 
@@ -19,13 +20,14 @@ def test_send_email_code_logs_code_in_dev_mode(monkeypatch):
         "Registration",
         "123456",
     )
-    ses_mock.send_email.assert_called_once()
+    ses_mock.send_email.assert_not_called()
 
 
 def test_send_email_code_prints_code_to_stderr_in_dev_mode(monkeypatch, capsys):
     ses_mock = Mock()
-    monkeypatch.setattr(mfa, "S", SimpleNamespace(dev_mode=True, ses_from_email="noreply@example.com"))
+    monkeypatch.setattr(mfa, "S", SimpleNamespace(dev_mode=True, ses_from_email="noreply@example.com", dev_email_log=None))
     monkeypatch.setattr(mfa, "ses", ses_mock)
+    monkeypatch.setattr(mfa, "_write_dev_log", lambda *a, **kw: None)
 
     mfa.send_email_code("user@example.com", "Registration", "123456")
 

--- a/tests/test_project_models.py
+++ b/tests/test_project_models.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from pydantic import ValidationError
+
+from app.models import ProjectModel, TrackedFileModel
+from app.services.projects_store import (
+    project_from_item,
+    project_to_item,
+    tracked_file_from_item,
+    tracked_file_to_item,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class TestProjectModel(unittest.TestCase):
+    def test_project_model_normalizes_tags_and_serializes(self):
+        ts = _now_iso()
+        model = ProjectModel(
+            id="proj-1",
+            owner="user-1",
+            name=" Project One ",
+            description="  A sample project  ",
+            tags=["Tag", "tag", "  analytics ", ""],
+            settings={"theme": "dark"},
+            created_at=ts,
+            updated_at=ts,
+        )
+
+        self.assertEqual(model.tags, ["tag", "analytics"])
+        self.assertEqual(model.description, "A sample project")
+
+        item = project_to_item(model)
+        roundtrip = project_from_item(item)
+        self.assertEqual(roundtrip.model_dump(), model.model_dump())
+
+    def test_project_model_requires_tz_aware_iso_timestamps(self):
+        with self.assertRaises(ValidationError):
+            ProjectModel(
+                id="proj-1",
+                owner="user-1",
+                name="Project",
+                created_at="2026-01-01T00:00:00",
+                updated_at="2026-01-01T00:00:00",
+            )
+
+
+class TestTrackedFileModel(unittest.TestCase):
+    def test_tracked_file_model_serialization(self):
+        ts = _now_iso()
+        model = TrackedFileModel(
+            id="tf-1",
+            project_id="proj-1",
+            owner="user-1",
+            provider="LOCAL",
+            provider_ref="  /docs/a.txt ",
+            display_path="/docs/a.txt",
+            status="active",
+            metadata={"size": 42},
+            created_at=ts,
+            updated_at=ts,
+            last_seen_at=ts,
+        )
+
+        self.assertEqual(model.provider, "local")
+        self.assertEqual(model.provider_ref, "/docs/a.txt")
+
+        item = tracked_file_to_item(model)
+        self.assertEqual(item["GSI1SK"], "PROVIDER_REF#local#/docs/a.txt")
+        roundtrip = tracked_file_from_item(item)
+        self.assertEqual(roundtrip.model_dump(), model.model_dump())
+
+    def test_tracked_file_archived_status_sets_archived_at(self):
+        ts = _now_iso()
+        model = TrackedFileModel(
+            id="tf-2",
+            project_id="proj-1",
+            owner="user-1",
+            provider="local",
+            provider_ref="/docs/b.txt",
+            display_path="/docs/b.txt",
+            status="archived",
+            metadata={},
+            created_at=ts,
+            updated_at=ts,
+        )
+        self.assertIsNotNone(model.archived_at)
+
+    def test_tracked_file_rejects_invalid_provider(self):
+        ts = _now_iso()
+        with self.assertRaises(ValidationError):
+            TrackedFileModel(
+                id="tf-3",
+                project_id="proj-1",
+                owner="user-1",
+                provider="Bad Provider!",
+                provider_ref="/docs/c.txt",
+                display_path="/docs/c.txt",
+                status="active",
+                metadata={},
+                created_at=ts,
+                updated_at=ts,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_policy.py
+++ b/tests/test_project_policy.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.routers import projects
+
+
+class TestProjectPolicy(unittest.TestCase):
+    def _collect_dependency_calls(self, deps):
+        calls = []
+        stack = list(deps)
+        while stack:
+            dep = stack.pop()
+            calls.append(getattr(dep, "call", None))
+            stack.extend(getattr(dep, "dependencies", []) or [])
+        return calls
+
+    def test_all_projects_routes_require_current_user_dependency(self):
+        for route in projects.router.routes:
+            calls = self._collect_dependency_calls(route.dependant.dependencies)
+            self.assertIn(
+                projects._current_user,
+                calls,
+                f"Route {route.path} ({route.methods}) is missing _current_user auth dependency",
+            )
+
+    def test_project_scoped_endpoints_block_non_owner_access(self):
+        with (
+            patch.object(projects, "get_project", side_effect=HTTPException(status_code=404, detail="project not found")),
+            patch.object(projects, "update_project", side_effect=HTTPException(status_code=404, detail="project not found")),
+            patch.object(projects, "delete_project", side_effect=HTTPException(status_code=404, detail="project not found")),
+            patch.object(projects, "add_tracked_file", side_effect=HTTPException(status_code=404, detail="project not found")),
+            patch.object(projects, "list_tracked_files", side_effect=HTTPException(status_code=404, detail="project not found")),
+            patch.object(projects, "remove_tracked_file", side_effect=HTTPException(status_code=404, detail="project not found")),
+            patch.object(projects, "get_project_detail", side_effect=HTTPException(status_code=404, detail="project not found")),
+            patch.object(projects, "list_project_events", side_effect=HTTPException(status_code=404, detail="project not found")),
+        ):
+            with self.assertRaises(HTTPException) as get_err:
+                projects.get_project_route("p-other", user="user-1")
+            with self.assertRaises(HTTPException) as update_err:
+                projects.update_project_route("p-other", projects.ProjectUpdateIn(name="x"), user="user-1")
+            with self.assertRaises(HTTPException) as delete_err:
+                projects.delete_project_route("p-other", user="user-1")
+            with self.assertRaises(HTTPException) as add_err:
+                projects.add_tracked_file_route(
+                    "p-other",
+                    projects.TrackedFileCreateIn(provider="local", provider_ref="/docs/a.txt"),
+                    user="user-1",
+                )
+            with self.assertRaises(HTTPException) as list_err:
+                projects.list_tracked_files_route("p-other", cursor=None, user="user-1")
+            with self.assertRaises(HTTPException) as remove_err:
+                projects.remove_tracked_file_route("p-other", "tf-1", user="user-1")
+            with self.assertRaises(HTTPException) as detail_err:
+                projects.get_project_detail_route("p-other", cursor=None, user="user-1")
+            with self.assertRaises(HTTPException) as events_err:
+                projects.list_project_events_route("p-other", cursor=None, user="user-1")
+
+        for exc in (
+            get_err.exception,
+            update_err.exception,
+            delete_err.exception,
+            add_err.exception,
+            list_err.exception,
+            remove_err.exception,
+            detail_err.exception,
+            events_err.exception,
+        ):
+            self.assertEqual(exc.status_code, 404)
+            self.assertEqual(exc.detail, "project not found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_routes.py
+++ b/tests/test_project_routes.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.main import create_app
+from app.routers import projects
+
+
+def _ctx(user: str = "user-1"):
+    return {"user_sub": user, "session_id": "sid"}
+
+
+class TestProjectRoutes(unittest.TestCase):
+    def test_create_project_route(self):
+        body = projects.ProjectCreateIn(name="Project A", tags=["One"], settings={"x": 1})
+        project = SimpleNamespace(
+            model_dump=lambda: {
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Project A",
+                "description": None,
+                "tags": ["one"],
+                "settings": {"x": 1},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        )
+        with patch.object(projects, "create_project", return_value=project) as create_project:
+            out = projects.create_project_route(body, user="user-1")
+        create_project.assert_called_once_with("user-1", "Project A", description=None, tags=["One"], settings={"x": 1})
+        self.assertEqual(out.id, "p1")
+
+    def test_get_project_route_not_found(self):
+        with patch.object(projects, "get_project", side_effect=HTTPException(status_code=404, detail="project not found")):
+            with self.assertRaises(HTTPException) as ctx:
+                projects.get_project_route("missing", user="user-1")
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_list_projects_route_cursor_and_filters(self):
+        item = SimpleNamespace(
+            model_dump=lambda: {
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": ["billing"],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        )
+        with patch.object(projects, "list_projects", return_value={"items": [item], "cursor": {"PK": "OWNER#user-1"}}) as list_projects:
+            out = projects.list_projects_route(limit=10, cursor=None, tag="billing", name_query="alp", user="user-1")
+        list_projects.assert_called_once_with("user-1", limit=10, cursor=None, tag="billing", name_query="alp")
+        self.assertEqual(len(out.items), 1)
+        self.assertIsNotNone(out.cursor)
+
+    def test_list_projects_route_invalid_cursor(self):
+        with self.assertRaises(HTTPException) as ctx:
+            projects.list_projects_route(limit=10, cursor="not-base64", user="user-1")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "invalid cursor")
+
+    def test_update_project_route(self):
+        body = projects.ProjectUpdateIn(name="New")
+        project = SimpleNamespace(
+            model_dump=lambda: {
+                "id": "p1",
+                "owner": "user-1",
+                "name": "New",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            }
+        )
+        with patch.object(projects, "update_project", return_value=project) as update_project:
+            out = projects.update_project_route("p1", body, user="user-1")
+        update_project.assert_called_once_with("user-1", "p1", name="New", description=None, tags=None, settings=None)
+        self.assertEqual(out.name, "New")
+
+
+    def test_add_tracked_file_route(self):
+        body = projects.TrackedFileCreateIn(provider="local", provider_ref="/docs/a.txt")
+        tracked = SimpleNamespace(
+            model_dump=lambda: {
+                "id": "tf-1",
+                "project_id": "p1",
+                "owner": "user-1",
+                "provider": "local",
+                "provider_ref": "/docs/a.txt",
+                "display_path": "/docs/a.txt",
+                "status": "active",
+                "metadata": {"size": 1},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "last_seen_at": "2026-01-01T00:00:00+00:00",
+                "archived_at": None,
+            }
+        )
+        with patch.object(projects, "add_tracked_file", return_value=tracked) as add_tracked_file:
+            out = projects.add_tracked_file_route("p1", body, user="user-1")
+        add_tracked_file.assert_called_once_with("user-1", "p1", provider="local", provider_ref="/docs/a.txt", display_path=None, metadata={})
+        self.assertEqual(out.id, "tf-1")
+
+    def test_add_tracked_file_route_missing_file(self):
+        body = projects.TrackedFileCreateIn(provider="local", provider_ref="/docs/missing.txt")
+        with patch.object(projects, "add_tracked_file", side_effect=HTTPException(status_code=404, detail="tracked file target not found")):
+            with self.assertRaises(HTTPException) as ctx:
+                projects.add_tracked_file_route("p1", body, user="user-1")
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_add_tracked_file_route_forbidden_project(self):
+        body = projects.TrackedFileCreateIn(provider="local", provider_ref="/docs/a.txt")
+        with patch.object(projects, "add_tracked_file", side_effect=HTTPException(status_code=404, detail="project not found")):
+            with self.assertRaises(HTTPException) as ctx:
+                projects.add_tracked_file_route("other-users-project", body, user="user-1")
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+
+    def test_add_tracked_file_route_duplicate_provider_ref(self):
+        body = projects.TrackedFileCreateIn(provider="local", provider_ref="/docs/a.txt")
+        with patch.object(projects, "add_tracked_file", side_effect=HTTPException(status_code=409, detail="tracked file already exists for provider_ref")):
+            with self.assertRaises(HTTPException) as ctx:
+                projects.add_tracked_file_route("p1", body, user="user-1")
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    def test_remove_tracked_file_route_idempotent(self):
+        with patch.object(projects, "remove_tracked_file", return_value={"ok": True, "deleted": False}) as remove_tracked_file:
+            out = projects.remove_tracked_file_route("p1", "tf-1", user="user-1")
+        remove_tracked_file.assert_called_once_with("user-1", "p1", "tf-1")
+        self.assertTrue(out.ok)
+        self.assertFalse(out.deleted)
+
+
+    def test_get_project_detail_route_returns_display_rows(self):
+        result = {
+            "project": SimpleNamespace(model_dump=lambda: {
+                "id": "p1", "owner": "user-1", "name": "Alpha", "description": None,
+                "tags": [], "settings": {}, "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00"
+            }),
+            "files": [
+                {
+                    "id": "tf-1",
+                    "project_id": "p1",
+                    "owner": "user-1",
+                    "provider": "local",
+                    "provider_ref": "/docs/a.txt",
+                    "display_path": "/docs/a.txt",
+                    "status": "active",
+                    "metadata": {"size": 10},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                    "last_seen_at": "2026-01-01T00:00:00+00:00",
+                    "archived_at": None,
+                }
+            ],
+            "cursor": None,
+        }
+        with patch.object(projects, "get_project_detail", return_value=result) as get_project_detail:
+            out = projects.get_project_detail_route("p1", cursor=None, user="user-1")
+        get_project_detail.assert_called_once()
+        self.assertEqual(out.project.id, "p1")
+        self.assertEqual(len(out.files), 1)
+        self.assertEqual(out.files[0].display_path, "/docs/a.txt")
+
+    def test_list_project_events_route(self):
+        result = {
+            "items": [
+                SimpleNamespace(model_dump=lambda: {
+                    "id": "e1",
+                    "project_id": "p1",
+                    "owner": "user-1",
+                    "event_type": "file_added",
+                    "tracked_file_id": "tf-1",
+                    "provider": "local",
+                    "provider_ref": "/docs/a.txt",
+                    "message": None,
+                    "metadata": {"display_path": "/docs/a.txt"},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                })
+            ],
+            "cursor": {"PK": "PROJECT#p1", "SK": "EVENT#x"},
+        }
+        with patch.object(projects, "list_project_events", return_value=result) as list_project_events:
+            out = projects.list_project_events_route("p1", limit=10, cursor=None, user="user-1")
+        list_project_events.assert_called_once_with("user-1", "p1", limit=10, cursor=None)
+        self.assertEqual(len(out.items), 1)
+        self.assertEqual(out.items[0].event_type, "file_added")
+        self.assertIsNotNone(out.cursor)
+
+    def test_upsert_provider_credential_route(self):
+        body = projects.ProviderCredentialUpsertIn(
+            token="token",
+            required_scopes=["repo"],
+            api_base_url="https://ghe.local/api/v3",
+        )
+        stored = SimpleNamespace(
+            provider="github",
+            org=None,
+            scopes=["repo"],
+            metadata={"login": "octocat"},
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+        with patch.object(projects, "upsert_provider_credential", return_value=stored) as upsert_provider_credential:
+            out = projects.upsert_provider_credential_route("github", body, user="user-1")
+        upsert_provider_credential.assert_called_once_with(
+            "user-1",
+            "github",
+            "token",
+            org=None,
+            required_scopes=["repo"],
+            api_base_url="https://ghe.local/api/v3",
+        )
+        self.assertEqual(out.provider, "github")
+        self.assertEqual(out.scopes, ["repo"])
+
+    def test_get_provider_credential_route(self):
+        stored = SimpleNamespace(
+            provider="gitlab",
+            org="org-1",
+            scopes=["api"],
+            metadata={"active": True},
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+        with patch.object(projects, "get_provider_credential", return_value=stored) as get_provider_credential:
+            out = projects.get_provider_credential_route("gitlab", org="org-1", user="user-1")
+        get_provider_credential.assert_called_once_with("user-1", "gitlab", org="org-1")
+        self.assertEqual(out.provider, "gitlab")
+        self.assertEqual(out.org, "org-1")
+
+    def test_delete_provider_credential_route(self):
+        with patch.object(projects, "delete_provider_credential", return_value={"ok": True, "deleted": True}) as delete_provider_credential:
+            out = projects.delete_provider_credential_route("github", org=None, user="user-1")
+        delete_provider_credential.assert_called_once_with("user-1", "github", org=None)
+        self.assertTrue(out.ok)
+        self.assertTrue(out.deleted)
+
+
+    def test_openapi_includes_project_crud_paths(self):
+        app = create_app()
+        schema = app.openapi()
+        self.assertIn("/v1/projects", schema.get("paths", {}))
+        self.assertIn("/v1/projects/{project_id}", schema.get("paths", {}))
+        self.assertIn("/v1/projects/{project_id}/detail", schema.get("paths", {}))
+        self.assertIn("/v1/projects/{project_id}/files", schema.get("paths", {}))
+        self.assertIn("/v1/projects/{project_id}/files/{tracked_file_id}", schema.get("paths", {}))
+        self.assertIn("/v1/projects/{project_id}/events", schema.get("paths", {}))
+        self.assertIn("/v1/projects/providers/{provider}/credentials", schema.get("paths", {}))
+
+    def test_delete_project_route(self):
+        with patch.object(projects, "delete_project", return_value={"ok": True}) as delete_project:
+            out = projects.delete_project_route("p1", user="user-1")
+        delete_project.assert_called_once_with("user-1", "p1")
+        self.assertTrue(out.ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_projects_contract_drift.py
+++ b/tests/test_projects_contract_drift.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SWAGGER_PATH = Path("docs/swagger.json")
+
+
+def test_projects_contract_paths_and_schemas_present() -> None:
+    assert SWAGGER_PATH.exists(), "Canonical OpenAPI source missing: docs/swagger.json"
+    spec = json.loads(SWAGGER_PATH.read_text())
+
+    paths = spec.get("paths", {})
+    assert "/v1/projects" in paths
+    assert "/v1/projects/{project_id}" in paths
+    assert "/v1/projects/{project_id}/files" in paths
+    assert "/v1/projects/{project_id}/files/{tracked_file_id}" in paths
+    assert "/v1/projects/{project_id}/detail" in paths
+    assert "/v1/projects/{project_id}/events" in paths
+    assert "/v1/projects/providers/{provider}/credentials" in paths
+
+    schemas = spec.get("components", {}).get("schemas", {})
+    assert "ProjectOut" in schemas
+    assert "ProjectListOut" in schemas
+    assert "ProjectDetailOut" in schemas
+    assert "TrackedFileOut" in schemas
+    assert "TrackedFileListOut" in schemas
+    assert "ProjectEventOut" in schemas
+    assert "ProjectEventListOut" in schemas
+    assert "ProviderCredentialOut" in schemas

--- a/tests/test_projects_reconcile.py
+++ b/tests/test_projects_reconcile.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+from app.services import projects_reconcile
+
+
+class TestProjectsReconcile(unittest.TestCase):
+    def _tracked_item(self, *, status: str = "active", owner: str = "user-1", tracked_id: str = "tf-1"):
+        return {
+            "entity_type": "tracked_file",
+            "id": tracked_id,
+            "project_id": "p1",
+            "owner": owner,
+            "provider": "local",
+            "provider_ref": "/docs/a.txt",
+            "display_path": "/docs/a.txt",
+            "status": status,
+            "metadata": {"saved": 1},
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "last_seen_at": "2026-01-01T00:00:00+00:00",
+            "archived_at": None,
+        }
+
+    def _project_item(self, *, owner: str = "user-1", project_id: str = "p1"):
+        return {
+            "entity_type": "project",
+            "id": project_id,
+            "owner": owner,
+            "name": "Alpha",
+            "description": None,
+            "tags": [],
+            "settings": {},
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }
+
+    def test_reconcile_marks_missing_when_provider_target_absent(self):
+        table = MagicMock()
+        table.scan.return_value = {"Items": [self._tracked_item(status="active")], "LastEvaluatedKey": None}
+        table.get_item.return_value = {"Item": self._project_item()}
+
+        provider = MagicMock()
+        provider.resolve.return_value = "/docs/a.txt"
+        provider.exists.return_value = False
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        with (
+            patch.object(projects_reconcile, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_reconcile, "now_iso", return_value="2026-01-02T00:00:00+00:00"),
+            patch.object(projects_reconcile, "emit_project_event") as emit_project_event,
+            patch.object(projects_reconcile, "record_provider_latency") as record_provider_latency,
+            patch.object(projects_reconcile, "record_provider_failure_streak") as record_provider_failure_streak,
+        ):
+            out = projects_reconcile.reconcile_tracked_files_batch(registry=registry, sleep_fn=lambda _: None)
+
+        self.assertEqual(out["checked"], 1)
+        self.assertEqual(out["missing"], 1)
+        self.assertEqual(out["errors"], 0)
+        put_item = table.put_item.call_args.kwargs["Item"]
+        self.assertEqual(put_item["status"], "missing")
+        self.assertEqual(put_item["last_seen_at"], "2026-01-01T00:00:00+00:00")
+        emit_project_event.assert_called_once()
+        self.assertEqual(emit_project_event.call_args.args[2], "sync_ran")
+        record_provider_latency.assert_called_once()
+        record_provider_failure_streak.assert_called_with("local", 0)
+
+    def test_reconcile_marks_active_and_refreshes_metadata_when_present(self):
+        table = MagicMock()
+        table.scan.return_value = {"Items": [self._tracked_item(status="missing")], "LastEvaluatedKey": None}
+        table.get_item.return_value = {"Item": self._project_item()}
+
+        provider = MagicMock()
+        provider.resolve.return_value = "/docs/a.txt"
+        provider.exists.return_value = True
+        provider.get_metadata.return_value = {"size": 42}
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        with (
+            patch.object(projects_reconcile, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_reconcile, "now_iso", return_value="2026-01-03T00:00:00+00:00"),
+            patch.object(projects_reconcile, "emit_project_event") as emit_project_event,
+            patch.object(projects_reconcile, "record_provider_latency") as record_provider_latency,
+            patch.object(projects_reconcile, "record_provider_failure_streak") as record_provider_failure_streak,
+        ):
+            out = projects_reconcile.reconcile_tracked_files_batch(registry=registry, sleep_fn=lambda _: None)
+
+        self.assertEqual(out["updated"], 1)
+        put_item = table.put_item.call_args.kwargs["Item"]
+        self.assertEqual(put_item["status"], "active")
+        self.assertEqual(put_item["last_seen_at"], "2026-01-03T00:00:00+00:00")
+        self.assertEqual(put_item["metadata"]["saved"], 1)
+        self.assertEqual(put_item["metadata"]["size"], 42)
+        emit_project_event.assert_called_once()
+        self.assertEqual(emit_project_event.call_args.args[2], "sync_ran")
+        record_provider_latency.assert_called_once()
+        record_provider_failure_streak.assert_called_with("local", 0)
+
+    def test_reconcile_retries_transient_provider_error_with_backoff(self):
+        table = MagicMock()
+        table.scan.return_value = {"Items": [self._tracked_item(status="active")], "LastEvaluatedKey": None}
+        table.get_item.return_value = {"Item": self._project_item()}
+
+        provider = MagicMock()
+        provider.resolve.return_value = "/docs/a.txt"
+        provider.exists.side_effect = [HTTPException(status_code=503, detail="busy"), True]
+        provider.get_metadata.return_value = {"size": 9}
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        sleeps: list[float] = []
+
+        with (
+            patch.object(projects_reconcile, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_reconcile, "now_iso", return_value="2026-01-03T00:00:00+00:00"),
+            patch.object(projects_reconcile, "emit_project_event") as emit_project_event,
+            patch.object(projects_reconcile, "record_provider_latency") as record_provider_latency,
+            patch.object(projects_reconcile, "record_provider_failure_streak") as record_provider_failure_streak,
+        ):
+            out = projects_reconcile.reconcile_tracked_files_batch(
+                registry=registry,
+                sleep_fn=lambda value: sleeps.append(value),
+                max_attempts=2,
+                base_backoff_seconds=0.1,
+            )
+
+        self.assertEqual(out["errors"], 0)
+        self.assertEqual(out["updated"], 1)
+        self.assertEqual(sleeps, [0.1])
+        emit_project_event.assert_called_once()
+        self.assertEqual(emit_project_event.call_args.args[2], "sync_ran")
+        record_provider_latency.assert_called_once()
+        record_provider_failure_streak.assert_called_with("local", 0)
+
+    def test_reconcile_continues_across_projects_when_one_errors(self):
+        table = MagicMock()
+        table.scan.return_value = {
+            "Items": [
+                self._tracked_item(tracked_id="tf-1", owner="user-1"),
+                self._tracked_item(tracked_id="tf-2", owner="user-2"),
+            ],
+            "LastEvaluatedKey": None,
+        }
+        table.get_item.side_effect = [
+            {"Item": self._project_item(owner="user-1")},
+            {"Item": self._project_item(owner="user-2")},
+        ]
+
+        provider_ok = MagicMock()
+        provider_ok.resolve.return_value = "/docs/a.txt"
+        provider_ok.exists.return_value = True
+        provider_ok.get_metadata.return_value = {"size": 11}
+
+        provider_error = MagicMock()
+        provider_error.resolve.return_value = "/docs/a.txt"
+        provider_error.exists.side_effect = RuntimeError("boom")
+
+        registry = MagicMock()
+        registry.get.side_effect = [provider_ok, provider_error]
+
+        with (
+            patch.object(projects_reconcile, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_reconcile, "now_iso", return_value="2026-01-03T00:00:00+00:00"),
+            patch.object(projects_reconcile, "emit_project_event") as emit_project_event,
+            patch.object(projects_reconcile, "record_provider_latency") as record_provider_latency,
+            patch.object(projects_reconcile, "record_reconcile_failure") as record_reconcile_failure,
+            patch.object(projects_reconcile, "record_provider_failure_streak") as record_provider_failure_streak,
+            patch.object(projects_reconcile, "record_provider_failure_alert") as record_provider_failure_alert,
+            patch.object(
+                projects_reconcile,
+                "S",
+                SimpleNamespace(
+                    projects_provider_failure_alert_threshold=2,
+                    projects_reconcile_scan_limit=200,
+                    projects_reconcile_max_attempts=3,
+                    projects_reconcile_backoff_seconds=0.2,
+                ),
+            ),
+        ):
+            out = projects_reconcile.reconcile_tracked_files_batch(registry=registry, sleep_fn=lambda _: None)
+
+        self.assertEqual(out["checked"], 2)
+        self.assertEqual(out["updated"], 1)
+        self.assertEqual(out["errors"], 1)
+        self.assertEqual(table.put_item.call_count, 1)
+        self.assertEqual(emit_project_event.call_count, 2)
+        event_types = [call.args[2] for call in emit_project_event.call_args_list]
+        self.assertIn("sync_ran", event_types)
+        self.assertIn("provider_error", event_types)
+        self.assertEqual(record_provider_latency.call_count, 2)
+        record_reconcile_failure.assert_called_once()
+        self.assertGreaterEqual(record_provider_failure_streak.call_count, 2)
+        record_provider_failure_alert.assert_not_called()
+
+    def test_reconcile_triggers_provider_failure_alert_threshold(self):
+        table = MagicMock()
+        table.scan.return_value = {
+            "Items": [
+                self._tracked_item(tracked_id="tf-1", owner="user-1"),
+                self._tracked_item(tracked_id="tf-2", owner="user-1"),
+            ],
+            "LastEvaluatedKey": None,
+        }
+        table.get_item.return_value = {"Item": self._project_item(owner="user-1")}
+
+        provider_error = MagicMock()
+        provider_error.resolve.return_value = "/docs/a.txt"
+        provider_error.exists.side_effect = RuntimeError("boom")
+
+        registry = MagicMock()
+        registry.get.side_effect = [provider_error, provider_error]
+
+        with (
+            patch.object(projects_reconcile, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_reconcile, "now_iso", return_value="2026-01-03T00:00:00+00:00"),
+            patch.object(projects_reconcile, "emit_project_event"),
+            patch.object(projects_reconcile, "record_provider_latency"),
+            patch.object(projects_reconcile, "record_reconcile_failure"),
+            patch.object(projects_reconcile, "record_provider_failure_streak"),
+            patch.object(projects_reconcile, "record_provider_failure_alert") as record_provider_failure_alert,
+            patch.object(
+                projects_reconcile,
+                "S",
+                SimpleNamespace(
+                    projects_provider_failure_alert_threshold=2,
+                    projects_reconcile_scan_limit=200,
+                    projects_reconcile_max_attempts=3,
+                    projects_reconcile_backoff_seconds=0.2,
+                ),
+            ),
+            patch.object(projects_reconcile, "_PROVIDER_FAILURE_STREAKS", {}),
+        ):
+            out = projects_reconcile.reconcile_tracked_files_batch(registry=registry, sleep_fn=lambda _: None)
+
+        self.assertEqual(out["errors"], 2)
+        record_provider_failure_alert.assert_called_once_with("local")
+
+    def test_reconcile_skips_when_project_owner_scope_is_invalid(self):
+        table = MagicMock()
+        table.scan.return_value = {
+            "Items": [self._tracked_item(status="active", owner="user-1", tracked_id="tf-3")],
+            "LastEvaluatedKey": None,
+        }
+        table.get_item.return_value = {"Item": self._project_item(owner="user-2")}
+
+        provider = MagicMock()
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        with patch.object(projects_reconcile, "T", SimpleNamespace(projects=table)):
+            out = projects_reconcile.reconcile_tracked_files_batch(registry=registry, sleep_fn=lambda _: None)
+
+        self.assertEqual(out["checked"], 1)
+        self.assertEqual(out["skipped"], 1)
+        self.assertEqual(out["updated"], 0)
+        self.assertEqual(out["missing"], 0)
+        self.assertEqual(out["errors"], 0)
+        provider.resolve.assert_not_called()
+        provider.exists.assert_not_called()
+        table.put_item.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_projects_store.py
+++ b/tests/test_projects_store.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+
+from botocore.exceptions import ClientError
+from fastapi import HTTPException
+
+from app.services import projects_store
+
+
+class TestProjectsStoreService(unittest.TestCase):
+    def test_create_project_normalizes_tags_and_settings(self):
+        table = MagicMock()
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)), patch.object(projects_store, "record_project_count_delta") as record_project_count_delta:
+            out = projects_store.create_project(
+                "user-1",
+                " Project Alpha ",
+                description="  desc  ",
+                tags=["A", "a", "  B "],
+                settings={"theme": "dark"},
+            )
+
+        self.assertEqual(out.name, "Project Alpha")
+        self.assertEqual(out.tags, ["a", "b"])
+        self.assertEqual(out.settings, {"theme": "dark"})
+        table.put_item.assert_called_once()
+        record_project_count_delta.assert_called_once_with(1)
+
+    def test_create_project_invalid_payload_returns_400(self):
+        table = MagicMock()
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.create_project("user-1", "", tags=["x"])  # invalid required name
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "invalid project payload")
+
+    def test_get_project_not_found_returns_404(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.get_project("user-1", "proj-1")
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_list_projects_with_filters_and_pagination(self):
+        table = MagicMock()
+        table.query.side_effect = [
+            {
+                "Items": [
+                    {
+                        "entity_type": "project",
+                        "id": "p3",
+                        "owner": "user-1",
+                        "name": "Alpha Security",
+                        "description": None,
+                        "tags": ["security"],
+                        "settings": {},
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                    {
+                        "entity_type": "project",
+                        "id": "p2",
+                        "owner": "user-1",
+                        "name": "Beta Payments",
+                        "description": None,
+                        "tags": ["billing"],
+                        "settings": {},
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                ],
+                "LastEvaluatedKey": {"PK": "OWNER#user-1", "SK": "PROJECT#p2"},
+            },
+            {
+                "Items": [
+                    {
+                        "entity_type": "project",
+                        "id": "p1",
+                        "owner": "user-1",
+                        "name": "Alpha Billing",
+                        "description": None,
+                        "tags": ["billing"],
+                        "settings": {},
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            },
+        ]
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.list_projects("user-1", limit=1, tag="billing", name_query="alpha")
+
+        self.assertEqual(len(out["items"]), 1)
+        self.assertEqual(out["items"][0].id, "p1")
+        self.assertIsNone(out["cursor"])
+        self.assertEqual(table.query.call_count, 2)
+
+    def test_list_projects_invalid_limit_returns_400(self):
+        with self.assertRaises(HTTPException) as ctx:
+            projects_store.list_projects("user-1", limit=0)
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "invalid limit")
+
+    def test_update_project_happy_path(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": "Old",
+                "tags": ["old"],
+                "settings": {"x": 1},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.update_project(
+                "user-1",
+                "p1",
+                name=" New Name ",
+                tags=["Tag", "tag"],
+                settings={"x": 2},
+            )
+
+        self.assertEqual(out.name, "New Name")
+        self.assertEqual(out.tags, ["tag"])
+        self.assertEqual(out.settings, {"x": 2})
+        table.put_item.assert_called_once()
+
+    def test_update_project_invalid_returns_400(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.update_project("user-1", "p1", name="")
+
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_delete_project_updates_project_count_metric(self):
+        table = MagicMock()
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)), patch.object(projects_store, "record_project_count_delta") as record_project_count_delta:
+            out = projects_store.delete_project("user-1", "p1")
+        self.assertTrue(out["ok"])
+        record_project_count_delta.assert_called_once_with(-1)
+
+    def test_delete_project_not_found_returns_404(self):
+        table = MagicMock()
+        table.delete_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": "missing"}},
+            "DeleteItem",
+        )
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.delete_project("user-1", "p1")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertEqual(ctx.exception.detail, "project not found")
+
+
+    def test_put_tracked_file_uses_provider_for_canonicalization(self):
+        table = MagicMock()
+        table.query.return_value = {"Items": []}
+        provider = MagicMock()
+        provider.resolve.return_value = "/docs/a.txt"
+        provider.exists.return_value = True
+        provider.get_metadata.return_value = {"size": 100, "type": "file"}
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        tracked = projects_store.TrackedFileModel(
+            id="tf-1",
+            project_id="p1",
+            owner="user-1",
+            provider="local",
+            provider_ref="docs//a.txt",
+            display_path="/docs/raw.txt",
+            status="active",
+            metadata={"custom": True},
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.put_tracked_file(tracked, registry=registry)
+
+        provider.resolve.assert_called_once_with("docs//a.txt")
+        provider.exists.assert_called_once_with("/docs/a.txt")
+        provider.get_metadata.assert_called_once_with("/docs/a.txt")
+        self.assertEqual(out.provider_ref, "/docs/a.txt")
+        self.assertEqual(out.display_path, "/docs/raw.txt")
+        self.assertEqual(out.metadata["size"], 100)
+        self.assertTrue(out.metadata["custom"])
+        table.put_item.assert_called_once()
+
+    def test_put_tracked_file_missing_target_returns_404(self):
+        table = MagicMock()
+        provider = MagicMock()
+        provider.resolve.return_value = "/docs/missing.txt"
+        provider.exists.return_value = False
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        tracked = projects_store.TrackedFileModel(
+            id="tf-2",
+            project_id="p1",
+            owner="user-1",
+            provider="local",
+            provider_ref="/docs/missing.txt",
+            display_path="/docs/missing.txt",
+            status="active",
+            metadata={},
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.put_tracked_file(tracked, registry=registry)
+
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertEqual(ctx.exception.detail, "tracked file target not found")
+        table.put_item.assert_not_called()
+
+
+    def test_add_tracked_file_enforces_project_scope(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            with self.assertRaises(HTTPException) as ctx:
+                projects_store.add_tracked_file(
+                    "user-1",
+                    "p1",
+                    provider="local",
+                    provider_ref="/docs/a.txt",
+                )
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_list_tracked_files_filters_owner_and_provider(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        table.query.return_value = {
+            "Items": [
+                {
+                    "entity_type": "tracked_file",
+                    "id": "tf-1",
+                    "project_id": "p1",
+                    "owner": "user-1",
+                    "provider": "local",
+                    "provider_ref": "/docs/a.txt",
+                    "display_path": "/docs/a.txt",
+                    "status": "active",
+                    "metadata": {},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                },
+                {
+                    "entity_type": "tracked_file",
+                    "id": "tf-2",
+                    "project_id": "p1",
+                    "owner": "user-2",
+                    "provider": "local",
+                    "provider_ref": "/docs/b.txt",
+                    "display_path": "/docs/b.txt",
+                    "status": "active",
+                    "metadata": {},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                },
+            ]
+        }
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.list_tracked_files("user-1", "p1", provider="local")
+        self.assertEqual(len(out["items"]), 1)
+        self.assertEqual(out["items"][0].id, "tf-1")
+
+    def test_add_and_list_github_tracked_file(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        provider = MagicMock()
+        provider.resolve.return_value = "github://octocat/hello-world/README.md?ref=main"
+        provider.exists.return_value = True
+        provider.get_metadata.return_value = {"type": "file", "size": 10}
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        # uniqueness query for add, then list query
+        table.query.side_effect = [
+            {"Items": []},
+            {
+                "Items": [
+                    {
+                        "entity_type": "tracked_file",
+                        "id": "tf-1",
+                        "project_id": "p1",
+                        "owner": "user-1",
+                        "provider": "github",
+                        "provider_ref": "github://octocat/hello-world/README.md?ref=main",
+                        "display_path": "github://octocat/hello-world/README.md?ref=main",
+                        "status": "active",
+                        "metadata": {"type": "file", "size": 10},
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ]
+            },
+        ]
+
+        with (
+            patch.object(projects_store, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_store, "record_tracked_file_count_delta"),
+            patch.object(projects_store, "emit_project_event"),
+        ):
+            projects_store.add_tracked_file(
+                "user-1",
+                "p1",
+                provider="github",
+                provider_ref="octocat/hello-world/README.md?ref=main",
+                registry=registry,
+            )
+            out = projects_store.list_tracked_files("user-1", "p1", provider="github")
+
+        self.assertEqual(len(out["items"]), 1)
+        self.assertEqual(out["items"][0].provider, "github")
+
+    def test_add_and_list_gitlab_tracked_file(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        provider = MagicMock()
+        provider.resolve.return_value = "gitlab://group/project//README.md?ref=main"
+        provider.exists.return_value = True
+        provider.get_metadata.return_value = {"type": "file", "size": 12}
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        table.query.side_effect = [
+            {"Items": []},
+            {
+                "Items": [
+                    {
+                        "entity_type": "tracked_file",
+                        "id": "tf-2",
+                        "project_id": "p1",
+                        "owner": "user-1",
+                        "provider": "gitlab",
+                        "provider_ref": "gitlab://group/project//README.md?ref=main",
+                        "display_path": "gitlab://group/project//README.md?ref=main",
+                        "status": "active",
+                        "metadata": {"type": "file", "size": 12},
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ]
+            },
+        ]
+
+        with (
+            patch.object(projects_store, "T", SimpleNamespace(projects=table)),
+            patch.object(projects_store, "record_tracked_file_count_delta"),
+            patch.object(projects_store, "emit_project_event"),
+        ):
+            projects_store.add_tracked_file(
+                "user-1",
+                "p1",
+                provider="gitlab",
+                provider_ref="group/project//README.md?ref=main",
+                registry=registry,
+            )
+            out = projects_store.list_tracked_files("user-1", "p1", provider="gitlab")
+
+        self.assertEqual(len(out["items"]), 1)
+        self.assertEqual(out["items"][0].provider, "gitlab")
+
+    def test_remove_tracked_file_is_idempotent(self):
+        table = MagicMock()
+        table.get_item.side_effect = [
+            {
+                "Item": {
+                    "entity_type": "project",
+                    "id": "p1",
+                    "owner": "user-1",
+                    "name": "Alpha",
+                    "description": None,
+                    "tags": [],
+                    "settings": {},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+            {},
+        ]
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.remove_tracked_file("user-1", "p1", "missing")
+        self.assertTrue(out["ok"])
+        self.assertFalse(out["deleted"])
+        table.put_item.assert_not_called()
+
+    def test_add_tracked_file_emits_file_added_event(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        table.query.return_value = {"Items": []}
+        provider = MagicMock()
+        provider.resolve.return_value = "/docs/a.txt"
+        provider.exists.return_value = True
+        provider.get_metadata.return_value = {"size": 3}
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)), patch.object(projects_store, "record_tracked_file_count_delta") as record_tracked_file_count_delta:
+            projects_store.add_tracked_file(
+                "user-1",
+                "p1",
+                provider="local",
+                provider_ref="/docs/a.txt",
+                registry=registry,
+            )
+
+        self.assertGreaterEqual(table.put_item.call_count, 2)
+        event_item = table.put_item.call_args_list[1].kwargs["Item"]
+        self.assertEqual(event_item["entity_type"], "project_event")
+        self.assertEqual(event_item["event_type"], "file_added")
+        record_tracked_file_count_delta.assert_called_once_with(1)
+
+    def test_remove_tracked_file_emits_file_removed_event(self):
+        table = MagicMock()
+        table.get_item.side_effect = [
+            {
+                "Item": {
+                    "entity_type": "project",
+                    "id": "p1",
+                    "owner": "user-1",
+                    "name": "Alpha",
+                    "description": None,
+                    "tags": [],
+                    "settings": {},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+            {
+                "Item": {
+                    "entity_type": "tracked_file",
+                    "id": "tf-1",
+                    "project_id": "p1",
+                    "owner": "user-1",
+                    "provider": "local",
+                    "provider_ref": "/docs/a.txt",
+                    "display_path": "/docs/a.txt",
+                    "status": "active",
+                    "metadata": {},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        ]
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)), patch.object(projects_store, "record_tracked_file_count_delta") as record_tracked_file_count_delta:
+            out = projects_store.remove_tracked_file("user-1", "p1", "tf-1")
+
+        self.assertTrue(out["deleted"])
+        self.assertGreaterEqual(table.put_item.call_count, 2)
+        event_item = table.put_item.call_args_list[1].kwargs["Item"]
+        self.assertEqual(event_item["entity_type"], "project_event")
+        self.assertEqual(event_item["event_type"], "file_removed")
+        record_tracked_file_count_delta.assert_called_once_with(-1)
+
+    def test_list_project_events_paginates(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        table.query.return_value = {
+            "Items": [
+                {
+                    "entity_type": "project_event",
+                    "id": "e1",
+                    "project_id": "p1",
+                    "owner": "user-1",
+                    "event_type": "sync_ran",
+                    "metadata": {"status": "active"},
+                    "created_at": "2026-01-02T00:00:00+00:00",
+                }
+            ],
+            "LastEvaluatedKey": {"PK": "PROJECT#p1", "SK": "EVENT#x"},
+        }
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.list_project_events("user-1", "p1", limit=10)
+
+        self.assertEqual(len(out["items"]), 1)
+        self.assertEqual(out["items"][0].event_type, "sync_ran")
+        self.assertEqual(out["cursor"], {"PK": "PROJECT#p1", "SK": "EVENT#x"})
+
+
+    def test_get_project_detail_hydrates_metadata_and_missing_fallback(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "project",
+                "id": "p1",
+                "owner": "user-1",
+                "name": "Alpha",
+                "description": None,
+                "tags": [],
+                "settings": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        table.query.return_value = {
+            "Items": [
+                {
+                    "entity_type": "tracked_file",
+                    "id": "tf-1",
+                    "project_id": "p1",
+                    "owner": "user-1",
+                    "provider": "local",
+                    "provider_ref": "docs//a.txt",
+                    "display_path": "/docs/a.txt",
+                    "status": "active",
+                    "metadata": {"custom": True},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                    "last_seen_at": "2026-01-01T00:00:00+00:00",
+                },
+                {
+                    "entity_type": "tracked_file",
+                    "id": "tf-2",
+                    "project_id": "p1",
+                    "owner": "user-1",
+                    "provider": "local",
+                    "provider_ref": "/docs/missing.txt",
+                    "display_path": "/docs/missing.txt",
+                    "status": "active",
+                    "metadata": {"saved": 1},
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                    "last_seen_at": "2026-01-01T00:00:00+00:00",
+                },
+            ]
+        }
+        provider = MagicMock()
+        provider.resolve.side_effect = ["/docs/a.txt", "/docs/missing.txt"]
+        provider.exists.side_effect = [True, False]
+        provider.get_metadata.return_value = {"size": 9, "type": "file"}
+        registry = MagicMock()
+        registry.get.return_value = provider
+
+        with patch.object(projects_store, "T", SimpleNamespace(projects=table)):
+            out = projects_store.get_project_detail("user-1", "p1", registry=registry)
+
+        self.assertEqual(out["project"].id, "p1")
+        self.assertEqual(len(out["files"]), 2)
+        self.assertEqual(out["files"][0]["provider_ref"], "/docs/a.txt")
+        self.assertEqual(out["files"][0]["metadata"]["size"], 9)
+        self.assertEqual(out["files"][1]["status"], "missing")
+        self.assertEqual(out["files"][1]["metadata"]["saved"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_credentials.py
+++ b/tests/test_provider_credentials.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+from app.services import provider_credentials
+
+
+class TestProviderCredentials(unittest.TestCase):
+    def test_upsert_encrypts_token_at_rest(self):
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"X-OAuth-Scopes": "repo, read:user"}
+        response.content = b"1"
+        response.json.return_value = {"login": "octocat", "id": 1}
+
+        with (
+            patch.object(provider_credentials, "T", SimpleNamespace(projects=table)),
+            patch.object(provider_credentials.requests, "get", return_value=response),
+            patch.object(provider_credentials, "kms_encrypt", return_value="ciphertext") as kms_encrypt,
+        ):
+            out = provider_credentials.upsert_provider_credential(
+                "user-1",
+                "github",
+                "ghp_token",
+                required_scopes=["repo"],
+            )
+
+        self.assertEqual(out.token_ct_b64, "ciphertext")
+        kms_encrypt.assert_called_once_with("ghp_token")
+        stored = table.put_item.call_args.kwargs["Item"]
+        self.assertEqual(stored["token_ct_b64"], "ciphertext")
+        self.assertNotIn("ghp_token", str(stored))
+        self.assertEqual(stored["metadata"]["api_base_url"], "https://api.github.com")
+
+    def test_validate_github_token_uses_enterprise_api_base_url(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"X-OAuth-Scopes": "repo"}
+        response.content = b"1"
+        response.json.return_value = {"login": "octocat", "id": 1}
+
+        with patch.object(provider_credentials.requests, "get", return_value=response) as requests_get:
+            out = provider_credentials.validate_provider_token(
+                "github",
+                "ghp_token",
+                required_scopes=["repo"],
+                api_base_url="https://ghe.local/api/v3",
+            )
+
+        self.assertEqual(out["metadata"]["api_base_url"], "https://ghe.local/api/v3")
+        requests_get.assert_called_once()
+        self.assertTrue(requests_get.call_args.args[0].startswith("https://ghe.local/api/v3"))
+
+    def test_validate_gitlab_token_uses_self_hosted_api_base_url(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {}
+        response.content = b"1"
+        response.json.return_value = {"id": 7, "active": True, "expires_at": None, "scopes": ["read_api"]}
+
+        with patch.object(provider_credentials.requests, "get", return_value=response) as requests_get:
+            out = provider_credentials.validate_provider_token(
+                "gitlab",
+                "glpat_token",
+                required_scopes=["read_api"],
+                api_base_url="https://gitlab.local/api/v4",
+            )
+
+        self.assertEqual(out["metadata"]["api_base_url"], "https://gitlab.local/api/v4")
+        self.assertTrue(requests_get.call_args.args[0].startswith("https://gitlab.local/api/v4"))
+
+    def test_missing_scope_returns_actionable_400(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"X-OAuth-Scopes": "read:user"}
+        response.content = b"1"
+        response.json.return_value = {"login": "octocat", "id": 1}
+
+        with patch.object(provider_credentials.requests, "get", return_value=response):
+            with self.assertRaises(HTTPException) as ctx:
+                provider_credentials.validate_provider_token("github", "ghp_token", required_scopes=["repo"])
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("missing required scopes", ctx.exception.detail)
+
+    def test_invalid_token_returns_actionable_401(self):
+        response = MagicMock()
+        response.status_code = 401
+        response.content = b""
+
+        with patch.object(provider_credentials.requests, "get", return_value=response):
+            with self.assertRaises(HTTPException) as ctx:
+                provider_credentials.validate_provider_token("gitlab", "badtoken")
+
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertIn("invalid/expired", ctx.exception.detail)
+
+    def test_get_provider_token_decrypts_and_validates_required_scopes(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "entity_type": "provider_credential",
+                "owner": "user-1",
+                "provider": "github",
+                "org": None,
+                "token_ct_b64": "ciphertext",
+                "scopes": ["repo"],
+                "metadata": {},
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+
+        with (
+            patch.object(provider_credentials, "T", SimpleNamespace(projects=table)),
+            patch.object(provider_credentials, "kms_decrypt", return_value=b"clear-token") as kms_decrypt,
+        ):
+            token = provider_credentials.get_provider_token("user-1", "github", required_scopes=["repo"])
+
+        self.assertEqual(token, "clear-token")
+        kms_decrypt.assert_called_once_with("ciphertext")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -129,7 +129,7 @@ class TestRegisterRoutes(unittest.TestCase):
 
     def test_register_start_duplicate_user(self):
         req = build_request()
-        with patch.object(register, "_cognito_available", return_value=True),              patch.object(register, "_require_cognito"),              patch.object(register, "check_password_breach", return_value=0),              patch.object(register, "cognito_sign_up", side_effect=HTTPException(400, "Exists")),              patch.object(register, "record_lockout_failure") as record_lockout_failure,              patch.object(register, "enforce_lockout") as enforce_lockout,              patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery,              patch.object(register, "audit_event") as audit_event:
+        with patch.object(register, "_cognito_available", return_value=True),              patch.object(register, "_require_cognito"),              patch.object(register, "check_password_breach", return_value=0),              patch.object(register, "cognito_sign_up", side_effect=HTTPException(409, "Exists")),              patch.object(register, "record_lockout_failure") as record_lockout_failure,              patch.object(register, "enforce_lockout") as enforce_lockout,              patch.object(register, "rate_limit_password_recovery") as rate_limit_password_recovery,              patch.object(register, "audit_event") as audit_event:
             result = run_async(register.register_start(
                 req,
                 RegisterStartReq(
@@ -338,7 +338,7 @@ class TestRegisterRoutes(unittest.TestCase):
 
     def test_register_start_is_generic_on_signup_failure(self):
         req = build_request()
-        with patch.object(register, "_cognito_available", return_value=True),              patch.object(register, "_require_cognito"),              patch.object(register, "check_password_breach", return_value=0),              patch.object(register, "cognito_sign_up", side_effect=HTTPException(400, "Exists")),              patch.object(register, "record_lockout_failure"):
+        with patch.object(register, "_cognito_available", return_value=True),              patch.object(register, "_require_cognito"),              patch.object(register, "check_password_breach", return_value=0),              patch.object(register, "cognito_sign_up", side_effect=HTTPException(409, "Exists")),              patch.object(register, "record_lockout_failure"):
             result = run_async(register.register_start(
                 req,
                 RegisterStartReq(

--- a/tests/test_root_invariant.py
+++ b/tests/test_root_invariant.py
@@ -8,6 +8,14 @@ from app.auth.roles import Role
 from app.core.settings import S
 
 
+@pytest.fixture(autouse=True)
+def restore_root_user_sub():
+    """Restore S.root_user_sub after each test that may mutate it."""
+    original = S.root_user_sub
+    yield
+    object.__setattr__(S, "root_user_sub", original)
+
+
 def test_validate_root_user_sub_config_rejects_missing() -> None:
     object.__setattr__(S, "root_user_sub", "")
     with pytest.raises(RuntimeError):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -201,7 +201,10 @@ class TestUiSessionRoutes(unittest.TestCase):
 
     def test_ui_session_start_rejects_root_subject(self):
         req = build_request()
-        with self.assertRaises(HTTPException) as ctx:
+        with patch.object(ui_session, "S", SimpleNamespace(
+            root_user_sub=ui_session.S.root_user_sub,
+            dev_mode=False,
+        )), self.assertRaises(HTTPException) as ctx:
             run_async(ui_session.ui_session_start(req, UiSessionStartReq(), user_sub=ui_session.S.root_user_sub))
         self.assertEqual(ctx.exception.status_code, 403)
 


### PR DESCRIPTION
## Summary

- **Projects/file-providers layer**: ports the full projects API from `main` — CRUD for projects, tracked files, provider credentials (GitHub, GitLab, Local), and the background reconcile task (`app/routers/projects.py`, `app/services/projects_store.py`, `app/services/projects_reconcile.py`, `app/services/file_providers.py`, `app/services/provider_credentials.py`)
- **Dev-mode stack fixes**: cookie-based browser auth, local DDB login, mock SES/Twilio/S3/PayPal sinks, dev-mode guards in ui_session, filemanager, and billing so the app boots and functions without cloud credentials
- **Helpdesk/messaging fixes**: view-once/expiring/PPV messages, scheduled messages, Decimal serialization in audit events, masked sender projection
- **Test isolation**: 23 pre-existing test failures fixed — `object.__setattr__` mutations to the global `S` singleton were leaking across test modules; fixed with `autouse` fixtures and try/finally save-restore patterns
- **New tests**: 78 new project-layer tests in `tests/test_filemanager_projects.py`; fixed `test_messaging_routes.py` indentation bug that prevented collection

## Test plan

- [x] 1026 tests pass locally (`pytest tests/`)
- [x] Fixed `FakeBillingTable` key rename (`user_sub` → `pk`)
- [x] Fixed `test_auth_cognito.py` Cognito settings leak across tests
- [x] Fixed `test_root_invariant.py` / `test_auth_roles.py` `root_user_sub` leak across tests
- [x] Fixed dev-mode guards: `ui_session` root rejection, `filemanager` metadata check, `billing.list_subscriptions` Stripe bypass
- [x] Fixed `api_metering_contract` to exclude `/mock` S3 routes with `{key:path}` params
- [x] `docs/swagger.json` regenerated to include all project routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)