### PR TITLE
Newsfeed: add markdown and rich-text content model, validation, rendering, and migration tooling

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -379,6 +379,13 @@ class Settings:
     api_usage_rate_limit_counts_toward_quota: bool = os.environ.get("API_USAGE_RATE_LIMIT_COUNTS_TOWARD_QUOTA", "true").lower() in ("1", "true", "yes", "on")
     api_usage_auth_failed_billable: bool = os.environ.get("API_USAGE_AUTH_FAILED_BILLABLE", "false").lower() in ("1", "true", "yes", "on")
     api_usage_auth_failed_counts_toward_quota: bool = os.environ.get("API_USAGE_AUTH_FAILED_COUNTS_TOWARD_QUOTA", "true").lower() in ("1", "true", "yes", "on")
+
+
+    # Newsfeed rich-content validation
+    newsfeed_content_max_plain_chars: int = int(os.environ.get("NEWSFEED_CONTENT_MAX_PLAIN_CHARS", "10000"))
+    newsfeed_content_max_markdown_chars: int = int(os.environ.get("NEWSFEED_CONTENT_MAX_MARKDOWN_CHARS", "20000"))
+    newsfeed_content_max_rich_nodes: int = int(os.environ.get("NEWSFEED_CONTENT_MAX_RICH_NODES", "500"))
+    newsfeed_content_max_rich_depth: int = int(os.environ.get("NEWSFEED_CONTENT_MAX_RICH_DEPTH", "20"))
     api_usage_pricing_catalog: str = os.environ.get("API_USAGE_PRICING_CATALOG", "")
     api_usage_default_pricing_catalog_version: str = os.environ.get("API_USAGE_DEFAULT_PRICING_CATALOG_VERSION", "v1")
     api_usage_pricing_missing_route_behavior: str = os.environ.get("API_USAGE_PRICING_MISSING_ROUTE_BEHAVIOR", "default_route")
@@ -406,6 +413,10 @@ class Settings:
     api_entitlement_low_balance_thresholds: str = os.environ.get("API_ENTITLEMENT_LOW_BALANCE_THRESHOLDS", "0.2,0.1,0.05")
     api_entitlement_near_cap_thresholds: str = os.environ.get("API_ENTITLEMENT_NEAR_CAP_THRESHOLDS", "0.8,0.9,0.95")
 
+
+    # Newsfeed rich-content feature flags
+    newsfeed_markdown_enabled: bool = os.environ.get("NEWSFEED_MARKDOWN_ENABLED", "false").lower() in ("1", "true", "yes", "on")
+    newsfeed_richtext_enabled: bool = os.environ.get("NEWSFEED_RICHTEXT_ENABLED", "false").lower() in ("1", "true", "yes", "on")
 
     # Messaging feature flags
     messaging_encrypted_messages_enabled: bool = os.environ.get("MESSAGING_ENCRYPTED_MESSAGES_ENABLED", "false").lower() == "true"

--- a/app/routers/newsfeed.py
+++ b/app/routers/newsfeed.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
+from html import escape
 import os
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Annotated, Any, Dict, List, Literal, Optional, Set
+from typing import Annotated, Any, Dict, List, Literal, Optional, Set, Tuple
 
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, File, Header, HTTPException, Query, Request, UploadFile
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from starlette.responses import StreamingResponse
 
 from app.core.aws import ddb
@@ -44,6 +46,18 @@ sqs = sqs_client() if EVENTS_SQS_URL else None
 
 router = APIRouter(tags=["newsfeed"])
 logger = logging.getLogger(__name__)
+
+
+def _emit_newsfeed_content_metric(event: str, **fields: Any) -> None:
+    logger.info("newsfeed content metric", extra={"event": event, **fields})
+
+
+def _emit_newsfeed_content_reject(reason_code: str, *, source: str, body_format: Optional[str] = None) -> None:
+    logger.warning(
+        "newsfeed content reject",
+        extra={"event": "newsfeed_content_reject", "source": source, "reason_code": reason_code, "body_format": body_format or "unknown"},
+    )
+
 
 
 # -----------------------------
@@ -360,12 +374,345 @@ class Attachment(BaseModel):
     url: Optional[str] = None
 
 
-class CreatePostRequest(BaseModel):
-    body: str
+BodyFormat = Literal["plain", "markdown", "rich"]
+
+ALLOWED_MARKDOWN_HTML_TAGS: Set[str] = {"p", "br", "strong", "em", "code", "pre", "blockquote", "ul", "ol", "li", "a"}
+ALLOWED_MARKDOWN_HTML_ATTRS: Dict[str, Set[str]] = {"a": {"href", "rel", "target"}}
+ALLOWED_MARKDOWN_URL_PROTOCOLS: Set[str] = {"https", "mailto"}
+
+ALLOWED_RICH_NODE_TYPES: Set[str] = {
+    "doc", "paragraph", "text", "heading", "blockquote", "bulletList", "orderedList", "listItem", "codeBlock", "hardBreak",
+}
+ALLOWED_RICH_MARK_TYPES: Set[str] = {"bold", "italic", "code", "link"}
+ALLOWED_RICH_NODE_ATTRS: Dict[str, Set[str]] = {
+    "heading": {"level"},
+}
+ALLOWED_RICH_MARK_ATTRS: Dict[str, Set[str]] = {
+    "link": {"href", "title", "target", "rel"},
+}
+
+
+def _is_safe_rich_link_url(url: str) -> bool:
+    return _is_safe_markdown_url(url)
+
+
+def _raise_rich_schema_error(reason_code: str, message: str) -> None:
+    logger.warning("newsfeed rich schema validation failed", extra={"reason_code": reason_code, "detail": message})
+    raise ValueError(f"invalid_content_schema:{reason_code}: {message}")
+
+
+def _validate_rich_node_or_error(node: Any, *, path: str = "doc") -> int:
+    if not isinstance(node, dict):
+        _raise_rich_schema_error("node_not_object", f"{path} must be a JSON object")
+
+    node_type = node.get("type")
+    if not isinstance(node_type, str):
+        _raise_rich_schema_error("node_missing_type", f"{path}.type must be a string")
+    if node_type not in ALLOWED_RICH_NODE_TYPES:
+        _raise_rich_schema_error("unsupported_node_type", f"{path}.type '{node_type}' is not allowed")
+    if node_type in {"html", "raw", "rawHtml", "script"}:
+        _raise_rich_schema_error("raw_html_not_allowed", f"{path}.type '{node_type}' is not allowed")
+
+    attrs = node.get("attrs")
+    if attrs is not None:
+        if not isinstance(attrs, dict):
+            _raise_rich_schema_error("invalid_node_attrs", f"{path}.attrs must be an object")
+        allowed_attrs = ALLOWED_RICH_NODE_ATTRS.get(node_type, set())
+        extra_attrs = set(attrs.keys()) - allowed_attrs
+        if extra_attrs:
+            _raise_rich_schema_error("unsupported_node_attr", f"{path}.attrs contains unsupported keys: {sorted(extra_attrs)}")
+
+    if node_type == "text":
+        if not isinstance(node.get("text"), str):
+            _raise_rich_schema_error("invalid_text_node", f"{path}.text must be a string")
+
+    marks = node.get("marks")
+    if marks is not None:
+        if not isinstance(marks, list):
+            _raise_rich_schema_error("invalid_marks", f"{path}.marks must be an array")
+        for i, mark in enumerate(marks):
+            mark_path = f"{path}.marks[{i}]"
+            if not isinstance(mark, dict):
+                _raise_rich_schema_error("mark_not_object", f"{mark_path} must be an object")
+            mark_type = mark.get("type")
+            if mark_type not in ALLOWED_RICH_MARK_TYPES:
+                _raise_rich_schema_error("unsupported_mark_type", f"{mark_path}.type '{mark_type}' is not allowed")
+            mark_attrs = mark.get("attrs")
+            if mark_attrs is not None:
+                if not isinstance(mark_attrs, dict):
+                    _raise_rich_schema_error("invalid_mark_attrs", f"{mark_path}.attrs must be an object")
+                allowed_mark_attrs = ALLOWED_RICH_MARK_ATTRS.get(mark_type, set())
+                extra_mark_attrs = set(mark_attrs.keys()) - allowed_mark_attrs
+                if extra_mark_attrs:
+                    _raise_rich_schema_error("unsupported_mark_attr", f"{mark_path}.attrs contains unsupported keys: {sorted(extra_mark_attrs)}")
+                if mark_type == "link" and "href" in mark_attrs and not _is_safe_rich_link_url(str(mark_attrs.get("href") or "")):
+                    _raise_rich_schema_error("unsafe_link_protocol", f"{mark_path}.attrs.href uses a blocked protocol")
+
+    children = node.get("content")
+    count = 1
+    if children is not None:
+        if not isinstance(children, list):
+            _raise_rich_schema_error("invalid_content_children", f"{path}.content must be an array")
+        for idx, child in enumerate(children):
+            count += _validate_rich_node_or_error(child, path=f"{path}.content[{idx}]")
+    return count
+
+
+def _is_safe_markdown_url(url: str) -> bool:
+    candidate = (url or "").strip()
+    if not candidate or any(ch in candidate for ch in ['"', "'", " ", "\n", "\r", "\t"]):
+        return False
+    parsed = urlparse(candidate)
+    scheme = (parsed.scheme or "").lower()
+    if not (scheme and scheme in ALLOWED_MARKDOWN_URL_PROTOCOLS):
+        return False
+    if scheme == "https" and not parsed.netloc:
+        return False
+    if scheme == "mailto" and not parsed.path:
+        return False
+    return True
+
+
+def _sanitize_markdown_inline(text: str) -> str:
+    safe = escape(text or "")
+    safe = re.sub(r"`([^`]+)`", lambda m: f"<code>{m.group(1)}</code>", safe)
+    safe = re.sub(r"\*\*([^*]+)\*\*", lambda m: f"<strong>{m.group(1)}</strong>", safe)
+    safe = re.sub(r"\*([^*]+)\*", lambda m: f"<em>{m.group(1)}</em>", safe)
+
+    def _link_sub(match: re.Match[str]) -> str:
+        label = match.group(1)
+        href = match.group(2).strip()
+        if not _is_safe_markdown_url(href):
+            _emit_newsfeed_content_reject("unsafe_link_protocol", source="markdown_sanitizer", body_format="markdown")
+            return label
+        return f'<a href="{escape(href, quote=True)}" rel="nofollow noopener noreferrer" target="_blank">{label}</a>'
+
+    safe = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _link_sub, safe)
+    return safe
+
+
+def render_markdown_sanitized_html(markdown_text: str) -> str:
+    text = (markdown_text or "").strip()
+    if not text:
+        return ""
+
+    lines = text.splitlines()
+    html_parts: List[str] = []
+    in_ul = False
+    in_ol = False
+
+    def _close_lists() -> None:
+        nonlocal in_ul, in_ol
+        if in_ul:
+            html_parts.append("</ul>")
+            in_ul = False
+        if in_ol:
+            html_parts.append("</ol>")
+            in_ol = False
+
+    for raw in lines:
+        line = raw.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            _close_lists()
+            continue
+
+        if stripped.startswith("- "):
+            if in_ol:
+                html_parts.append("</ol>")
+                in_ol = False
+            if not in_ul:
+                html_parts.append("<ul>")
+                in_ul = True
+            html_parts.append(f"<li>{_sanitize_markdown_inline(stripped[2:].strip())}</li>")
+            continue
+
+        if re.match(r"^\d+\.\s+", stripped):
+            if in_ul:
+                html_parts.append("</ul>")
+                in_ul = False
+            if not in_ol:
+                html_parts.append("<ol>")
+                in_ol = True
+            item_text = re.sub(r"^\d+\.\s+", "", stripped, count=1)
+            html_parts.append(f"<li>{_sanitize_markdown_inline(item_text)}</li>")
+            continue
+
+        _close_lists()
+        if stripped.startswith(">"):
+            html_parts.append(f"<blockquote>{_sanitize_markdown_inline(stripped[1:].strip())}</blockquote>")
+            continue
+        html_parts.append(f"<p>{_sanitize_markdown_inline(stripped)}</p>")
+
+    _close_lists()
+    return "".join(html_parts)
+
+
+def _content_limit_int(name: str, default: int) -> int:
+    raw = getattr(S, name, default)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = default
+    return value if value > 0 else default
+
+
+def _content_max_plain_chars() -> int:
+    return _content_limit_int("newsfeed_content_max_plain_chars", 10000)
+
+
+def _content_max_markdown_chars() -> int:
+    return _content_limit_int("newsfeed_content_max_markdown_chars", 20000)
+
+
+def _content_max_rich_nodes() -> int:
+    return _content_limit_int("newsfeed_content_max_rich_nodes", 500)
+
+
+def _content_max_rich_depth() -> int:
+    return _content_limit_int("newsfeed_content_max_rich_depth", 20)
+
+
+def _walk_rich_tree_stats(node: Any, *, depth: int = 1) -> tuple[int, int]:
+    if not isinstance(node, (dict, list)):
+        return (0, depth)
+    if isinstance(node, list):
+        count = 0
+        max_depth = depth
+        for child in node:
+            c_count, c_depth = _walk_rich_tree_stats(child, depth=depth)
+            count += c_count
+            max_depth = max(max_depth, c_depth)
+        return count, max_depth
+
+    count = 1
+    max_depth = depth
+    for child in node.get("content") or []:
+        c_count, c_depth = _walk_rich_tree_stats(child, depth=depth + 1)
+        count += c_count
+        max_depth = max(max_depth, c_depth)
+    return count, max_depth
+
+
+def _validate_rich_schema_or_error(doc: Any) -> None:
+    if not isinstance(doc, dict):
+        _raise_rich_schema_error("root_not_object", "body_rich must be a JSON object")
+    if doc.get("type") != "doc":
+        _raise_rich_schema_error("root_not_doc", "body_rich.type must be 'doc'")
+    content = doc.get("content")
+    if not isinstance(content, list):
+        _raise_rich_schema_error("root_content_not_array", "body_rich.content must be a JSON array")
+
+    node_count = _validate_rich_node_or_error(doc, path="doc")
+    _legacy_node_count, max_depth = _walk_rich_tree_stats(doc)
+    max_nodes = _content_max_rich_nodes()
+    max_allowed_depth = _content_max_rich_depth()
+    if node_count > max_nodes:
+        _raise_rich_schema_error("node_limit_exceeded", f"body_rich node count exceeds max ({max_nodes})")
+    if max_depth > max_allowed_depth:
+        _raise_rich_schema_error("depth_limit_exceeded", f"body_rich depth exceeds max ({max_allowed_depth})")
+
+
+class ContentFieldsMixin(BaseModel):
+    # Legacy compatibility field kept for older clients.
+    body: Optional[str] = None
+    # Canonical content envelope fields.
+    body_plain: Optional[str] = None
+    body_markdown: Optional[str] = None
+    body_markdown_html: Optional[str] = None
+    body_rich: Optional[Dict[str, Any]] = None
+    body_format: Optional[BodyFormat] = None
+    body_version: Optional[int] = Field(default=1, ge=1)
+
+    @model_validator(mode="after")
+    def validate_content_fields(self):
+        has_legacy = bool((self.body or "").strip())
+        has_plain = bool((self.body_plain or "").strip())
+        has_markdown = bool((self.body_markdown or "").strip())
+        has_rich = bool(self.body_rich)
+
+        if not (has_legacy or has_plain or has_markdown or has_rich):
+            raise ValueError("invalid_content_payload: one of body/body_plain/body_markdown/body_rich is required")
+
+        chosen_format = self.body_format or (
+            "rich" if has_rich else "markdown" if has_markdown else "plain"
+        )
+        if chosen_format == "rich" and not has_rich:
+            raise ValueError("invalid_content_payload: body_rich is required when body_format is rich")
+        if chosen_format == "markdown" and not has_markdown:
+            raise ValueError("invalid_content_payload: body_markdown is required when body_format is markdown")
+
+        if chosen_format == "markdown" and not bool(getattr(S, "newsfeed_markdown_enabled", False)):
+            _emit_newsfeed_content_reject("markdown_feature_disabled", source="validator", body_format="markdown")
+            raise ValueError("feature_disabled: markdown format is disabled")
+        if chosen_format == "rich" and not bool(getattr(S, "newsfeed_richtext_enabled", False)):
+            _emit_newsfeed_content_reject("rich_feature_disabled", source="validator", body_format="rich")
+            raise ValueError("feature_disabled: rich format is disabled")
+
+        if chosen_format == "rich" and not (has_plain or has_legacy):
+            raise ValueError("invalid_content_payload: body_plain (or legacy body) is required when body_rich is provided")
+
+        plain_text = (self.body_plain or self.body or "").strip()
+        markdown_text = (self.body_markdown or "").strip()
+        if plain_text and len(plain_text) > _content_max_plain_chars():
+            raise ValueError(
+                f"invalid_content_payload: body_plain/body exceeds max length ({_content_max_plain_chars()})"
+            )
+        if markdown_text and len(markdown_text) > _content_max_markdown_chars():
+            raise ValueError(
+                f"invalid_content_payload: body_markdown exceeds max length ({_content_max_markdown_chars()})"
+            )
+        if has_rich:
+            _validate_rich_schema_or_error(self.body_rich)
+        return self
+
+
+def _content_from_payload(req: ContentFieldsMixin) -> Dict[str, Any]:
+    body_plain = (req.body_plain or req.body or "").strip()
+    body_markdown = (req.body_markdown or "").strip() or None
+    body_rich = req.body_rich or None
+    body_format: BodyFormat = req.body_format or (
+        "rich" if body_rich else "markdown" if body_markdown else "plain"
+    )
+    if body_format == "markdown" and not body_plain:
+        body_plain = body_markdown or ""
+    body_markdown_html = render_markdown_sanitized_html(body_markdown or "") if body_markdown else None
+    return {
+        "body": body_plain,
+        "body_plain": body_plain,
+        "body_markdown": body_markdown,
+        "body_markdown_html": body_markdown_html,
+        "body_rich": body_rich,
+        "body_format": body_format,
+        "body_version": int(req.body_version or 1),
+    }
+
+
+class CreatePostRequest(ContentFieldsMixin):
     image_urls: List[str] = Field(default_factory=list)
     visibility: Literal["followers", "public"] = "followers"
     unlock_price_cents: Optional[int] = Field(default=None, ge=0)
     file_paths: List[str] = Field(default_factory=list)
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"body": "Legacy plain text post", "visibility": "followers"},
+                {
+                    "body_plain": "Hello world",
+                    "body_markdown": "# Hello world",
+                    "body_format": "markdown",
+                    "body_version": 1,
+                },
+                {
+                    "body_plain": "Hello rich world",
+                    "body_rich": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Hello rich world"}]}]},
+                    "body_format": "rich",
+                    "body_version": 1,
+                },
+            ]
+        }
+    }
 
 
 class PostResponse(BaseModel):
@@ -373,6 +720,12 @@ class PostResponse(BaseModel):
     author_id: str
     created_at: str
     body: str
+    body_plain: Optional[str] = None
+    body_markdown: Optional[str] = None
+    body_markdown_html: Optional[str] = None
+    body_rich: Optional[Dict[str, Any]] = None
+    body_format: BodyFormat = "plain"
+    body_version: int = 1
     image_urls: List[str] = Field(default_factory=list)
     visibility: str
     locked: bool
@@ -381,13 +734,25 @@ class PostResponse(BaseModel):
     comment_count: int = 0
 
 
-class CreateCommentRequest(BaseModel):
-    body: str
+class CreateCommentRequest(ContentFieldsMixin):
     parent_comment_id: Optional[str] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"body": "Legacy plain comment"},
+                {"body_plain": "Item one", "body_markdown": "- Item one", "body_format": "markdown"},
+                {
+                    "body_plain": "Rich comment",
+                    "body_rich": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Rich comment"}]}]},
+                    "body_format": "rich",
+                },
+            ]
+        }
+    }
 
-class EditCommentRequest(BaseModel):
-    body: str
+
+class EditCommentRequest(ContentFieldsMixin):
     expected_version: int = Field(default=1, ge=1)
 
 
@@ -400,6 +765,12 @@ class CommentResponse(BaseModel):
     deleted: bool = False
     parent_comment_id: Optional[str] = None
     body: Optional[str] = None
+    body_plain: Optional[str] = None
+    body_markdown: Optional[str] = None
+    body_markdown_html: Optional[str] = None
+    body_rich: Optional[Dict[str, Any]] = None
+    body_format: BodyFormat = "plain"
+    body_version: int = 1
     version: int = 1
     tip_total_cents: int = 0
 
@@ -417,8 +788,7 @@ class HidePostRequest(BaseModel):
     post_id: str
 
 
-class EditPostRequest(BaseModel):
-    body: str
+class EditPostRequest(ContentFieldsMixin):
     image_urls: Optional[List[str]] = None
 
 
@@ -453,10 +823,83 @@ class PostTipRequest(BaseModel):
 class ReactionRequest(BaseModel):
     emoji: str = Field(..., min_length=1, max_length=10)
 
+class ContentRenderTelemetryRequest(BaseModel):
+    reason: Literal["unsupported_format", "render_exception"]
+    body_format: Optional[str] = None
+    surface: Literal["post", "comment", "unknown"] = "unknown"
+
 
 # -----------------------------
 # Post serialization helper
 # -----------------------------
+def _rich_doc_to_plain_text(doc: Any) -> str:
+    """Best-effort plain text extraction for legacy fallback rendering."""
+    parts: List[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            text = node.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+            for child in node.get("content") or []:
+                walk(child)
+        elif isinstance(node, list):
+            for child in node:
+                walk(child)
+
+    walk(doc)
+    return " ".join(part.strip() for part in parts if part and part.strip()).strip()
+
+
+def _coerce_body_text(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    return None
+
+
+def _resolve_read_body_fields(item: Dict[str, Any]) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[Dict[str, Any]], BodyFormat, int]:
+    """Resolve legacy/new content fields for response serialization with rollout-safe fallbacks."""
+    legacy_body = _coerce_body_text(item.get("body"))
+    body_plain = _coerce_body_text(item.get("body_plain"))
+    body_markdown = _coerce_body_text(item.get("body_markdown"))
+    body_rich = item.get("body_rich") if isinstance(item.get("body_rich"), dict) else None
+    rich_plain = _rich_doc_to_plain_text(body_rich) if body_rich else None
+
+    resolved_plain = body_plain or legacy_body or body_markdown or rich_plain or ""
+    resolved_body = resolved_plain
+
+    body_markdown_html = item.get("body_markdown_html")
+    if not isinstance(body_markdown_html, str) or not body_markdown_html.strip():
+        body_markdown_html = render_markdown_sanitized_html(body_markdown or "") if body_markdown else None
+
+    raw_body_format = item.get("body_format")
+    if raw_body_format in {"plain", "markdown", "rich"}:
+        body_format: BodyFormat = raw_body_format
+    elif body_rich:
+        body_format = "rich"
+    elif body_markdown:
+        body_format = "markdown"
+    else:
+        body_format = "plain"
+
+    markdown_enabled = bool(getattr(S, "newsfeed_markdown_enabled", False))
+    rich_enabled = bool(getattr(S, "newsfeed_richtext_enabled", False))
+
+    if body_format == "rich" and not rich_enabled:
+        body_format = "plain"
+        body_rich = None
+        body_markdown = None
+        body_markdown_html = None
+    elif body_format == "markdown" and not markdown_enabled:
+        body_format = "plain"
+        body_markdown = None
+        body_markdown_html = None
+
+    body_version = int(item.get("body_version") or 1)
+    return resolved_body, resolved_plain or None, body_markdown, body_markdown_html, body_rich, body_format, body_version
+
+
 def _reaction_summaries(reactions_map: Dict, viewer_id: Optional[str] = None):
     """Compute per-emoji counts and the viewer's own reactions from a DDB reactions map."""
     counts: Dict[str, int] = {}
@@ -471,10 +914,8 @@ def _reaction_summaries(reactions_map: Dict, viewer_id: Optional[str] = None):
 
 def _post_to_dict(post: Dict[str, Any], locked_body: bool = False, liked_by_me: bool = False, unlocked: bool = False, viewer_id: Optional[str] = None) -> Dict[str, Any]:
     """Map a raw DDB post item to the FeedPost shape expected by the frontend."""
-    body = post.get("body", "")
-    # Handle legacy dict-format bodies gracefully
-    if isinstance(body, dict):
-        body = "[Content unavailable]"
+    body, body_plain, body_markdown, body_markdown_html, body_rich, body_format, body_version = _resolve_read_body_fields(post)
+
     # Support both old image_url (str) and new image_urls (list)
     image_urls = list(post.get("image_urls") or [])
     if not image_urls and post.get("image_url"):
@@ -482,6 +923,12 @@ def _post_to_dict(post: Dict[str, Any], locked_body: bool = False, liked_by_me: 
     if locked_body:
         body = "[Locked content]"
         image_urls = []
+        body_plain = body
+        body_markdown = None
+        body_markdown_html = None
+        body_rich = None
+        body_format = "plain"
+        body_version = 1
     reactions_map = post.get("reactions") or {}
     reactions_counts, my_reactions = _reaction_summaries(reactions_map, viewer_id)
     post_id = post["post_id"]
@@ -501,6 +948,12 @@ def _post_to_dict(post: Dict[str, Any], locked_body: bool = False, liked_by_me: 
         "created_at": post.get("created_at", ""),
         "updated_at": post.get("updated_at"),
         "body": body,
+        "body_plain": body_plain,
+        "body_markdown": body_markdown,
+        "body_markdown_html": body_markdown_html,
+        "body_rich": body_rich,
+        "body_format": body_format,
+        "body_version": body_version,
         "image_urls": image_urls,
         "file_attachments": file_attachments,
         "visibility": post.get("visibility", "followers"),
@@ -518,11 +971,14 @@ def _post_to_dict(post: Dict[str, Any], locked_body: bool = False, liked_by_me: 
 
 def _comment_to_dict(it: Dict[str, Any]) -> Dict[str, Any]:
     """Map a raw DDB comment item to the FeedComment shape expected by the frontend."""
-    body = it.get("body")
-    if isinstance(body, dict):
-        body = None  # deleted or legacy rich-text; treat as no body
+    body, body_plain, body_markdown, body_markdown_html, body_rich, body_format, _body_version = _resolve_read_body_fields(it)
     if it.get("deleted"):
         body = None
+        body_plain = None
+        body_markdown = None
+        body_markdown_html = None
+        body_rich = None
+        body_format = "plain"
     return {
         "comment_id": it["comment_id"],
         "post_id": it["post_id"],
@@ -532,6 +988,12 @@ def _comment_to_dict(it: Dict[str, Any]) -> Dict[str, Any]:
         "deleted": bool(it.get("deleted")),
         "parent_comment_id": it.get("parent_comment_id"),
         "body": body,
+        "body_plain": body_plain,
+        "body_markdown": body_markdown,
+        "body_markdown_html": body_markdown_html,
+        "body_rich": body_rich,
+        "body_format": body_format,
+        "body_version": _body_version,
         "version": int(it.get("version", 1)),
         "tip_total_cents": int(it.get("tip_total_cents", 0)),
     }
@@ -810,6 +1272,8 @@ def create_post(req: CreatePostRequest, user_id: UserIdDep):
 
     unlock_price_cents = req.unlock_price_cents if req.unlock_price_cents and req.unlock_price_cents > 0 else None
     locked = unlock_price_cents is not None
+    content = _content_from_payload(req)
+    _emit_newsfeed_content_metric("create_post", surface="post", body_format=content.get("body_format", "plain"))
 
     # Validate and collect file attachment metadata (max 5)
     file_attachments = []
@@ -831,7 +1295,7 @@ def create_post(req: CreatePostRequest, user_id: UserIdDep):
         "post_id": post_id,
         "user_id": user_id,
         "created_at": created_at,
-        "body": req.body,
+        **content,
         "image_urls": req.image_urls,
         "visibility": req.visibility,
         "locked": locked,
@@ -859,7 +1323,13 @@ def create_post(req: CreatePostRequest, user_id: UserIdDep):
         post_id=post_id,
         author_id=user_id,
         created_at=created_at,
-        body=req.body,
+        body=content["body"],
+        body_plain=content["body_plain"],
+        body_markdown=content["body_markdown"],
+        body_markdown_html=content["body_markdown_html"],
+        body_rich=content["body_rich"],
+        body_format=content["body_format"],
+        body_version=content["body_version"],
         image_urls=req.image_urls,
         visibility=req.visibility,
         locked=locked,
@@ -876,16 +1346,18 @@ def edit_post(post_id: str, req: EditPostRequest, user_id: UserIdDep):
         raise HTTPException(status_code=404, detail="Post not found")
     if post.get("user_id") != user_id:
         raise HTTPException(status_code=403, detail="Not your post")
+    content = _content_from_payload(req)
+    _emit_newsfeed_content_metric("edit_post", surface="post", body_format=content.get("body_format", "plain"))
     image_urls_in_payload = "image_urls" in req.model_fields_set
     if image_urls_in_payload and req.image_urls:
-        update_expr = "SET #body = :b, image_urls = :imgs, updated_at = :u"
-        expr_vals = {":b": req.body, ":imgs": req.image_urls, ":u": now_iso()}
+        update_expr = "SET #body = :b, body_plain = :bp, body_markdown = :bm, body_markdown_html = :bmh, body_rich = :br, body_format = :bf, body_version = :bv, image_urls = :imgs, updated_at = :u"
+        expr_vals = {":b": content["body"], ":bp": content["body_plain"], ":bm": content["body_markdown"], ":bmh": content["body_markdown_html"], ":br": content["body_rich"], ":bf": content["body_format"], ":bv": content["body_version"], ":imgs": req.image_urls, ":u": now_iso()}
     elif image_urls_in_payload:
-        update_expr = "SET #body = :b, updated_at = :u REMOVE image_urls"
-        expr_vals = {":b": req.body, ":u": now_iso()}
+        update_expr = "SET #body = :b, body_plain = :bp, body_markdown = :bm, body_markdown_html = :bmh, body_rich = :br, body_format = :bf, body_version = :bv, updated_at = :u REMOVE image_urls"
+        expr_vals = {":b": content["body"], ":bp": content["body_plain"], ":bm": content["body_markdown"], ":bmh": content["body_markdown_html"], ":br": content["body_rich"], ":bf": content["body_format"], ":bv": content["body_version"], ":u": now_iso()}
     else:
-        update_expr = "SET #body = :b, updated_at = :u"
-        expr_vals = {":b": req.body, ":u": now_iso()}
+        update_expr = "SET #body = :b, body_plain = :bp, body_markdown = :bm, body_markdown_html = :bmh, body_rich = :br, body_format = :bf, body_version = :bv, updated_at = :u"
+        expr_vals = {":b": content["body"], ":bp": content["body_plain"], ":bm": content["body_markdown"], ":bmh": content["body_markdown_html"], ":br": content["body_rich"], ":bf": content["body_format"], ":bv": content["body_version"], ":u": now_iso()}
     updated = ddb_update_item(
         key={"pk": pk_post(post_id), "sk": sk_post()},
         update_expr=update_expr,
@@ -1332,6 +1804,8 @@ def create_comment(post_id: str, req: CreateCommentRequest, user_id: UserIdDep):
     comment_id = new_id("cmt")
     created_at = now_iso()
     parent = req.parent_comment_id
+    content = _content_from_payload(req)
+    _emit_newsfeed_content_metric("create_comment", surface="comment", body_format=content.get("body_format", "plain"))
 
     item = {
         "pk": pk_post_comments(post_id),
@@ -1344,7 +1818,7 @@ def create_comment(post_id: str, req: CreateCommentRequest, user_id: UserIdDep):
         "updated_at": None,
         "deleted": False,
         "parent_comment_id": parent,
-        "body": req.body,
+        **content,
         "version": 1,
         "tip_total_cents": 0,
         "GSI2PK": pk_post_comments(post_id),
@@ -1398,7 +1872,13 @@ def create_comment(post_id: str, req: CreateCommentRequest, user_id: UserIdDep):
         updated_at=None,
         deleted=False,
         parent_comment_id=parent,
-        body=req.body,
+        body=content["body"],
+        body_plain=content["body_plain"],
+        body_markdown=content["body_markdown"],
+        body_markdown_html=content["body_markdown_html"],
+        body_rich=content["body_rich"],
+        body_format=content["body_format"],
+        body_version=content["body_version"],
         version=1,
         tip_total_cents=0,
     )
@@ -1454,11 +1934,13 @@ def edit_comment(post_id: str, comment_id: str, req: EditCommentRequest, user_id
     key = {"pk": target["pk"], "sk": target["sk"]}
     new_version = int(req.expected_version) + 1
 
+    content = _content_from_payload(req)
+    _emit_newsfeed_content_metric("edit_comment", surface="comment", body_format=content.get("body_format", "plain"))
     updated = ddb_update_item(
         key=key,
-        update_expr="SET #body = :b, updated_at = :u, version = :nv",
+        update_expr="SET #body = :b, body_plain = :bp, body_markdown = :bm, body_markdown_html = :bmh, body_rich = :br, body_format = :bf, body_version = :bv, updated_at = :u, version = :nv",
         expr_names={"#body": "body"},
-        expr_vals={":b": req.body, ":u": now_iso(), ":nv": new_version, ":ev": int(req.expected_version)},
+        expr_vals={":b": content["body"], ":bp": content["body_plain"], ":bm": content["body_markdown"], ":bmh": content["body_markdown_html"], ":br": content["body_rich"], ":bf": content["body_format"], ":bv": content["body_version"], ":u": now_iso(), ":nv": new_version, ":ev": int(req.expected_version)},
         condition_expr="version = :ev",
     )
 
@@ -1470,7 +1952,13 @@ def edit_comment(post_id: str, comment_id: str, req: EditCommentRequest, user_id
         updated_at=updated.get("updated_at"),
         deleted=bool(updated.get("deleted")),
         parent_comment_id=updated.get("parent_comment_id"),
-        body=updated.get("body") if not updated.get("deleted") else None,
+        body=(updated.get("body_plain") or updated.get("body")) if not updated.get("deleted") else None,
+        body_plain=updated.get("body_plain") if not updated.get("deleted") else None,
+        body_markdown=updated.get("body_markdown") if not updated.get("deleted") else None,
+        body_markdown_html=updated.get("body_markdown_html") if not updated.get("deleted") else None,
+        body_rich=updated.get("body_rich") if not updated.get("deleted") else None,
+        body_format=updated.get("body_format") if updated.get("body_format") in {"plain", "markdown", "rich"} else "plain",
+        body_version=int(updated.get("body_version") or 1),
         version=int(updated.get("version", 1)),
         tip_total_cents=int(updated.get("tip_total_cents", 0)),
     )
@@ -1679,6 +2167,13 @@ def list_notifications(
         ExclusiveStartKey=eks if eks else None,
     )
     return {"items": resp.get("Items", []), "next_cursor": encode_cursor(resp.get("LastEvaluatedKey"))}
+
+
+
+@router.post("/telemetry/content-render")
+def content_render_telemetry(req: ContentRenderTelemetryRequest, user_id: UserIdDep):
+    _emit_newsfeed_content_reject(req.reason, source="renderer", body_format=req.body_format)
+    return {"ok": True}
 
 
 # -----------------------------

--- a/docs/newsfeed-markdown-richtext-support-plan.md
+++ b/docs/newsfeed-markdown-richtext-support-plan.md
@@ -1,0 +1,177 @@
+# Newsfeed Markdown + Rich Text Support Plan
+
+## Current baseline
+
+- Post and comment payloads are plain text (`body: string`) in the current API and frontend types.
+- Create/edit UX uses textareas, and renderers display plain text with whitespace preservation.
+- Backend serializers include some legacy handling where `body` might be a dict, but that is not a first-class rich-content contract.
+
+## Goals
+
+- Support **Markdown authoring and rendering**.
+- Support **Rich Text (WYSIWYG) authoring and rendering**.
+- Keep backward compatibility for existing plain-text posts/comments.
+- Ship safely with sanitization, validation, and incremental rollout controls.
+
+## 1) Define a versioned content model
+
+Introduce a content envelope for posts and comments:
+
+- `body_plain: string` (required fallback; used for search/safety/fallback rendering)
+- `body_markdown?: string`
+- `body_rich?: object` (editor-native JSON structure)
+- `body_format: "plain" | "markdown" | "rich"`
+- `body_version: number` (schema version)
+
+Design choice:
+
+- **Markdown canonical** if portability/interoperability is most important.
+- **Rich JSON canonical** if fidelity in WYSIWYG editing is most important.
+
+Either way, always derive and persist `body_plain`.
+
+## 2) Evolve backend contracts with compatibility
+
+For create/edit post and comment endpoints:
+
+- Continue accepting legacy `body: string` requests.
+- Add optional richer payload fields (format + rich/markdown content).
+- Add response fields for richer content while preserving legacy `body`.
+
+Validation rules:
+
+- Max payload size and text length.
+- Allowed format checks and schema validation for rich JSON.
+- Content normalization (trim, canonicalization).
+
+Serializer behavior:
+
+- On read, return content in requested/stored format + fallback plain text.
+- Continue returning legacy `body` during transition.
+
+Locked-content behavior:
+
+- Ensure all format variants are masked consistently for locked posts.
+
+## 3) Security and sanitization hardening
+
+Implement an explicit sanitization pipeline:
+
+- Markdown -> sanitized HTML (strict allowlist of tags/attrs).
+- Rich JSON -> validated node schema (disallow arbitrary/raw HTML nodes by default).
+- URL protocol allowlist (`https`, optional `mailto`) and block dangerous protocols.
+
+Add abuse controls:
+
+- Max nesting depth and node count.
+- Limits for embeds/links/mentions per post/comment.
+
+Add security tests for XSS and injection edge cases.
+
+## 4) Frontend authoring experience (incremental)
+
+Replace/augment textarea flows in:
+
+- Create post
+- Edit post
+- Create comment
+- Edit comment
+
+Phased UI:
+
+1. **Phase A:** Markdown mode with preview toggle.
+2. **Phase B:** Rich-text WYSIWYG mode (toolbar for bold/italic/link/list/code/quote).
+3. **Phase C:** Enhancements (mentions, inline embeds, slash commands).
+
+Fallback behavior:
+
+- If a format is unsupported on client, render `body_plain`.
+
+## 5) Rendering architecture
+
+Create a shared `RichContentRenderer` used for:
+
+- Feed post body
+- Comment body
+
+Responsibilities:
+
+- Render by `body_format` (`plain`, `markdown`, `rich`).
+- Use sanitized output only.
+- Keep typography, spacing, and truncation behavior consistent.
+- Graceful fallback to plain text if parsing/rendering fails.
+
+## 6) Data migration strategy
+
+No hard cutover required:
+
+- Existing records with `body` remain readable as `plain`.
+- On edit by new clients, write new content envelope fields.
+
+Optional backfill:
+
+- Populate derived `body_plain` and `body_format` defaults on legacy rows for analytics/search consistency.
+
+Operational runbook:
+
+- Use `docs/newsfeed-rich-content-migration-runbook.md` for the no-downtime phased rollout (`dual-read`, `dual-write`, `cleanup`) and rollback playbook.
+
+## 7) Testing strategy
+
+Backend:
+
+- Create/edit/get for each content format.
+- Legacy compatibility tests (`body` only).
+- Validation failure tests (bad schema/oversized payload).
+- Sanitization/XSS regression tests.
+- Locked post/comment masking tests.
+
+Frontend:
+
+- Editor input + preview tests.
+- Rendering snapshots for markdown/rich/plain variants.
+- Fallback rendering tests.
+
+E2E:
+
+- Create markdown post/comment and verify rendering.
+- Create rich-text post/comment and verify rendering.
+- Edit preserves formatting.
+- Malicious content does not execute.
+
+## 8) Rollout and observability
+
+Feature flags:
+
+- `newsfeed_markdown_enabled`
+- `newsfeed_richtext_enabled`
+
+Rollout stages:
+
+1. Internal staff only.
+2. Small creator cohort.
+3. Gradual percentage rollout.
+4. Full rollout after stability/security checks.
+
+Metrics and monitoring:
+
+- Adoption by content format.
+- Sanitizer rejection counts and top failure reasons.
+- Renderer error rates.
+- Client-side fallback usage rates.
+
+## 9) Suggested implementation sequence
+
+1. Finalize API/content schema RFC (1-2 days).
+2. Backend model + validation + serializer compatibility (2-4 days).
+3. Markdown editor/render support (2-3 days).
+4. Rich-text editor/render support (4-8 days).
+5. Security hardening and regression test pass (2-4 days).
+6. Feature-flag rollout + telemetry review (ongoing).
+
+## Definition of done
+
+- Legacy plain-text clients continue to work.
+- Markdown and rich-text clients can create/edit/render safely.
+- Sanitization and validation protections are in place and tested.
+- Rollout is controlled by flags with observability dashboards in place.

--- a/docs/newsfeed-markdown-richtext-support-tickets.md
+++ b/docs/newsfeed-markdown-richtext-support-tickets.md
@@ -1,0 +1,312 @@
+# Newsfeed Markdown + Rich Text Implementation Tickets
+
+This backlog translates `docs/newsfeed-markdown-richtext-support-plan.md` into concrete implementation tickets with dependencies and acceptance criteria.
+
+## Conventions
+
+- Priority: `P0` (must-have), `P1` (important), `P2` (nice-to-have)
+- Size: `S` (~0.5–1 day), `M` (~1–3 days), `L` (~3–5 days)
+- Type: `Backend`, `Frontend`, `API`, `Data`, `Security`, `Ops`, `QA`
+
+---
+
+## Epic A — Contracts and Content Model
+
+### NFR-001 — Finalize versioned content envelope for posts/comments
+- **Type:** API / Backend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Define canonical fields for plain, markdown, and rich content while preserving legacy compatibility.
+- **Deliverables:**
+  - Contract update for `body_plain`, `body_markdown`, `body_rich`, `body_format`, `body_version`.
+  - Backward-compatibility policy for `body` legacy string field.
+- **Acceptance criteria:**
+  - Contract examples include `plain`, `markdown`, and `rich` payloads.
+  - Legacy `body: string` request/response compatibility is documented and approved.
+- **Dependencies:** none
+
+### NFR-002 — Implement backend request/response model support
+- **Type:** Backend / API
+- **Priority:** P0
+- **Size:** L
+- **Description:** Extend create/edit/get post and comment models to accept and return rich content fields.
+- **Deliverables:**
+  - Pydantic model updates for post/comment create/edit.
+  - Serialization updates to include format-aware fields and legacy `body`.
+- **Acceptance criteria:**
+  - Existing clients using `body` continue to pass unchanged.
+  - New clients can submit/read markdown and rich payloads.
+- **Dependencies:** NFR-001
+
+### NFR-003 — Add schema/version validation rules
+- **Type:** Backend / Security
+- **Priority:** P0
+- **Size:** M
+- **Description:** Enforce payload limits and schema validity for rich content.
+- **Deliverables:**
+  - Validation for max text length, node depth/count, and allowed `body_format` values.
+  - Error response contract for invalid payloads.
+- **Acceptance criteria:**
+  - Invalid schema payloads return deterministic 4xx errors.
+  - Limits are configurable via settings and covered by tests.
+- **Dependencies:** NFR-001
+
+---
+
+## Epic B — Security and Sanitization
+
+### NFR-101 — Introduce markdown sanitization pipeline
+- **Type:** Security / Backend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Convert markdown to safe renderable output using strict sanitization.
+- **Deliverables:**
+  - Sanitizer allowlist for tags/attributes.
+  - URL protocol policy (`https`, optional `mailto`; block dangerous schemes).
+- **Acceptance criteria:**
+  - Script/event-handler injection attempts are stripped or rejected.
+  - Sanitizer policy is centrally defined and unit-tested.
+- **Dependencies:** NFR-001
+
+### NFR-102 — Validate rich JSON node schema
+- **Type:** Security / Backend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Enforce structural constraints for rich editor JSON payloads.
+- **Deliverables:**
+  - Rich content schema validator.
+  - Rejection path for unsupported node types/attributes.
+- **Acceptance criteria:**
+  - Unsupported/raw HTML nodes are rejected by default.
+  - Validation failures are observable with reason codes.
+- **Dependencies:** NFR-001
+
+### NFR-103 — Locked content masking for all formats
+- **Type:** Backend / Security
+- **Priority:** P0
+- **Size:** S
+- **Description:** Ensure locked posts never leak markdown or rich payloads in responses.
+- **Deliverables:**
+  - Serializer masking for `body_plain`, `body_markdown`, `body_rich` under lock conditions.
+- **Acceptance criteria:**
+  - Locked views expose only placeholder content.
+  - Regression tests prove no format-specific bypass.
+- **Dependencies:** NFR-002
+
+---
+
+## Epic C — Frontend Authoring UX
+
+### NFR-201 — Add markdown editor mode with preview
+- **Type:** Frontend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Replace plain textarea-only flow with markdown mode + preview for create/edit post/comment.
+- **Deliverables:**
+  - Markdown mode toggle and preview panel.
+  - API payload wiring with `body_format = markdown`.
+- **Acceptance criteria:**
+  - Users can compose markdown and preview rendered output before submit.
+  - Existing plain text flow remains available behind fallback.
+- **Dependencies:** NFR-002, NFR-101
+
+### NFR-202 — Add rich-text editor mode (WYSIWYG)
+- **Type:** Frontend
+- **Priority:** P1
+- **Size:** L
+- **Description:** Integrate a rich-text editor supporting core formatting tools.
+- **Deliverables:**
+  - Toolbar actions: bold, italic, links, lists, quote, code.
+  - API payload wiring with `body_format = rich` and structured JSON.
+- **Acceptance criteria:**
+  - Rich content round-trips through create/edit/get without losing structure.
+  - Validation errors are surfaced clearly in the UI.
+- **Dependencies:** NFR-002, NFR-102, NFR-201
+
+### NFR-203 — Format-aware create/edit forms for comments
+- **Type:** Frontend
+- **Priority:** P1
+- **Size:** M
+- **Description:** Bring markdown/rich capabilities to comment create/edit with parity to posts.
+- **Deliverables:**
+  - Updated comment input/edit components.
+  - Compatibility handling for legacy comment bodies.
+- **Acceptance criteria:**
+  - Comment editor supports chosen format and saves correctly.
+  - Existing comments still display/edit safely.
+- **Dependencies:** NFR-201
+
+---
+
+## Epic D — Rendering and Fallbacks
+
+### NFR-301 — Build shared rich content renderer
+- **Type:** Frontend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Implement one renderer used by post cards and comments.
+- **Deliverables:**
+  - `RichContentRenderer` with format switch (`plain`, `markdown`, `rich`).
+  - Typography and spacing standards for feed consistency.
+- **Acceptance criteria:**
+  - Same renderer is used in post and comment surfaces.
+  - Render failures fallback to safe plain text.
+- **Dependencies:** NFR-201, NFR-202
+
+### NFR-302 — Add truncation/expand behavior for long formatted content
+- **Type:** Frontend
+- **Priority:** P1
+- **Size:** S
+- **Description:** Preserve feed readability with expand/collapse support for long rich content.
+- **Deliverables:**
+  - Character/line threshold policy.
+  - Expand/collapse UX and accessibility labels.
+- **Acceptance criteria:**
+  - Truncated content can be expanded without losing formatting.
+  - Collapsed view does not break layout across formats.
+- **Dependencies:** NFR-301
+
+### NFR-303 — Legacy fallback rendering and migration read-path
+- **Type:** Frontend / Backend
+- **Priority:** P0
+- **Size:** S
+- **Description:** Ensure old records and old clients continue to function during rollout.
+- **Deliverables:**
+  - Read-path fallback from format fields to legacy `body`.
+  - Client fallback to `body_plain` when unsupported format encountered.
+- **Acceptance criteria:**
+  - Legacy rows render correctly without migration prerequisites.
+  - No regressions for plain text posts/comments.
+- **Dependencies:** NFR-002, NFR-301
+
+---
+
+## Epic E — Data Migration and Backfill
+
+### NFR-401 — Define no-downtime migration strategy
+- **Type:** Data / Backend
+- **Priority:** P0
+- **Size:** S
+- **Description:** Formalize read/write ordering to avoid cutover downtime.
+- **Deliverables:**
+  - Migration runbook with phases: dual-read, dual-write, cleanup.
+- **Acceptance criteria:**
+  - Plan supports safe deploy with mixed client versions.
+  - Rollback steps are documented.
+- **Dependencies:** NFR-002
+
+### NFR-402 — Optional backfill for derived plain fields
+- **Type:** Data / Ops
+- **Priority:** P2
+- **Size:** M
+- **Description:** Backfill `body_plain` / default `body_format` on older records for consistency.
+- **Deliverables:**
+  - Backfill script and dry-run mode.
+  - Progress metrics + retry behavior.
+- **Acceptance criteria:**
+  - Backfill can run incrementally and idempotently.
+  - Data integrity checks report zero malformed rows.
+- **Dependencies:** NFR-401
+
+---
+
+## Epic F — Testing and Quality Gates
+
+### NFR-501 — Backend test coverage for formats and validation
+- **Type:** QA / Backend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Add unit/integration tests for plain/markdown/rich create-edit-get paths.
+- **Deliverables:**
+  - Tests for valid payloads across formats.
+  - Tests for invalid schema/size/depth and sanitizer rejection.
+- **Acceptance criteria:**
+  - Test suite covers all format combinations and failure paths.
+  - Locked-content masking test cases pass.
+- **Dependencies:** NFR-002, NFR-101, NFR-102, NFR-103
+
+### NFR-502 — Frontend component tests for editor and renderer
+- **Type:** QA / Frontend
+- **Priority:** P1
+- **Size:** M
+- **Description:** Add tests for editor state transitions and renderer output.
+- **Deliverables:**
+  - Tests for markdown preview and rich editor actions.
+  - Snapshot/DOM tests for rendered content and fallback behavior.
+- **Acceptance criteria:**
+  - Core formatting features covered by component tests.
+  - Fallback behavior verified for unsupported/invalid format data.
+- **Dependencies:** NFR-201, NFR-202, NFR-301
+
+### NFR-503 — E2E tests for author and viewer journeys
+- **Type:** QA
+- **Priority:** P1
+- **Size:** M
+- **Description:** Validate end-to-end post/comment create/edit/render behavior for markdown and rich formats.
+- **Deliverables:**
+  - New e2e scenarios for feed post/comment format workflows.
+- **Acceptance criteria:**
+  - Author publish + viewer render passes for markdown and rich.
+  - Malicious payload attempts are rendered safely and do not execute.
+- **Dependencies:** NFR-501, NFR-502
+
+---
+
+## Epic G — Rollout, Flags, and Observability
+
+### NFR-601 — Add feature flags for markdown and rich text
+- **Type:** Backend / Frontend / Ops
+- **Priority:** P0
+- **Size:** S
+- **Description:** Gate features independently for safe rollout.
+- **Deliverables:**
+  - `newsfeed_markdown_enabled`
+  - `newsfeed_richtext_enabled`
+- **Acceptance criteria:**
+  - Flags can be toggled independently per environment.
+  - Disabled flags preserve legacy behavior.
+- **Dependencies:** NFR-002, NFR-201
+
+### NFR-602 — Instrument content-format telemetry
+- **Type:** Ops / Backend / Frontend
+- **Priority:** P1
+- **Size:** S
+- **Description:** Track adoption and failure rates by format.
+- **Deliverables:**
+  - Metrics for create/edit by format.
+  - Validation/sanitization reject counters.
+  - Renderer fallback/error counters.
+- **Acceptance criteria:**
+  - Dashboards show format adoption trend and top errors.
+  - Alerts configured for sanitizer/renderer error spikes.
+- **Dependencies:** NFR-601
+
+### NFR-603 — Execute phased rollout and post-launch review
+- **Type:** Ops / QA
+- **Priority:** P1
+- **Size:** M
+- **Description:** Roll out to internal users, then cohorts, then broad release with checkpoints.
+- **Deliverables:**
+  - Rollout checklist and go/no-go criteria.
+  - Post-launch report with incidents, adoption, and follow-ups.
+- **Acceptance criteria:**
+  - Each phase has explicit success criteria before progression.
+  - Launch review completed with action items tracked.
+- **Dependencies:** NFR-503, NFR-602
+
+---
+
+## Suggested execution order
+
+1. Epic A (contracts/models) + Epic B (security foundations)
+2. Epic C (authoring) + Epic D (rendering/fallback)
+3. Epic F (test hardening)
+4. Epic G (flags/telemetry/rollout)
+5. Epic E optional backfill as needed
+
+## Milestone definition of done
+
+- Markdown and rich text create/edit/render flows work for posts and comments.
+- Legacy plain-text compatibility remains intact.
+- Sanitization and schema validation protections are enforced and tested.
+- Feature-flagged rollout completed with production telemetry and documented sign-off.

--- a/docs/newsfeed-rich-content-contract.md
+++ b/docs/newsfeed-rich-content-contract.md
@@ -1,0 +1,143 @@
+# Newsfeed Rich Content Contract (NFR-001)
+
+This document defines the canonical content envelope for posts/comments and the legacy compatibility policy.
+
+## Canonical envelope
+
+Each post/comment body supports the following fields:
+
+- `body_plain: string` — required fallback/plain representation.
+- `body_markdown?: string` — optional markdown source.
+- `body_rich?: object` — optional rich-text document JSON.
+- `body_format: "plain" | "markdown" | "rich"` — selected source format.
+- `body_version: number` — envelope schema version (current: `1`).
+
+## Legacy compatibility policy
+
+- The legacy `body: string` field remains accepted in create/edit requests.
+- The legacy `body: string` field remains present in responses.
+- For backward compatibility, `body` always maps to the plain fallback representation (`body_plain`).
+- New clients should send the canonical envelope and may continue to include `body` during transition.
+
+## Validation rules (contract level)
+
+- At least one of `body`, `body_plain`, `body_markdown`, `body_rich` must be present.
+- If `body_format = "markdown"`, `body_markdown` is required.
+- If `body_format = "rich"`, `body_rich` is required.
+- If `body_rich` is provided, a plain fallback (`body_plain` or legacy `body`) is required.
+
+---
+
+## Request examples
+
+### 1) Legacy/plain request
+
+```json
+{
+  "body": "Legacy plain text post",
+  "visibility": "followers"
+}
+```
+
+### 2) Markdown request
+
+```json
+{
+  "body_plain": "Hello world",
+  "body_markdown": "# Hello world",
+  "body_format": "markdown",
+  "body_version": 1
+}
+```
+
+### 3) Rich-text request
+
+```json
+{
+  "body_plain": "Hello rich world",
+  "body_rich": {
+    "type": "doc",
+    "content": [
+      {
+        "type": "paragraph",
+        "content": [{ "type": "text", "text": "Hello rich world" }]
+      }
+    ]
+  },
+  "body_format": "rich",
+  "body_version": 1
+}
+```
+
+## Response example
+
+```json
+{
+  "post_id": "post_123",
+  "author_id": "user_abc",
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "body": "Hello world",
+  "body_plain": "Hello world",
+  "body_markdown": "# Hello world",
+  "body_rich": null,
+  "body_format": "markdown",
+  "body_version": 1
+}
+```
+
+
+## Error response contract
+
+Invalid content payloads are rejected with HTTP `422` and deterministic validation message prefixes:
+
+- `invalid_content_payload:` for missing/invalid field combinations and text length limit failures.
+- `invalid_content_schema:` for malformed `body_rich` JSON shape or rich tree constraint failures.
+
+Examples:
+
+- `invalid_content_payload: body_markdown is required when body_format is markdown`
+- `invalid_content_schema: body_rich node count exceeds max (500)`
+
+
+## Markdown sanitization policy
+
+Markdown input is converted to sanitized HTML on write and exposed as `body_markdown_html` in responses.
+
+Allowlist (centrally defined in backend):
+
+- Tags: `p`, `br`, `strong`, `em`, `code`, `pre`, `blockquote`, `ul`, `ol`, `li`, `a`
+- Attributes: `a[href|rel|target]`
+
+URL protocol policy for links:
+
+- Allowed: `https`, `mailto`
+- Blocked/rejected: everything else (including `javascript:`)
+
+Any raw HTML/script/event-handler injection payloads are escaped (rendered as text) or stripped from link rendering.
+
+
+## Rich JSON schema policy
+
+Rich payloads (`body_rich`) are validated against a strict allowlist. By default, unsupported nodes and raw HTML/script-like nodes are rejected.
+
+Allowed node types:
+
+- `doc`, `paragraph`, `text`, `heading`, `blockquote`, `bulletList`, `orderedList`, `listItem`, `codeBlock`, `hardBreak`
+
+Allowed mark types:
+
+- `bold`, `italic`, `code`, `link`
+
+Allowed mark URL protocols:
+
+- `https`, `mailto`
+
+Validation failures include deterministic reason codes in the error message prefix:
+
+- `invalid_content_schema:unsupported_node_type:`
+- `invalid_content_schema:unsupported_node_attr:`
+- `invalid_content_schema:unsafe_link_protocol:`
+- `invalid_content_schema:node_limit_exceeded:`
+- `invalid_content_schema:depth_limit_exceeded:`
+
+Server logs also include `reason_code` for observability.

--- a/docs/newsfeed-rich-content-migration-runbook.md
+++ b/docs/newsfeed-rich-content-migration-runbook.md
@@ -1,0 +1,166 @@
+# Newsfeed Rich Content No-Downtime Migration Runbook
+
+## Purpose
+
+Define a **no-downtime** migration strategy for rolling out the newsfeed rich-content envelope (`body_plain`, `body_markdown`, `body_rich`, `body_format`, `body_version`) while preserving compatibility for legacy rows and mixed client versions.
+
+## Scope
+
+- Posts + comments read/write paths.
+- Backend serializers, request models, and persistence.
+- Frontend clients with mixed release versions.
+- Operational rollback for each phase.
+
+## Compatibility guarantees
+
+- Legacy records containing only `body` remain readable during all phases.
+- Legacy clients sending only `body` remain writable during all phases.
+- New clients can send/read `plain`, `markdown`, and `rich` payloads without requiring a full backfill first.
+
+## Migration phases
+
+## Phase 0 — Preconditions
+
+1. Ensure feature flags are available and defaulted safely:
+   - `newsfeed_markdown_enabled = false`
+   - `newsfeed_richtext_enabled = false`
+2. Deploy backend read-path support that can resolve content from either:
+   - new envelope fields, or
+   - legacy `body` fallback.
+3. Verify dashboards/alerts exist for:
+   - request validation failures,
+   - serializer fallback rates,
+   - client render fallback rates,
+   - 4xx/5xx error changes on post/comment APIs.
+
+Exit criteria:
+- Backend can serve old and new shapes safely before any frontend behavior change.
+
+## Phase 1 — Dual-read (required first deploy)
+
+Behavior:
+- **Read:** Prefer envelope fields when present.
+- **Read fallback:** If envelope fields are missing/partial, fall back to legacy `body` and derive safe plain content.
+- **Write:** Keep current behavior unchanged until Phase 2.
+
+Operational checks:
+- Compare feed render outcomes for legacy-heavy cohorts.
+- Confirm no increase in empty-body responses for old rows.
+
+Rollback:
+- Keep code deployed; disable markdown/rich feature flags if any UI regression appears.
+- Because this phase is read-only behavior expansion, rollback is low-risk and does not require data revert.
+
+## Phase 2 — Dual-write (mixed client safe)
+
+Behavior:
+- Accept both payload styles:
+  - legacy `body`, and
+  - envelope format fields.
+- Persist envelope fields for all writes from new clients.
+- Continue writing/deriving legacy-compatible `body` from `body_plain` for backward compatibility.
+
+Ordering requirements:
+1. Backend dual-read must already be live (Phase 1 complete).
+2. Then enable frontend markdown mode (incremental cohort).
+3. Then enable frontend rich mode (incremental cohort).
+
+Operational checks:
+- Monitor ratio of legacy writes vs envelope writes.
+- Confirm old clients can still create/edit without validation regressions.
+- Confirm new content round-trips (`create -> get -> edit -> get`) across formats.
+
+Rollback:
+- Disable `newsfeed_richtext_enabled` first, then `newsfeed_markdown_enabled` if needed.
+- Keep dual-read enabled; do **not** remove envelope reads during rollback.
+- If needed, hotfix to force serializer output format to plain fallback while preserving stored source fields.
+
+## Phase 3 — Cleanup / convergence (optional, post-stability)
+
+Prerequisites:
+- Sustained stable error budget for at least one release window.
+- Legacy-client traffic below agreed threshold.
+- Migration metrics show acceptable fallback/validation rates.
+
+Actions:
+1. Optional background backfill:
+   - Fill missing `body_plain`/`body_format` for historical rows.
+   - Do not rewrite content semantics; preserve original text.
+2. Keep dual-read permanently (recommended) or deprecate legacy-only paths only after formal API deprecation notice.
+3. Update API docs to mark `body` as legacy compatibility field.
+
+Rollback:
+- Cleanup tasks are reversible by stopping backfill jobs.
+- Do not delete legacy read compatibility until at least one full client upgrade cycle is complete.
+
+## Deployment ordering (safe sequence)
+
+1. Deploy backend with dual-read support.
+2. Deploy backend with dual-write support + validations.
+3. Enable markdown UI for small cohort.
+4. Enable rich-text UI for small cohort.
+5. Ramp cohorts gradually while monitoring.
+6. Execute optional backfill after steady-state.
+
+## Mixed-version matrix (must-pass)
+
+- Old client + old row (`body` only): read/write success.
+- Old client + new row (envelope present): read success via legacy `body`/`body_plain` fallback.
+- New client + old row: read success with derived format fallback.
+- New client + new row: full round-trip by selected format.
+
+## Rollback playbook (quick reference)
+
+1. Freeze rollout (stop cohort expansion).
+2. Disable rich flag.
+3. Disable markdown flag.
+4. Validate legacy post/comment create/edit flows.
+5. Keep backend dual-read and compatibility serializers active.
+6. Triage metrics/log reason codes and patch forward.
+
+## Ownership
+
+- Backend owner: API contract + serializers + validation.
+- Frontend owner: editor mode gating + renderer fallback UX.
+- SRE/on-call owner: rollout gating, alert response, rollback execution.
+
+
+## Optional backfill execution (NFR-402)
+
+Script:
+
+- `scripts/backfill_newsfeed_plain_fields.py`
+
+Recommended run sequence:
+
+1. Dry run (no writes):
+   - `python scripts/backfill_newsfeed_plain_fields.py --dry-run --page-limit 200 --max-items 1000`
+2. Incremental write run:
+   - `python scripts/backfill_newsfeed_plain_fields.py --page-limit 200 --max-items 1000`
+3. Resume until checkpoint reports `done=true`.
+
+Operational behavior:
+
+- **Incremental:** `--max-items` supports bounded batches per run.
+- **Idempotent:** rows already containing matching `body_plain`/`body_format` are skipped (`no_change`).
+- **Retry:** retryable DynamoDB write errors are retried with backoff (`--max-retries`).
+- **Progress metrics:** script reports `scanned`, `eligible`, `updated`, `dry_run_updates`, `no_change`, `malformed`, `errors`, `retries`.
+- **Checkpointing:** progress checkpoint is persisted at `pk=SYSTEM#NEWSFEED_BACKFILL`, `sk=CONTENT#PLAIN_FORMAT`.
+- **Integrity check:** run exits non-zero if malformed rows remain (`integrity.malformed_rows > 0`).
+
+
+## Telemetry and alerting (NFR-602)
+
+Track these metrics in dashboards:
+
+- `newsfeed content metric` events by `event` + `body_format` (`create_post`, `edit_post`, `create_comment`, `edit_comment`) for adoption trend.
+- `newsfeed content reject` events by `source` + `reason_code` for validation/sanitizer/renderer failures.
+
+Recommended alerts:
+
+- Sanitizer/validator reject spike: alert when `source in (markdown_sanitizer, validator)` reject count increases above normal baseline.
+- Renderer fallback/error spike: alert when `source=renderer` reject events (`unsupported_format`, `render_exception`) breach threshold.
+
+Operational note:
+
+- Frontend renderer reports fallback/error events to `POST /telemetry/content-render`; backend emits structured logs that can be charted in dashboard tools.

--- a/frontend/e2e/feed-rich-content.spec.ts
+++ b/frontend/e2e/feed-rich-content.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * NFR-503 — E2E scenarios for newsfeed markdown/rich author + viewer journeys.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import path from "path";
+
+const BASE = "http://localhost:3000";
+const API = "http://localhost:8000";
+const ALICE_ID = "e2e_alice@test.local";
+const BOB_ID = "e2e_bob@test.local";
+
+interface SessionData {
+  user_sub: string;
+  csrf_token: string;
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: "Lax" | "Strict" | "None";
+    expires: number;
+  }>;
+}
+
+let _sessions: Record<string, SessionData> | null = null;
+
+function getSessions(): Record<string, SessionData> {
+  if (!_sessions) {
+    const repoRoot = process.cwd().includes("/frontend") ? path.resolve(process.cwd(), "..") : process.cwd();
+    const setupScript = path.join(repoRoot, "e2e_session_setup.py");
+    const raw = execSync(`python3 ${setupScript}`, { cwd: repoRoot, timeout: 30_000 }).toString();
+    _sessions = JSON.parse(raw);
+  }
+  return _sessions!;
+}
+
+async function injectAuth(page: Page, userId: string) {
+  const session = getSessions()[userId];
+  if (!session) throw new Error(`No session for ${userId}`);
+  await page.context().addCookies(session.cookies);
+  await page.goto(`${BASE}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((uid: string) => {
+    const state = { userId: uid, accessToken: null, isAuthenticated: true };
+    localStorage.setItem("auth-store", JSON.stringify({ state, version: 0 }));
+  }, userId);
+}
+
+async function apiPost(page: Page, userId: string, endpoint: string, data: object) {
+  const session = getSessions()[userId];
+  return page.request.post(`${API}${endpoint}`, {
+    data,
+    headers: { "x-csrf-token": session.csrf_token },
+  });
+}
+
+async function apiPatch(page: Page, userId: string, endpoint: string, data: object) {
+  const session = getSessions()[userId];
+  return page.request.patch(`${API}${endpoint}`, {
+    data,
+    headers: { "x-csrf-token": session.csrf_token },
+  });
+}
+
+async function apiGet(page: Page, userId: string, endpoint: string) {
+  const session = getSessions()[userId];
+  return page.request.get(`${API}${endpoint}`, {
+    headers: { "x-csrf-token": session.csrf_token },
+  });
+}
+
+async function apiDelete(page: Page, userId: string, endpoint: string) {
+  const session = getSessions()[userId];
+  return page.request.delete(`${API}${endpoint}`, {
+    headers: { "x-csrf-token": session.csrf_token },
+  });
+}
+
+test.describe("NFR-503: newsfeed rich content e2e journeys", () => {
+  test("author publish + viewer render for markdown post/comment create-edit-get", async ({ browser }) => {
+    const author = await browser.newPage();
+    const viewer = await browser.newPage();
+    await injectAuth(author, ALICE_ID);
+    await injectAuth(viewer, BOB_ID);
+
+    let postId: string | null = null;
+
+    try {
+      const createPost = await apiPost(author, ALICE_ID, "/posts", {
+        body_plain: "Markdown title",
+        body_markdown: "# Markdown title\n\n- one\n- two",
+        body_format: "markdown",
+        visibility: "followers",
+      });
+      expect(createPost.ok()).toBeTruthy();
+      const created = await createPost.json();
+      postId = created.post_id;
+      expect(created.body_format).toBe("markdown");
+      expect(created.body_markdown).toContain("# Markdown title");
+
+      const createComment = await apiPost(author, ALICE_ID, `/posts/${postId}/comments`, {
+        body_plain: "Markdown comment",
+        body_markdown: "**Markdown comment**",
+        body_format: "markdown",
+      });
+      expect(createComment.ok()).toBeTruthy();
+      const comment = await createComment.json();
+      expect(comment.body_format).toBe("markdown");
+
+      const editPost = await apiPatch(author, ALICE_ID, `/posts/${postId}`, {
+        body_plain: "Markdown title edited",
+        body_markdown: "## Markdown title edited",
+        body_format: "markdown",
+      });
+      expect(editPost.ok()).toBeTruthy();
+
+      const editComment = await apiPatch(author, ALICE_ID, `/posts/${postId}/comments/${comment.comment_id}`, {
+        body_plain: "Markdown comment edited",
+        body_markdown: "*Markdown comment edited*",
+        body_format: "markdown",
+        expected_version: comment.version,
+      });
+      expect(editComment.ok()).toBeTruthy();
+
+      const viewerPost = await apiGet(viewer, BOB_ID, `/posts/${postId}`);
+      expect(viewerPost.ok()).toBeTruthy();
+      const viewerPostJson = await viewerPost.json();
+      expect(viewerPostJson.body_format).toBe("markdown");
+      expect(viewerPostJson.body_markdown).toContain("Markdown title edited");
+
+      const viewerComments = await apiGet(viewer, BOB_ID, `/posts/${postId}/comments`);
+      expect(viewerComments.ok()).toBeTruthy();
+      const viewerCommentsJson = await viewerComments.json();
+      const editedComment = viewerCommentsJson.items.find((c: any) => c.comment_id === comment.comment_id);
+      expect(editedComment).toBeTruthy();
+      expect(editedComment.body_format).toBe("markdown");
+      expect(editedComment.body_markdown).toContain("Markdown comment edited");
+    } finally {
+      if (postId) await apiDelete(author, ALICE_ID, `/posts/${postId}`);
+      await author.close();
+      await viewer.close();
+    }
+  });
+
+  test("author publish + viewer render for rich post/comment create-edit-get", async ({ browser }) => {
+    const author = await browser.newPage();
+    const viewer = await browser.newPage();
+    await injectAuth(author, ALICE_ID);
+    await injectAuth(viewer, BOB_ID);
+
+    let postId: string | null = null;
+
+    try {
+      const richDoc = {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Rich post text" }] }],
+      };
+      const richCommentDoc = {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Rich comment text" }] }],
+      };
+
+      const createPost = await apiPost(author, ALICE_ID, "/posts", {
+        body_plain: "Rich post text",
+        body_rich: richDoc,
+        body_format: "rich",
+        visibility: "followers",
+      });
+      expect(createPost.ok()).toBeTruthy();
+      const created = await createPost.json();
+      postId = created.post_id;
+      expect(created.body_format).toBe("rich");
+      expect(created.body_rich?.type).toBe("doc");
+
+      const createComment = await apiPost(author, ALICE_ID, `/posts/${postId}/comments`, {
+        body_plain: "Rich comment text",
+        body_rich: richCommentDoc,
+        body_format: "rich",
+      });
+      expect(createComment.ok()).toBeTruthy();
+      const comment = await createComment.json();
+
+      const editPostDoc = {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Rich post edited" }] }],
+      };
+      const editPost = await apiPatch(author, ALICE_ID, `/posts/${postId}`, {
+        body_plain: "Rich post edited",
+        body_rich: editPostDoc,
+        body_format: "rich",
+      });
+      expect(editPost.ok()).toBeTruthy();
+
+      const editCommentDoc = {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Rich comment edited" }] }],
+      };
+      const editComment = await apiPatch(author, ALICE_ID, `/posts/${postId}/comments/${comment.comment_id}`, {
+        body_plain: "Rich comment edited",
+        body_rich: editCommentDoc,
+        body_format: "rich",
+        expected_version: comment.version,
+      });
+      expect(editComment.ok()).toBeTruthy();
+
+      const viewerPost = await apiGet(viewer, BOB_ID, `/posts/${postId}`);
+      expect(viewerPost.ok()).toBeTruthy();
+      const viewerPostJson = await viewerPost.json();
+      expect(viewerPostJson.body_format).toBe("rich");
+      expect(viewerPostJson.body_plain).toContain("Rich post edited");
+      expect(viewerPostJson.body_rich?.type).toBe("doc");
+
+      const viewerComments = await apiGet(viewer, BOB_ID, `/posts/${postId}/comments`);
+      expect(viewerComments.ok()).toBeTruthy();
+      const viewerCommentsJson = await viewerComments.json();
+      const editedComment = viewerCommentsJson.items.find((c: any) => c.comment_id === comment.comment_id);
+      expect(editedComment).toBeTruthy();
+      expect(editedComment.body_format).toBe("rich");
+      expect(editedComment.body_plain).toContain("Rich comment edited");
+      expect(editedComment.body_rich?.type).toBe("doc");
+    } finally {
+      if (postId) await apiDelete(author, ALICE_ID, `/posts/${postId}`);
+      await author.close();
+      await viewer.close();
+    }
+  });
+
+  test("malicious payload attempts are sanitized or rejected", async ({ browser }) => {
+    const author = await browser.newPage();
+    const viewer = await browser.newPage();
+    await injectAuth(author, ALICE_ID);
+    await injectAuth(viewer, BOB_ID);
+
+    let postId: string | null = null;
+
+    try {
+      const maliciousMarkdown = '<script>window.__pwned = true</script> [bad](javascript:alert(1)) safe';
+      const createPost = await apiPost(author, ALICE_ID, "/posts", {
+        body_plain: "safe",
+        body_markdown: maliciousMarkdown,
+        body_format: "markdown",
+        visibility: "followers",
+      });
+      expect(createPost.ok()).toBeTruthy();
+      const created = await createPost.json();
+      postId = created.post_id;
+
+      const viewerPost = await apiGet(viewer, BOB_ID, `/posts/${postId}`);
+      expect(viewerPost.ok()).toBeTruthy();
+      const viewerPostJson = await viewerPost.json();
+      expect(viewerPostJson.body_markdown_html).not.toContain("<script>");
+      expect(viewerPostJson.body_markdown_html).not.toContain("javascript:");
+
+      // Ensure UI render does not execute injected script when opening feed route.
+      await viewer.goto(`${BASE}/`, { waitUntil: "domcontentloaded" });
+      await viewer.locator('a[href="/feed"]').first().click();
+      await viewer.waitForTimeout(1200);
+      const pwned = await viewer.evaluate(() => (window as any).__pwned === true);
+      expect(pwned).toBeFalsy();
+
+      const maliciousRich = await apiPost(author, ALICE_ID, "/posts", {
+        body_plain: "x",
+        body_rich: { type: "doc", content: [{ type: "rawHtml", content: [] }] },
+        body_format: "rich",
+      });
+      expect(maliciousRich.ok()).toBeFalsy();
+      expect(maliciousRich.status()).toBeGreaterThanOrEqual(400);
+      expect(maliciousRich.status()).toBeLessThan(500);
+    } finally {
+      if (postId) await apiDelete(author, ALICE_ID, `/posts/${postId}`);
+      await author.close();
+      await viewer.close();
+    }
+  });
+});

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1456,6 +1456,12 @@ export interface FeedPost {
   post_id: string;
   author_id: string;
   body: string;
+  body_plain?: string;
+  body_markdown?: string;
+  body_markdown_html?: string;
+  body_rich?: Record<string, unknown>;
+  body_format?: "plain" | "markdown" | "rich";
+  body_version?: number;
   image_urls?: string[];
   file_attachments?: PostFileAttachment[];
   unlock_price_cents?: number;
@@ -1475,6 +1481,12 @@ export interface FeedComment {
   post_id: string;
   author_id: string;
   body: string;
+  body_plain?: string;
+  body_markdown?: string;
+  body_markdown_html?: string;
+  body_rich?: Record<string, unknown>;
+  body_format?: "plain" | "markdown" | "rich";
+  body_version?: number;
   created_at: string;
   updated_at?: string;
   deleted?: boolean;
@@ -1483,23 +1495,43 @@ export interface FeedComment {
 }
 
 export interface CreatePostReq {
-  body: string;
+  body?: string;
+  body_plain?: string;
+  body_markdown?: string;
+  body_rich?: Record<string, unknown>;
+  body_format?: "plain" | "markdown" | "rich";
+  body_version?: number;
   image_urls?: string[];
   file_paths?: string[];
   unlock_price_cents?: number;
 }
 
 export interface CreateCommentReq {
-  body: string;
+  body?: string;
+  body_plain?: string;
+  body_markdown?: string;
+  body_rich?: Record<string, unknown>;
+  body_format?: "plain" | "markdown" | "rich";
+  body_version?: number;
 }
 
 export interface EditPostReq {
-  body: string;
+  body?: string;
+  body_plain?: string;
+  body_markdown?: string;
+  body_rich?: Record<string, unknown>;
+  body_format?: "plain" | "markdown" | "rich";
+  body_version?: number;
   image_urls?: string[] | null;
 }
 
 export interface EditCommentReq {
-  body: string;
+  body?: string;
+  body_plain?: string;
+  body_markdown?: string;
+  body_rich?: Record<string, unknown>;
+  body_format?: "plain" | "markdown" | "rich";
+  body_version?: number;
 }
 
 export interface HidePostReq {

--- a/frontend/src/lib/featureFlags.ts
+++ b/frontend/src/lib/featureFlags.ts
@@ -38,3 +38,7 @@ export const isMessagingViewOnceImageEnabled = () => isMessagingOnceMediaCompose
 export const isMessagingViewOnceVideoEnabled = () => isMessagingOnceMediaComposerEnabled() && messagingOnceMediaVideoEnabled;
 export const isMessagingListenOnceAudioEnabled = () => isMessagingOnceMediaComposerEnabled() && messagingOnceMediaAudioEnabled;
 
+
+
+export const newsfeedMarkdownEnabled = toBool(env.VITE_NEWSFEED_MARKDOWN_ENABLED, false);
+export const newsfeedRichtextEnabled = toBool(env.VITE_NEWSFEED_RICHTEXT_ENABLED, false);

--- a/frontend/src/lib/newsfeedTelemetry.ts
+++ b/frontend/src/lib/newsfeedTelemetry.ts
@@ -1,0 +1,18 @@
+export function reportNewsfeedRendererEvent(reason: "unsupported_format" | "render_exception", bodyFormat?: string, surface: "post" | "comment" | "unknown" = "unknown") {
+  const payload = JSON.stringify({ reason, body_format: bodyFormat, surface });
+  const url = "/telemetry/content-render";
+  try {
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      navigator.sendBeacon(url, new Blob([payload], { type: "application/json" }));
+      return;
+    }
+  } catch {
+    // no-op
+  }
+  void fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: payload,
+  }).catch(() => undefined);
+}

--- a/frontend/src/pages/feed/CommentsThread.tsx
+++ b/frontend/src/pages/feed/CommentsThread.tsx
@@ -3,7 +3,6 @@ import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-q
 import { Send, MoreHorizontal, Pencil, Trash2, X, Check, DollarSign } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -22,6 +21,8 @@ import {
 import { useAuthStore } from "@/stores/authStore";
 import type { FeedComment } from "@/api/types";
 import { TipDialog } from "./TipDialog";
+import { MarkdownComposer, type EditorMode, type RichDoc, richDocToPlain, buildContentPayload } from "./MarkdownComposer";
+import { RichContentRenderer } from "./RichContentRenderer";
 
 interface CommentsThreadProps {
   postId: string;
@@ -31,6 +32,8 @@ export function CommentsThread({ postId }: CommentsThreadProps) {
   const userId = useAuthStore((s) => s.userId);
   const queryClient = useQueryClient();
   const [body, setBody] = useState("");
+  const [editorMode, setEditorMode] = useState<EditorMode>("plain");
+  const [richDoc, setRichDoc] = useState<RichDoc | null>(null);
 
   const commentsQuery = useInfiniteQuery({
     queryKey: ["comments", postId],
@@ -40,14 +43,16 @@ export function CommentsThread({ postId }: CommentsThreadProps) {
   });
 
   const sendMutation = useMutation({
-    mutationFn: () => createComment(postId, { body }),
+    mutationFn: () => createComment(postId, buildContentPayload(body, editorMode, richDoc)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["comments", postId] });
       queryClient.invalidateQueries({ queryKey: ["feed"] });
       setBody("");
+      setEditorMode("plain");
+      setRichDoc(null);
     },
-    onError: () => {
-      toast.error("Failed to post comment");
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : "Failed to post comment");
     },
   });
 
@@ -94,21 +99,28 @@ export function CommentsThread({ postId }: CommentsThreadProps) {
       )}
 
       {/* Add comment */}
-      <form onSubmit={handleSubmit} className="flex gap-2">
-        <Input
-          placeholder="Write a comment..."
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <MarkdownComposer
+          mode={editorMode}
+          onModeChange={setEditorMode}
           value={body}
-          onChange={(e) => setBody(e.target.value)}
-          className="text-sm"
+          onChange={setBody}
+          richDoc={richDoc}
+          onRichDocChange={setRichDoc}
+          placeholder="Write a comment..."
+          rows={2}
         />
-        <Button
-          type="submit"
-          size="icon"
-          variant="ghost"
-          disabled={!body.trim() || sendMutation.isPending}
-        >
-          <Send className="h-4 w-4" />
-        </Button>
+        <div className="flex justify-end">
+          <Button
+            type="submit"
+            size="sm"
+            variant="ghost"
+            disabled={!body.trim() || sendMutation.isPending}
+          >
+            <Send className="mr-1 h-4 w-4" />
+            Post
+          </Button>
+        </div>
       </form>
     </div>
   );
@@ -122,21 +134,52 @@ interface CommentRowProps {
   isOwn: boolean;
 }
 
+
+function commentMode(comment: FeedComment): EditorMode {
+  if (comment.body_format === "rich" && comment.body_rich) return "rich";
+  if (comment.body_format === "markdown" && (comment.body_markdown || comment.body_plain || comment.body)) return "markdown";
+  return "plain";
+}
+
+function commentDraftText(comment: FeedComment): string {
+  if (comment.body_format === "markdown") return comment.body_markdown ?? comment.body_plain ?? comment.body;
+  if (comment.body_format === "rich") {
+    const doc = (comment.body_rich as RichDoc | undefined) ?? null;
+    return doc ? (richDocToPlain(doc) || comment.body_plain || comment.body) : (comment.body_plain || comment.body);
+  }
+  return comment.body_plain ?? comment.body;
+}
+
+function CommentBodyView({ comment }: { comment: FeedComment }) {
+  return (
+    <RichContentRenderer
+      body={comment.body}
+      bodyPlain={comment.body_plain}
+      bodyMarkdown={comment.body_markdown}
+      bodyMarkdownHtml={comment.body_markdown_html}
+      bodyRich={(comment.body_rich as Record<string, unknown> | null) ?? null}
+      bodyFormat={comment.body_format}
+    />
+  );
+}
+
 function CommentRow({ comment, postId, isOwn }: CommentRowProps) {
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
-  const [editBody, setEditBody] = useState(comment.body);
+  const [editBody, setEditBody] = useState(commentDraftText(comment));
+  const [editMode, setEditMode] = useState<EditorMode>(commentMode(comment));
+  const [editRichDoc, setEditRichDoc] = useState<RichDoc | null>((comment.body_rich as RichDoc | undefined) ?? null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [tipOpen, setTipOpen] = useState(false);
 
   const editMut = useMutation({
-    mutationFn: () => editComment(postId, comment.comment_id, { body: editBody }),
+    mutationFn: () => editComment(postId, comment.comment_id, buildContentPayload(editBody, editMode, editRichDoc)),
     onSuccess: () => {
       toast.success("Comment updated");
       void queryClient.invalidateQueries({ queryKey: ["comments", postId] });
       setEditing(false);
     },
-    onError: () => toast.error("Failed to update comment"),
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : "Failed to update comment"),
   });
 
   const deleteMut = useMutation({
@@ -162,13 +205,19 @@ function CommentRow({ comment, postId, isOwn }: CommentRowProps) {
   }
 
   const startEdit = () => {
-    setEditBody(comment.body);
+    const existingRich = (comment.body_rich as RichDoc | undefined) ?? null;
+    setEditBody(commentDraftText(comment));
+    setEditMode(commentMode(comment));
+    setEditRichDoc(existingRich);
     setEditing(true);
   };
 
   const cancelEdit = () => {
     setEditing(false);
-    setEditBody(comment.body);
+    const existingRich = (comment.body_rich as RichDoc | undefined) ?? null;
+    setEditBody(commentDraftText(comment));
+    setEditMode(commentMode(comment));
+    setEditRichDoc(existingRich);
   };
 
   const saveEdit = () => {
@@ -196,37 +245,39 @@ function CommentRow({ comment, postId, isOwn }: CommentRowProps) {
           </div>
 
           {editing ? (
-            <div className="mt-1 flex items-center gap-1">
-              <Input
+            <div className="mt-1 space-y-2">
+              <MarkdownComposer
+                mode={editMode}
+                onModeChange={setEditMode}
                 value={editBody}
-                onChange={(e) => setEditBody(e.target.value)}
-                className="h-7 text-sm"
-                autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") saveEdit();
-                  if (e.key === "Escape") cancelEdit();
-                }}
+                onChange={setEditBody}
+                richDoc={editRichDoc}
+                onRichDocChange={setEditRichDoc}
+                placeholder="Write a comment..."
+                rows={2}
               />
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 shrink-0"
-                onClick={saveEdit}
-                disabled={!editBody.trim() || editMut.isPending}
-              >
-                <Check className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 shrink-0"
-                onClick={cancelEdit}
-              >
-                <X className="h-3.5 w-3.5" />
-              </Button>
+              <div className="flex items-center justify-end gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0"
+                  onClick={saveEdit}
+                  disabled={!editBody.trim() || editMut.isPending}
+                >
+                  <Check className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0"
+                  onClick={cancelEdit}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
             </div>
           ) : (
-            <p className="text-sm">{comment.body}</p>
+            <CommentBodyView comment={comment} />
           )}
 
           {/* Tip total + tip button for non-own comments */}

--- a/frontend/src/pages/feed/CreatePost.tsx
+++ b/frontend/src/pages/feed/CreatePost.tsx
@@ -3,11 +3,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Send, ImagePlus, X, Loader2, FolderOpen, Lock, Paperclip } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent } from "@/components/ui/card";
 import { createPost, uploadPostImage } from "@/api/endpoints/newsfeed";
 import { downloadUrl } from "@/api/endpoints/files";
 import { FilePickerDialog } from "@/pages/messages/FilePickerDialog";
+import { MarkdownComposer, type EditorMode, type RichDoc, buildContentPayload } from "./MarkdownComposer";
 import type { FileEntry } from "@/api/types";
 
 const MAX_IMAGES = 10;
@@ -17,6 +17,8 @@ export function CreatePost() {
   const queryClient = useQueryClient();
   const fileRef = useRef<HTMLInputElement>(null);
   const [body, setBody] = useState("");
+  const [editorMode, setEditorMode] = useState<EditorMode>("plain");
+  const [richDoc, setRichDoc] = useState<RichDoc | null>(null);
   const [imageUrls, setImageUrls] = useState<string[]>([]);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -35,7 +37,7 @@ export function CreatePost() {
   const mutation = useMutation({
     mutationFn: () =>
       createPost({
-        body,
+        ...buildContentPayload(body, editorMode, richDoc),
         ...(imageUrls.length > 0 ? { image_urls: imageUrls } : {}),
         ...(pendingFiles.length > 0 ? { file_paths: pendingFiles.map((f) => f.path) } : {}),
         ...(unlockPriceCents ? { unlock_price_cents: unlockPriceCents } : {}),
@@ -43,14 +45,17 @@ export function CreatePost() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["feed"] });
       setBody("");
+      setEditorMode("plain");
+      setRichDoc(null);
       setImageUrls([]);
       setPendingFiles([]);
       setLockEnabled(false);
       setLockPrice("");
       toast.success("Post published");
     },
-    onError: () => {
-      toast.error("Failed to create post");
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : "Failed to create post";
+      toast.error(msg);
     },
   });
 
@@ -153,10 +158,14 @@ export function CreatePost() {
     <Card>
       <CardContent className="p-4">
         <form onSubmit={handleSubmit} className="space-y-3">
-          <Textarea
-            placeholder="What's on your mind?"
+          <MarkdownComposer
+            mode={editorMode}
+            onModeChange={setEditorMode}
             value={body}
-            onChange={(e) => setBody(e.target.value)}
+            onChange={setBody}
+            richDoc={richDoc}
+            onRichDocChange={setRichDoc}
+            placeholder="What's on your mind?"
             rows={3}
           />
 

--- a/frontend/src/pages/feed/EditPostDialog.tsx
+++ b/frontend/src/pages/feed/EditPostDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { MarkdownComposer, type EditorMode, type RichDoc, richDocToPlain, buildContentPayload } from "./MarkdownComposer";
 import { editPost, uploadPostImage } from "@/api/endpoints/newsfeed";
 
 const MAX_IMAGES = 10;
@@ -21,6 +21,7 @@ interface EditPostDialogProps {
   postId: string;
   initialBody: string;
   initialImageUrls?: string[];
+  initialBodyRich?: RichDoc | null;
 }
 
 export function EditPostDialog({
@@ -29,29 +30,34 @@ export function EditPostDialog({
   postId,
   initialBody,
   initialImageUrls,
+  initialBodyRich,
 }: EditPostDialogProps) {
   const queryClient = useQueryClient();
   const fileRef = useRef<HTMLInputElement>(null);
   const [body, setBody] = useState(initialBody);
+  const [editorMode, setEditorMode] = useState<EditorMode>(initialBodyRich ? "rich" : "plain");
+  const [richDoc, setRichDoc] = useState<RichDoc | null>(initialBodyRich ?? null);
   const [imageUrls, setImageUrls] = useState<string[]>(initialImageUrls ?? []);
   const [uploading, setUploading] = useState(false);
 
   // Sync with props when dialog opens
   useEffect(() => {
     if (open) {
-      setBody(initialBody);
+      setBody(initialBodyRich ? richDocToPlain(initialBodyRich) || initialBody : initialBody);
       setImageUrls(initialImageUrls ?? []);
+      setEditorMode(initialBodyRich ? "rich" : "plain");
+      setRichDoc(initialBodyRich ?? null);
     }
-  }, [open, initialBody, initialImageUrls]);
+  }, [open, initialBody, initialImageUrls, initialBodyRich]);
 
   const mutation = useMutation({
-    mutationFn: () => editPost(postId, { body, image_urls: imageUrls }),
+    mutationFn: () => editPost(postId, { ...buildContentPayload(body, editorMode, richDoc), image_urls: imageUrls }),
     onSuccess: () => {
       toast.success("Post updated");
       void queryClient.invalidateQueries({ queryKey: ["feed"] });
       onOpenChange(false);
     },
-    onError: () => toast.error("Failed to update post"),
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : "Failed to update post"),
   });
 
   const handleSave = () => {
@@ -96,11 +102,14 @@ export function EditPostDialog({
           <DialogTitle>Edit Post</DialogTitle>
         </DialogHeader>
 
-        <Textarea
+        <MarkdownComposer
+          mode={editorMode}
+          onModeChange={setEditorMode}
           value={body}
-          onChange={(e) => setBody(e.target.value)}
+          onChange={setBody}
+          richDoc={richDoc}
+          onRichDocChange={setRichDoc}
           rows={5}
-          className="resize-none"
           placeholder="Write something..."
         />
 

--- a/frontend/src/pages/feed/MarkdownComposer.tsx
+++ b/frontend/src/pages/feed/MarkdownComposer.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { newsfeedMarkdownEnabled, newsfeedRichtextEnabled } from "@/lib/featureFlags";
+import { Textarea } from "@/components/ui/textarea";
+
+export type EditorMode = "plain" | "markdown" | "rich";
+
+export type RichNode = {
+  type: string;
+  text?: string;
+  attrs?: Record<string, unknown>;
+  marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+  content?: RichNode[];
+};
+
+export type RichDoc = { type: "doc"; content: RichNode[] };
+
+interface MarkdownComposerProps {
+  mode: EditorMode;
+  onModeChange: (mode: EditorMode) => void;
+  value: string;
+  onChange: (value: string) => void;
+  richDoc?: RichDoc | null;
+  onRichDocChange?: (doc: RichDoc | null) => void;
+  placeholder: string;
+  rows?: number;
+}
+
+function safeLink(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "mailto:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderInlineMarkdown(line: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  const regex = /(\[[^\]]+\]\([^\)]+\)|\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`)/g;
+  let last = 0;
+  let idx = 0;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(line)) !== null) {
+    if (m.index > last) out.push(line.slice(last, m.index));
+    const token = m[0];
+    if (token.startsWith("**") && token.endsWith("**")) {
+      out.push(<strong key={`b-${idx++}`}>{token.slice(2, -2)}</strong>);
+    } else if (token.startsWith("*") && token.endsWith("*")) {
+      out.push(<em key={`i-${idx++}`}>{token.slice(1, -1)}</em>);
+    } else if (token.startsWith("`") && token.endsWith("`")) {
+      out.push(<code key={`c-${idx++}`}>{token.slice(1, -1)}</code>);
+    } else if (token.startsWith("[")) {
+      const mm = token.match(/^\[([^\]]+)\]\(([^\)]+)\)$/);
+      if (mm) {
+        const label = mm[1] ?? "";
+        const rawHref = mm[2] ?? "";
+        const href = safeLink(rawHref.trim());
+        if (href) {
+          out.push(
+            <a key={`a-${idx++}`} href={href} target="_blank" rel="noopener noreferrer nofollow" className="underline">
+              {label}
+            </a>,
+          );
+        } else {
+          out.push(label);
+        }
+      } else {
+        out.push(token);
+      }
+    }
+    last = m.index + token.length;
+  }
+  if (last < line.length) out.push(line.slice(last));
+  return out;
+}
+
+export function MarkdownPreview({ value }: { value: string }) {
+  const lines = value.split(/\r?\n/);
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 text-sm space-y-1">
+      {lines.map((line, i) => {
+        const t = line.trim();
+        if (!t) return <div key={i} className="h-4" />;
+        if (t.startsWith("- ")) return <p key={i}>• {renderInlineMarkdown(t.slice(2))}</p>;
+        if (/^\d+\.\s+/.test(t)) return <p key={i}>{renderInlineMarkdown(t.replace(/^\d+\.\s+/, ""))}</p>;
+        if (t.startsWith(">")) return <p key={i} className="border-l-2 pl-2 italic">{renderInlineMarkdown(t.slice(1).trim())}</p>;
+        return <p key={i}>{renderInlineMarkdown(t)}</p>;
+      })}
+    </div>
+  );
+}
+
+function collectText(node: RichNode): string {
+  if (node.type === "text") return node.text ?? "";
+  return (node.content ?? []).map(collectText).join("");
+}
+
+export function richDocToPlain(doc: RichDoc | null | undefined): string {
+  if (!doc?.content?.length) return "";
+  return doc.content.map((n) => collectText(n)).join("\n").trim();
+}
+
+function marksWrap(text: string, marks?: RichNode["marks"]): string {
+  let out = text;
+  for (const mark of marks ?? []) {
+    if (mark.type === "bold") out = `<strong>${out}</strong>`;
+    else if (mark.type === "italic") out = `<em>${out}</em>`;
+    else if (mark.type === "code") out = `<code>${out}</code>`;
+    else if (mark.type === "link") {
+      const href = typeof mark.attrs?.href === "string" ? mark.attrs.href : "";
+      const safe = safeLink(href);
+      if (safe) out = `<a href="${safe}">${out}</a>`;
+    }
+  }
+  return out;
+}
+
+function nodeToHtml(node: RichNode): string {
+  if (node.type === "text") return marksWrap((node.text ?? "").replace(/</g, "&lt;").replace(/>/g, "&gt;"), node.marks);
+  const children = (node.content ?? []).map(nodeToHtml).join("");
+  if (node.type === "paragraph") return `<p>${children || "<br>"}</p>`;
+  if (node.type === "blockquote") return `<blockquote>${children}</blockquote>`;
+  if (node.type === "codeBlock") return `<pre><code>${children}</code></pre>`;
+  if (node.type === "bulletList") return `<ul>${children}</ul>`;
+  if (node.type === "orderedList") return `<ol>${children}</ol>`;
+  if (node.type === "listItem") return `<li>${children}</li>`;
+  if (node.type === "hardBreak") return "<br>";
+  return children;
+}
+
+export function richDocToHtml(doc: RichDoc | null | undefined, fallback: string): string {
+  if (!doc?.content?.length) return fallback ? `<p>${fallback}</p>` : "<p><br></p>";
+  return doc.content.map(nodeToHtml).join("");
+}
+
+function parseInlineNode(el: ChildNode): RichNode[] {
+  if (el.nodeType === Node.TEXT_NODE) {
+    const t = el.textContent ?? "";
+    return t ? [{ type: "text", text: t }] : [];
+  }
+  if (!(el instanceof HTMLElement)) return [];
+  const tag = el.tagName.toLowerCase();
+  if (tag === "br") return [{ type: "hardBreak" }];
+  if (["strong", "b", "em", "i", "code", "a"].includes(tag)) {
+    const markType = tag === "strong" || tag === "b" ? "bold" : tag === "em" || tag === "i" ? "italic" : tag === "code" ? "code" : "link";
+    const attrs = markType === "link" ? { href: el.getAttribute("href") ?? "" } : undefined;
+    const children = Array.from(el.childNodes).flatMap(parseInlineNode);
+    return children.map((n) => ({ ...n, marks: [...(n.marks ?? []), { type: markType, ...(attrs ? { attrs } : {}) }] }));
+  }
+  return Array.from(el.childNodes).flatMap(parseInlineNode);
+}
+
+function parseBlock(el: HTMLElement): RichNode | null {
+  const tag = el.tagName.toLowerCase();
+  if (tag === "p" || tag === "div") return { type: "paragraph", content: Array.from(el.childNodes).flatMap(parseInlineNode) };
+  if (tag === "blockquote") return { type: "blockquote", content: [{ type: "paragraph", content: Array.from(el.childNodes).flatMap(parseInlineNode) }] };
+  if (tag === "pre") return { type: "codeBlock", content: [{ type: "text", text: el.textContent ?? "" }] };
+  if (tag === "ul" || tag === "ol") {
+    const listType = tag === "ul" ? "bulletList" : "orderedList";
+    const items = Array.from(el.querySelectorAll(":scope > li")).map((li) => ({ type: "listItem", content: [{ type: "paragraph", content: Array.from(li.childNodes).flatMap(parseInlineNode) }] }));
+    return { type: listType, content: items };
+  }
+  return { type: "paragraph", content: Array.from(el.childNodes).flatMap(parseInlineNode) };
+}
+
+function htmlToRichDoc(html: string): RichDoc {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(`<div>${html}</div>`, "text/html");
+  const root = doc.body.firstElementChild;
+  const content: RichNode[] = [];
+  if (root) {
+    for (const child of Array.from(root.children)) {
+      const node = parseBlock(child as HTMLElement);
+      if (node) content.push(node);
+    }
+  }
+  if (content.length === 0) content.push({ type: "paragraph", content: [] });
+  return { type: "doc", content };
+}
+
+
+export function RichPreview({ doc, fallback }: { doc?: RichDoc | null; fallback?: string }) {
+  const html = richDocToHtml(doc, fallback ?? "");
+  return <div className="rounded-md border bg-muted/30 p-3 text-sm" dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+function RichTextEditor({
+  value,
+  richDoc,
+  onChange,
+  onRichDocChange,
+  placeholder,
+}: {
+  value: string;
+  richDoc?: RichDoc | null;
+  onChange: (v: string) => void;
+  onRichDocChange?: (d: RichDoc | null) => void;
+  placeholder: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const initialHtml = useMemo(() => richDocToHtml(richDoc, value), [richDoc, value]);
+
+  useEffect(() => {
+    if (ref.current && document.activeElement !== ref.current) {
+      ref.current.innerHTML = initialHtml;
+    }
+  }, [initialHtml]);
+
+  const run = (cmd: string, arg?: string) => {
+    ref.current?.focus();
+    document.execCommand(cmd, false, arg);
+    const html = ref.current?.innerHTML ?? "";
+    onRichDocChange?.(htmlToRichDoc(html));
+    onChange(ref.current?.innerText ?? "");
+  };
+
+  const addLink = () => {
+    const url = window.prompt("Enter link URL (https:// or mailto:)");
+    if (!url) return;
+    const safe = safeLink(url.trim());
+    if (!safe) return;
+    ref.current?.focus();
+    document.execCommand("createLink", false, safe);
+    const html = ref.current?.innerHTML ?? "";
+    onRichDocChange?.(htmlToRichDoc(html));
+    onChange(ref.current?.innerText ?? "");
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-1">
+        <Button type="button" size="sm" variant="ghost" onClick={() => run("bold")}>B</Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => run("italic")}>I</Button>
+        <Button type="button" size="sm" variant="ghost" onClick={addLink}>Link</Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => run("insertUnorderedList")}>• List</Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => run("insertOrderedList")}>1. List</Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => run("formatBlock", "blockquote")}>Quote</Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => run("formatBlock", "pre")}>Code</Button>
+      </div>
+      <div
+        ref={ref}
+        contentEditable
+        suppressContentEditableWarning
+        onInput={() => {
+          const html = ref.current?.innerHTML ?? "";
+          onRichDocChange?.(htmlToRichDoc(html));
+          onChange(ref.current?.innerText ?? "");
+        }}
+        className="min-h-[120px] rounded-md border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-placeholder={placeholder}
+      />
+    </div>
+  );
+}
+
+export function MarkdownComposer({
+  mode,
+  onModeChange,
+  value,
+  onChange,
+  richDoc,
+  onRichDocChange,
+  placeholder,
+  rows = 4,
+}: MarkdownComposerProps) {
+  const markdownEnabled = newsfeedMarkdownEnabled;
+  const richEnabled = newsfeedRichtextEnabled;
+  const effectiveMode: EditorMode = mode === "rich" && !richEnabled ? "plain" : mode === "markdown" && !markdownEnabled ? "plain" : mode;
+
+  useEffect(() => {
+    if (effectiveMode !== mode) {
+      onModeChange(effectiveMode);
+    }
+  }, [effectiveMode, mode, onModeChange]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1">
+        <Button type="button" size="sm" variant={effectiveMode === "plain" ? "secondary" : "ghost"} onClick={() => onModeChange("plain")}>Plain</Button>
+        {markdownEnabled && (
+          <Button type="button" size="sm" variant={effectiveMode === "markdown" ? "secondary" : "ghost"} onClick={() => onModeChange("markdown")}>Markdown</Button>
+        )}
+        {richEnabled && (
+          <Button type="button" size="sm" variant={effectiveMode === "rich" ? "secondary" : "ghost"} onClick={() => onModeChange("rich")}>Rich</Button>
+        )}
+      </div>
+
+      {effectiveMode === "rich" ? (
+        <RichTextEditor
+          value={value}
+          richDoc={richDoc}
+          onChange={onChange}
+          onRichDocChange={onRichDocChange}
+          placeholder={placeholder}
+        />
+      ) : (
+        <Textarea placeholder={placeholder} value={value} onChange={(e) => onChange(e.target.value)} rows={rows} />
+      )}
+
+      {effectiveMode === "markdown" && value.trim() && (
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground">Preview</p>
+          <MarkdownPreview value={value} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function buildContentPayload(body: string, mode: EditorMode, richDoc?: RichDoc | null) {
+  if (mode === "markdown" && newsfeedMarkdownEnabled) {
+    return {
+      body_plain: body,
+      body_markdown: body,
+      body_format: "markdown" as const,
+      body_version: 1,
+    };
+  }
+  if (mode === "rich" && newsfeedRichtextEnabled) {
+    return {
+      body_plain: body,
+      body_rich: richDoc ?? { type: "doc", content: [{ type: "paragraph", content: [] }] },
+      body_format: "rich" as const,
+      body_version: 1,
+    };
+  }
+  return { body };
+}

--- a/frontend/src/pages/feed/PostCard.tsx
+++ b/frontend/src/pages/feed/PostCard.tsx
@@ -21,6 +21,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { CommentsThread } from "./CommentsThread";
 import { PostActions } from "./PostActions";
 import { EditPostDialog } from "./EditPostDialog";
+import { RichContentRenderer } from "./RichContentRenderer";
 import { TipDialog } from "./TipDialog";
 import { SharePostDialog } from "./SharePostDialog";
 import { FilePreview } from "@/pages/files/FilePreview";
@@ -288,9 +289,16 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
         <div className="mt-3">
           {isLocked ? (
             <div className="relative">
-              <p className="whitespace-pre-wrap text-sm blur-sm select-none">
-                {post.body}
-              </p>
+              <div className="blur-sm select-none">
+                <RichContentRenderer
+                  body={post.body}
+                  bodyPlain={post.body_plain}
+                  bodyMarkdown={post.body_markdown}
+                  bodyMarkdownHtml={post.body_markdown_html}
+                  bodyRich={(post.body_rich as Record<string, unknown> | null) ?? null}
+                  bodyFormat={post.body_format}
+                />
+              </div>
               <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background/60 rounded">
                 <Lock className="h-6 w-6 text-muted-foreground" />
                 {paymentMethods.length === 0 ? (
@@ -312,7 +320,14 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
               </div>
             </div>
           ) : (
-            <p className="whitespace-pre-wrap text-sm">{post.body}</p>
+            <RichContentRenderer
+              body={post.body}
+              bodyPlain={post.body_plain}
+              bodyMarkdown={post.body_markdown}
+              bodyMarkdownHtml={post.body_markdown_html}
+              bodyRich={(post.body_rich as Record<string, unknown> | null) ?? null}
+              bodyFormat={post.body_format}
+            />
           )}
         </div>
 
@@ -432,6 +447,7 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
         postId={post.post_id}
         initialBody={post.body}
         initialImageUrls={imageUrls}
+        initialBodyRich={(post.body_rich as any) ?? null}
       />
 
       {/* Tip dialog */}

--- a/frontend/src/pages/feed/RichContentRenderer.tsx
+++ b/frontend/src/pages/feed/RichContentRenderer.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useMemo, useState } from "react";
+import { richDocToHtml, type RichDoc } from "./MarkdownComposer";
+import { reportNewsfeedRendererEvent } from "@/lib/newsfeedTelemetry";
+
+type BodyFormat = "plain" | "markdown" | "rich";
+const KNOWN_FORMATS: ReadonlySet<string> = new Set(["plain", "markdown", "rich"]);
+
+interface RichContentRendererProps {
+  body?: string;
+  bodyPlain?: string;
+  bodyMarkdown?: string;
+  bodyMarkdownHtml?: string;
+  bodyRich?: Record<string, unknown> | null;
+  bodyFormat?: BodyFormat | string;
+  className?: string;
+}
+
+const COLLAPSE_CHAR_THRESHOLD = 380;
+const COLLAPSE_LINE_THRESHOLD = 8;
+const COLLAPSED_MAX_HEIGHT_PX = 180;
+
+function plainTextFromProps(props: RichContentRendererProps): string {
+  return props.bodyPlain ?? props.body ?? props.bodyMarkdown ?? "";
+}
+
+function markdownHtmlFromProps(props: RichContentRendererProps): string {
+  if (props.bodyMarkdownHtml?.trim()) return props.bodyMarkdownHtml;
+  const text = props.bodyMarkdown ?? props.bodyPlain ?? props.body ?? "";
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => `<p>${line.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</p>`)
+    .join("");
+}
+
+export function RichContentRenderer({ className = "", ...props }: RichContentRendererProps) {
+  const baseClass = `text-sm whitespace-pre-wrap ${className}`.trim();
+  const plain = plainTextFromProps(props);
+
+  const shouldCollapse = useMemo(() => {
+    const text = plain.trim();
+    if (!text) return false;
+    const lineCount = text.split(/\r?\n/).length;
+    return text.length > COLLAPSE_CHAR_THRESHOLD || lineCount > COLLAPSE_LINE_THRESHOLD;
+  }, [plain]);
+
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    setExpanded(false);
+  }, [plain, props.bodyFormat, props.bodyMarkdownHtml]);
+
+  const contentNode = (() => {
+    try {
+      const rawFormat = String(props.bodyFormat ?? "plain");
+      const format = KNOWN_FORMATS.has(rawFormat) ? props.bodyFormat : "plain";
+      if (!KNOWN_FORMATS.has(rawFormat) && props.bodyFormat) {
+        reportNewsfeedRendererEvent("unsupported_format", rawFormat);
+      }
+      if (format === "rich" && props.bodyRich) {
+        const richHtml = richDocToHtml((props.bodyRich as RichDoc) ?? null, plain);
+        return <div className={baseClass} dangerouslySetInnerHTML={{ __html: richHtml }} />;
+      }
+      if (format === "markdown") {
+        const markdownHtml = markdownHtmlFromProps(props);
+        return <div className={baseClass} dangerouslySetInnerHTML={{ __html: markdownHtml }} />;
+      }
+      return <p className={baseClass}>{plain}</p>;
+    } catch {
+      reportNewsfeedRendererEvent("render_exception", String(props.bodyFormat ?? "plain"));
+      return <p className={baseClass}>{plain}</p>;
+    }
+  })();
+
+  if (!shouldCollapse) {
+    return contentNode;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div
+        className={expanded ? "" : "overflow-hidden"}
+        style={expanded ? undefined : { maxHeight: `${COLLAPSED_MAX_HEIGHT_PX}px` }}
+        aria-expanded={expanded}
+      >
+        {contentNode}
+      </div>
+      <button
+        type="button"
+        className="text-xs font-medium text-muted-foreground hover:text-foreground"
+        onClick={() => setExpanded((v) => !v)}
+        aria-label={expanded ? "Collapse content" : "Expand content"}
+      >
+        {expanded ? "Show less" : "Show more"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/feed/__tests__/MarkdownComposer.test.tsx
+++ b/frontend/src/pages/feed/__tests__/MarkdownComposer.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { MarkdownComposer } from "../MarkdownComposer";
+
+vi.mock("@/lib/featureFlags", () => ({
+  newsfeedMarkdownEnabled: true,
+  newsfeedRichtextEnabled: true,
+}));
+
+function ComposerHarness() {
+  const [mode, setMode] = React.useState<"plain" | "markdown" | "rich">("plain");
+  const [value, setValue] = React.useState("");
+  const [richDoc, setRichDoc] = React.useState<any>(null);
+  return (
+    <MarkdownComposer
+      mode={mode}
+      onModeChange={setMode}
+      value={value}
+      onChange={setValue}
+      richDoc={richDoc}
+      onRichDocChange={setRichDoc}
+      placeholder="Write something"
+      rows={4}
+    />
+  );
+}
+
+describe("MarkdownComposer", () => {
+  it("shows markdown preview after switching modes and typing", async () => {
+    const user = userEvent.setup();
+    render(<ComposerHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Markdown" }));
+    const textarea = screen.getByPlaceholderText("Write something");
+    await user.type(textarea, "**bold**\n- item");
+
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.getByText("bold")).toBeInTheDocument();
+    expect(screen.getByText(/•/)).toBeInTheDocument();
+  });
+
+  it("executes rich editor toolbar actions", async () => {
+    const user = userEvent.setup();
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", { value: execCommand, configurable: true });
+
+    render(<ComposerHarness />);
+    await user.click(screen.getByRole("button", { name: "Rich" }));
+
+    await user.click(screen.getByRole("button", { name: "B" }));
+    await user.click(screen.getByRole("button", { name: "I" }));
+    await user.click(screen.getByRole("button", { name: "• List" }));
+    await user.click(screen.getByRole("button", { name: "1. List" }));
+    await user.click(screen.getByRole("button", { name: "Quote" }));
+    await user.click(screen.getByRole("button", { name: "Code" }));
+
+    expect(execCommand).toHaveBeenCalledWith("bold", false, undefined);
+    expect(execCommand).toHaveBeenCalledWith("italic", false, undefined);
+    expect(execCommand).toHaveBeenCalledWith("insertUnorderedList", false, undefined);
+    expect(execCommand).toHaveBeenCalledWith("insertOrderedList", false, undefined);
+    expect(execCommand).toHaveBeenCalledWith("formatBlock", false, "blockquote");
+    expect(execCommand).toHaveBeenCalledWith("formatBlock", false, "pre");
+
+  });
+
+  it("updates text content from rich editor input", async () => {
+    const user = userEvent.setup();
+    render(<ComposerHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Rich" }));
+    const editable = document.querySelector('[contenteditable="true"]') as HTMLElement;
+    expect(editable).toBeTruthy();
+
+    fireEvent.input(editable, {
+      target: { innerText: "hello rich", innerHTML: "<p>hello rich</p>" },
+    });
+
+    expect(editable.textContent ?? "").toContain("hello rich");
+  });
+});

--- a/frontend/src/pages/feed/__tests__/RichContentRenderer.test.tsx
+++ b/frontend/src/pages/feed/__tests__/RichContentRenderer.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { RichContentRenderer } from "../RichContentRenderer";
+
+const telemetrySpy = vi.fn();
+vi.mock("@/lib/newsfeedTelemetry", () => ({
+  reportNewsfeedRendererEvent: (...args: unknown[]) => telemetrySpy(...args),
+}));
+
+describe("RichContentRenderer", () => {
+  it("renders markdown html when format is markdown", () => {
+    render(
+      <RichContentRenderer
+        body="fallback"
+        bodyFormat="markdown"
+        bodyMarkdown="**hello**"
+        bodyMarkdownHtml="<p><strong>hello</strong></p>"
+      />,
+    );
+
+    expect(screen.getByText("hello").tagName.toLowerCase()).toBe("strong");
+  });
+
+  it("falls back to plain rendering for unsupported format", () => {
+    telemetrySpy.mockClear();
+    render(
+      <RichContentRenderer
+        body="legacy"
+        bodyPlain="plain fallback"
+        bodyFormat="unsupported_format"
+      />,
+    );
+
+    expect(screen.getByText("plain fallback")).toBeInTheDocument();
+    expect(telemetrySpy).toHaveBeenCalledWith("unsupported_format", "unsupported_format");
+  });
+
+  it("collapses long content and expands/collapses on toggle", async () => {
+    const user = userEvent.setup();
+    const longText = "line\n".repeat(12);
+
+    render(<RichContentRenderer body={longText} bodyPlain={longText} bodyFormat="plain" />);
+
+    const button = screen.getByRole("button", { name: "Expand content" });
+    expect(button).toHaveTextContent("Show more");
+
+    await user.click(button);
+    expect(screen.getByRole("button", { name: "Collapse content" })).toHaveTextContent("Show less");
+
+    await user.click(screen.getByRole("button", { name: "Collapse content" }));
+    expect(screen.getByRole("button", { name: "Expand content" })).toHaveTextContent("Show more");
+  });
+
+  it("falls back to safe plain text if rich payload is invalid", () => {
+    telemetrySpy.mockClear();
+    render(
+      <RichContentRenderer
+        body="safe plain"
+        bodyPlain="safe plain"
+        bodyFormat="rich"
+        bodyRich={{ type: "doc", content: 123 as unknown as [] }}
+      />,
+    );
+
+    expect(screen.getByText("safe plain")).toBeInTheDocument();
+  });
+});

--- a/scripts/backfill_newsfeed_plain_fields.py
+++ b/scripts/backfill_newsfeed_plain_fields.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+from botocore.exceptions import ClientError
+
+from app.core.aws import ddb
+
+APP_TABLE = os.environ.get("APP_TABLE", "app_single_table")
+CHECKPOINT_PK = "SYSTEM#NEWSFEED_BACKFILL"
+CHECKPOINT_SK = "CONTENT#PLAIN_FORMAT"
+VALID_FORMATS = {"plain", "markdown", "rich"}
+
+RETRYABLE_ERROR_CODES = {
+    "ProvisionedThroughputExceededException",
+    "ThrottlingException",
+    "RequestLimitExceeded",
+    "InternalServerError",
+    "TransactionConflictException",
+}
+
+
+@dataclass
+class BackfillStats:
+    scanned: int = 0
+    eligible: int = 0
+    updated: int = 0
+    dry_run_updates: int = 0
+    no_change: int = 0
+    malformed: int = 0
+    errors: int = 0
+    retries: int = 0
+
+
+def _table():
+    return ddb.Table(APP_TABLE)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_text(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return None
+
+
+def _rich_doc_to_plain_text(doc: Any) -> str:
+    parts: list[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            text = node.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+            for child in node.get("content") or []:
+                walk(child)
+        elif isinstance(node, list):
+            for child in node:
+                walk(child)
+
+    walk(doc)
+    return " ".join(parts).strip()
+
+
+def infer_body_plain(item: Dict[str, Any]) -> Optional[str]:
+    return (
+        _coerce_text(item.get("body_plain"))
+        or _coerce_text(item.get("body"))
+        or _coerce_text(item.get("body_markdown"))
+        or (_rich_doc_to_plain_text(item.get("body_rich")) if isinstance(item.get("body_rich"), dict) else None)
+    )
+
+
+def infer_body_format(item: Dict[str, Any]) -> str:
+    raw = item.get("body_format")
+    if raw in VALID_FORMATS:
+        return raw
+    if isinstance(item.get("body_rich"), dict):
+        return "rich"
+    if _coerce_text(item.get("body_markdown")):
+        return "markdown"
+    return "plain"
+
+
+def is_newsfeed_content_row(item: Dict[str, Any]) -> bool:
+    entity = item.get("Entity")
+    return (entity == "Post" and bool(item.get("post_id"))) or (entity == "Comment" and bool(item.get("comment_id")))
+
+
+def plan_update(item: Dict[str, Any]) -> Tuple[bool, Dict[str, Any], Optional[str]]:
+    if not is_newsfeed_content_row(item):
+        return False, {}, None
+
+    desired_plain = infer_body_plain(item)
+    desired_format = infer_body_format(item)
+    if not desired_plain:
+        return False, {}, "missing_plain_source"
+
+    current_plain = _coerce_text(item.get("body_plain"))
+    current_format = item.get("body_format") if item.get("body_format") in VALID_FORMATS else None
+
+    needs_update = current_plain != desired_plain or current_format != desired_format
+    if not needs_update:
+        return False, {}, None
+
+    update_values = {":bp": desired_plain, ":bf": desired_format, ":ts": _now_iso()}
+    return True, update_values, None
+
+
+def load_checkpoint(tbl) -> Optional[Dict[str, Any]]:
+    resp = tbl.get_item(Key={"pk": CHECKPOINT_PK, "sk": CHECKPOINT_SK})
+    return resp.get("Item")
+
+
+def save_checkpoint(tbl, *, start_key: Optional[Dict[str, Any]], stats: BackfillStats, done: bool) -> None:
+    item: Dict[str, Any] = {
+        "pk": CHECKPOINT_PK,
+        "sk": CHECKPOINT_SK,
+        "updated_at": _now_iso(),
+        "done": done,
+        "scanned": stats.scanned,
+        "eligible": stats.eligible,
+        "updated": stats.updated,
+        "dry_run_updates": stats.dry_run_updates,
+        "no_change": stats.no_change,
+        "malformed": stats.malformed,
+        "errors": stats.errors,
+        "retries": stats.retries,
+    }
+    if start_key:
+        item["last_evaluated_key"] = start_key
+    tbl.put_item(Item=item)
+
+
+def _update_with_retry(tbl, *, key: Dict[str, Any], expr_vals: Dict[str, Any], max_retries: int) -> int:
+    retries = 0
+    for attempt in range(max_retries + 1):
+        try:
+            tbl.update_item(
+                Key=key,
+                UpdateExpression="SET body_plain = :bp, body_format = :bf, backfill_updated_at = :ts",
+                ExpressionAttributeValues=expr_vals,
+            )
+            return retries
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code not in RETRYABLE_ERROR_CODES or attempt == max_retries:
+                raise
+            retries += 1
+            time.sleep(min(0.2 * (2**attempt), 2.0))
+    return retries
+
+
+def _integrity_check(items: Iterable[Dict[str, Any]]) -> int:
+    malformed = 0
+    for item in items:
+        if not is_newsfeed_content_row(item):
+            continue
+        if not infer_body_plain(item):
+            malformed += 1
+    return malformed
+
+
+def run(*, page_limit: int, max_items: Optional[int], reset_checkpoint: bool, dry_run: bool, max_retries: int) -> Dict[str, Any]:
+    tbl = _table()
+    stats = BackfillStats()
+    start_key = None
+
+    if not reset_checkpoint:
+        cp = load_checkpoint(tbl)
+        if cp and cp.get("last_evaluated_key") and not cp.get("done"):
+            start_key = cp.get("last_evaluated_key")
+
+    processed_items: list[Dict[str, Any]] = []
+
+    while True:
+        kwargs: Dict[str, Any] = {"Limit": page_limit}
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+        resp = tbl.scan(**kwargs)
+        items = resp.get("Items", [])
+
+        if max_items is not None and stats.scanned + len(items) > max_items:
+            take = max_items - stats.scanned
+            if take <= 0:
+                break
+            items = items[:take]
+            start_key = resp.get("LastEvaluatedKey")
+            # force stop after this clipped batch
+            next_key = start_key
+            stop_after = True
+        else:
+            next_key = resp.get("LastEvaluatedKey")
+            stop_after = False
+
+        stats.scanned += len(items)
+        processed_items.extend(items)
+
+        for item in items:
+            if not is_newsfeed_content_row(item):
+                continue
+            stats.eligible += 1
+            should_update, expr_vals, reason = plan_update(item)
+            if reason == "missing_plain_source":
+                stats.malformed += 1
+                continue
+            if not should_update:
+                stats.no_change += 1
+                continue
+
+            if dry_run:
+                stats.dry_run_updates += 1
+                continue
+
+            try:
+                key = {"pk": item["pk"], "sk": item["sk"]}
+                stats.retries += _update_with_retry(tbl, key=key, expr_vals=expr_vals, max_retries=max_retries)
+                stats.updated += 1
+            except Exception:
+                stats.errors += 1
+
+        done = not bool(next_key) or stop_after
+        save_checkpoint(tbl, start_key=next_key if not done else None, stats=stats, done=done)
+
+        if done:
+            break
+        start_key = next_key
+
+    malformed_check = _integrity_check(processed_items)
+    report = {
+        "table": APP_TABLE,
+        "dry_run": dry_run,
+        "page_limit": page_limit,
+        "max_items": max_items,
+        "stats": stats.__dict__,
+        "integrity": {
+            "malformed_rows": malformed_check,
+            "ok": malformed_check == 0,
+        },
+    }
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backfill newsfeed body_plain and default body_format for legacy records.")
+    parser.add_argument("--page-limit", type=int, default=200, help="DynamoDB scan page size")
+    parser.add_argument("--max-items", type=int, default=None, help="Optional cap for incremental runs")
+    parser.add_argument("--reset-checkpoint", action="store_true", help="Start from the beginning")
+    parser.add_argument("--dry-run", action="store_true", help="Plan changes without writing updates")
+    parser.add_argument("--max-retries", type=int, default=3, help="Retry count for retryable write errors")
+    args = parser.parse_args()
+
+    report = run(
+        page_limit=args.page_limit,
+        max_items=args.max_items,
+        reset_checkpoint=args.reset_checkpoint,
+        dry_run=args.dry_run,
+        max_retries=args.max_retries,
+    )
+    print(report)
+
+    if report["integrity"]["malformed_rows"] > 0:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_newsfeed_backfill_script.py
+++ b/tests/test_newsfeed_backfill_script.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from scripts.backfill_newsfeed_plain_fields import (
+    infer_body_format,
+    infer_body_plain,
+    is_newsfeed_content_row,
+    plan_update,
+)
+
+
+def test_infer_body_plain_prefers_existing_plain_then_legacy_then_markdown_then_rich() -> None:
+    assert infer_body_plain({"body_plain": "  plain  ", "body": "legacy"}) == "plain"
+    assert infer_body_plain({"body": " legacy "}) == "legacy"
+    assert infer_body_plain({"body_markdown": " # title "}) == "# title"
+    assert (
+        infer_body_plain({"body_rich": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Hello"}]}]}})
+        == "Hello"
+    )
+
+
+def test_infer_body_format_defaults_and_inference() -> None:
+    assert infer_body_format({"body_format": "markdown"}) == "markdown"
+    assert infer_body_format({"body_rich": {"type": "doc", "content": []}}) == "rich"
+    assert infer_body_format({"body_markdown": "- item"}) == "markdown"
+    assert infer_body_format({"body": "legacy"}) == "plain"
+    assert infer_body_format({"body_format": "html", "body": "legacy"}) == "plain"
+
+
+def test_is_newsfeed_content_row_matches_post_and_comment_entities() -> None:
+    assert is_newsfeed_content_row({"Entity": "Post", "post_id": "p1"}) is True
+    assert is_newsfeed_content_row({"Entity": "Comment", "comment_id": "c1"}) is True
+    assert is_newsfeed_content_row({"Entity": "FeedRef", "post_id": "p1"}) is False
+
+
+def test_plan_update_flags_missing_plain_source_as_malformed() -> None:
+    should_update, values, reason = plan_update({"Entity": "Post", "post_id": "p1", "pk": "POST#p1", "sk": "META"})
+    assert should_update is False
+    assert values == {}
+    assert reason == "missing_plain_source"
+
+
+def test_plan_update_is_idempotent_when_fields_already_match() -> None:
+    item = {
+        "Entity": "Comment",
+        "comment_id": "c1",
+        "pk": "POST#p1#COMMENTS",
+        "sk": "2026-01-01#CMT#c1",
+        "body": "legacy",
+        "body_plain": "legacy",
+        "body_format": "plain",
+    }
+    should_update, values, reason = plan_update(item)
+    assert should_update is False
+    assert values == {}
+    assert reason is None
+
+
+def test_plan_update_sets_plain_and_default_format_for_legacy_row() -> None:
+    item = {
+        "Entity": "Post",
+        "post_id": "p1",
+        "pk": "POST#p1",
+        "sk": "META",
+        "body": " legacy body ",
+        "body_format": "html",
+    }
+    should_update, values, reason = plan_update(item)
+    assert should_update is True
+    assert reason is None
+    assert values[":bp"] == "legacy body"
+    assert values[":bf"] == "plain"

--- a/tests/test_newsfeed_content_envelope.py
+++ b/tests/test_newsfeed_content_envelope.py
@@ -1,0 +1,624 @@
+import unittest
+from unittest.mock import patch
+
+from pydantic import ValidationError
+
+from app.routers import newsfeed
+
+
+class TestNewsfeedContentEnvelope(unittest.TestCase):
+    def setUp(self):
+        self._orig_markdown_flag = getattr(newsfeed.S, "newsfeed_markdown_enabled", False)
+        self._orig_rich_flag = getattr(newsfeed.S, "newsfeed_richtext_enabled", False)
+        object.__setattr__(newsfeed.S, "newsfeed_markdown_enabled", True)
+        object.__setattr__(newsfeed.S, "newsfeed_richtext_enabled", True)
+
+    def tearDown(self):
+        object.__setattr__(newsfeed.S, "newsfeed_markdown_enabled", self._orig_markdown_flag)
+        object.__setattr__(newsfeed.S, "newsfeed_richtext_enabled", self._orig_rich_flag)
+
+    def test_create_post_request_accepts_legacy_body(self):
+        req = newsfeed.CreatePostRequest(body="Legacy plain")
+
+        content = newsfeed._content_from_payload(req)
+
+        self.assertEqual(content["body"], "Legacy plain")
+        self.assertEqual(content["body_plain"], "Legacy plain")
+        self.assertIsNone(content["body_markdown"])
+        self.assertIsNone(content["body_rich"])
+        self.assertEqual(content["body_format"], "plain")
+        self.assertEqual(content["body_version"], 1)
+
+    def test_create_post_request_accepts_markdown_content(self):
+        req = newsfeed.CreatePostRequest(
+            body_plain="hello",
+            body_markdown="# hello",
+            body_format="markdown",
+            body_version=1,
+        )
+
+        content = newsfeed._content_from_payload(req)
+
+        self.assertEqual(content["body"], "hello")
+        self.assertEqual(content["body_plain"], "hello")
+        self.assertEqual(content["body_markdown"], "# hello")
+        self.assertEqual(content["body_format"], "markdown")
+
+    def test_create_post_request_accepts_rich_content(self):
+        req = newsfeed.CreatePostRequest(
+            body_plain="hello rich",
+            body_rich={"type": "doc", "content": []},
+            body_format="rich",
+            body_version=1,
+        )
+
+        content = newsfeed._content_from_payload(req)
+
+        self.assertEqual(content["body"], "hello rich")
+        self.assertEqual(content["body_plain"], "hello rich")
+        self.assertEqual(content["body_rich"], {"type": "doc", "content": []})
+        self.assertEqual(content["body_format"], "rich")
+
+    def test_markdown_format_requires_markdown_payload(self):
+        with self.assertRaises(ValidationError):
+            newsfeed.CreatePostRequest(body_plain="x", body_format="markdown")
+
+    def test_rich_payload_requires_plain_fallback(self):
+        with self.assertRaises(ValidationError):
+            newsfeed.CreateCommentRequest(
+                body_rich={"type": "doc", "content": []},
+                body_format="rich",
+            )
+
+
+    def test_plain_text_length_limit_is_configurable(self):
+        with patch.object(newsfeed, "_content_max_plain_chars", return_value=5):
+            with self.assertRaises(ValidationError) as ctx:
+                newsfeed.CreatePostRequest(body="123456")
+        self.assertIn("invalid_content_payload: body_plain/body exceeds max length (5)", str(ctx.exception))
+
+    def test_markdown_length_limit_is_configurable(self):
+        with (
+            patch.object(newsfeed, "_content_max_plain_chars", return_value=100),
+            patch.object(newsfeed, "_content_max_markdown_chars", return_value=5),
+        ):
+            with self.assertRaises(ValidationError) as ctx:
+                newsfeed.CreatePostRequest(body_plain="ok", body_markdown="123456", body_format="markdown")
+        self.assertIn("invalid_content_payload: body_markdown exceeds max length (5)", str(ctx.exception))
+
+    def test_rich_schema_type_must_be_doc(self):
+        with self.assertRaises(ValidationError) as ctx:
+            newsfeed.CreatePostRequest(
+                body_plain="x",
+                body_rich={"type": "paragraph", "content": []},
+                body_format="rich",
+            )
+        self.assertIn("invalid_content_schema:root_not_doc: body_rich.type must be 'doc'", str(ctx.exception))
+
+    def test_rich_schema_node_limit_is_configurable(self):
+        rich_doc = {
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": []},
+                {"type": "paragraph", "content": []},
+            ],
+        }
+        with patch.object(newsfeed, "_content_max_rich_nodes", return_value=2):
+            with self.assertRaises(ValidationError) as ctx:
+                newsfeed.CreatePostRequest(body_plain="x", body_rich=rich_doc, body_format="rich")
+        self.assertIn("invalid_content_schema:node_limit_exceeded: body_rich node count exceeds max (2)", str(ctx.exception))
+
+    def test_rich_schema_depth_limit_is_configurable(self):
+        rich_doc = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "paragraph", "content": []}]}
+                    ],
+                }
+            ],
+        }
+        with (
+            patch.object(newsfeed, "_content_max_rich_nodes", return_value=999),
+            patch.object(newsfeed, "_content_max_rich_depth", return_value=3),
+        ):
+            with self.assertRaises(ValidationError) as ctx:
+                newsfeed.CreatePostRequest(body_plain="x", body_rich=rich_doc, body_format="rich")
+        self.assertIn("invalid_content_schema:depth_limit_exceeded: body_rich depth exceeds max (3)", str(ctx.exception))
+
+
+
+    def test_rich_schema_rejects_unsupported_node_type_with_reason_code(self):
+        with self.assertRaises(ValidationError) as ctx:
+            newsfeed.CreatePostRequest(
+                body_plain="x",
+                body_rich={"type": "doc", "content": [{"type": "iframe", "content": []}]},
+                body_format="rich",
+            )
+        self.assertIn("invalid_content_schema:unsupported_node_type:", str(ctx.exception))
+
+    def test_rich_schema_rejects_raw_html_nodes_by_default(self):
+        with self.assertRaises(ValidationError) as ctx:
+            newsfeed.CreatePostRequest(
+                body_plain="x",
+                body_rich={"type": "doc", "content": [{"type": "rawHtml", "content": []}]},
+                body_format="rich",
+            )
+        self.assertIn("invalid_content_schema:unsupported_node_type:", str(ctx.exception))
+
+    def test_rich_schema_rejects_unsupported_node_attrs(self):
+        with self.assertRaises(ValidationError) as ctx:
+            newsfeed.CreatePostRequest(
+                body_plain="x",
+                body_rich={
+                    "type": "doc",
+                    "content": [{"type": "paragraph", "attrs": {"style": "color:red"}, "content": []}],
+                },
+                body_format="rich",
+            )
+        self.assertIn("invalid_content_schema:unsupported_node_attr:", str(ctx.exception))
+
+    def test_rich_schema_rejects_unsafe_link_mark(self):
+        with self.assertRaises(ValidationError) as ctx:
+            newsfeed.CreatePostRequest(
+                body_plain="x",
+                body_rich={
+                    "type": "doc",
+                    "content": [{
+                        "type": "text",
+                        "text": "click",
+                        "marks": [{"type": "link", "attrs": {"href": "javascript:alert(1)"}}],
+                    }],
+                },
+                body_format="rich",
+            )
+        self.assertIn("invalid_content_schema:unsafe_link_protocol:", str(ctx.exception))
+
+    def test_rich_schema_logs_reason_code(self):
+        with patch.object(newsfeed.logger, "warning") as warn:
+            with self.assertRaises(ValidationError):
+                newsfeed.CreatePostRequest(
+                    body_plain="x",
+                    body_rich={"type": "doc", "content": [{"type": "iframe", "content": []}]},
+                    body_format="rich",
+                )
+        self.assertTrue(warn.called)
+        self.assertEqual(warn.call_args.kwargs["extra"]["reason_code"], "unsupported_node_type")
+
+    def test_markdown_sanitizer_allows_https_and_mailto_links(self):
+        md = "See [safe](https://example.com) and [mail](mailto:test@example.com)"
+        html = newsfeed.render_markdown_sanitized_html(md)
+        self.assertIn('href="https://example.com"', html)
+        self.assertIn('href="mailto:test@example.com"', html)
+        self.assertIn('rel="nofollow noopener noreferrer"', html)
+
+    def test_markdown_sanitizer_blocks_javascript_links(self):
+        md = "Click [bad](javascript:alert(1))"
+        html = newsfeed.render_markdown_sanitized_html(md)
+        self.assertNotIn('javascript:', html)
+        self.assertNotIn('<a ', html)
+        self.assertIn('bad', html)
+
+    def test_markdown_sanitizer_escapes_raw_script_and_event_handlers(self):
+        md = '<script>alert(1)</script> [x](https://a.com" onclick="alert(1))'
+        html = newsfeed.render_markdown_sanitized_html(md)
+        self.assertNotIn('<script>', html)
+        self.assertIn('&lt;script&gt;alert(1)&lt;/script&gt;', html)
+        self.assertNotIn('onclick=', html)
+
+    def test_create_post_returns_legacy_and_format_aware_fields(self):
+        req = newsfeed.CreatePostRequest(
+            body_plain="Hello world",
+            body_markdown="# Hello world",
+            body_format="markdown",
+            visibility="followers",
+        )
+
+        with (
+            patch.object(newsfeed, "new_id", return_value="post_1"),
+            patch.object(newsfeed, "now_iso", return_value="2026-01-01T00:00:00+00:00"),
+            patch.object(newsfeed, "ddb_put_item"),
+            patch.object(newsfeed, "_meter_newsfeed_post_publish"),
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            resp = newsfeed.create_post(req, user_id="u1")
+
+        self.assertEqual(resp.body, "Hello world")
+        self.assertEqual(resp.body_plain, "Hello world")
+        self.assertEqual(resp.body_markdown, "# Hello world")
+        self.assertIsNotNone(resp.body_markdown_html)
+        self.assertIsNone(resp.body_rich)
+        self.assertEqual(resp.body_format, "markdown")
+        self.assertEqual(resp.body_version, 1)
+
+
+    def test_post_serializer_masks_all_format_fields_when_locked(self):
+        post = {
+            "post_id": "p1",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "legacy body",
+            "body_plain": "plain body",
+            "body_markdown": "# heading",
+            "body_markdown_html": "<p>heading</p>",
+            "body_rich": {"type": "doc", "content": [{"type": "text", "text": "secret"}]},
+            "body_format": "rich",
+            "body_version": 1,
+            "image_urls": ["https://cdn.example.com/a.png"],
+            "locked": True,
+        }
+
+        out = newsfeed._post_to_dict(post, locked_body=True)
+
+        self.assertEqual(out["body"], "[Locked content]")
+        self.assertEqual(out["body_plain"], "[Locked content]")
+        self.assertIsNone(out["body_markdown"])
+        self.assertIsNone(out["body_markdown_html"])
+        self.assertIsNone(out["body_rich"])
+        self.assertEqual(out["body_format"], "plain")
+        self.assertEqual(out["body_version"], 1)
+        self.assertEqual(out["image_urls"], [])
+
+    def test_get_post_masks_locked_content_without_format_bypass(self):
+        locked_post = {
+            "pk": newsfeed.pk_post("p1"),
+            "sk": newsfeed.sk_post(),
+            "post_id": "p1",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body_plain": "plain secret",
+            "body_markdown": "[x](https://example.com)",
+            "body_markdown_html": '<p><a href="https://example.com">x</a></p>',
+            "body_rich": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "secret"}]}]},
+            "body_format": "rich",
+            "body_version": 1,
+            "locked": True,
+            "image_urls": ["https://cdn.example.com/private.png"],
+        }
+
+        with (
+            patch.object(newsfeed, "ddb_get_item", side_effect=[locked_post, None]),
+            patch.object(newsfeed, "can_access_creator", return_value=True),
+            patch.object(newsfeed, "has_unlocked", return_value=False),
+        ):
+            out = newsfeed.get_post("p1", user_id="viewer_1")
+
+        self.assertEqual(out["body"], "[Locked content]")
+        self.assertEqual(out["body_plain"], "[Locked content]")
+        self.assertIsNone(out["body_markdown"])
+        self.assertIsNone(out["body_markdown_html"])
+        self.assertIsNone(out["body_rich"])
+        self.assertEqual(out["body_format"], "plain")
+        self.assertEqual(out["image_urls"], [])
+
+    def test_comment_serializer_emits_legacy_body_and_content_fields(self):
+        item = {
+            "comment_id": "c1",
+            "post_id": "p1",
+            "user_id": "u1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body_plain": "Hello",
+            "body_markdown": "**Hello**",
+            "body_format": "markdown",
+            "body_version": 1,
+            "deleted": False,
+            "version": 2,
+            "tip_total_cents": 50,
+        }
+
+        out = newsfeed._comment_to_dict(item)
+
+        self.assertEqual(out["body"], "Hello")
+        self.assertEqual(out["body_plain"], "Hello")
+        self.assertEqual(out["body_markdown"], "**Hello**")
+        self.assertEqual(out["body_format"], "markdown")
+        self.assertEqual(out["body_version"], 1)
+
+    def test_post_serializer_read_path_fallback_from_format_fields_to_legacy_body(self):
+        post = {
+            "post_id": "p-migrate",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body_markdown": "# Migrated markdown",
+            "body_format": "markdown",
+            "body_version": 2,
+            "locked": False,
+        }
+
+        out = newsfeed._post_to_dict(post)
+
+        self.assertEqual(out["body"], "# Migrated markdown")
+        self.assertEqual(out["body_plain"], "# Migrated markdown")
+        self.assertEqual(out["body_markdown"], "# Migrated markdown")
+        self.assertEqual(out["body_format"], "markdown")
+        self.assertIsNotNone(out["body_markdown_html"])
+
+    def test_comment_serializer_falls_back_to_body_plain_for_unknown_format(self):
+        item = {
+            "comment_id": "c-legacy",
+            "post_id": "p1",
+            "user_id": "u1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body_plain": "Safe plain fallback",
+            "body_format": "html",
+            "body_version": 1,
+            "deleted": False,
+            "version": 1,
+        }
+
+        out = newsfeed._comment_to_dict(item)
+
+        self.assertEqual(out["body"], "Safe plain fallback")
+        self.assertEqual(out["body_plain"], "Safe plain fallback")
+        self.assertEqual(out["body_format"], "plain")
+        self.assertIsNone(out["body_markdown"])
+        self.assertIsNone(out["body_rich"])
+
+
+
+    def test_create_comment_supports_rich_payload(self):
+        req = newsfeed.CreateCommentRequest(
+            body_plain="Rich fallback",
+            body_rich={"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Rich fallback"}]}]},
+            body_format="rich",
+        )
+        post_item = {"pk": newsfeed.pk_post("p1"), "sk": newsfeed.sk_post(), "post_id": "p1", "user_id": "author_1", "locked": False}
+
+        with (
+            patch.object(newsfeed, "ddb_get_item", return_value=post_item),
+            patch.object(newsfeed, "can_access_creator", return_value=True),
+            patch.object(newsfeed, "new_id", return_value="cmt_1"),
+            patch.object(newsfeed, "now_iso", return_value="2026-01-01T00:00:00+00:00"),
+            patch.object(newsfeed, "ddb_put_item"),
+            patch.object(newsfeed, "ddb_update_item"),
+        ):
+            resp = newsfeed.create_comment("p1", req, user_id="u1")
+
+        self.assertEqual(resp.body, "Rich fallback")
+        self.assertEqual(resp.body_plain, "Rich fallback")
+        self.assertEqual(resp.body_format, "rich")
+        self.assertIsNotNone(resp.body_rich)
+        self.assertIsNone(resp.body_markdown)
+
+    def test_edit_post_roundtrip_for_plain_markdown_and_rich_formats(self):
+        existing = {"pk": newsfeed.pk_post("p1"), "sk": newsfeed.sk_post(), "post_id": "p1", "user_id": "u1", "created_at": "2026-01-01T00:00:00+00:00"}
+
+        cases = [
+            (
+                newsfeed.EditPostRequest(body="legacy plain"),
+                {
+                    "body": "legacy plain",
+                    "body_plain": "legacy plain",
+                    "body_markdown": None,
+                    "body_rich": None,
+                    "body_format": "plain",
+                },
+            ),
+            (
+                newsfeed.EditPostRequest(body_plain="md fallback", body_markdown="## md fallback", body_format="markdown"),
+                {
+                    "body": "md fallback",
+                    "body_plain": "md fallback",
+                    "body_markdown": "## md fallback",
+                    "body_rich": None,
+                    "body_format": "markdown",
+                },
+            ),
+            (
+                newsfeed.EditPostRequest(
+                    body_plain="rich fallback",
+                    body_rich={"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "rich fallback"}]}]},
+                    body_format="rich",
+                ),
+                {
+                    "body": "rich fallback",
+                    "body_plain": "rich fallback",
+                    "body_markdown": None,
+                    "body_rich": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "rich fallback"}]}]},
+                    "body_format": "rich",
+                },
+            ),
+        ]
+
+        for req, expected in cases:
+            with self.subTest(format=expected["body_format"]):
+                with (
+                    patch.object(newsfeed, "ddb_get_item", return_value=existing),
+                    patch.object(newsfeed, "now_iso", return_value="2026-01-01T00:00:00+00:00"),
+                    patch.object(newsfeed, "ddb_update_item") as upd,
+                ):
+                    upd.return_value = {
+                        **existing,
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                        "body": expected["body"],
+                        "body_plain": expected["body_plain"],
+                        "body_markdown": expected["body_markdown"],
+                        "body_markdown_html": "<p>md</p>" if expected["body_markdown"] else None,
+                        "body_rich": expected["body_rich"],
+                        "body_format": expected["body_format"],
+                        "body_version": 1,
+                        "locked": False,
+                    }
+                    out = newsfeed.edit_post("p1", req, user_id="u1")
+
+                self.assertEqual(out["body"], expected["body"])
+                self.assertEqual(out["body_plain"], expected["body_plain"])
+                self.assertEqual(out["body_markdown"], expected["body_markdown"])
+                self.assertEqual(out["body_format"], expected["body_format"])
+                self.assertEqual(out["body_rich"], expected["body_rich"])
+
+    def test_get_post_unlocked_roundtrip_for_rich_content(self):
+        rich_post = {
+            "pk": newsfeed.pk_post("p1"),
+            "sk": newsfeed.sk_post(),
+            "post_id": "p1",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body_plain": "rich text",
+            "body_rich": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "rich text"}]}]},
+            "body_format": "rich",
+            "body_version": 1,
+            "locked": True,
+        }
+
+        with (
+            patch.object(newsfeed, "ddb_get_item", side_effect=[rich_post, None]),
+            patch.object(newsfeed, "can_access_creator", return_value=True),
+            patch.object(newsfeed, "has_unlocked", return_value=True),
+        ):
+            out = newsfeed.get_post("p1", user_id="viewer_1")
+
+        self.assertEqual(out["body"], "rich text")
+        self.assertEqual(out["body_plain"], "rich text")
+        self.assertEqual(out["body_format"], "rich")
+        self.assertIsNotNone(out["body_rich"])
+
+    def test_edit_comment_roundtrip_for_markdown(self):
+        req = newsfeed.EditCommentRequest(
+            body_plain="new fallback",
+            body_markdown="**new fallback**",
+            body_format="markdown",
+            expected_version=1,
+        )
+        existing = {
+            "pk": newsfeed.pk_post_comments("p1"),
+            "sk": "2026-01-01T00:00:00+00:00#CMT#c1",
+            "comment_id": "c1",
+            "post_id": "p1",
+            "user_id": "u1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "deleted": False,
+            "version": 1,
+        }
+
+        with (
+            patch.object(newsfeed, "ddb_query", return_value={"Items": [existing]}),
+            patch.object(newsfeed, "now_iso", return_value="2026-01-02T00:00:00+00:00"),
+            patch.object(newsfeed, "ddb_update_item") as upd,
+        ):
+            upd.return_value = {
+                **existing,
+                "updated_at": "2026-01-02T00:00:00+00:00",
+                "body": "new fallback",
+                "body_plain": "new fallback",
+                "body_markdown": "**new fallback**",
+                "body_markdown_html": "<p><strong>new fallback</strong></p>",
+                "body_rich": None,
+                "body_format": "markdown",
+                "body_version": 1,
+                "version": 2,
+                "tip_total_cents": 0,
+            }
+            out = newsfeed.edit_comment("p1", "c1", req, user_id="u1")
+
+        self.assertEqual(out.body, "new fallback")
+        self.assertEqual(out.body_plain, "new fallback")
+        self.assertEqual(out.body_markdown, "**new fallback**")
+        self.assertEqual(out.body_format, "markdown")
+        self.assertEqual(out.version, 2)
+
+    def test_list_comments_returns_all_formats(self):
+        post = {"pk": newsfeed.pk_post("p1"), "sk": newsfeed.sk_post(), "post_id": "p1", "user_id": "author_1", "locked": False}
+        items = [
+            {
+                "comment_id": "c_plain",
+                "post_id": "p1",
+                "user_id": "u1",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "body": "legacy",
+                "deleted": False,
+                "version": 1,
+            },
+            {
+                "comment_id": "c_md",
+                "post_id": "p1",
+                "user_id": "u2",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "body_plain": "md",
+                "body_markdown": "**md**",
+                "body_format": "markdown",
+                "deleted": False,
+                "version": 1,
+            },
+            {
+                "comment_id": "c_rich",
+                "post_id": "p1",
+                "user_id": "u3",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "body_plain": "rich",
+                "body_rich": {"type": "doc", "content": []},
+                "body_format": "rich",
+                "deleted": False,
+                "version": 1,
+            },
+        ]
+
+        with (
+            patch.object(newsfeed, "ddb_get_item", return_value=post),
+            patch.object(newsfeed, "ddb_query", return_value={"Items": items}),
+            patch.object(newsfeed, "encode_cursor", return_value=None),
+        ):
+            out = newsfeed.list_comments("p1", limit=20, cursor=None, user_id="viewer")
+
+        self.assertEqual(len(out["items"]), 3)
+        self.assertEqual(out["items"][0]["body_format"], "plain")
+        self.assertEqual(out["items"][1]["body_format"], "markdown")
+        self.assertEqual(out["items"][2]["body_format"], "rich")
+
+
+
+
+    def test_serializer_downgrades_to_plain_when_markdown_flag_disabled(self):
+        object.__setattr__(newsfeed.S, "newsfeed_markdown_enabled", False)
+        item = {
+            "post_id": "p1",
+            "user_id": "u1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body_plain": "plain",
+            "body_markdown": "# md",
+            "body_markdown_html": "<h1>md</h1>",
+            "body_format": "markdown",
+        }
+        out = newsfeed._post_to_dict(item)
+        self.assertEqual(out["body_format"], "plain")
+        self.assertIsNone(out["body_markdown"])
+        self.assertIsNone(out["body_markdown_html"])
+        self.assertEqual(out["body"], "plain")
+
+    def test_serializer_downgrades_to_plain_when_rich_flag_disabled(self):
+        object.__setattr__(newsfeed.S, "newsfeed_richtext_enabled", False)
+        item = {
+            "comment_id": "c1",
+            "post_id": "p1",
+            "user_id": "u1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body_plain": "plain",
+            "body_rich": {"type": "doc", "content": []},
+            "body_format": "rich",
+            "deleted": False,
+            "version": 1,
+        }
+        out = newsfeed._comment_to_dict(item)
+        self.assertEqual(out["body_format"], "plain")
+        self.assertIsNone(out["body_rich"])
+        self.assertEqual(out["body"], "plain")
+
+
+    def test_markdown_payload_rejected_when_markdown_flag_disabled(self):
+        object.__setattr__(newsfeed.S, "newsfeed_markdown_enabled", False)
+        with self.assertRaises(ValidationError) as ctx:
+            newsfeed.CreatePostRequest(body_plain="x", body_markdown="# x", body_format="markdown")
+        self.assertIn("feature_disabled: markdown format is disabled", str(ctx.exception))
+
+    def test_rich_payload_rejected_when_rich_flag_disabled(self):
+        object.__setattr__(newsfeed.S, "newsfeed_richtext_enabled", False)
+        with self.assertRaises(ValidationError) as ctx:
+            newsfeed.CreatePostRequest(body_plain="x", body_rich={"type": "doc", "content": []}, body_format="rich")
+        self.assertIn("feature_disabled: rich format is disabled", str(ctx.exception))
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Introduce first-class support for Markdown and Rich Text authoring/rendering in posts and comments while preserving legacy `body` compatibility.
- Enforce sanitization and strict rich-schema validation to prevent XSS and unsafe links and to provide configurable limits for text length, node count, and depth.
- Provide rollout controls via feature flags and telemetry for safe incremental enablement and observability.

### Description

- Add settings and feature flags (`newsfeed_markdown_enabled`, `newsfeed_richtext_enabled`, and size/limit settings) and emit structured content metrics and rejection logs.
- Implement server-side content envelope support and validation: `body_plain`, `body_markdown`, `body_markdown_html`, `body_rich`, `body_format`, `body_version`, plus `ContentFieldsMixin` Pydantic validation, Markdown sanitizer (`render_markdown_sanitized_html`), rich-schema validator, and safe URL checks.
- Update newsfeed endpoints and serializers to accept and persist the envelope, derive sanitized HTML for markdown, resolve format-aware read-paths with rollout-safe fallbacks, mask formatted fields for locked posts, and add a telemetry endpoint `POST /telemetry/content-render`.
- Add migration/backfill tooling and docs: `scripts/backfill_newsfeed_plain_fields.py`, new spec/docs for contract, plan, runbook and tickets, frontend types and feature-flag wiring, a rich composer/editor and preview (`MarkdownComposer`), a `RichContentRenderer`, and corresponding unit/e2e test assets.

### Testing

- Ran backend unit tests `tests/test_newsfeed_content_envelope.py` and `tests/test_newsfeed_backfill_script.py` (Python unittest/pytest targets for validation, serializer, and backfill logic) and they passed.
- Ran frontend unit tests for the composer and renderer (`frontend/src/pages/feed/__tests__/MarkdownComposer.test.tsx` and `RichContentRenderer.test.tsx`) with the component test runner (Vitest) and they passed.
- Added Playwright E2E spec (`frontend/e2e/feed-rich-content.spec.ts`) to validate author/viewer flows and XSS scenarios, which is included in the PR but was not executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39c70bdc8832b867bc25560fdf26d)