### PR TITLE
Internal Dev Log UI: add parsers, APIs, frontend UI, and run_dev integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -69,6 +69,11 @@ UI_ACCESS_TOKEN_SECRET=
 SES_FROM_EMAIL=dev-no-reply@example.com
 # DEV_EMAIL_LOG=.logs/dev/emails.log
 # DEV_SMS_LOG=.logs/dev/sms.log
+# Internal Dev Log UI discovery defaults (optional overrides)
+# DEVTOOLS_EMAIL_LOG_PATH=.logs/dev/emails.log
+# DEVTOOLS_SMS_LOG_PATH=.logs/dev/sms.log
+# DEVTOOLS_BILLING_STRIPE_LOG_PATH=.local/logs/stripe-mock.log
+# DEVTOOLS_BILLING_BACKEND_LOG_PATH=.logs/dev/backend.log
 
 # Messaging encrypted messages rollout flags
 MESSAGING_ENCRYPTED_MESSAGES_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ session management, MFA, billing, notifications, and a lightweight control panel
 - [Stripe billing](docs/stripe.md)
 - [PayPal billing](docs/paypal.md)
 - [UPS integration](docs/ups.md)
+- [Internal Dev Log UI (local/dev)](docs/internal-dev-log-ui.md)
 
 ## What ships in this service
 - **FastAPI API surface**: routers for account management, MFA, alerts, messaging, catalog, shopping cart, purchase history, billing, and file management.
@@ -42,6 +43,16 @@ scripts/run_dev.sh
 # in another terminal
 scripts/test_mock_mode.sh
 ```
+
+### Internal Dev Log UI (local/dev)
+
+`scripts/run_dev.sh` auto-enables the internal Dev Log UI route in local runs.
+
+- URL: `http://localhost:5173/dev-tools/log-ui`
+- Data inputs: `DEVTOOLS_EMAIL_LOG_PATH`, `DEVTOOLS_SMS_LOG_PATH`, `DEVTOOLS_BILLING_STRIPE_LOG_PATH`, `DEVTOOLS_BILLING_BACKEND_LOG_PATH`
+- Security/read-only: Email/SMS/Billing are read-only; the only editable input is local TOTP config paste in browser.
+
+See [Internal Dev Log UI (local/dev)](docs/internal-dev-log-ui.md) for quickstart + troubleshooting.
 
 ## Required environment variables (minimum)
 | Variable | Purpose | Notes |

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -183,6 +183,13 @@ class Settings:
     dev_registration_phone: str = os.environ.get("DEV_REGISTRATION_PHONE", "")
     dev_email_log: str = os.environ.get("DEV_EMAIL_LOG", ".logs/dev/emails.log")
     dev_sms_log: str = os.environ.get("DEV_SMS_LOG", ".logs/dev/sms.log")
+    # Internal Dev Log UI discovery defaults (DLU-001).
+    devtools_email_log_path: str = os.environ.get("DEVTOOLS_EMAIL_LOG_PATH", os.environ.get("DEV_EMAIL_LOG", ".logs/dev/emails.log"))
+    devtools_sms_log_path: str = os.environ.get("DEVTOOLS_SMS_LOG_PATH", os.environ.get("DEV_SMS_LOG", ".logs/dev/sms.log"))
+    # Stripe mock writes provider logs under .local/logs in host-mode startup.
+    devtools_billing_stripe_log_path: str = os.environ.get("DEVTOOLS_BILLING_STRIPE_LOG_PATH", ".local/logs/stripe-mock.log")
+    # CCBill/PayPal mock calls are served in-process and observable from backend logs.
+    devtools_billing_backend_log_path: str = os.environ.get("DEVTOOLS_BILLING_BACKEND_LOG_PATH", ".logs/dev/backend.log")
 
     # Billing / CCBill
     ccbill_base_url: str = os.environ.get("CCBILL_BASE_URL", "https://api.ccbill.com").rstrip("/")

--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,7 @@ from app.routers.entitlements import router as entitlements_router
 from app.routers.commercial_checkout import router as commercial_checkout_router
 from app.routers.tickets import router as tickets_router
 from app.routers.ticket_spaces import router as ticket_spaces_router
+from app.routers.internal_devtools import router as internal_devtools_router
 from app.services.billing_reconcile import start_billing_reconcile_task
 from app.services.billing_dunning import start_billing_dunning_task
 from app.services.filemanager import start_filemgr_purge_task
@@ -210,6 +211,7 @@ def create_app() -> FastAPI:
     app.include_router(contacts_router)
     app.include_router(tickets_router)
     app.include_router(ticket_spaces_router)
+    app.include_router(internal_devtools_router)
     app.add_event_handler("startup", start_billing_reconcile_task)
     app.add_event_handler("startup", start_projects_reconcile_task)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1385,3 +1385,172 @@ class ProviderCredentialModel(BaseModel):
         if parsed.tzinfo is None:
             raise ValueError("timestamp must include timezone")
         return value
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Internal Dev Tools (DLU-002) canonical read models
+# ──────────────────────────────────────────────────────────────────────────────
+
+class DevtoolsParseWarningOut(BaseModel):
+    """Parser warning surfaced to callers without failing the whole response."""
+
+    source: Literal["email", "sms", "billing"]
+    line_number: Optional[int] = None
+    code: str = Field(min_length=1, max_length=64)
+    message: str = Field(min_length=1, max_length=512)
+    sample: Optional[str] = Field(default=None, max_length=1024)
+
+
+class DevtoolsIdentityOut(BaseModel):
+    """Stable deterministic identifier metadata.
+
+    `id` should remain stable across refreshes for unchanged source logs.
+    `id_strategy` documents what inputs were hashed/combined by parsers.
+    """
+
+    id: str = Field(min_length=1, max_length=128)
+    id_strategy: str = Field(min_length=1, max_length=128)
+
+
+class DevtoolsTimestampMixin(BaseModel):
+    """Normalize API timestamps to UTC RFC3339 (`YYYY-MM-DDTHH:MM:SSZ`)."""
+
+    @staticmethod
+    def _normalize_utc_timestamp(value: str) -> str:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise ValueError("timestamp must include timezone")
+        return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class DevtoolsEmailMessageOut(DevtoolsTimestampMixin, DevtoolsIdentityOut):
+    thread_id: str = Field(min_length=1, max_length=128)
+    mailbox: str = Field(min_length=1, max_length=320)
+    sent_at: str
+    event_kind: Literal["mfa_email_code", "alert_email", "unknown"] = "unknown"
+    direction: Literal["inbound", "outbound", "unknown"] = "unknown"
+    from_email: Optional[str] = Field(default=None, max_length=320)
+    to_emails: List[str] = Field(default_factory=list)
+    subject: Optional[str] = Field(default=None, max_length=512)
+    body_text: Optional[str] = None
+    body_html: Optional[str] = None
+    code: Optional[str] = Field(default=None, max_length=64)
+    purpose: Optional[str] = Field(default=None, max_length=64)
+    status: Optional[str] = Field(default=None, max_length=64)
+    parse_warnings: List[DevtoolsParseWarningOut] = Field(default_factory=list)
+
+    @field_validator("sent_at")
+    @classmethod
+    def _normalize_sent_at(cls, value: str) -> str:
+        return cls._normalize_utc_timestamp(value)
+
+
+class DevtoolsEmailThreadOut(DevtoolsTimestampMixin, DevtoolsIdentityOut):
+    mailbox: str = Field(min_length=1, max_length=320)
+    subject: Optional[str] = Field(default=None, max_length=512)
+    message_count: int = Field(default=0, ge=0)
+    unread_count: int = Field(default=0, ge=0)
+    participant_emails: List[str] = Field(default_factory=list)
+    latest_message_at: str
+
+    @field_validator("latest_message_at")
+    @classmethod
+    def _normalize_latest_message_at(cls, value: str) -> str:
+        return cls._normalize_utc_timestamp(value)
+
+
+class DevtoolsEmailMailboxOut(DevtoolsIdentityOut):
+    mailbox: str = Field(min_length=1, max_length=320)
+    thread_count: int = Field(default=0, ge=0)
+    unread_count: int = Field(default=0, ge=0)
+
+
+class DevtoolsEmailMessagesOut(BaseModel):
+    mailboxes: List[DevtoolsEmailMailboxOut] = Field(default_factory=list)
+    threads: List[DevtoolsEmailThreadOut] = Field(default_factory=list)
+    messages: List[DevtoolsEmailMessageOut] = Field(default_factory=list)
+    next_cursor: Optional[str] = None
+    parse_warnings: List[DevtoolsParseWarningOut] = Field(default_factory=list)
+
+
+class DevtoolsSmsMessageOut(DevtoolsTimestampMixin, DevtoolsIdentityOut):
+    conversation_id: str = Field(min_length=1, max_length=128)
+    sent_at: str
+    from_number: Optional[str] = Field(default=None, max_length=32)
+    to_number: Optional[str] = Field(default=None, max_length=32)
+    direction: Literal["inbound", "outbound", "unknown"] = "unknown"
+    body_text: Optional[str] = None
+    code: Optional[str] = Field(default=None, max_length=64)
+    status: Optional[str] = Field(default=None, max_length=64)
+    provider_message_id: Optional[str] = Field(default=None, max_length=128)
+    event_kind: Literal["mfa_sms_code", "alert_sms", "unknown"] = "unknown"
+    parse_warnings: List[DevtoolsParseWarningOut] = Field(default_factory=list)
+
+    @field_validator("sent_at")
+    @classmethod
+    def _normalize_sent_at(cls, value: str) -> str:
+        return cls._normalize_utc_timestamp(value)
+
+
+class DevtoolsSmsConversationOut(DevtoolsTimestampMixin, DevtoolsIdentityOut):
+    participant_numbers: List[str] = Field(default_factory=list)
+    message_count: int = Field(default=0, ge=0)
+    latest_message_at: str
+    latest_preview: Optional[str] = Field(default=None, max_length=256)
+
+    @field_validator("latest_message_at")
+    @classmethod
+    def _normalize_latest_message_at(cls, value: str) -> str:
+        return cls._normalize_utc_timestamp(value)
+
+
+class DevtoolsSmsConversationsOut(BaseModel):
+    conversations: List[DevtoolsSmsConversationOut] = Field(default_factory=list)
+    messages: List[DevtoolsSmsMessageOut] = Field(default_factory=list)
+    next_cursor: Optional[str] = None
+    parse_warnings: List[DevtoolsParseWarningOut] = Field(default_factory=list)
+
+
+class DevtoolsBillingLedgerEntryOut(DevtoolsTimestampMixin, DevtoolsIdentityOut):
+    provider: Literal["stripe", "ccbill", "paypal", "unknown"] = "unknown"
+    event_type: str = Field(min_length=1, max_length=128)
+    status: str = Field(min_length=1, max_length=64)
+    occurred_at: str
+    external_id: Optional[str] = Field(default=None, max_length=128)
+    amount: float = 0.0
+    fee: float = 0.0
+    net: float = 0.0
+    currency: str = Field(default="usd", min_length=3, max_length=3)
+    source_path: Optional[str] = Field(default=None, max_length=512)
+    raw_payload: Dict[str, Any] = Field(default_factory=dict)
+    parse_warnings: List[DevtoolsParseWarningOut] = Field(default_factory=list)
+
+    @field_validator("occurred_at")
+    @classmethod
+    def _normalize_occurred_at(cls, value: str) -> str:
+        return cls._normalize_utc_timestamp(value)
+
+    @field_validator("currency")
+    @classmethod
+    def _normalize_currency(cls, value: str) -> str:
+        normalized = (value or "").strip().lower()
+        if len(normalized) != 3:
+            raise ValueError("currency must be an ISO-4217 3-letter code")
+        return normalized
+
+
+class DevtoolsBillingLedgerSummaryOut(BaseModel):
+    gross_inflow: float = 0.0
+    fees: float = 0.0
+    net_total_balance: float = 0.0
+    transaction_count: int = Field(default=0, ge=0)
+    provider_counts: Dict[str, int] = Field(default_factory=dict)
+    status_counts: Dict[str, int] = Field(default_factory=dict)
+    parse_warnings: List[DevtoolsParseWarningOut] = Field(default_factory=list)
+
+
+class DevtoolsBillingLedgerOut(BaseModel):
+    entries: List[DevtoolsBillingLedgerEntryOut] = Field(default_factory=list)
+    summary: DevtoolsBillingLedgerSummaryOut = Field(default_factory=DevtoolsBillingLedgerSummaryOut)
+    next_cursor: Optional[str] = None
+    parse_warnings: List[DevtoolsParseWarningOut] = Field(default_factory=list)

--- a/app/routers/internal_devtools.py
+++ b/app/routers/internal_devtools.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Literal, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.core.settings import S
+from app.models import (
+    DevtoolsBillingLedgerOut,
+    DevtoolsBillingLedgerSummaryOut,
+    DevtoolsEmailMessagesOut,
+    DevtoolsSmsConversationsOut,
+)
+from app.services.devtools.read_service import (
+    get_billing_ledger,
+    get_billing_summary,
+    get_email_messages,
+    get_sms_conversations,
+)
+
+router = APIRouter(prefix="/internal/dev-tools", tags=["internal-dev-tools"])
+logger = logging.getLogger(__name__)
+
+
+def _require_devtools_enabled() -> None:
+    if not S.dev_mode:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "devtools_disabled", "message": "internal dev-tools routes are disabled"},
+        )
+
+
+def _audit_devtools_access(endpoint: str, **filters: object) -> None:
+    # Dev-only access note for local debugging traceability.
+    logger.info("internal_devtools_access", extra={"endpoint": endpoint, "filters": filters})
+
+
+def _decode_cursor(cursor: Optional[str]) -> int:
+    """Decode URL-safe base64 cursor that stores {"offset": <int>}.
+
+    Contract behavior:
+    - missing cursor -> offset=0
+    - malformed cursor -> 400 with deterministic `invalid_cursor` error payload
+    """
+
+    if not cursor:
+        return 0
+
+    try:
+        # Add safe padding for urlsafe base64 decode.
+        padded = cursor + "=" * (-len(cursor) % 4)
+        decoded = base64.urlsafe_b64decode(padded.encode("utf-8")).decode("utf-8")
+        payload = json.loads(decoded)
+    except Exception as exc:  # pragma: no cover - defensive parsing path
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_cursor",
+                "message": "cursor must be urlsafe base64 JSON with an integer offset",
+            },
+        ) from exc
+
+    offset = payload.get("offset")
+    if not isinstance(offset, int) or offset < 0:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_cursor",
+                "message": "cursor offset must be a non-negative integer",
+            },
+        )
+    return offset
+
+
+@router.get("/email/messages", response_model=DevtoolsEmailMessagesOut)
+def get_devtools_email_messages(
+    mailbox: Optional[str] = Query(default=None, max_length=320),
+    thread_id: Optional[str] = Query(default=None, max_length=128),
+    q: Optional[str] = Query(default=None, max_length=256),
+    state: Optional[Literal["all", "unread", "sent"]] = Query(default="all"),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: Optional[str] = Query(default=None, max_length=512),
+) -> DevtoolsEmailMessagesOut:
+    _require_devtools_enabled()
+    _audit_devtools_access("email/messages", mailbox=mailbox, thread_id=thread_id, q=q, state=state, limit=limit, cursor=bool(cursor))
+    offset = _decode_cursor(cursor)
+    return get_email_messages(
+        S.devtools_email_log_path,
+        mailbox=mailbox,
+        thread_id=thread_id,
+        q=q,
+        state=state or "all",
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/sms/conversations", response_model=DevtoolsSmsConversationsOut)
+def get_devtools_sms_conversations(
+    participant: Optional[str] = Query(default=None, max_length=64),
+    q: Optional[str] = Query(default=None, max_length=256),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: Optional[str] = Query(default=None, max_length=512),
+) -> DevtoolsSmsConversationsOut:
+    _require_devtools_enabled()
+    _audit_devtools_access("sms/conversations", participant=participant, q=q, limit=limit, cursor=bool(cursor))
+    offset = _decode_cursor(cursor)
+    return get_sms_conversations(
+        S.devtools_sms_log_path,
+        participant=participant,
+        q=q,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/billing/ledger", response_model=DevtoolsBillingLedgerOut)
+def get_devtools_billing_ledger(
+    provider: Optional[Literal["stripe", "ccbill", "paypal"]] = None,
+    status: Optional[Literal["pending", "completed", "failed", "refunded", "canceled"]] = None,
+    from_ts: Optional[str] = Query(default=None, alias="from", max_length=40),
+    to_ts: Optional[str] = Query(default=None, alias="to", max_length=40),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: Optional[str] = Query(default=None, max_length=512),
+) -> DevtoolsBillingLedgerOut:
+    _require_devtools_enabled()
+    _audit_devtools_access("billing/ledger", provider=provider, status=status, from_ts=from_ts, to_ts=to_ts, limit=limit, cursor=bool(cursor))
+    offset = _decode_cursor(cursor)
+    return get_billing_ledger(
+        S.devtools_billing_stripe_log_path,
+        S.devtools_billing_backend_log_path,
+        provider=provider,
+        status=status,
+        from_ts=from_ts,
+        to_ts=to_ts,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/billing/summary", response_model=DevtoolsBillingLedgerSummaryOut)
+def get_devtools_billing_summary(
+    provider: Optional[Literal["stripe", "ccbill", "paypal"]] = None,
+    status: Optional[Literal["pending", "completed", "failed", "refunded", "canceled"]] = None,
+    from_ts: Optional[str] = Query(default=None, alias="from", max_length=40),
+    to_ts: Optional[str] = Query(default=None, alias="to", max_length=40),
+) -> DevtoolsBillingLedgerSummaryOut:
+    _require_devtools_enabled()
+    _audit_devtools_access("billing/summary", provider=provider, status=status, from_ts=from_ts, to_ts=to_ts)
+    return get_billing_summary(
+        S.devtools_billing_stripe_log_path,
+        S.devtools_billing_backend_log_path,
+        provider=provider,
+        status=status,
+        from_ts=from_ts,
+        to_ts=to_ts,
+    )

--- a/app/services/devtools/__init__.py
+++ b/app/services/devtools/__init__.py
@@ -1,0 +1,1 @@
+"""Devtools parsing and read-model helpers."""

--- a/app/services/devtools/billing_log_parser.py
+++ b/app/services/devtools/billing_log_parser.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import heapq
+import json
+import os
+import re
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
+
+from app.models import (
+    DevtoolsBillingLedgerEntryOut,
+    DevtoolsBillingLedgerOut,
+    DevtoolsParseWarningOut,
+)
+from app.services.devtools.billing_summary_service import build_billing_summary
+
+Provider = Literal["stripe", "ccbill", "paypal"]
+
+_ACCESS_RE = re.compile(r'"(?P<method>[A-Z]+)\s+(?P<path>/[^\s]+)\s+HTTP/[0-9.]+"\s+(?P<status>\d{3})')
+
+
+def _warning(code: str, message: str, *, line_number: Optional[int] = None, sample: Optional[str] = None) -> DevtoolsParseWarningOut:
+    return DevtoolsParseWarningOut(source="billing", code=code, message=message, line_number=line_number, sample=sample)
+
+
+def _stable_id(*parts: str, length: int = 20) -> str:
+    return sha256("|".join(parts).encode("utf-8")).hexdigest()[:length]
+
+
+def _iso_utc(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, (int, float)):
+            dt = datetime.fromtimestamp(float(value), tz=timezone.utc)
+        else:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def _parse_amount(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, int):
+            # Stripe often stores minor units.
+            return round(value / 100.0, 6)
+        return float(value)
+    except Exception:
+        return None
+
+
+def _detect_provider(payload: Dict[str, Any]) -> Optional[Provider]:
+    explicit = str(payload.get("provider") or "").strip().lower()
+    if explicit in {"stripe", "ccbill", "paypal"}:
+        return explicit  # type: ignore[return-value]
+    if payload.get("transactionId") or payload.get("paymentUniqueId"):
+        return "ccbill"
+    if payload.get("purchase_units") or str(payload.get("id") or "").startswith("CAP-"):
+        return "paypal"
+    if payload.get("type") and payload.get("data"):
+        return "stripe"
+    return None
+
+
+def _stripe_entry(payload: Dict[str, Any], source_path: str) -> Optional[Dict[str, Any]]:
+    obj = payload.get("data", {}).get("object", {}) if isinstance(payload.get("data"), dict) else {}
+    event_type = str(payload.get("type") or "stripe.event")
+    status = str(obj.get("status") or payload.get("status") or "unknown")
+    created = _iso_utc(payload.get("created") or obj.get("created") or payload.get("timestamp"))
+    amount = _parse_amount(obj.get("amount") or obj.get("amount_total") or payload.get("amount"))
+    fee = _parse_amount(obj.get("fee") or payload.get("fee")) or 0.0
+    currency = str(obj.get("currency") or payload.get("currency") or "usd").lower()
+    external_id = str(obj.get("id") or payload.get("id") or "").strip() or None
+
+    if not created or amount is None:
+        return None
+
+    return {
+        "provider": "stripe",
+        "event_type": event_type,
+        "status": status,
+        "occurred_at": created,
+        "external_id": external_id,
+        "amount": amount,
+        "fee": fee,
+        "net": amount - fee,
+        "currency": currency,
+        "source_path": source_path,
+        "raw_payload": payload,
+    }
+
+
+def _ccbill_entry(payload: Dict[str, Any], source_path: str) -> Optional[Dict[str, Any]]:
+    created = _iso_utc(payload.get("timestamp") or payload.get("created_at") or payload.get("time"))
+    amount = _parse_amount(payload.get("amount") or payload.get("initialPrice") or payload.get("recurringPrice"))
+    fee = _parse_amount(payload.get("fee")) or 0.0
+    currency = str(payload.get("currency") or payload.get("currencyCode") or "usd").lower()
+    status = str(payload.get("status") or ("completed" if payload.get("approved") else "failed"))
+    event_type = str(payload.get("eventType") or payload.get("type") or "ccbill.charge")
+    external_id = str(payload.get("transactionId") or payload.get("paymentUniqueId") or payload.get("subscriptionId") or "").strip() or None
+
+    if not created or amount is None:
+        return None
+
+    return {
+        "provider": "ccbill",
+        "event_type": event_type,
+        "status": status,
+        "occurred_at": created,
+        "external_id": external_id,
+        "amount": amount,
+        "fee": fee,
+        "net": amount - fee,
+        "currency": currency,
+        "source_path": source_path,
+        "raw_payload": payload,
+    }
+
+
+def _paypal_entry(payload: Dict[str, Any], source_path: str) -> Optional[Dict[str, Any]]:
+    cap = None
+    units = payload.get("purchase_units")
+    if isinstance(units, list) and units:
+        cap = (((units[0] or {}).get("payments") or {}).get("captures") or [None])[0]
+
+    amount_obj = (cap or {}).get("amount") or payload.get("amount") or {}
+    amount = _parse_amount((amount_obj or {}).get("value") if isinstance(amount_obj, dict) else amount_obj)
+    currency = str((amount_obj or {}).get("currency_code") if isinstance(amount_obj, dict) else payload.get("currency") or "usd").lower()
+
+    created = _iso_utc(payload.get("timestamp") or payload.get("create_time") or payload.get("update_time") or payload.get("created_at"))
+    if not created:
+        # Many mock payloads omit create_time; use deterministic epoch fallback only when explicitly absent.
+        created = "1970-01-01T00:00:00Z"
+
+    fee = _parse_amount(payload.get("fee")) or 0.0
+    status = str((cap or {}).get("status") or payload.get("status") or "unknown")
+    event_type = str(payload.get("event_type") or payload.get("type") or "paypal.capture")
+    external_id = str((cap or {}).get("id") or payload.get("id") or "").strip() or None
+
+    if amount is None:
+        return None
+
+    return {
+        "provider": "paypal",
+        "event_type": event_type,
+        "status": status,
+        "occurred_at": created,
+        "external_id": external_id,
+        "amount": amount,
+        "fee": fee,
+        "net": amount - fee,
+        "currency": currency,
+        "source_path": source_path,
+        "raw_payload": payload,
+    }
+
+
+def _iter_file(path: str) -> Iterable[Tuple[int, str]]:
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for idx, raw in enumerate(fh, start=1):
+            line = raw.strip()
+            if line:
+                yield idx, line
+
+
+def _parse_access_line(line: str, *, line_number: int, source_path: str) -> Optional[DevtoolsParseWarningOut]:
+    m = _ACCESS_RE.search(line)
+    if not m:
+        return _warning("unsupported_line", "unrecognized billing log line", line_number=line_number, sample=line[:300])
+    path = m.group("path")
+    if "/mock/ccbill/" in path or "/mock/paypal/" in path or "/mock/stripe" in path:
+        return _warning(
+            "access_log_without_payload",
+            "provider access log line found without payload body; skipping",
+            line_number=line_number,
+            sample=line[:300],
+        )
+    return None
+
+
+def _normalize_payload(provider: Provider, payload: Dict[str, Any], source_path: str) -> Optional[Dict[str, Any]]:
+    if provider == "stripe":
+        return _stripe_entry(payload, source_path)
+    if provider == "ccbill":
+        return _ccbill_entry(payload, source_path)
+    return _paypal_entry(payload, source_path)
+
+
+def parse_billing_logs(
+    stripe_log_path: str,
+    backend_log_path: str,
+    *,
+    provider: Optional[Provider] = None,
+    status: Optional[str] = None,
+    from_ts: Optional[str] = None,
+    to_ts: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+    max_entries: int = 5000,
+) -> DevtoolsBillingLedgerOut:
+    warnings: List[DevtoolsParseWarningOut] = []
+    from_cutoff = _iso_utc(from_ts) if from_ts else None
+    to_cutoff = _iso_utc(to_ts) if to_ts else None
+
+    heap: List[Tuple[float, int, Dict[str, Any]]] = []
+    seq = 0
+
+    for source_path in [stripe_log_path, backend_log_path]:
+        if not os.path.exists(source_path):
+            warnings.append(_warning("missing_log_file", "billing log file does not exist", sample=source_path))
+            continue
+
+        for line_number, line in _iter_file(source_path):
+            if line.startswith("{"):
+                try:
+                    payload = json.loads(line)
+                except Exception:
+                    warnings.append(_warning("invalid_json", "billing log JSON could not be parsed", line_number=line_number, sample=line[:300]))
+                    continue
+                if not isinstance(payload, dict):
+                    warnings.append(_warning("json_not_object", "billing log JSON entry must be an object", line_number=line_number, sample=line[:300]))
+                    continue
+                detected = _detect_provider(payload)
+                if not detected:
+                    warnings.append(_warning("unknown_provider", "could not determine billing provider for payload", line_number=line_number, sample=line[:300]))
+                    continue
+                if provider and detected != provider:
+                    continue
+
+                normalized = _normalize_payload(detected, payload, source_path)
+                if not normalized:
+                    warnings.append(_warning("unsupported_event", "provider payload missing required amount/timestamp fields", line_number=line_number, sample=line[:300]))
+                    continue
+
+                if status and str(normalized["status"]).lower() != status.lower():
+                    continue
+
+                occurred = normalized["occurred_at"]
+                if from_cutoff and occurred < from_cutoff:
+                    continue
+                if to_cutoff and occurred > to_cutoff:
+                    continue
+
+                normalized["id"] = f"ledger_{_stable_id(normalized['provider'], normalized.get('external_id') or '', normalized['occurred_at'], str(normalized['amount']))}"
+                normalized["id_strategy"] = "sha256(provider|external_id|occurred_at|amount)"
+
+                ts = datetime.fromisoformat(occurred.replace("Z", "+00:00")).timestamp()
+                seq += 1
+                heapq.heappush(heap, (ts, seq, normalized))
+                if len(heap) > max_entries:
+                    heapq.heappop(heap)
+            else:
+                warn = _parse_access_line(line, line_number=line_number, source_path=source_path)
+                if warn:
+                    warnings.append(warn)
+
+    if seq > max_entries:
+        warnings.append(_warning("entry_cap_reached", f"retained most recent {max_entries} billing entries while streaming large logs"))
+
+    retained = [heapq.heappop(heap)[2] for _ in range(len(heap))]
+    retained.sort(key=lambda e: (e["occurred_at"], e["id"]), reverse=True)
+
+    paged = retained[offset : offset + limit]
+    next_cursor = None
+    if offset + limit < len(retained):
+        payload = json.dumps({"offset": offset + limit}).encode("utf-8")
+        import base64
+
+        next_cursor = base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+
+    entries = [DevtoolsBillingLedgerEntryOut(**row) for row in paged]
+
+    summary = build_billing_summary(retained)
+
+    return DevtoolsBillingLedgerOut(
+        entries=entries,
+        summary=summary,
+        next_cursor=next_cursor,
+        parse_warnings=warnings,
+    )

--- a/app/services/devtools/billing_summary_service.py
+++ b/app/services/devtools/billing_summary_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable, Mapping, Any
+
+from app.models import DevtoolsBillingLedgerSummaryOut, DevtoolsParseWarningOut
+
+
+def _num(value: Any) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return 0.0
+
+
+def build_billing_summary(entries: Iterable[Mapping[str, Any]]) -> DevtoolsBillingLedgerSummaryOut:
+    """Aggregate normalized ledger entries into a summary DTO.
+
+    Sign/currency handling rules:
+    - `gross_inflow`: sum of positive `amount` values only (inflow-oriented).
+    - `fees`: sum of absolute positive fee values.
+    - `net_total_balance`: signed sum of each row net (`net` if present else `amount - fee`).
+    - Mixed currencies are tolerated; totals are numeric aggregates and a parse warning
+      is emitted if more than one currency appears.
+    """
+
+    gross_inflow = 0.0
+    fees = 0.0
+    net_total_balance = 0.0
+    transaction_count = 0
+    provider_counts: dict[str, int] = defaultdict(int)
+    status_counts: dict[str, int] = defaultdict(int)
+    currency_counts: dict[str, int] = defaultdict(int)
+
+    for row in entries:
+        amount = _num(row.get("amount"))
+        fee = _num(row.get("fee"))
+        net = _num(row.get("net"))
+        if row.get("net") is None:
+            net = amount - fee
+
+        if amount > 0:
+            gross_inflow += amount
+        if fee > 0:
+            fees += fee
+        else:
+            fees += abs(fee)
+        net_total_balance += net
+
+        provider = str(row.get("provider") or "unknown")
+        status = str(row.get("status") or "unknown")
+        currency = str(row.get("currency") or "unknown").lower()
+
+        provider_counts[provider] += 1
+        status_counts[status] += 1
+        currency_counts[currency] += 1
+        transaction_count += 1
+
+    warnings: list[DevtoolsParseWarningOut] = []
+    if len(currency_counts) > 1:
+        warnings.append(
+            DevtoolsParseWarningOut(
+                source="billing",
+                code="mixed_currency_totals",
+                message="summary totals include multiple currencies; amounts are aggregated numerically",
+                sample=",".join(sorted(currency_counts.keys())),
+            )
+        )
+
+    return DevtoolsBillingLedgerSummaryOut(
+        gross_inflow=round(gross_inflow, 6),
+        fees=round(fees, 6),
+        net_total_balance=round(net_total_balance, 6),
+        transaction_count=transaction_count,
+        provider_counts=dict(provider_counts),
+        status_counts=dict(status_counts),
+        parse_warnings=warnings,
+    )

--- a/app/services/devtools/email_log_parser.py
+++ b/app/services/devtools/email_log_parser.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import heapq
+import json
+import os
+import re
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from app.models import (
+    DevtoolsEmailMailboxOut,
+    DevtoolsEmailMessageOut,
+    DevtoolsEmailMessagesOut,
+    DevtoolsEmailThreadOut,
+    DevtoolsParseWarningOut,
+)
+
+_HEADER_RE = re.compile(r"^\[(?P<ts>[^\]]+)\]\s+(?P<body>.*)$")
+_TO_RE = re.compile(r"TO=([^\s]+)")
+_PURPOSE_RE = re.compile(r"PURPOSE=([^\s]+)")
+
+
+def _iso_utc(value: str) -> Optional[str]:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def _stable_id(*parts: str, length: int = 20) -> str:
+    joined = "|".join(parts)
+    return sha256(joined.encode("utf-8")).hexdigest()[:length]
+
+
+def _warning(code: str, message: str, *, line_number: Optional[int] = None, sample: Optional[str] = None) -> DevtoolsParseWarningOut:
+    return DevtoolsParseWarningOut(source="email", code=code, message=message, line_number=line_number, sample=sample)
+
+
+def _parse_json_line(raw: str, *, line_number: int) -> Tuple[Optional[Dict[str, Any]], Optional[DevtoolsParseWarningOut]]:
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None, _warning("invalid_json", "line looked like JSON but could not be parsed", line_number=line_number, sample=raw[:300])
+
+    if not isinstance(payload, dict):
+        return None, _warning("json_not_object", "JSON log entry must be an object", line_number=line_number, sample=raw[:300])
+
+    ts = payload.get("sent_at") or payload.get("timestamp") or payload.get("ts")
+    sent_at = _iso_utc(str(ts)) if ts else None
+    if not sent_at:
+        return None, _warning("missing_timestamp", "JSON email entry is missing a valid timestamp", line_number=line_number, sample=raw[:300])
+
+    to_emails: List[str] = []
+    raw_to = payload.get("to") or payload.get("to_email") or payload.get("to_emails")
+    if isinstance(raw_to, str) and raw_to.strip():
+        to_emails = [raw_to.strip()]
+    elif isinstance(raw_to, list):
+        to_emails = [str(v).strip() for v in raw_to if str(v).strip()]
+
+    mailbox = str(payload.get("mailbox") or (to_emails[0] if to_emails else "unknown@example.invalid")).strip().lower()
+    subject = str(payload.get("subject") or "").strip() or None
+    body_text = str(payload.get("body") or payload.get("body_text") or "").strip() or None
+    code = str(payload.get("code") or "").strip() or None
+    purpose = str(payload.get("purpose") or "").strip() or None
+    event_kind = str(payload.get("event_kind") or ("mfa_email_code" if code else "unknown")).strip() or "unknown"
+    status = str(payload.get("status") or "").strip() or None
+
+    thread_seed = subject or body_text or "(no-subject)"
+    thread_id = f"thread_{_stable_id(mailbox, thread_seed)}"
+    message_id = f"email_{_stable_id(mailbox, sent_at, subject or '', body_text or '', code or '')}"
+
+    return {
+        "id": message_id,
+        "id_strategy": "sha256(mailbox|sent_at|subject|body_text|code)",
+        "thread_id": thread_id,
+        "mailbox": mailbox,
+        "sent_at": sent_at,
+        "event_kind": event_kind if event_kind in {"mfa_email_code", "alert_email", "unknown"} else "unknown",
+        "direction": "outbound",
+        "from_email": str(payload.get("from") or payload.get("from_email") or "").strip() or None,
+        "to_emails": to_emails or ([mailbox] if mailbox else []),
+        "subject": subject,
+        "body_text": body_text,
+        "body_html": str(payload.get("body_html") or "").strip() or None,
+        "code": code,
+        "purpose": purpose,
+        "status": status,
+        "parse_warnings": [],
+    }, None
+
+
+def _parse_plain_block(lines: List[str], *, start_line: int) -> Tuple[Optional[Dict[str, Any]], Optional[DevtoolsParseWarningOut]]:
+    if not lines:
+        return None, None
+
+    header = lines[0].strip()
+    m = _HEADER_RE.match(header)
+    if not m:
+        return None, _warning("invalid_header", "plain-text email block is missing a valid header", line_number=start_line, sample=header[:300])
+
+    ts = _iso_utc(m.group("ts").strip())
+    if not ts:
+        return None, _warning("invalid_timestamp", "plain-text email block has invalid timestamp", line_number=start_line, sample=header[:300])
+
+    body = m.group("body").strip()
+    to_match = _TO_RE.search(body)
+    mailbox = (to_match.group(1).strip().lower() if to_match else "unknown@example.invalid")
+    purpose_match = _PURPOSE_RE.search(body)
+    purpose = purpose_match.group(1).strip() if purpose_match else None
+    event_kind = "alert_email" if "ALERT_EMAIL" in body else "mfa_email_code"
+
+    subject: Optional[str] = None
+    code: Optional[str] = None
+    body_text: Optional[str] = None
+
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped.startswith("Subject:"):
+            subject = stripped.split("Subject:", 1)[1].strip() or None
+        elif stripped.startswith("Code:"):
+            code = stripped.split("Code:", 1)[1].strip() or None
+        elif stripped.startswith("Body:"):
+            body_text = stripped.split("Body:", 1)[1].strip() or None
+
+    if not subject and not body_text and not code:
+        return None, _warning("missing_content", "plain-text email block did not contain subject/body/code fields", line_number=start_line, sample=header[:300])
+
+    thread_seed = subject or body_text or "(no-subject)"
+    thread_id = f"thread_{_stable_id(mailbox, thread_seed)}"
+    message_id = f"email_{_stable_id(mailbox, ts, subject or '', body_text or '', code or '')}"
+
+    return {
+        "id": message_id,
+        "id_strategy": "sha256(mailbox|sent_at|subject|body_text|code)",
+        "thread_id": thread_id,
+        "mailbox": mailbox,
+        "sent_at": ts,
+        "event_kind": event_kind,
+        "direction": "outbound",
+        "from_email": None,
+        "to_emails": [mailbox] if mailbox else [],
+        "subject": subject,
+        "body_text": body_text,
+        "body_html": None,
+        "code": code,
+        "purpose": purpose,
+        "status": None,
+        "parse_warnings": [],
+    }, None
+
+
+def _iter_blocks(path: str) -> Iterable[Tuple[List[str], int]]:
+    """Yield plain-text entry blocks while streaming file lines."""
+
+    buf: List[str] = []
+    block_start = 1
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for idx, raw in enumerate(fh, start=1):
+            line = raw.rstrip("\n")
+
+            if not buf:
+                if not line.strip():
+                    continue
+                buf = [line]
+                block_start = idx
+                continue
+
+            if line.strip() == "":
+                yield buf, block_start
+                buf = []
+                continue
+
+            if line.startswith("[") and _HEADER_RE.match(line):
+                yield buf, block_start
+                buf = [line]
+                block_start = idx
+                continue
+
+            buf.append(line)
+
+    if buf:
+        yield buf, block_start
+
+
+def parse_email_log(
+    path: str,
+    *,
+    mailbox: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    q: Optional[str] = None,
+    state: str = "all",
+    limit: int = 50,
+    offset: int = 0,
+    max_messages: int = 5000,
+) -> DevtoolsEmailMessagesOut:
+    """Parse email log into canonical email mailbox/thread/message read models.
+
+    The parser streams file input and caps retained messages (`max_messages`) to
+    keep memory bounded for large logs.
+    """
+
+    warnings: List[DevtoolsParseWarningOut] = []
+    selected_mailbox = mailbox.strip().lower() if mailbox else None
+    query = q.strip().lower() if q else None
+
+    if not os.path.exists(path):
+        warnings.append(_warning("missing_log_file", "email log file does not exist", sample=path))
+        return DevtoolsEmailMessagesOut(parse_warnings=warnings)
+
+    # keep newest N using min-heap of (timestamp, seq, item)
+    heap: List[Tuple[float, int, Dict[str, Any]]] = []
+    seq = 0
+
+    for block, start_line in _iter_blocks(path):
+        first = block[0].lstrip()
+        if first.startswith("{"):
+            item, warn = _parse_json_line("\n".join(block), line_number=start_line)
+        else:
+            item, warn = _parse_plain_block(block, start_line=start_line)
+
+        if warn is not None:
+            warnings.append(warn)
+            continue
+        if not item:
+            continue
+
+        if selected_mailbox and item["mailbox"] != selected_mailbox:
+            continue
+        if thread_id and item["thread_id"] != thread_id:
+            continue
+
+        if state == "unread":
+            # dev logs are generated outbound and do not currently model unread state.
+            continue
+        if state == "sent" and item["direction"] != "outbound":
+            continue
+
+        if query:
+            haystack = " ".join(
+                [
+                    item.get("subject") or "",
+                    item.get("body_text") or "",
+                    item.get("mailbox") or "",
+                    " ".join(item.get("to_emails") or []),
+                ]
+            ).lower()
+            if query not in haystack:
+                continue
+
+        ts_dt = datetime.fromisoformat(item["sent_at"].replace("Z", "+00:00"))
+        ts_val = ts_dt.timestamp()
+        seq += 1
+        heapq.heappush(heap, (ts_val, seq, item))
+        if len(heap) > max_messages:
+            heapq.heappop(heap)
+
+    if seq > max_messages:
+        warnings.append(
+            _warning(
+                "message_cap_reached",
+                f"retained most recent {max_messages} messages while streaming large log",
+            )
+        )
+
+    retained = [heapq.heappop(heap)[2] for _ in range(len(heap))]
+    retained.sort(key=lambda m: (m["sent_at"], m["id"]), reverse=True)
+
+    paged = retained[offset : offset + limit]
+    next_cursor = None
+    if offset + limit < len(retained):
+        cursor_payload = json.dumps({"offset": offset + limit}).encode("utf-8")
+        import base64
+
+        next_cursor = base64.urlsafe_b64encode(cursor_payload).decode("utf-8").rstrip("=")
+
+    messages: List[DevtoolsEmailMessageOut] = []
+    thread_map: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    mailbox_map: Dict[str, Dict[str, Any]] = {}
+
+    for item in retained:
+        mailbox_key = item["mailbox"]
+        thread_key = (mailbox_key, item["thread_id"])
+
+        mb = mailbox_map.setdefault(
+            mailbox_key,
+            {
+                "id": f"mailbox_{_stable_id(mailbox_key)}",
+                "id_strategy": "sha256(mailbox)",
+                "mailbox": mailbox_key,
+                "thread_ids": set(),
+                "unread_count": 0,
+            },
+        )
+        mb["thread_ids"].add(item["thread_id"])
+
+        thread_entry = thread_map.setdefault(
+            thread_key,
+            {
+                "id": item["thread_id"],
+                "id_strategy": "sha256(mailbox|subject-or-body)",
+                "mailbox": mailbox_key,
+                "subject": item.get("subject"),
+                "message_count": 0,
+                "unread_count": 0,
+                "participant_emails": set(item.get("to_emails") or []),
+                "latest_message_at": item["sent_at"],
+            },
+        )
+        thread_entry["message_count"] += 1
+        thread_entry["participant_emails"].update(item.get("to_emails") or [])
+        if item["sent_at"] > thread_entry["latest_message_at"]:
+            thread_entry["latest_message_at"] = item["sent_at"]
+
+    for item in paged:
+        messages.append(DevtoolsEmailMessageOut(**item))
+
+    threads = [
+        DevtoolsEmailThreadOut(
+            id=v["id"],
+            id_strategy=v["id_strategy"],
+            mailbox=v["mailbox"],
+            subject=v["subject"],
+            message_count=v["message_count"],
+            unread_count=v["unread_count"],
+            participant_emails=sorted(v["participant_emails"]),
+            latest_message_at=v["latest_message_at"],
+        )
+        for _, v in sorted(thread_map.items(), key=lambda kv: (kv[1]["latest_message_at"], kv[1]["id"]), reverse=True)
+    ]
+
+    mailboxes = [
+        DevtoolsEmailMailboxOut(
+            id=v["id"],
+            id_strategy=v["id_strategy"],
+            mailbox=v["mailbox"],
+            thread_count=len(v["thread_ids"]),
+            unread_count=v["unread_count"],
+        )
+        for _, v in sorted(mailbox_map.items(), key=lambda kv: kv[0])
+    ]
+
+    return DevtoolsEmailMessagesOut(
+        mailboxes=mailboxes,
+        threads=threads,
+        messages=messages,
+        next_cursor=next_cursor,
+        parse_warnings=warnings,
+    )

--- a/app/services/devtools/read_service.py
+++ b/app/services/devtools/read_service.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Hashable, Optional, Tuple
+
+from app.models import (
+    DevtoolsBillingLedgerOut,
+    DevtoolsBillingLedgerSummaryOut,
+    DevtoolsEmailMessagesOut,
+    DevtoolsSmsConversationsOut,
+)
+from app.services.devtools.billing_log_parser import parse_billing_logs
+from app.services.devtools.email_log_parser import parse_email_log
+from app.services.devtools.sms_log_parser import parse_sms_log
+
+_CACHE_TTL_SECONDS = 3.0
+
+
+@dataclass(frozen=True)
+class FileState:
+    exists: bool
+    mtime_ns: int
+    size: int
+
+
+@dataclass
+class CacheEntry:
+    created_at: float
+    file_state: Tuple[FileState, ...]
+    payload: Any
+
+
+_CACHE: Dict[Hashable, CacheEntry] = {}
+
+
+def _file_state(path: str) -> FileState:
+    try:
+        st = os.stat(path)
+        return FileState(exists=True, mtime_ns=int(st.st_mtime_ns), size=int(st.st_size))
+    except FileNotFoundError:
+        return FileState(exists=False, mtime_ns=0, size=0)
+
+
+def _is_fresh(entry: CacheEntry, current_state: Tuple[FileState, ...]) -> bool:
+    now = time.monotonic()
+    if now - entry.created_at > _CACHE_TTL_SECONDS:
+        return False
+    return entry.file_state == current_state
+
+
+def clear_devtools_cache() -> None:
+    _CACHE.clear()
+
+
+def _get_or_build(key: Hashable, state_paths: Tuple[str, ...], builder) -> Any:
+    current_state = tuple(_file_state(p) for p in state_paths)
+    entry = _CACHE.get(key)
+    if entry and _is_fresh(entry, current_state):
+        return entry.payload
+
+    payload = builder()
+    _CACHE[key] = CacheEntry(created_at=time.monotonic(), file_state=current_state, payload=payload)
+    return payload
+
+
+def get_email_messages(
+    log_path: str,
+    *,
+    mailbox: Optional[str],
+    thread_id: Optional[str],
+    q: Optional[str],
+    state: str,
+    limit: int,
+    offset: int,
+) -> DevtoolsEmailMessagesOut:
+    key = (
+        "email",
+        log_path,
+        mailbox or "",
+        thread_id or "",
+        q or "",
+        state,
+        int(limit),
+        int(offset),
+    )
+    return _get_or_build(
+        key,
+        (log_path,),
+        lambda: parse_email_log(
+            log_path,
+            mailbox=mailbox,
+            thread_id=thread_id,
+            q=q,
+            state=state,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+
+
+def get_sms_conversations(
+    log_path: str,
+    *,
+    participant: Optional[str],
+    q: Optional[str],
+    limit: int,
+    offset: int,
+) -> DevtoolsSmsConversationsOut:
+    key = (
+        "sms",
+        log_path,
+        participant or "",
+        q or "",
+        int(limit),
+        int(offset),
+    )
+    return _get_or_build(
+        key,
+        (log_path,),
+        lambda: parse_sms_log(
+            log_path,
+            participant=participant,
+            q=q,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+
+
+def get_billing_ledger(
+    stripe_log_path: str,
+    backend_log_path: str,
+    *,
+    provider: Optional[str],
+    status: Optional[str],
+    from_ts: Optional[str],
+    to_ts: Optional[str],
+    limit: int,
+    offset: int,
+) -> DevtoolsBillingLedgerOut:
+    key = (
+        "billing_ledger",
+        stripe_log_path,
+        backend_log_path,
+        provider or "",
+        status or "",
+        from_ts or "",
+        to_ts or "",
+        int(limit),
+        int(offset),
+    )
+    return _get_or_build(
+        key,
+        (stripe_log_path, backend_log_path),
+        lambda: parse_billing_logs(
+            stripe_log_path,
+            backend_log_path,
+            provider=provider,  # type: ignore[arg-type]
+            status=status,
+            from_ts=from_ts,
+            to_ts=to_ts,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+
+
+def get_billing_summary(
+    stripe_log_path: str,
+    backend_log_path: str,
+    *,
+    provider: Optional[str],
+    status: Optional[str],
+    from_ts: Optional[str],
+    to_ts: Optional[str],
+) -> DevtoolsBillingLedgerSummaryOut:
+    key = (
+        "billing_summary",
+        stripe_log_path,
+        backend_log_path,
+        provider or "",
+        status or "",
+        from_ts or "",
+        to_ts or "",
+    )
+
+    out: DevtoolsBillingLedgerOut = _get_or_build(
+        key,
+        (stripe_log_path, backend_log_path),
+        lambda: parse_billing_logs(
+            stripe_log_path,
+            backend_log_path,
+            provider=provider,  # type: ignore[arg-type]
+            status=status,
+            from_ts=from_ts,
+            to_ts=to_ts,
+            limit=1,
+            offset=0,
+        ),
+    )
+    summary = out.summary.model_copy(deep=True)
+    summary.parse_warnings = out.parse_warnings
+    return summary

--- a/app/services/devtools/sms_log_parser.py
+++ b/app/services/devtools/sms_log_parser.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import heapq
+import json
+import os
+import re
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from app.models import (
+    DevtoolsParseWarningOut,
+    DevtoolsSmsConversationOut,
+    DevtoolsSmsConversationsOut,
+    DevtoolsSmsMessageOut,
+)
+
+_HEADER_RE = re.compile(r"^\[(?P<ts>[^\]]+)\]\s+(?P<body>.*)$")
+_TO_RE = re.compile(r"TO=([^\s]+)")
+_FROM_RE = re.compile(r"FROM=([^\s]+)")
+_CODE_RE = re.compile(r"Code:\s*([^\s]+)")
+
+
+def _iso_utc(value: str) -> Optional[str]:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def _stable_id(*parts: str, length: int = 20) -> str:
+    return sha256("|".join(parts).encode("utf-8")).hexdigest()[:length]
+
+
+def _warning(code: str, message: str, *, line_number: Optional[int] = None, sample: Optional[str] = None) -> DevtoolsParseWarningOut:
+    return DevtoolsParseWarningOut(source="sms", code=code, message=message, line_number=line_number, sample=sample)
+
+
+def _normalize_phone(raw: Optional[str]) -> Optional[str]:
+    if raw is None:
+        return None
+    cleaned = str(raw).strip()
+    return cleaned or None
+
+
+def _conversation_id(from_number: Optional[str], to_number: Optional[str]) -> str:
+    participants = sorted([p for p in [from_number, to_number] if p])
+    seed = ",".join(participants) or "unknown"
+    return f"conv_{_stable_id(seed)}"
+
+
+def _parse_json_line(raw: str, *, line_number: int) -> Tuple[Optional[Dict[str, Any]], Optional[DevtoolsParseWarningOut]]:
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None, _warning("invalid_json", "line looked like JSON but could not be parsed", line_number=line_number, sample=raw[:300])
+
+    if not isinstance(payload, dict):
+        return None, _warning("json_not_object", "JSON sms entry must be an object", line_number=line_number, sample=raw[:300])
+
+    ts = payload.get("sent_at") or payload.get("timestamp") or payload.get("ts")
+    sent_at = _iso_utc(str(ts)) if ts else None
+    if not sent_at:
+        return None, _warning("missing_timestamp", "JSON SMS entry is missing a valid timestamp", line_number=line_number, sample=raw[:300])
+
+    to_number = _normalize_phone(payload.get("to") or payload.get("to_number") or payload.get("recipient"))
+    from_number = _normalize_phone(payload.get("from") or payload.get("from_number") or payload.get("sender"))
+    body_text = str(payload.get("body") or payload.get("body_text") or "").strip() or None
+    code = str(payload.get("code") or "").strip() or None
+    status = str(payload.get("status") or "").strip() or None
+    provider_message_id = str(payload.get("message_id") or payload.get("provider_message_id") or "").strip() or None
+
+    event_kind = str(payload.get("event_kind") or ("mfa_sms_code" if code else "unknown")).strip() or "unknown"
+    event_kind = event_kind if event_kind in {"mfa_sms_code", "alert_sms", "unknown"} else "unknown"
+
+    conversation_id = str(payload.get("conversation_id") or _conversation_id(from_number, to_number))
+    message_id = f"sms_{_stable_id(conversation_id, sent_at, from_number or '', to_number or '', body_text or '', code or '')}"
+
+    return {
+        "id": message_id,
+        "id_strategy": "sha256(conversation_id|sent_at|from|to|body|code)",
+        "conversation_id": conversation_id,
+        "sent_at": sent_at,
+        "from_number": from_number,
+        "to_number": to_number,
+        "direction": str(payload.get("direction") or "outbound") if str(payload.get("direction") or "outbound") in {"inbound", "outbound", "unknown"} else "unknown",
+        "body_text": body_text,
+        "code": code,
+        "status": status,
+        "provider_message_id": provider_message_id,
+        "event_kind": event_kind,
+        "parse_warnings": [],
+    }, None
+
+
+def _parse_plain_block(lines: List[str], *, start_line: int) -> Tuple[Optional[Dict[str, Any]], Optional[DevtoolsParseWarningOut]]:
+    if not lines:
+        return None, None
+
+    m = _HEADER_RE.match(lines[0].strip())
+    if not m:
+        return None, _warning("invalid_header", "plain-text SMS block is missing a valid header", line_number=start_line, sample=lines[0][:300])
+
+    sent_at = _iso_utc(m.group("ts").strip())
+    if not sent_at:
+        return None, _warning("invalid_timestamp", "plain-text SMS block has invalid timestamp", line_number=start_line, sample=lines[0][:300])
+
+    header_body = m.group("body").strip()
+    to_match = _TO_RE.search(header_body)
+    from_match = _FROM_RE.search(header_body)
+    code_match = _CODE_RE.search(header_body)
+
+    to_number = _normalize_phone(to_match.group(1) if to_match else None)
+    from_number = _normalize_phone(from_match.group(1) if from_match else None)
+    code = _normalize_phone(code_match.group(1) if code_match else None)
+
+    event_kind = "alert_sms" if "ALERT_SMS" in header_body else "mfa_sms_code"
+    body_text: Optional[str] = None
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped.startswith("Body:"):
+            body_text = stripped.split("Body:", 1)[1].strip() or None
+
+    if not to_number and not from_number:
+        return None, _warning("missing_participants", "plain-text SMS block missing TO/FROM metadata", line_number=start_line, sample=lines[0][:300])
+
+    conversation_id = _conversation_id(from_number, to_number)
+    message_id = f"sms_{_stable_id(conversation_id, sent_at, from_number or '', to_number or '', body_text or '', code or '')}"
+
+    return {
+        "id": message_id,
+        "id_strategy": "sha256(conversation_id|sent_at|from|to|body|code)",
+        "conversation_id": conversation_id,
+        "sent_at": sent_at,
+        "from_number": from_number,
+        "to_number": to_number,
+        "direction": "outbound",
+        "body_text": body_text,
+        "code": code,
+        "status": None,
+        "provider_message_id": None,
+        "event_kind": event_kind,
+        "parse_warnings": [],
+    }, None
+
+
+def _iter_blocks(path: str) -> Iterable[Tuple[List[str], int]]:
+    buf: List[str] = []
+    block_start = 1
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for idx, raw in enumerate(fh, start=1):
+            line = raw.rstrip("\n")
+            if not buf:
+                if not line.strip():
+                    continue
+                buf = [line]
+                block_start = idx
+                continue
+            if not line.strip():
+                yield buf, block_start
+                buf = []
+                continue
+            if line.startswith("[") and _HEADER_RE.match(line):
+                yield buf, block_start
+                buf = [line]
+                block_start = idx
+                continue
+            buf.append(line)
+    if buf:
+        yield buf, block_start
+
+
+def parse_sms_log(
+    path: str,
+    *,
+    participant: Optional[str] = None,
+    q: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+    max_messages: int = 5000,
+) -> DevtoolsSmsConversationsOut:
+    warnings: List[DevtoolsParseWarningOut] = []
+    participant_filter = participant.strip() if participant else None
+    query = q.strip().lower() if q else None
+
+    if not os.path.exists(path):
+        warnings.append(_warning("missing_log_file", "sms log file does not exist", sample=path))
+        return DevtoolsSmsConversationsOut(parse_warnings=warnings)
+
+    heap: List[Tuple[float, int, Dict[str, Any]]] = []
+    seq = 0
+
+    for block, start_line in _iter_blocks(path):
+        first = block[0].lstrip()
+        if first.startswith("{"):
+            item, warn = _parse_json_line("\n".join(block), line_number=start_line)
+        else:
+            item, warn = _parse_plain_block(block, start_line=start_line)
+
+        if warn is not None:
+            warnings.append(warn)
+            continue
+        if not item:
+            continue
+
+        participants = [p for p in [item.get("from_number"), item.get("to_number")] if p]
+        if participant_filter and participant_filter not in participants:
+            continue
+        if query:
+            haystack = " ".join([item.get("body_text") or "", item.get("from_number") or "", item.get("to_number") or ""]).lower()
+            if query not in haystack:
+                continue
+
+        ts = datetime.fromisoformat(item["sent_at"].replace("Z", "+00:00")).timestamp()
+        seq += 1
+        heapq.heappush(heap, (ts, seq, item))
+        if len(heap) > max_messages:
+            heapq.heappop(heap)
+
+    if seq > max_messages:
+        warnings.append(_warning("message_cap_reached", f"retained most recent {max_messages} sms messages while streaming large log"))
+
+    retained = [heapq.heappop(heap)[2] for _ in range(len(heap))]
+    retained.sort(key=lambda m: (m["sent_at"], m["id"]), reverse=True)
+
+    paged = retained[offset : offset + limit]
+    next_cursor = None
+    if offset + limit < len(retained):
+        payload = json.dumps({"offset": offset + limit}).encode("utf-8")
+        import base64
+
+        next_cursor = base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+
+    conv_map: Dict[str, Dict[str, Any]] = {}
+    for item in retained:
+        cid = item["conversation_id"]
+        participants = sorted({p for p in [item.get("from_number"), item.get("to_number")] if p})
+        conv = conv_map.setdefault(
+            cid,
+            {
+                "id": cid,
+                "id_strategy": "sha256(sorted(participants))",
+                "participant_numbers": participants,
+                "message_count": 0,
+                "latest_message_at": item["sent_at"],
+                "latest_preview": item.get("body_text") or item.get("code"),
+            },
+        )
+        conv["message_count"] += 1
+        if item["sent_at"] > conv["latest_message_at"]:
+            conv["latest_message_at"] = item["sent_at"]
+            conv["latest_preview"] = item.get("body_text") or item.get("code")
+
+    messages = [DevtoolsSmsMessageOut(**item) for item in paged]
+    conversations = [
+        DevtoolsSmsConversationOut(
+            id=v["id"],
+            id_strategy=v["id_strategy"],
+            participant_numbers=v["participant_numbers"],
+            message_count=v["message_count"],
+            latest_message_at=v["latest_message_at"],
+            latest_preview=v["latest_preview"],
+        )
+        for _, v in sorted(conv_map.items(), key=lambda kv: (kv[1]["latest_message_at"], kv[0]), reverse=True)
+    ]
+
+    return DevtoolsSmsConversationsOut(
+        conversations=conversations,
+        messages=messages,
+        next_cursor=next_cursor,
+        parse_warnings=warnings,
+    )

--- a/docs/internal-dev-log-ui-api-contract.md
+++ b/docs/internal-dev-log-ui-api-contract.md
@@ -1,0 +1,64 @@
+# DLU-003 — Internal Dev Tools API Contract and Pagination
+
+This document finalizes the read-only API contract for Dev Log UI endpoints.
+
+## Base
+- Prefix: `/internal/dev-tools`
+- Verbs: **GET only**
+- Cursor format: URL-safe base64 JSON payload (`{"offset": <non-negative int>}`)
+
+## Error mapping
+- `400 invalid_cursor`: cursor is not URL-safe base64 JSON or has invalid `offset` shape.
+- `422 validation_error`: invalid enum values / `limit` outside `[1, 200]` / malformed query fields.
+
+## Endpoints
+
+### `GET /internal/dev-tools/email/messages`
+Query params:
+- `mailbox` (optional)
+- `thread_id` (optional)
+- `q` (optional search)
+- `state` (optional enum: `all | unread | sent`, default `all`)
+- `limit` (optional int, default `50`, min `1`, max `200`)
+- `cursor` (optional base64 cursor)
+
+Response model: `DevtoolsEmailMessagesOut`
+
+### `GET /internal/dev-tools/sms/conversations`
+Query params:
+- `participant` (optional)
+- `q` (optional search)
+- `limit` (optional int, default `50`, min `1`, max `200`)
+- `cursor` (optional base64 cursor)
+
+Response model: `DevtoolsSmsConversationsOut`
+
+### `GET /internal/dev-tools/billing/ledger`
+Query params:
+- `provider` (optional enum: `stripe | ccbill | paypal`)
+- `status` (optional enum: `pending | completed | failed | refunded | canceled`)
+- `from` (optional timestamp)
+- `to` (optional timestamp)
+- `limit` (optional int, default `50`, min `1`, max `200`)
+- `cursor` (optional base64 cursor)
+
+Response model: `DevtoolsBillingLedgerOut`
+
+### `GET /internal/dev-tools/billing/summary`
+Query params:
+- `provider` (optional enum: `stripe | ccbill | paypal`)
+- `status` (optional enum: `pending | completed | failed | refunded | canceled`)
+- `from` (optional timestamp)
+- `to` (optional timestamp)
+
+Response model: `DevtoolsBillingLedgerSummaryOut`
+
+## Deterministic behavior rules
+- Identical query and cursor inputs return schema-equivalent output shape.
+- Invalid cursor behavior is deterministic (`400` + `invalid_cursor` payload).
+- Filter enums and limit bounds are validated at request boundary.
+
+## Source of truth
+- Router contract: `app/routers/internal_devtools.py`
+- Output DTO models: `app/models.py`
+- Contract tests: `tests/test_internal_devtools_contract.py`

--- a/docs/internal-dev-log-ui-log-input-inventory.md
+++ b/docs/internal-dev-log-ui-log-input-inventory.md
@@ -1,0 +1,185 @@
+# DLU-001 — Internal Dev Log UI Log Input Inventory
+
+This document closes DLU-001 by defining the canonical local log/artifact inputs for the Dev Log UI, including sample record shapes and malformed data patterns the parsers must tolerate.
+
+## Scope
+- Email source(s): dev-mode email verification/alert writes.
+- SMS source(s): dev-mode SMS verification/alert writes.
+- Billing source(s): local Stripe mock process log + backend access log lines for in-process CCBill/PayPal mocks.
+
+---
+
+## 1) Canonical path defaults (ready for env wiring)
+
+| Domain | Canonical default | Env override |
+|---|---|---|
+| Email | `.logs/dev/emails.log` | `DEVTOOLS_EMAIL_LOG_PATH` (fallback `DEV_EMAIL_LOG`) |
+| SMS | `.logs/dev/sms.log` | `DEVTOOLS_SMS_LOG_PATH` (fallback `DEV_SMS_LOG`) |
+| Stripe provider log | `.local/logs/stripe-mock.log` | `DEVTOOLS_BILLING_STRIPE_LOG_PATH` |
+| CCBill/PayPal request traces | `.logs/dev/backend.log` | `DEVTOOLS_BILLING_BACKEND_LOG_PATH` |
+
+Notes:
+- Email/SMS dev logs are application-authored files.
+- Stripe has a dedicated mock process log under `.local/logs`.
+- CCBill and PayPal mock providers run in-process on backend routes (`/mock/ccbill/*`, `/mock/paypal/*`), so request visibility comes through backend logs.
+
+---
+
+## 2) Format matrix with sample records
+
+## 2.1 Email log (`.logs/dev/emails.log`)
+Source writers:
+- MFA email code sender
+- Alerts email sender
+
+Observed shape: plaintext multi-line blocks with UTC timestamp header.
+
+### Sample (MFA email code)
+```txt
+[2026-02-28T14:01:22Z] TO=user@example.com PURPOSE=login
+  Subject: Your verification code (login)
+  Code: 123456
+  Body: Your verification code is: 123456
+
+```
+
+### Sample (alert email)
+```txt
+[2026-02-28T14:03:50Z] ALERT_EMAIL TO=user@example.com
+  Subject: New sign-in detected
+  Body: We detected a new sign-in from device X
+
+```
+
+Key fields by parser:
+- `timestamp` (header bracket time)
+- `to`
+- `event_kind` (`mfa_email_code` vs `alert_email`)
+- `purpose` (MFA only)
+- `subject`
+- `body`
+- optional `code` (MFA only)
+
+## 2.2 SMS log (`.logs/dev/sms.log`)
+Source writers:
+- MFA SMS code sender
+- Alerts SMS sender
+
+Observed shape: plaintext single-line (MFA) and multi-line (alert) entries.
+
+### Sample (MFA SMS)
+```txt
+[2026-02-28T14:02:10Z] SMS TO=+14155550123 Code: 654321
+```
+
+### Sample (alert SMS)
+```txt
+[2026-02-28T14:04:12Z] ALERT_SMS TO=+14155550123
+  Body: Payment failed for subscription sub_123
+
+```
+
+Key fields by parser:
+- `timestamp`
+- `to` (E.164 where available)
+- `event_kind` (`mfa_sms_code` vs `alert_sms`)
+- optional `code` (MFA only)
+- optional `body` (alert only)
+
+## 2.3 Billing provider inputs
+
+### A) Stripe mock process log (`.local/logs/stripe-mock.log`)
+Produced by `scripts/local-stack-up.sh` when `stripe-mock` is started via `nohup` redirection.
+
+Typical shape: process/runtime log lines (not canonical transaction JSON).
+
+### B) Backend log request traces (`.logs/dev/backend.log`)
+Contains uvicorn/backend output for in-process mock endpoints, including:
+- `POST /mock/ccbill/ccbill-auth/oauth/token`
+- `POST /mock/ccbill/transactions/payment-tokens/{id}`
+- `POST /mock/paypal/v2/checkout/orders`
+- `POST /mock/paypal/v2/checkout/orders/{id}/capture`
+- `POST /mock/paypal/v1/billing/subscriptions`
+
+Representative access-log shape:
+```txt
+INFO:     127.0.0.1:53342 - "POST /mock/paypal/v2/checkout/orders HTTP/1.1" 200 OK
+INFO:     127.0.0.1:53343 - "POST /mock/ccbill/transactions/payment-tokens/tok_abc HTTP/1.1" 200 OK
+```
+
+### C) Provider response payloads (for parser fixtures)
+Because provider process/backend logs are not normalized ledgers, adapters should parse known mock response payload shapes from provider routes and correlate with request traces.
+
+Representative CCBill mock charge response:
+```json
+{
+  "approved": true,
+  "responseCode": "200",
+  "transactionId": "txn_1740759312123",
+  "paymentUniqueId": "txn_1740759312123",
+  "subscriptionId": "sub_1740759312123",
+  "nextRenewalDate": "2026-03-30T12:00:00Z",
+  "message": "Approved"
+}
+```
+
+Representative PayPal capture response:
+```json
+{
+  "id": "MOCK-ORDER-ABC123",
+  "status": "COMPLETED",
+  "purchase_units": [
+    {
+      "payments": {
+        "captures": [
+          {
+            "id": "CAP-XYZ987",
+            "status": "COMPLETED",
+            "amount": {"currency_code": "USD", "value": "9.99"}
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+---
+
+## 3) Malformed-line patterns parsers must tolerate
+
+## 3.1 Email/SMS plaintext parser tolerance
+- Missing bracket timestamp (`[...Z]`).
+- Header present but missing `TO=` token.
+- Truncated multi-line blocks (missing subject/body/code line).
+- Mixed entry types back-to-back without blank line separator.
+- Non-UTF8 bytes or partial writes during tail.
+- Duplicate lines after process restart/retry.
+
+## 3.2 Billing parser tolerance
+- Missing provider logs (e.g., stripe-mock not started yet).
+- Access log lines missing HTTP method/path/status (partial writes).
+- Unknown `/mock/*` endpoint variants.
+- Provider payloads missing expected IDs (`transactionId`, capture `id`, subscription id).
+- Currency or amount values malformed/non-numeric.
+- Out-of-order events (capture before create in merged view).
+
+---
+
+## 4) Resolved ambiguities
+
+1. **`email.log` naming vs existing config:** the repo currently defaults to `.logs/dev/emails.log` (plural). DLU parser and UI should treat this as canonical default and optionally support `email.log` aliases via env override.
+2. **CCBill/PayPal file location:** no dedicated provider-process logfile exists; these providers are mocked in-process and therefore traced via backend logs.
+3. **Billing ledger source quality:** provider logs are useful for trace/debug, but normalized ledger rows should be derived from provider payload contracts + app billing transaction records when available.
+
+---
+
+## 5) Implementation handoff notes
+
+- Settings fields for DLU-001 path defaults are now available as:
+  - `S.devtools_email_log_path`
+  - `S.devtools_sms_log_path`
+  - `S.devtools_billing_stripe_log_path`
+  - `S.devtools_billing_backend_log_path`
+- Local env template includes commented overrides for all four variables.
+- Next ticket (DLU-002) should define canonical DTOs using these inputs.

--- a/docs/internal-dev-log-ui-plan.md
+++ b/docs/internal-dev-log-ui-plan.md
@@ -1,0 +1,211 @@
+# Internal Dev Log UI Plan
+
+## 1. Goals and Non-Goals
+
+### Goals
+- Build a **read-only internal developer UI** that surfaces local test artifacts in familiar formats:
+  - Gmail-like inbox/message detail for `email.log`.
+  - iMessage-like conversation view for `sms.log`.
+  - Live TOTP code generator from pasted MFA configuration.
+  - Billing ledger that normalizes mock processor transactions (Stripe, CCBill, PayPal) and computes totals.
+- Support **multiple email addresses/inboxes** in the email experience.
+- Keep data entry/write actions disabled except for **frontend-only TOTP config paste**.
+- Make it easy to run locally and have it start automatically with `scripts/run_dev.sh`.
+
+### Non-Goals
+- No external auth accounts or outbound mailbox/SMS integrations.
+- No write-back flows to logs or payment providers.
+- No persistence requirement for pasted TOTP config beyond local browser storage/session.
+
+---
+
+## 2. Target User Experience
+
+### Shell Navigation
+Add a new route group under the existing frontend app (e.g., `/dev-tools/log-ui`) with tabs:
+1. **Email**
+2. **SMS**
+3. **MFA (TOTP)**
+4. **Billing Ledger**
+
+### Email (Gmail-like, read-only)
+- Left rail: list of mailboxes (email addresses discovered in `email.log`).
+- Main pane: inbox thread list for selected mailbox.
+- Detail pane: selected message/thread with headers, text/html body, timestamp, delivery state.
+- Filters: unread/sent/all, search by subject/from/to.
+- Multi-address support via mailbox switcher and aggregate “All inboxes” view.
+
+### SMS (iMessage-like, read-only)
+- Conversation list on the left, ordered by last activity.
+- Message bubbles in thread view, grouped by sender/recipient and timestamp.
+- Display metadata (to/from, gateway status, message id) in an info panel.
+- Optional compact mode to quickly inspect webhook/transport anomalies.
+
+### MFA (TOTP generator)
+- Input area to paste:
+  - `otpauth://` URI, or
+  - raw Base32 secret plus metadata fields.
+- Frontend parses and validates locally, then starts a 30-second live countdown.
+- Display current code + next code preview.
+- Allow storing config in `localStorage` (opt-in) and clear/reset action.
+- Explicit label that this feature is local-only and never sent to backend.
+
+### Billing Ledger (read-only)
+- Unified table with normalized fields: provider, event type, amount, currency, fee, net, timestamp, external id, status.
+- Provider filters (Stripe/CCBill/PayPal), date range, and transaction status.
+- Summary cards:
+  - Gross inflow
+  - Fees
+  - Net total balance
+  - Counts by provider/status
+- “Source detail” drawer to inspect raw event payload for debugging.
+
+---
+
+## 3. Data Sources and Contracts
+
+## 3.1 Log Inputs
+- `email.log`: parse line-delimited JSON if available; fallback to regex parser for plain-text entries.
+- `sms.log`: same strategy as `email.log`.
+- Billing inputs: read mock transaction logs/artifacts produced by current mock provider flows.
+  - If processor-specific logs differ, normalize through a provider adapter layer.
+
+## 3.2 Proposed Backend Endpoints (read-only)
+Create an internal-only API namespace:
+- `GET /internal/dev-tools/email/messages`
+  - Query: `mailbox`, `thread_id`, `q`, `limit`, `cursor`.
+- `GET /internal/dev-tools/sms/conversations`
+  - Query: `participant`, `q`, `limit`, `cursor`.
+- `GET /internal/dev-tools/billing/ledger`
+  - Query: `provider`, `status`, `from`, `to`, `limit`, `cursor`.
+- `GET /internal/dev-tools/billing/summary`
+
+No endpoint for TOTP generation is required; perform this entirely in frontend.
+
+## 3.3 Parsing and Normalization Layer
+Introduce parser modules:
+- `app/services/devtools/email_log_parser.py`
+- `app/services/devtools/sms_log_parser.py`
+- `app/services/devtools/billing_log_parser.py`
+
+Each parser should:
+- Stream files safely (tail-friendly, bounded memory).
+- Return canonical models with stable IDs.
+- Tolerate malformed lines and expose parse warnings.
+
+---
+
+## 4. System Design
+
+## 4.1 Backend
+- Add internal router (e.g., `app/routers/internal_dev_tools.py`) guarded by local/dev-only gate.
+- Provide read models from parsers and in-memory cache with short TTL (e.g., 2–5s) to avoid reparsing on every request.
+- Add config env vars:
+  - `DEVTOOLS_EMAIL_LOG_PATH` (default to local generated path)
+  - `DEVTOOLS_SMS_LOG_PATH`
+  - `DEVTOOLS_BILLING_LOG_DIR`
+
+## 4.2 Frontend
+- New page container: `frontend/src/pages/devtools/DevToolsLogUiPage.tsx`.
+- Reusable components:
+  - Mailbox/Conversation lists
+  - Message viewer
+  - Ledger table + summary cards
+  - TOTP panel
+- Keep TOTP logic in frontend utility (e.g., `frontend/src/utils/totp.ts`) using a vetted implementation approach.
+- Add API client wrappers in `frontend/src/api/endpoints/...` for the new internal endpoints.
+
+## 4.3 Security and Safety
+- Default hidden behind a development feature flag (`VITE_ENABLE_DEVTOOLS_LOG_UI=1`).
+- Backend route disabled outside local/dev mode.
+- Read-only guarantees:
+  - Backend exposes only `GET` endpoints.
+  - UI disables mutating actions.
+- TOTP secret never transmitted to backend; keep in memory unless user opts into local storage.
+
+---
+
+## 5. Implementation Phases
+
+### Phase 0 — Discovery and Contract Freeze
+- Inventory current log formats and sample records.
+- Define canonical schema for email, sms, and billing events.
+- Confirm log file paths produced in local environment.
+
+### Phase 1 — Backend Parsers + Internal APIs
+- Implement parser modules + tests for malformed/partial lines.
+- Add internal dev-tools router and response DTOs.
+- Add summary computation for ledger balances.
+
+### Phase 2 — Frontend UI Skeleton
+- Add new route and tab layout.
+- Wire API calls and loading/empty/error states.
+- Implement Gmail-like and iMessage-like layouts with read-only semantics.
+
+### Phase 3 — TOTP Panel (Frontend-only)
+- Parse otpauth URI/raw secret.
+- Live code generation with timer and validation UX.
+- Optional localStorage persistence toggle.
+
+### Phase 4 — `run_dev.sh` Integration
+- Ensure logs are generated in predictable locations.
+- Auto-enable dev-tools route when `scripts/run_dev.sh` launches frontend (set env flag).
+- Print direct local URL in startup output.
+
+### Phase 5 — Hardening and QA
+- Unit tests for parser edge cases and ledger math.
+- Frontend tests for read-only behavior and TOTP lifecycle.
+- End-to-end smoke test covering each tab.
+
+---
+
+## 6. `run_dev.sh` Integration Plan
+
+1. Extend script env bootstrap to export:
+   - `VITE_ENABLE_DEVTOOLS_LOG_UI=1`
+   - default log paths for email/sms/billing if unset.
+2. Ensure dependent mock services emit expected logs before frontend starts.
+3. On startup, print:
+   - `Dev Tools Log UI: http://localhost:5173/dev-tools/log-ui`
+4. Keep `--no-clean` behavior compatible by preserving log files and reusing history.
+
+---
+
+## 7. Testing Strategy
+
+### Backend Tests
+- Parser fixtures for valid/invalid/mixed log lines.
+- API tests for filtering, pagination, and summary totals.
+- Access control tests ensuring routes are disabled outside local/dev mode.
+
+### Frontend Tests
+- Component tests for:
+  - multi-mailbox switching
+  - SMS conversation rendering
+  - billing summary consistency
+  - TOTP parse + countdown + refresh rollover
+- E2E smoke: navigate all tabs and verify read-only controls.
+
+### Manual Validation Checklist
+- Launch with `scripts/run_dev.sh` and verify route is reachable.
+- Confirm mailbox list includes multiple addresses.
+- Confirm SMS grouping resembles iMessage threading.
+- Paste known TOTP seed and verify code correctness against reference app.
+- Validate ledger totals match underlying mock transaction data.
+
+---
+
+## 8. Open Questions
+- Exact canonical location/format of `email.log`, `sms.log`, and provider logs in current local stack.
+- Whether billing data should include refunds/disputes in first release.
+- Whether to offer downloadable JSON for selected events.
+- Expected retention limits for very large log files (performance budget).
+
+---
+
+## 9. Deliverables
+- Internal API routes + parser services + tests.
+- Dev tools frontend route with four tabs.
+- Frontend-only TOTP utility and UI panel.
+- `scripts/run_dev.sh` updates for auto-enable behavior.
+- Documentation snippet in `README.md` for usage.

--- a/docs/internal-dev-log-ui-read-models.md
+++ b/docs/internal-dev-log-ui-read-models.md
@@ -1,0 +1,37 @@
+# DLU-002 — Canonical Read Models (Email / SMS / Billing)
+
+This document defines the stable response contracts for internal Dev Log UI read APIs.
+
+## Stability rules
+- **Stable IDs:** every mailbox/thread/message/conversation/ledger row includes `id` + `id_strategy`.
+- **Timestamp normalization:** all API timestamps are normalized to UTC RFC3339 (`YYYY-MM-DDTHH:MM:SSZ`).
+- **Parse warnings:** top-level and item-level `parse_warnings` arrays surface non-fatal parser issues.
+
+## Model families
+
+### Email models
+- `DevtoolsEmailMailboxOut`
+- `DevtoolsEmailThreadOut`
+- `DevtoolsEmailMessageOut`
+- `DevtoolsEmailMessagesOut`
+
+### SMS models
+- `DevtoolsSmsConversationOut`
+- `DevtoolsSmsMessageOut`
+- `DevtoolsSmsConversationsOut`
+
+### Billing models
+- `DevtoolsBillingLedgerEntryOut`
+- `DevtoolsBillingLedgerSummaryOut`
+- `DevtoolsBillingLedgerOut`
+
+## Parse warning model
+- `DevtoolsParseWarningOut`
+  - `source`: `email | sms | billing`
+  - `line_number` (optional)
+  - `code`
+  - `message`
+  - `sample` (optional)
+
+## Source of truth
+Canonical model definitions live in `app/models.py` under the **Internal Dev Tools (DLU-002) canonical read models** section.

--- a/docs/internal-dev-log-ui-tickets.md
+++ b/docs/internal-dev-log-ui-tickets.md
@@ -1,0 +1,344 @@
+# Internal Dev Log UI — Implementation Tickets
+
+This ticket set maps directly to `docs/internal-dev-log-ui-plan.md` and breaks execution into backend contracts, frontend UX, TOTP handling, run script integration, and QA hardening.
+
+---
+
+## Epic A — Discovery, contracts, and data model alignment
+
+### DLU-001 — Inventory and lock log input formats
+- **Type:** Backend / Discovery
+- **Priority:** P0
+- **Size:** S
+- **Description:** Confirm canonical location and shape of `email.log`, `sms.log`, and billing-provider logs produced by the local mock stack.
+- **Deliverables:**
+  - Format matrix with sample records per source.
+  - Canonical dev path defaults for each log input.
+  - List of malformed-line patterns that must be tolerated.
+- **Acceptance criteria:**
+  - All required log sources are documented with at least one real sample.
+  - Path defaults are agreed and ready for env wiring.
+  - Unknown/ambiguous fields are flagged and resolved.
+- **Dependencies:** None.
+
+### DLU-002 — Define canonical read models for email/SMS/billing
+- **Type:** Backend / API
+- **Priority:** P0
+- **Size:** S
+- **Description:** Establish stable schema contracts returned by internal dev-tools APIs.
+- **Deliverables:**
+  - Canonical model definitions for mailbox/message/thread, SMS conversation/message, and billing ledger entry/summary.
+  - Stable ID strategy and timestamp normalization rules.
+- **Acceptance criteria:**
+  - Schemas cover all fields needed by target UI.
+  - Stable IDs are deterministic across refreshes for unchanged logs.
+  - All models include parse warning surfaces where needed.
+- **Dependencies:** DLU-001.
+
+### DLU-003 — Define internal API contract and pagination behavior
+- **Type:** Backend / API
+- **Priority:** P0
+- **Size:** S
+- **Description:** Finalize request/response contracts for internal read-only endpoints.
+- **Deliverables:**
+  - Contract for:
+    - `GET /internal/dev-tools/email/messages`
+    - `GET /internal/dev-tools/sms/conversations`
+    - `GET /internal/dev-tools/billing/ledger`
+    - `GET /internal/dev-tools/billing/summary`
+  - Cursor semantics, filtering/query behavior, and error mapping.
+- **Acceptance criteria:**
+  - Contract documented and testable.
+  - Pagination and filter semantics are deterministic.
+  - No mutating verbs are present in this surface.
+- **Dependencies:** DLU-002.
+
+---
+
+## Epic B — Backend parsers and read-only API implementation
+
+### DLU-004 — Build `email.log` parser with mailbox/thread extraction
+- **Type:** Backend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Implement robust parser supporting line-delimited JSON and plain-text fallback parsing for email logs.
+- **Deliverables:**
+  - Parser module for mailbox/message/thread canonicalization.
+  - Multi-address mailbox extraction and All Inboxes aggregation support.
+  - Parse-warning collection for malformed lines.
+- **Acceptance criteria:**
+  - Parser handles mixed valid/invalid lines without crashing.
+  - Mailbox and thread lists are deterministic.
+  - Large files are streamed with bounded memory.
+- **Dependencies:** DLU-001, DLU-002.
+
+### DLU-005 — Build `sms.log` parser with conversation grouping
+- **Type:** Backend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Implement SMS parser that normalizes conversation participants and message ordering.
+- **Deliverables:**
+  - Parser module for conversation-level and message-level records.
+  - Grouping logic matching iMessage-style thread expectations.
+  - Metadata mapping (`to`, `from`, status, external message ID).
+- **Acceptance criteria:**
+  - Conversations sort by latest activity deterministically.
+  - Message ordering/grouping is stable.
+  - Parse warnings are exposed without blocking results.
+- **Dependencies:** DLU-001, DLU-002.
+
+### DLU-006 — Build billing parser/adapter normalization for Stripe/CCBill/PayPal
+- **Type:** Backend / Billing
+- **Priority:** P0
+- **Size:** M
+- **Description:** Normalize provider-specific transaction artifacts into unified ledger entries.
+- **Deliverables:**
+  - Provider adapters for Stripe, CCBill, and PayPal mock logs.
+  - Canonical fields (`provider`, `event_type`, `amount`, `currency`, `fee`, `net`, `status`, `timestamp`, `external_id`, raw payload pointer).
+  - Warning handling for unsupported event variants.
+- **Acceptance criteria:**
+  - Unified schema produced for all three providers.
+  - Summary math inputs are complete and consistent.
+  - Parser tolerates partial provider outages/missing files.
+- **Dependencies:** DLU-001, DLU-002.
+
+### DLU-007 — Implement internal dev-tools router and service wiring
+- **Type:** Backend / API
+- **Priority:** P0
+- **Size:** M
+- **Description:** Add read-only internal routes backed by parser services and query filters.
+- **Deliverables:**
+  - Router implementation and registration.
+  - Endpoint filtering, pagination, and response DTOs.
+  - Short-TTL in-memory cache for file parse reuse.
+- **Acceptance criteria:**
+  - All four endpoints return contract-compliant responses.
+  - Filters and cursors work consistently across refreshes.
+  - Parse cache respects TTL and invalidation rules.
+- **Dependencies:** DLU-003, DLU-004, DLU-005, DLU-006.
+
+### DLU-008 — Enforce local/dev-only and read-only security controls
+- **Type:** Backend / Security
+- **Priority:** P0
+- **Size:** S
+- **Description:** Guard internal dev-tools endpoints from non-dev environments and preserve strict read-only posture.
+- **Deliverables:**
+  - Environment gate (disabled outside local/dev mode).
+  - Explicit GET-only routing and hardened error behavior.
+  - Logging/audit note for route access in dev context.
+- **Acceptance criteria:**
+  - Routes are unavailable in non-dev mode.
+  - No accidental write paths are exposed.
+  - Unauthorized/disabled responses are deterministic.
+- **Dependencies:** DLU-007.
+
+### DLU-009 — Implement billing summary aggregation service
+- **Type:** Backend / Billing
+- **Priority:** P0
+- **Size:** S
+- **Description:** Compute gross, fees, net balance, and provider/status counts from normalized ledger entries.
+- **Deliverables:**
+  - Summary aggregation service and DTO.
+  - Currency and sign-handling rules for totals.
+- **Acceptance criteria:**
+  - Totals match ledger source data.
+  - Empty/partial datasets return valid zero-state summaries.
+- **Dependencies:** DLU-006, DLU-007.
+
+---
+
+## Epic C — Frontend route, layouts, and data integration
+
+### DLU-010 — Add dev-tools route shell and feature-flag gating
+- **Type:** Frontend
+- **Priority:** P0
+- **Size:** S
+- **Description:** Add `/dev-tools/log-ui` route and gate visibility with `VITE_ENABLE_DEVTOOLS_LOG_UI`.
+- **Deliverables:**
+  - Route registration and nav entry.
+  - Tabbed shell for Email, SMS, MFA (TOTP), and Billing.
+- **Acceptance criteria:**
+  - Route hidden when flag is disabled.
+  - Route accessible and tabbed when enabled.
+- **Dependencies:** None.
+
+### DLU-011 — Implement frontend API clients and query hooks for dev-tools endpoints
+- **Type:** Frontend / API
+- **Priority:** P0
+- **Size:** M
+- **Description:** Add typed endpoint clients and query hooks for email, SMS, ledger, and summary data.
+- **Deliverables:**
+  - New endpoint client methods.
+  - Query hooks with filter/cursor support and cache keys.
+  - Standard loading/empty/error state support.
+- **Acceptance criteria:**
+  - Requests map correctly to backend contracts.
+  - Cache keying avoids collisions across tabs and filters.
+  - Error states display actionable debug info.
+- **Dependencies:** DLU-003, DLU-010.
+
+### DLU-012 — Build Gmail-like email UI with multi-mailbox support
+- **Type:** Frontend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Create read-only email experience with mailbox switcher, thread list, and message detail pane.
+- **Deliverables:**
+  - Mailbox rail, thread list, and detail panel.
+  - All Inboxes aggregate mode.
+  - Search and state filters (e.g., unread/sent/all as available by data).
+- **Acceptance criteria:**
+  - Multi-address browsing works end-to-end.
+  - Selected message/thread renders headers and body metadata.
+  - No mutating controls are exposed.
+- **Dependencies:** DLU-011.
+
+### DLU-013 — Build iMessage-like SMS UI with conversation list and bubble thread
+- **Type:** Frontend
+- **Priority:** P0
+- **Size:** M
+- **Description:** Create read-only SMS experience mirroring iMessage conversation ergonomics.
+- **Deliverables:**
+  - Left-side conversation list ordered by latest activity.
+  - Bubble thread renderer with sender grouping.
+  - Metadata drawer/info panel for status and IDs.
+- **Acceptance criteria:**
+  - Conversation switching is fast and stable.
+  - Bubble grouping/order matches canonical data.
+  - No message send/edit/delete actions exist.
+- **Dependencies:** DLU-011.
+
+### DLU-014 — Build billing ledger table, filters, and summary cards
+- **Type:** Frontend / Billing
+- **Priority:** P0
+- **Size:** M
+- **Description:** Implement unified billing ledger experience across Stripe/CCBill/PayPal.
+- **Deliverables:**
+  - Ledger data table with provider/status/date filters.
+  - Summary cards (gross, fees, net, counts).
+  - Raw source detail drawer.
+- **Acceptance criteria:**
+  - Table reflects backend filtering and pagination.
+  - Summary values stay consistent with visible dataset scope.
+  - Raw payload inspection is read-only.
+- **Dependencies:** DLU-011, DLU-009.
+
+---
+
+## Epic D — Frontend-only TOTP support
+
+### DLU-015 — Implement TOTP parser utility (otpauth URI + raw secret)
+- **Type:** Frontend / Security
+- **Priority:** P0
+- **Size:** S
+- **Description:** Build utility to parse/validate pasted MFA configuration locally in browser.
+- **Deliverables:**
+  - Parser for `otpauth://` URI and raw Base32 input mode.
+  - Validation feedback for invalid secrets and unsupported parameters.
+- **Acceptance criteria:**
+  - Valid inputs normalize into one internal config shape.
+  - Invalid inputs produce clear non-blocking errors.
+  - No network calls occur for parser execution.
+- **Dependencies:** DLU-010.
+
+### DLU-016 — Implement live TOTP generator panel with countdown and reset
+- **Type:** Frontend / Security
+- **Priority:** P0
+- **Size:** M
+- **Description:** Build UI panel to generate live codes entirely client-side.
+- **Deliverables:**
+  - Current code, next rollover countdown, and refresh cadence.
+  - Optional localStorage persistence toggle.
+  - Clear/reset controls and local-only disclosure text.
+- **Acceptance criteria:**
+  - Codes update on 30-second cadence.
+  - Reset clears in-memory and optional stored values.
+  - TOTP secret is never sent to backend.
+- **Dependencies:** DLU-015.
+
+---
+
+## Epic E — Dev runtime integration (`run_dev.sh`) and docs
+
+### DLU-017 — Wire `scripts/run_dev.sh` to auto-enable Dev Log UI
+- **Type:** DevEx / Tooling
+- **Priority:** P0
+- **Size:** S
+- **Description:** Set required frontend/backend env defaults and startup messaging so the UI comes up automatically in local runs.
+- **Deliverables:**
+  - Export `VITE_ENABLE_DEVTOOLS_LOG_UI=1` in dev flow.
+  - Default `DEVTOOLS_*` log path variables when unset.
+  - Startup output line with direct UI URL.
+- **Acceptance criteria:**
+  - Running `scripts/run_dev.sh` exposes the dev-tools route without extra setup.
+  - `--no-clean` mode remains compatible with retained logs.
+  - Existing startup behavior remains stable.
+- **Dependencies:** DLU-007, DLU-010.
+
+### DLU-018 — Add operator/developer documentation for local usage
+- **Type:** Docs
+- **Priority:** P1
+- **Size:** S
+- **Description:** Document feature purpose, route, log inputs, and limitations.
+- **Deliverables:**
+  - README (or docs) section with quickstart and troubleshooting.
+  - Note that UI is read-only except local TOTP config paste.
+- **Acceptance criteria:**
+  - New developers can discover and run the tool from docs only.
+  - Known limitations and security boundaries are explicit.
+- **Dependencies:** DLU-017.
+
+---
+
+## Epic F — Quality, test coverage, and release readiness
+
+### DLU-019 — Add backend tests for parsers and internal APIs
+- **Type:** Backend / QA
+- **Priority:** P0
+- **Size:** M
+- **Description:** Cover parser edge cases, endpoint filtering/pagination, security gating, and summary math.
+- **Deliverables:**
+  - Unit tests for email/SMS/billing parser robustness.
+  - API tests for endpoint contract, query filters, cursor behavior.
+  - Access-control tests for dev-only route availability.
+- **Acceptance criteria:**
+  - Core parser and API scenarios are deterministic in CI.
+  - Security gate tests fail if route is exposed outside dev.
+  - Summary totals are verified with fixture data.
+- **Dependencies:** DLU-004, DLU-005, DLU-006, DLU-007, DLU-008, DLU-009.
+
+### DLU-020 — Add frontend tests for read-only UX and TOTP lifecycle
+- **Type:** Frontend / QA
+- **Priority:** P0
+- **Size:** M
+- **Description:** Validate tab behavior, rendering, and TOTP runtime updates.
+- **Deliverables:**
+  - Component/hook tests for email/SMS/billing tabs.
+  - Tests asserting absence of mutating actions.
+  - TOTP tests for parse, countdown, rollover, and reset.
+- **Acceptance criteria:**
+  - Major loading/empty/error/content states are covered.
+  - TOTP behavior is deterministic under controlled timers.
+  - Read-only contract is enforced via UI tests.
+- **Dependencies:** DLU-012, DLU-013, DLU-014, DLU-016.
+
+### DLU-021 — Add end-to-end smoke for full tab flow in dev mode
+- **Type:** E2E / QA
+- **Priority:** P1
+- **Size:** S
+- **Description:** Add e2e scenario validating accessibility of all tabs and basic data rendering using mock artifacts.
+- **Deliverables:**
+  - E2E spec that opens `/dev-tools/log-ui`, visits all tabs, and verifies expected read-only markers.
+  - Optional fixture seed or setup helper for predictable logs.
+- **Acceptance criteria:**
+  - Smoke test passes locally/CI with mock stack.
+  - Regressions in route wiring and primary render paths are caught.
+- **Dependencies:** DLU-017, DLU-020.
+
+---
+
+## Suggested Milestones
+- **Milestone 1 (MVP backend + shell):** DLU-001 through DLU-011.
+- **Milestone 2 (Core UX):** DLU-012 through DLU-014.
+- **Milestone 3 (MFA local tooling):** DLU-015 and DLU-016.
+- **Milestone 4 (Autostart + docs):** DLU-017 and DLU-018.
+- **Milestone 5 (QA hardening):** DLU-019 through DLU-021.

--- a/docs/internal-dev-log-ui.md
+++ b/docs/internal-dev-log-ui.md
@@ -1,0 +1,76 @@
+# Internal Dev Log UI (local/dev only)
+
+The Internal Dev Log UI is a **read-only** troubleshooting surface for local development.
+It helps developers inspect mock artifacts produced by the local stack in one place:
+
+- Email log view (Gmail-like, read-only)
+- SMS log view (iMessage-like, read-only)
+- Billing ledger + summary for Stripe/CCBill/PayPal mock traffic (read-only)
+- MFA/TOTP helper panel (frontend-only parser + generator)
+
+> Security boundary: this UI is intended for local/dev usage only and should not be enabled for production-facing environments.
+
+## Quickstart
+
+1. Start the local stack:
+
+```bash
+scripts/run_dev.sh
+```
+
+2. Open the frontend app:
+
+- Main app: `http://localhost:5173`
+- Dev Log UI: `http://localhost:5173/dev-tools/log-ui`
+
+`run_dev.sh` auto-enables the route by exporting `VITE_ENABLE_DEVTOOLS_LOG_UI=1` for local runs.
+
+## Data inputs and defaults
+
+The backend reads log files from these environment variables (defaults shown):
+
+- `DEVTOOLS_EMAIL_LOG_PATH` (default: `.logs/dev/emails.log`)
+- `DEVTOOLS_SMS_LOG_PATH` (default: `.logs/dev/sms.log`)
+- `DEVTOOLS_BILLING_STRIPE_LOG_PATH` (default: `.local/logs/stripe-mock.log`)
+- `DEVTOOLS_BILLING_BACKEND_LOG_PATH` (default: `.logs/dev/backend.log`)
+
+`run_dev.sh` sets these defaults automatically if they are unset.
+
+## Read-only behavior
+
+All Email/SMS/Billing views are read-only.
+
+The only interactive write-like action is in-memory/local browser handling for the MFA panel:
+
+- You can paste TOTP configuration input (`otpauth://` URI or raw Base32 secret).
+- Optional persistence stores this value in browser `localStorage` only.
+- The TOTP secret is not sent to backend APIs by design.
+
+## Troubleshooting
+
+### Dev Log route returns 404
+
+- Confirm frontend flag is enabled: `VITE_ENABLE_DEVTOOLS_LOG_UI=1`
+- If using local flow, prefer `scripts/run_dev.sh` (it sets this automatically).
+
+### Page loads but no records appear
+
+- Confirm logs exist at the configured `DEVTOOLS_*` paths.
+- Check backend/frontend logs printed by `run_dev.sh` startup output.
+- If you used `--no-clean`, old logs may be retained; verify file timestamps and active path values.
+
+### Billing tab is empty
+
+- Ensure Stripe mock/backend logs are being written to configured billing paths.
+- Validate provider/status/date filters are not excluding all rows.
+
+### TOTP panel shows invalid config
+
+- Use an `otpauth://totp/...` URI or valid Base32 secret.
+- Unsupported URI parameters are ignored with warnings; invalid secrets produce non-blocking errors.
+
+## Known limitations
+
+- This is an internal debugging surface, not a production customer UI.
+- Parsed results depend on local log availability and formatting quality.
+- Very stale retained logs (especially in `--no-clean` runs) can mix old/new artifacts.

--- a/frontend/e2e/devtools-log-ui-smoke.spec.ts
+++ b/frontend/e2e/devtools-log-ui-smoke.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = "http://localhost:3000";
+
+test.describe("Dev Tools Log UI smoke", () => {
+  test.skip(process.env.VITE_ENABLE_DEVTOOLS_LOG_UI !== "1", "Requires VITE_ENABLE_DEVTOOLS_LOG_UI=1 in dev mode");
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "auth-store",
+        JSON.stringify({
+          state: {
+            userId: "e2e-devtools@test.local",
+            accessToken: "devtools-e2e-token",
+            isAuthenticated: true,
+          },
+          version: 0,
+        }),
+      );
+    });
+
+    await page.route("**/internal/dev-tools/email/messages**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          mailboxes: [
+            { id: "mb1", id_strategy: "hash", mailbox: "qa@example.com", thread_count: 1, unread_count: 1 },
+          ],
+          threads: [
+            {
+              id: "th1",
+              id_strategy: "hash",
+              mailbox: "qa@example.com",
+              subject: "Smoke email",
+              message_count: 1,
+              unread_count: 1,
+              participant_emails: ["qa@example.com"],
+              latest_message_at: "2026-01-01T12:00:00Z",
+            },
+          ],
+          messages: [
+            {
+              id: "msg1",
+              id_strategy: "hash",
+              thread_id: "th1",
+              mailbox: "qa@example.com",
+              sent_at: "2026-01-01T12:00:00Z",
+              event_kind: "mfa_email_code",
+              direction: "outbound",
+              from_email: "noreply@testlogon.dev",
+              to_emails: ["qa@example.com"],
+              subject: "Smoke email",
+              body_text: "Your OTP code is 123456",
+              status: "delivered",
+              parse_warnings: [],
+            },
+          ],
+          parse_warnings: [],
+          next_cursor: null,
+        }),
+      });
+    });
+
+    await page.route("**/internal/dev-tools/sms/conversations**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          conversations: [
+            {
+              id: "conv-1",
+              id_strategy: "hash",
+              participant_numbers: ["+15550000001"],
+              message_count: 2,
+              latest_message_at: "2026-01-01T12:01:00Z",
+              latest_preview: "Code: 654321",
+            },
+          ],
+          messages: [
+            {
+              id: "sms-1",
+              id_strategy: "hash",
+              conversation_id: "conv-1",
+              sent_at: "2026-01-01T12:00:00Z",
+              from_number: "+15550000001",
+              to_number: "+15559999999",
+              direction: "inbound",
+              body_text: "Code: 654321",
+              status: "received",
+              provider_message_id: "provider-1",
+              event_kind: "mfa_sms_code",
+              parse_warnings: [],
+            },
+            {
+              id: "sms-2",
+              id_strategy: "hash",
+              conversation_id: "conv-1",
+              sent_at: "2026-01-01T12:01:00Z",
+              from_number: "+15559999999",
+              to_number: "+15550000001",
+              direction: "outbound",
+              body_text: "Thanks",
+              status: "sent",
+              provider_message_id: "provider-2",
+              event_kind: "alert_sms",
+              parse_warnings: [],
+            },
+          ],
+          parse_warnings: [],
+          next_cursor: null,
+        }),
+      });
+    });
+
+    await page.route("**/internal/dev-tools/billing/ledger**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          entries: [
+            {
+              id: "bill-1",
+              id_strategy: "hash",
+              provider: "stripe",
+              event_type: "charge.succeeded",
+              status: "completed",
+              occurred_at: "2026-01-01T12:02:00Z",
+              external_id: "ch_123",
+              amount: 10,
+              fee: 0.5,
+              net: 9.5,
+              currency: "usd",
+              source_path: "stripe.log",
+              raw_payload: { ok: true },
+              parse_warnings: [],
+            },
+          ],
+          parse_warnings: [],
+          next_cursor: null,
+        }),
+      });
+    });
+
+    await page.route("**/internal/dev-tools/billing/summary**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          gross_inflow: 10,
+          fees: 0.5,
+          net_total_balance: 9.5,
+          transaction_count: 1,
+          provider_counts: { stripe: 1 },
+          status_counts: { completed: 1 },
+          parse_warnings: [],
+        }),
+      });
+    });
+  });
+
+  test("opens the route, visits each tab, and verifies read-only markers", async ({ page }) => {
+    await page.goto(`${BASE_URL}/dev-tools/log-ui`, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Dev Tools Log UI" })).toBeVisible();
+
+    // Email
+    await expect(page.getByText("All Inboxes")).toBeVisible();
+    await expect(page.getByText("Smoke email").first()).toBeVisible();
+    await expect(page.getByText("Your OTP code is 123456")).toBeVisible();
+    await expect(page.getByRole("button", { name: /send/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /delete/i })).toHaveCount(0);
+
+    // SMS
+    await page.getByRole("tab", { name: "SMS" }).click();
+    await expect(page.getByText("+15550000001").first()).toBeVisible();
+    await expect(page.getByText("Code: 654321").first()).toBeVisible();
+    await expect(page.getByText("Message metadata")).toBeVisible();
+    await expect(page.getByRole("button", { name: /edit/i })).toHaveCount(0);
+
+    // MFA
+    await page.getByRole("tab", { name: "MFA (TOTP)" }).click();
+    await expect(page.getByText(/Local-only tool:/)).toBeVisible();
+    await expect(page.getByText("Provide a valid TOTP configuration to generate live codes.")).toBeVisible();
+
+    // Billing
+    await page.getByRole("tab", { name: "Billing" }).click();
+    await expect(page.getByText("Gross inflow")).toBeVisible();
+    await expect(page.getByText("charge.succeeded")).toBeVisible();
+    await page.getByRole("button", { name: "View raw" }).click();
+    await expect(page.getByText("Raw billing payload")).toBeVisible();
+    await expect(page.getByRole("button", { name: /refund/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /charge/i })).toHaveCount(0);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from "lucide-react";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import AppShell from "@/components/layout/AppShell";
 import { ErrorPage } from "@/components/shared/ErrorPage";
+import { isDevtoolsLogUiEnabled } from "@/lib/featureFlags";
 
 // ─── Lazy-loaded pages (code-split per route) ───────────────────
 const Login = lazy(() => import("@/pages/Login"));
@@ -37,6 +38,7 @@ const HelpdeskPage = lazy(() => import("@/pages/helpdesk/HelpdeskPage"));
 const TicketsPage = lazy(() => import("@/pages/tickets/TicketsPage"));
 const TicketSpacesPage = lazy(() => import("@/pages/tickets/TicketSpacesPage"));
 const TicketSpaceDetailPage = lazy(() => import("@/pages/tickets/TicketSpaceDetailPage"));
+const DevToolsLogUiPage = lazy(() => import("@/pages/devtools/DevToolsLogUiPage"));
 
 function PageSpinner() {
   return (
@@ -47,6 +49,8 @@ function PageSpinner() {
 }
 
 export default function App() {
+  const showDevtoolsLogUi = isDevtoolsLogUiEnabled();
+
   return (
     <Suspense fallback={<PageSpinner />}>
       <Routes>
@@ -85,6 +89,7 @@ export default function App() {
           <Route path="purchases/:txnId" element={<PurchasesPage />} />
           <Route path="subscriptions" element={<SubscriptionsPage />} />
           <Route path="root/roles" element={<RootRoleManagementPage />} />
+          {showDevtoolsLogUi && <Route path="dev-tools/log-ui" element={<DevToolsLogUiPage />} />}
           <Route path="*" element={<ErrorPage status={404} />} />
         </Route>
 

--- a/frontend/src/api/endpoints/devtools.test.ts
+++ b/frontend/src/api/endpoints/devtools.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { api } from "@/api/client";
+import {
+  getDevtoolsBillingLedger,
+  getDevtoolsBillingSummary,
+  getDevtoolsEmailMessages,
+  getDevtoolsSmsConversations,
+} from "@/api/endpoints/devtools";
+
+describe("devtools endpoints", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps email request params to backend contract", async () => {
+    const spy = vi.spyOn(api, "get").mockResolvedValue({} as never);
+    await getDevtoolsEmailMessages({ mailbox: "a@x.com", thread_id: "t1", q: "code", state: "all", limit: 10, cursor: "abc" });
+    expect(spy).toHaveBeenCalledWith("/internal/dev-tools/email/messages", {
+      mailbox: "a@x.com",
+      thread_id: "t1",
+      q: "code",
+      state: "all",
+      limit: "10",
+      cursor: "abc",
+    });
+  });
+
+  it("maps sms request params to backend contract", async () => {
+    const spy = vi.spyOn(api, "get").mockResolvedValue({} as never);
+    await getDevtoolsSmsConversations({ participant: "+14155550123", q: "hello", limit: 25, cursor: "c1" });
+    expect(spy).toHaveBeenCalledWith("/internal/dev-tools/sms/conversations", {
+      participant: "+14155550123",
+      q: "hello",
+      limit: "25",
+      cursor: "c1",
+    });
+  });
+
+  it("maps billing ledger and summary params to backend contract", async () => {
+    const spy = vi.spyOn(api, "get").mockResolvedValue({} as never);
+    await getDevtoolsBillingLedger({ provider: "paypal", status: "completed", from: "2026-01-01", to: "2026-01-02", limit: 50, cursor: "n1" });
+    expect(spy).toHaveBeenNthCalledWith(1, "/internal/dev-tools/billing/ledger", {
+      provider: "paypal",
+      status: "completed",
+      from: "2026-01-01",
+      to: "2026-01-02",
+      limit: "50",
+      cursor: "n1",
+    });
+
+    await getDevtoolsBillingSummary({ provider: "stripe", status: "failed", from: "2026-01-01", to: "2026-01-02" });
+    expect(spy).toHaveBeenNthCalledWith(2, "/internal/dev-tools/billing/summary", {
+      provider: "stripe",
+      status: "failed",
+      from: "2026-01-01",
+      to: "2026-01-02",
+    });
+  });
+});

--- a/frontend/src/api/endpoints/devtools.ts
+++ b/frontend/src/api/endpoints/devtools.ts
@@ -1,0 +1,83 @@
+import { api } from "@/api/client";
+import type {
+  DevtoolsBillingLedgerOut,
+  DevtoolsBillingLedgerSummaryOut,
+  DevtoolsEmailMessagesOut,
+  DevtoolsSmsConversationsOut,
+} from "@/api/types";
+
+export interface DevtoolsEmailMessagesQuery {
+  mailbox?: string;
+  thread_id?: string;
+  q?: string;
+  state?: "all" | "unread" | "sent";
+  limit?: number;
+  cursor?: string;
+}
+
+export interface DevtoolsSmsConversationsQuery {
+  participant?: string;
+  q?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface DevtoolsBillingLedgerQuery {
+  provider?: "stripe" | "ccbill" | "paypal";
+  status?: "pending" | "completed" | "failed" | "refunded" | "canceled";
+  from?: string;
+  to?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+const cleanParams = (params: Record<string, string | undefined>) =>
+  Object.fromEntries(Object.entries(params).filter(([, v]) => v != null && v !== "")) as Record<string, string>;
+
+export const getDevtoolsEmailMessages = (query: DevtoolsEmailMessagesQuery = {}) =>
+  api.get<DevtoolsEmailMessagesOut>(
+    "/internal/dev-tools/email/messages",
+    cleanParams({
+      mailbox: query.mailbox,
+      thread_id: query.thread_id,
+      q: query.q,
+      state: query.state,
+      limit: query.limit != null ? String(query.limit) : undefined,
+      cursor: query.cursor,
+    }),
+  );
+
+export const getDevtoolsSmsConversations = (query: DevtoolsSmsConversationsQuery = {}) =>
+  api.get<DevtoolsSmsConversationsOut>(
+    "/internal/dev-tools/sms/conversations",
+    cleanParams({
+      participant: query.participant,
+      q: query.q,
+      limit: query.limit != null ? String(query.limit) : undefined,
+      cursor: query.cursor,
+    }),
+  );
+
+export const getDevtoolsBillingLedger = (query: DevtoolsBillingLedgerQuery = {}) =>
+  api.get<DevtoolsBillingLedgerOut>(
+    "/internal/dev-tools/billing/ledger",
+    cleanParams({
+      provider: query.provider,
+      status: query.status,
+      from: query.from,
+      to: query.to,
+      limit: query.limit != null ? String(query.limit) : undefined,
+      cursor: query.cursor,
+    }),
+  );
+
+export const getDevtoolsBillingSummary = (query: Omit<DevtoolsBillingLedgerQuery, "limit" | "cursor"> = {}) =>
+  api.get<DevtoolsBillingLedgerSummaryOut>(
+    "/internal/dev-tools/billing/summary",
+    cleanParams({
+      provider: query.provider,
+      status: query.status,
+      from: query.from,
+      to: query.to,
+    }),
+  );

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1830,3 +1830,118 @@ export interface WalletDepositReq {
 export interface WalletWithdrawReq {
   amount_cents: number;
 }
+
+// ─── Internal Dev Tools ─────────────────────────────────────────
+
+export interface DevtoolsParseWarningOut {
+  source: "email" | "sms" | "billing";
+  line_number?: number;
+  code: string;
+  message: string;
+  sample?: string;
+}
+
+export interface DevtoolsIdentityOut {
+  id: string;
+  id_strategy: string;
+}
+
+export interface DevtoolsEmailMailboxOut extends DevtoolsIdentityOut {
+  mailbox: string;
+  thread_count: number;
+  unread_count: number;
+}
+
+export interface DevtoolsEmailThreadOut extends DevtoolsIdentityOut {
+  mailbox: string;
+  subject?: string;
+  message_count: number;
+  unread_count: number;
+  participant_emails: string[];
+  latest_message_at: string;
+}
+
+export interface DevtoolsEmailMessageOut extends DevtoolsIdentityOut {
+  thread_id: string;
+  mailbox: string;
+  sent_at: string;
+  event_kind: "mfa_email_code" | "alert_email" | "unknown";
+  direction: "inbound" | "outbound" | "unknown";
+  from_email?: string;
+  to_emails: string[];
+  subject?: string;
+  body_text?: string;
+  body_html?: string;
+  code?: string;
+  purpose?: string;
+  status?: string;
+  parse_warnings: DevtoolsParseWarningOut[];
+}
+
+export interface DevtoolsEmailMessagesOut {
+  mailboxes: DevtoolsEmailMailboxOut[];
+  threads: DevtoolsEmailThreadOut[];
+  messages: DevtoolsEmailMessageOut[];
+  next_cursor?: string | null;
+  parse_warnings: DevtoolsParseWarningOut[];
+}
+
+export interface DevtoolsSmsConversationOut extends DevtoolsIdentityOut {
+  participant_numbers: string[];
+  message_count: number;
+  latest_message_at: string;
+  latest_preview?: string;
+}
+
+export interface DevtoolsSmsMessageOut extends DevtoolsIdentityOut {
+  conversation_id: string;
+  sent_at: string;
+  from_number?: string;
+  to_number?: string;
+  direction: "inbound" | "outbound" | "unknown";
+  body_text?: string;
+  code?: string;
+  status?: string;
+  provider_message_id?: string;
+  event_kind: "mfa_sms_code" | "alert_sms" | "unknown";
+  parse_warnings: DevtoolsParseWarningOut[];
+}
+
+export interface DevtoolsSmsConversationsOut {
+  conversations: DevtoolsSmsConversationOut[];
+  messages: DevtoolsSmsMessageOut[];
+  next_cursor?: string | null;
+  parse_warnings: DevtoolsParseWarningOut[];
+}
+
+export interface DevtoolsBillingLedgerEntryOut extends DevtoolsIdentityOut {
+  provider: "stripe" | "ccbill" | "paypal" | "unknown";
+  event_type: string;
+  status: string;
+  occurred_at: string;
+  external_id?: string;
+  amount: number;
+  fee: number;
+  net: number;
+  currency: string;
+  source_path?: string;
+  raw_payload: Record<string, unknown>;
+  parse_warnings: DevtoolsParseWarningOut[];
+}
+
+export interface DevtoolsBillingLedgerSummaryOut {
+  gross_inflow: number;
+  fees: number;
+  net_total_balance: number;
+  transaction_count: number;
+  provider_counts: Record<string, number>;
+  status_counts: Record<string, number>;
+  parse_warnings: DevtoolsParseWarningOut[];
+}
+
+export interface DevtoolsBillingLedgerOut {
+  entries: DevtoolsBillingLedgerEntryOut[];
+  summary: DevtoolsBillingLedgerSummaryOut;
+  next_cursor?: string | null;
+  parse_warnings: DevtoolsParseWarningOut[];
+}

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -16,6 +16,7 @@ import {
   LifeBuoy,
   Settings,
   UsersRound,
+  Bug,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -28,6 +29,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useAuthStore } from "@/stores/authStore";
 import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
+import { isDevtoolsLogUiEnabled } from "@/lib/featureFlags";
 
 // ─── Tab config ─────────────────────────────────────────────────
 
@@ -49,6 +51,7 @@ const MORE_LINKS = [
   { label: "Tickets", path: "/tickets", icon: LifeBuoy },
   { label: "Ticket Spaces", path: "/tickets/spaces", icon: LifeBuoy },
   { label: "Settings", path: "/settings", icon: Settings },
+  { label: "Dev Tools", path: "/dev-tools/log-ui", icon: Bug },
   { label: "Role Mgmt", path: "/root/roles", icon: UsersRound },
 ];
 
@@ -60,7 +63,11 @@ export default function MobileNav() {
   const accessToken = useAuthStore((s) => s.accessToken);
   const showRootRoleManagement = canSeeRootRoleManagement(accessToken);
 
-  const moreLinks = MORE_LINKS.filter((item) => item.path !== "/root/roles" || showRootRoleManagement);
+  const moreLinks = MORE_LINKS.filter((item) => {
+    if (item.path === "/root/roles") return showRootRoleManagement;
+    if (item.path === "/dev-tools/log-ui") return isDevtoolsLogUiEnabled();
+    return true;
+  });
 
   return (
     <>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Headphones,
   PanelLeftClose,
   PanelLeft,
+  Bug,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -31,6 +32,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 import { useQuery } from "@tanstack/react-query";
 import { getConversations } from "@/api/endpoints/messaging";
+import { isDevtoolsLogUiEnabled } from "@/lib/featureFlags";
 
 // ─── Navigation Config ──────────────────────────────────────────
 
@@ -84,6 +86,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Tickets", path: "/tickets", icon: <LifeBuoy className="h-5 w-5" /> },
       { label: "Ticket Spaces", path: "/tickets/spaces", icon: <LifeBuoy className="h-5 w-5" /> },
       { label: "Settings", path: "/settings", icon: <Settings className="h-5 w-5" /> },
+      { label: "Dev Tools Log UI", path: "/dev-tools/log-ui", icon: <Bug className="h-5 w-5" /> },
       { label: "Role Management", path: "/root/roles", icon: <UsersRound className="h-5 w-5" /> },
     ],
   },
@@ -140,7 +143,11 @@ export default function Sidebar() {
       {/* Navigation */}
       <nav className="flex-1 overflow-y-auto px-2 py-3">
         {NAV_GROUPS.map((group, gi) => {
-          const items = group.items.filter((item) => item.path !== "/root/roles" || showRootRoleManagement);
+          const items = group.items.filter((item) => {
+            if (item.path === "/root/roles") return showRootRoleManagement;
+            if (item.path === "/dev-tools/log-ui") return isDevtoolsLogUiEnabled();
+            return true;
+          });
           if (items.length === 0) return null;
           return (
           <div key={group.title}>

--- a/frontend/src/hooks/useDevtoolsData.test.tsx
+++ b/frontend/src/hooks/useDevtoolsData.test.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import {
+  useDevtoolsBillingLedger,
+  useDevtoolsBillingSummary,
+  useDevtoolsEmailMessages,
+  useDevtoolsSmsConversations,
+} from "@/hooks/useDevtoolsData";
+
+const getDevtoolsEmailMessages = vi.fn();
+const getDevtoolsSmsConversations = vi.fn();
+const getDevtoolsBillingLedger = vi.fn();
+const getDevtoolsBillingSummary = vi.fn();
+
+vi.mock("@/api/endpoints/devtools", () => ({
+  getDevtoolsEmailMessages: (...args: unknown[]) => getDevtoolsEmailMessages(...args),
+  getDevtoolsSmsConversations: (...args: unknown[]) => getDevtoolsSmsConversations(...args),
+  getDevtoolsBillingLedger: (...args: unknown[]) => getDevtoolsBillingLedger(...args),
+  getDevtoolsBillingSummary: (...args: unknown[]) => getDevtoolsBillingSummary(...args),
+}));
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useDevtoolsData", () => {
+  beforeEach(() => {
+    getDevtoolsEmailMessages.mockReset();
+    getDevtoolsSmsConversations.mockReset();
+    getDevtoolsBillingLedger.mockReset();
+    getDevtoolsBillingSummary.mockReset();
+  });
+
+  it("uses collision-safe cache keys per filter set", async () => {
+    getDevtoolsEmailMessages.mockResolvedValue({ mailboxes: [], threads: [], messages: [], parse_warnings: [] });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const first = renderHook(() => useDevtoolsEmailMessages({ mailbox: "a@example.com", state: "all", limit: 10 }, true), { wrapper: wrapper(client) });
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+
+    const second = renderHook(() => useDevtoolsEmailMessages({ mailbox: "b@example.com", state: "all", limit: 10 }, true), { wrapper: wrapper(client) });
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+
+    const queries = client.getQueryCache().findAll({ queryKey: ["devtools", "email"] });
+    const keys = queries.map((q) => q.queryKey.join("|"));
+    expect(keys.some((k) => k.includes("|a@example.com|"))).toBe(true);
+    expect(keys.some((k) => k.includes("|b@example.com|"))).toBe(true);
+  });
+
+  it("passes cursor for infinite paging and exposes empty state", async () => {
+    getDevtoolsSmsConversations
+      .mockResolvedValueOnce({ conversations: [], messages: [], next_cursor: "next-1", parse_warnings: [] })
+      .mockResolvedValueOnce({ conversations: [], messages: [], parse_warnings: [] });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useDevtoolsSmsConversations({ participant: "+14155550123", limit: 5 }, true), {
+      wrapper: wrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isEmpty).toBe(true);
+    await result.current.fetchNextPage();
+
+    expect(getDevtoolsSmsConversations).toHaveBeenNthCalledWith(1, expect.objectContaining({ cursor: undefined, limit: 5 }));
+    expect(getDevtoolsSmsConversations).toHaveBeenNthCalledWith(2, expect.objectContaining({ cursor: "next-1", limit: 5 }));
+  });
+
+  it("provides actionable error text and separate billing cache keys", async () => {
+    getDevtoolsBillingLedger
+      .mockRejectedValueOnce(new Error("ledger exploded"))
+      .mockResolvedValue({ entries: [], summary: { gross_inflow: 0, fees: 0, net_total_balance: 0, transaction_count: 0, provider_counts: {}, status_counts: {}, parse_warnings: [] }, parse_warnings: [] });
+    getDevtoolsBillingSummary.mockResolvedValue({ gross_inflow: 0, fees: 0, net_total_balance: 0, transaction_count: 0, provider_counts: {}, status_counts: {}, parse_warnings: [] });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const bad = renderHook(() => useDevtoolsBillingLedger({ provider: "stripe", status: "failed", limit: 10 }, true), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(bad.result.current.isError).toBe(true));
+    expect(bad.result.current.errorMessage).toContain("ledger exploded");
+
+    const good = renderHook(() => useDevtoolsBillingLedger({ provider: "stripe", status: "completed", limit: 10 }, true), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(good.result.current.isSuccess).toBe(true));
+
+    const summary = renderHook(() => useDevtoolsBillingSummary({ provider: "stripe", status: "completed" }, true), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(summary.result.current.isSuccess).toBe(true));
+
+    const ledgerQueries = client.getQueryCache().findAll({ queryKey: ["devtools", "billing", "ledger", "stripe"] });
+    expect(ledgerQueries.length).toBeGreaterThanOrEqual(2);
+    const summaryQueries = client.getQueryCache().findAll({ queryKey: ["devtools", "billing", "summary", "stripe", "completed"] });
+    expect(summaryQueries.length).toBe(1);
+  });
+});

--- a/frontend/src/hooks/useDevtoolsData.ts
+++ b/frontend/src/hooks/useDevtoolsData.ts
@@ -1,0 +1,117 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { ApiError, normalizeErrorDetail } from "@/api/client";
+import {
+  getDevtoolsBillingLedger,
+  getDevtoolsBillingSummary,
+  getDevtoolsEmailMessages,
+  getDevtoolsSmsConversations,
+  type DevtoolsBillingLedgerQuery,
+  type DevtoolsEmailMessagesQuery,
+  type DevtoolsSmsConversationsQuery,
+} from "@/api/endpoints/devtools";
+
+const asErrorMessage = (error: unknown): string | null => {
+  if (!error) return null;
+  if (error instanceof ApiError) {
+    return normalizeErrorDetail((error.body as Record<string, unknown> | undefined)?.detail, error.detail);
+  }
+  if (error instanceof Error) return error.message;
+  return "Unknown error";
+};
+
+export function useDevtoolsEmailMessages(query: Omit<DevtoolsEmailMessagesQuery, "cursor">, enabled = true) {
+  const limit = query.limit ?? 50;
+  const rq = useInfiniteQuery({
+    queryKey: ["devtools", "email", query.mailbox ?? "", query.thread_id ?? "", query.q ?? "", query.state ?? "all", limit],
+    queryFn: ({ pageParam }) => getDevtoolsEmailMessages({ ...query, limit, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    enabled,
+  });
+
+  const firstPage = rq.data?.pages?.[0];
+  const messages = rq.data?.pages.flatMap((p) => p.messages) ?? [];
+  const warnings = rq.data?.pages.flatMap((p) => p.parse_warnings ?? []) ?? [];
+
+  return {
+    ...rq,
+    mailboxes: firstPage?.mailboxes ?? [],
+    threads: firstPage?.threads ?? [],
+    messages,
+    parseWarnings: warnings,
+    isEmpty: !rq.isLoading && messages.length === 0,
+    errorMessage: asErrorMessage(rq.error),
+  };
+}
+
+export function useDevtoolsSmsConversations(query: Omit<DevtoolsSmsConversationsQuery, "cursor">, enabled = true) {
+  const limit = query.limit ?? 50;
+  const rq = useInfiniteQuery({
+    queryKey: ["devtools", "sms", query.participant ?? "", query.q ?? "", limit],
+    queryFn: ({ pageParam }) => getDevtoolsSmsConversations({ ...query, limit, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    enabled,
+  });
+
+  const firstPage = rq.data?.pages?.[0];
+  const messages = rq.data?.pages.flatMap((p) => p.messages) ?? [];
+  const warnings = rq.data?.pages.flatMap((p) => p.parse_warnings ?? []) ?? [];
+
+  return {
+    ...rq,
+    conversations: firstPage?.conversations ?? [],
+    messages,
+    parseWarnings: warnings,
+    isEmpty: !rq.isLoading && messages.length === 0 && (firstPage?.conversations?.length ?? 0) === 0,
+    errorMessage: asErrorMessage(rq.error),
+  };
+}
+
+export function useDevtoolsBillingLedger(query: Omit<DevtoolsBillingLedgerQuery, "cursor">, enabled = true) {
+  const limit = query.limit ?? 50;
+  const rq = useInfiniteQuery({
+    queryKey: [
+      "devtools",
+      "billing",
+      "ledger",
+      query.provider ?? "",
+      query.status ?? "",
+      query.from ?? "",
+      query.to ?? "",
+      limit,
+    ],
+    queryFn: ({ pageParam }) => getDevtoolsBillingLedger({ ...query, limit, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    enabled,
+  });
+
+  const firstPage = rq.data?.pages?.[0];
+  const entries = rq.data?.pages.flatMap((p) => p.entries) ?? [];
+  const warnings = rq.data?.pages.flatMap((p) => p.parse_warnings ?? []) ?? [];
+
+  return {
+    ...rq,
+    summary: firstPage?.summary,
+    entries,
+    parseWarnings: warnings,
+    isEmpty: !rq.isLoading && entries.length === 0,
+    errorMessage: asErrorMessage(rq.error),
+  };
+}
+
+export function useDevtoolsBillingSummary(query: Omit<DevtoolsBillingLedgerQuery, "limit" | "cursor">, enabled = true) {
+  const rq = useQuery({
+    queryKey: ["devtools", "billing", "summary", query.provider ?? "", query.status ?? "", query.from ?? "", query.to ?? ""],
+    queryFn: () => getDevtoolsBillingSummary(query),
+    enabled,
+  });
+
+  return {
+    ...rq,
+    parseWarnings: rq.data?.parse_warnings ?? [],
+    isEmpty: !rq.isLoading && (rq.data?.transaction_count ?? 0) === 0,
+    errorMessage: asErrorMessage(rq.error),
+  };
+}

--- a/frontend/src/lib/featureFlags.ts
+++ b/frontend/src/lib/featureFlags.ts
@@ -38,3 +38,6 @@ export const isMessagingViewOnceImageEnabled = () => isMessagingOnceMediaCompose
 export const isMessagingViewOnceVideoEnabled = () => isMessagingOnceMediaComposerEnabled() && messagingOnceMediaVideoEnabled;
 export const isMessagingListenOnceAudioEnabled = () => isMessagingOnceMediaComposerEnabled() && messagingOnceMediaAudioEnabled;
 
+
+export const devtoolsLogUiEnabled = toBool(env.VITE_ENABLE_DEVTOOLS_LOG_UI, false);
+export const isDevtoolsLogUiEnabled = () => devtoolsLogUiEnabled;

--- a/frontend/src/lib/totpConfigParser.test.ts
+++ b/frontend/src/lib/totpConfigParser.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTotpConfigInput } from "@/lib/totpConfigParser";
+
+describe("parseTotpConfigInput", () => {
+  it("normalizes a valid otpauth URI into canonical config", () => {
+    const result = parseTotpConfigInput(
+      "otpauth://totp/TestLogon:alice@example.com?secret=JBSW-Y3DP EHPK3PXP&issuer=TestLogon&algorithm=SHA256&digits=8&period=45",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.config).toEqual({
+      mode: "otpauth",
+      secret: "JBSWY3DPEHPK3PXP",
+      issuer: "TestLogon",
+      accountName: "alice@example.com",
+      label: "TestLogon:alice@example.com",
+      algorithm: "SHA256",
+      digits: 8,
+      period: 45,
+    });
+  });
+
+  it("supports raw Base32 mode without network calls", () => {
+    const result = parseTotpConfigInput("jbsw y3dp ehpk 3pxp");
+
+    expect(result.ok).toBe(true);
+    expect(result.config?.mode).toBe("raw");
+    expect(result.config?.secret).toBe("JBSWY3DPEHPK3PXP");
+    expect(result.config?.algorithm).toBe("SHA1");
+    expect(result.config?.digits).toBe(6);
+    expect(result.config?.period).toBe(30);
+  });
+
+  it("returns clear validation errors for invalid secret", () => {
+    const result = parseTotpConfigInput("otpauth://totp/Example:user?secret=INVALID$SECRET");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("TOTP secret must be valid Base32 characters (A-Z and 2-7).");
+  });
+
+  it("returns non-blocking warnings for unsupported parameters", () => {
+    const result = parseTotpConfigInput(
+      "otpauth://totp/Test:user?secret=JBSWY3DPEHPK3PXP&algorithm=md5&digits=7&period=0&counter=1&foo=bar",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        "Unsupported algorithm 'MD5'. Falling back to SHA1.",
+        "Unsupported digits '7'. Falling back to 6.",
+        "Invalid period '0'. Falling back to 30 seconds.",
+        "Unsupported parameter 'counter' ignored.",
+        "HOTP counter parameter is ignored for TOTP.",
+        "Unsupported parameter 'foo' ignored.",
+      ]),
+    );
+    expect(result.config?.algorithm).toBe("SHA1");
+    expect(result.config?.digits).toBe(6);
+    expect(result.config?.period).toBe(30);
+  });
+
+  it("fails for non-TOTP otpauth types", () => {
+    const result = parseTotpConfigInput("otpauth://hotp/Test:user?secret=JBSWY3DPEHPK3PXP");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("Unsupported OTP type 'hotp'. Only TOTP is supported.");
+  });
+});

--- a/frontend/src/lib/totpConfigParser.ts
+++ b/frontend/src/lib/totpConfigParser.ts
@@ -1,0 +1,140 @@
+const BASE32_SECRET_PATTERN = /^[A-Z2-7]+=*$/;
+const SUPPORTED_ALGORITHMS = new Set(["SHA1", "SHA256", "SHA512"]);
+const SUPPORTED_DIGITS = new Set([6, 8]);
+
+type TotpAlgorithm = "SHA1" | "SHA256" | "SHA512";
+
+export interface TotpConfig {
+  mode: "otpauth" | "raw";
+  secret: string;
+  issuer?: string;
+  accountName?: string;
+  label?: string;
+  algorithm: TotpAlgorithm;
+  digits: 6 | 8;
+  period: number;
+}
+
+export interface TotpParseResult {
+  ok: boolean;
+  config?: TotpConfig;
+  errors: string[];
+  warnings: string[];
+}
+
+const normalizeSecret = (raw: string) => raw.trim().replace(/[\s-]/g, "").toUpperCase();
+
+const validateSecret = (secret: string, errors: string[]) => {
+  if (!secret) {
+    errors.push("Missing TOTP secret.");
+    return;
+  }
+  if (!BASE32_SECRET_PATTERN.test(secret)) {
+    errors.push("TOTP secret must be valid Base32 characters (A-Z and 2-7).");
+    return;
+  }
+  if (secret.length < 16) {
+    errors.push("TOTP secret is too short. Expected at least 16 Base32 characters.");
+  }
+};
+
+const parseSafeInt = (value: string | null) => {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const parseTotpConfigInput = (input: string): TotpParseResult => {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { ok: false, errors: ["Paste an otpauth URI or raw Base32 secret."], warnings };
+  }
+
+  if (!trimmed.toLowerCase().startsWith("otpauth://")) {
+    const secret = normalizeSecret(trimmed);
+    validateSecret(secret, errors);
+    if (errors.length > 0) return { ok: false, errors, warnings };
+
+    return {
+      ok: true,
+      errors,
+      warnings,
+      config: {
+        mode: "raw",
+        secret,
+        algorithm: "SHA1",
+        digits: 6,
+        period: 30,
+      },
+    };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return { ok: false, errors: ["Invalid otpauth URI format."], warnings };
+  }
+
+  const otpType = url.hostname.toLowerCase();
+  if (otpType !== "totp") {
+    return { ok: false, errors: [`Unsupported OTP type '${otpType}'. Only TOTP is supported.`], warnings };
+  }
+
+  const label = decodeURIComponent(url.pathname.replace(/^\//, ""));
+  const [labelIssuer, labelAccountName] = label.includes(":") ? label.split(/:(.+)/, 2) : [undefined, label || undefined];
+
+  const secret = normalizeSecret(url.searchParams.get("secret") ?? "");
+  validateSecret(secret, errors);
+
+  const issuerParam = url.searchParams.get("issuer")?.trim();
+  const issuer = issuerParam || labelIssuer;
+  const accountName = labelAccountName;
+
+  const algorithmRaw = (url.searchParams.get("algorithm") || "SHA1").toUpperCase();
+  const algorithm = SUPPORTED_ALGORITHMS.has(algorithmRaw) ? (algorithmRaw as TotpAlgorithm) : "SHA1";
+  if (!SUPPORTED_ALGORITHMS.has(algorithmRaw)) {
+    warnings.push(`Unsupported algorithm '${algorithmRaw}'. Falling back to SHA1.`);
+  }
+
+  const parsedDigits = parseSafeInt(url.searchParams.get("digits"));
+  const digits = parsedDigits && SUPPORTED_DIGITS.has(parsedDigits) ? (parsedDigits as 6 | 8) : 6;
+  if (parsedDigits != null && !SUPPORTED_DIGITS.has(parsedDigits)) {
+    warnings.push(`Unsupported digits '${parsedDigits}'. Falling back to 6.`);
+  }
+
+  const parsedPeriod = parseSafeInt(url.searchParams.get("period"));
+  const period = parsedPeriod && parsedPeriod > 0 ? parsedPeriod : 30;
+  if (parsedPeriod != null && parsedPeriod <= 0) {
+    warnings.push(`Invalid period '${parsedPeriod}'. Falling back to 30 seconds.`);
+  }
+
+  const knownParams = new Set(["secret", "issuer", "algorithm", "digits", "period"]);
+  for (const [key] of url.searchParams.entries()) {
+    if (!knownParams.has(key)) warnings.push(`Unsupported parameter '${key}' ignored.`);
+  }
+  if (url.searchParams.has("counter")) {
+    warnings.push("HOTP counter parameter is ignored for TOTP.");
+  }
+
+  if (errors.length > 0) return { ok: false, errors, warnings };
+
+  return {
+    ok: true,
+    errors,
+    warnings,
+    config: {
+      mode: "otpauth",
+      secret,
+      issuer,
+      accountName,
+      label: label || undefined,
+      algorithm,
+      digits,
+      period,
+    },
+  };
+};

--- a/frontend/src/lib/totpGenerator.test.ts
+++ b/frontend/src/lib/totpGenerator.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { generateTotpCode } from "@/lib/totpGenerator";
+
+const rfcSecret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+
+describe("generateTotpCode", () => {
+  it("matches RFC6238 SHA1 test vectors with 8 digits", async () => {
+    const config = {
+      mode: "raw" as const,
+      secret: rfcSecret,
+      algorithm: "SHA1" as const,
+      digits: 8 as const,
+      period: 30,
+    };
+
+    const v1 = await generateTotpCode(config, 59_000);
+    const v2 = await generateTotpCode(config, 1_111_111_109_000);
+    const v3 = await generateTotpCode(config, 1_234_567_890_000);
+
+    expect(v1.code).toBe("94287082");
+    expect(v2.code).toBe("07081804");
+    expect(v3.code).toBe("89005924");
+  });
+
+  it("returns countdown and counter for cadence handling", async () => {
+    const result = await generateTotpCode(
+      {
+        mode: "raw",
+        secret: rfcSecret,
+        algorithm: "SHA1",
+        digits: 6,
+        period: 30,
+      },
+      61_000,
+    );
+
+    expect(result.counter).toBe(2);
+    expect(result.periodSeconds).toBe(30);
+    expect(result.secondsRemaining).toBe(29);
+    expect(result.code).toHaveLength(6);
+  });
+});

--- a/frontend/src/lib/totpGenerator.ts
+++ b/frontend/src/lib/totpGenerator.ts
@@ -1,0 +1,81 @@
+import type { TotpConfig } from "@/lib/totpConfigParser";
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+const base32ToBytes = (input: string): Uint8Array => {
+  const normalized = input.replace(/=+$/g, "").toUpperCase();
+  let bits = "";
+  for (const char of normalized) {
+    const idx = BASE32_ALPHABET.indexOf(char);
+    if (idx < 0) throw new Error("Invalid Base32 secret.");
+    bits += idx.toString(2).padStart(5, "0");
+  }
+
+  const bytes = new Uint8Array(Math.floor(bits.length / 8));
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(bits.slice(i * 8, i * 8 + 8), 2);
+  }
+  return bytes;
+};
+
+const counterToBytes = (counter: number): Uint8Array => {
+  const bytes = new Uint8Array(8);
+  let value = BigInt(counter);
+  for (let i = 7; i >= 0; i -= 1) {
+    bytes[i] = Number(value & BigInt(0xff));
+    value >>= BigInt(8);
+  }
+  return bytes;
+};
+
+const hashName = (algorithm: TotpConfig["algorithm"]) => {
+  if (algorithm === "SHA1") return "SHA-1";
+  if (algorithm === "SHA256") return "SHA-256";
+  return "SHA-512";
+};
+
+export interface TotpCodeResult {
+  code: string;
+  counter: number;
+  periodSeconds: number;
+  secondsRemaining: number;
+}
+
+export const generateTotpCode = async (config: TotpConfig, nowMs = Date.now()): Promise<TotpCodeResult> => {
+  const periodSeconds = config.period;
+  const counter = Math.floor(nowMs / 1000 / periodSeconds);
+  const secondsRemaining = periodSeconds - (Math.floor(nowMs / 1000) % periodSeconds);
+
+  const secretBytes = base32ToBytes(config.secret);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    secretBytes,
+    { name: "HMAC", hash: { name: hashName(config.algorithm) } },
+    false,
+    ["sign"],
+  );
+
+  const signature = new Uint8Array(
+    await crypto.subtle.sign({ name: "HMAC" }, key, counterToBytes(counter)),
+  );
+
+  const offset = (signature[signature.length - 1] ?? 0) & 0x0f;
+  const b0 = signature[offset] ?? 0;
+  const b1 = signature[offset + 1] ?? 0;
+  const b2 = signature[offset + 2] ?? 0;
+  const b3 = signature[offset + 3] ?? 0;
+  const binary =
+    ((b0 & 0x7f) << 24)
+    | ((b1 & 0xff) << 16)
+    | ((b2 & 0xff) << 8)
+    | (b3 & 0xff);
+
+  const code = String(binary % 10 ** config.digits).padStart(config.digits, "0");
+
+  return {
+    code,
+    counter,
+    periodSeconds,
+    secondsRemaining,
+  };
+};

--- a/frontend/src/pages/devtools/DevToolsLogUiPage.tsx
+++ b/frontend/src/pages/devtools/DevToolsLogUiPage.tsx
@@ -1,0 +1,822 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { PageHeader } from "@/components/shared/PageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  useDevtoolsBillingLedger,
+  useDevtoolsBillingSummary,
+  useDevtoolsEmailMessages,
+  useDevtoolsSmsConversations,
+} from "@/hooks/useDevtoolsData";
+import { parseTotpConfigInput, type TotpConfig } from "@/lib/totpConfigParser";
+import { generateTotpCode } from "@/lib/totpGenerator";
+
+const ALL_INBOXES = "__all_inboxes__";
+
+type EmailStateFilter = "all" | "unread" | "sent";
+type BillingProviderFilter = "all" | "stripe" | "ccbill" | "paypal";
+type BillingStatusFilter = "all" | "pending" | "completed" | "failed" | "refunded" | "canceled";
+
+
+const DEVTOOLS_TOTP_INPUT_STORAGE_KEY = "devtools:totp:input";
+const DEVTOOLS_TOTP_PERSIST_STORAGE_KEY = "devtools:totp:persist";
+
+type SmsBubbleGroup = {
+  key: string;
+  direction: "inbound" | "outbound" | "unknown";
+  fromLabel: string;
+  toLabel: string;
+  messages: ReturnType<typeof useDevtoolsSmsConversations>["messages"];
+};
+
+const formatTimestamp = (iso?: string) => {
+  if (!iso) return "Unknown";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+};
+
+const formatAmount = (amount: number, currency = "usd") => {
+  const safeCurrency = currency || "usd";
+  try {
+    return new Intl.NumberFormat("en-US", { style: "currency", currency: safeCurrency.toUpperCase() }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${safeCurrency.toUpperCase()}`;
+  }
+};
+
+const sortBySentAtAscending = <T extends { sent_at: string }>(items: T[]) =>
+  [...items].sort((a, b) => (a.sent_at < b.sent_at ? -1 : 1));
+
+export default function DevToolsLogUiPage() {
+  const [activeTab, setActiveTab] = useState("email");
+
+  const [selectedMailbox, setSelectedMailbox] = useState<string>(ALL_INBOXES);
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [stateFilter, setStateFilter] = useState<EmailStateFilter>("all");
+
+  const [smsQuery, setSmsQuery] = useState("");
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
+  const [selectedSmsMessageId, setSelectedSmsMessageId] = useState<string | null>(null);
+
+  const [billingProvider, setBillingProvider] = useState<BillingProviderFilter>("all");
+  const [billingStatus, setBillingStatus] = useState<BillingStatusFilter>("all");
+  const [billingFrom, setBillingFrom] = useState("");
+  const [billingTo, setBillingTo] = useState("");
+
+  const [mfaInput, setMfaInput] = useState("");
+  const [persistMfaInput, setPersistMfaInput] = useState(false);
+  const [mfaConfig, setMfaConfig] = useState<TotpConfig | null>(null);
+  const [mfaErrors, setMfaErrors] = useState<string[]>([]);
+  const [mfaWarnings, setMfaWarnings] = useState<string[]>([]);
+  const [mfaCode, setMfaCode] = useState<string | null>(null);
+  const [mfaSecondsRemaining, setMfaSecondsRemaining] = useState<number>(30);
+  const [mfaPeriodSeconds, setMfaPeriodSeconds] = useState<number>(30);
+
+  const emailQuery = useMemo(
+    () => ({
+      mailbox: selectedMailbox === ALL_INBOXES ? undefined : selectedMailbox,
+      q: searchQuery.trim() || undefined,
+      state: stateFilter,
+      limit: 100,
+    }),
+    [searchQuery, selectedMailbox, stateFilter],
+  );
+
+  const billingQuery = useMemo(
+    () => ({
+      provider: billingProvider === "all" ? undefined : billingProvider,
+      status: billingStatus === "all" ? undefined : billingStatus,
+      from: billingFrom || undefined,
+      to: billingTo || undefined,
+      limit: 50,
+    }),
+    [billingFrom, billingProvider, billingStatus, billingTo],
+  );
+
+  const emailData = useDevtoolsEmailMessages(emailQuery, activeTab === "email");
+  const smsData = useDevtoolsSmsConversations({ q: smsQuery.trim() || undefined, limit: 100 }, activeTab === "sms");
+  const billingLedger = useDevtoolsBillingLedger(billingQuery, activeTab === "billing");
+  const billingSummary = useDevtoolsBillingSummary(
+    {
+      provider: billingQuery.provider,
+      status: billingQuery.status,
+      from: billingQuery.from,
+      to: billingQuery.to,
+    },
+    activeTab === "billing",
+  );
+
+  useEffect(() => {
+    const threadIds = new Set(emailData.threads.map((thread) => thread.id));
+    if (selectedThreadId && threadIds.has(selectedThreadId)) return;
+    setSelectedThreadId(emailData.threads[0]?.id ?? null);
+  }, [emailData.threads, selectedThreadId]);
+
+  const orderedConversations = useMemo(
+    () => [...smsData.conversations].sort((a, b) => (a.latest_message_at < b.latest_message_at ? 1 : -1)),
+    [smsData.conversations],
+  );
+
+  useEffect(() => {
+    const conversationIds = new Set(orderedConversations.map((conversation) => conversation.id));
+    if (selectedConversationId && conversationIds.has(selectedConversationId)) return;
+    setSelectedConversationId(orderedConversations[0]?.id ?? null);
+  }, [orderedConversations, selectedConversationId]);
+
+  const selectedThread = emailData.threads.find((thread) => thread.id === selectedThreadId) ?? null;
+  const selectedMessages = sortBySentAtAscending(
+    emailData.messages.filter((message) => message.thread_id === selectedThreadId),
+  );
+  const selectedMessage = selectedMessages[selectedMessages.length - 1] ?? null;
+
+  const selectedConversation = orderedConversations.find((conversation) => conversation.id === selectedConversationId) ?? null;
+  const selectedConversationMessages = sortBySentAtAscending(
+    smsData.messages.filter((message) => message.conversation_id === selectedConversationId),
+  );
+
+  useEffect(() => {
+    const messageIds = new Set(selectedConversationMessages.map((message) => message.id));
+    if (selectedSmsMessageId && messageIds.has(selectedSmsMessageId)) return;
+    setSelectedSmsMessageId(selectedConversationMessages[selectedConversationMessages.length - 1]?.id ?? null);
+  }, [selectedConversationMessages, selectedSmsMessageId]);
+
+  const selectedSmsMessage = selectedConversationMessages.find((message) => message.id === selectedSmsMessageId) ?? null;
+
+  const smsBubbleGroups = useMemo(() => {
+    const groups: SmsBubbleGroup[] = [];
+
+    selectedConversationMessages.forEach((message, index) => {
+      const fromLabel = message.from_number || "Unknown sender";
+      const toLabel = message.to_number || "Unknown recipient";
+      const prev = selectedConversationMessages[index - 1];
+      const canGroupWithPrevious =
+        prev &&
+        prev.direction === message.direction &&
+        (prev.from_number || "") === (message.from_number || "") &&
+        (prev.to_number || "") === (message.to_number || "");
+
+      if (!canGroupWithPrevious) {
+        groups.push({
+          key: `group-${message.id}`,
+          direction: message.direction,
+          fromLabel,
+          toLabel,
+          messages: [message],
+        });
+        return;
+      }
+
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup) {
+        lastGroup.messages.push(message);
+      }
+    });
+
+    return groups;
+  }, [selectedConversationMessages]);
+
+  useEffect(() => {
+    try {
+      setPersistMfaInput(localStorage.getItem(DEVTOOLS_TOTP_PERSIST_STORAGE_KEY) === "1");
+      const savedInput = localStorage.getItem(DEVTOOLS_TOTP_INPUT_STORAGE_KEY);
+      if (savedInput) setMfaInput(savedInput);
+    } catch {
+      // no-op for storage access errors
+    }
+  }, []);
+
+  useEffect(() => {
+    const result = parseTotpConfigInput(mfaInput);
+    setMfaErrors(result.errors);
+    setMfaWarnings(result.warnings);
+    setMfaConfig(result.ok ? result.config ?? null : null);
+    if (!result.ok) setMfaCode(null);
+  }, [mfaInput]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(DEVTOOLS_TOTP_PERSIST_STORAGE_KEY, persistMfaInput ? "1" : "0");
+      if (persistMfaInput && mfaInput.trim()) {
+        localStorage.setItem(DEVTOOLS_TOTP_INPUT_STORAGE_KEY, mfaInput);
+      } else {
+        localStorage.removeItem(DEVTOOLS_TOTP_INPUT_STORAGE_KEY);
+      }
+    } catch {
+      // no-op for storage access errors
+    }
+  }, [mfaInput, persistMfaInput]);
+
+  useEffect(() => {
+    if (activeTab !== "mfa" || !mfaConfig) return;
+
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const next = await generateTotpCode(mfaConfig);
+        if (cancelled) return;
+        setMfaCode(next.code);
+        setMfaSecondsRemaining(next.secondsRemaining);
+        setMfaPeriodSeconds(next.periodSeconds);
+      } catch {
+        if (!cancelled) {
+          setMfaCode(null);
+          setMfaErrors((prev) => (prev.includes("Failed to generate TOTP code from the provided config.") ? prev : [...prev, "Failed to generate TOTP code from the provided config."]));
+        }
+      }
+    };
+
+    void tick();
+    const id = window.setInterval(() => {
+      void tick();
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [activeTab, mfaConfig]);
+
+  const handleMfaReset = () => {
+    setMfaInput("");
+    setMfaCode(null);
+    setMfaErrors([]);
+    setMfaWarnings([]);
+    setMfaConfig(null);
+    setMfaSecondsRemaining(30);
+    setMfaPeriodSeconds(30);
+    if (!persistMfaInput) {
+      try {
+        localStorage.removeItem(DEVTOOLS_TOTP_INPUT_STORAGE_KEY);
+      } catch {
+        // no-op
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-6 pb-24 md:pb-6">
+      <PageHeader
+        title="Dev Tools Log UI"
+        description="Read-only internal log explorer for Email, SMS, MFA, and Billing dev artifacts."
+      />
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4">
+          <TabsTrigger value="email">Email</TabsTrigger>
+          <TabsTrigger value="sms">SMS</TabsTrigger>
+          <TabsTrigger value="mfa">MFA (TOTP)</TabsTrigger>
+          <TabsTrigger value="billing">Billing</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="email" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-lg border bg-card p-3 md:flex-row md:items-center">
+            <Input
+              placeholder="Search subject, body, sender, recipient"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              className="md:max-w-md"
+              aria-label="Search email logs"
+            />
+            <Select value={stateFilter} onValueChange={(value) => setStateFilter(value as EmailStateFilter)}>
+              <SelectTrigger className="w-full md:w-44" aria-label="State filter">
+                <SelectValue placeholder="Filter state" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="unread">Unread</SelectItem>
+                <SelectItem value="sent">Sent</SelectItem>
+              </SelectContent>
+            </Select>
+            {emailData.parseWarnings.length > 0 && (
+              <Badge variant="secondary">Warnings: {emailData.parseWarnings.length}</Badge>
+            )}
+          </div>
+
+          {emailData.errorMessage && (
+            <div className="rounded-lg border border-destructive/60 bg-destructive/10 p-3 text-sm text-destructive">
+              Unable to load email logs: {emailData.errorMessage}
+            </div>
+          )}
+
+          {emailData.isLoading ? (
+            <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">Loading email logs…</div>
+          ) : (
+            <div className="grid min-h-[520px] grid-cols-1 overflow-hidden rounded-lg border bg-card lg:grid-cols-[240px_320px_1fr]">
+              <aside className="border-b p-3 lg:border-b-0 lg:border-r">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Mailboxes</div>
+                <div className="space-y-1">
+                  <button
+                    type="button"
+                    className={`w-full rounded-md px-3 py-2 text-left text-sm ${
+                      selectedMailbox === ALL_INBOXES ? "bg-primary/10 text-primary" : "hover:bg-accent"
+                    }`}
+                    onClick={() => setSelectedMailbox(ALL_INBOXES)}
+                  >
+                    All Inboxes
+                  </button>
+                  {emailData.mailboxes.map((mailbox) => (
+                    <button
+                      key={mailbox.id}
+                      type="button"
+                      className={`w-full rounded-md px-3 py-2 text-left text-sm ${
+                        selectedMailbox === mailbox.mailbox ? "bg-primary/10 text-primary" : "hover:bg-accent"
+                      }`}
+                      onClick={() => setSelectedMailbox(mailbox.mailbox)}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="truncate">{mailbox.mailbox}</span>
+                        <Badge variant="outline">{mailbox.thread_count}</Badge>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </aside>
+
+              <section className="border-b p-3 lg:border-b-0 lg:border-r">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Threads</div>
+                {emailData.threads.length === 0 ? (
+                  <div className="rounded border border-dashed p-3 text-sm text-muted-foreground">No threads for selected filters.</div>
+                ) : (
+                  <div className="space-y-1">
+                    {emailData.threads.map((thread) => (
+                      <button
+                        key={thread.id}
+                        type="button"
+                        className={`w-full rounded-md px-3 py-2 text-left text-sm ${
+                          thread.id === selectedThreadId ? "bg-primary/10 text-primary" : "hover:bg-accent"
+                        }`}
+                        onClick={() => setSelectedThreadId(thread.id)}
+                      >
+                        <div className="truncate font-medium">{thread.subject || "(no subject)"}</div>
+                        <div className="truncate text-xs text-muted-foreground">{thread.mailbox}</div>
+                        <div className="mt-1 text-xs text-muted-foreground">{formatTimestamp(thread.latest_message_at)}</div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              <section className="p-3">
+                {!selectedThread || !selectedMessage ? (
+                  <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+                    Select a thread to view message details.
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    <div>
+                      <h2 className="text-lg font-semibold">{selectedThread.subject || "(no subject)"}</h2>
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {selectedMessages.length} message{selectedMessages.length === 1 ? "" : "s"} in thread
+                      </div>
+                    </div>
+                    <Separator />
+                    <dl className="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+                      <div>
+                        <dt className="text-xs text-muted-foreground">Mailbox</dt>
+                        <dd>{selectedMessage.mailbox}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">Sent</dt>
+                        <dd>{formatTimestamp(selectedMessage.sent_at)}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">From</dt>
+                        <dd>{selectedMessage.from_email || "Unknown"}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">To</dt>
+                        <dd>{selectedMessage.to_emails.join(", ") || "Unknown"}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">Event</dt>
+                        <dd>{selectedMessage.event_kind}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">Status</dt>
+                        <dd>{selectedMessage.status || "n/a"}</dd>
+                      </div>
+                    </dl>
+                    <Separator />
+                    <div>
+                      <div className="mb-1 text-xs text-muted-foreground">Body</div>
+                      <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-sm">
+                        {selectedMessage.body_text || selectedMessage.body_html || "(empty body)"}
+                      </pre>
+                    </div>
+                  </div>
+                )}
+              </section>
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="sms" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-lg border bg-card p-3 md:flex-row md:items-center">
+            <Input
+              placeholder="Search phone number or message text"
+              value={smsQuery}
+              onChange={(event) => setSmsQuery(event.target.value)}
+              className="md:max-w-md"
+              aria-label="Search sms logs"
+            />
+            {smsData.parseWarnings.length > 0 && (
+              <Badge variant="secondary">Warnings: {smsData.parseWarnings.length}</Badge>
+            )}
+            <Badge variant="outline">Read-only</Badge>
+          </div>
+
+          {smsData.errorMessage && (
+            <div className="rounded-lg border border-destructive/60 bg-destructive/10 p-3 text-sm text-destructive">
+              Unable to load SMS logs: {smsData.errorMessage}
+            </div>
+          )}
+
+          {smsData.isLoading ? (
+            <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">Loading SMS logs…</div>
+          ) : (
+            <div className="grid min-h-[520px] grid-cols-1 overflow-hidden rounded-lg border bg-card lg:grid-cols-[280px_1fr_300px]">
+              <aside className="border-b p-3 lg:border-b-0 lg:border-r">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Conversations</div>
+                {orderedConversations.length === 0 ? (
+                  <div className="rounded border border-dashed p-3 text-sm text-muted-foreground">No conversations found.</div>
+                ) : (
+                  <div className="space-y-1">
+                    {orderedConversations.map((conversation) => (
+                      <button
+                        key={conversation.id}
+                        type="button"
+                        className={`w-full rounded-md px-3 py-2 text-left text-sm ${
+                          conversation.id === selectedConversationId ? "bg-primary/10 text-primary" : "hover:bg-accent"
+                        }`}
+                        onClick={() => setSelectedConversationId(conversation.id)}
+                      >
+                        <div className="truncate font-medium">{conversation.participant_numbers.join(", ") || "Unknown"}</div>
+                        <div className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                          {conversation.latest_preview || "No preview"}
+                        </div>
+                        <div className="mt-1 text-xs text-muted-foreground">{formatTimestamp(conversation.latest_message_at)}</div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </aside>
+
+              <section className="border-b p-3 lg:border-b-0 lg:border-r">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Thread</div>
+                {!selectedConversation ? (
+                  <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+                    Select a conversation to view messages.
+                  </div>
+                ) : selectedConversationMessages.length === 0 ? (
+                  <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">No messages in this conversation.</div>
+                ) : (
+                  <div className="space-y-3">
+                    {smsBubbleGroups.map((group) => {
+                      const outbound = group.direction === "outbound";
+                      return (
+                        <div
+                          key={group.key}
+                          className={`flex flex-col gap-1 ${outbound ? "items-end" : "items-start"}`}
+                        >
+                          <div className="text-[11px] text-muted-foreground">{`${group.fromLabel} → ${group.toLabel}`}</div>
+                          {group.messages.map((message) => (
+                            <button
+                              key={message.id}
+                              type="button"
+                              className={`max-w-[82%] rounded-2xl px-3 py-2 text-left text-sm ${
+                                outbound
+                                  ? "bg-primary text-primary-foreground"
+                                  : "bg-muted text-foreground"
+                              } ${selectedSmsMessageId === message.id ? "ring-2 ring-ring" : ""}`}
+                              onClick={() => setSelectedSmsMessageId(message.id)}
+                            >
+                              <div>{message.body_text || "(empty message)"}</div>
+                              <div className={`mt-1 text-[11px] ${outbound ? "text-primary-foreground/80" : "text-muted-foreground"}`}>
+                                {formatTimestamp(message.sent_at)}
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+
+              <aside className="p-3">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Message metadata</div>
+                {!selectedSmsMessage ? (
+                  <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+                    Select a bubble to inspect status and IDs.
+                  </div>
+                ) : (
+                  <dl className="space-y-2 text-sm">
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Conversation ID</dt>
+                      <dd className="break-all">{selectedSmsMessage.conversation_id}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Message ID</dt>
+                      <dd className="break-all">{selectedSmsMessage.id}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Provider message ID</dt>
+                      <dd className="break-all">{selectedSmsMessage.provider_message_id || "n/a"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Direction</dt>
+                      <dd>{selectedSmsMessage.direction}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">From</dt>
+                      <dd>{selectedSmsMessage.from_number || "Unknown"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">To</dt>
+                      <dd>{selectedSmsMessage.to_number || "Unknown"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Status</dt>
+                      <dd>{selectedSmsMessage.status || "n/a"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Event kind</dt>
+                      <dd>{selectedSmsMessage.event_kind}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Sent</dt>
+                      <dd>{formatTimestamp(selectedSmsMessage.sent_at)}</dd>
+                    </div>
+                  </dl>
+                )}
+              </aside>
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="mfa" className="space-y-4">
+          <div className="rounded-lg border bg-card p-4 text-sm">
+            <p className="text-muted-foreground">
+              Local-only tool: pasted TOTP configuration is parsed and used entirely in your browser. Secrets are never sent to backend APIs.
+            </p>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+            <section className="rounded-lg border bg-card p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold">TOTP configuration</h3>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span>Persist locally</span>
+                  <Switch checked={persistMfaInput} onCheckedChange={setPersistMfaInput} aria-label="Persist TOTP config locally" />
+                </div>
+              </div>
+
+              <Textarea
+                value={mfaInput}
+                onChange={(event) => setMfaInput(event.target.value)}
+                placeholder="Paste otpauth:// URI or raw Base32 secret"
+                className="min-h-[140px]"
+                aria-label="Paste TOTP configuration"
+              />
+
+              {mfaErrors.length > 0 && (
+                <div className="rounded-md border border-destructive/60 bg-destructive/10 p-3 text-sm text-destructive space-y-1">
+                  {mfaErrors.map((error) => (
+                    <div key={error}>{error}</div>
+                  ))}
+                </div>
+              )}
+
+              {mfaWarnings.length > 0 && (
+                <div className="rounded-md border bg-muted p-3 text-sm text-muted-foreground space-y-1">
+                  {mfaWarnings.map((warning) => (
+                    <div key={warning}>{warning}</div>
+                  ))}
+                </div>
+              )}
+
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" onClick={handleMfaReset}>Clear / Reset</Button>
+              </div>
+            </section>
+
+            <section className="rounded-lg border bg-card p-4 space-y-3">
+              <h3 className="font-semibold">Live code</h3>
+              {!mfaConfig || mfaErrors.length > 0 ? (
+                <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+                  Provide a valid TOTP configuration to generate live codes.
+                </div>
+              ) : (
+                <>
+                  <div className="rounded-md bg-muted p-4">
+                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Current code</div>
+                    <div className="mt-2 font-mono text-4xl tracking-[0.25em]">{mfaCode ?? "------"}</div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div className="rounded-md border p-3">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">Rollover in</div>
+                      <div className="mt-1 text-xl font-semibold">{mfaSecondsRemaining}s</div>
+                    </div>
+                    <div className="rounded-md border p-3">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">Cadence</div>
+                      <div className="mt-1 text-xl font-semibold">{mfaPeriodSeconds}s</div>
+                    </div>
+                  </div>
+
+                  <dl className="space-y-2 text-sm">
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Mode</dt>
+                      <dd>{mfaConfig.mode}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-muted-foreground">Algorithm / digits</dt>
+                      <dd>{mfaConfig.algorithm} / {mfaConfig.digits}</dd>
+                    </div>
+                    {mfaConfig.issuer && (
+                      <div>
+                        <dt className="text-xs text-muted-foreground">Issuer</dt>
+                        <dd>{mfaConfig.issuer}</dd>
+                      </div>
+                    )}
+                    {mfaConfig.accountName && (
+                      <div>
+                        <dt className="text-xs text-muted-foreground">Account</dt>
+                        <dd>{mfaConfig.accountName}</dd>
+                      </div>
+                    )}
+                  </dl>
+                </>
+              )}
+            </section>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="billing" className="space-y-4">
+          <div className="grid gap-3 rounded-lg border bg-card p-3 md:grid-cols-2 xl:grid-cols-5">
+            <Select value={billingProvider} onValueChange={(value) => setBillingProvider(value as BillingProviderFilter)}>
+              <SelectTrigger aria-label="Billing provider filter">
+                <SelectValue placeholder="Provider" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All providers</SelectItem>
+                <SelectItem value="stripe">Stripe</SelectItem>
+                <SelectItem value="ccbill">CCBill</SelectItem>
+                <SelectItem value="paypal">PayPal</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select value={billingStatus} onValueChange={(value) => setBillingStatus(value as BillingStatusFilter)}>
+              <SelectTrigger aria-label="Billing status filter">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                <SelectItem value="pending">Pending</SelectItem>
+                <SelectItem value="completed">Completed</SelectItem>
+                <SelectItem value="failed">Failed</SelectItem>
+                <SelectItem value="refunded">Refunded</SelectItem>
+                <SelectItem value="canceled">Canceled</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Input type="datetime-local" aria-label="Billing from date" value={billingFrom} onChange={(e) => setBillingFrom(e.target.value)} />
+            <Input type="datetime-local" aria-label="Billing to date" value={billingTo} onChange={(e) => setBillingTo(e.target.value)} />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setBillingProvider("all");
+                setBillingStatus("all");
+                setBillingFrom("");
+                setBillingTo("");
+              }}
+            >
+              Reset filters
+            </Button>
+          </div>
+
+          {(billingLedger.errorMessage || billingSummary.errorMessage) && (
+            <div className="rounded-lg border border-destructive/60 bg-destructive/10 p-3 text-sm text-destructive">
+              Unable to load billing logs: {billingLedger.errorMessage || billingSummary.errorMessage}
+            </div>
+          )}
+
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-lg border bg-card p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Gross inflow</div>
+              <div className="mt-2 text-2xl font-semibold">{formatAmount(billingSummary.data?.gross_inflow ?? 0)}</div>
+            </div>
+            <div className="rounded-lg border bg-card p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Fees</div>
+              <div className="mt-2 text-2xl font-semibold">{formatAmount(billingSummary.data?.fees ?? 0)}</div>
+            </div>
+            <div className="rounded-lg border bg-card p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Net balance</div>
+              <div className="mt-2 text-2xl font-semibold">{formatAmount(billingSummary.data?.net_total_balance ?? 0)}</div>
+            </div>
+            <div className="rounded-lg border bg-card p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Transactions</div>
+              <div className="mt-2 text-2xl font-semibold">{billingSummary.data?.transaction_count ?? 0}</div>
+            </div>
+          </div>
+
+          {billingLedger.isLoading ? (
+            <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">Loading billing ledger…</div>
+          ) : billingLedger.isEmpty ? (
+            <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">No ledger entries for selected filters.</div>
+          ) : (
+            <div className="rounded-lg border bg-card">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Occurred</TableHead>
+                    <TableHead>Provider</TableHead>
+                    <TableHead>Event</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                    <TableHead className="text-right">Fee</TableHead>
+                    <TableHead className="text-right">Net</TableHead>
+                    <TableHead>External ID</TableHead>
+                    <TableHead>Source</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {billingLedger.entries.map((entry) => (
+                    <TableRow key={entry.id}>
+                      <TableCell className="whitespace-nowrap text-xs">{formatTimestamp(entry.occurred_at)}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{entry.provider}</Badge>
+                      </TableCell>
+                      <TableCell className="text-xs">{entry.event_type}</TableCell>
+                      <TableCell>
+                        <Badge variant={entry.status === "completed" ? "default" : "secondary"}>{entry.status}</Badge>
+                      </TableCell>
+                      <TableCell className="text-right text-xs">{formatAmount(entry.amount, entry.currency)}</TableCell>
+                      <TableCell className="text-right text-xs">{formatAmount(entry.fee, entry.currency)}</TableCell>
+                      <TableCell className="text-right text-xs">{formatAmount(entry.net, entry.currency)}</TableCell>
+                      <TableCell className="max-w-[180px] truncate font-mono text-xs">{entry.external_id || "-"}</TableCell>
+                      <TableCell>
+                        <Dialog>
+                          <DialogTrigger asChild>
+                            <Button variant="outline" size="sm">View raw</Button>
+                          </DialogTrigger>
+                          <DialogContent className="max-h-[85vh] max-w-3xl overflow-auto">
+                            <DialogHeader>
+                              <DialogTitle>Raw billing payload</DialogTitle>
+                              <DialogDescription>Read-only source payload details for this ledger entry.</DialogDescription>
+                            </DialogHeader>
+                            <div className="space-y-2 text-sm">
+                              <div>
+                                <span className="text-muted-foreground">Source path: </span>
+                                <span className="font-mono text-xs">{entry.source_path || "n/a"}</span>
+                              </div>
+                              <div>
+                                <span className="text-muted-foreground">External ID: </span>
+                                <span className="font-mono text-xs">{entry.external_id || "n/a"}</span>
+                              </div>
+                              <pre className="overflow-auto rounded-md bg-muted p-3 text-xs">
+                                {JSON.stringify(entry.raw_payload, null, 2)}
+                              </pre>
+                            </div>
+                          </DialogContent>
+                        </Dialog>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              <div className="flex items-center justify-between gap-3 border-t p-3">
+                <div className="text-xs text-muted-foreground">
+                  Showing {billingLedger.entries.length} loaded entries for the selected scope.
+                </div>
+                {billingLedger.hasNextPage && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => billingLedger.fetchNextPage()}
+                    disabled={billingLedger.isFetchingNextPage}
+                  >
+                    {billingLedger.isFetchingNextPage ? "Loading…" : "Load more"}
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/pages/devtools/__tests__/DevToolsLogUiPage.test.tsx
+++ b/frontend/src/pages/devtools/__tests__/DevToolsLogUiPage.test.tsx
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import DevToolsLogUiPage from "@/pages/devtools/DevToolsLogUiPage";
+
+const useDevtoolsEmailMessages = vi.fn();
+const useDevtoolsSmsConversations = vi.fn();
+const useDevtoolsBillingLedger = vi.fn();
+const useDevtoolsBillingSummary = vi.fn();
+const generateTotpCode = vi.fn();
+
+vi.mock("@/hooks/useDevtoolsData", () => ({
+  useDevtoolsEmailMessages: (...args: unknown[]) => useDevtoolsEmailMessages(...args),
+  useDevtoolsSmsConversations: (...args: unknown[]) => useDevtoolsSmsConversations(...args),
+  useDevtoolsBillingLedger: (...args: unknown[]) => useDevtoolsBillingLedger(...args),
+  useDevtoolsBillingSummary: (...args: unknown[]) => useDevtoolsBillingSummary(...args),
+}));
+
+vi.mock("@/lib/totpGenerator", () => ({
+  generateTotpCode: (...args: unknown[]) => generateTotpCode(...args),
+}));
+
+const emailHookBase = {
+  mailboxes: [
+    { id: "mb1", id_strategy: "hash", mailbox: "alpha@example.com", thread_count: 1, unread_count: 1 },
+    { id: "mb2", id_strategy: "hash", mailbox: "beta@example.com", thread_count: 1, unread_count: 0 },
+  ],
+  threads: [
+    {
+      id: "th1",
+      id_strategy: "hash",
+      mailbox: "alpha@example.com",
+      subject: "Your code",
+      message_count: 1,
+      unread_count: 1,
+      participant_emails: ["alpha@example.com"],
+      latest_message_at: "2026-01-01T12:00:00Z",
+    },
+  ],
+  messages: [
+    {
+      id: "msg1",
+      id_strategy: "hash",
+      thread_id: "th1",
+      mailbox: "alpha@example.com",
+      sent_at: "2026-01-01T12:00:00Z",
+      event_kind: "mfa_email_code",
+      direction: "outbound",
+      from_email: "noreply@testlogon.dev",
+      to_emails: ["alpha@example.com"],
+      subject: "Your code",
+      body_text: "Your OTP code is 123456",
+      status: "delivered",
+      parse_warnings: [],
+    },
+  ],
+  parseWarnings: [],
+  errorMessage: null as string | null,
+  isLoading: false,
+};
+
+const smsHookBase = {
+  conversations: [
+    {
+      id: "conv-2",
+      id_strategy: "hash",
+      participant_numbers: ["+15550000002"],
+      message_count: 1,
+      latest_message_at: "2026-01-01T13:00:00Z",
+      latest_preview: "Newest convo",
+    },
+    {
+      id: "conv-1",
+      id_strategy: "hash",
+      participant_numbers: ["+15550000001"],
+      message_count: 3,
+      latest_message_at: "2026-01-01T12:00:00Z",
+      latest_preview: "Code: 123456",
+    },
+  ],
+  messages: [
+    {
+      id: "sms-1",
+      id_strategy: "hash",
+      conversation_id: "conv-1",
+      sent_at: "2026-01-01T11:59:00Z",
+      from_number: "+15550000001",
+      to_number: "+15559999999",
+      direction: "inbound",
+      body_text: "Hello",
+      status: "received",
+      provider_message_id: "provider-1",
+      event_kind: "alert_sms",
+      parse_warnings: [],
+    },
+    {
+      id: "sms-2",
+      id_strategy: "hash",
+      conversation_id: "conv-1",
+      sent_at: "2026-01-01T12:00:00Z",
+      from_number: "+15550000001",
+      to_number: "+15559999999",
+      direction: "inbound",
+      body_text: "Code: 123456",
+      status: "received",
+      provider_message_id: "provider-2",
+      event_kind: "mfa_sms_code",
+      parse_warnings: [],
+    },
+    {
+      id: "sms-3",
+      id_strategy: "hash",
+      conversation_id: "conv-1",
+      sent_at: "2026-01-01T12:01:00Z",
+      from_number: "+15559999999",
+      to_number: "+15550000001",
+      direction: "outbound",
+      body_text: "Thanks",
+      status: "sent",
+      provider_message_id: "provider-3",
+      event_kind: "alert_sms",
+      parse_warnings: [],
+    },
+  ],
+  parseWarnings: [],
+  errorMessage: null as string | null,
+  isLoading: false,
+};
+
+const billingLedgerBase = {
+  entries: [
+    {
+      id: "b1",
+      id_strategy: "hash",
+      provider: "stripe",
+      event_type: "charge.succeeded",
+      status: "completed",
+      occurred_at: "2026-01-01T12:02:00Z",
+      external_id: "ch_123",
+      amount: 10,
+      fee: 0.5,
+      net: 9.5,
+      currency: "usd",
+      source_path: "stripe.log",
+      raw_payload: { ok: true },
+      parse_warnings: [],
+    },
+  ],
+  parseWarnings: [],
+  summary: { gross_inflow: 10, fees: 0.5, net_total_balance: 9.5, transaction_count: 1, provider_counts: { stripe: 1 }, status_counts: { completed: 1 }, parse_warnings: [] },
+  isLoading: false,
+  isEmpty: false,
+  errorMessage: null as string | null,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: vi.fn(),
+};
+
+const billingSummaryBase = {
+  data: { gross_inflow: 10, fees: 0.5, net_total_balance: 9.5, transaction_count: 1, provider_counts: { stripe: 1 }, status_counts: { completed: 1 }, parse_warnings: [] },
+  parseWarnings: [],
+  isLoading: false,
+  isEmpty: false,
+  errorMessage: null as string | null,
+};
+
+describe("DevToolsLogUiPage", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    useDevtoolsEmailMessages.mockReset();
+    useDevtoolsSmsConversations.mockReset();
+    useDevtoolsBillingLedger.mockReset();
+    useDevtoolsBillingSummary.mockReset();
+    generateTotpCode.mockReset();
+    localStorage.clear();
+  });
+
+  const setupHooks = (overrides?: {
+    email?: Partial<typeof emailHookBase>;
+    sms?: Partial<typeof smsHookBase>;
+    billingLedger?: Partial<typeof billingLedgerBase>;
+    billingSummary?: Partial<typeof billingSummaryBase>;
+  }) => {
+    useDevtoolsEmailMessages.mockReturnValue({ ...emailHookBase, ...(overrides?.email ?? {}) });
+    useDevtoolsSmsConversations.mockReturnValue({ ...smsHookBase, ...(overrides?.sms ?? {}) });
+    useDevtoolsBillingLedger.mockReturnValue({ ...billingLedgerBase, ...(overrides?.billingLedger ?? {}) });
+    useDevtoolsBillingSummary.mockReturnValue({ ...billingSummaryBase, ...(overrides?.billingSummary ?? {}) });
+    generateTotpCode.mockResolvedValue({ code: "123456", counter: 1, secondsRemaining: 30, periodSeconds: 30 });
+  };
+
+  it("renders mailbox rail, thread list, and message detail", () => {
+    setupHooks();
+
+    render(<DevToolsLogUiPage />);
+
+    expect(screen.getByText("All Inboxes")).toBeInTheDocument();
+    expect(screen.getAllByText("alpha@example.com").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Your code").length).toBeGreaterThan(0);
+    expect(screen.getByText("Your OTP code is 123456")).toBeInTheDocument();
+  });
+
+  it("passes mailbox/search/state filters to hook", async () => {
+    const user = userEvent.setup();
+    setupHooks();
+
+    render(<DevToolsLogUiPage />);
+
+    await user.click(screen.getByText("beta@example.com"));
+    await user.type(screen.getByLabelText("Search email logs"), "invoice");
+
+    expect(useDevtoolsEmailMessages).toHaveBeenLastCalledWith(
+      expect.objectContaining({ mailbox: "beta@example.com", q: "invoice", state: "all", limit: 100 }),
+      true,
+    );
+  });
+
+  it("covers loading, empty, and error states across tabs", async () => {
+    const user = userEvent.setup();
+    setupHooks({
+      email: { isLoading: true },
+      sms: { conversations: [], messages: [], isLoading: false, errorMessage: "sms exploded" },
+      billingLedger: { entries: [], isEmpty: true, errorMessage: "ledger exploded" },
+      billingSummary: { errorMessage: "summary exploded" },
+    });
+
+    render(<DevToolsLogUiPage />);
+    expect(screen.getByText("Loading email logs…")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "SMS" }));
+    expect(screen.getByText(/Unable to load SMS logs: sms exploded/)).toBeInTheDocument();
+    expect(screen.getByText("No conversations found.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+    expect(screen.getByText(/Unable to load billing logs:/)).toBeInTheDocument();
+    expect(screen.getByText("No ledger entries for selected filters.")).toBeInTheDocument();
+  });
+
+  it("renders iMessage-like thread with metadata and no mutating controls", async () => {
+    const user = userEvent.setup();
+    setupHooks();
+
+    render(<DevToolsLogUiPage />);
+
+    await user.click(screen.getByRole("tab", { name: "SMS" }));
+
+    const convoButtons = screen.getAllByRole("button", { name: /\+1555000000/i });
+    expect(convoButtons[0]).toHaveTextContent("+15550000002");
+    await user.click(screen.getByRole("button", { name: /\+15550000001/i }));
+
+    expect(screen.getAllByText("Code: 123456").length).toBeGreaterThan(0);
+    expect(screen.getByText("Message metadata")).toBeInTheDocument();
+    expect(screen.getByText("provider-3")).toBeInTheDocument();
+
+    expect(screen.queryByRole("button", { name: /send/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
+  });
+
+  it("enforces read-only billing UX with raw inspection only", async () => {
+    const user = userEvent.setup();
+    setupHooks();
+
+    render(<DevToolsLogUiPage />);
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+
+    expect(screen.getByText("Gross inflow")).toBeInTheDocument();
+    expect(screen.getByText("charge.succeeded")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View raw" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View raw" }));
+    expect(screen.getByText("Raw billing payload")).toBeInTheDocument();
+    expect(screen.getByText(/ok/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(useDevtoolsBillingLedger).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: undefined, status: undefined, limit: 50 }),
+      true,
+    );
+
+    expect(screen.queryByRole("button", { name: /refund/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /charge/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("drives deterministic TOTP lifecycle: parse, countdown tick, rollover, and reset", async () => {
+    const user = userEvent.setup();
+    setupHooks();
+
+    let call = 0;
+    generateTotpCode.mockImplementation(async () => {
+      call += 1;
+      if (call === 1) return { code: "111111", counter: 1, secondsRemaining: 30, periodSeconds: 30 };
+      if (call === 2) return { code: "111111", counter: 1, secondsRemaining: 29, periodSeconds: 30 };
+      return { code: "222222", counter: 2, secondsRemaining: 30, periodSeconds: 30 };
+    });
+
+    render(<DevToolsLogUiPage />);
+    await user.click(screen.getByRole("tab", { name: "MFA (TOTP)" }));
+
+    vi.useFakeTimers();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Paste TOTP configuration" }), {
+      target: {
+        value: "otpauth://totp/TestLogon:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=TestLogon",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(screen.getByText("111111")).toBeInTheDocument();
+    expect(screen.getAllByText("30s").length).toBeGreaterThan(0);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(screen.getByText("29s")).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(screen.getByText("222222")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear / Reset" }));
+    expect(screen.getByRole("textbox", { name: "Paste TOTP configuration" })).toHaveValue("");
+    expect(screen.getByText("Provide a valid TOTP configuration to generate live codes.")).toBeInTheDocument();
+  }, 15000);
+});

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -55,9 +55,6 @@ done
 mkdir -p "$(dirname "$BACKEND_LOG_PATH")" "$(dirname "$FRONTEND_LOG_PATH")"
 touch "$BACKEND_LOG_PATH" "$FRONTEND_LOG_PATH"
 
-echo "Dev logs will be written to:"
-echo "  backend : $BACKEND_LOG_PATH"
-echo "  frontend: $FRONTEND_LOG_PATH"
 
 if [[ -d ".venv" ]]; then
   # shellcheck disable=SC1091
@@ -85,6 +82,26 @@ if [[ -f ".env" ]]; then
   source .env
 fi
 set +a
+
+# DLU-017: auto-enable Dev Tools Log UI and canonical log path defaults for local runs.
+: "${VITE_ENABLE_DEVTOOLS_LOG_UI:=1}"
+: "${DEVTOOLS_EMAIL_LOG_PATH:=${DEV_EMAIL_LOG:-$DEV_LOG_DIR/emails.log}}"
+: "${DEVTOOLS_SMS_LOG_PATH:=${DEV_SMS_LOG:-$DEV_LOG_DIR/sms.log}}"
+: "${DEVTOOLS_BILLING_STRIPE_LOG_PATH:=.local/logs/stripe-mock.log}"
+: "${DEVTOOLS_BILLING_BACKEND_LOG_PATH:=${DEV_BACKEND_LOG_PATH:-$DEV_LOG_DIR/backend.log}}"
+export VITE_ENABLE_DEVTOOLS_LOG_UI
+export DEVTOOLS_EMAIL_LOG_PATH DEVTOOLS_SMS_LOG_PATH
+export DEVTOOLS_BILLING_STRIPE_LOG_PATH DEVTOOLS_BILLING_BACKEND_LOG_PATH
+
+echo "Dev logs will be written to:"
+echo "  backend : $BACKEND_LOG_PATH"
+echo "  frontend: $FRONTEND_LOG_PATH"
+echo "Dev Tools Log UI enabled: VITE_ENABLE_DEVTOOLS_LOG_UI=${VITE_ENABLE_DEVTOOLS_LOG_UI}"
+echo "Dev Tools log sources:"
+echo "  email   : ${DEVTOOLS_EMAIL_LOG_PATH}"
+echo "  sms     : ${DEVTOOLS_SMS_LOG_PATH}"
+echo "  stripe  : ${DEVTOOLS_BILLING_STRIPE_LOG_PATH}"
+echo "  backend : ${DEVTOOLS_BILLING_BACKEND_LOG_PATH}"
 
 detect_external_ip() {
   local detected
@@ -329,6 +346,10 @@ if [[ "$backend_mode" == "mock" ]]; then
 fi
 
 if [[ -f "frontend/package.json" ]]; then
+  echo "Frontend dev server starting on http://localhost:5173"
+  if [[ "${VITE_ENABLE_DEVTOOLS_LOG_UI}" == "1" ]]; then
+    echo "Dev Tools Log UI: http://localhost:5173/dev-tools/log-ui"
+  fi
   npm --prefix frontend run dev >>"$FRONTEND_LOG_PATH" 2>&1
 else
   wait "$BACKEND_PID"

--- a/tests/test_devtools_billing_log_parser.py
+++ b/tests/test_devtools_billing_log_parser.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.devtools.billing_log_parser import parse_billing_logs
+
+
+def test_billing_parser_normalizes_stripe_ccbill_paypal_to_unified_schema(tmp_path: Path) -> None:
+    stripe = tmp_path / "stripe.log"
+    backend = tmp_path / "backend.log"
+
+    stripe.write_text(
+        "\n".join(
+            [
+                '{"provider":"stripe","type":"payment_intent.succeeded","created":1700000000,"data":{"object":{"id":"pi_1","status":"succeeded","amount":1500,"currency":"USD"}},"fee":50}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    backend.write_text(
+        "\n".join(
+            [
+                '{"transactionId":"txn_1","approved":true,"status":"completed","amount":"10.00","currencyCode":"USD","timestamp":"2026-03-01T10:00:00Z"}',
+                '{"id":"MOCK-ORDER-1","status":"COMPLETED","purchase_units":[{"payments":{"captures":[{"id":"CAP-1","status":"COMPLETED","amount":{"currency_code":"USD","value":"9.99"}}]}}],"timestamp":"2026-03-01T11:00:00Z"}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out = parse_billing_logs(str(stripe), str(backend), limit=20)
+
+    assert len(out.entries) == 3
+    providers = {e.provider for e in out.entries}
+    assert providers == {"stripe", "ccbill", "paypal"}
+
+    for entry in out.entries:
+        assert entry.event_type
+        assert entry.currency == "usd"
+        assert entry.occurred_at.endswith("Z")
+        assert entry.id
+        assert entry.id_strategy
+
+    assert out.summary.transaction_count == 3
+    assert out.summary.gross_inflow > 0
+    assert out.summary.net_total_balance == round(sum(e.net for e in out.entries), 6)
+
+
+def test_billing_parser_filters_deterministic_order_and_warnings(tmp_path: Path) -> None:
+    stripe = tmp_path / "stripe.log"
+    backend = tmp_path / "backend.log"
+    stripe.write_text(
+        "\n".join(
+            [
+                '{"provider":"stripe","type":"payment_intent.succeeded","created":1700000010,"data":{"object":{"id":"pi_a","status":"completed","amount":1000,"currency":"usd"}}}',
+                '{"provider":"stripe","type":"payment_intent.failed","created":1700000020,"data":{"object":{"id":"pi_b","status":"failed","amount":2000,"currency":"usd"}}}',
+                '{bad json}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    backend.write_text('INFO: 127.0.0.1 - "POST /mock/paypal/v2/checkout/orders HTTP/1.1" 200 OK\n', encoding="utf-8")
+
+    first = parse_billing_logs(str(stripe), str(backend), provider="stripe", status="completed", limit=10)
+    second = parse_billing_logs(str(stripe), str(backend), provider="stripe", status="completed", limit=10)
+
+    assert first.model_dump() == second.model_dump()
+    assert len(first.entries) == 1
+    assert first.entries[0].status == "completed"
+    warning_codes = {w.code for w in first.parse_warnings}
+    assert "invalid_json" in warning_codes
+    assert "access_log_without_payload" in warning_codes
+
+
+def test_billing_parser_tolerates_missing_logs_and_pagination(tmp_path: Path) -> None:
+    stripe = tmp_path / "stripe.log"
+    stripe.write_text(
+        "\n".join(
+            [
+                '{"provider":"stripe","type":"payment_intent.succeeded","created":1700000000,"data":{"object":{"id":"pi_1","status":"succeeded","amount":1000,"currency":"usd"}}}',
+                '{"provider":"stripe","type":"payment_intent.succeeded","created":1700000001,"data":{"object":{"id":"pi_2","status":"succeeded","amount":1100,"currency":"usd"}}}',
+                '{"provider":"stripe","type":"payment_intent.succeeded","created":1700000002,"data":{"object":{"id":"pi_3","status":"succeeded","amount":1200,"currency":"usd"}}}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out = parse_billing_logs(str(stripe), str(tmp_path / "missing-backend.log"), limit=2, offset=0)
+    assert len(out.entries) == 2
+    assert out.next_cursor is not None
+    assert any(w.code == "missing_log_file" for w in out.parse_warnings)

--- a/tests/test_devtools_billing_summary_service.py
+++ b/tests/test_devtools_billing_summary_service.py
@@ -1,0 +1,61 @@
+from app.services.devtools.billing_summary_service import build_billing_summary
+
+
+def test_summary_aggregates_totals_counts_and_sign_handling() -> None:
+    entries = [
+        {
+            "provider": "stripe",
+            "status": "completed",
+            "amount": 10.0,
+            "fee": 0.5,
+            "net": 9.5,
+            "currency": "usd",
+        },
+        {
+            "provider": "paypal",
+            "status": "refunded",
+            "amount": -2.0,
+            "fee": -0.2,
+            "net": -1.8,
+            "currency": "usd",
+        },
+        {
+            "provider": "ccbill",
+            "status": "completed",
+            "amount": 5.0,
+            "fee": 0.25,
+            "net": 4.75,
+            "currency": "usd",
+        },
+    ]
+
+    out = build_billing_summary(entries)
+
+    # inflow ignores negative amount
+    assert out.gross_inflow == 15.0
+    # fees accumulate absolute fee values
+    assert out.fees == 0.95
+    assert out.net_total_balance == 12.45
+    assert out.transaction_count == 3
+    assert out.provider_counts == {"stripe": 1, "paypal": 1, "ccbill": 1}
+    assert out.status_counts == {"completed": 2, "refunded": 1}
+    assert out.parse_warnings == []
+
+
+def test_summary_empty_and_mixed_currency_warning() -> None:
+    empty = build_billing_summary([])
+    assert empty.gross_inflow == 0.0
+    assert empty.fees == 0.0
+    assert empty.net_total_balance == 0.0
+    assert empty.transaction_count == 0
+    assert empty.provider_counts == {}
+    assert empty.status_counts == {}
+
+    mixed = build_billing_summary(
+        [
+            {"provider": "stripe", "status": "completed", "amount": 1, "fee": 0, "net": 1, "currency": "usd"},
+            {"provider": "paypal", "status": "completed", "amount": 1, "fee": 0, "net": 1, "currency": "eur"},
+        ]
+    )
+    assert len(mixed.parse_warnings) == 1
+    assert mixed.parse_warnings[0].code == "mixed_currency_totals"

--- a/tests/test_devtools_email_log_parser.py
+++ b/tests/test_devtools_email_log_parser.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.devtools.email_log_parser import parse_email_log
+
+
+def test_parser_handles_mixed_plaintext_json_and_invalid_entries(tmp_path: Path) -> None:
+    log = tmp_path / "emails.log"
+    log.write_text(
+        "\n".join(
+            [
+                "[2026-03-01T10:00:00Z] TO=alice@example.com PURPOSE=login",
+                "  Subject: Your verification code (login)",
+                "  Code: 123456",
+                "  Body: Your verification code is: 123456",
+                "",
+                '{"timestamp":"2026-03-01T10:02:00Z","to":["bob@example.com"],"subject":"Alert","body_text":"Device sign in","event_kind":"alert_email"}',
+                "",
+                "{not valid json}",
+                "",
+                "[bad-ts] TO=alice@example.com PURPOSE=login",
+                "  Subject: broken",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out = parse_email_log(str(log), limit=10)
+
+    assert [m.mailbox for m in out.mailboxes] == ["alice@example.com", "bob@example.com"]
+    assert len(out.messages) == 2
+    assert len(out.threads) == 2
+    codes = {w.code for w in out.parse_warnings}
+    assert "invalid_json" in codes
+    assert "invalid_timestamp" in codes
+
+
+def test_parser_deterministic_and_supports_mailbox_filter(tmp_path: Path) -> None:
+    log = tmp_path / "emails.log"
+    log.write_text(
+        "\n".join(
+            [
+                "[2026-03-01T10:00:00Z] TO=alice@example.com PURPOSE=login",
+                "  Subject: Login code",
+                "  Code: 111111",
+                "  Body: Code",
+                "",
+                "[2026-03-01T10:01:00Z] TO=bob@example.com PURPOSE=login",
+                "  Subject: Login code",
+                "  Code: 222222",
+                "  Body: Code",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    first = parse_email_log(str(log), mailbox="alice@example.com", limit=10)
+    second = parse_email_log(str(log), mailbox="alice@example.com", limit=10)
+
+    assert first.model_dump() == second.model_dump()
+    assert len(first.messages) == 1
+    assert first.messages[0].mailbox == "alice@example.com"
+
+
+def test_parser_paginates_and_returns_next_cursor(tmp_path: Path) -> None:
+    log = tmp_path / "emails.log"
+    blocks = []
+    for i in range(3):
+        blocks.extend(
+            [
+                f"[2026-03-01T10:0{i}:00Z] TO=user@example.com PURPOSE=login",
+                f"  Subject: Code {i}",
+                f"  Code: 10000{i}",
+                "  Body: code body",
+                "",
+            ]
+        )
+    log.write_text("\n".join(blocks), encoding="utf-8")
+
+    out = parse_email_log(str(log), limit=2, offset=0)
+    assert len(out.messages) == 2
+    assert out.next_cursor is not None
+
+
+def test_parser_missing_file_returns_warning_not_exception(tmp_path: Path) -> None:
+    out = parse_email_log(str(tmp_path / "missing.log"))
+    assert out.messages == []
+    assert out.threads == []
+    assert out.mailboxes == []
+    assert any(w.code == "missing_log_file" for w in out.parse_warnings)

--- a/tests/test_devtools_models.py
+++ b/tests/test_devtools_models.py
@@ -1,0 +1,61 @@
+from app.models import (
+    DevtoolsBillingLedgerEntryOut,
+    DevtoolsEmailMessageOut,
+    DevtoolsParseWarningOut,
+    DevtoolsSmsMessageOut,
+)
+
+
+def test_devtools_email_message_normalizes_timestamp_and_keeps_stable_id_fields() -> None:
+    model = DevtoolsEmailMessageOut(
+        id="email#e6a9a5",
+        id_strategy="sha256(mailbox|timestamp|subject|body)",
+        thread_id="thread#123",
+        mailbox="user@example.com",
+        sent_at="2026-03-01T12:34:56+02:00",
+        event_kind="mfa_email_code",
+        to_emails=["user@example.com"],
+        subject="Your verification code",
+        body_text="Code is 123456",
+        code="123456",
+        parse_warnings=[
+            DevtoolsParseWarningOut(source="email", line_number=10, code="missing_subject", message="subject missing")
+        ],
+    )
+
+    assert model.sent_at == "2026-03-01T10:34:56Z"
+    assert model.id == "email#e6a9a5"
+    assert model.id_strategy.startswith("sha256(")
+    assert model.parse_warnings[0].code == "missing_subject"
+
+
+def test_devtools_sms_message_requires_timezone_aware_timestamp() -> None:
+    try:
+        DevtoolsSmsMessageOut(
+            id="sms#abc",
+            id_strategy="sha256(participants|timestamp|body)",
+            conversation_id="conv#1",
+            sent_at="2026-03-01T12:00:00",
+        )
+    except ValueError as exc:
+        assert "timestamp must include timezone" in str(exc)
+    else:
+        raise AssertionError("Expected timezone validation error")
+
+
+def test_devtools_billing_entry_normalizes_currency_and_timestamp() -> None:
+    model = DevtoolsBillingLedgerEntryOut(
+        id="bill#1",
+        id_strategy="sha256(provider|external_id|occurred_at|amount)",
+        provider="paypal",
+        event_type="capture",
+        status="completed",
+        occurred_at="2026-03-01T12:00:30+00:00",
+        amount=9.99,
+        fee=0.59,
+        net=9.40,
+        currency="USD",
+    )
+
+    assert model.occurred_at == "2026-03-01T12:00:30Z"
+    assert model.currency == "usd"

--- a/tests/test_devtools_read_service_cache.py
+++ b/tests/test_devtools_read_service_cache.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from app.services.devtools import read_service
+
+
+def test_email_cache_hit_and_ttl_expiry(tmp_path: Path, monkeypatch) -> None:
+    log = tmp_path / "emails.log"
+    log.write_text(
+        "\n".join(
+            [
+                "[2026-03-01T10:00:00Z] TO=user@example.com PURPOSE=login",
+                "  Subject: Code",
+                "  Code: 123456",
+                "  Body: body",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    read_service.clear_devtools_cache()
+    calls = {"n": 0}
+
+    real = read_service.parse_email_log
+
+    def wrapped(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(read_service, "parse_email_log", wrapped)
+
+    out1 = read_service.get_email_messages(str(log), mailbox=None, thread_id=None, q=None, state="all", limit=10, offset=0)
+    out2 = read_service.get_email_messages(str(log), mailbox=None, thread_id=None, q=None, state="all", limit=10, offset=0)
+
+    assert out1.model_dump() == out2.model_dump()
+    assert calls["n"] == 1
+
+    original_monotonic = read_service.time.monotonic
+    monkeypatch.setattr(read_service.time, "monotonic", lambda: original_monotonic() + 10)
+    read_service.get_email_messages(str(log), mailbox=None, thread_id=None, q=None, state="all", limit=10, offset=0)
+    assert calls["n"] == 2
+
+
+def test_sms_cache_invalidation_on_file_change(tmp_path: Path, monkeypatch) -> None:
+    log = tmp_path / "sms.log"
+    log.write_text("[2026-03-01T10:00:00Z] SMS TO=+14155550123 Code: 111111\n", encoding="utf-8")
+
+    read_service.clear_devtools_cache()
+    calls = {"n": 0}
+    real = read_service.parse_sms_log
+
+    def wrapped(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(read_service, "parse_sms_log", wrapped)
+
+    read_service.get_sms_conversations(str(log), participant=None, q=None, limit=10, offset=0)
+    read_service.get_sms_conversations(str(log), participant=None, q=None, limit=10, offset=0)
+    assert calls["n"] == 1
+
+    time.sleep(0.001)
+    log.write_text(
+        "[2026-03-01T10:00:00Z] SMS TO=+14155550123 Code: 111111\n[2026-03-01T10:01:00Z] SMS TO=+14155550123 Code: 222222\n",
+        encoding="utf-8",
+    )
+
+    read_service.get_sms_conversations(str(log), participant=None, q=None, limit=10, offset=0)
+    assert calls["n"] == 2
+
+
+def test_billing_cache_keys_include_filters(tmp_path: Path, monkeypatch) -> None:
+    stripe = tmp_path / "stripe.log"
+    backend = tmp_path / "backend.log"
+    stripe.write_text('{"provider":"stripe","type":"payment_intent.succeeded","created":1700000010,"data":{"object":{"id":"pi_a","status":"completed","amount":1000,"currency":"usd"}}}\n', encoding="utf-8")
+    backend.write_text('', encoding="utf-8")
+
+    read_service.clear_devtools_cache()
+    calls = {"n": 0}
+    real = read_service.parse_billing_logs
+
+    def wrapped(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(read_service, "parse_billing_logs", wrapped)
+
+    read_service.get_billing_ledger(str(stripe), str(backend), provider="stripe", status="completed", from_ts=None, to_ts=None, limit=10, offset=0)
+    read_service.get_billing_ledger(str(stripe), str(backend), provider="stripe", status="completed", from_ts=None, to_ts=None, limit=10, offset=0)
+    assert calls["n"] == 1
+
+    read_service.get_billing_ledger(str(stripe), str(backend), provider="stripe", status="failed", from_ts=None, to_ts=None, limit=10, offset=0)
+    assert calls["n"] == 2

--- a/tests/test_devtools_sms_log_parser.py
+++ b/tests/test_devtools_sms_log_parser.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.devtools.sms_log_parser import parse_sms_log
+
+
+def test_sms_parser_handles_plain_json_invalid_and_groups_conversations(tmp_path: Path) -> None:
+    log = tmp_path / "sms.log"
+    log.write_text(
+        "\n".join(
+            [
+                "[2026-03-01T10:00:00Z] SMS TO=+14155550123 Code: 123456",
+                "",
+                "[2026-03-01T10:03:00Z] ALERT_SMS TO=+14155550123",
+                "  Body: Payment failed",
+                "",
+                '{"timestamp":"2026-03-01T10:04:00Z","from":"+14155550124","to":"+14155550199","body_text":"hello","status":"delivered","message_id":"mid_1","event_kind":"alert_sms"}',
+                "",
+                "{bad json}",
+                "",
+                "[bad-ts] SMS TO=+14155550123 Code: 111111",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out = parse_sms_log(str(log), limit=10)
+
+    assert len(out.messages) == 3
+    assert len(out.conversations) == 2
+    # conversations sorted by latest activity desc
+    assert out.conversations[0].latest_message_at >= out.conversations[1].latest_message_at
+    warning_codes = {w.code for w in out.parse_warnings}
+    assert "invalid_json" in warning_codes
+    assert "invalid_timestamp" in warning_codes
+
+
+def test_sms_parser_deterministic_message_ordering_and_filtering(tmp_path: Path) -> None:
+    log = tmp_path / "sms.log"
+    log.write_text(
+        "\n".join(
+            [
+                "[2026-03-01T10:00:00Z] SMS TO=+14155550123 Code: 111111",
+                "",
+                "[2026-03-01T10:01:00Z] SMS TO=+14155550123 Code: 222222",
+                "",
+                "[2026-03-01T10:02:00Z] SMS TO=+14155550000 Code: 333333",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    first = parse_sms_log(str(log), participant="+14155550123", limit=10)
+    second = parse_sms_log(str(log), participant="+14155550123", limit=10)
+
+    assert first.model_dump() == second.model_dump()
+    assert len(first.messages) == 2
+    assert all(m.to_number == "+14155550123" for m in first.messages)
+    assert first.messages[0].sent_at >= first.messages[1].sent_at
+
+
+def test_sms_parser_pagination_and_missing_file_warning(tmp_path: Path) -> None:
+    log = tmp_path / "sms.log"
+    lines = []
+    for i in range(3):
+        lines.extend([f"[2026-03-01T10:0{i}:00Z] SMS TO=+14155550123 Code: 99999{i}", ""])
+    log.write_text("\n".join(lines), encoding="utf-8")
+
+    paged = parse_sms_log(str(log), limit=2, offset=0)
+    assert len(paged.messages) == 2
+    assert paged.next_cursor is not None
+
+    missing = parse_sms_log(str(tmp_path / "missing.log"))
+    assert missing.messages == []
+    assert missing.conversations == []
+    assert any(w.code == "missing_log_file" for w in missing.parse_warnings)

--- a/tests/test_internal_devtools_api_behavior.py
+++ b/tests/test_internal_devtools_api_behavior.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import (
+    DevtoolsBillingLedgerEntryOut,
+    DevtoolsBillingLedgerOut,
+    DevtoolsBillingLedgerSummaryOut,
+    DevtoolsEmailMessagesOut,
+)
+from app.routers import internal_devtools
+
+
+def _cursor(offset: int) -> str:
+    payload = json.dumps({"offset": offset}).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+
+
+def test_email_endpoint_applies_filters_and_decodes_cursor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        internal_devtools,
+        "S",
+        type("Stub", (), {"dev_mode": True, "devtools_email_log_path": "/tmp/dev-email.log"})(),
+    )
+
+    calls: dict[str, Any] = {}
+
+    def fake_get_email_messages(log_path: str, **kwargs: Any) -> DevtoolsEmailMessagesOut:
+        calls["log_path"] = log_path
+        calls.update(kwargs)
+        return DevtoolsEmailMessagesOut(next_cursor=_cursor(kwargs["offset"] + kwargs["limit"]))
+
+    monkeypatch.setattr(internal_devtools, "get_email_messages", fake_get_email_messages)
+
+    out = internal_devtools.get_devtools_email_messages(
+        mailbox="alice@example.com",
+        q="verify",
+        state="unread",
+        limit=25,
+        cursor=_cursor(7),
+    )
+
+    assert out.next_cursor == _cursor(32)
+    assert calls["log_path"] == "/tmp/dev-email.log"
+    assert calls["mailbox"] == "alice@example.com"
+    assert calls["q"] == "verify"
+    assert calls["state"] == "unread"
+    assert calls["limit"] == 25
+    assert calls["offset"] == 7
+
+
+def test_billing_endpoints_filter_contract_and_summary_totals(monkeypatch) -> None:
+    monkeypatch.setattr(
+        internal_devtools,
+        "S",
+        type(
+            "Stub",
+            (),
+            {
+                "dev_mode": True,
+                "devtools_billing_stripe_log_path": "/tmp/stripe.log",
+                "devtools_billing_backend_log_path": "/tmp/backend.log",
+            },
+        )(),
+    )
+
+    ledger_calls: dict[str, Any] = {}
+
+    def fake_ledger(stripe_path: str, backend_path: str, **kwargs: Any) -> DevtoolsBillingLedgerOut:
+        ledger_calls["stripe_path"] = stripe_path
+        ledger_calls["backend_path"] = backend_path
+        ledger_calls.update(kwargs)
+        entries = [
+            DevtoolsBillingLedgerEntryOut(
+                id="e1",
+                id_strategy="fixture",
+                provider="stripe",
+                event_type="payment_intent.succeeded",
+                status="completed",
+                occurred_at="2026-03-01T10:00:00Z",
+                amount=10.0,
+                fee=0.5,
+                net=9.5,
+                currency="usd",
+                raw_payload={"id": "pi_1"},
+            ),
+            DevtoolsBillingLedgerEntryOut(
+                id="e2",
+                id_strategy="fixture",
+                provider="stripe",
+                event_type="payment_intent.succeeded",
+                status="completed",
+                occurred_at="2026-03-01T11:00:00Z",
+                amount=5.0,
+                fee=0.25,
+                net=4.75,
+                currency="usd",
+                raw_payload={"id": "pi_2"},
+            ),
+        ]
+        summary = DevtoolsBillingLedgerSummaryOut(
+            gross_inflow=15.0,
+            fees=0.75,
+            net_total_balance=14.25,
+            transaction_count=2,
+            provider_counts={"stripe": 2},
+            status_counts={"completed": 2},
+        )
+        return DevtoolsBillingLedgerOut(entries=entries, summary=summary, next_cursor=_cursor(kwargs["offset"] + kwargs["limit"]))
+
+    monkeypatch.setattr(internal_devtools, "get_billing_ledger", fake_ledger)
+    monkeypatch.setattr(
+        internal_devtools,
+        "get_billing_summary",
+        lambda *args, **kwargs: DevtoolsBillingLedgerSummaryOut(
+            gross_inflow=15.0,
+            fees=0.75,
+            net_total_balance=14.25,
+            transaction_count=2,
+            provider_counts={"stripe": 2},
+            status_counts={"completed": 2},
+        ),
+    )
+
+    ledger = internal_devtools.get_devtools_billing_ledger(
+        provider="stripe",
+        status="completed",
+        from_ts="2026-03-01T00:00:00Z",
+        to_ts="2026-03-02T00:00:00Z",
+        limit=2,
+        cursor=_cursor(3),
+    )
+    summary = internal_devtools.get_devtools_billing_summary(
+        provider="stripe",
+        status="completed",
+        from_ts="2026-03-01T00:00:00Z",
+        to_ts="2026-03-02T00:00:00Z",
+    )
+
+    assert ledger.summary.gross_inflow == 15.0
+    assert ledger.summary.fees == 0.75
+    assert ledger.summary.net_total_balance == 14.25
+    assert ledger.next_cursor == _cursor(5)
+
+    assert ledger_calls["stripe_path"] == "/tmp/stripe.log"
+    assert ledger_calls["backend_path"] == "/tmp/backend.log"
+    assert ledger_calls["provider"] == "stripe"
+    assert ledger_calls["status"] == "completed"
+    assert ledger_calls["offset"] == 3
+
+    assert summary.gross_inflow == 15.0
+    assert summary.fees == 0.75
+    assert summary.net_total_balance == 14.25
+
+
+def test_devtools_route_security_gate_and_invalid_cursor_errors(monkeypatch) -> None:
+    monkeypatch.setattr(
+        internal_devtools,
+        "S",
+        type("Stub", (), {"dev_mode": False, "devtools_email_log_path": "/tmp/none.log"})(),
+    )
+
+    with pytest.raises(HTTPException) as disabled:
+        internal_devtools.get_devtools_email_messages()
+
+    assert disabled.value.status_code == 404
+    assert disabled.value.detail == {
+        "code": "devtools_disabled",
+        "message": "internal dev-tools routes are disabled",
+    }
+
+    monkeypatch.setattr(
+        internal_devtools,
+        "S",
+        type("Stub", (), {"dev_mode": True, "devtools_email_log_path": "/tmp/none.log"})(),
+    )
+
+    with pytest.raises(HTTPException) as bad_cursor:
+        internal_devtools.get_devtools_email_messages(cursor="not-valid!!!")
+
+    assert bad_cursor.value.status_code == 400
+    assert bad_cursor.value.detail == {
+        "code": "invalid_cursor",
+        "message": "cursor must be urlsafe base64 JSON with an integer offset",
+    }

--- a/tests/test_internal_devtools_contract.py
+++ b/tests/test_internal_devtools_contract.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from app.main import create_app
+from app.routers import internal_devtools
+
+
+def _cursor(offset: int) -> str:
+    payload = json.dumps({"offset": offset}).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+
+
+def test_openapi_contains_internal_devtools_routes_with_get_only() -> None:
+    app = create_app()
+    schema = app.openapi()
+    paths = schema.get("paths", {})
+
+    expected = [
+        "/internal/dev-tools/email/messages",
+        "/internal/dev-tools/sms/conversations",
+        "/internal/dev-tools/billing/ledger",
+        "/internal/dev-tools/billing/summary",
+    ]
+
+    for path in expected:
+        assert path in paths
+        methods = set(paths[path].keys())
+        assert methods == {"get"}
+
+
+def test_openapi_documents_limit_bounds_and_enums() -> None:
+    app = create_app()
+    schema = app.openapi()
+
+    email_params = schema["paths"]["/internal/dev-tools/email/messages"]["get"]["parameters"]
+    limit_param = next(p for p in email_params if p["name"] == "limit")
+    assert limit_param["schema"]["minimum"] == 1
+    assert limit_param["schema"]["maximum"] == 200
+
+    ledger_params = schema["paths"]["/internal/dev-tools/billing/ledger"]["get"]["parameters"]
+    provider_param = next(p for p in ledger_params if p["name"] == "provider")
+    enum_values = next(
+        option["enum"]
+        for option in provider_param["schema"]["anyOf"]
+        if "enum" in option
+    )
+    assert enum_values == ["stripe", "ccbill", "paypal"]
+
+
+def test_email_messages_contract_returns_expected_shape() -> None:
+    out = internal_devtools.get_devtools_email_messages(
+        mailbox="user@example.com",
+        thread_id="thread#1",
+        q="verification",
+        state="all",
+        limit=25,
+        cursor=_cursor(0),
+    )
+    payload = out.model_dump()
+    assert set(payload.keys()) == {"mailboxes", "threads", "messages", "next_cursor", "parse_warnings"}
+    assert payload["messages"] == []
+    assert isinstance(payload["parse_warnings"], list)
+
+
+def test_sms_conversations_contract_returns_expected_shape() -> None:
+    out = internal_devtools.get_devtools_sms_conversations(
+        participant="+14155550123",
+        q="code",
+        limit=10,
+        cursor=_cursor(0),
+    )
+    payload = out.model_dump()
+    assert set(payload.keys()) == {"conversations", "messages", "next_cursor", "parse_warnings"}
+    assert payload["messages"] == []
+    assert isinstance(payload["parse_warnings"], list)
+
+
+def test_billing_contract_returns_expected_shapes() -> None:
+    ledger = internal_devtools.get_devtools_billing_ledger(
+        provider="paypal",
+        status="completed",
+        from_ts="2026-03-01T00:00:00Z",
+        to_ts="2026-03-02T00:00:00Z",
+        limit=50,
+        cursor=_cursor(100),
+    )
+    ledger_payload = ledger.model_dump()
+    assert set(ledger_payload.keys()) == {"entries", "summary", "next_cursor", "parse_warnings"}
+    assert set(ledger_payload["summary"].keys()) == {
+        "gross_inflow",
+        "fees",
+        "net_total_balance",
+        "transaction_count",
+        "provider_counts",
+        "status_counts",
+        "parse_warnings",
+    }
+
+    summary = internal_devtools.get_devtools_billing_summary(
+        provider="stripe",
+        status="failed",
+        from_ts="2026-03-01T00:00:00Z",
+        to_ts="2026-03-02T00:00:00Z",
+    )
+    summary_payload = summary.model_dump()
+    assert set(summary_payload.keys()) == {
+        "gross_inflow",
+        "fees",
+        "net_total_balance",
+        "transaction_count",
+        "provider_counts",
+        "status_counts",
+        "parse_warnings",
+    }
+
+
+def test_invalid_cursor_maps_to_deterministic_400_error() -> None:
+    with pytest.raises(HTTPException) as exc:
+        internal_devtools.get_devtools_email_messages(cursor="not-valid!!!")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "code": "invalid_cursor",
+        "message": "cursor must be urlsafe base64 JSON with an integer offset",
+    }
+
+
+def test_repeated_calls_with_same_filters_are_deterministic() -> None:
+    params = {
+        "provider": "ccbill",
+        "status": "pending",
+        "from_ts": "2026-03-01T00:00:00Z",
+        "to_ts": "2026-03-02T00:00:00Z",
+        "limit": 20,
+        "cursor": _cursor(40),
+    }
+
+    first = internal_devtools.get_devtools_billing_ledger(**params)
+    second = internal_devtools.get_devtools_billing_ledger(**params)
+    assert first.model_dump() == second.model_dump()
+
+
+def test_routes_disabled_outside_dev_mode_have_deterministic_error(monkeypatch) -> None:
+    monkeypatch.setattr(internal_devtools, "S", type("Stub", (), {"dev_mode": False})())
+    with pytest.raises(HTTPException) as exc:
+        internal_devtools.get_devtools_email_messages()
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == {
+        "code": "devtools_disabled",
+        "message": "internal dev-tools routes are disabled",
+    }
+
+
+def test_dev_access_is_logged(monkeypatch) -> None:
+    monkeypatch.setattr(internal_devtools, "S", type("Stub", (), {"dev_mode": True, "devtools_sms_log_path": "/tmp/missing-sms.log"})())
+    calls = {"n": 0}
+
+    def fake_info(*args, **kwargs):
+        calls["n"] += 1
+
+    monkeypatch.setattr(internal_devtools.logger, "info", fake_info)
+    internal_devtools.get_devtools_sms_conversations(participant=None, q=None, limit=50, cursor=None)
+    assert calls["n"] == 1


### PR DESCRIPTION
### Motivation
- Provide a read-only internal developer UI to inspect local artifacts (email, SMS, billing mock logs) and a browser-only TOTP helper for faster local debugging and operator workflows.
- Normalize disparate local mock outputs into stable, paginated read models with deterministic IDs, timestamps, and parse-warning surfaces so the UI and tests can rely on consistent shapes.
- Keep the surface disabled outside dev mode and behind a feature flag to avoid exposing internal tools in production.

### Description
- Add backend DTOs and validators under `app/models.py` for email, SMS, and billing read models and parse warnings (`Devtools*` models). 
- Implement streaming parsers and normalizers in `app/services/devtools/*` for email (`email_log_parser.py`), SMS (`sms_log_parser.py`), and billing (`billing_log_parser.py`) plus a billing summary service and a read-service cache (`read_service.py`).
- Add a guarded router `app/routers/internal_devtools.py` exposing `GET /internal/dev-tools/*` endpoints that decode cursor pagination and call the read service; register the router in `app/main.py` and gate access with `S.dev_mode`.
- Wire settings and env defaults (`S.devtools_*`), update `.env.local.example` and `app/core/settings.py`, and auto-export canonical local defaults and `VITE_ENABLE_DEVTOOLS_LOG_UI` from `scripts/run_dev.sh` for local runs.
- Add a frontend feature-flagged Dev Tools Log UI at `frontend/src/pages/devtools/DevToolsLogUiPage.tsx` plus typed API clients (`frontend/src/api/endpoints/devtools.ts`), hooks (`frontend/src/hooks/useDevtoolsData.ts`), types, feature-flag helpers, TOTP parsing/generation utilities, and UI wiring (`App.tsx`, `Sidebar`, `MobileNav`).
- Add comprehensive docs under `docs/` covering plan, inputs, contract, read models, and tickets; include OpenAPI contract behavior for the new routes.

### Testing
- Ran backend unit tests via `pytest` covering parsers, models, read-service caching, router contract and behavior (notable tests: `tests/test_devtools_email_log_parser.py`, `tests/test_devtools_sms_log_parser.py`, `tests/test_devtools_billing_log_parser.py`, `tests/test_devtools_billing_summary_service.py`, `tests/test_devtools_read_service_cache.py`, `tests/test_internal_devtools_contract.py`, `tests/test_internal_devtools_api_behavior.py`) and they passed.
- Ran frontend unit tests with `vitest` for endpoints/hooks/components and TOTP utilities (files under `frontend/src/...` and tests like `frontend/src/api/endpoints/devtools.test.ts`, `frontend/src/hooks/useDevtoolsData.test.ts`, `frontend/src/lib/totp*`), and they passed.
- Included a Playwright smoke spec `frontend/e2e/devtools-log-ui-smoke.spec.ts` to validate the overall UI flow (it is skipped unless `VITE_ENABLE_DEVTOOLS_LOG_UI=1`); the spec is present for CI/e2e runs and did not fail in validated runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3a2e479c0832b89c501dff5157d89)