### PR TITLE
Add Questionnaire feature: draft/publish/respond workflows, validation engine, PDF export, frontend UI & tests

### DIFF
--- a/app/contracts/questionnaire_validation_contract.py
+++ b/app/contracts/questionnaire_validation_contract.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+VALIDATION_CONTRACT_VERSION = "2026-03-validation-v1"
+SUPPORTED_VALIDATION_CONTRACT_VERSIONS = {VALIDATION_CONTRACT_VERSION}
+
+
+class ValidationIssue(BaseModel):
+    code: str
+    message: str
+    blocking: bool | None = None
+    rule_id: str | None = None
+
+
+class QuestionnaireValidationRequest(BaseModel):
+    contract_version: Literal["2026-03-validation-v1"] = VALIDATION_CONTRACT_VERSION
+    answers_by_question_id: dict[str, Any] = Field(default_factory=dict)
+    group_rules: list[dict[str, Any]] = Field(default_factory=list)
+    form_rules: list[dict[str, Any]] = Field(default_factory=list)
+    final_submit: bool = False
+
+
+class QuestionnaireValidationResponse(BaseModel):
+    contract_version: Literal["2026-03-validation-v1"] = VALIDATION_CONTRACT_VERSION
+    is_valid: bool
+    can_submit: bool
+    has_blocking_form_error: bool
+    errors: dict[str, list[ValidationIssue]]

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -433,6 +433,16 @@ class Settings:
     messaging_gallery_index_enabled: bool = os.environ.get("MESSAGING_GALLERY_INDEX_ENABLED", "false").lower() == "true"
     # Subscriptions
     subscriptions_table_name: str = os.environ.get("SUBSCRIPTIONS_TABLE_NAME", "subscriptions")
+    questionnaire_table_name: str = os.environ.get("QUESTIONNAIRE_TABLE_NAME", "questionnaires")
+    questionnaire_owner_index_name: str = os.environ.get("QUESTIONNAIRE_OWNER_INDEX_NAME", "owner-updated-index")
+    questionnaire_status_index_name: str = os.environ.get("QUESTIONNAIRE_STATUS_INDEX_NAME", "status-updated-index")
+    questionnaire_published_index_name: str = os.environ.get("QUESTIONNAIRE_PUBLISHED_INDEX_NAME", "published_slug-index")
+    questionnaire_response_status_index_name: str = os.environ.get("QUESTIONNAIRE_RESPONSE_STATUS_INDEX_NAME", "response_status-updated-index")
+    questionnaire_anon_submit_max_per_window: int = int(os.environ.get("QUESTIONNAIRE_ANON_SUBMIT_MAX_PER_WINDOW", "30"))
+    questionnaire_anon_submit_window_seconds: int = int(os.environ.get("QUESTIONNAIRE_ANON_SUBMIT_WINDOW_SECONDS", "300"))
+    questionnaire_captcha_required_anonymous: bool = os.environ.get("QUESTIONNAIRE_CAPTCHA_REQUIRED_ANONYMOUS", "false").lower() in ("1", "true", "yes", "on")
+    questionnaire_captcha_static_token: str = os.environ.get("QUESTIONNAIRE_CAPTCHA_STATIC_TOKEN", "")
+    questionnaire_encrypt_sensitive_answers: bool = os.environ.get("QUESTIONNAIRE_ENCRYPT_SENSITIVE_ANSWERS", "false").lower() in ("1", "true", "yes", "on")
 
 
 S = Settings()

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -44,6 +44,7 @@ class Tables:
     signature_packet_events: Any
     signature_packet_artifacts: Any
     tickets: Any
+    questionnaires: Any
 
 T = Tables(
     sessions=ddb.Table(S.ddb_sessions_table),
@@ -82,4 +83,5 @@ T = Tables(
     signature_packet_events=ddb.Table(S.signature_packet_events_table_name),
     signature_packet_artifacts=ddb.Table(S.signature_packet_artifacts_table_name),
     tickets=ddb.Table(S.tickets_table_name),
+    questionnaires=ddb.Table(S.questionnaire_table_name),
 )

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,7 @@ from app.routers.commercial_checkout import router as commercial_checkout_router
 from app.routers.tickets import router as tickets_router
 from app.routers.ticket_spaces import router as ticket_spaces_router
 from app.routers.internal_devtools import router as internal_devtools_router
+from app.routers.questionnaires import router as questionnaires_router
 from app.services.billing_reconcile import start_billing_reconcile_task
 from app.services.billing_dunning import start_billing_dunning_task
 from app.services.filemanager import start_filemgr_purge_task
@@ -212,6 +213,7 @@ def create_app() -> FastAPI:
     app.include_router(tickets_router)
     app.include_router(ticket_spaces_router)
     app.include_router(internal_devtools_router)
+    app.include_router(questionnaires_router)
     app.add_event_handler("startup", start_billing_reconcile_task)
     app.add_event_handler("startup", start_projects_reconcile_task)
 

--- a/app/models_questionnaire.py
+++ b/app/models_questionnaire.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+QuestionType = Literal[
+    "text",
+    "select",
+    "multiselect",
+    "radio",
+    "slider",
+    "date",
+    "time",
+    "timezone",
+    "address",
+]
+
+QuestionnaireStatus = Literal["draft", "published", "archived"]
+ResponseSessionStatus = Literal["in_progress", "submitted"]
+ValidationScope = Literal["question", "group", "form"]
+GroupRuleType = Literal["min_answered", "requires_if_answered", "mutually_exclusive"]
+FormRuleType = Literal["requires_if_answered", "mutually_exclusive"]
+
+
+class Questionnaire(BaseModel):
+    questionnaire_id: str
+    owner_id: str
+    title: str
+    description: str = ""
+    status: QuestionnaireStatus = "draft"
+    published_version_id: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class QuestionnaireVersion(BaseModel):
+    version_id: str
+    questionnaire_id: str
+    version_number: int
+    schema_json: dict[str, Any] = Field(default_factory=dict)
+    published_at: datetime
+
+
+class Section(BaseModel):
+    section_id: str
+    version_id: str
+    title: str
+    description: str = ""
+    position: int = 0
+
+
+class Question(BaseModel):
+    question_id: str
+    section_id: str
+    type: QuestionType
+    label: str
+    hint: str = ""
+    required: bool = False
+    config_json: dict[str, Any] = Field(default_factory=dict)
+    position: int = 0
+
+
+class GroupValidationRuleDefinition(BaseModel):
+    rule_id: str
+    group_id: str
+    rule_type: GroupRuleType
+    question_ids: list[str] = Field(default_factory=list)
+    config_json: dict[str, Any] = Field(default_factory=dict)
+
+
+class FormValidationRuleDefinition(BaseModel):
+    rule_id: str
+    rule_type: FormRuleType
+    config_json: dict[str, Any] = Field(default_factory=dict)
+    blocking: bool = True
+
+
+class ValidationRule(BaseModel):
+    rule_id: str
+    version_id: str
+    scope: ValidationScope
+    scope_ref: str
+    rule_type: str
+    rule_config_json: dict[str, Any] = Field(default_factory=dict)
+    error_message: str
+
+
+class ResponseSession(BaseModel):
+    response_session_id: str
+    version_id: str
+    respondent_id: str | None = None
+    status: ResponseSessionStatus = "in_progress"
+    started_at: datetime
+    submitted_at: datetime | None = None
+    current_section_index: int = 0
+
+
+class Answer(BaseModel):
+    answer_id: str
+    response_session_id: str
+    question_id: str
+    value_json: Any
+    is_valid: bool = True
+    validation_errors_json: list[dict[str, Any]] = Field(default_factory=list)

--- a/app/routers/questionnaires.py
+++ b/app/routers/questionnaires.py
@@ -1,0 +1,918 @@
+from __future__ import annotations
+
+import base64
+import time
+
+from uuid import uuid4
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from pydantic import BaseModel, Field
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.contracts.questionnaire_validation_contract import QuestionnaireValidationRequest, QuestionnaireValidationResponse
+from app.core.normalize import client_ip_from_request
+from app.core.settings import S
+from app.services.questionnaire_validation import validate_form_submission
+from app.services.questionnaire_response_pdf import html_to_pdf_bytes, render_response_html
+from app.services.text_sanitizer import sanitize_user_text
+from app.services.questionnaires_repository import DynamoQuestionnaireRepository
+from app.services.rate_limit import rate_limit_password_recovery
+from app.services.sessions import require_ui_session
+
+router = APIRouter(prefix="/questionnaires", tags=["questionnaires"])
+REPO = DynamoQuestionnaireRepository()
+
+_ALLOWED_TYPES = {"text", "select", "multiselect", "radio", "slider", "date", "time", "timezone", "address"}
+
+
+class QuestionnaireDraftCreateReq(BaseModel):
+    questionnaire_id: str = Field(..., min_length=1, max_length=120)
+    title: str = Field(..., min_length=1, max_length=240)
+    description: str = Field(default="", max_length=4000)
+    visibility: str = Field(default="private", pattern="^(private|public|unlisted)$")
+
+
+class QuestionnaireDraftUpdateReq(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=240)
+    description: str | None = Field(default=None, max_length=4000)
+    visibility: str | None = Field(default=None, pattern="^(private|public|unlisted)$")
+
+
+class SectionCreateReq(BaseModel):
+    section_id: str = Field(..., min_length=1, max_length=120)
+    title: str = Field(..., min_length=1, max_length=240)
+    description: str = Field(default="", max_length=4000)
+
+
+class SectionUpdateReq(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=240)
+    description: str | None = Field(default=None, max_length=4000)
+
+
+class SectionReorderReq(BaseModel):
+    section_ids: list[str] = Field(default_factory=list)
+
+
+class QuestionCreateReq(BaseModel):
+    section_id: str = Field(..., min_length=1, max_length=120)
+    question_id: str = Field(..., min_length=1, max_length=120)
+    type: str = Field(..., min_length=1, max_length=32)
+    label: str = Field(..., min_length=1, max_length=400)
+    required: bool = False
+    hint: str = Field(default="", max_length=4000)
+    config_json: dict[str, Any] = Field(default_factory=dict)
+
+
+class QuestionUpdateReq(BaseModel):
+    label: str | None = Field(default=None, min_length=1, max_length=400)
+    required: bool | None = None
+    hint: str | None = Field(default=None, max_length=4000)
+    config_json: dict[str, Any] | None = None
+
+
+class QuestionReorderReq(BaseModel):
+    section_id: str = Field(..., min_length=1, max_length=120)
+    question_ids: list[str] = Field(default_factory=list)
+
+
+class PublishDraftReq(BaseModel):
+    published_slug: str | None = Field(default=None, min_length=1, max_length=240)
+
+
+class QuestionnaireVersionEnvelope(BaseModel):
+    version: dict[str, Any]
+
+
+class QuestionnaireDraftEnvelope(BaseModel):
+    draft: dict[str, Any]
+
+
+class QuestionnaireDraftListEnvelope(BaseModel):
+    items: list[dict[str, Any]]
+
+
+class SectionEnvelope(BaseModel):
+    section: dict[str, Any]
+
+
+class SectionListEnvelope(BaseModel):
+    items: list[dict[str, Any]]
+
+
+class QuestionEnvelope(BaseModel):
+    question: dict[str, Any]
+
+
+class QuestionListEnvelope(BaseModel):
+    items: list[dict[str, Any]]
+
+
+
+
+class ResponseSessionStartReq(BaseModel):
+    questionnaire_id: str | None = Field(default=None, min_length=1, max_length=120)
+
+
+class ResponseSessionEnvelope(BaseModel):
+    session: dict[str, Any]
+
+
+class PublishedQuestionnaireEnvelope(BaseModel):
+    version: dict[str, Any]
+
+
+
+class SessionSaveReq(BaseModel):
+    answers_by_question_id: dict[str, Any] = Field(default_factory=dict)
+    current_section_index: int | None = Field(default=None, ge=0)
+    current_question_id: str | None = Field(default=None, min_length=1, max_length=120)
+
+
+class SessionStateEnvelope(BaseModel):
+    session: dict[str, Any]
+    answers_by_question_id: dict[str, Any]
+
+
+class SessionPdfEnvelope(BaseModel):
+    artifact: dict[str, Any]
+
+
+class QuestionnaireAnalyticsEnvelope(BaseModel):
+    analytics: dict[str, Any]
+
+
+class SessionSubmitEnvelope(BaseModel):
+    session: dict[str, Any]
+    result: QuestionnaireValidationResponse
+
+
+def _compute_questionnaire_analytics(*, questionnaire_id: str, versions: list[dict[str, Any]]) -> dict[str, Any]:
+    sessions = REPO.list_response_sessions(questionnaire_id=questionnaire_id)
+    events = REPO.list_response_events(questionnaire_id=questionnaire_id)
+
+    version_rows: list[dict[str, Any]] = []
+    all_dropoffs: dict[str, int] = {}
+    all_hotspots: dict[str, int] = {}
+
+    for version in versions:
+        vid = str(version.get("version_id") or "")
+        schema = version.get("schema_json") or {}
+        sections = schema.get("sections") or []
+        section_title_by_index = {idx: str(section.get("title") or f"Section {idx + 1}") for idx, section in enumerate(sections)}
+
+        version_sessions = [s for s in sessions if str(s.get("version_id") or "") == vid]
+        starts = len(version_sessions)
+        completed_sessions = [s for s in version_sessions if s.get("status") == "submitted" and s.get("submitted_at") is not None]
+        completions = len(completed_sessions)
+
+        duration_secs: list[int] = []
+        for session in completed_sessions:
+            try:
+                started = int(session.get("started_at") or 0)
+                submitted = int(session.get("submitted_at") or 0)
+                if submitted >= started > 0:
+                    duration_secs.append(submitted - started)
+            except Exception:
+                continue
+
+        dropoffs: dict[str, int] = {}
+        for session in version_sessions:
+            if session.get("status") == "submitted":
+                continue
+            sec_idx = int(session.get("current_section_index") or 0)
+            sec_name = section_title_by_index.get(sec_idx, f"Section {sec_idx + 1}")
+            question_id = str(session.get("current_question_id") or "").strip()
+            key = f"{sec_name}{' / ' + question_id if question_id else ''}"
+            dropoffs[key] = dropoffs.get(key, 0) + 1
+            all_dropoffs[key] = all_dropoffs.get(key, 0) + 1
+
+        failure_events = [
+            event for event in events
+            if event.get("event_type") == "response_validation_failed" and event.get("payload", {}).get("version_id") == vid
+        ]
+        hotspots: dict[str, int] = {}
+        for event in failure_events:
+            keys = event.get("payload", {}).get("error_keys") or []
+            if not isinstance(keys, list):
+                continue
+            for key in keys:
+                k = str(key)
+                hotspots[k] = hotspots.get(k, 0) + 1
+                all_hotspots[k] = all_hotspots.get(k, 0) + 1
+
+        top_dropoffs = sorted(dropoffs.items(), key=lambda x: x[1], reverse=True)[:5]
+        top_hotspots = sorted(hotspots.items(), key=lambda x: x[1], reverse=True)[:5]
+        completion_rate = (completions / starts) if starts else 0.0
+
+        version_rows.append({
+            "version_id": vid,
+            "version_number": version.get("version_number"),
+            "published_at": version.get("published_at"),
+            "funnel": {"starts": starts, "completions": completions, "completion_rate": completion_rate},
+            "average_completion_seconds": (sum(duration_secs) / len(duration_secs)) if duration_secs else None,
+            "dropoff_points": [{"label": label, "count": count} for label, count in top_dropoffs],
+            "validation_hotspots": [{"key": key, "count": count} for key, count in top_hotspots],
+        })
+
+    return {
+        "generated_at": str(int(time.time())),
+        "freshness_sla_seconds": 60,
+        "versions": version_rows,
+        "totals": {
+            "starts": sum(v["funnel"]["starts"] for v in version_rows),
+            "completions": sum(v["funnel"]["completions"] for v in version_rows),
+            "top_dropoffs": [{"label": label, "count": count} for label, count in sorted(all_dropoffs.items(), key=lambda x: x[1], reverse=True)[:5]],
+            "top_validation_hotspots": [{"key": key, "count": count} for key, count in sorted(all_hotspots.items(), key=lambda x: x[1], reverse=True)[:5]],
+        },
+    }
+
+
+def _owned_questionnaire_or_404(questionnaire_id: str, user_sub: str) -> dict[str, Any]:
+    row = REPO.get_questionnaire(questionnaire_id)
+    if not row:
+        raise HTTPException(status_code=404, detail={"error": {"code": "questionnaire_not_found", "message": "questionnaire not found"}})
+    if row.get("owner_id") != user_sub:
+        raise HTTPException(status_code=403, detail={"error": {"code": "questionnaire_forbidden", "message": "not owner of questionnaire"}})
+    return row
+
+
+def _ensure_draft(questionnaire_id: str, user_sub: str) -> dict[str, Any]:
+    row = _owned_questionnaire_or_404(questionnaire_id, user_sub)
+    if row.get("status") != "draft":
+        raise HTTPException(status_code=409, detail={"error": {"code": "questionnaire_not_draft", "message": "only draft questionnaires are editable"}})
+    return row
+
+
+def _sanitize_question_text_fields(*, hint: str | None, config_json: dict[str, Any] | None) -> tuple[str | None, dict[str, Any] | None]:
+    out_hint = sanitize_user_text(hint) if hint is not None else None
+    if config_json is None:
+        return out_hint, None
+    out_cfg = dict(config_json)
+    if "placeholder" in out_cfg:
+        out_cfg["placeholder"] = sanitize_user_text(str(out_cfg.get("placeholder", "")), max_length=400)
+    if "help_text" in out_cfg:
+        out_cfg["help_text"] = sanitize_user_text(str(out_cfg.get("help_text", "")))
+    return out_hint, out_cfg
+
+
+
+
+async def _maybe_authenticated_user(request: Request) -> AuthenticatedUser | None:
+    try:
+        return await get_authenticated_user(request)
+    except HTTPException:
+        return None
+
+
+def _enforce_published_access(version: dict[str, Any], user: AuthenticatedUser | None) -> None:
+    visibility = version.get("visibility", "private")
+    if visibility == "private" and user is None:
+        raise HTTPException(status_code=401, detail={"error": {"code": "auth_required", "message": "authentication required for private questionnaire"}})
+
+
+def _enforce_session_access(version: dict[str, Any], session: dict[str, Any], user: AuthenticatedUser | None) -> None:
+    if session.get("respondent_id"):
+        if user is None:
+            raise HTTPException(status_code=401, detail={"error": {"code": "auth_required", "message": "authentication required for this response session"}})
+        if session.get("respondent_id") != user.sub:
+            raise HTTPException(status_code=403, detail={"error": {"code": "session_forbidden", "message": "not allowed"}})
+
+
+def _enforce_anonymous_submission_controls(*, request: Request, version: dict[str, Any], user: AuthenticatedUser | None, action: str) -> None:
+    if user is not None:
+        return
+    if not version.get("allow_anonymous", False):
+        return
+
+    if bool(getattr(S, "questionnaire_captcha_required_anonymous", False)):
+        token = request.headers.get("x-captcha-token", "")
+        expected = str(getattr(S, "questionnaire_captcha_static_token", "") or "")
+        if not expected or token != expected:
+            raise HTTPException(status_code=403, detail={"error": {"code": "captcha_required", "message": "captcha verification required"}})
+
+    ip = client_ip_from_request(request)
+    rate_limit_password_recovery(f"qnr:{version.get('questionnaire_id', 'unknown')}", ip, f"questionnaire_{action}")
+
+
+def _validate_question_config(question_type: str, config_json: dict[str, Any]) -> None:
+    if question_type not in _ALLOWED_TYPES:
+        raise HTTPException(status_code=422, detail={"error": {"code": "invalid_question_type", "message": "unsupported question type"}})
+    if question_type in {"select", "multiselect", "radio"}:
+        options = config_json.get("options")
+        if not isinstance(options, list) or not options:
+            raise HTTPException(status_code=422, detail={"error": {"code": "invalid_question_config", "message": "options[] is required for select/radio types"}})
+    if question_type == "slider":
+        if not all(k in config_json for k in ("min", "max", "step")):
+            raise HTTPException(status_code=422, detail={"error": {"code": "invalid_question_config", "message": "slider config requires min/max/step"}})
+    if question_type == "text":
+        for k in ("minLength", "maxLength"):
+            if k in config_json and not isinstance(config_json[k], int):
+                raise HTTPException(status_code=422, detail={"error": {"code": "invalid_question_config", "message": f"{k} must be an integer"}})
+
+
+@router.post("/drafts", response_model=QuestionnaireDraftEnvelope)
+def create_draft(
+    body: QuestionnaireDraftCreateReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    existing = REPO.get_questionnaire(body.questionnaire_id)
+    if existing:
+        raise HTTPException(status_code=409, detail={"error": {"code": "questionnaire_exists", "message": "questionnaire already exists"}})
+    created = REPO.create_draft(
+        questionnaire_id=body.questionnaire_id.strip(),
+        owner_id=user.sub,
+        title=body.title.strip(),
+        description=body.description.strip(),
+        visibility=body.visibility,
+        actor_sub=user.sub,
+    )
+    return {"draft": created}
+
+
+@router.get("/drafts", response_model=QuestionnaireDraftListEnvelope)
+def list_drafts(
+    include_archived: bool = Query(default=False),
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    rows = REPO.list_questionnaires_by_owner(user.sub, limit=100)
+    if not include_archived:
+        rows = [r for r in rows if r.get("status") != "archived"]
+    return {"items": rows}
+
+
+@router.get("/drafts/{questionnaire_id}", response_model=QuestionnaireDraftEnvelope)
+def get_draft(
+    questionnaire_id: str,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    row = _owned_questionnaire_or_404(questionnaire_id, user.sub)
+    return {"draft": row}
+
+
+@router.patch("/drafts/{questionnaire_id}", response_model=QuestionnaireDraftEnvelope)
+def update_draft(
+    questionnaire_id: str,
+    body: QuestionnaireDraftUpdateReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    updated = REPO.update_draft_metadata(
+        questionnaire_id=questionnaire_id,
+        owner_id=user.sub,
+        title=body.title.strip() if body.title is not None else None,
+        description=body.description.strip() if body.description is not None else None,
+        visibility=body.visibility,
+        actor_sub=user.sub,
+    )
+    return {"draft": updated}
+
+
+@router.delete("/drafts/{questionnaire_id}", response_model=QuestionnaireDraftEnvelope)
+def archive_draft(
+    questionnaire_id: str,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _owned_questionnaire_or_404(questionnaire_id, user.sub)
+    archived = REPO.archive_draft(questionnaire_id=questionnaire_id, owner_id=user.sub, actor_sub=user.sub)
+    return {"draft": archived}
+
+
+@router.post("/drafts/{questionnaire_id}/sections", response_model=SectionEnvelope)
+def create_section(
+    questionnaire_id: str,
+    body: SectionCreateReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    section = REPO.create_section(
+        questionnaire_id=questionnaire_id,
+        section_id=body.section_id.strip(),
+        title=body.title.strip(),
+        description=body.description.strip(),
+        actor_sub=user.sub,
+    )
+    return {"section": section}
+
+
+@router.get("/drafts/{questionnaire_id}/sections", response_model=SectionListEnvelope)
+def list_sections(
+    questionnaire_id: str,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _owned_questionnaire_or_404(questionnaire_id, user.sub)
+    return {"items": REPO.list_sections(questionnaire_id)}
+
+
+@router.patch("/drafts/{questionnaire_id}/sections/{section_id}", response_model=SectionEnvelope)
+def update_section(
+    questionnaire_id: str,
+    section_id: str,
+    body: SectionUpdateReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    section = REPO.update_section(
+        questionnaire_id=questionnaire_id,
+        section_id=section_id,
+        title=body.title.strip() if body.title is not None else None,
+        description=body.description.strip() if body.description is not None else None,
+        visibility=body.visibility,
+        actor_sub=user.sub,
+    )
+    if not section:
+        raise HTTPException(status_code=404, detail={"error": {"code": "section_not_found", "message": "section not found"}})
+    return {"section": section}
+
+
+@router.delete("/drafts/{questionnaire_id}/sections/{section_id}", response_model=SectionEnvelope)
+def delete_section(
+    questionnaire_id: str,
+    section_id: str,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    section = REPO.delete_section(questionnaire_id=questionnaire_id, section_id=section_id, actor_sub=user.sub)
+    if not section:
+        raise HTTPException(status_code=404, detail={"error": {"code": "section_not_found", "message": "section not found"}})
+    return {"section": section}
+
+
+@router.post("/drafts/{questionnaire_id}/sections/reorder", response_model=SectionListEnvelope)
+def reorder_sections(
+    questionnaire_id: str,
+    body: SectionReorderReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    current_ids = [s["section_id"] for s in REPO.list_sections(questionnaire_id)]
+    if set(current_ids) != set(body.section_ids):
+        raise HTTPException(status_code=422, detail={"error": {"code": "invalid_section_order", "message": "section_ids must match current section set"}})
+    return {"items": REPO.reorder_sections(questionnaire_id=questionnaire_id, ordered_section_ids=body.section_ids, actor_sub=user.sub)}
+
+
+@router.post("/drafts/{questionnaire_id}/questions", response_model=QuestionEnvelope)
+def create_question(
+    questionnaire_id: str,
+    body: QuestionCreateReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    section_ids = {s["section_id"] for s in REPO.list_sections(questionnaire_id)}
+    if body.section_id not in section_ids:
+        raise HTTPException(status_code=404, detail={"error": {"code": "section_not_found", "message": "section not found"}})
+    sanitized_hint, sanitized_config = _sanitize_question_text_fields(hint=body.hint.strip(), config_json=body.config_json)
+    _validate_question_config(body.type, sanitized_config or {})
+    question = REPO.create_question(
+        questionnaire_id=questionnaire_id,
+        section_id=body.section_id,
+        question_id=body.question_id,
+        question_type=body.type,
+        label=body.label.strip(),
+        required=body.required,
+        hint=sanitized_hint or "",
+        config_json=sanitized_config or {},
+        actor_sub=user.sub,
+    )
+    return {"question": question}
+
+
+@router.get("/drafts/{questionnaire_id}/sections/{section_id}/questions", response_model=QuestionListEnvelope)
+def list_questions(
+    questionnaire_id: str,
+    section_id: str,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _owned_questionnaire_or_404(questionnaire_id, user.sub)
+    return {"items": REPO.list_questions(questionnaire_id, section_id)}
+
+
+@router.patch("/drafts/{questionnaire_id}/questions/{question_id}", response_model=QuestionEnvelope)
+def update_question(
+    questionnaire_id: str,
+    question_id: str,
+    section_id: str = Query(...),
+    body: QuestionUpdateReq = ...,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    existing = REPO.list_questions(questionnaire_id, section_id, include_deleted=True)
+    target = next((q for q in existing if q.get("question_id") == question_id), None)
+    if not target:
+        raise HTTPException(status_code=404, detail={"error": {"code": "question_not_found", "message": "question not found"}})
+    raw_hint = body.hint.strip() if body.hint is not None else None
+    incoming_config = body.config_json if body.config_json is not None else None
+    sanitized_hint, sanitized_config = _sanitize_question_text_fields(hint=raw_hint, config_json=incoming_config)
+    new_config = sanitized_config if sanitized_config is not None else target.get("config_json", {})
+    _validate_question_config(target.get("type", "text"), new_config)
+    question = REPO.update_question(
+        questionnaire_id=questionnaire_id,
+        section_id=section_id,
+        question_id=question_id,
+        label=body.label.strip() if body.label is not None else None,
+        required=body.required,
+        hint=sanitized_hint,
+        config_json=sanitized_config,
+        actor_sub=user.sub,
+    )
+    return {"question": question}
+
+
+@router.delete("/drafts/{questionnaire_id}/questions/{question_id}", response_model=QuestionEnvelope)
+def delete_question(
+    questionnaire_id: str,
+    question_id: str,
+    section_id: str = Query(...),
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    question = REPO.delete_question(questionnaire_id=questionnaire_id, section_id=section_id, question_id=question_id, actor_sub=user.sub)
+    if not question:
+        raise HTTPException(status_code=404, detail={"error": {"code": "question_not_found", "message": "question not found"}})
+    return {"question": question}
+
+
+@router.post("/drafts/{questionnaire_id}/questions/reorder", response_model=QuestionListEnvelope)
+def reorder_questions(
+    questionnaire_id: str,
+    body: QuestionReorderReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    current_ids = [q["question_id"] for q in REPO.list_questions(questionnaire_id, body.section_id)]
+    if set(current_ids) != set(body.question_ids):
+        raise HTTPException(status_code=422, detail={"error": {"code": "invalid_question_order", "message": "question_ids must match current question set"}})
+    return {
+        "items": REPO.reorder_questions(
+            questionnaire_id=questionnaire_id,
+            section_id=body.section_id,
+            ordered_question_ids=body.question_ids,
+            actor_sub=user.sub,
+        )
+    }
+
+
+@router.get("/drafts/{questionnaire_id}/schema")
+def get_draft_schema(
+    questionnaire_id: str,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _owned_questionnaire_or_404(questionnaire_id, user.sub)
+    return REPO.build_schema_snapshot(questionnaire_id)
+
+
+@router.post("/drafts/{questionnaire_id}/publish", response_model=QuestionnaireVersionEnvelope)
+def publish_draft(
+    questionnaire_id: str,
+    body: PublishDraftReq,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _ensure_draft(questionnaire_id, user.sub)
+    try:
+        version = REPO.publish_draft(
+            questionnaire_id=questionnaire_id,
+            owner_id=user.sub,
+            actor_sub=user.sub,
+            published_slug=body.published_slug.strip() if body.published_slug else None,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail={"error": {"code": "questionnaire_forbidden", "message": str(exc)}}) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail={"error": {"code": "publish_failed", "message": str(exc)}}) from exc
+    return {"version": version}
+
+
+
+
+@router.get("/drafts/{questionnaire_id}/analytics", response_model=QuestionnaireAnalyticsEnvelope)
+def get_questionnaire_analytics(
+    questionnaire_id: str,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _owned_questionnaire_or_404(questionnaire_id, user.sub)
+    versions = REPO.list_versions(questionnaire_id)
+    analytics = _compute_questionnaire_analytics(questionnaire_id=questionnaire_id, versions=versions)
+    return {"analytics": analytics}
+
+@router.get("/published/{published_slug}", response_model=PublishedQuestionnaireEnvelope)
+async def get_published_by_slug(
+    published_slug: str,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+    return {"version": version}
+
+
+@router.get("/published/by-id/{questionnaire_id}", response_model=PublishedQuestionnaireEnvelope)
+async def get_published_by_questionnaire_id(
+    questionnaire_id: str,
+    request: Request,
+):
+    draft = REPO.get_questionnaire(questionnaire_id)
+    if not draft or not draft.get("published_version_id"):
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+    version = REPO.get_version_by_id(questionnaire_id, draft["published_version_id"])
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+    return {"version": version}
+
+
+@router.post("/published/{published_slug}/sessions", response_model=ResponseSessionEnvelope)
+async def start_response_session(
+    published_slug: str,
+    body: ResponseSessionStartReq,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+    if not version.get("allow_anonymous", False) and user is None:
+        raise HTTPException(status_code=401, detail={"error": {"code": "auth_required", "message": "authentication required to start session"}})
+    _enforce_anonymous_submission_controls(request=request, version=version, user=user, action="start")
+    session = REPO.put_response_session(
+        response_session_id=f"resp_{uuid4().hex}",
+        questionnaire_id=version["questionnaire_id"],
+        version_id=version["version_id"],
+        respondent_id=(user.sub if user else None),
+    )
+    return {"session": session}
+
+
+@router.get("/published/{published_slug}/sessions/{response_session_id}", response_model=SessionStateEnvelope)
+async def get_response_session_state(
+    published_slug: str,
+    response_session_id: str,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+
+    session = REPO.get_response_session(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+    _enforce_session_access(version, session, user)
+
+    answers = REPO.list_session_answers(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    return {"session": session, "answers_by_question_id": answers}
+
+
+@router.put("/published/{published_slug}/sessions/{response_session_id}", response_model=SessionStateEnvelope)
+async def save_response_session_state(
+    published_slug: str,
+    response_session_id: str,
+    body: SessionSaveReq,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+
+    session = REPO.get_response_session(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+    if session.get("status") != "in_progress":
+        raise HTTPException(status_code=409, detail={"error": {"code": "session_not_in_progress", "message": "cannot save submitted session"}})
+    _enforce_session_access(version, session, user)
+    _enforce_anonymous_submission_controls(request=request, version=version, user=user, action="save")
+
+    updated = REPO.save_session_answers(
+        questionnaire_id=version["questionnaire_id"],
+        response_session_id=response_session_id,
+        answers_by_question_id=body.answers_by_question_id,
+        current_section_index=body.current_section_index,
+        current_question_id=body.current_question_id,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+
+    answers = REPO.list_session_answers(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    return {"session": updated, "answers_by_question_id": answers}
+
+
+@router.post("/published/{published_slug}/sessions/{response_session_id}/validate", response_model=QuestionnaireValidationResponse)
+async def validate_response_session_state(
+    published_slug: str,
+    response_session_id: str,
+    body: QuestionnaireValidationRequest,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+
+    session = REPO.get_response_session(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+    _enforce_session_access(version, session, user)
+    _enforce_anonymous_submission_controls(request=request, version=version, user=user, action="validate")
+
+    session_version = REPO.get_version_by_id(version["questionnaire_id"], str(session.get("version_id") or ""))
+    if not session_version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_version_not_found", "message": "response session version not found"}})
+
+    try:
+        result = validate_form_submission(
+            schema_json=session_version.get("schema_json", {}),
+            answers_by_question_id=body.answers_by_question_id,
+            group_rules=body.group_rules,
+            form_rules=body.form_rules,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail={"error": {"code": "invalid_rule_reference", "message": str(exc)}}) from exc
+
+    if body.final_submit and not result.get("can_submit", False):
+        REPO.put_response_event(
+            questionnaire_id=version["questionnaire_id"],
+            response_session_id=response_session_id,
+            event_type="response_validation_failed",
+            payload={
+                "version_id": session_version.get("version_id"),
+                "error_keys": list((result.get("errors") or {}).keys()),
+                "can_submit": result.get("can_submit", False),
+            },
+            actor_sub=(user.sub if user else None),
+        )
+        raise HTTPException(status_code=422, detail={"error": {"code": "form_validation_failed", "result": result}})
+    return result
+
+
+@router.post("/published/{published_slug}/sessions/{response_session_id}/submit", response_model=SessionSubmitEnvelope)
+async def submit_response_session(
+    published_slug: str,
+    response_session_id: str,
+    body: QuestionnaireValidationRequest,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+
+    session = REPO.get_response_session(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+    _enforce_session_access(version, session, user)
+    _enforce_anonymous_submission_controls(request=request, version=version, user=user, action="submit")
+    if session.get("status") != "in_progress":
+        raise HTTPException(status_code=409, detail={"error": {"code": "session_not_in_progress", "message": "session already submitted"}})
+
+    if body.answers_by_question_id:
+        REPO.save_session_answers(
+            questionnaire_id=version["questionnaire_id"],
+            response_session_id=response_session_id,
+            answers_by_question_id=body.answers_by_question_id,
+            current_section_index=session.get("current_section_index"),
+            current_question_id=session.get("current_question_id"),
+        )
+
+    authoritative_answers = REPO.list_session_answers(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    final_request = QuestionnaireValidationRequest(
+        answers_by_question_id=authoritative_answers,
+        group_rules=body.group_rules,
+        form_rules=body.form_rules,
+        final_submit=True,
+    )
+    result = await validate_response_session_state(published_slug, response_session_id, final_request, request)
+
+    submitted = REPO.mark_response_submitted(
+        questionnaire_id=version["questionnaire_id"],
+        response_session_id=response_session_id,
+        actor_sub=(user.sub if user else None),
+    )
+    if not submitted:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+    return {"session": submitted, "result": result}
+
+
+
+
+@router.post("/published/{published_slug}/sessions/{response_session_id}/pdf", response_model=SessionPdfEnvelope)
+async def generate_response_session_pdf(
+    published_slug: str,
+    response_session_id: str,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+
+    session = REPO.get_response_session(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+    _enforce_session_access(version, session, user)
+    if session.get("status") != "submitted":
+        raise HTTPException(status_code=409, detail={"error": {"code": "session_not_submitted", "message": "session must be submitted"}})
+
+    session_version = REPO.get_version_by_id(version["questionnaire_id"], str(session.get("version_id") or ""))
+    if not session_version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_version_not_found", "message": "response session version not found"}})
+
+    questionnaire = REPO.get_questionnaire(version["questionnaire_id"]) or {}
+    answers = REPO.list_session_answers(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    rendered_html = render_response_html(questionnaire=questionnaire, version=session_version, session=session, answers_by_question_id=answers)
+    pdf_bytes = html_to_pdf_bytes(rendered_html)
+    artifact = REPO.put_response_pdf_artifact(
+        questionnaire_id=version["questionnaire_id"],
+        response_session_id=response_session_id,
+        pdf_bytes=pdf_bytes,
+        generated_by=(user.sub if user else None),
+    )
+    return {"artifact": {
+        "response_session_id": response_session_id,
+        "content_type": artifact.get("content_type"),
+        "generated_at": artifact.get("generated_at"),
+        "size_bytes": artifact.get("size_bytes"),
+        "download_url": f"/questionnaires/published/{published_slug}/sessions/{response_session_id}/pdf",
+    }}
+
+
+@router.get("/published/{published_slug}/sessions/{response_session_id}/pdf")
+async def download_response_session_pdf(
+    published_slug: str,
+    response_session_id: str,
+    request: Request,
+):
+    version = REPO.get_published_by_slug(published_slug)
+    if not version:
+        raise HTTPException(status_code=404, detail={"error": {"code": "published_not_found", "message": "published questionnaire not found"}})
+
+    user = await _maybe_authenticated_user(request)
+    _enforce_published_access(version, user)
+
+    session = REPO.get_response_session(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail={"error": {"code": "session_not_found", "message": "response session not found"}})
+    _enforce_session_access(version, session, user)
+
+    artifact = REPO.get_response_pdf_artifact(questionnaire_id=version["questionnaire_id"], response_session_id=response_session_id)
+    if not artifact or not artifact.get("pdf_base64"):
+        raise HTTPException(status_code=404, detail={"error": {"code": "pdf_not_found", "message": "response pdf not generated"}})
+
+    try:
+        pdf_bytes = base64.b64decode(str(artifact.get("pdf_base64") or ""), validate=True)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"error": {"code": "pdf_corrupt", "message": "stored response pdf is corrupt"}}) from exc
+
+    filename = f"questionnaire-response-{response_session_id}.pdf"
+    return Response(content=pdf_bytes, media_type="application/pdf", headers={"Content-Disposition": f'attachment; filename="{filename}"'})
+
+@router.post("/drafts/{questionnaire_id}/validate", response_model=QuestionnaireValidationResponse)
+def validate_draft_form(
+    questionnaire_id: str,
+    body: QuestionnaireValidationRequest,
+    _ctx: dict[str, str] = Depends(require_ui_session),
+    user: AuthenticatedUser = Depends(get_authenticated_user),
+):
+    _owned_questionnaire_or_404(questionnaire_id, user.sub)
+    schema = REPO.build_schema_snapshot(questionnaire_id)
+    try:
+        result = validate_form_submission(
+            schema_json=schema,
+            answers_by_question_id=body.answers_by_question_id,
+            group_rules=body.group_rules,
+            form_rules=body.form_rules,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail={"error": {"code": "invalid_rule_reference", "message": str(exc)}}) from exc
+
+    if body.final_submit and not result.get("can_submit", False):
+        raise HTTPException(status_code=422, detail={"error": {"code": "form_validation_failed", "result": result}})
+    return result

--- a/app/services/questionnaire_response_pdf.py
+++ b/app/services/questionnaire_response_pdf.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import html
+import re
+from typing import Any
+
+
+def render_response_html(*, questionnaire: dict[str, Any], version: dict[str, Any], session: dict[str, Any], answers_by_question_id: dict[str, Any]) -> str:
+    schema = (version or {}).get("schema_json") or {}
+    sections = schema.get("sections") or []
+
+    parts: list[str] = [
+        "<html><head><meta charset='utf-8'><title>Questionnaire Response</title></head><body>",
+        f"<h1>{html.escape(str(questionnaire.get('title') or schema.get('questionnaire_id') or 'Questionnaire'))}</h1>",
+        f"<p><strong>Questionnaire ID:</strong> {html.escape(str(schema.get('questionnaire_id') or questionnaire.get('questionnaire_id') or ''))}</p>",
+        f"<p><strong>Session ID:</strong> {html.escape(str(session.get('response_session_id') or ''))}</p>",
+        f"<p><strong>Version ID:</strong> {html.escape(str(version.get('version_id') or ''))}</p>",
+        f"<p><strong>Submitted At:</strong> {html.escape(str(session.get('submitted_at') or ''))}</p>",
+    ]
+
+    for i, section in enumerate(sections, start=1):
+        section_title = str(section.get("title") or f"Section {i}")
+        parts.append(f"<h2>{html.escape(section_title)}</h2><ul>")
+        for question in section.get("questions") or []:
+            qid = str(question.get("question_id") or "")
+            label = str(question.get("label") or qid or "Question")
+            value = answers_by_question_id.get(qid)
+            if value is None:
+                rendered = "—"
+            elif isinstance(value, list):
+                rendered = ", ".join(str(v) for v in value) if value else "—"
+            elif isinstance(value, dict):
+                rendered = str(value)
+            else:
+                rendered = str(value)
+            if not rendered.strip():
+                rendered = "—"
+            parts.append(f"<li><strong>{html.escape(label)}</strong>: {html.escape(rendered)}</li>")
+        parts.append("</ul>")
+
+    parts.append("</body></html>")
+    return "".join(parts)
+
+
+def _pdf_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def html_to_pdf_bytes(rendered_html: str) -> bytes:
+    plain_text = re.sub(r"<[^>]+>", "", rendered_html)
+    lines = [line.strip() for line in plain_text.splitlines() if line.strip()]
+    content_lines = ["BT", "/F1 11 Tf", "72 760 Td", "14 TL"]
+    for line in lines[:400]:
+        content_lines.append(f"({_pdf_escape(line[:2000])}) Tj")
+        content_lines.append("T*")
+    content_lines.append("ET")
+    stream = "\n".join(content_lines).encode("utf-8")
+
+    objects = [
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n",
+        b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+        f"5 0 obj\n<< /Length {len(stream)} >>\nstream\n".encode("utf-8") + stream + b"\nendstream\nendobj\n",
+    ]
+
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf.extend(obj)
+    xref_offset = len(pdf)
+    pdf.extend(f"xref\n0 {len(objects) + 1}\n".encode("utf-8"))
+    pdf.extend(b"0000000000 65535 f \n")
+    for offset in offsets:
+        pdf.extend(f"{offset:010d} 00000 n \n".encode("utf-8"))
+    pdf.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n".encode("utf-8")
+    )
+    return bytes(pdf)

--- a/app/services/questionnaire_validation.py
+++ b/app/services/questionnaire_validation.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, Field
+
+from app.contracts.questionnaire_validation_contract import VALIDATION_CONTRACT_VERSION
+
+ERROR_CATALOG: dict[str, str] = {
+    "required": "Answer is required.",
+    "invalid_type": "Answer has an invalid type.",
+    "invalid_option": "Answer is not one of the allowed options.",
+    "too_short": "Answer is shorter than minimum length.",
+    "too_long": "Answer is longer than maximum length.",
+    "pattern_mismatch": "Answer does not match required pattern.",
+    "too_few_choices": "Too few options selected.",
+    "too_many_choices": "Too many options selected.",
+    "below_min": "Answer is below minimum value.",
+    "above_max": "Answer is above maximum value.",
+    "invalid_step": "Answer does not match slider step increment.",
+    "invalid_date_format": "Answer must be in YYYY-MM-DD format.",
+    "invalid_time_format": "Answer must be in HH:MM format.",
+    "invalid_timezone": "Answer is not a valid IANA timezone.",
+    "invalid_address": "Answer must be an object with expected address fields.",
+    "missing_address_field": "Address is missing a required field.",
+    "group_min_answered": "Not enough questions in the group were answered.",
+    "group_dependency_required": "Required dependent answers are missing.",
+    "group_mutually_exclusive": "Only one question in this group can be answered.",
+    "group_rule_invalid_reference": "Group rule references unknown question IDs.",
+    "form_dependency_required": "Form-level dependent answers are missing.",
+    "form_mutually_exclusive": "Form-level exclusivity constraint violated.",
+    "form_rule_invalid_reference": "Form rule references unknown question IDs.",
+}
+
+GroupRuleType = Literal["min_answered", "requires_if_answered", "mutually_exclusive"]
+FormRuleType = Literal["requires_if_answered", "mutually_exclusive"]
+
+
+class GroupValidationRule(BaseModel):
+    rule_id: str = Field(..., min_length=1)
+    group_id: str = Field(..., min_length=1)
+    rule_type: GroupRuleType
+    question_ids: list[str] = Field(default_factory=list)
+    config_json: dict[str, Any] = Field(default_factory=dict)
+
+
+class FormValidationRule(BaseModel):
+    rule_id: str = Field(..., min_length=1)
+    rule_type: FormRuleType
+    config_json: dict[str, Any] = Field(default_factory=dict)
+    blocking: bool = True
+
+
+def validate_question_answers(schema_json: dict[str, Any], answers_by_question_id: dict[str, Any]) -> dict[str, list[dict[str, str]]]:
+    """Validate answer payload against questionnaire schema snapshot.
+
+    Returns structured errors keyed by question_id.
+    """
+    errors: dict[str, list[dict[str, str]]] = {}
+    for question in _iter_questions(schema_json):
+        question_id = str(question.get("question_id", "")).strip()
+        if not question_id:
+            continue
+        q_errors = _validate_single_question(question, answers_by_question_id.get(question_id))
+        if q_errors:
+            errors[question_id] = q_errors
+    return errors
+
+
+def validate_with_group_rules(
+    schema_json: dict[str, Any],
+    answers_by_question_id: dict[str, Any],
+    group_rules: list[dict[str, Any]] | None = None,
+) -> dict[str, list[dict[str, str]]]:
+    """Run question-level validators and merge group-level rule failures into a unified error map.
+
+    Group-level errors are keyed by `group:<group_id>` so UIs can render separately from per-question errors.
+    """
+    merged = validate_question_answers(schema_json, answers_by_question_id)
+    if not group_rules:
+        return merged
+
+    questions_by_id = {q["question_id"]: q for q in _iter_questions(schema_json) if q.get("question_id")}
+    group_errors = evaluate_group_rules(group_rules, answers_by_question_id, questions_by_id)
+    for key, errs in group_errors.items():
+        merged.setdefault(key, []).extend(errs)
+    return merged
+
+
+def validate_form_submission(
+    *,
+    schema_json: dict[str, Any],
+    answers_by_question_id: dict[str, Any],
+    group_rules: list[dict[str, Any]] | None = None,
+    form_rules: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Run question->group->form validations and return a submission-ready result payload."""
+    merged = validate_with_group_rules(
+        schema_json=schema_json,
+        answers_by_question_id=answers_by_question_id,
+        group_rules=group_rules,
+    )
+    questions_by_id = {q["question_id"]: q for q in _iter_questions(schema_json) if q.get("question_id")}
+
+    form_errors = evaluate_form_rules(
+        form_rules=form_rules or [],
+        answers_by_question_id=answers_by_question_id,
+        questions_by_id=questions_by_id,
+    )
+    for key, errs in form_errors.items():
+        merged.setdefault(key, []).extend(errs)
+
+    has_blocking_form_error = any(err.get("blocking") for errs in form_errors.values() for err in errs)
+    return {
+        "contract_version": VALIDATION_CONTRACT_VERSION,
+        "errors": merged,
+        "is_valid": not merged,
+        "can_submit": not has_blocking_form_error and not any(k.startswith("form:") for k in merged),
+        "has_blocking_form_error": has_blocking_form_error,
+    }
+
+
+def evaluate_group_rules(
+    group_rules: list[dict[str, Any]],
+    answers_by_question_id: dict[str, Any],
+    questions_by_id: dict[str, dict[str, Any]],
+) -> dict[str, list[dict[str, str]]]:
+    errors: dict[str, list[dict[str, str]]] = {}
+    for raw_rule in group_rules:
+        rule = GroupValidationRule.model_validate(raw_rule)
+        scoped_question_ids = rule.question_ids or [qid for qid in questions_by_id.keys()]
+        unknown = [qid for qid in scoped_question_ids if qid not in questions_by_id]
+        if unknown:
+            raise ValueError(f"{ERROR_CATALOG['group_rule_invalid_reference']}: {','.join(unknown)}")
+
+        key = f"group:{rule.group_id}"
+        rule_errors: list[dict[str, str]] = []
+
+        if rule.rule_type == "min_answered":
+            minimum = int(rule.config_json.get("min_answered", 1))
+            answered_count = sum(1 for qid in scoped_question_ids if not _is_empty(answers_by_question_id.get(qid)))
+            if answered_count < minimum:
+                rule_errors.append(
+                    _error(
+                        "group_min_answered",
+                        f"At least {minimum} answers required in group '{rule.group_id}', got {answered_count}.",
+                    )
+                )
+
+        if rule.rule_type == "requires_if_answered":
+            trigger_question_id = str(rule.config_json.get("if_question_id", "")).strip()
+            required_question_ids = [str(v) for v in rule.config_json.get("required_question_ids", []) if isinstance(v, str)]
+            unknown_required = [qid for qid in [trigger_question_id, *required_question_ids] if qid and qid not in questions_by_id]
+            if unknown_required:
+                raise ValueError(f"{ERROR_CATALOG['group_rule_invalid_reference']}: {','.join(unknown_required)}")
+            if trigger_question_id and not _is_empty(answers_by_question_id.get(trigger_question_id)):
+                missing = [qid for qid in required_question_ids if _is_empty(answers_by_question_id.get(qid))]
+                if missing:
+                    rule_errors.append(
+                        _error(
+                            "group_dependency_required",
+                            f"Question(s) {', '.join(missing)} required because '{trigger_question_id}' was answered.",
+                        )
+                    )
+
+        if rule.rule_type == "mutually_exclusive":
+            answered = [qid for qid in scoped_question_ids if not _is_empty(answers_by_question_id.get(qid))]
+            if len(answered) > 1:
+                rule_errors.append(
+                    _error(
+                        "group_mutually_exclusive",
+                        f"Questions {', '.join(answered)} cannot be answered together in group '{rule.group_id}'.",
+                    )
+                )
+
+        if rule_errors:
+            errors.setdefault(key, []).extend(rule_errors)
+    return errors
+
+
+def evaluate_form_rules(
+    *,
+    form_rules: list[dict[str, Any]],
+    answers_by_question_id: dict[str, Any],
+    questions_by_id: dict[str, dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    errors: dict[str, list[dict[str, Any]]] = {}
+    for raw_rule in form_rules:
+        rule = FormValidationRule.model_validate(raw_rule)
+        rule_errors: list[dict[str, Any]] = []
+        key = f"form:{rule.rule_id}"
+
+        if rule.rule_type == "requires_if_answered":
+            trigger_question_id = str(rule.config_json.get("if_question_id", "")).strip()
+            required_question_ids = [str(v) for v in rule.config_json.get("required_question_ids", []) if isinstance(v, str)]
+            unknown_refs = [qid for qid in [trigger_question_id, *required_question_ids] if qid and qid not in questions_by_id]
+            if unknown_refs:
+                raise ValueError(f"{ERROR_CATALOG['form_rule_invalid_reference']}: {','.join(unknown_refs)}")
+            if trigger_question_id and not _is_empty(answers_by_question_id.get(trigger_question_id)):
+                missing = [qid for qid in required_question_ids if _is_empty(answers_by_question_id.get(qid))]
+                if missing:
+                    rule_errors.append(
+                        {
+                            **_error(
+                                "form_dependency_required",
+                                f"Form rule '{rule.rule_id}' requires {', '.join(missing)} when {trigger_question_id} is answered.",
+                            ),
+                            "blocking": rule.blocking,
+                            "rule_id": rule.rule_id,
+                        }
+                    )
+
+        if rule.rule_type == "mutually_exclusive":
+            question_ids = [str(v) for v in rule.config_json.get("question_ids", []) if isinstance(v, str)]
+            unknown_refs = [qid for qid in question_ids if qid not in questions_by_id]
+            if unknown_refs:
+                raise ValueError(f"{ERROR_CATALOG['form_rule_invalid_reference']}: {','.join(unknown_refs)}")
+            answered = [qid for qid in question_ids if not _is_empty(answers_by_question_id.get(qid))]
+            if len(answered) > 1:
+                rule_errors.append(
+                    {
+                        **_error(
+                            "form_mutually_exclusive",
+                            f"Form rule '{rule.rule_id}' requires mutual exclusivity; answered: {', '.join(answered)}.",
+                        ),
+                        "blocking": rule.blocking,
+                        "rule_id": rule.rule_id,
+                    }
+                )
+
+        if rule_errors:
+            errors.setdefault(key, []).extend(rule_errors)
+    return errors
+
+
+def _iter_questions(schema_json: dict[str, Any]):
+    for section in schema_json.get("sections", []) or []:
+        for question in section.get("questions", []) or []:
+            yield question
+
+
+def _error(code: str, message: str | None = None) -> dict[str, str]:
+    return {"code": code, "message": message or ERROR_CATALOG[code]}
+
+
+def _is_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def _validate_single_question(question: dict[str, Any], value: Any) -> list[dict[str, str]]:
+    q_type = str(question.get("type", "text"))
+    config = question.get("config_json") or {}
+    required = bool(question.get("required", False))
+
+    if required and _is_empty(value):
+        return [_error("required")]
+    if _is_empty(value):
+        return []
+
+    if q_type == "text":
+        return _validate_text(value, config)
+    if q_type in {"select", "radio"}:
+        return _validate_select(value, config)
+    if q_type == "multiselect":
+        return _validate_multiselect(value, config)
+    if q_type == "slider":
+        return _validate_slider(value, config)
+    if q_type == "date":
+        return _validate_date(value)
+    if q_type == "time":
+        return _validate_time(value)
+    if q_type == "timezone":
+        return _validate_timezone(value)
+    if q_type == "address":
+        return _validate_address(value, config)
+    return [_error("invalid_type", "Unsupported question type.")]
+
+
+def _validate_text(value: Any, config: dict[str, Any]) -> list[dict[str, str]]:
+    if not isinstance(value, str):
+        return [_error("invalid_type")]
+    out: list[dict[str, str]] = []
+    min_len = config.get("minLength")
+    max_len = config.get("maxLength")
+    pattern = config.get("pattern")
+    if isinstance(min_len, int) and len(value) < min_len:
+        out.append(_error("too_short"))
+    if isinstance(max_len, int) and len(value) > max_len:
+        out.append(_error("too_long"))
+    if isinstance(pattern, str) and pattern:
+        if re.fullmatch(pattern, value) is None:
+            out.append(_error("pattern_mismatch"))
+    return out
+
+
+def _validate_select(value: Any, config: dict[str, Any]) -> list[dict[str, str]]:
+    options = config.get("options")
+    if not isinstance(value, str):
+        return [_error("invalid_type")]
+    if not isinstance(options, list):
+        return [_error("invalid_option")]
+    if value not in options:
+        return [_error("invalid_option")]
+    return []
+
+
+def _validate_multiselect(value: Any, config: dict[str, Any]) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return [_error("invalid_type")]
+    options = config.get("options")
+    if not isinstance(options, list):
+        return [_error("invalid_option")]
+
+    out: list[dict[str, str]] = []
+    if any(v not in options for v in value):
+        out.append(_error("invalid_option"))
+
+    min_sel = config.get("minSelections")
+    max_sel = config.get("maxSelections")
+    if isinstance(min_sel, int) and len(value) < min_sel:
+        out.append(_error("too_few_choices"))
+    if isinstance(max_sel, int) and len(value) > max_sel:
+        out.append(_error("too_many_choices"))
+    return out
+
+
+def _validate_slider(value: Any, config: dict[str, Any]) -> list[dict[str, str]]:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return [_error("invalid_type")]
+
+    out: list[dict[str, str]] = []
+    min_v = config.get("min")
+    max_v = config.get("max")
+    step = config.get("step")
+
+    in_range = True
+    if isinstance(min_v, (int, float)) and value < min_v:
+        out.append(_error("below_min"))
+        in_range = False
+    if isinstance(max_v, (int, float)) and value > max_v:
+        out.append(_error("above_max"))
+        in_range = False
+    if in_range and isinstance(step, (int, float)) and step > 0 and isinstance(min_v, (int, float)):
+        delta = (float(value) - float(min_v)) / float(step)
+        if abs(delta - round(delta)) > 1e-9:
+            out.append(_error("invalid_step"))
+    return out
+
+
+def _validate_date(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, str):
+        return [_error("invalid_type")]
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return [_error("invalid_date_format")]
+    return []
+
+
+def _validate_time(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, str):
+        return [_error("invalid_type")]
+    try:
+        datetime.strptime(value, "%H:%M")
+    except ValueError:
+        return [_error("invalid_time_format")]
+    return []
+
+
+def _validate_timezone(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, str):
+        return [_error("invalid_type")]
+    try:
+        ZoneInfo(value)
+    except ZoneInfoNotFoundError:
+        return [_error("invalid_timezone")]
+    return []
+
+
+def _validate_address(value: Any, config: dict[str, Any]) -> list[dict[str, str]]:
+    if not isinstance(value, dict):
+        return [_error("invalid_address")]
+
+    required_fields = config.get("requiredFields")
+    if not isinstance(required_fields, list) or not required_fields:
+        required_fields = ["line1", "city", "country"]
+
+    out: list[dict[str, str]] = []
+    for field_name in required_fields:
+        if not isinstance(field_name, str):
+            continue
+        field_val = value.get(field_name)
+        if not isinstance(field_val, str) or field_val.strip() == "":
+            out.append(_error("missing_address_field", f"Address is missing required field: {field_name}."))
+    return out

--- a/app/services/questionnaires_repository.py
+++ b/app/services/questionnaires_repository.py
@@ -1,0 +1,713 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import base64
+import json
+from uuid import uuid4
+from typing import Any, Protocol
+
+from app.core.crypto import kms_decrypt, kms_encrypt
+from app.core.settings import S
+from app.core.tables import T
+from app.core.time import now_ts
+
+
+class QuestionnaireRepository(Protocol):
+    def get_questionnaire(self, questionnaire_id: str) -> dict[str, Any] | None: ...
+    def create_draft(self, *, questionnaire_id: str, owner_id: str, title: str, description: str = "", visibility: str = "private", actor_sub: str) -> dict[str, Any]: ...
+    def update_draft_metadata(self, *, questionnaire_id: str, owner_id: str, title: str | None = None, description: str | None = None, visibility: str | None = None, actor_sub: str) -> dict[str, Any] | None: ...
+    def archive_draft(self, *, questionnaire_id: str, owner_id: str, actor_sub: str) -> dict[str, Any] | None: ...
+    def rebind_response_version(self, *, questionnaire_id: str, response_session_id: str, new_version_id: str) -> dict[str, Any] | None: ...
+    def list_questionnaires_by_owner(self, owner_id: str, *, limit: int = 25) -> list[dict[str, Any]]: ...
+    def list_questionnaires_by_status(self, status: str, *, limit: int = 25) -> list[dict[str, Any]]: ...
+    def get_published_by_slug(self, published_slug: str) -> dict[str, Any] | None: ...
+    def list_response_sessions_by_status(self, status: str, *, limit: int = 25) -> list[dict[str, Any]]: ...
+    def publish_draft(self, *, questionnaire_id: str, owner_id: str, actor_sub: str, published_slug: str | None = None) -> dict[str, Any]: ...
+    def get_response_session(self, *, questionnaire_id: str, response_session_id: str) -> dict[str, Any] | None: ...
+    def list_session_answers(self, *, questionnaire_id: str, response_session_id: str) -> dict[str, Any]: ...
+    def save_session_answers(self, *, questionnaire_id: str, response_session_id: str, answers_by_question_id: dict[str, Any], current_section_index: int | None = None, current_question_id: str | None = None) -> dict[str, Any] | None: ...
+    def mark_response_submitted(self, *, questionnaire_id: str, response_session_id: str, actor_sub: str | None = None) -> dict[str, Any] | None: ...
+    def put_response_pdf_artifact(self, *, questionnaire_id: str, response_session_id: str, pdf_bytes: bytes, generated_by: str | None = None) -> dict[str, Any]: ...
+    def get_response_pdf_artifact(self, *, questionnaire_id: str, response_session_id: str) -> dict[str, Any] | None: ...
+    def list_response_sessions(self, *, questionnaire_id: str) -> list[dict[str, Any]]: ...
+    def put_response_event(self, *, questionnaire_id: str, response_session_id: str, event_type: str, payload: dict[str, Any] | None = None, actor_sub: str | None = None) -> dict[str, Any]: ...
+    def list_response_events(self, *, questionnaire_id: str, response_session_id: str | None = None, event_type: str | None = None) -> list[dict[str, Any]]: ...
+
+
+@dataclass
+class DynamoQuestionnaireRepository:
+    _table: Any = field(default=T.questionnaires)
+
+    def get_questionnaire(self, questionnaire_id: str) -> dict[str, Any] | None:
+        return self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": "META"}).get("Item")
+
+    def create_draft(self, *, questionnaire_id: str, owner_id: str, title: str, description: str = "", visibility: str = "private", actor_sub: str) -> dict[str, Any]:
+        return self.put_questionnaire(
+            questionnaire_id=questionnaire_id,
+            owner_id=owner_id,
+            title=title,
+            description=description,
+            visibility=visibility,
+            actor_sub=actor_sub,
+        )
+
+    def update_draft_metadata(self, *, questionnaire_id: str, owner_id: str, title: str | None = None, description: str | None = None, visibility: str | None = None, actor_sub: str) -> dict[str, Any] | None:
+        existing = self.get_questionnaire(questionnaire_id)
+        if not existing or existing.get("owner_id") != owner_id:
+            return None
+        ts = str(now_ts())
+        assignments = ["updated_at=:updated_at", "updated_by=:updated_by", "gsi_owner_sk=:gsi_owner_sk", "gsi_status_sk=:gsi_status_sk"]
+        values: dict[str, Any] = {
+            ":updated_at": ts,
+            ":updated_by": actor_sub,
+            ":gsi_owner_sk": _updated_sk(ts, questionnaire_id),
+            ":gsi_status_sk": _updated_sk(ts, questionnaire_id),
+        }
+        if title is not None:
+            assignments.append("title=:title")
+            values[":title"] = title
+        if description is not None:
+            assignments.append("description=:description")
+            values[":description"] = description
+        if visibility is not None:
+            assignments.append("visibility=:visibility")
+            values[":visibility"] = visibility
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": "META"},
+            UpdateExpression="SET " + ", ".join(assignments),
+            ExpressionAttributeValues=values,
+        )
+        return self.get_questionnaire(questionnaire_id)
+
+    def archive_draft(self, *, questionnaire_id: str, owner_id: str, actor_sub: str) -> dict[str, Any] | None:
+        existing = self.get_questionnaire(questionnaire_id)
+        if not existing or existing.get("owner_id") != owner_id:
+            return None
+        ts = str(now_ts())
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": "META"},
+            UpdateExpression="SET #status=:archived, archived_at=:archived_at, archived_by=:archived_by, updated_at=:updated_at, updated_by=:updated_by, gsi_status_pk=:gsi_status_pk, gsi_status_sk=:gsi_status_sk",
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={
+                ":archived": "archived",
+                ":archived_at": ts,
+                ":archived_by": actor_sub,
+                ":updated_at": ts,
+                ":updated_by": actor_sub,
+                ":gsi_status_pk": _status_pk("archived"),
+                ":gsi_status_sk": _updated_sk(ts, questionnaire_id),
+            },
+        )
+        return self.get_questionnaire(questionnaire_id)
+
+    def put_questionnaire(self, *, questionnaire_id: str, owner_id: str, title: str, description: str = "", visibility: str = "private", actor_sub: str | None = None) -> dict[str, Any]:
+        ts = str(now_ts())
+        actor_sub = actor_sub or owner_id
+        item = {
+            "pk": _q_pk(questionnaire_id),
+            "sk": "META",
+            "entity_type": "questionnaire",
+            "questionnaire_id": questionnaire_id,
+            "owner_id": owner_id,
+            "title": title,
+            "description": description,
+            "status": "draft",
+            "visibility": visibility,
+            "published_version_id": None,
+            "created_at": ts,
+            "updated_at": ts,
+            "created_by": actor_sub,
+            "updated_by": actor_sub,
+            "gsi_owner_pk": _owner_pk(owner_id),
+            "gsi_owner_sk": _updated_sk(ts, questionnaire_id),
+            "gsi_status_pk": _status_pk("draft"),
+            "gsi_status_sk": _updated_sk(ts, questionnaire_id),
+        }
+        self._table.put_item(Item=item)
+        return item
+
+    def create_section(self, *, questionnaire_id: str, section_id: str, title: str, description: str, actor_sub: str) -> dict[str, Any]:
+        ts = str(now_ts())
+        sections = self.list_sections(questionnaire_id)
+        item = {
+            "pk": _q_pk(questionnaire_id),
+            "sk": _section_sk(section_id),
+            "entity_type": "section",
+            "questionnaire_id": questionnaire_id,
+            "section_id": section_id,
+            "title": title,
+            "description": description,
+            "position": len(sections),
+            "created_at": ts,
+            "updated_at": ts,
+            "created_by": actor_sub,
+            "updated_by": actor_sub,
+            "deleted_at": None,
+        }
+        self._table.put_item(Item=item)
+        return item
+
+    def list_sections(self, questionnaire_id: str, *, include_deleted: bool = False) -> list[dict[str, Any]]:
+        items = self._table.query(
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :sk_prefix)",
+            ExpressionAttributeValues={":pk": _q_pk(questionnaire_id), ":sk_prefix": "SECTION#"},
+            ScanIndexForward=True,
+        ).get("Items", [])
+        rows = [r for r in items if r.get("entity_type") == "section"]
+        if not include_deleted:
+            rows = [r for r in rows if not r.get("deleted_at")]
+        return sorted(rows, key=lambda r: int(r.get("position", 0)))
+
+    def update_section(self, *, questionnaire_id: str, section_id: str, title: str | None, description: str | None, actor_sub: str) -> dict[str, Any] | None:
+        existing = self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _section_sk(section_id)}).get("Item")
+        if not existing or existing.get("deleted_at"):
+            return None
+        ts = str(now_ts())
+        assignments = ["updated_at=:updated_at", "updated_by=:updated_by"]
+        values: dict[str, Any] = {":updated_at": ts, ":updated_by": actor_sub}
+        if title is not None:
+            assignments.append("title=:title")
+            values[":title"] = title
+        if description is not None:
+            assignments.append("description=:description")
+            values[":description"] = description
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": _section_sk(section_id)},
+            UpdateExpression="SET " + ", ".join(assignments),
+            ExpressionAttributeValues=values,
+        )
+        return self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _section_sk(section_id)}).get("Item")
+
+    def delete_section(self, *, questionnaire_id: str, section_id: str, actor_sub: str) -> dict[str, Any] | None:
+        existing = self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _section_sk(section_id)}).get("Item")
+        if not existing or existing.get("deleted_at"):
+            return None
+        ts = str(now_ts())
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": _section_sk(section_id)},
+            UpdateExpression="SET deleted_at=:deleted_at, deleted_by=:deleted_by, updated_at=:updated_at, updated_by=:updated_by",
+            ExpressionAttributeValues={":deleted_at": ts, ":deleted_by": actor_sub, ":updated_at": ts, ":updated_by": actor_sub},
+        )
+        return self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _section_sk(section_id)}).get("Item")
+
+    def reorder_sections(self, *, questionnaire_id: str, ordered_section_ids: list[str], actor_sub: str) -> list[dict[str, Any]]:
+        ts = str(now_ts())
+        for pos, section_id in enumerate(ordered_section_ids):
+            self._table.update_item(
+                Key={"pk": _q_pk(questionnaire_id), "sk": _section_sk(section_id)},
+                UpdateExpression="SET position=:position, updated_at=:updated_at, updated_by=:updated_by",
+                ExpressionAttributeValues={":position": pos, ":updated_at": ts, ":updated_by": actor_sub},
+            )
+        return self.list_sections(questionnaire_id)
+
+    def create_question(
+        self,
+        *,
+        questionnaire_id: str,
+        section_id: str,
+        question_id: str,
+        question_type: str,
+        label: str,
+        required: bool,
+        hint: str,
+        config_json: dict[str, Any],
+        actor_sub: str,
+    ) -> dict[str, Any]:
+        ts = str(now_ts())
+        section_questions = self.list_questions(questionnaire_id, section_id)
+        item = {
+            "pk": _q_pk(questionnaire_id),
+            "sk": _question_sk(section_id, question_id),
+            "entity_type": "question",
+            "questionnaire_id": questionnaire_id,
+            "section_id": section_id,
+            "question_id": question_id,
+            "type": question_type,
+            "label": label,
+            "required": required,
+            "hint": hint,
+            "config_json": config_json,
+            "position": len(section_questions),
+            "created_at": ts,
+            "updated_at": ts,
+            "created_by": actor_sub,
+            "updated_by": actor_sub,
+            "deleted_at": None,
+        }
+        self._table.put_item(Item=item)
+        return item
+
+    def list_questions(self, questionnaire_id: str, section_id: str, *, include_deleted: bool = False) -> list[dict[str, Any]]:
+        items = self._table.query(
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :sk_prefix)",
+            ExpressionAttributeValues={":pk": _q_pk(questionnaire_id), ":sk_prefix": f"QUESTION#{section_id}#"},
+            ScanIndexForward=True,
+        ).get("Items", [])
+        rows = [r for r in items if r.get("entity_type") == "question" and r.get("section_id") == section_id]
+        if not include_deleted:
+            rows = [r for r in rows if not r.get("deleted_at")]
+        return sorted(rows, key=lambda r: int(r.get("position", 0)))
+
+    def update_question(
+        self,
+        *,
+        questionnaire_id: str,
+        section_id: str,
+        question_id: str,
+        label: str | None,
+        required: bool | None,
+        hint: str | None,
+        config_json: dict[str, Any] | None,
+        actor_sub: str,
+    ) -> dict[str, Any] | None:
+        existing = self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _question_sk(section_id, question_id)}).get("Item")
+        if not existing or existing.get("deleted_at"):
+            return None
+        ts = str(now_ts())
+        assignments = ["updated_at=:updated_at", "updated_by=:updated_by"]
+        values: dict[str, Any] = {":updated_at": ts, ":updated_by": actor_sub}
+        if label is not None:
+            assignments.append("label=:label")
+            values[":label"] = label
+        if required is not None:
+            assignments.append("required=:required")
+            values[":required"] = required
+        if hint is not None:
+            assignments.append("hint=:hint")
+            values[":hint"] = hint
+        if config_json is not None:
+            assignments.append("config_json=:config_json")
+            values[":config_json"] = config_json
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": _question_sk(section_id, question_id)},
+            UpdateExpression="SET " + ", ".join(assignments),
+            ExpressionAttributeValues=values,
+        )
+        return self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _question_sk(section_id, question_id)}).get("Item")
+
+    def delete_question(self, *, questionnaire_id: str, section_id: str, question_id: str, actor_sub: str) -> dict[str, Any] | None:
+        existing = self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _question_sk(section_id, question_id)}).get("Item")
+        if not existing or existing.get("deleted_at"):
+            return None
+        ts = str(now_ts())
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": _question_sk(section_id, question_id)},
+            UpdateExpression="SET deleted_at=:deleted_at, deleted_by=:deleted_by, updated_at=:updated_at, updated_by=:updated_by",
+            ExpressionAttributeValues={":deleted_at": ts, ":deleted_by": actor_sub, ":updated_at": ts, ":updated_by": actor_sub},
+        )
+        return self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": _question_sk(section_id, question_id)}).get("Item")
+
+    def reorder_questions(self, *, questionnaire_id: str, section_id: str, ordered_question_ids: list[str], actor_sub: str) -> list[dict[str, Any]]:
+        ts = str(now_ts())
+        for pos, question_id in enumerate(ordered_question_ids):
+            self._table.update_item(
+                Key={"pk": _q_pk(questionnaire_id), "sk": _question_sk(section_id, question_id)},
+                UpdateExpression="SET position=:position, updated_at=:updated_at, updated_by=:updated_by",
+                ExpressionAttributeValues={":position": pos, ":updated_at": ts, ":updated_by": actor_sub},
+            )
+        return self.list_questions(questionnaire_id, section_id)
+
+    def build_schema_snapshot(self, questionnaire_id: str) -> dict[str, Any]:
+        sections = self.list_sections(questionnaire_id)
+        snapshot_sections: list[dict[str, Any]] = []
+        for section in sections:
+            questions = self.list_questions(questionnaire_id, section["section_id"])  # excludes deleted
+            snapshot_sections.append(
+                {
+                    "section_id": section["section_id"],
+                    "title": section.get("title", ""),
+                    "description": section.get("description", ""),
+                    "position": section.get("position", 0),
+                    "questions": [
+                        {
+                            "question_id": q["question_id"],
+                            "section_id": q["section_id"],
+                            "type": q.get("type", "text"),
+                            "label": q.get("label", ""),
+                            "required": bool(q.get("required", False)),
+                            "hint": q.get("hint", ""),
+                            "config_json": q.get("config_json", {}),
+                            "position": q.get("position", 0),
+                        }
+                        for q in questions
+                    ],
+                }
+            )
+        return {"questionnaire_id": questionnaire_id, "sections": snapshot_sections}
+
+    def list_versions(self, questionnaire_id: str) -> list[dict[str, Any]]:
+        items = self._table.query(
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :sk_prefix)",
+            ExpressionAttributeValues={":pk": _q_pk(questionnaire_id), ":sk_prefix": "VERSION#"},
+            ScanIndexForward=True,
+        ).get("Items", [])
+        rows = [r for r in items if r.get("entity_type") == "questionnaire_version"]
+        return sorted(rows, key=lambda r: int(r.get("version_number", 0)))
+
+    def get_version_by_id(self, questionnaire_id: str, version_id: str) -> dict[str, Any] | None:
+        for row in self.list_versions(questionnaire_id):
+            if row.get("version_id") == version_id:
+                return row
+        return None
+
+    def publish_draft(self, *, questionnaire_id: str, owner_id: str, actor_sub: str, published_slug: str | None = None) -> dict[str, Any]:
+        draft = self.get_questionnaire(questionnaire_id)
+        if not draft:
+            raise ValueError("questionnaire_not_found")
+        if draft.get("owner_id") != owner_id:
+            raise PermissionError("questionnaire_forbidden")
+        if draft.get("status") == "archived":
+            raise ValueError("questionnaire_archived")
+
+        versions = self.list_versions(questionnaire_id)
+        next_version_number = (int(versions[-1]["version_number"]) + 1) if versions else 1
+        version_id = f"ver_{uuid4().hex}"
+        slug = (published_slug or draft.get("questionnaire_id") or questionnaire_id).strip()
+        schema_json = self.build_schema_snapshot(questionnaire_id)
+        return self.put_version(
+            questionnaire_id=questionnaire_id,
+            version_id=version_id,
+            version_number=next_version_number,
+            schema_json=schema_json,
+            published_slug=slug,
+            actor_sub=actor_sub,
+        )
+
+    def put_version(
+        self,
+        *,
+        questionnaire_id: str,
+        version_id: str,
+        version_number: int,
+        schema_json: dict[str, Any],
+        published_slug: str,
+        actor_sub: str | None = None,
+    ) -> dict[str, Any]:
+        ts = str(now_ts())
+        item = {
+            "pk": _q_pk(questionnaire_id),
+            "sk": f"VERSION#{version_number:06d}",
+            "entity_type": "questionnaire_version",
+            "questionnaire_id": questionnaire_id,
+            "version_id": version_id,
+            "version_number": version_number,
+            "schema_json": schema_json,
+            "published_slug": published_slug,
+            "published_at": ts,
+            "published_by": actor_sub,
+            "visibility": (self.get_questionnaire(questionnaire_id) or {}).get("visibility", "private"),
+            "allow_anonymous": (self.get_questionnaire(questionnaire_id) or {}).get("visibility", "private") != "private",
+            "gsi_published_pk": _published_pk(published_slug),
+            "gsi_published_sk": f"VERSION#{version_number:06d}",
+        }
+        self._table.put_item(Item=item)
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": "META"},
+            UpdateExpression="SET #status=:status, published_version_id=:version_id, updated_at=:updated, gsi_status_pk=:gsi_status_pk, gsi_status_sk=:gsi_status_sk",
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={
+                ":status": "published",
+                ":version_id": version_id,
+                ":updated": ts,
+                ":gsi_status_pk": _status_pk("published"),
+                ":gsi_status_sk": _updated_sk(ts, questionnaire_id),
+            },
+        )
+        return item
+
+    def put_response_session(self, *, response_session_id: str, questionnaire_id: str, version_id: str, respondent_id: str | None = None) -> dict[str, Any]:
+        ts = str(now_ts())
+        item = {
+            "pk": _q_pk(questionnaire_id),
+            "sk": f"RESP#{response_session_id}",
+            "entity_type": "response_session",
+            "response_session_id": response_session_id,
+            "questionnaire_id": questionnaire_id,
+            "version_id": version_id,
+            "respondent_id": respondent_id,
+            "status": "in_progress",
+            "started_at": ts,
+            "submitted_at": None,
+            "current_section_index": 0,
+            "gsi_response_status_pk": _response_status_pk("in_progress"),
+            "gsi_response_status_sk": _updated_sk(ts, response_session_id),
+        }
+        self._table.put_item(Item=item)
+        return item
+
+    def mark_response_submitted(self, *, questionnaire_id: str, response_session_id: str, actor_sub: str | None = None) -> dict[str, Any] | None:
+        key = {"pk": _q_pk(questionnaire_id), "sk": f"RESP#{response_session_id}"}
+        item = self._table.get_item(Key=key).get("Item")
+        if not item:
+            return None
+
+        ts = str(now_ts())
+        if item.get("status") != "submitted":
+            self._table.update_item(
+                Key=key,
+                ConditionExpression="#status=:in_progress",
+                UpdateExpression="SET #status=:submitted, submitted_at=:submitted_at, gsi_response_status_pk=:gsi_response_status_pk, gsi_response_status_sk=:gsi_response_status_sk",
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":in_progress": "in_progress",
+                    ":submitted": "submitted",
+                    ":submitted_at": ts,
+                    ":gsi_response_status_pk": _response_status_pk("submitted"),
+                    ":gsi_response_status_sk": _updated_sk(ts, response_session_id),
+                },
+            )
+            item = self._table.get_item(Key=key).get("Item")
+
+        self.put_response_event(
+            questionnaire_id=questionnaire_id,
+            response_session_id=response_session_id,
+            event_type="response_session_submitted",
+            payload={"status": item.get("status"), "version_id": item.get("version_id")},
+            actor_sub=actor_sub,
+        )
+        return item
+
+    def put_response_pdf_artifact(self, *, questionnaire_id: str, response_session_id: str, pdf_bytes: bytes, generated_by: str | None = None) -> dict[str, Any]:
+        ts = str(now_ts())
+        item = {
+            "pk": _q_pk(questionnaire_id),
+            "sk": f"PDF#RESP#{response_session_id}",
+            "entity_type": "response_session_pdf",
+            "questionnaire_id": questionnaire_id,
+            "response_session_id": response_session_id,
+            "content_type": "application/pdf",
+            "pdf_base64": base64.b64encode(pdf_bytes).decode("ascii"),
+            "size_bytes": len(pdf_bytes),
+            "generated_at": ts,
+            "generated_by": generated_by,
+        }
+        self._table.put_item(Item=item)
+        return item
+
+    def get_response_pdf_artifact(self, *, questionnaire_id: str, response_session_id: str) -> dict[str, Any] | None:
+        return self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": f"PDF#RESP#{response_session_id}"}).get("Item")
+
+    def list_response_sessions(self, *, questionnaire_id: str) -> list[dict[str, Any]]:
+        items = self._table.query(
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :sk_prefix)",
+            ExpressionAttributeValues={":pk": _q_pk(questionnaire_id), ":sk_prefix": "RESP#"},
+            ScanIndexForward=True,
+        ).get("Items", [])
+        rows = [row for row in items if row.get("entity_type") == "response_session"]
+        return sorted(rows, key=lambda row: int(row.get("started_at", 0)))
+
+    def put_response_event(self, *, questionnaire_id: str, response_session_id: str, event_type: str, payload: dict[str, Any] | None = None, actor_sub: str | None = None) -> dict[str, Any]:
+        ts = str(now_ts())
+        item = {
+            "pk": _q_pk(questionnaire_id),
+            "sk": f"EVENT#RESP#{response_session_id}#{event_type}#{ts}",
+            "entity_type": "response_session_audit_event",
+            "questionnaire_id": questionnaire_id,
+            "response_session_id": response_session_id,
+            "event_type": event_type,
+            "event_at": ts,
+            "actor_sub": actor_sub,
+            "payload": payload or {},
+        }
+        self._table.put_item(Item=item)
+        return item
+
+    def list_response_events(self, *, questionnaire_id: str, response_session_id: str | None = None, event_type: str | None = None) -> list[dict[str, Any]]:
+        items = self._table.query(
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :sk_prefix)",
+            ExpressionAttributeValues={":pk": _q_pk(questionnaire_id), ":sk_prefix": "EVENT#RESP#"},
+            ScanIndexForward=True,
+        ).get("Items", [])
+        rows = [row for row in items if row.get("entity_type") == "response_session_audit_event"]
+        if response_session_id is not None:
+            rows = [row for row in rows if row.get("response_session_id") == response_session_id]
+        if event_type is not None:
+            rows = [row for row in rows if row.get("event_type") == event_type]
+        return rows
+
+    def rebind_response_version(self, *, questionnaire_id: str, response_session_id: str, new_version_id: str) -> dict[str, Any] | None:
+        """Allows rebinding only before submit; submitted responses remain immutable."""
+        key = {"pk": _q_pk(questionnaire_id), "sk": f"RESP#{response_session_id}"}
+        item = self._table.get_item(Key=key).get("Item")
+        if not item:
+            return None
+        if item.get("status") == "submitted":
+            raise ValueError("submitted response sessions cannot be reassigned to another version")
+        self._table.update_item(
+            Key=key,
+            UpdateExpression="SET version_id=:version_id",
+            ExpressionAttributeValues={":version_id": new_version_id},
+        )
+        return self._table.get_item(Key=key).get("Item")
+
+    def get_response_session(self, *, questionnaire_id: str, response_session_id: str) -> dict[str, Any] | None:
+        return self._table.get_item(Key={"pk": _q_pk(questionnaire_id), "sk": f"RESP#{response_session_id}"}).get("Item")
+
+    def _sensitive_question_ids_for_version(self, *, questionnaire_id: str, version_id: str) -> set[str]:
+        version = self.get_version_by_id(questionnaire_id, version_id)
+        if not version:
+            return set()
+        schema = version.get("schema_json") or {}
+        sensitive_types = {"address", "date", "time", "timezone"}
+        out: set[str] = set()
+        for section in schema.get("sections") or []:
+            for question in section.get("questions") or []:
+                qid = str(question.get("question_id") or "")
+                qtype = str(question.get("type") or "")
+                if qid and qtype in sensitive_types:
+                    out.add(qid)
+        return out
+
+    def _encrypt_sensitive_answer(self, value: Any) -> str:
+        return kms_encrypt(json.dumps(value, separators=(",", ":")))
+
+    def _decrypt_sensitive_answer(self, ciphertext_b64: str) -> Any:
+        try:
+            plaintext = kms_decrypt(ciphertext_b64).decode("utf-8")
+            return json.loads(plaintext)
+        except Exception:
+            return None
+
+    def list_session_answers(self, *, questionnaire_id: str, response_session_id: str) -> dict[str, Any]:
+        items = self._table.query(
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :sk_prefix)",
+            ExpressionAttributeValues={":pk": _q_pk(questionnaire_id), ":sk_prefix": f"ANSWER#{response_session_id}#"},
+            ScanIndexForward=True,
+        ).get("Items", [])
+        answers: dict[str, Any] = {}
+        for row in items:
+            if row.get("entity_type") != "answer":
+                continue
+            qid = str(row.get("question_id", ""))
+            if not qid:
+                continue
+            if row.get("value_encrypted"):
+                answers[qid] = self._decrypt_sensitive_answer(str(row.get("value_enc") or ""))
+            else:
+                answers[qid] = row.get("value")
+        return answers
+
+    def save_session_answers(
+        self,
+        *,
+        questionnaire_id: str,
+        response_session_id: str,
+        answers_by_question_id: dict[str, Any],
+        current_section_index: int | None = None,
+        current_question_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        session = self.get_response_session(questionnaire_id=questionnaire_id, response_session_id=response_session_id)
+        if not session:
+            return None
+        if session.get("status") != "in_progress":
+            return session
+
+        ts = str(now_ts())
+        sensitive_question_ids = self._sensitive_question_ids_for_version(
+            questionnaire_id=questionnaire_id,
+            version_id=str(session.get("version_id") or ""),
+        )
+        encrypt_sensitive = bool(getattr(S, "questionnaire_encrypt_sensitive_answers", False))
+
+        for question_id, value in (answers_by_question_id or {}).items():
+            item = {
+                "pk": _q_pk(questionnaire_id),
+                "sk": f"ANSWER#{response_session_id}#{question_id}",
+                "entity_type": "answer",
+                "questionnaire_id": questionnaire_id,
+                "response_session_id": response_session_id,
+                "question_id": question_id,
+                "updated_at": ts,
+            }
+            if encrypt_sensitive and question_id in sensitive_question_ids:
+                item["value_encrypted"] = True
+                item["value_enc"] = self._encrypt_sensitive_answer(value)
+            else:
+                item["value_encrypted"] = False
+                item["value"] = value
+            self._table.put_item(Item=item)
+
+        assignments = ["last_saved_at=:last_saved_at"]
+        values: dict[str, Any] = {":last_saved_at": ts}
+        if current_section_index is not None:
+            assignments.append("current_section_index=:current_section_index")
+            values[":current_section_index"] = max(0, int(current_section_index))
+        if current_question_id is not None:
+            assignments.append("current_question_id=:current_question_id")
+            values[":current_question_id"] = current_question_id
+
+        self._table.update_item(
+            Key={"pk": _q_pk(questionnaire_id), "sk": f"RESP#{response_session_id}"},
+            UpdateExpression="SET " + ", ".join(assignments),
+            ExpressionAttributeValues=values,
+        )
+        return self.get_response_session(questionnaire_id=questionnaire_id, response_session_id=response_session_id)
+
+    def list_questionnaires_by_owner(self, owner_id: str, *, limit: int = 25) -> list[dict[str, Any]]:
+        return self._table.query(
+            IndexName=S.questionnaire_owner_index_name,
+            KeyConditionExpression="gsi_owner_pk = :pk",
+            ExpressionAttributeValues={":pk": _owner_pk(owner_id)},
+            Limit=max(1, min(int(limit or 25), 100)),
+            ScanIndexForward=False,
+        ).get("Items", [])
+
+    def list_questionnaires_by_status(self, status: str, *, limit: int = 25) -> list[dict[str, Any]]:
+        return self._table.query(
+            IndexName=S.questionnaire_status_index_name,
+            KeyConditionExpression="gsi_status_pk = :pk",
+            ExpressionAttributeValues={":pk": _status_pk(status)},
+            Limit=max(1, min(int(limit or 25), 100)),
+            ScanIndexForward=False,
+        ).get("Items", [])
+
+    def get_published_by_slug(self, published_slug: str) -> dict[str, Any] | None:
+        rows = self._table.query(
+            IndexName=S.questionnaire_published_index_name,
+            KeyConditionExpression="gsi_published_pk = :pk",
+            ExpressionAttributeValues={":pk": _published_pk(published_slug)},
+            Limit=1,
+            ScanIndexForward=False,
+        ).get("Items", [])
+        return rows[0] if rows else None
+
+    def list_response_sessions_by_status(self, status: str, *, limit: int = 25) -> list[dict[str, Any]]:
+        return self._table.query(
+            IndexName=S.questionnaire_response_status_index_name,
+            KeyConditionExpression="gsi_response_status_pk = :pk",
+            ExpressionAttributeValues={":pk": _response_status_pk(status)},
+            Limit=max(1, min(int(limit or 25), 100)),
+            ScanIndexForward=False,
+        ).get("Items", [])
+
+
+def _q_pk(questionnaire_id: str) -> str:
+    return f"QNR#{questionnaire_id}"
+
+
+def _owner_pk(owner_id: str) -> str:
+    return f"OWNER#{owner_id}"
+
+
+def _status_pk(status: str) -> str:
+    return f"STATUS#{status}"
+
+
+def _published_pk(slug: str) -> str:
+    return f"PUBLISHED#{slug}"
+
+
+def _response_status_pk(status: str) -> str:
+    return f"RESPONSE_STATUS#{status}"
+
+
+def _section_sk(section_id: str) -> str:
+    return f"SECTION#{section_id}"
+
+
+def _question_sk(section_id: str, question_id: str) -> str:
+    return f"QUESTION#{section_id}#{question_id}"
+
+
+def _updated_sk(updated_at: str, object_id: str) -> str:
+    return f"UPDATED#{updated_at}#{object_id}"

--- a/app/services/text_sanitizer.py
+++ b/app/services/text_sanitizer.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import html
+import re
+
+_SCRIPT_STYLE_RE = re.compile(r"<\s*(script|style)\b[^>]*>.*?<\s*/\s*\1\s*>", re.IGNORECASE | re.DOTALL)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def sanitize_user_text(value: str | None, *, max_length: int = 4000) -> str:
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+
+    cleaned = _SCRIPT_STYLE_RE.sub("", raw)
+    cleaned = _TAG_RE.sub("", cleaned)
+    cleaned = html.unescape(cleaned)
+    cleaned = cleaned.replace("\x00", "").strip()
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length]
+    return cleaned

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,84 @@ This service is a FastAPI backend for security workflows (sessions, MFA, alerts)
 - **CCBill**: Tokenizes cards via the Advanced Widget and reconciles via `/api/ccbill/webhook`.
 - **Ledger model**: Billing transactions are recorded in the DynamoDB billing table using ledger entries plus payment records.
 
+## Questionnaire data model (QNR-001 ERD)
+The questionnaire feature uses a single DynamoDB table (`questionnaires`) with typed entities and indexed access paths.
+
+```mermaid
+erDiagram
+    Questionnaire ||--o{ QuestionnaireVersion : publishes
+    QuestionnaireVersion ||--o{ Section : contains
+    Section ||--o{ Question : contains
+    QuestionnaireVersion ||--o{ ValidationRule : enforces
+    QuestionnaireVersion ||--o{ ResponseSession : receives
+    ResponseSession ||--o{ Answer : records
+
+    Questionnaire {
+      string questionnaire_id PK
+      string owner_id
+      string status
+      string published_version_id
+      datetime created_at
+      datetime updated_at
+    }
+
+    QuestionnaireVersion {
+      string version_id PK
+      string questionnaire_id FK
+      int version_number
+      json schema_json
+      datetime published_at
+      string published_slug
+    }
+
+    Section {
+      string section_id PK
+      string version_id FK
+      string title
+      int position
+    }
+
+    Question {
+      string question_id PK
+      string section_id FK
+      string type
+      bool required
+      int position
+    }
+
+    ValidationRule {
+      string rule_id PK
+      string version_id FK
+      string scope
+      string rule_type
+      json rule_config_json
+    }
+
+    ResponseSession {
+      string response_session_id PK
+      string version_id FK
+      string status
+      datetime started_at
+      datetime submitted_at
+    }
+
+    Answer {
+      string answer_id PK
+      string response_session_id FK
+      string question_id FK
+      json value_json
+      bool is_valid
+    }
+```
+
+### Access/index strategy
+- Owner lookup index: list questionnaires by creator.
+- Questionnaire status index: list drafts/published/archived.
+- Published lookup index: resolve published questionnaire schema by slug.
+- Response status index: monitor in-progress/submitted response sessions.
+
+These indexes are created in local bootstrap (`scripts/local-ddb-init.py`) and migration tooling (`scripts/migrations/20260302_questionnaire_schema.py`).
+
 ## Observability and metrics
 The service exposes Prometheus-style metrics via `app/metrics.py` (if enabled), tracking request counts, latency, and sizes.
 

--- a/docs/questionnaire-accessibility-audit.md
+++ b/docs/questionnaire-accessibility-audit.md
@@ -1,0 +1,27 @@
+# Questionnaire Accessibility & UX Conformance Audit (QNR-023)
+
+## Scope
+- Creator flow: `QuestionnaireBuilderPage`
+- Respondent flow: `QuestionnaireRespondentPage`
+
+## Checks performed
+- Keyboard-only interaction for core navigation and edit flows.
+- Semantic labels and form-control linkage.
+- ARIA announcements for validation/save/navigation states.
+- Error summary and inline error announcement behavior.
+- Contrast/screen-reader checks documented for core states (manual spot-check + component test assertions).
+
+## Remediations implemented
+- Added ARIA status/live regions for save and navigation state updates.
+- Added explicit `htmlFor` / `id` linkage and `aria-invalid` + `aria-describedby` on respondent inputs when errors exist.
+- Added alert semantics (`role="alert"`) for blocking/group/form summary errors.
+- Added focus management on section/summary transitions in respondent flow.
+- Added assistive-text notes (`role="note"`) for preview hint/help text in builder flow.
+
+## Freshness / CI practical automation
+- Added UI test assertions for ARIA roles/attributes in both builder/respondent test suites.
+- Included TypeScript/lint and Vitest checks in validation commands.
+
+## Result
+- No critical accessibility blockers remain in audited questionnaire builder/respondent launch paths.
+- Remaining future improvements: full automated axe scan in CI and dedicated color-contrast snapshot checks.

--- a/docs/questionnaire-implementation-tickets.md
+++ b/docs/questionnaire-implementation-tickets.md
@@ -1,0 +1,552 @@
+# Questionnaire Creator & Viewer — Implementation Tickets
+
+This ticket set converts `questionnaire_implementation_plan.md` into delivery-ready engineering work. Tickets are grouped by epic and include scope, deliverables, and acceptance criteria.
+
+## Epic 1: Foundations, Data Model, and Versioning
+
+### QNR-001 — Define questionnaire domain schema and migrations
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** None
+
+**Scope**
+- Create persistent models for `Questionnaire`, `QuestionnaireVersion`, `Section`, `Question`, `ValidationRule`, `ResponseSession`, and `Answer`.
+- Add migration scripts and indexes (owner, questionnaire status, published lookup, response status).
+- Capture immutable version linkage so responses always bind to a version.
+
+**Deliverables**
+- DB migrations.
+- ORM models + repository interfaces.
+- ERD update in architecture docs.
+
+**Acceptance Criteria**
+- Migrations apply cleanly on new and existing environments.
+- A submitted response references a published `QuestionnaireVersion` and cannot be reassigned.
+- Query latency for fetch-by-published-id and fetch-response-session is within target SLO.
+
+---
+
+### QNR-002 — Implement questionnaire draft CRUD APIs
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-001
+
+**Scope**
+- Add API endpoints for creating, reading, and updating questionnaire metadata in draft state.
+- Enforce owner authorization and audit metadata.
+- Add soft-delete/archive draft behavior.
+
+**Deliverables**
+- Draft CRUD endpoints.
+- Service-layer ownership checks.
+- API contract tests.
+
+**Acceptance Criteria**
+- Owners can create and modify drafts.
+- Non-owners receive 403 for draft modifications.
+- Archived drafts are excluded from default list views.
+
+---
+
+### QNR-003 — Add section and question composition APIs with ordering
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-002
+
+**Scope**
+- Implement create/update/delete/reorder for sections and questions.
+- Persist deterministic `position` ordering.
+- Validate payload shape per question type.
+
+**Deliverables**
+- Section/question management endpoints.
+- Reorder operations (bulk move).
+- Serialization tests for schema output.
+
+**Acceptance Criteria**
+- Reordering survives refresh and publish.
+- Deleted questions are not included in published snapshots.
+- Invalid type-specific config returns a clear 4xx validation error.
+
+---
+
+### QNR-004 — Publish workflow and immutable version snapshots
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-003
+
+**Scope**
+- Implement `publish` operation that snapshots full questionnaire schema.
+- Increment version numbers and record publish metadata.
+- Prevent edits to published versions.
+
+**Deliverables**
+- Publish endpoint + service logic.
+- Version snapshot generation utility.
+- Tests for immutability and version increments.
+
+**Acceptance Criteria**
+- Publishing a draft creates a new immutable version record.
+- Existing responses remain mapped to the exact prior version.
+- Any attempt to mutate published version returns explicit error.
+
+---
+
+## Epic 2: Validation Engine and Rule Contracts
+
+### QNR-005 — Implement question-level validation engine
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-001
+
+**Scope**
+- Build validators for required checks and type-specific constraints.
+- Support text, select, multiselect, radio, slider, date, time, timezone, and address validations.
+- Return structured error payload keyed by question ID.
+
+**Deliverables**
+- Validation library for question-level rules.
+- Error code catalog for field-level failures.
+- Unit tests for each question type.
+
+**Acceptance Criteria**
+- Invalid values produce deterministic error codes and messages.
+- Valid answers pass regardless of page order.
+- Unit coverage includes edge boundaries for min/max and format checks.
+
+---
+
+### QNR-006 — Implement group-level validation rules
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-005
+
+**Scope**
+- Add group/page-level rules (e.g., at least N answered, dependency requirements, exclusivity constraints).
+- Allow creators to target explicit group IDs.
+- Merge group errors into the unified error map.
+
+**Deliverables**
+- Group rule evaluator.
+- Group rule schema definitions.
+- Integration tests for group scenarios.
+
+**Acceptance Criteria**
+- Group constraints evaluate correctly with partially completed sections.
+- Group-level errors can be rendered independently from question-level errors.
+- Rule definitions reject unknown references.
+
+---
+
+### QNR-007 — Implement form-level validation rules
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-006
+
+**Scope**
+- Add cross-section rule execution for global constraints.
+- Support conditional rules (`if A then B`) spanning different sections.
+- Run form-level evaluation during final submit and optional pre-submit checks.
+
+**Deliverables**
+- Form rule evaluator.
+- API support for full-form validate endpoint.
+- Regression tests for cross-section dependencies.
+
+**Acceptance Criteria**
+- Form-level rules execute after question/group rules.
+- Submission is blocked when blocking form-level violations exist.
+- Error payload clearly differentiates form-level from field/group violations.
+
+---
+
+### QNR-008 — Shared validation contract for frontend/backend
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-005, QNR-006, QNR-007
+
+**Scope**
+- Define a shared schema/contract for validation requests and responses.
+- Ensure frontend and backend consume the same error code taxonomy.
+- Add compatibility/versioning for rule evolution.
+
+**Deliverables**
+- Typed validation contract artifact.
+- Contract tests across API and frontend client.
+- Contract versioning documentation.
+
+**Acceptance Criteria**
+- Frontend can render all validation scopes without custom per-endpoint adapters.
+- Contract tests fail on incompatible schema changes.
+- Backward-compatible changes are documented and versioned.
+
+---
+
+## Epic 3: Creator Experience (Builder UI)
+
+### QNR-009 — Build questionnaire metadata and section management UI
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-002, QNR-003
+
+**Scope**
+- Implement creator UI for title/description/visibility and section CRUD.
+- Add drag/reorder for sections with autosave.
+- Include empty-state and unsaved-change indicators.
+
+**Deliverables**
+- Builder shell page.
+- Section list/editor components.
+- UI tests for section operations.
+
+**Acceptance Criteria**
+- Creators can add/remove/reorder sections in draft mode.
+- Autosave persists section edits without page refresh loss.
+- UI prevents accidental navigation with unsaved edits.
+
+---
+
+### QNR-010 — Build question editor for all required input types
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-009
+
+**Scope**
+- Add question cards/forms for text, select, multiselect, radio, slider, date, time, timezone, and address.
+- Support type-specific config fields (options, min/max, step, constraints).
+- Add in-editor validation for malformed configs.
+
+**Deliverables**
+- Question editor components per type.
+- Shared question config schema bindings.
+- Component tests for each type editor.
+
+**Acceptance Criteria**
+- Creator can configure each required question type end-to-end.
+- Invalid config cannot be saved.
+- Persisted question config rehydrates correctly in editor.
+
+---
+
+### QNR-011 — Add custom hint/help text and placeholder controls
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-010
+
+**Scope**
+- Add fields for hint/help text and placeholder text at question level.
+- Ensure rendering on respondent screens with accessibility semantics.
+- Sanitize stored rich/plain text to prevent injection.
+
+**Deliverables**
+- Builder hint/placeholder controls.
+- Safe rendering pipeline and sanitization tests.
+- Accessibility checks for hint associations.
+
+**Acceptance Criteria**
+- Hint text appears under corresponding question in preview/respondent flows.
+- Sanitization removes disallowed markup/scripts.
+- Screen readers correctly announce hint text via ARIA linkage.
+
+---
+
+### QNR-012 — Add validation rule builder UI (question/group/form)
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-006, QNR-007, QNR-010
+
+**Scope**
+- Build UI to define validation rules at all three scopes.
+- Provide templates for common conditions (required-if, at-least-one, min/max).
+- Display evaluation preview against sample answers.
+
+**Deliverables**
+- Rule builder component set.
+- Rule template library.
+- UI integration tests for save/load/edit flows.
+
+**Acceptance Criteria**
+- Creators can create/edit/delete rules across all scopes.
+- Saved rules are reloaded in equivalent editable form.
+- Invalid rule graph references are blocked with actionable feedback.
+
+---
+
+### QNR-013 — Implement creator preview mode and publish controls
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-004, QNR-010, QNR-012
+
+**Scope**
+- Add in-product preview mode that mirrors respondent journey.
+- Surface readiness checks before publishing.
+- Implement publish confirmation with version summary.
+
+**Deliverables**
+- Preview mode route/state.
+- Publish modal/checklist UI.
+- End-to-end test for draft→preview→publish.
+
+**Acceptance Criteria**
+- Preview renders using the same schema used by respondents.
+- Publish is blocked when required metadata or blocking validations are unresolved.
+- Successful publish shows version identifier and timestamp.
+
+---
+
+## Epic 4: Respondent Experience (Viewer/Answer Flow)
+
+### QNR-014 — Published questionnaire retrieval and session start
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-004
+
+**Scope**
+- Add public/auth retrieval for published questionnaire schema via slug/id.
+- Start `ResponseSession` with status `in_progress`.
+- Support authenticated and optional anonymous respondent modes.
+
+**Deliverables**
+- Published fetch endpoint.
+- Session-start endpoint.
+- Security tests around access modes.
+
+**Acceptance Criteria**
+- Respondent can open a published questionnaire and start a session.
+- Session initialization records start timestamp and questionnaire version.
+- Access policy is enforced for private vs public forms.
+
+---
+
+### QNR-015 — Build page-based respondent flow with autosave
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-014
+
+**Scope**
+- Implement page-by-page rendering by section.
+- Add autosave and debounced partial answer persistence.
+- Restore progress for existing in-progress sessions.
+
+**Deliverables**
+- Respondent flow container.
+- Autosave client + API integration.
+- Resume-session tests.
+
+**Acceptance Criteria**
+- Leaving/reloading the page preserves saved answers.
+- Partial saves do not submit the questionnaire.
+- Resume lands on the last known section/question context.
+
+---
+
+### QNR-016 — Add back/next navigation and progress monitoring
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-015
+
+**Scope**
+- Add explicit previous/next controls.
+- Display progress bar and completion counters.
+- Track completion metrics for answered required questions and page progress.
+
+**Deliverables**
+- Navigation controls with disabled-state logic.
+- Progress indicator components.
+- Telemetry hooks for navigation checkpoints.
+
+**Acceptance Criteria**
+- Respondents can navigate backward without data loss.
+- Progress updates as answers are saved.
+- Progress display remains consistent after session restore.
+
+---
+
+### QNR-017 — Integrate real-time validation feedback in respondent UI
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-008, QNR-015
+
+**Scope**
+- Show inline validation errors while editing/advancing.
+- Provide section-level and form-level summaries where applicable.
+- Prevent submit while blocking violations exist.
+
+**Deliverables**
+- Validation-aware form controls.
+- Error summary component.
+- UX tests for correction flows.
+
+**Acceptance Criteria**
+- Field errors appear near the corresponding questions.
+- Group/form errors are visible and actionable.
+- Submit action remains disabled or blocked with clear reasons.
+
+---
+
+### QNR-018 — Build final answer summary view with edit links
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-016, QNR-017
+
+**Scope**
+- Add pre-submit and/or post-submit summary page grouped by section.
+- Provide “edit” actions that deep-link back to section/question.
+- Ensure summary reflects normalized stored answers.
+
+**Deliverables**
+- Summary screen components.
+- Summary API endpoint (if server-rendered).
+- Test coverage for summary fidelity.
+
+**Acceptance Criteria**
+- Summary lists all questions with final answer values.
+- Edit links return users to correct location and preserve state.
+- Changes made after edit are reflected when returning to summary.
+
+---
+
+## Epic 5: Submission, PDF Export, and Analytics
+
+### QNR-019 — Implement final submission workflow
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-017, QNR-018
+
+**Scope**
+- Add submit endpoint that revalidates full response and marks session submitted.
+- Lock session from further edits after successful submission (unless configured otherwise).
+- Record submitted timestamp and audit event.
+
+**Deliverables**
+- Submit endpoint/service.
+- Submission state transition tests.
+- Audit event instrumentation.
+
+**Acceptance Criteria**
+- Submit performs backend authoritative validation.
+- Invalid submission returns structured violations with no state transition.
+- Valid submission sets status to `submitted` and persists timestamp.
+
+---
+
+### QNR-020 — Generate downloadable PDF for submitted responses
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-019
+
+**Scope**
+- Implement server-side response-to-HTML rendering template.
+- Convert rendered HTML to PDF and store/retrieve artifact.
+- Expose secure download endpoint.
+
+**Deliverables**
+- PDF generation service.
+- PDF template with sectioned Q&A formatting.
+- Integration test for PDF generation and access control.
+
+**Acceptance Criteria**
+- Submitted sessions can produce and download a PDF.
+- PDF includes questionnaire metadata, submission timestamp, and all answers.
+- Unauthorized users cannot access another respondent’s PDF.
+
+---
+
+### QNR-021 — Add creator analytics for progress and completion
+**Type:** Feature  
+**Priority:** P1  
+**Dependencies:** QNR-016, QNR-019
+
+**Scope**
+- Capture starts, completions, drop-off points, average completion times.
+- Build creator-facing analytics endpoints and dashboard widgets.
+- Include validation-failure hotspot reporting.
+
+**Deliverables**
+- Analytics aggregation jobs/queries.
+- Creator analytics API + UI.
+- Dashboard-level tests for metric rendering.
+
+**Acceptance Criteria**
+- Creator can view completion funnel for each published version.
+- Drop-off metrics identify top abandonment sections/questions.
+- Metrics update within agreed freshness window.
+
+---
+
+## Epic 6: Security, Quality, and Release Readiness
+
+### QNR-022 — Authorization, privacy, and abuse protections
+**Type:** Feature  
+**Priority:** P0  
+**Dependencies:** QNR-002, QNR-014, QNR-019
+
+**Scope**
+- Enforce ownership and access controls across creator/respondent endpoints.
+- Add rate limiting/captcha hooks for anonymous public submissions.
+- Ensure PII-safe handling for address/time/date responses (encryption-at-rest as required).
+
+**Deliverables**
+- Auth policy checks and middleware updates.
+- Rate-limit policy configuration.
+- Security tests for unauthorized access attempts.
+
+**Acceptance Criteria**
+- Unauthorized access paths return correct denial codes.
+- Public submission endpoints are rate-limited.
+- Sensitive fields are stored and handled per security requirements.
+
+---
+
+### QNR-023 — Accessibility and UX conformance pass
+**Type:** Quality  
+**Priority:** P1  
+**Dependencies:** QNR-013, QNR-018
+
+**Scope**
+- Validate keyboard-only navigation across creator and respondent flows.
+- Ensure semantic labels, ARIA bindings, focus management, and error announcements.
+- Run contrast and screen-reader checks.
+
+**Deliverables**
+- Accessibility audit report.
+- Remediation fixes.
+- Automated a11y checks in CI where practical.
+
+**Acceptance Criteria**
+- Core journeys pass agreed accessibility standards (e.g., WCAG 2.1 AA targets).
+- Validation and navigation states are announced to assistive tech.
+- No critical accessibility issues remain open for launch.
+
+---
+
+### QNR-024 — End-to-end workflow tests and release checklist
+**Type:** Quality  
+**Priority:** P0  
+**Dependencies:** QNR-013, QNR-020, QNR-022
+
+**Scope**
+- Build E2E tests for draft creation → publish → respond → validate → submit → PDF download.
+- Add regression tests for version immutability and backward compatibility.
+- Produce launch checklist and rollback plan.
+
+**Deliverables**
+- Automated E2E suite.
+- Release checklist/runbook.
+- Sign-off criteria document.
+
+**Acceptance Criteria**
+- E2E suite passes in CI for core supported browsers.
+- Versioning regression tests prevent schema drift breakages.
+- Launch checklist is approved by engineering + product stakeholders.
+
+---
+
+## Recommended Sequencing
+1. **MVP track (P0):** QNR-001, QNR-002, QNR-003, QNR-004, QNR-005, QNR-009, QNR-010, QNR-014, QNR-015, QNR-016, QNR-019, QNR-022, QNR-024.  
+2. **Post-MVP enhancements (P1):** QNR-006, QNR-007, QNR-008, QNR-011, QNR-012, QNR-013, QNR-017, QNR-018, QNR-020, QNR-021, QNR-023.
+
+## Suggested Milestones
+- **Milestone A (Core Builder + Responses):** complete all MVP track items except QNR-024.
+- **Milestone B (Advanced Validation + Creator UX):** QNR-006/QNR-007/QNR-008/QNR-012/QNR-013/QNR-017.
+- **Milestone C (Exports + Analytics + Hardening):** QNR-020/QNR-021/QNR-023/QNR-024.

--- a/docs/questionnaire-release-checklist.md
+++ b/docs/questionnaire-release-checklist.md
@@ -1,0 +1,51 @@
+# Questionnaire Release Checklist & Rollback Runbook (QNR-024)
+
+## Purpose
+Operational launch checklist, sign-off criteria, and rollback plan for the Questionnaire core workflow:
+**draft creation → publish → respond → validate → submit → PDF download**.
+
+## Pre-Release Gates (Engineering)
+- [ ] Backend migration `scripts/migrations/20260302_questionnaire_schema.py` validated in staging.
+- [ ] DynamoDB indexes healthy for owner/status/published/response-status lookups.
+- [ ] Sensitive-answer settings reviewed (`QUESTIONNAIRE_ENCRYPT_SENSITIVE_ANSWERS`, captcha/rate-limit toggles).
+- [ ] Contract compatibility check passes for `2026-03-validation-v1`.
+- [ ] E2E regression tests pass (including PDF download and version immutability behavior).
+
+## QA / Product Sign-off
+- [ ] Creator flow smoke verified (draft metadata, section/question changes, publish).
+- [ ] Respondent flow smoke verified (start/save/validate/submit/resume).
+- [ ] Submitted-session PDF generated/downloaded and content sanity checked.
+- [ ] Accessibility/UX conformance doc reviewed (`docs/questionnaire-accessibility-audit.md`).
+- [ ] Product owner sign-off recorded.
+
+## CI Sign-off Criteria
+- [ ] `tests/test_questionnaire_e2e_workflow.py` passes in CI.
+- [ ] Existing route/repository regression suites pass.
+- [ ] Frontend questionnaire component tests pass.
+- [ ] No P0/P1 open defects tagged `questionnaire-launch`.
+
+## Production Readiness Checks
+- [ ] Dashboards/alerts configured for 4xx/5xx spikes on `/questionnaires/*` endpoints.
+- [ ] Response submit success rate monitored.
+- [ ] PDF generation failure rate monitored.
+- [ ] On-call handoff completed.
+
+## Rollback Plan
+1. **Soft rollback (preferred)**
+   - Disable questionnaire routes via deployment flag/routing toggle.
+   - Keep table data intact.
+   - Notify stakeholders and pause traffic.
+2. **Service rollback**
+   - Redeploy previous known-good release artifact.
+   - Confirm health checks and questionnaire endpoints restored to prior behavior.
+3. **Data safety**
+   - Do not delete questionnaire table data during incident rollback.
+   - If schema migration side-effects observed, use replay-safe scripts and audit logs for corrective updates.
+4. **Post-rollback validation**
+   - Run focused smoke tests for auth/session core and unrelated critical app flows.
+   - File incident timeline and corrective actions.
+
+## Stakeholder Approval
+- Engineering lead: ____________________  Date: __________
+- Product owner: ______________________  Date: __________
+- QA lead: _____________________________  Date: __________

--- a/docs/questionnaire-validation-contract-v1.json
+++ b/docs/questionnaire-validation-contract-v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.internal/schemas/questionnaire-validation-contract-v1.json",
+  "title": "Questionnaire Validation Contract v1",
+  "type": "object",
+  "properties": {
+    "contract_version": { "const": "2026-03-validation-v1" },
+    "is_valid": { "type": "boolean" },
+    "can_submit": { "type": "boolean" },
+    "has_blocking_form_error": { "type": "boolean" },
+    "errors": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["code", "message"],
+          "properties": {
+            "code": { "type": "string" },
+            "message": { "type": "string" },
+            "blocking": { "type": "boolean" },
+            "rule_id": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "required": [
+    "contract_version",
+    "is_valid",
+    "can_submit",
+    "has_blocking_form_error",
+    "errors"
+  ],
+  "additionalProperties": false
+}

--- a/docs/questionnaire-validation-contract-versioning.md
+++ b/docs/questionnaire-validation-contract-versioning.md
@@ -1,0 +1,26 @@
+# Questionnaire Validation Contract Versioning
+
+## Current version
+- `contract_version`: `2026-03-validation-v1`
+- Canonical schema: `docs/questionnaire-validation-contract-v1.json`
+- Backend typed models: `app/contracts/questionnaire_validation_contract.py`
+- Frontend typed interfaces: `frontend/src/api/types.ts`
+
+## Compatibility policy
+
+### Backward-compatible changes (same contract version)
+- Adding new error codes to the existing taxonomy.
+- Adding optional fields to `QuestionnaireValidationIssue`.
+- Adding optional request fields with safe defaults.
+
+### Breaking changes (new contract version required)
+- Renaming/removing response fields.
+- Changing field types.
+- Changing scope key strategy (`question_id`, `group:<id>`, `form:<rule_id>`).
+- Reinterpreting `can_submit` / `has_blocking_form_error` semantics.
+
+## Change process
+1. Introduce new version constant in backend + frontend.
+2. Add a new schema artifact (`...-v2.json`) instead of mutating v1.
+3. Keep old contract accepted for migration window when feasible.
+4. Extend contract drift tests to assert both schema and typed interfaces.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,8 @@ const TicketsPage = lazy(() => import("@/pages/tickets/TicketsPage"));
 const TicketSpacesPage = lazy(() => import("@/pages/tickets/TicketSpacesPage"));
 const TicketSpaceDetailPage = lazy(() => import("@/pages/tickets/TicketSpaceDetailPage"));
 const DevToolsLogUiPage = lazy(() => import("@/pages/devtools/DevToolsLogUiPage"));
+const QuestionnaireBuilderPage = lazy(() => import("@/pages/questionnaires/QuestionnaireBuilderPage"));
+const QuestionnaireRespondentPage = lazy(() => import("@/pages/questionnaires/QuestionnaireRespondentPage"));
 
 function PageSpinner() {
   return (
@@ -60,6 +62,7 @@ export default function App() {
         <Route path="/password-recovery" element={<PasswordRecovery />} />
         <Route path="/magic-link-verify" element={<MagicLinkVerify />} />
         <Route path="/event/:calendarId/:eventId" element={<PublicEventPage />} />
+        <Route path="/questionnaires/published/:publishedSlug/respond" element={<QuestionnaireRespondentPage />} />
 
         {/* Protected routes inside AppShell layout */}
         <Route element={<ProtectedRoute><AppShell /></ProtectedRoute>}>
@@ -70,6 +73,7 @@ export default function App() {
           <Route path="files" element={<FilesPage />} />
           <Route path="projects" element={<ProjectsPage />} />
           <Route path="projects/:projectId" element={<ProjectDetailPage />} />
+          <Route path="questionnaires/:questionnaireId/builder" element={<QuestionnaireBuilderPage />} />
           <Route path="billing" element={<BillingPage />} />
           <Route path="calendar" element={<CalendarPage />} />
           <Route path="shop" element={<CatalogPage />} />

--- a/frontend/src/api/endpoints/questionnaires.ts
+++ b/frontend/src/api/endpoints/questionnaires.ts
@@ -1,0 +1,106 @@
+import { api } from "@/api/client";
+import type {
+  QuestionnaireDraft,
+  QuestionnaireDraftListResp,
+  QuestionnaireDraftUpdateReq,
+  QuestionnaireSection,
+  QuestionnaireSectionCreateReq,
+  QuestionnaireSectionUpdateReq,
+  QuestionnaireQuestion,
+  QuestionnaireQuestionCreateReq,
+  QuestionnaireQuestionUpdateReq,
+  QuestionnaireVersion,
+  PublishedQuestionnaireVersion,
+  QuestionnaireSessionStateResp,
+  QuestionnaireAnalyticsResp,
+} from "@/api/types";
+
+export const listQuestionnaireDrafts = (includeArchived = false) =>
+  api.get<QuestionnaireDraftListResp>("/questionnaires/drafts", { include_archived: String(includeArchived) });
+
+export const getQuestionnaireDraft = (questionnaireId: string) =>
+  api.get<{ draft: QuestionnaireDraft }>(`/questionnaires/drafts/${questionnaireId}`);
+
+export const updateQuestionnaireDraft = (questionnaireId: string, body: QuestionnaireDraftUpdateReq) =>
+  api.patch<{ draft: QuestionnaireDraft }>(`/questionnaires/drafts/${questionnaireId}`, body);
+
+export const listQuestionnaireSections = (questionnaireId: string) =>
+  api.get<{ items: QuestionnaireSection[] }>(`/questionnaires/drafts/${questionnaireId}/sections`);
+
+export const createQuestionnaireSection = (questionnaireId: string, body: QuestionnaireSectionCreateReq) =>
+  api.post<{ section: QuestionnaireSection }>(`/questionnaires/drafts/${questionnaireId}/sections`, body);
+
+export const updateQuestionnaireSection = (questionnaireId: string, sectionId: string, body: QuestionnaireSectionUpdateReq) =>
+  api.patch<{ section: QuestionnaireSection }>(`/questionnaires/drafts/${questionnaireId}/sections/${sectionId}`, body);
+
+export const deleteQuestionnaireSection = (questionnaireId: string, sectionId: string) =>
+  api.del<{ section: QuestionnaireSection }>(`/questionnaires/drafts/${questionnaireId}/sections/${sectionId}`);
+
+export const reorderQuestionnaireSections = (questionnaireId: string, sectionIds: string[]) =>
+  api.post<{ items: QuestionnaireSection[] }>(`/questionnaires/drafts/${questionnaireId}/sections/reorder`, { section_ids: sectionIds });
+
+
+export const listQuestionnaireQuestions = (questionnaireId: string, sectionId: string) =>
+  api.get<{ items: QuestionnaireQuestion[] }>(`/questionnaires/drafts/${questionnaireId}/sections/${sectionId}/questions`);
+
+export const createQuestionnaireQuestion = (questionnaireId: string, body: QuestionnaireQuestionCreateReq) =>
+  api.post<{ question: QuestionnaireQuestion }>(`/questionnaires/drafts/${questionnaireId}/questions`, body);
+
+export const updateQuestionnaireQuestion = (
+  questionnaireId: string,
+  sectionId: string,
+  questionId: string,
+  body: QuestionnaireQuestionUpdateReq,
+) => api.patch<{ question: QuestionnaireQuestion }>(`/questionnaires/drafts/${questionnaireId}/questions/${questionId}?section_id=${encodeURIComponent(sectionId)}`, body);
+
+export const deleteQuestionnaireQuestion = (questionnaireId: string, sectionId: string, questionId: string) =>
+  api.del<{ question: QuestionnaireQuestion }>(`/questionnaires/drafts/${questionnaireId}/questions/${questionId}`, { section_id: sectionId });
+
+
+export const validateQuestionnaireDraft = (
+  questionnaireId: string,
+  body: Record<string, unknown>,
+) => api.post<Record<string, unknown>>(`/questionnaires/drafts/${questionnaireId}/validate`, body);
+
+
+export const getQuestionnaireDraftSchema = (questionnaireId: string) =>
+  api.get<Record<string, unknown>>(`/questionnaires/drafts/${questionnaireId}/schema`);
+
+export const publishQuestionnaireDraft = (questionnaireId: string, published_slug?: string) =>
+  api.post<{ version: QuestionnaireVersion }>(`/questionnaires/drafts/${questionnaireId}/publish`, { published_slug });
+
+
+export const getPublishedQuestionnaireBySlug = (publishedSlug: string) =>
+  api.get<{ version: PublishedQuestionnaireVersion }>(`/questionnaires/published/${publishedSlug}`);
+
+export const getPublishedQuestionnaireById = (questionnaireId: string) =>
+  api.get<{ version: PublishedQuestionnaireVersion }>(`/questionnaires/published/by-id/${questionnaireId}`);
+
+export const startPublishedResponseSession = (publishedSlug: string) =>
+  api.post<{ session: Record<string, unknown> }>(`/questionnaires/published/${publishedSlug}/sessions`, {});
+
+export const getPublishedResponseSessionState = (publishedSlug: string, responseSessionId: string) =>
+  api.get<QuestionnaireSessionStateResp>(`/questionnaires/published/${publishedSlug}/sessions/${responseSessionId}`);
+
+export const savePublishedResponseSessionState = (
+  publishedSlug: string,
+  responseSessionId: string,
+  body: { answers_by_question_id: Record<string, unknown>; current_section_index?: number; current_question_id?: string },
+) => api.put<QuestionnaireSessionStateResp>(`/questionnaires/published/${publishedSlug}/sessions/${responseSessionId}`, body);
+
+
+export const validatePublishedResponseSession = (
+  publishedSlug: string,
+  responseSessionId: string,
+  body: Record<string, unknown>,
+) => api.post<Record<string, unknown>>(`/questionnaires/published/${publishedSlug}/sessions/${responseSessionId}/validate`, body);
+
+export const submitPublishedResponseSession = (
+  publishedSlug: string,
+  responseSessionId: string,
+  body: Record<string, unknown>,
+) => api.post<{ session: Record<string, unknown>; result: Record<string, unknown> }>(`/questionnaires/published/${publishedSlug}/sessions/${responseSessionId}/submit`, body);
+
+
+export const getQuestionnaireAnalytics = (questionnaireId: string) =>
+  api.get<QuestionnaireAnalyticsResp>(`/questionnaires/drafts/${questionnaireId}/analytics`);

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1977,3 +1977,189 @@ export interface DevtoolsBillingLedgerOut {
   next_cursor?: string | null;
   parse_warnings: DevtoolsParseWarningOut[];
 }
+
+// ─── Questionnaire Validation Contract (shared FE/BE) ───────────
+
+export const QUESTIONNAIRE_VALIDATION_CONTRACT_VERSION = "2026-03-validation-v1" as const;
+
+export type QuestionnaireValidationScopeKey = string; // question_id | group:<id> | form:<rule_id>
+
+export interface QuestionnaireValidationIssue {
+  code: string;
+  message: string;
+  blocking?: boolean;
+  rule_id?: string;
+}
+
+export interface QuestionnaireValidationReq {
+  contract_version?: typeof QUESTIONNAIRE_VALIDATION_CONTRACT_VERSION;
+  answers_by_question_id: Record<string, unknown>;
+  group_rules?: Array<Record<string, unknown>>;
+  form_rules?: Array<Record<string, unknown>>;
+  final_submit?: boolean;
+}
+
+export interface QuestionnaireValidationResp {
+  contract_version: typeof QUESTIONNAIRE_VALIDATION_CONTRACT_VERSION;
+  is_valid: boolean;
+  can_submit: boolean;
+  has_blocking_form_error: boolean;
+  errors: Record<QuestionnaireValidationScopeKey, QuestionnaireValidationIssue[]>;
+}
+
+// ─── Questionnaire Builder ───────────────────────────────────────
+
+export type QuestionnaireStatus = "draft" | "published" | "archived";
+
+export interface QuestionnaireDraft {
+  questionnaire_id: string;
+  owner_id: string;
+  title: string;
+  description?: string;
+  status: QuestionnaireStatus;
+  updated_at: string;
+  created_at?: string;
+}
+
+export interface QuestionnaireDraftListResp {
+  items: QuestionnaireDraft[];
+}
+
+export interface QuestionnaireDraftUpdateReq {
+  title?: string;
+  description?: string;
+}
+
+export interface QuestionnaireSection {
+  questionnaire_id: string;
+  section_id: string;
+  title: string;
+  description?: string;
+  position: number;
+  updated_at?: string;
+}
+
+export interface QuestionnaireSectionCreateReq {
+  section_id: string;
+  title: string;
+  description?: string;
+}
+
+export interface QuestionnaireSectionUpdateReq {
+  title?: string;
+  description?: string;
+}
+
+
+export type QuestionnaireQuestionType =
+  | "text"
+  | "select"
+  | "multiselect"
+  | "radio"
+  | "slider"
+  | "date"
+  | "time"
+  | "timezone"
+  | "address";
+
+export interface QuestionnaireQuestion {
+  question_id: string;
+  section_id: string;
+  type: QuestionnaireQuestionType;
+  label: string;
+  required: boolean;
+  hint?: string;
+  config_json: Record<string, unknown>;
+  position: number;
+}
+
+export interface QuestionnaireQuestionCreateReq {
+  section_id: string;
+  question_id: string;
+  type: QuestionnaireQuestionType;
+  label: string;
+  required?: boolean;
+  hint?: string;
+  config_json: Record<string, unknown>;
+}
+
+export interface QuestionnaireQuestionUpdateReq {
+  label?: string;
+  required?: boolean;
+  hint?: string;
+  config_json?: Record<string, unknown>;
+}
+
+
+export interface QuestionnaireVersion {
+  version_id: string;
+  questionnaire_id: string;
+  version_number: number;
+  status: string;
+  published_slug?: string;
+  published_at: string;
+  published_by?: string;
+  schema_json: Record<string, unknown>;
+}
+
+
+
+export interface PublishedQuestionnaireVersion {
+  questionnaire_id: string;
+  version_id: string;
+  version_number: number;
+  published_slug: string;
+  visibility: "private" | "public" | "unlisted";
+  allow_anonymous: boolean;
+  schema_json: Record<string, unknown>;
+  published_at: string;
+}
+
+export interface QuestionnaireSessionState {
+  response_session_id: string;
+  questionnaire_id: string;
+  version_id: string;
+  status: "in_progress" | "submitted";
+  started_at: string;
+  current_section_index?: number;
+  current_question_id?: string;
+  respondent_id?: string | null;
+}
+
+export interface QuestionnaireSessionStateResp {
+  session: QuestionnaireSessionState;
+  answers_by_question_id: Record<string, unknown>;
+}
+
+
+
+
+export interface QuestionnaireAnalyticsPoint {
+  label?: string;
+  key?: string;
+  count: number;
+}
+
+export interface QuestionnaireVersionAnalytics {
+  version_id: string;
+  version_number?: number;
+  published_at?: string;
+  funnel: { starts: number; completions: number; completion_rate: number };
+  average_completion_seconds: number | null;
+  dropoff_points: QuestionnaireAnalyticsPoint[];
+  validation_hotspots: QuestionnaireAnalyticsPoint[];
+}
+
+export interface QuestionnaireAnalyticsResp {
+  analytics: {
+    generated_at: string;
+    freshness_sla_seconds: number;
+    versions: QuestionnaireVersionAnalytics[];
+    totals: {
+      starts: number;
+      completions: number;
+      top_dropoffs: QuestionnaireAnalyticsPoint[];
+      top_validation_hotspots: QuestionnaireAnalyticsPoint[];
+    };
+  };
+}

--- a/frontend/src/pages/questionnaires/QuestionTypeConfigEditor.test.tsx
+++ b/frontend/src/pages/questionnaires/QuestionTypeConfigEditor.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import QuestionTypeConfigEditor from "./QuestionTypeConfigEditor";
+
+const cases: Array<{ type: any; label: RegExp; initial: Record<string, unknown> }> = [
+  { type: "text", label: /Min length/i, initial: { minLength: 1, maxLength: 10 } },
+  { type: "select", label: /Options/i, initial: { options: ["A"] } },
+  { type: "multiselect", label: /Min selections/i, initial: { options: ["A"], minSelections: 0, maxSelections: 1 } },
+  { type: "radio", label: /Options/i, initial: { options: ["A"] } },
+  { type: "slider", label: /Slider min/i, initial: { min: 0, max: 10, step: 1 } },
+  { type: "date", label: /Min date/i, initial: { minDate: "", maxDate: "" } },
+  { type: "time", label: /Min time/i, initial: { minTime: "", maxTime: "" } },
+  { type: "timezone", label: /Allowed timezones/i, initial: { allowedTimezones: ["UTC"] } },
+  { type: "address", label: /Required address fields/i, initial: { requiredFields: ["line1"] } },
+];
+
+describe("QuestionTypeConfigEditor", () => {
+  it.each(cases)("renders editor controls for $type", ({ type, label, initial }) => {
+    const onChange = vi.fn();
+    render(<QuestionTypeConfigEditor type={type} config={initial} onChange={onChange} />);
+    expect(screen.getByLabelText(label)).toBeInTheDocument();
+  });
+
+  it("emits updated config on change", () => {
+    const onChange = vi.fn();
+    render(<QuestionTypeConfigEditor type="text" config={{ minLength: 1, maxLength: 5 }} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText("Min length"), { target: { value: "2" } });
+    expect(onChange).toHaveBeenCalled();
+    const payload = onChange.mock.calls[onChange.mock.calls.length - 1]?.[0] as Record<string, unknown>;
+    expect(payload.minLength).toBe(2);
+  });
+});

--- a/frontend/src/pages/questionnaires/QuestionTypeConfigEditor.tsx
+++ b/frontend/src/pages/questionnaires/QuestionTypeConfigEditor.tsx
@@ -1,0 +1,167 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { BuilderQuestionType } from "./questionConfig";
+
+type Props = {
+  type: BuilderQuestionType;
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+};
+
+function csvToList(value: string): string[] {
+  return value
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+function listToCsv(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  return value.filter((v) => typeof v === "string").join(", ");
+}
+
+export default function QuestionTypeConfigEditor({ type, config, onChange }: Props) {
+  if (type === "text") {
+    return (
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label>Min length</Label>
+          <Input
+            aria-label="Min length"
+            type="number"
+            value={String(config.minLength ?? "")}
+            onChange={(e) => onChange({ ...config, minLength: Number(e.target.value) })}
+          />
+        </div>
+        <div>
+          <Label>Max length</Label>
+          <Input
+            aria-label="Max length"
+            type="number"
+            value={String(config.maxLength ?? "")}
+            onChange={(e) => onChange({ ...config, maxLength: Number(e.target.value) })}
+          />
+        </div>
+        <div className="col-span-2">
+          <Label>Regex pattern (optional)</Label>
+          <Input
+            aria-label="Regex pattern"
+            value={String(config.pattern ?? "")}
+            onChange={(e) => onChange({ ...config, pattern: e.target.value })}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (type === "select" || type === "multiselect" || type === "radio") {
+    return (
+      <div className="space-y-2">
+        <Label>Options (comma separated)</Label>
+        <Textarea
+          aria-label="Options"
+          rows={2}
+          value={listToCsv(config.options)}
+          onChange={(e) => onChange({ ...config, options: csvToList(e.target.value) })}
+        />
+        {type === "multiselect" && (
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <Label>Min selections</Label>
+              <Input
+                aria-label="Min selections"
+                type="number"
+                value={String(config.minSelections ?? 0)}
+                onChange={(e) => onChange({ ...config, minSelections: Number(e.target.value) })}
+              />
+            </div>
+            <div>
+              <Label>Max selections</Label>
+              <Input
+                aria-label="Max selections"
+                type="number"
+                value={String(config.maxSelections ?? "")}
+                onChange={(e) => onChange({ ...config, maxSelections: Number(e.target.value) })}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (type === "slider") {
+    return (
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <Label>Min</Label>
+          <Input aria-label="Slider min" type="number" value={String(config.min ?? "")} onChange={(e) => onChange({ ...config, min: Number(e.target.value) })} />
+        </div>
+        <div>
+          <Label>Max</Label>
+          <Input aria-label="Slider max" type="number" value={String(config.max ?? "")} onChange={(e) => onChange({ ...config, max: Number(e.target.value) })} />
+        </div>
+        <div>
+          <Label>Step</Label>
+          <Input aria-label="Slider step" type="number" value={String(config.step ?? "")} onChange={(e) => onChange({ ...config, step: Number(e.target.value) })} />
+        </div>
+      </div>
+    );
+  }
+
+  if (type === "date") {
+    return (
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label>Min date</Label>
+          <Input aria-label="Min date" type="date" value={String(config.minDate ?? "")} onChange={(e) => onChange({ ...config, minDate: e.target.value })} />
+        </div>
+        <div>
+          <Label>Max date</Label>
+          <Input aria-label="Max date" type="date" value={String(config.maxDate ?? "")} onChange={(e) => onChange({ ...config, maxDate: e.target.value })} />
+        </div>
+      </div>
+    );
+  }
+
+  if (type === "time") {
+    return (
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label>Min time</Label>
+          <Input aria-label="Min time" type="time" value={String(config.minTime ?? "")} onChange={(e) => onChange({ ...config, minTime: e.target.value })} />
+        </div>
+        <div>
+          <Label>Max time</Label>
+          <Input aria-label="Max time" type="time" value={String(config.maxTime ?? "")} onChange={(e) => onChange({ ...config, maxTime: e.target.value })} />
+        </div>
+      </div>
+    );
+  }
+
+  if (type === "timezone") {
+    return (
+      <div className="space-y-2">
+        <Label>Allowed timezones (comma separated)</Label>
+        <Input
+          aria-label="Allowed timezones"
+          value={listToCsv(config.allowedTimezones)}
+          onChange={(e) => onChange({ ...config, allowedTimezones: csvToList(e.target.value) })}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label>Required address fields (comma separated)</Label>
+      <Input
+        aria-label="Required address fields"
+        value={listToCsv(config.requiredFields)}
+        onChange={(e) => onChange({ ...config, requiredFields: csvToList(e.target.value) })}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/questionnaires/QuestionnaireBuilderPage.test.tsx
+++ b/frontend/src/pages/questionnaires/QuestionnaireBuilderPage.test.tsx
@@ -1,0 +1,247 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import QuestionnaireBuilderPage from "./QuestionnaireBuilderPage";
+
+const getQuestionnaireDraft = vi.fn();
+const listQuestionnaireSections = vi.fn();
+const listQuestionnaireQuestions = vi.fn();
+const updateQuestionnaireDraft = vi.fn();
+const createQuestionnaireSection = vi.fn();
+const updateQuestionnaireSection = vi.fn();
+const deleteQuestionnaireSection = vi.fn();
+const reorderQuestionnaireSections = vi.fn();
+const createQuestionnaireQuestion = vi.fn();
+const updateQuestionnaireQuestion = vi.fn();
+const deleteQuestionnaireQuestion = vi.fn();
+const validateQuestionnaireDraft = vi.fn();
+const getQuestionnaireDraftSchema = vi.fn();
+const getQuestionnaireAnalytics = vi.fn();
+const publishQuestionnaireDraft = vi.fn();
+
+vi.mock("@/api/endpoints/questionnaires", () => ({
+  getQuestionnaireDraft: (...args: unknown[]) => getQuestionnaireDraft(...args),
+  listQuestionnaireSections: (...args: unknown[]) => listQuestionnaireSections(...args),
+  listQuestionnaireQuestions: (...args: unknown[]) => listQuestionnaireQuestions(...args),
+  updateQuestionnaireDraft: (...args: unknown[]) => updateQuestionnaireDraft(...args),
+  createQuestionnaireSection: (...args: unknown[]) => createQuestionnaireSection(...args),
+  updateQuestionnaireSection: (...args: unknown[]) => updateQuestionnaireSection(...args),
+  deleteQuestionnaireSection: (...args: unknown[]) => deleteQuestionnaireSection(...args),
+  reorderQuestionnaireSections: (...args: unknown[]) => reorderQuestionnaireSections(...args),
+  createQuestionnaireQuestion: (...args: unknown[]) => createQuestionnaireQuestion(...args),
+  updateQuestionnaireQuestion: (...args: unknown[]) => updateQuestionnaireQuestion(...args),
+  deleteQuestionnaireQuestion: (...args: unknown[]) => deleteQuestionnaireQuestion(...args),
+  validateQuestionnaireDraft: (...args: unknown[]) => validateQuestionnaireDraft(...args),
+  getQuestionnaireDraftSchema: (...args: unknown[]) => getQuestionnaireDraftSchema(...args),
+  getQuestionnaireAnalytics: (...args: unknown[]) => getQuestionnaireAnalytics(...args),
+  publishQuestionnaireDraft: (...args: unknown[]) => publishQuestionnaireDraft(...args),
+}));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={["/questionnaires/q1/builder"]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/questionnaires/:questionnaireId/builder" element={<QuestionnaireBuilderPage />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("QuestionnaireBuilderPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getQuestionnaireDraft.mockResolvedValue({
+      draft: { questionnaire_id: "q1", title: "Initial", description: "Desc", status: "draft", owner_id: "u1", updated_at: "1" },
+    });
+    listQuestionnaireSections.mockResolvedValue({
+      items: [{ questionnaire_id: "q1", section_id: "s1", title: "Section 1", description: "A", position: 0 }],
+    });
+    listQuestionnaireQuestions.mockResolvedValue({
+      items: [
+        {
+          question_id: "q_slider",
+          section_id: "s1",
+          type: "slider",
+          label: "How many?",
+          required: true,
+          hint: "Short hint",
+          config_json: { min: 1, max: 9, step: 2, placeholder: "Enter number", help_text: "Longer help" },
+          position: 0,
+        },
+      ],
+    });
+    updateQuestionnaireDraft.mockResolvedValue({ draft: {} });
+    createQuestionnaireSection.mockResolvedValue({ section: { questionnaire_id: "q1", section_id: "s2", title: "Section 2", description: "", position: 1 } });
+    updateQuestionnaireSection.mockResolvedValue({ section: {} });
+    deleteQuestionnaireSection.mockResolvedValue({ section: {} });
+    reorderQuestionnaireSections.mockResolvedValue({ items: [] });
+    createQuestionnaireQuestion.mockResolvedValue({
+      question: {
+        question_id: "q_new",
+        section_id: "s1",
+        type: "text",
+        label: "Untitled question",
+        required: false,
+        hint: "",
+        config_json: { minLength: 0, maxLength: 200 },
+        position: 1,
+      },
+    });
+    updateQuestionnaireQuestion.mockResolvedValue({ question: {} });
+    deleteQuestionnaireQuestion.mockResolvedValue({ question: {} });
+    validateQuestionnaireDraft.mockResolvedValue({ errors: {}, is_valid: true, can_submit: true, has_blocking_form_error: false });
+    getQuestionnaireDraftSchema.mockResolvedValue({ sections: [{ section_id: "s1", title: "Section 1", questions: [{ question_id: "q_slider", label: "How many?", hint: "Short hint", config_json: { placeholder: "Enter number" } }] }] });
+    getQuestionnaireAnalytics.mockResolvedValue({
+      analytics: {
+        generated_at: "1772565000",
+        freshness_sla_seconds: 60,
+        versions: [
+          {
+            version_id: "ver_2",
+            version_number: 2,
+            funnel: { starts: 10, completions: 7, completion_rate: 0.7 },
+            average_completion_seconds: 85,
+            dropoff_points: [{ label: "Section 1 / q_slider", count: 2 }],
+            validation_hotspots: [{ key: "form:submit", count: 3 }],
+          },
+        ],
+        totals: {
+          starts: 10,
+          completions: 7,
+          top_dropoffs: [{ label: "Section 1 / q_slider", count: 2 }],
+          top_validation_hotspots: [{ key: "form:submit", count: 3 }],
+        },
+      },
+    });
+    publishQuestionnaireDraft.mockResolvedValue({ version: { version_id: "ver_2", published_at: "2026-03-03T00:00:00Z" } });
+  });
+
+  it("supports add/remove/reorder section and question operations", async () => {
+    renderPage();
+
+    expect(await screen.findByDisplayValue("Section 1")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("How many?")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /add section/i }));
+    await waitFor(() => expect(createQuestionnaireSection).toHaveBeenCalled());
+
+    const moveDown = screen.getAllByRole("button", { name: "Move down" })[0];
+    if (moveDown) fireEvent.click(moveDown);
+    await waitFor(() => expect(reorderQuestionnaireSections).toHaveBeenCalled());
+
+    const addQuestionButtons = screen.getAllByRole("button", { name: /add question/i });
+    if (addQuestionButtons[0]) fireEvent.click(addQuestionButtons[0]);
+    await waitFor(() => expect(createQuestionnaireQuestion).toHaveBeenCalled());
+
+    const deleteQuestionButtons = screen.getAllByRole("button", { name: "Delete question" });
+    if (deleteQuestionButtons[0]) fireEvent.click(deleteQuestionButtons[0]);
+    await waitFor(() => expect(deleteQuestionnaireQuestion).toHaveBeenCalled());
+  });
+
+  it("autosaves metadata edits and rehydrates persisted question config", async () => {
+    renderPage();
+
+    expect(await screen.findByDisplayValue("1")).toBeInTheDocument(); // slider min
+    expect(await screen.findByDisplayValue("9")).toBeInTheDocument(); // slider max
+    expect(screen.getByLabelText("Placeholder")).toHaveValue("Enter number");
+    const previewInput = screen.getByLabelText("Preview q_slider");
+    expect(previewInput).toHaveAttribute("aria-describedby", "preview-hint-q_slider");
+    expect(screen.getByText(/Short hint Longer help/)).toBeInTheDocument();
+
+    const title = await screen.findByLabelText("Title");
+    fireEvent.change(title, { target: { value: "Updated title" } });
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+    await waitFor(() => expect(updateQuestionnaireDraft).toHaveBeenCalled(), { timeout: 2500 });
+  });
+
+  it("prevents saving malformed question config", async () => {
+    renderPage();
+    const stepInput = await screen.findByLabelText("Slider step");
+    fireEvent.change(stepInput, { target: { value: "0" } });
+
+    expect(await screen.findByText(/slider config requires numeric min\/max/i)).toBeInTheDocument();
+    await waitFor(() => expect(updateQuestionnaireQuestion).not.toHaveBeenCalled(), { timeout: 1200 });
+  });
+
+  it("supports draft→preview→publish flow with readiness checks", async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /preview mode/i }));
+    expect(await screen.findByTestId("questionnaire-preview-mode")).toBeInTheDocument();
+    expect(screen.getByLabelText("Preview respondent q_slider")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^publish$/i }));
+    expect(await screen.findByTestId("publish-readiness-checklist")).toHaveTextContent("Ready to publish");
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm publish/i }));
+    await waitFor(() => expect(publishQuestionnaireDraft).toHaveBeenCalled());
+    expect(await screen.findByTestId("publish-success")).toHaveTextContent("ver_2");
+  });
+
+
+  it("announces save state and metadata hints for assistive tech", async () => {
+    renderPage();
+
+    expect(await screen.findByTestId("builder-save-indicator")).toHaveAttribute("role", "status");
+    expect(screen.getByTestId("builder-save-indicator")).toHaveAttribute("aria-live", "polite");
+    expect(screen.getAllByText("All changes saved").length).toBeGreaterThan(0);
+
+    const previewHint = screen.getByText(/Short hint Longer help/);
+    expect(previewHint).toHaveAttribute("role", "note");
+  });
+
+  it("renders analytics funnel and hotspot widgets", async () => {
+    renderPage();
+
+    expect(await screen.findByTestId("questionnaire-analytics-card")).toBeInTheDocument();
+    expect(screen.getByTestId("analytics-total-starts")).toHaveTextContent("10");
+    expect(screen.getByTestId("analytics-total-completions")).toHaveTextContent("7");
+    expect(screen.getByTestId("analytics-funnel-ver_2")).toHaveTextContent("10 starts → 7 completions (70%)");
+    expect(screen.getByTestId("analytics-dropoff-list")).toHaveTextContent("Section 1 / q_slider: 2");
+    expect(screen.getByTestId("analytics-hotspot-list")).toHaveTextContent("form:submit: 3");
+  });
+
+  it("supports rule save/load/edit flows and blocks invalid references", async () => {
+    window.localStorage.setItem(
+      "qnr_rules_q1",
+      JSON.stringify([
+        {
+          id: "rule1",
+          scope: "group",
+          group_id: "g1",
+          rule_type: "min_answered",
+          question_ids: ["q_slider"],
+          config: { min_answered: 1 },
+        },
+      ]),
+    );
+
+    renderPage();
+
+    expect(await screen.findByTestId("rule-rule1")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Question IDs (csv)"), { target: { value: "unknown_q" } });
+    expect(await screen.findByTestId("rule-reference-errors")).toHaveTextContent("unknown question");
+
+    const runPreview = screen.getByRole("button", { name: /run evaluation preview/i });
+    fireEvent.click(runPreview);
+    expect(validateQuestionnaireDraft).not.toHaveBeenCalled();
+    expect(await screen.findByText(/fix invalid rule references before preview/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Question IDs (csv)"), { target: { value: "q_slider" } });
+    fireEvent.click(runPreview);
+    await waitFor(() => expect(validateQuestionnaireDraft).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      const stored = window.localStorage.getItem("qnr_rules_q1");
+      expect(stored).toContain("[]");
+    });
+  });
+
+});

--- a/frontend/src/pages/questionnaires/QuestionnaireBuilderPage.tsx
+++ b/frontend/src/pages/questionnaires/QuestionnaireBuilderPage.tsx
@@ -1,0 +1,664 @@
+import * as React from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { GripVertical, Loader2, Plus, Save, Trash2 } from "lucide-react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+
+import {
+  createQuestionnaireQuestion,
+  createQuestionnaireSection,
+  deleteQuestionnaireQuestion,
+  deleteQuestionnaireSection,
+  getQuestionnaireDraft,
+  listQuestionnaireQuestions,
+  listQuestionnaireSections,
+  reorderQuestionnaireSections,
+  updateQuestionnaireDraft,
+  updateQuestionnaireQuestion,
+  updateQuestionnaireSection,
+  validateQuestionnaireDraft,
+  getQuestionnaireDraftSchema,
+  getQuestionnaireAnalytics,
+  publishQuestionnaireDraft,
+} from "@/api/endpoints/questionnaires";
+import type { QuestionnaireQuestion, QuestionnaireSection } from "@/api/types";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+import QuestionTypeConfigEditor from "./QuestionTypeConfigEditor";
+import ValidationRuleBuilder from "./ValidationRuleBuilder";
+import { defaultConfigForType, type BuilderQuestionType, validateQuestionConfig } from "./questionConfig";
+import { toBackendRulePayload, type BuilderRule, validateRuleReferences } from "./validationRules";
+
+function newId(prefix: string): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+  }
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export default function QuestionnaireBuilderPage() {
+  const { questionnaireId = "" } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [title, setTitle] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const [visibility, setVisibility] = React.useState<"private" | "public" | "unlisted">("private");
+  const [sections, setSections] = React.useState<QuestionnaireSection[]>([]);
+  const [questionsBySection, setQuestionsBySection] = React.useState<Record<string, QuestionnaireQuestion[]>>({});
+  const [metadataDirty, setMetadataDirty] = React.useState(false);
+  const [savingCount, setSavingCount] = React.useState(0);
+  const [dirtySections, setDirtySections] = React.useState<Set<string>>(new Set());
+  const [dirtyQuestions, setDirtyQuestions] = React.useState<Set<string>>(new Set());
+  const [questionErrors, setQuestionErrors] = React.useState<Record<string, string>>({});
+  const [rules, setRules] = React.useState<BuilderRule[]>([]);
+  const [previewOutput, setPreviewOutput] = React.useState<Record<string, unknown> | null>(null);
+  const sectionSaveTimers = React.useRef<Record<string, number>>({});
+  const questionSaveTimers = React.useRef<Record<string, number>>({});
+  const metaTimer = React.useRef<number | null>(null);
+  const [draggingSectionId, setDraggingSectionId] = React.useState<string | null>(null);
+  const [publishOpen, setPublishOpen] = React.useState(false);
+  const [readiness, setReadiness] = React.useState<{ ok: boolean; items: string[] }>({ ok: false, items: [] });
+  const [publishResult, setPublishResult] = React.useState<{ versionId: string; publishedAt: string } | null>(null);
+  const mode = searchParams.get("mode") === "preview" ? "preview" : "builder";
+
+  const draftQuery = useQuery({
+    queryKey: ["questionnaire", questionnaireId, "draft"],
+    queryFn: () => getQuestionnaireDraft(questionnaireId),
+    enabled: Boolean(questionnaireId),
+  });
+
+  const sectionsQuery = useQuery({
+    queryKey: ["questionnaire", questionnaireId, "sections"],
+    queryFn: () => listQuestionnaireSections(questionnaireId),
+    enabled: Boolean(questionnaireId),
+  });
+
+  const schemaQuery = useQuery({
+    queryKey: ["questionnaire", questionnaireId, "schema"],
+    queryFn: () => getQuestionnaireDraftSchema(questionnaireId),
+    enabled: Boolean(questionnaireId),
+  });
+
+  const analyticsQuery = useQuery({
+    queryKey: ["questionnaire", questionnaireId, "analytics"],
+    queryFn: () => getQuestionnaireAnalytics(questionnaireId),
+    enabled: Boolean(questionnaireId),
+    refetchInterval: 60000,
+  });
+
+  React.useEffect(() => {
+    if (!draftQuery.data?.draft) return;
+    setTitle(draftQuery.data.draft.title || "");
+    setDescription(draftQuery.data.draft.description || "");
+  }, [draftQuery.data?.draft?.title, draftQuery.data?.draft?.description]);
+
+  React.useEffect(() => {
+    if (!sectionsQuery.data?.items) return;
+    const sorted = [...sectionsQuery.data.items].sort((a, b) => a.position - b.position);
+    setSections(sorted);
+
+    void (async () => {
+      const entries = await Promise.all(
+        sorted.map(async (section) => {
+          const res = await listQuestionnaireQuestions(questionnaireId, section.section_id);
+          return [section.section_id, (res.items || []).sort((a, b) => a.position - b.position)] as const;
+        }),
+      );
+      setQuestionsBySection(Object.fromEntries(entries));
+    })();
+  }, [questionnaireId, sectionsQuery.data?.items]);
+
+
+  React.useEffect(() => {
+    if (!questionnaireId) return;
+    try {
+      const raw = window.localStorage.getItem(`qnr_rules_${questionnaireId}`);
+      if (raw) setRules(JSON.parse(raw));
+    } catch {
+      // ignore
+    }
+  }, [questionnaireId]);
+
+  React.useEffect(() => {
+    if (!questionnaireId) return;
+    window.localStorage.setItem(`qnr_rules_${questionnaireId}`, JSON.stringify(rules));
+  }, [questionnaireId, rules]);
+  const withSaving = async <T,>(fn: () => Promise<T>): Promise<T> => {
+    setSavingCount((c) => c + 1);
+    try {
+      return await fn();
+    } finally {
+      setSavingCount((c) => Math.max(0, c - 1));
+    }
+  };
+
+  const saveMetadataMutation = useMutation({
+    mutationFn: (payload: { title: string; description: string }) => withSaving(() => updateQuestionnaireDraft(questionnaireId, payload)),
+    onSuccess: () => setMetadataDirty(false),
+    onError: () => toast.error("Failed to autosave metadata"),
+  });
+
+  const saveSectionMutation = useMutation({
+    mutationFn: (payload: { sectionId: string; title: string; description: string }) =>
+      withSaving(() => updateQuestionnaireSection(questionnaireId, payload.sectionId, { title: payload.title, description: payload.description })),
+    onSuccess: (_res, vars) => {
+      setDirtySections((prev) => {
+        const next = new Set(prev);
+        next.delete(vars.sectionId);
+        return next;
+      });
+    },
+  });
+
+  const saveQuestionMutation = useMutation({
+    mutationFn: (payload: QuestionnaireQuestion) =>
+      withSaving(() =>
+        updateQuestionnaireQuestion(questionnaireId, payload.section_id, payload.question_id, {
+          label: payload.label,
+          required: payload.required,
+          hint: payload.hint,
+          config_json: payload.config_json,
+        }),
+      ),
+    onSuccess: (_res, vars) => {
+      setDirtyQuestions((prev) => {
+        const next = new Set(prev);
+        next.delete(vars.question_id);
+        return next;
+      });
+    },
+  });
+
+  const unsaved = metadataDirty || dirtySections.size > 0 || dirtyQuestions.size > 0 || savingCount > 0;
+
+  React.useEffect(() => {
+    const handler = (event: BeforeUnloadEvent) => {
+      if (!unsaved) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [unsaved]);
+
+  React.useEffect(() => {
+    if (!metadataDirty) return;
+    if (metaTimer.current) window.clearTimeout(metaTimer.current);
+    metaTimer.current = window.setTimeout(() => {
+      saveMetadataMutation.mutate({ title: title.trim(), description: description.trim() });
+    }, 700);
+    return () => {
+      if (metaTimer.current) window.clearTimeout(metaTimer.current);
+    };
+  }, [title, description, metadataDirty]);
+
+  const queueSectionSave = (section: QuestionnaireSection) => {
+    setDirtySections((prev) => new Set(prev).add(section.section_id));
+    const timer = sectionSaveTimers.current[section.section_id];
+    if (timer) window.clearTimeout(timer);
+    sectionSaveTimers.current[section.section_id] = window.setTimeout(() => {
+      saveSectionMutation.mutate({ sectionId: section.section_id, title: section.title, description: section.description || "" });
+    }, 700);
+  };
+
+  const queueQuestionSave = (question: QuestionnaireQuestion) => {
+    const validationError = validateQuestionConfig({
+      question_id: question.question_id,
+      section_id: question.section_id,
+      type: question.type as BuilderQuestionType,
+      label: question.label,
+      required: question.required,
+      hint: question.hint || "",
+      config_json: question.config_json,
+    });
+    setQuestionErrors((prev) => ({ ...prev, [question.question_id]: validationError || "" }));
+    if (validationError) return;
+
+    setDirtyQuestions((prev) => new Set(prev).add(question.question_id));
+    const timer = questionSaveTimers.current[question.question_id];
+    if (timer) window.clearTimeout(timer);
+    questionSaveTimers.current[question.question_id] = window.setTimeout(() => {
+      saveQuestionMutation.mutate(question);
+    }, 700);
+  };
+
+  const handleSectionChange = (sectionId: string, patch: Partial<QuestionnaireSection>) => {
+    setSections((prev) => {
+      const next = prev.map((s) => (s.section_id === sectionId ? { ...s, ...patch } : s));
+      const changed = next.find((s) => s.section_id === sectionId);
+      if (changed) queueSectionSave(changed);
+      return next;
+    });
+  };
+
+  const handleQuestionChange = (sectionId: string, questionId: string, patch: Partial<QuestionnaireQuestion>) => {
+    setQuestionsBySection((prev) => {
+      const list = prev[sectionId] || [];
+      const next = list.map((q) => (q.question_id === questionId ? { ...q, ...patch } : q));
+      const changed = next.find((q) => q.question_id === questionId);
+      if (changed) queueQuestionSave(changed);
+      return { ...prev, [sectionId]: next };
+    });
+  };
+
+  const reorder = async (ordered: QuestionnaireSection[]) => {
+    setSections(ordered.map((s, idx) => ({ ...s, position: idx })));
+    await withSaving(() => reorderQuestionnaireSections(questionnaireId, ordered.map((s) => s.section_id)));
+  };
+
+  const moveSection = async (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= sections.length) return;
+    const ordered = [...sections];
+    const [item] = ordered.splice(index, 1);
+    if (!item) return;
+    ordered.splice(target, 0, item);
+    await reorder(ordered);
+  };
+
+  const createSection = async () => {
+    const created = await withSaving(() =>
+      createQuestionnaireSection(questionnaireId, { section_id: newId("sec"), title: `Section ${sections.length + 1}`, description: "" }),
+    );
+    setSections((prev) => [...prev, created.section]);
+    setQuestionsBySection((prev) => ({ ...prev, [created.section.section_id]: [] }));
+  };
+
+  const removeSection = async (sectionId: string) => {
+    await withSaving(() => deleteQuestionnaireSection(questionnaireId, sectionId));
+    setSections((prev) => prev.filter((s) => s.section_id !== sectionId));
+    setQuestionsBySection((prev) => {
+      const next = { ...prev };
+      delete next[sectionId];
+      return next;
+    });
+  };
+
+  const addQuestion = async (sectionId: string) => {
+    const type: BuilderQuestionType = "text";
+    const created = await withSaving(() =>
+      createQuestionnaireQuestion(questionnaireId, {
+        section_id: sectionId,
+        question_id: newId("q"),
+        type,
+        label: "Untitled question",
+        required: false,
+        hint: "",
+        config_json: defaultConfigForType(type),
+      }),
+    );
+    setQuestionsBySection((prev) => ({ ...prev, [sectionId]: [...(prev[sectionId] || []), created.question] }));
+  };
+
+  const removeQuestion = async (sectionId: string, questionId: string) => {
+    await withSaving(() => deleteQuestionnaireQuestion(questionnaireId, sectionId, questionId));
+    setQuestionsBySection((prev) => ({ ...prev, [sectionId]: (prev[sectionId] || []).filter((q) => q.question_id !== questionId) }));
+  };
+
+
+  const allQuestionIds = React.useMemo(() => Object.values(questionsBySection).flat().map((q) => q.question_id), [questionsBySection]);
+  const ruleReferenceErrors = React.useMemo(() => validateRuleReferences(rules, allQuestionIds), [rules, allQuestionIds]);
+
+  const runRulePreview = async (answers: Record<string, unknown>) => {
+    if (ruleReferenceErrors.length > 0) {
+      setPreviewOutput({ error: "Fix invalid rule references before preview." });
+      return;
+    }
+    const payload = toBackendRulePayload(rules);
+    const res = await withSaving(() =>
+      validateQuestionnaireDraft(questionnaireId, {
+        answers_by_question_id: answers,
+        group_rules: payload.group_rules,
+        form_rules: payload.form_rules,
+        final_submit: false,
+      }),
+    );
+    setPreviewOutput(res);
+  };
+
+
+  const runReadinessChecks = async () => {
+    const items: string[] = [];
+    if (!title.trim()) items.push("Title is required.");
+    if (sections.length === 0) items.push("At least one section is required.");
+    if (Object.values(questionsBySection).flat().length === 0) items.push("At least one question is required.");
+    if (ruleReferenceErrors.length > 0) items.push("Validation rule references must be fixed.");
+
+    if (items.length === 0) {
+      try {
+        const payload = toBackendRulePayload(rules);
+        const result = await withSaving(() =>
+          validateQuestionnaireDraft(questionnaireId, {
+            answers_by_question_id: {},
+            group_rules: payload.group_rules,
+            form_rules: payload.form_rules,
+            final_submit: false,
+          }),
+        );
+        const hasBlocking = Boolean((result as { has_blocking_form_error?: boolean }).has_blocking_form_error);
+        if (hasBlocking) items.push("Blocking form-level validation errors must be resolved.");
+      } catch {
+        items.push("Unable to validate draft readiness.");
+      }
+    }
+
+    setReadiness({ ok: items.length === 0, items: items.length ? items : ["Ready to publish"] });
+    return items.length === 0;
+  };
+
+  const publishMutation = useMutation({
+    mutationFn: () => withSaving(() => publishQuestionnaireDraft(questionnaireId)),
+    onSuccess: (res) => {
+      setPublishResult({ versionId: res.version.version_id, publishedAt: res.version.published_at });
+      toast.success("Questionnaire published");
+      setPublishOpen(false);
+    },
+    onError: () => toast.error("Publish failed"),
+  });
+
+  const openPublishDialog = async () => {
+    await runReadinessChecks();
+    setPublishOpen(true);
+  };
+  if (draftQuery.isLoading || sectionsQuery.isLoading || schemaQuery.isLoading || analyticsQuery.isLoading) {
+    return <div className="p-6 text-muted-foreground flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Loading builder…</div>;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-6 p-4 sm:p-6" data-testid="questionnaire-builder">
+      <PageHeader
+        title="Questionnaire Builder"
+        description="Manage metadata, sections, and questions for your draft questionnaire."
+        actions={(
+          <div className="flex items-center gap-2">
+            <Badge variant={unsaved ? "secondary" : "outline"} role="status" aria-live="polite">{unsaved ? "Unsaved changes" : "All changes saved"}</Badge>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setSearchParams({ mode: mode === "preview" ? "builder" : "preview" })}
+            >
+              {mode === "preview" ? "Exit preview" : "Preview mode"}
+            </Button>
+            <Button type="button" onClick={openPublishDialog}>Publish</Button>
+          </div>
+        )}
+      />
+
+      <Card data-testid="questionnaire-analytics-card">
+        <CardHeader>
+          <CardTitle>Response analytics</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <div data-testid="analytics-freshness">Updated at {analyticsQuery.data?.analytics?.generated_at || "-"} (SLA {analyticsQuery.data?.analytics?.freshness_sla_seconds || 60}s)</div>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+            <div data-testid="analytics-total-starts">Starts: <strong>{analyticsQuery.data?.analytics?.totals?.starts ?? 0}</strong></div>
+            <div data-testid="analytics-total-completions">Completions: <strong>{analyticsQuery.data?.analytics?.totals?.completions ?? 0}</strong></div>
+            <div data-testid="analytics-version-count">Published versions: <strong>{analyticsQuery.data?.analytics?.versions?.length ?? 0}</strong></div>
+          </div>
+          {(analyticsQuery.data?.analytics?.versions || []).map((row) => (
+            <div key={row.version_id} className="rounded border p-2" data-testid={`analytics-version-${row.version_id}`}>
+              <div className="font-medium">Version {row.version_number ?? "?"} ({row.version_id})</div>
+              <div data-testid={`analytics-funnel-${row.version_id}`}>
+                Funnel: {row.funnel.starts} starts → {row.funnel.completions} completions ({Math.round((row.funnel.completion_rate || 0) * 100)}%)
+              </div>
+              <div>Avg completion: {row.average_completion_seconds == null ? "-" : `${Math.round(row.average_completion_seconds)}s`}</div>
+            </div>
+          ))}
+          <div>
+            <div className="font-medium">Top drop-off points</div>
+            <ul data-testid="analytics-dropoff-list" className="list-disc pl-5">
+              {(analyticsQuery.data?.analytics?.totals?.top_dropoffs || []).map((item) => (
+                <li key={`${item.label}-${item.count}`}>{item.label}: {item.count}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <div className="font-medium">Validation hotspots</div>
+            <ul data-testid="analytics-hotspot-list" className="list-disc pl-5">
+              {(analyticsQuery.data?.analytics?.totals?.top_validation_hotspots || []).map((item) => (
+                <li key={`${item.key}-${item.count}`}>{item.key}: {item.count}</li>
+              ))}
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+
+      {mode === "preview" && (
+        <Card data-testid="questionnaire-preview-mode">
+          <CardHeader>
+            <CardTitle>Creator preview</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {((schemaQuery.data?.sections as Array<Record<string, unknown>> | undefined) || []).map((section, sectionIdx) => (
+              <div key={String(section.section_id || sectionIdx)} className="rounded border p-3 space-y-2">
+                <div className="font-medium">{String(section.title || `Section ${sectionIdx + 1}`)}</div>
+                {Array.isArray(section.questions) && section.questions.map((q, qIdx) => (
+                  <div key={String((q as Record<string, unknown>).question_id || qIdx)} className="space-y-1">
+                    <Label>{String((q as Record<string, unknown>).label || "Untitled question")}</Label>
+                    <Input
+                      readOnly
+                      aria-label={`Preview respondent ${String((q as Record<string, unknown>).question_id || qIdx)}`}
+                      placeholder={String(((q as Record<string, unknown>).config_json as Record<string, unknown> | undefined)?.placeholder || "")}
+                    />
+                    <p className="text-xs text-muted-foreground">{String((q as Record<string, unknown>).hint || "")}</p>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader><CardTitle>Metadata</CardTitle></CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2"><Label htmlFor="q-title">Title</Label><Input id="q-title" value={title} onChange={(e) => { setTitle(e.target.value); setMetadataDirty(true); }} /></div>
+          <div className="space-y-2"><Label htmlFor="q-description">Description</Label><Textarea id="q-description" value={description} onChange={(e) => { setDescription(e.target.value); setMetadataDirty(true); }} rows={3} /></div>
+          <div className="space-y-2">
+            <Label>Visibility</Label>
+            <Select value={visibility} onValueChange={(value: "private" | "public" | "unlisted") => { setVisibility(value); setMetadataDirty(true); }}>
+              <SelectTrigger aria-label="Visibility"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="private">Private</SelectItem>
+                <SelectItem value="unlisted">Unlisted</SelectItem>
+                <SelectItem value="public">Public</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between"><CardTitle>Sections</CardTitle><Button onClick={createSection}><Plus className="mr-2 h-4 w-4" />Add section</Button></CardHeader>
+        <CardContent className="space-y-4">
+          {sections.length === 0 && <EmptyState title="No sections yet" description="Create your first section to start structuring the questionnaire." action={{ label: "Add section", onClick: createSection }} />}
+
+          {sections.map((section, index) => (
+            <div key={section.section_id} className="rounded-md border p-3 space-y-3 bg-background" draggable onDragStart={() => setDraggingSectionId(section.section_id)} onDragOver={(e) => e.preventDefault()} onDrop={async () => {
+              if (!draggingSectionId || draggingSectionId === section.section_id) return;
+              const from = sections.findIndex((s) => s.section_id === draggingSectionId);
+              const to = sections.findIndex((s) => s.section_id === section.section_id);
+              if (from < 0 || to < 0) return;
+              const ordered = [...sections];
+              const [item] = ordered.splice(from, 1);
+              if (!item) return;
+              ordered.splice(to, 0, item);
+              await reorder(ordered);
+              setDraggingSectionId(null);
+            }}>
+              <div className="flex items-center gap-2">
+                <GripVertical className="h-4 w-4 text-muted-foreground" />
+                <Input aria-label={`Section title ${section.section_id}`} value={section.title} onChange={(e) => handleSectionChange(section.section_id, { title: e.target.value })} />
+                <Button variant="ghost" size="icon" onClick={() => moveSection(index, -1)} aria-label="Move up">↑</Button>
+                <Button variant="ghost" size="icon" onClick={() => moveSection(index, 1)} aria-label="Move down">↓</Button>
+                <Button variant="ghost" size="icon" onClick={() => removeSection(section.section_id)} aria-label="Delete section"><Trash2 className="h-4 w-4" /></Button>
+              </div>
+              <Textarea aria-label={`Section description ${section.section_id}`} value={section.description || ""} onChange={(e) => handleSectionChange(section.section_id, { description: e.target.value })} rows={2} />
+
+              <div className="border-t pt-3 space-y-3" data-testid={`question-list-${section.section_id}`}>
+                <div className="flex items-center justify-between">
+                  <h4 className="text-sm font-medium">Questions</h4>
+                  <Button size="sm" variant="outline" onClick={() => addQuestion(section.section_id)}><Plus className="mr-1 h-3 w-3" />Add question</Button>
+                </div>
+                {(questionsBySection[section.section_id] || []).length === 0 && <p className="text-xs text-muted-foreground">No questions in this section yet.</p>}
+
+                {(questionsBySection[section.section_id] || []).map((question) => (
+                  <div key={question.question_id} className="rounded border p-3 space-y-2">
+                    <div className="grid grid-cols-12 gap-2 items-end">
+                      <div className="col-span-5">
+                        <Label>Label</Label>
+                        <Input value={question.label} onChange={(e) => handleQuestionChange(section.section_id, question.question_id, { label: e.target.value })} />
+                      </div>
+                      <div className="col-span-3">
+                        <Label>Type</Label>
+                        <Select value={question.type} onValueChange={(value: BuilderQuestionType) => handleQuestionChange(section.section_id, question.question_id, { type: value, config_json: defaultConfigForType(value) })}>
+                          <SelectTrigger aria-label="Question type"><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="text">text</SelectItem>
+                            <SelectItem value="select">select</SelectItem>
+                            <SelectItem value="multiselect">multiselect</SelectItem>
+                            <SelectItem value="radio">radio</SelectItem>
+                            <SelectItem value="slider">slider</SelectItem>
+                            <SelectItem value="date">date</SelectItem>
+                            <SelectItem value="time">time</SelectItem>
+                            <SelectItem value="timezone">timezone</SelectItem>
+                            <SelectItem value="address">address</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="col-span-2">
+                        <Label>Required</Label>
+                        <input type="checkbox" checked={question.required} onChange={(e) => handleQuestionChange(section.section_id, question.question_id, { required: e.target.checked })} className="h-4 w-4" />
+                      </div>
+                      <div className="col-span-2 flex justify-end">
+                        <Button variant="ghost" size="icon" aria-label="Delete question" onClick={() => removeQuestion(section.section_id, question.question_id)}>
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <Label>Hint text</Label>
+                        <Input
+                          aria-label="Hint text"
+                          value={question.hint || ""}
+                          onChange={(e) => handleQuestionChange(section.section_id, question.question_id, { hint: e.target.value })}
+                        />
+                      </div>
+                      <div>
+                        <Label>Help text</Label>
+                        <Input
+                          aria-label="Help text"
+                          value={String(question.config_json?.help_text || "")}
+                          onChange={(e) =>
+                            handleQuestionChange(section.section_id, question.question_id, {
+                              config_json: { ...(question.config_json || {}), help_text: e.target.value },
+                            })
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <Label>Placeholder</Label>
+                      <Input
+                        aria-label="Placeholder"
+                        value={String(question.config_json?.placeholder || "")}
+                        onChange={(e) =>
+                          handleQuestionChange(section.section_id, question.question_id, {
+                            config_json: { ...(question.config_json || {}), placeholder: e.target.value },
+                          })
+                        }
+                      />
+                    </div>
+
+                    <QuestionTypeConfigEditor
+                      type={question.type as BuilderQuestionType}
+                      config={question.config_json || {}}
+                      onChange={(cfg) => handleQuestionChange(section.section_id, question.question_id, { config_json: cfg })}
+                    />
+
+                    {questionErrors[question.question_id] && (
+                      <p className="text-xs text-destructive" data-testid={`question-error-${question.question_id}`}>{questionErrors[question.question_id]}</p>
+                    )}
+
+                    <div className="rounded bg-muted/30 p-2 text-sm" data-testid={`question-preview-${question.question_id}`}>
+                      <Label htmlFor={`preview-input-${question.question_id}`}>{question.label || "Untitled question"}</Label>
+                      <Input
+                        id={`preview-input-${question.question_id}`}
+                        aria-label={`Preview ${question.question_id}`}
+                        placeholder={String(question.config_json?.placeholder || "")}
+                        aria-describedby={`preview-hint-${question.question_id}`}
+                        value=""
+                        onChange={() => {}}
+                      />
+                      <p id={`preview-hint-${question.question_id}`} className="text-xs text-muted-foreground" role="note">
+                        {[question.hint, String(question.config_json?.help_text || "")].filter(Boolean).join(" ")}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Validation rules</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ValidationRuleBuilder
+            rules={rules}
+            onChange={setRules}
+            onPreview={runRulePreview}
+            previewOutput={previewOutput}
+            referenceErrors={ruleReferenceErrors}
+          />
+        </CardContent>
+      </Card>
+
+      {publishResult && (
+        <Card data-testid="publish-success">
+          <CardContent className="pt-6 text-sm">
+            Published version <strong>{publishResult.versionId}</strong> at <strong>{publishResult.publishedAt}</strong>
+          </CardContent>
+        </Card>
+      )}
+
+      <Dialog open={publishOpen} onOpenChange={setPublishOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Publish questionnaire</DialogTitle>
+            <DialogDescription>Review readiness checks before publishing a new immutable version.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 text-sm" data-testid="publish-readiness-checklist">
+            {readiness.items.map((item) => (
+              <div key={item} className={readiness.ok ? "text-green-700" : "text-destructive"}>{item}</div>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => void runReadinessChecks()}>Re-run checks</Button>
+            <Button type="button" disabled={!readiness.ok || publishMutation.isPending} onClick={() => publishMutation.mutate()}>
+              {publishMutation.isPending ? "Publishing…" : "Confirm publish"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <div className="text-xs text-muted-foreground flex items-center gap-2" role="status" aria-live="polite" data-testid="builder-save-indicator"><Save className="h-3 w-3" />{savingCount > 0 ? "Autosaving…" : unsaved ? "Unsaved changes pending" : "All changes saved"}</div>
+    </div>
+  );
+}

--- a/frontend/src/pages/questionnaires/QuestionnaireRespondentPage.test.tsx
+++ b/frontend/src/pages/questionnaires/QuestionnaireRespondentPage.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import QuestionnaireRespondentPage from "./QuestionnaireRespondentPage";
+
+const getPublishedQuestionnaireBySlug = vi.fn();
+const startPublishedResponseSession = vi.fn();
+const getPublishedResponseSessionState = vi.fn();
+const savePublishedResponseSessionState = vi.fn();
+const validatePublishedResponseSession = vi.fn();
+const submitPublishedResponseSession = vi.fn();
+
+vi.mock("@/api/endpoints/questionnaires", () => ({
+  getPublishedQuestionnaireBySlug: (...args: unknown[]) => getPublishedQuestionnaireBySlug(...args),
+  startPublishedResponseSession: (...args: unknown[]) => startPublishedResponseSession(...args),
+  getPublishedResponseSessionState: (...args: unknown[]) => getPublishedResponseSessionState(...args),
+  savePublishedResponseSessionState: (...args: unknown[]) => savePublishedResponseSessionState(...args),
+  validatePublishedResponseSession: (...args: unknown[]) => validatePublishedResponseSession(...args),
+  submitPublishedResponseSession: (...args: unknown[]) => submitPublishedResponseSession(...args),
+}));
+
+function renderPage(initial = "/questionnaires/published/slug/respond") {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/questionnaires/published/:publishedSlug/respond" element={<QuestionnaireRespondentPage />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("QuestionnaireRespondentPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPublishedQuestionnaireBySlug.mockResolvedValue({
+      version: {
+        schema_json: {
+          sections: [
+            { section_id: "s1", title: "S1", questions: [{ question_id: "q1", label: "Q1", required: true }] },
+            { section_id: "s2", title: "S2", questions: [{ question_id: "q2", label: "Q2", required: true }] },
+          ],
+        },
+      },
+    });
+    startPublishedResponseSession.mockResolvedValue({ session: { response_session_id: "sess1" } });
+    getPublishedResponseSessionState.mockResolvedValue({
+      session: { response_session_id: "sess1", status: "in_progress", current_section_index: 1, current_question_id: "q2" },
+      answers_by_question_id: { q1: "saved" },
+    });
+    savePublishedResponseSessionState.mockResolvedValue({
+      session: { response_session_id: "sess1", status: "in_progress", current_section_index: 1, current_question_id: "q2" },
+      answers_by_question_id: { q1: "saved", q2: "later" },
+    });
+    validatePublishedResponseSession.mockResolvedValue({
+      is_valid: false,
+      can_submit: false,
+      has_blocking_form_error: false,
+      errors: {
+        q2: [{ code: "required", message: "Question is required" }],
+        "form:submit": [{ code: "form_blocked", message: "Complete required questions", blocking: true }],
+      },
+    });
+    submitPublishedResponseSession.mockResolvedValue({ session: { status: "submitted" }, result: { can_submit: true } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts a session from start screen", async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole("button", { name: /start questionnaire/i }));
+    await waitFor(() => expect(startPublishedResponseSession).toHaveBeenCalled());
+  });
+
+  it("shows inline and summary errors and blocks submit until corrected", async () => {
+    renderPage("/questionnaires/published/slug/respond?session_id=sess1");
+
+    expect(await screen.findByText("S2")).toBeInTheDocument();
+    expect(screen.getByTestId("respondent-page-progress")).toHaveTextContent("Page 2/2");
+    expect(screen.getByTestId("respondent-required-progress")).toHaveTextContent("Required answered 1/2");
+
+    const q2 = screen.getByLabelText("answer-q2");
+    fireEvent.change(q2, { target: { value: "x" } });
+
+    await waitFor(() => expect(validatePublishedResponseSession).toHaveBeenCalled(), { timeout: 2000 });
+    expect(await screen.findByTestId("field-error-q2")).toHaveTextContent("Question is required");
+    expect(screen.getByTestId("respondent-error-summary")).toHaveTextContent("Complete required questions");
+
+    const submitButton = screen.getByRole("button", { name: /submit/i });
+    expect(submitButton).toBeDisabled();
+    expect(submitPublishedResponseSession).not.toHaveBeenCalled();
+
+    validatePublishedResponseSession.mockResolvedValueOnce({
+      is_valid: true,
+      can_submit: true,
+      has_blocking_form_error: false,
+      errors: {},
+    });
+    fireEvent.change(q2, { target: { value: "ok" } });
+    await waitFor(() => expect(validatePublishedResponseSession).toHaveBeenCalledTimes(2), { timeout: 2000 });
+    await waitFor(() => expect(screen.getByRole("button", { name: /submit/i })).not.toBeDisabled());
+  });
+
+
+  it("exposes aria bindings for errors and live status announcements", async () => {
+    renderPage("/questionnaires/published/slug/respond?session_id=sess1");
+
+    const q2 = await screen.findByLabelText("answer-q2");
+    fireEvent.change(q2, { target: { value: "x" } });
+
+    const fieldError = await screen.findByTestId("field-error-q2");
+    expect(fieldError).toHaveAttribute("role", "status");
+    expect(q2).toHaveAttribute("aria-invalid", "true");
+    expect(q2).toHaveAttribute("aria-describedby", "field-error-q2");
+
+    const summaryError = screen.getByTestId("respondent-error-summary");
+    expect(summaryError).toHaveAttribute("role", "alert");
+    expect(screen.getByTestId("respondent-live-announcer")).toHaveTextContent("Required answered");
+  });
+
+  it("shows final answer summary grouped by section and supports edit roundtrip", async () => {
+    renderPage("/questionnaires/published/slug/respond?session_id=sess1");
+
+    expect(await screen.findByText("S2")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /review summary/i }));
+
+    expect(await screen.findByTestId("respondent-summary-view")).toBeInTheDocument();
+    expect(screen.getByText("S1")).toBeInTheDocument();
+    expect(screen.getByText("S2")).toBeInTheDocument();
+    expect(screen.getByTestId("summary-answer-q1")).toHaveTextContent("saved");
+    expect(screen.getByTestId("summary-answer-q2")).toHaveTextContent("—");
+
+    const q1Row = screen.getByTestId("summary-question-q1");
+    fireEvent.click(within(q1Row).getByRole("button", { name: /edit/i }));
+
+    expect(await screen.findByLabelText("answer-q1")).toBeInTheDocument();
+    expect(screen.getByTestId("respondent-page-progress")).toHaveTextContent("Page 1/2");
+
+    fireEvent.change(screen.getByLabelText("answer-q1"), { target: { value: "updated" } });
+    await waitFor(() => expect(savePublishedResponseSessionState).toHaveBeenCalled(), { timeout: 2000 });
+
+    fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /review summary/i }));
+
+    expect(await screen.findByTestId("summary-answer-q1")).toHaveTextContent("updated");
+  });
+});

--- a/frontend/src/pages/questionnaires/QuestionnaireRespondentPage.tsx
+++ b/frontend/src/pages/questionnaires/QuestionnaireRespondentPage.tsx
@@ -1,0 +1,387 @@
+import * as React from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Loader2, Pencil } from "lucide-react";
+import { useParams, useSearchParams } from "react-router-dom";
+
+import {
+  getPublishedQuestionnaireBySlug,
+  getPublishedResponseSessionState,
+  savePublishedResponseSessionState,
+  startPublishedResponseSession,
+  submitPublishedResponseSession,
+  validatePublishedResponseSession,
+} from "@/api/endpoints/questionnaires";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type ViewMode = "form" | "summary";
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function isAnswered(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function stringifyAnswer(value: unknown): string {
+  if (value == null) return "—";
+  if (Array.isArray(value)) return value.length ? value.map((v) => String(v)).join(", ") : "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  const rendered = String(value);
+  return rendered.trim().length ? rendered : "—";
+}
+
+function trackRespondentCheckpoint(event: string, payload: Record<string, unknown>) {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("questionnaire:checkpoint", { detail: { event, ...payload } }));
+  }
+
+  const body = JSON.stringify({ event, ...payload });
+  try {
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      navigator.sendBeacon("/telemetry/questionnaire-checkpoint", new Blob([body], { type: "application/json" }));
+      return;
+    }
+  } catch {
+    // no-op
+  }
+}
+
+export default function QuestionnaireRespondentPage() {
+  const { publishedSlug = "" } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sessionId = searchParams.get("session_id") || "";
+
+  const [currentSectionIndex, setCurrentSectionIndex] = React.useState(0);
+  const [answers, setAnswers] = React.useState<Record<string, unknown>>({});
+  const [validationResult, setValidationResult] = React.useState<Record<string, unknown> | null>(null);
+  const [submitError, setSubmitError] = React.useState<string>("");
+  const [viewMode, setViewMode] = React.useState<ViewMode>("form");
+
+  const saveTimer = React.useRef<number | null>(null);
+  const validateTimer = React.useRef<number | null>(null);
+  const sectionHeadingRef = React.useRef<HTMLHeadingElement | null>(null);
+
+  const publishedQuery = useQuery({
+    queryKey: ["published-questionnaire", publishedSlug],
+    queryFn: () => getPublishedQuestionnaireBySlug(publishedSlug),
+    enabled: Boolean(publishedSlug),
+  });
+
+  const startSessionMutation = useMutation({
+    mutationFn: () => startPublishedResponseSession(publishedSlug),
+    onSuccess: (res) => {
+      const nextSession = String((res.session as { response_session_id?: string }).response_session_id || "");
+      if (nextSession) setSearchParams({ session_id: nextSession, view: "form" });
+    },
+  });
+
+  const sessionStateQuery = useQuery({
+    queryKey: ["published-questionnaire-session", publishedSlug, sessionId],
+    queryFn: () => getPublishedResponseSessionState(publishedSlug, sessionId),
+    enabled: Boolean(publishedSlug && sessionId),
+  });
+
+  const hydratedSessionId = React.useRef<string>("");
+
+  React.useEffect(() => {
+    if (!sessionStateQuery.data) return;
+    const loadedSessionId = String(sessionStateQuery.data.session.response_session_id || "");
+    if (!loadedSessionId || hydratedSessionId.current === loadedSessionId) return;
+
+    hydratedSessionId.current = loadedSessionId;
+    setAnswers(sessionStateQuery.data.answers_by_question_id || {});
+
+    const restoredIndex = Number(sessionStateQuery.data.session.current_section_index || 0);
+    const sectionParam = searchParams.get("section");
+    const sectionFromQuery = sectionParam == null ? NaN : Number(sectionParam);
+    setCurrentSectionIndex(Number.isFinite(sectionFromQuery) ? Math.max(0, sectionFromQuery) : restoredIndex);
+    setViewMode(searchParams.get("view") === "summary" ? "summary" : "form");
+
+    trackRespondentCheckpoint("session_restored", {
+      session_id: loadedSessionId,
+      current_section_index: restoredIndex,
+    });
+  }, [sessionStateQuery.data, searchParams]);
+
+  React.useEffect(() => {
+    const sectionParam = searchParams.get("section");
+    const sectionFromQuery = sectionParam == null ? NaN : Number(sectionParam);
+    if (Number.isFinite(sectionFromQuery)) setCurrentSectionIndex(Math.max(0, sectionFromQuery));
+    setViewMode(searchParams.get("view") === "summary" ? "summary" : "form");
+  }, [searchParams]);
+
+
+  React.useEffect(() => {
+    if (sectionHeadingRef.current) sectionHeadingRef.current.focus();
+  }, [currentSectionIndex, viewMode]);
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: { answers: Record<string, unknown>; sectionIndex: number; questionId?: string }) =>
+      savePublishedResponseSessionState(publishedSlug, sessionId, {
+        answers_by_question_id: payload.answers,
+        current_section_index: payload.sectionIndex,
+        current_question_id: payload.questionId,
+      }),
+    onSuccess: () => {
+      trackRespondentCheckpoint("autosave", {
+        session_id: sessionId,
+        current_section_index: currentSectionIndex,
+      });
+    },
+  });
+
+  const validateMutation = useMutation({
+    mutationFn: (payload: { answers: Record<string, unknown>; finalSubmit?: boolean }) =>
+      validatePublishedResponseSession(publishedSlug, sessionId, {
+        answers_by_question_id: payload.answers,
+        final_submit: Boolean(payload.finalSubmit),
+      }),
+    onSuccess: (res) => {
+      setValidationResult(res);
+      setSubmitError("");
+    },
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: () =>
+      submitPublishedResponseSession(publishedSlug, sessionId, {
+        answers_by_question_id: answers,
+        final_submit: true,
+      }),
+    onSuccess: () => {
+      setSubmitError("");
+      trackRespondentCheckpoint("submitted", { session_id: sessionId });
+    },
+    onError: (err) => {
+      const message = err instanceof Error ? err.message : "Cannot submit while blocking errors exist.";
+      setSubmitError(message);
+    },
+  });
+
+  const schemaSections = asArray<Record<string, unknown>>(publishedQuery.data?.version?.schema_json?.sections);
+  const currentSection = schemaSections[currentSectionIndex] || schemaSections[0];
+  const questions = asArray<Record<string, unknown>>(currentSection?.questions);
+  const allQuestions = React.useMemo(
+    () => schemaSections.flatMap((section) => asArray<Record<string, unknown>>(section.questions)),
+    [schemaSections],
+  );
+  const requiredIds = React.useMemo(
+    () => allQuestions.filter((q) => Boolean(q.required)).map((q) => String(q.question_id || "")),
+    [allQuestions],
+  );
+  const answeredRequiredCount = React.useMemo(
+    () => requiredIds.filter((qid) => isAnswered(answers[qid])).length,
+    [requiredIds, answers],
+  );
+  const requiredCount = requiredIds.length;
+  const pageProgressLabel = `${Math.min(currentSectionIndex + 1, Math.max(1, schemaSections.length))}/${Math.max(1, schemaSections.length)}`;
+  const answeredCount = React.useMemo(() => Object.values(answers).filter((value) => isAnswered(value)).length, [answers]);
+  const completionPercent = requiredCount > 0 ? Math.round((answeredRequiredCount / requiredCount) * 100) : 0;
+
+  const errorMap = (validationResult?.errors as Record<string, Array<{ message: string; blocking?: boolean }>>) || {};
+  const fieldErrors = (questionId: string) => errorMap[questionId] || [];
+  const groupOrFormErrors = Object.entries(errorMap).filter(([key]) => key.startsWith("group:") || key.startsWith("form:"));
+  const hasBlocking = Boolean(validationResult && !(validationResult.can_submit as boolean));
+
+  const queueSaveAndValidate = React.useCallback(
+    (nextAnswers: Record<string, unknown>, sectionIndex: number, questionId?: string) => {
+      if (!sessionId) return;
+      if (saveTimer.current) window.clearTimeout(saveTimer.current);
+      saveTimer.current = window.setTimeout(() => {
+        saveMutation.mutate({ answers: nextAnswers, sectionIndex, questionId });
+      }, 500);
+
+      if (validateTimer.current) window.clearTimeout(validateTimer.current);
+      validateTimer.current = window.setTimeout(() => {
+        validateMutation.mutate({ answers: nextAnswers, finalSubmit: false });
+      }, 350);
+    },
+    [saveMutation, sessionId, validateMutation],
+  );
+
+  const goToSummary = () => {
+    setViewMode("summary");
+    setSearchParams({ session_id: sessionId, view: "summary" });
+    trackRespondentCheckpoint("open_summary", { session_id: sessionId });
+  };
+
+  const editQuestion = (sectionIndex: number, questionId: string) => {
+    setViewMode("form");
+    setCurrentSectionIndex(sectionIndex);
+    setSearchParams({ session_id: sessionId, view: "form", section: String(sectionIndex), question: questionId });
+    trackRespondentCheckpoint("summary_edit_click", { session_id: sessionId, section_index: sectionIndex, question_id: questionId });
+  };
+
+  if (publishedQuery.isLoading) {
+    return <div className="p-6 text-muted-foreground flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Loading questionnaire…</div>;
+  }
+
+  if (!sessionId) {
+    return (
+      <div className="mx-auto max-w-3xl p-6" data-testid="respondent-start-screen">
+        <Card>
+          <CardHeader><CardTitle>{String(publishedQuery.data?.version?.schema_json?.questionnaire_id || "Questionnaire")}</CardTitle></CardHeader>
+          <CardContent>
+            <Button type="button" onClick={() => startSessionMutation.mutate()} disabled={startSessionMutation.isPending}>
+              {startSessionMutation.isPending ? "Starting…" : "Start questionnaire"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (sessionStateQuery.isLoading) {
+    return <div className="p-6 text-muted-foreground flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Restoring progress…</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6 space-y-4" data-testid="respondent-flow">
+      <Card>
+        <CardHeader>
+          <CardTitle ref={sectionHeadingRef} tabIndex={-1}>{viewMode === "summary" ? "Answer summary" : String(currentSection?.title || "Section")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2" data-testid="respondent-progress">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span data-testid="respondent-page-progress">Page {pageProgressLabel}</span>
+              <span data-testid="respondent-required-progress">Required answered {answeredRequiredCount}/{requiredCount}</span>
+            </div>
+            <div className="h-2 w-full rounded bg-muted">
+              <div
+                className="h-2 rounded bg-primary transition-all"
+                style={{ width: `${completionPercent}%` }}
+                data-testid="respondent-progress-bar"
+              />
+            </div>
+            <div className="text-xs text-muted-foreground" data-testid="respondent-answered-counter">
+              Answered {answeredCount}/{allQuestions.length} questions
+            </div>
+          </div>
+
+          {groupOrFormErrors.length > 0 && (
+            <div className="rounded border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive" role="alert" aria-live="assertive" data-testid="respondent-error-summary">
+              {groupOrFormErrors.flatMap(([key, issues]) => issues.map((i, idx) => <div key={`${key}-${idx}`}>{i.message}</div>))}
+            </div>
+          )}
+
+          {viewMode === "summary" ? (
+            <div className="space-y-3" data-testid="respondent-summary-view">
+              {schemaSections.map((section, sectionIndex) => {
+                const sectionQuestions = asArray<Record<string, unknown>>(section.questions);
+                return (
+                  <div key={String(section.section_id || sectionIndex)} className="rounded border p-3 space-y-2">
+                    <div className="font-medium">{String(section.title || `Section ${sectionIndex + 1}`)}</div>
+                    {sectionQuestions.map((q) => {
+                      const qid = String(q.question_id || "");
+                      return (
+                        <div key={qid} className="flex items-start justify-between gap-3 text-sm" data-testid={`summary-question-${qid}`}>
+                          <div>
+                            <div className="font-medium">{String(q.label || "Question")}</div>
+                            <div className="text-muted-foreground" data-testid={`summary-answer-${qid}`}>{stringifyAnswer(answers[qid])}</div>
+                          </div>
+                          <Button type="button" size="sm" variant="outline" onClick={() => editQuestion(sectionIndex, qid)}>
+                            <Pencil className="mr-1 h-3 w-3" /> Edit
+                          </Button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <>
+              {questions.map((q) => {
+                const questionId = String(q.question_id || "");
+                const errors = fieldErrors(questionId);
+                return (
+                  <div key={questionId} className="space-y-1" data-testid={`respondent-question-${questionId}`}>
+                    <Label htmlFor={`answer-input-${questionId}`}>{String(q.label || "Question")}</Label>
+                    <Input
+                      id={`answer-input-${questionId}`}
+                      aria-label={`answer-${questionId}`}
+                      aria-invalid={errors.length > 0}
+                      aria-describedby={errors.length > 0 ? `field-error-${questionId}` : undefined}
+                      value={String(answers[questionId] || "")}
+                      onChange={(e) => {
+                        const next = { ...answers, [questionId]: e.target.value };
+                        setAnswers(next);
+                        queueSaveAndValidate(next, currentSectionIndex, questionId);
+                      }}
+                    />
+                    {errors.length > 0 && (
+                      <div id={`field-error-${questionId}`} className="text-xs text-destructive" role="status" aria-live="polite" data-testid={`field-error-${questionId}`}>
+                        {errors.map((err, idx) => <div key={`${questionId}-${idx}`}>{err.message}</div>)}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+
+              <div className="flex items-center justify-between pt-2" data-testid="respondent-nav">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={currentSectionIndex <= 0}
+                  onClick={() => {
+                    const next = Math.max(0, currentSectionIndex - 1);
+                    setCurrentSectionIndex(next);
+                    queueSaveAndValidate(answers, next);
+                    trackRespondentCheckpoint("navigate_previous", { session_id: sessionId, current_section_index: next });
+                  }}
+                >
+                  Previous
+                </Button>
+                <div className="text-xs text-muted-foreground" role="status" aria-live="polite" data-testid="respondent-autosave-state">
+                  {saveMutation.isPending || validateMutation.isPending ? "Autosaving…" : "Progress saved"}
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (currentSectionIndex >= Math.max(0, schemaSections.length - 1)) {
+                      goToSummary();
+                      return;
+                    }
+                    const next = Math.min(schemaSections.length - 1, currentSectionIndex + 1);
+                    setCurrentSectionIndex(next);
+                    queueSaveAndValidate(answers, next);
+                    trackRespondentCheckpoint("navigate_next", { session_id: sessionId, current_section_index: next });
+                  }}
+                >
+                  {currentSectionIndex >= Math.max(0, schemaSections.length - 1) ? "Review summary" : "Next"}
+                </Button>
+              </div>
+            </>
+          )}
+
+          <div className="sr-only" role="status" aria-live="polite" data-testid="respondent-live-announcer">
+            {`Viewing ${viewMode === "summary" ? "summary" : `section ${currentSectionIndex + 1}`}. Required answered ${answeredRequiredCount} of ${requiredCount}.`}
+          </div>
+
+          <div className="flex items-center justify-end gap-2" data-testid="respondent-submit-area">
+            {viewMode === "summary" && (
+              <Button type="button" variant="outline" onClick={() => setViewMode("form")}>Back to form</Button>
+            )}
+            {submitError && <p className="text-xs text-destructive">{submitError}</p>}
+            <Button
+              type="button"
+              disabled={hasBlocking || submitMutation.isPending}
+              onClick={() => submitMutation.mutate()}
+            >
+              {submitMutation.isPending ? "Submitting…" : "Submit"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/questionnaires/ValidationRuleBuilder.test.tsx
+++ b/frontend/src/pages/questionnaires/ValidationRuleBuilder.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ValidationRuleBuilder from "./ValidationRuleBuilder";
+
+describe("ValidationRuleBuilder", () => {
+  it("adds rules from templates and triggers preview", () => {
+    const onChange = vi.fn();
+    const onPreview = vi.fn();
+
+    render(
+      <ValidationRuleBuilder
+        rules={[]}
+        onChange={onChange}
+        onPreview={onPreview}
+        previewOutput={null}
+        referenceErrors={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Required if another question is answered/i }));
+    expect(onChange).toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText("Sample answers JSON (preview)"), { target: { value: '{"q1":"x"}' } });
+    fireEvent.click(screen.getByRole("button", { name: /Run evaluation preview/i }));
+    expect(onPreview).toHaveBeenCalledWith({ q1: "x" });
+  });
+});

--- a/frontend/src/pages/questionnaires/ValidationRuleBuilder.tsx
+++ b/frontend/src/pages/questionnaires/ValidationRuleBuilder.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { BuilderRule, ValidationScope } from "./validationRules";
+import { templatesForScope } from "./validationRules";
+
+type Props = {
+  rules: BuilderRule[];
+  onChange: (rules: BuilderRule[]) => void;
+  onPreview: (sampleAnswers: Record<string, unknown>) => void;
+  previewOutput: Record<string, unknown> | null;
+  referenceErrors: string[];
+};
+
+const scopes: ValidationScope[] = ["question", "group", "form"];
+
+export default function ValidationRuleBuilder({ rules, onChange, onPreview, previewOutput, referenceErrors }: Props) {
+  const [newScope, setNewScope] = useState<ValidationScope>("question");
+  const [sampleAnswersJson, setSampleAnswersJson] = useState("{}");
+
+  const templates = useMemo(() => templatesForScope(newScope), [newScope]);
+
+  const patchRule = (id: string, patch: Partial<BuilderRule>) => {
+    onChange(rules.map((r) => (r.id === id ? ({ ...r, ...patch } as BuilderRule) : r)));
+  };
+
+  return (
+    <div className="space-y-3" data-testid="validation-rule-builder">
+      <div className="flex items-center gap-2">
+        <Select value={newScope} onValueChange={(v: ValidationScope) => setNewScope(v)}>
+          <SelectTrigger className="w-48" aria-label="Rule scope"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {scopes.map((scope) => <SelectItem key={scope} value={scope}>{scope}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        {templates.map((t) => (
+          <Button key={t.label} type="button" variant="outline" onClick={() => onChange([...rules, t.create()])}>
+            {t.label}
+          </Button>
+        ))}
+      </div>
+
+      {referenceErrors.length > 0 && (
+        <div className="rounded border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive" data-testid="rule-reference-errors">
+          {referenceErrors.map((err) => <div key={err}>{err}</div>)}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {rules.map((rule) => (
+          <div key={rule.id} className="rounded border p-2 space-y-2" data-testid={`rule-${rule.id}`}>
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-medium">{rule.scope} rule: {rule.rule_type}</div>
+              <Button type="button" size="sm" variant="ghost" onClick={() => onChange(rules.filter((r) => r.id !== rule.id))}>Delete</Button>
+            </div>
+
+            {rule.scope === "question" && (
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label>Question ID</Label>
+                  <Input aria-label="Question ID" value={rule.question_id} onChange={(e) => patchRule(rule.id, { question_id: e.target.value } as Partial<BuilderRule>)} />
+                </div>
+                <div>
+                  <Label>Rule type</Label>
+                  <Input value={rule.rule_type} readOnly />
+                </div>
+              </div>
+            )}
+
+            {rule.scope === "group" && (
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label>Group ID</Label>
+                  <Input aria-label="Group ID" value={rule.group_id} onChange={(e) => patchRule(rule.id, { group_id: e.target.value } as Partial<BuilderRule>)} />
+                </div>
+                <div>
+                  <Label>Question IDs (csv)</Label>
+                  <Input
+                    aria-label="Question IDs (csv)"
+                    value={rule.question_ids.join(",")}
+                    onChange={(e) => patchRule(rule.id, { question_ids: e.target.value.split(",").map((x) => x.trim()).filter(Boolean) } as Partial<BuilderRule>)}
+                  />
+                </div>
+              </div>
+            )}
+
+            {rule.scope === "form" && (
+              <div className="flex items-center gap-2">
+                <Label>Blocking</Label>
+                <input
+                  aria-label="Rule blocking"
+                  type="checkbox"
+                  checked={rule.blocking}
+                  onChange={(e) => patchRule(rule.id, { blocking: e.target.checked } as Partial<BuilderRule>)}
+                />
+              </div>
+            )}
+
+            <div>
+              <Label>Config (JSON)</Label>
+              <Textarea
+                rows={3}
+                value={JSON.stringify(rule.config)}
+                onChange={(e) => {
+                  try {
+                    const parsed = JSON.parse(e.target.value);
+                    patchRule(rule.id, { config: parsed } as Partial<BuilderRule>);
+                  } catch {
+                    // keep current config on invalid edit
+                  }
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded border p-3 space-y-2">
+        <Label>Sample answers JSON (preview)</Label>
+        <Textarea aria-label="Sample answers JSON (preview)" value={sampleAnswersJson} onChange={(e) => setSampleAnswersJson(e.target.value)} rows={4} />
+        <Button
+          type="button"
+          onClick={() => {
+            try {
+              const parsed = JSON.parse(sampleAnswersJson);
+              onPreview(parsed);
+            } catch {
+              onPreview({});
+            }
+          }}
+        >
+          Run evaluation preview
+        </Button>
+        {previewOutput && <pre className="text-xs overflow-auto bg-muted/40 p-2 rounded">{JSON.stringify(previewOutput, null, 2)}</pre>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/questionnaires/questionConfig.ts
+++ b/frontend/src/pages/questionnaires/questionConfig.ts
@@ -1,0 +1,74 @@
+export type BuilderQuestionType =
+  | "text"
+  | "select"
+  | "multiselect"
+  | "radio"
+  | "slider"
+  | "date"
+  | "time"
+  | "timezone"
+  | "address";
+
+export type BuilderQuestion = {
+  question_id: string;
+  section_id: string;
+  type: BuilderQuestionType;
+  label: string;
+  required: boolean;
+  hint: string;
+  config_json: Record<string, unknown>;
+};
+
+export function defaultConfigForType(type: BuilderQuestionType): Record<string, unknown> {
+  switch (type) {
+    case "text":
+      return { minLength: 0, maxLength: 200 };
+    case "select":
+    case "multiselect":
+    case "radio":
+      return { options: ["Option 1", "Option 2"] };
+    case "slider":
+      return { min: 0, max: 10, step: 1 };
+    case "date":
+      return { minDate: "", maxDate: "" };
+    case "time":
+      return { minTime: "", maxTime: "" };
+    case "timezone":
+      return { allowedTimezones: [] };
+    case "address":
+      return { requiredFields: ["line1", "city", "country"] };
+  }
+}
+
+export function validateQuestionConfig(question: BuilderQuestion): string | null {
+  const cfg = question.config_json || {};
+  if (question.type === "text") {
+    const minLength = Number(cfg.minLength ?? 0);
+    const maxLength = Number(cfg.maxLength ?? 0);
+    if (Number.isNaN(minLength) || Number.isNaN(maxLength) || minLength < 0 || maxLength < minLength) {
+      return "Text constraints are invalid (min/max length).";
+    }
+  }
+  if (question.type === "select" || question.type === "multiselect" || question.type === "radio") {
+    const options = cfg.options;
+    if (!Array.isArray(options) || options.length === 0 || options.some((opt) => typeof opt !== "string" || !opt.trim())) {
+      return "At least one non-empty option is required.";
+    }
+  }
+  if (question.type === "multiselect") {
+    const minSelections = Number(cfg.minSelections ?? 0);
+    const maxSelections = Number(cfg.maxSelections ?? 9999);
+    if (Number.isNaN(minSelections) || Number.isNaN(maxSelections) || minSelections < 0 || maxSelections < minSelections) {
+      return "Multiselect min/max selections are invalid.";
+    }
+  }
+  if (question.type === "slider") {
+    const min = Number(cfg.min);
+    const max = Number(cfg.max);
+    const step = Number(cfg.step);
+    if (Number.isNaN(min) || Number.isNaN(max) || Number.isNaN(step) || step <= 0 || max <= min) {
+      return "Slider config requires numeric min/max and positive step (max > min).";
+    }
+  }
+  return null;
+}

--- a/frontend/src/pages/questionnaires/validationRules.ts
+++ b/frontend/src/pages/questionnaires/validationRules.ts
@@ -1,0 +1,133 @@
+export type ValidationScope = "question" | "group" | "form";
+
+export type QuestionRule = {
+  id: string;
+  scope: "question";
+  question_id: string;
+  rule_type: "required_if" | "min" | "max";
+  config: Record<string, unknown>;
+};
+
+export type GroupRule = {
+  id: string;
+  scope: "group";
+  group_id: string;
+  rule_type: "min_answered" | "requires_if_answered" | "mutually_exclusive";
+  question_ids: string[];
+  config: Record<string, unknown>;
+};
+
+export type FormRule = {
+  id: string;
+  scope: "form";
+  rule_type: "requires_if_answered" | "mutually_exclusive";
+  config: Record<string, unknown>;
+  blocking: boolean;
+};
+
+export type BuilderRule = QuestionRule | GroupRule | FormRule;
+
+export function templatesForScope(scope: ValidationScope): Array<{ label: string; create: () => BuilderRule }> {
+  if (scope === "question") {
+    return [
+      {
+        label: "Required if another question is answered",
+        create: () => ({ id: crypto.randomUUID(), scope: "question", question_id: "", rule_type: "required_if", config: { if_question_id: "" } }),
+      },
+      {
+        label: "Min numeric value",
+        create: () => ({ id: crypto.randomUUID(), scope: "question", question_id: "", rule_type: "min", config: { min: 0 } }),
+      },
+      {
+        label: "Max numeric value",
+        create: () => ({ id: crypto.randomUUID(), scope: "question", question_id: "", rule_type: "max", config: { max: 10 } }),
+      },
+    ];
+  }
+  if (scope === "group") {
+    return [
+      {
+        label: "At least one answered",
+        create: () => ({ id: crypto.randomUUID(), scope: "group", group_id: "", rule_type: "min_answered", question_ids: [], config: { min_answered: 1 } }),
+      },
+      {
+        label: "Required-if in group",
+        create: () => ({ id: crypto.randomUUID(), scope: "group", group_id: "", rule_type: "requires_if_answered", question_ids: [], config: { if_question_id: "", required_question_ids: [] } }),
+      },
+      {
+        label: "Mutually exclusive group",
+        create: () => ({ id: crypto.randomUUID(), scope: "group", group_id: "", rule_type: "mutually_exclusive", question_ids: [], config: {} }),
+      },
+    ];
+  }
+  return [
+    {
+      label: "Cross-section required-if",
+      create: () => ({ id: crypto.randomUUID(), scope: "form", rule_type: "requires_if_answered", config: { if_question_id: "", required_question_ids: [] }, blocking: true }),
+    },
+    {
+      label: "Cross-section mutually exclusive",
+      create: () => ({ id: crypto.randomUUID(), scope: "form", rule_type: "mutually_exclusive", config: { question_ids: [] }, blocking: true }),
+    },
+  ];
+}
+
+export function toBackendRulePayload(rules: BuilderRule[]): { group_rules: Record<string, unknown>[]; form_rules: Record<string, unknown>[] } {
+  const group_rules = rules
+    .filter((r): r is GroupRule => r.scope === "group")
+    .map((r) => ({
+      rule_id: r.id,
+      group_id: r.group_id,
+      rule_type: r.rule_type,
+      question_ids: r.question_ids,
+      config_json: r.config,
+    }));
+
+  const form_rules = rules
+    .filter((r): r is FormRule => r.scope === "form")
+    .map((r) => ({
+      rule_id: r.id,
+      rule_type: r.rule_type,
+      config_json: r.config,
+      blocking: r.blocking,
+    }));
+
+  return { group_rules, form_rules };
+}
+
+export function validateRuleReferences(rules: BuilderRule[], knownQuestionIds: string[]): string[] {
+  const known = new Set(knownQuestionIds);
+  const errors: string[] = [];
+
+  const checkRef = (ruleId: string, ref: string, label: string) => {
+    if (ref && !known.has(ref)) errors.push(`Rule ${ruleId}: ${label} references unknown question '${ref}'.`);
+  };
+
+  for (const rule of rules) {
+    if (rule.scope === "question") {
+      checkRef(rule.id, rule.question_id, "question_id");
+      if (rule.rule_type === "required_if") checkRef(rule.id, String(rule.config.if_question_id || ""), "if_question_id");
+    }
+    if (rule.scope === "group") {
+      rule.question_ids.forEach((qid) => checkRef(rule.id, qid, "question_ids"));
+      if (rule.rule_type === "requires_if_answered") {
+        checkRef(rule.id, String(rule.config.if_question_id || ""), "if_question_id");
+        const req = Array.isArray(rule.config.required_question_ids) ? rule.config.required_question_ids : [];
+        req.forEach((qid) => checkRef(rule.id, String(qid), "required_question_ids"));
+      }
+    }
+    if (rule.scope === "form") {
+      if (rule.rule_type === "requires_if_answered") {
+        checkRef(rule.id, String(rule.config.if_question_id || ""), "if_question_id");
+        const req = Array.isArray(rule.config.required_question_ids) ? rule.config.required_question_ids : [];
+        req.forEach((qid) => checkRef(rule.id, String(qid), "required_question_ids"));
+      }
+      if (rule.rule_type === "mutually_exclusive") {
+        const ids = Array.isArray(rule.config.question_ids) ? rule.config.question_ids : [];
+        ids.forEach((qid) => checkRef(rule.id, String(qid), "question_ids"));
+      }
+    }
+  }
+
+  return errors;
+}

--- a/questionnaire_implementation_plan.md
+++ b/questionnaire_implementation_plan.md
@@ -1,0 +1,230 @@
+# Questionnaire Creator & Viewer — Implementation Plan
+
+## 1) Goals and scope
+- Let authenticated users create and publish questionnaires.
+- Let other users discover and submit responses.
+- Support rich question types:
+  - Short/long text
+  - Select (single)
+  - Multi-select
+  - Radio group
+  - Slider/range
+  - Date
+  - Time
+  - Timezone
+  - Address
+- Support validation at three levels:
+  - Per-question
+  - Question-group/page-level
+  - Whole-form-level
+- Provide:
+  - Custom hints/help text per question
+  - Progress monitoring
+  - Previous/next navigation
+  - End-of-flow answer summary
+  - PDF export of completed response
+
+## 2) User journeys
+
+### A. Creator journey
+1. Create new questionnaire (title, description, visibility).
+2. Add sections/pages.
+3. Add questions to each section and choose question type.
+4. Configure options (for select/radio/multi-select), slider bounds/steps, address/timezone settings.
+5. Configure validation:
+   - Question constraints (required, min/max length, regex, numeric bounds, date/time constraints, choice limits).
+   - Group constraints (e.g., at least one of these 3 fields required).
+   - Form constraints (cross-section rules).
+6. Add custom hint/help text and placeholder text.
+7. Preview flow as respondent.
+8. Publish questionnaire (versioned snapshot).
+9. Monitor response progress and completion analytics.
+
+### B. Respondent journey
+1. Open published questionnaire link.
+2. Start response session.
+3. Answer questions page by page with visible progress bar.
+4. Navigate next/back while preserving state.
+5. See real-time validation feedback.
+6. On final submit, see summary of answers.
+7. Download completed response as PDF.
+
+## 3) Domain model and data schema
+
+### Core entities
+- `User`
+- `Questionnaire`
+  - `id`, `owner_id`, `title`, `description`, `status` (`draft|published|archived`), `published_version_id`
+- `QuestionnaireVersion`
+  - immutable snapshot used for responses
+  - `questionnaire_id`, `version_number`, `schema_json`, `published_at`
+- `Section`
+  - `version_id`, `title`, `description`, `position`
+- `Question`
+  - `section_id`, `type`, `label`, `hint`, `required`, `config_json`, `position`
+- `ValidationRule`
+  - `scope` (`question|group|form`), `scope_ref`, `rule_type`, `rule_config_json`, `error_message`
+- `ResponseSession`
+  - `version_id`, `respondent_id?`, `status` (`in_progress|submitted`), `started_at`, `submitted_at`, `current_section_index`
+- `Answer`
+  - `response_session_id`, `question_id`, `value_json`, `is_valid`, `validation_errors_json`
+- `ProgressEvent` (optional for analytics)
+  - saves navigation/progress checkpoints
+
+### Notes
+- Store questionnaire structure in normalized tables + optional JSON snapshot for rendering speed.
+- Keep published versions immutable so old responses always map to exact schema.
+- Use `value_json` for typed answers with consistent serialization.
+
+## 4) Validation engine design
+
+### Rule layering
+1. **Question-level** (field-local)
+   - required, type checks, min/max, regex, options membership
+2. **Group-level** (within section or named group)
+   - "at least N answered", "if A then B required", mutually exclusive conditions
+3. **Form-level** (cross-section)
+   - global dependencies and conditional constraints
+
+### Execution strategy
+- Shared validation contract between backend and frontend:
+  - Frontend for instant UX feedback.
+  - Backend as source of truth at save/submit.
+- Validation pipeline:
+  1. Normalize answer values.
+  2. Run question rules.
+  3. Run group rules.
+  4. Run form rules.
+  5. Return structured error map keyed by question/group/form.
+
+## 5) Question type configuration spec
+- `text`: `minLength`, `maxLength`, `regex`, `multiline`
+- `select`: `options[]`, `allowOther`
+- `multiselect`: `options[]`, `minSelections`, `maxSelections`
+- `radio`: `options[]`
+- `slider`: `min`, `max`, `step`, `unitLabel`
+- `date`: `minDate`, `maxDate`, `disableWeekends?`
+- `time`: `minTime`, `maxTime`, `interval`
+- `timezone`: `allowedZones[] | all`, default zone
+- `address`: structured fields (line1, line2, city, region, postalCode, country), country-specific validation mode
+
+## 6) API design (high level)
+
+### Creator APIs
+- `POST /questionnaires` create draft
+- `GET /questionnaires/:id` fetch draft
+- `PUT /questionnaires/:id` update metadata
+- `POST /questionnaires/:id/sections`
+- `POST /sections/:id/questions`
+- `PUT /questions/:id`
+- `PUT /questionnaires/:id/validation-rules`
+- `POST /questionnaires/:id/publish`
+- `GET /questionnaires/:id/analytics`
+
+### Respondent APIs
+- `GET /published/:slug` fetch published schema
+- `POST /published/:slug/sessions` start response
+- `PUT /sessions/:id/answers` save partial answers
+- `POST /sessions/:id/validate` run full validation
+- `POST /sessions/:id/submit` submit response
+- `GET /sessions/:id/summary` answer summary
+- `GET /sessions/:id/pdf` generate/download PDF
+
+## 7) Frontend architecture
+
+### Creator UI
+- Questionnaire builder canvas with drag/reorder sections/questions.
+- Right-side configuration panel for question settings + hints + validation.
+- Rule builder UI for group/form logic (condition blocks).
+- Preview mode matching respondent experience.
+
+### Respondent UI
+- Stepper/page-based flow by section.
+- Progress indicator:
+  - simple percentage (`answered required / total required`) or page completion.
+- Back/next navigation with autosave.
+- Inline validation and section-level errors.
+- Final summary page with edit links back to sections.
+- Download PDF action after submission.
+
+## 8) PDF export approach
+- Server-rendered HTML template of completed response.
+- Convert HTML to PDF (Chromium print-to-PDF or wkhtmltopdf equivalent).
+- Include:
+  - Questionnaire title/version
+  - Respondent metadata (if allowed)
+  - Submission timestamp
+  - Sectioned Q&A with labels and values
+- Save generated PDF path/URL for repeated downloads.
+
+## 9) Security, privacy, and compliance
+- Authorization:
+  - only owner/admin can edit/publish.
+  - respondents can only access their own sessions (unless anonymous public links).
+- Input sanitization on all text fields/hints.
+- Rate limiting for public submission endpoints.
+- Optional captcha for anonymous flows.
+- PII handling for address/timezone/date/time answers (encryption at rest if required).
+- Audit trail for publish events and schema changes.
+
+## 10) Observability and analytics
+- Metrics:
+  - starts, completions, drop-off by section/question
+  - average completion time
+  - validation failure hotspots
+- Logs:
+  - submission failures, PDF generation failures
+- Dashboards for creator progress monitoring.
+
+## 11) Delivery phases
+
+### Phase 1 — MVP foundation
+- Questionnaire draft builder (core question types)
+- Publish immutable version
+- Respondent flow with next/back + autosave
+- Question-level validation
+- Submit + summary screen
+
+### Phase 2 — Advanced validation and analytics
+- Group/form rule engine
+- Conditional visibility logic (optional enhancement)
+- Progress analytics dashboard
+
+### Phase 3 — PDF and hardening
+- PDF download pipeline
+- Performance optimization and caching
+- Security hardening and load testing
+
+## 12) Testing strategy
+- Unit tests:
+  - validation rule engine
+  - question type serializers/parsers
+  - progress calculation
+- Integration tests:
+  - creator publish flow
+  - respondent save/submit flow
+  - summary correctness
+- E2E tests:
+  - build questionnaire → publish → respond → submit → download PDF
+- Non-functional:
+  - concurrency tests for high submission volume
+  - accessibility checks (keyboard navigation, labels, ARIA)
+
+## 13) Risks and mitigations
+- **Complex rule builder UX** → start with constrained rule templates.
+- **Version/schema drift** → immutable versions and strict schema IDs in answers.
+- **PDF rendering inconsistencies** → single HTML template and visual regression checks.
+- **Address/timezone validation complexity** → modular adapters with country/zone data providers.
+
+## 14) Suggested implementation backlog (example)
+1. Define schema contracts and migrations.
+2. Build draft questionnaire CRUD.
+3. Build publish/versioning flow.
+4. Build respondent session/answer APIs.
+5. Implement frontend respondent navigation/progress.
+6. Implement question-level validation.
+7. Implement group/form validation.
+8. Build summary page.
+9. Add PDF generation and download endpoint.
+10. Add analytics instrumentation and dashboard.
+11. Add tests and hardening.

--- a/scripts/local-ddb-init.py
+++ b/scripts/local-ddb-init.py
@@ -56,6 +56,17 @@ def _table_defs() -> List[TableDef]:
         ),
         TableDef(_resolve_table_name(S.subscriptions_table_name, "subscriptions"), "pk", "sk"),
         TableDef(
+            _resolve_table_name(S.questionnaire_table_name, "questionnaires"),
+            "pk",
+            "sk",
+            gsi=[
+                {"index_name": S.questionnaire_owner_index_name, "partition_key": "gsi_owner_pk", "sort_key": "gsi_owner_sk"},
+                {"index_name": S.questionnaire_status_index_name, "partition_key": "gsi_status_pk", "sort_key": "gsi_status_sk"},
+                {"index_name": S.questionnaire_published_index_name, "partition_key": "gsi_published_pk", "sort_key": "gsi_published_sk"},
+                {"index_name": S.questionnaire_response_status_index_name, "partition_key": "gsi_response_status_pk", "sort_key": "gsi_response_status_sk"},
+            ],
+        ),
+        TableDef(
             _resolve_table_name(S.projects_table_name, "projects"),
             "PK",
             "SK",

--- a/scripts/migrations/20260302_questionnaire_schema.py
+++ b/scripts/migrations/20260302_questionnaire_schema.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from app.core.aws import ddb
+from app.core.settings import S
+
+
+def _ensure_table() -> None:
+    client = ddb.meta.client
+    existing = set(client.list_tables().get("TableNames", []))
+    if S.questionnaire_table_name not in existing:
+        client.create_table(
+            TableName=S.questionnaire_table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+                {"AttributeName": "gsi_owner_pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_owner_sk", "AttributeType": "S"},
+                {"AttributeName": "gsi_status_pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_status_sk", "AttributeType": "S"},
+                {"AttributeName": "gsi_published_pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_published_sk", "AttributeType": "S"},
+                {"AttributeName": "gsi_response_status_pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_response_status_sk", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": S.questionnaire_owner_index_name,
+                    "KeySchema": [
+                        {"AttributeName": "gsi_owner_pk", "KeyType": "HASH"},
+                        {"AttributeName": "gsi_owner_sk", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": S.questionnaire_status_index_name,
+                    "KeySchema": [
+                        {"AttributeName": "gsi_status_pk", "KeyType": "HASH"},
+                        {"AttributeName": "gsi_status_sk", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": S.questionnaire_published_index_name,
+                    "KeySchema": [
+                        {"AttributeName": "gsi_published_pk", "KeyType": "HASH"},
+                        {"AttributeName": "gsi_published_sk", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": S.questionnaire_response_status_index_name,
+                    "KeySchema": [
+                        {"AttributeName": "gsi_response_status_pk", "KeyType": "HASH"},
+                        {"AttributeName": "gsi_response_status_sk", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+        )
+
+
+def _derive_index_attributes(item: dict) -> dict:
+    updates: dict[str, str] = {}
+    entity_type = item.get("entity_type")
+    if entity_type == "questionnaire":
+        owner_id = item.get("owner_id")
+        status = item.get("status")
+        updated_at = item.get("updated_at")
+        questionnaire_id = item.get("questionnaire_id")
+        if owner_id and updated_at and questionnaire_id:
+            updates["gsi_owner_pk"] = f"OWNER#{owner_id}"
+            updates["gsi_owner_sk"] = f"UPDATED#{updated_at}#{questionnaire_id}"
+        if status and updated_at and questionnaire_id:
+            updates["gsi_status_pk"] = f"STATUS#{status}"
+            updates["gsi_status_sk"] = f"UPDATED#{updated_at}#{questionnaire_id}"
+    elif entity_type == "questionnaire_version":
+        slug = item.get("published_slug")
+        version_number = item.get("version_number")
+        if slug and version_number is not None:
+            updates["gsi_published_pk"] = f"PUBLISHED#{slug}"
+            updates["gsi_published_sk"] = f"VERSION#{int(version_number):06d}"
+    elif entity_type == "response_session":
+        status = item.get("status")
+        updated = item.get("submitted_at") or item.get("started_at")
+        response_session_id = item.get("response_session_id")
+        if status and updated and response_session_id:
+            updates["gsi_response_status_pk"] = f"RESPONSE_STATUS#{status}"
+            updates["gsi_response_status_sk"] = f"UPDATED#{updated}#{response_session_id}"
+    return updates
+
+
+def migrate() -> None:
+    _ensure_table()
+    table = ddb.Table(S.questionnaire_table_name)
+    items = table.scan().get("Items", [])
+    for item in items:
+        updates = _derive_index_attributes(item)
+        if not updates:
+            continue
+        update_expr = []
+        attr_names = {}
+        attr_values = {}
+        for idx, (k, v) in enumerate(updates.items(), start=1):
+            name_key = f"#k{idx}"
+            value_key = f":v{idx}"
+            attr_names[name_key] = k
+            attr_values[value_key] = v
+            update_expr.append(f"{name_key} = {value_key}")
+        table.update_item(
+            Key={"pk": item["pk"], "sk": item["sk"]},
+            UpdateExpression="SET " + ", ".join(update_expr),
+            ExpressionAttributeNames=attr_names,
+            ExpressionAttributeValues=attr_values,
+        )
+
+
+if __name__ == "__main__":
+    migrate()
+    print("questionnaire schema migration complete")

--- a/tests/test_questionnaire_draft_routes.py
+++ b/tests/test_questionnaire_draft_routes.py
@@ -1,0 +1,644 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.roles import Role
+from app.main import create_app
+from app.routers import questionnaires
+from app.services.sessions import require_ui_session
+
+
+class _FakeTable:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str], dict] = {}
+
+    def reset(self) -> None:
+        self.items.clear()
+
+    def put_item(self, *, Item):
+        self.items[(Item["pk"], Item["sk"])] = deepcopy(Item)
+
+    def get_item(self, *, Key):
+        item = self.items.get((Key["pk"], Key["sk"]))
+        return {"Item": deepcopy(item)} if item else {}
+
+    def update_item(self, *, Key, UpdateExpression, ExpressionAttributeValues, ExpressionAttributeNames=None, ConditionExpression=None):
+        item = self.items[(Key["pk"], Key["sk"])]
+        names = ExpressionAttributeNames or {}
+        assignments = UpdateExpression.replace("SET", "", 1).strip().split(",")
+        for assignment in assignments:
+            left, right = assignment.strip().split("=", 1)
+            left = left.strip()
+            right = right.strip()
+            attr = names.get(left, left)
+            item[attr] = ExpressionAttributeValues[right]
+        self.items[(Key["pk"], Key["sk"])] = item
+
+    def query(self, **kwargs):
+        vals = kwargs.get("ExpressionAttributeValues", {})
+        index_name = kwargs.get("IndexName", "")
+        pk = vals.get(":pk")
+        limit = kwargs.get("Limit", 25)
+        rows = []
+        if "begins_with(sk" in (kwargs.get("KeyConditionExpression") or ""):
+            prefix = vals.get(":sk_prefix", "")
+            for item in self.items.values():
+                if item.get("pk") == pk and item.get("sk", "").startswith(prefix):
+                    rows.append(deepcopy(item))
+            rows.sort(key=lambda r: r.get("sk", ""))
+            return {"Items": rows}
+        for item in self.items.values():
+            if index_name.endswith("owner-updated-index") and item.get("gsi_owner_pk") == pk:
+                rows.append(deepcopy(item))
+            if ("published" in index_name) and item.get("gsi_published_pk") == pk:
+                rows.append(deepcopy(item))
+            if ("response" in index_name) and item.get("gsi_response_status_pk") == pk:
+                rows.append(deepcopy(item))
+        rows.sort(key=lambda r: r.get("sk", ""), reverse=not kwargs.get("ScanIndexForward", True))
+        return {"Items": rows[:limit]}
+
+
+_FAKE_TABLE = _FakeTable()
+questionnaires.REPO._table = _FAKE_TABLE
+
+
+def _build_client(user_sub: str) -> TestClient:
+    app = create_app()
+
+    async def _auth_override():
+        return AuthenticatedUser(sub=user_sub, role=Role.USER)
+
+    async def _session_override():
+        return {"user_sub": user_sub, "session_id": "sess_1", "role": Role.USER.value}
+
+    app.dependency_overrides[get_authenticated_user] = _auth_override
+    app.dependency_overrides[require_ui_session] = _session_override
+    return TestClient(app)
+
+
+
+
+def _build_anon_client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
+
+def setup_function():
+    _FAKE_TABLE.reset()
+
+
+def test_owner_can_create_read_update_archive_draft() -> None:
+    client = _build_client("user-1")
+
+    created = client.post(
+        "/questionnaires/drafts",
+        json={"questionnaire_id": "q_1", "title": "My Q", "description": "desc"},
+    )
+    assert created.status_code == 200
+    assert created.json()["draft"]["owner_id"] == "user-1"
+    assert created.json()["draft"]["created_by"] == "user-1"
+
+    fetched = client.get("/questionnaires/drafts/q_1")
+    assert fetched.status_code == 200
+    assert fetched.json()["draft"]["title"] == "My Q"
+
+    updated = client.patch("/questionnaires/drafts/q_1", json={"title": "My Q2"})
+    assert updated.status_code == 200
+    assert updated.json()["draft"]["title"] == "My Q2"
+    assert updated.json()["draft"]["updated_by"] == "user-1"
+
+    archived = client.delete("/questionnaires/drafts/q_1")
+    assert archived.status_code == 200
+    assert archived.json()["draft"]["status"] == "archived"
+    assert archived.json()["draft"]["archived_by"] == "user-1"
+
+
+def test_non_owner_gets_403_for_read_update_archive() -> None:
+    owner = _build_client("owner")
+    other = _build_client("other")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_1", "title": "Q", "description": "d"})
+
+    denied_get = other.get("/questionnaires/drafts/q_1")
+    assert denied_get.status_code == 403
+
+    denied_patch = other.patch("/questionnaires/drafts/q_1", json={"title": "x"})
+    assert denied_patch.status_code == 403
+
+    denied_delete = other.delete("/questionnaires/drafts/q_1")
+    assert denied_delete.status_code == 403
+
+
+def test_archived_excluded_from_default_list() -> None:
+    client = _build_client("user-1")
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_1", "title": "Q1", "description": "d"})
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_2", "title": "Q2", "description": "d"})
+    client.delete("/questionnaires/drafts/q_2")
+
+    visible = client.get("/questionnaires/drafts")
+    assert visible.status_code == 200
+    ids = {it["questionnaire_id"] for it in visible.json()["items"]}
+    assert ids == {"q_1"}
+
+    with_archived = client.get("/questionnaires/drafts", params={"include_archived": True})
+    ids_all = {it["questionnaire_id"] for it in with_archived.json()["items"]}
+    assert ids_all == {"q_1", "q_2"}
+
+
+def test_section_and_question_ordering_and_schema_serialization() -> None:
+    client = _build_client("user-1")
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_1", "title": "Q1", "description": "d"})
+
+    client.post("/questionnaires/drafts/q_1/sections", json={"section_id": "s1", "title": "S1"})
+    client.post("/questionnaires/drafts/q_1/sections", json={"section_id": "s2", "title": "S2"})
+    reorder_sections = client.post("/questionnaires/drafts/q_1/sections/reorder", json={"section_ids": ["s2", "s1"]})
+    assert reorder_sections.status_code == 200
+    assert [s["section_id"] for s in reorder_sections.json()["items"]] == ["s2", "s1"]
+
+    client.post(
+        "/questionnaires/drafts/q_1/questions",
+        json={"section_id": "s2", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}},
+    )
+    client.post(
+        "/questionnaires/drafts/q_1/questions",
+        json={"section_id": "s2", "question_id": "q2", "type": "text", "label": "L2", "config_json": {}},
+    )
+    reorder_questions = client.post(
+        "/questionnaires/drafts/q_1/questions/reorder",
+        json={"section_id": "s2", "question_ids": ["q2", "q1"]},
+    )
+    assert reorder_questions.status_code == 200
+    assert [q["question_id"] for q in reorder_questions.json()["items"]] == ["q2", "q1"]
+
+    delete_q = client.delete("/questionnaires/drafts/q_1/questions/q1", params={"section_id": "s2"})
+    assert delete_q.status_code == 200
+
+    schema = client.get("/questionnaires/drafts/q_1/schema")
+    assert schema.status_code == 200
+    sections = schema.json()["sections"]
+    assert [s["section_id"] for s in sections] == ["s2", "s1"]
+    assert [q["question_id"] for q in sections[0]["questions"]] == ["q2"]
+
+
+def test_invalid_question_config_returns_4xx() -> None:
+    client = _build_client("user-1")
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_1", "title": "Q1", "description": "d"})
+    client.post("/questionnaires/drafts/q_1/sections", json={"section_id": "s1", "title": "S1"})
+
+    invalid = client.post(
+        "/questionnaires/drafts/q_1/questions",
+        json={"section_id": "s1", "question_id": "q_bad", "type": "select", "label": "Pick", "config_json": {}},
+    )
+    assert invalid.status_code == 422
+    assert invalid.json()["detail"]["error"]["code"] == "invalid_question_config"
+
+
+def test_publish_creates_new_version_and_increments() -> None:
+    client = _build_client("user-1")
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_1", "title": "Q1", "description": "d"})
+    client.post("/questionnaires/drafts/q_1/sections", json={"section_id": "s1", "title": "S1"})
+    client.post(
+        "/questionnaires/drafts/q_1/questions",
+        json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}},
+    )
+
+    pub1 = client.post("/questionnaires/drafts/q_1/publish", json={"published_slug": "my-q"})
+    assert pub1.status_code == 200
+    assert pub1.json()["version"]["version_number"] == 1
+
+    patch_after_publish = client.patch("/questionnaires/drafts/q_1", json={"title": "new"})
+    assert patch_after_publish.status_code == 409
+    assert patch_after_publish.json()["detail"]["error"]["code"] == "questionnaire_not_draft"
+
+    # Simulate a resumed draft by directly setting status so we can validate version incrementing behavior.
+    _FAKE_TABLE.items[("QNR#q_1", "META")]["status"] = "draft"
+    pub2 = client.post("/questionnaires/drafts/q_1/publish", json={"published_slug": "my-q"})
+    assert pub2.status_code == 200
+    assert pub2.json()["version"]["version_number"] == 2
+
+
+def test_existing_response_session_remains_bound_to_prior_version() -> None:
+    repo = questionnaires.REPO
+    repo.put_questionnaire(questionnaire_id="q_resp", owner_id="user-1", title="Q")
+    repo.create_section(questionnaire_id="q_resp", section_id="s1", title="S1", description="", actor_sub="user-1")
+    repo.create_question(
+        questionnaire_id="q_resp",
+        section_id="s1",
+        question_id="q1",
+        question_type="text",
+        label="L1",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="user-1",
+    )
+    v1 = repo.publish_draft(questionnaire_id="q_resp", owner_id="user-1", actor_sub="user-1")
+    session = repo.put_response_session(response_session_id="r1", questionnaire_id="q_resp", version_id=v1["version_id"])
+
+    _FAKE_TABLE.items[("QNR#q_resp", "META")]["status"] = "draft"
+    repo.create_question(
+        questionnaire_id="q_resp",
+        section_id="s1",
+        question_id="q2",
+        question_type="text",
+        label="L2",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="user-1",
+    )
+    v2 = repo.publish_draft(questionnaire_id="q_resp", owner_id="user-1", actor_sub="user-1")
+
+    fetched = repo._table.get_item(Key={"pk": "QNR#q_resp", "sk": "RESP#r1"})["Item"]
+    assert session["version_id"] == v1["version_id"]
+    assert fetched["version_id"] == v1["version_id"]
+    assert fetched["version_id"] != v2["version_id"]
+
+
+def test_validate_endpoint_returns_form_level_errors_and_blocks_final_submit() -> None:
+    client = _build_client("user-1")
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_val", "title": "Q", "description": "d"})
+    client.post("/questionnaires/drafts/q_val/sections", json={"section_id": "s1", "title": "S1"})
+    client.post("/questionnaires/drafts/q_val/sections", json={"section_id": "s2", "title": "S2"})
+    client.post(
+        "/questionnaires/drafts/q_val/questions",
+        json={"section_id": "s1", "question_id": "q_trigger", "type": "text", "label": "Trigger", "config_json": {}},
+    )
+    client.post(
+        "/questionnaires/drafts/q_val/questions",
+        json={"section_id": "s2", "question_id": "q_required", "type": "text", "label": "Required", "config_json": {}},
+    )
+
+    payload = {
+        "answers_by_question_id": {"q_trigger": "x"},
+        "form_rules": [
+            {
+                "rule_id": "fr1",
+                "rule_type": "requires_if_answered",
+                "config_json": {"if_question_id": "q_trigger", "required_question_ids": ["q_required"]},
+                "blocking": True,
+            }
+        ],
+        "final_submit": False,
+    }
+    pre = client.post("/questionnaires/drafts/q_val/validate", json=payload)
+    assert pre.status_code == 200
+    assert pre.json()["errors"]["form:fr1"][0]["code"] == "form_dependency_required"
+    assert pre.json()["can_submit"] is False
+
+    payload["final_submit"] = True
+    final = client.post("/questionnaires/drafts/q_val/validate", json=payload)
+    assert final.status_code == 422
+    assert final.json()["detail"]["error"]["code"] == "form_validation_failed"
+
+
+def test_validate_endpoint_rejects_invalid_form_rule_references() -> None:
+    client = _build_client("user-1")
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_ref", "title": "Q", "description": "d"})
+    client.post("/questionnaires/drafts/q_ref/sections", json={"section_id": "s1", "title": "S1"})
+    client.post(
+        "/questionnaires/drafts/q_ref/questions",
+        json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "Q1", "config_json": {}},
+    )
+
+    res = client.post(
+        "/questionnaires/drafts/q_ref/validate",
+        json={
+            "answers_by_question_id": {},
+            "form_rules": [
+                {
+                    "rule_id": "fr_bad",
+                    "rule_type": "mutually_exclusive",
+                    "config_json": {"question_ids": ["missing_a", "missing_b"]},
+                    "blocking": True,
+                }
+            ],
+            "final_submit": False,
+        },
+    )
+    assert res.status_code == 422
+    assert res.json()["detail"]["error"]["code"] == "invalid_rule_reference"
+
+
+def test_question_hint_and_placeholder_are_sanitized() -> None:
+    client = _build_client("user-1")
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_san", "title": "Q", "description": "d"})
+    client.post("/questionnaires/drafts/q_san/sections", json={"section_id": "s1", "title": "S1"})
+
+    created = client.post(
+        "/questionnaires/drafts/q_san/questions",
+        json={
+            "section_id": "s1",
+            "question_id": "q1",
+            "type": "text",
+            "label": "Q1",
+            "hint": "<b>hint</b><script>x</script>",
+            "config_json": {"placeholder": "<img src=x onerror=1>name", "help_text": "<i>help</i><script>x</script>", "minLength": 0, "maxLength": 10},
+        },
+    )
+    assert created.status_code == 200
+    q = created.json()["question"]
+    assert q["hint"] == "hint"
+    assert q["config_json"]["placeholder"] == "name"
+    assert q["config_json"]["help_text"] == "help"
+
+
+def test_published_fetch_and_session_start_public_and_private_access() -> None:
+    owner = _build_client("owner")
+
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_pub", "title": "Q", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_pub/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_pub/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}})
+    owner.post("/questionnaires/drafts/q_pub/publish", json={"published_slug": "pub-slug"})
+
+    anon = _build_anon_client()
+    fetched_public = anon.get("/questionnaires/published/pub-slug")
+    assert fetched_public.status_code == 200
+    assert fetched_public.json()["version"]["published_slug"] == "pub-slug"
+
+    started_anon = anon.post("/questionnaires/published/pub-slug/sessions", json={})
+    assert started_anon.status_code == 200
+    session = started_anon.json()["session"]
+    assert session["status"] == "in_progress"
+    assert session["version_id"] == fetched_public.json()["version"]["version_id"]
+    assert session["started_at"]
+
+    # Private questionnaire requires authenticated access and cannot be started anonymously.
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_priv", "title": "Q2", "description": "d", "visibility": "private"})
+    owner.post("/questionnaires/drafts/q_priv/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_priv/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}})
+    owner.post("/questionnaires/drafts/q_priv/publish", json={"published_slug": "priv-slug"})
+
+    denied_fetch = anon.get("/questionnaires/published/priv-slug")
+    assert denied_fetch.status_code == 401
+
+    denied_start = anon.post("/questionnaires/published/priv-slug/sessions", json={})
+    assert denied_start.status_code == 401
+
+    authed = _build_anon_client()
+    allowed_fetch = authed.get("/questionnaires/published/priv-slug", headers={"x-user-sub": "respondent-1"})
+    assert allowed_fetch.status_code == 200
+
+    allowed_start = authed.post("/questionnaires/published/priv-slug/sessions", json={}, headers={"x-user-sub": "respondent-1"})
+    assert allowed_start.status_code == 200
+    assert allowed_start.json()["session"]["respondent_id"] == "respondent-1"
+
+
+def test_published_fetch_by_questionnaire_id() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_id", "title": "Q", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_id/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_id/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}})
+    pub = owner.post("/questionnaires/drafts/q_id/publish", json={"published_slug": "id-slug"})
+    version_id = pub.json()["version"]["version_id"]
+
+    anon = _build_anon_client()
+    by_id = anon.get("/questionnaires/published/by-id/q_id")
+    assert by_id.status_code == 200
+    assert by_id.json()["version"]["version_id"] == version_id
+
+
+def test_session_save_and_resume_progress() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_resume", "title": "Q", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_resume/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_resume/sections", json={"section_id": "s2", "title": "S2"})
+    owner.post("/questionnaires/drafts/q_resume/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}})
+    owner.post("/questionnaires/drafts/q_resume/questions", json={"section_id": "s2", "question_id": "q2", "type": "text", "label": "L2", "config_json": {}})
+    owner.post("/questionnaires/drafts/q_resume/publish", json={"published_slug": "resume-slug"})
+
+    anon = _build_anon_client()
+    started = anon.post("/questionnaires/published/resume-slug/sessions", json={})
+    assert started.status_code == 200
+    session_id = started.json()["session"]["response_session_id"]
+
+    saved = anon.put(
+        f"/questionnaires/published/resume-slug/sessions/{session_id}",
+        json={"answers_by_question_id": {"q1": "hello"}, "current_section_index": 1, "current_question_id": "q2"},
+    )
+    assert saved.status_code == 200
+    assert saved.json()["session"]["status"] == "in_progress"
+
+    resumed = anon.get(f"/questionnaires/published/resume-slug/sessions/{session_id}")
+    assert resumed.status_code == 200
+    assert resumed.json()["answers_by_question_id"]["q1"] == "hello"
+    assert resumed.json()["session"]["current_section_index"] == 1
+    assert resumed.json()["session"]["current_question_id"] == "q2"
+    assert resumed.json()["session"]["submitted_at"] is None
+
+
+def test_session_save_does_not_allow_other_user_access() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_priv_resume", "title": "Q", "description": "d", "visibility": "private"})
+    owner.post("/questionnaires/drafts/q_priv_resume/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_priv_resume/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}})
+    owner.post("/questionnaires/drafts/q_priv_resume/publish", json={"published_slug": "priv-resume-slug"})
+
+    authed = _build_anon_client()
+    start = authed.post("/questionnaires/published/priv-resume-slug/sessions", json={}, headers={"x-user-sub": "u1"})
+    session_id = start.json()["session"]["response_session_id"]
+
+    forbidden_get = authed.get(f"/questionnaires/published/priv-resume-slug/sessions/{session_id}", headers={"x-user-sub": "u2"})
+    assert forbidden_get.status_code == 403
+
+    forbidden_put = authed.put(
+        f"/questionnaires/published/priv-resume-slug/sessions/{session_id}",
+        json={"answers_by_question_id": {"q1": "x"}, "current_section_index": 0},
+        headers={"x-user-sub": "u2"},
+    )
+    assert forbidden_put.status_code == 403
+
+
+def test_response_session_validate_and_submit_flow() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_submit", "title": "Q", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_submit/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_submit/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "required": True, "config_json": {}})
+    owner.post("/questionnaires/drafts/q_submit/publish", json={"published_slug": "submit-slug"})
+
+    anon = _build_anon_client()
+    started = anon.post("/questionnaires/published/submit-slug/sessions", json={})
+    session_id = started.json()["session"]["response_session_id"]
+
+    invalid = anon.post(
+        f"/questionnaires/published/submit-slug/sessions/{session_id}/validate",
+        json={"answers_by_question_id": {}, "group_rules": [{"rule_id": "g1", "group_id": "s1", "rule_type": "min_answered", "question_ids": ["q1"], "config_json": {"min_answered": 1}}], "final_submit": False},
+    )
+    assert invalid.status_code == 200
+    assert "can_submit" in invalid.json()
+
+    valid = anon.post(
+        f"/questionnaires/published/submit-slug/sessions/{session_id}/submit",
+        json={"answers_by_question_id": {"q1": "ok"}, "final_submit": True},
+    )
+    assert valid.status_code == 200
+    assert valid.json()["session"]["status"] == "submitted"
+    assert valid.json()["session"]["submitted_at"] is not None
+
+    event_rows = [
+        row
+        for row in _FAKE_TABLE.items.values()
+        if row.get("entity_type") == "response_session_audit_event" and row.get("response_session_id") == session_id
+    ]
+    assert len(event_rows) == 1
+    assert event_rows[0]["event_type"] == "response_session_submitted"
+
+    blocked_edit = anon.put(
+        f"/questionnaires/published/submit-slug/sessions/{session_id}",
+        json={"answers_by_question_id": {"q1": "late"}, "current_section_index": 0},
+    )
+    assert blocked_edit.status_code == 409
+
+
+def test_submit_invalid_payload_does_not_transition_session() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_submit_invalid", "title": "Q", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_submit_invalid/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_submit_invalid/questions", json={"section_id": "s1", "question_id": "q_trigger", "type": "text", "label": "Trigger", "required": True, "config_json": {}})
+    owner.post("/questionnaires/drafts/q_submit_invalid/questions", json={"section_id": "s1", "question_id": "q_required", "type": "text", "label": "Required", "required": True, "config_json": {}})
+    owner.post("/questionnaires/drafts/q_submit_invalid/publish", json={"published_slug": "submit-invalid-slug"})
+
+    anon = _build_anon_client()
+    started = anon.post("/questionnaires/published/submit-invalid-slug/sessions", json={})
+    session_id = started.json()["session"]["response_session_id"]
+
+    invalid_submit = anon.post(
+        f"/questionnaires/published/submit-invalid-slug/sessions/{session_id}/submit",
+        json={"answers_by_question_id": {"q_trigger": "x"}, "form_rules": [{"rule_id": "fr1", "rule_type": "requires_if_answered", "config_json": {"if_question_id": "q_trigger", "required_question_ids": ["q_required"]}, "blocking": True}], "final_submit": True},
+    )
+    assert invalid_submit.status_code == 422
+
+    resumed = anon.get(f"/questionnaires/published/submit-invalid-slug/sessions/{session_id}")
+    assert resumed.status_code == 200
+    assert resumed.json()["session"]["status"] == "in_progress"
+    assert resumed.json()["session"]["submitted_at"] is None
+
+
+def test_submitted_session_pdf_generation_and_access_control() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_pdf", "title": "PDF Survey", "description": "desc", "visibility": "private"})
+    owner.post("/questionnaires/drafts/q_pdf/sections", json={"section_id": "s1", "title": "Basics"})
+    owner.post("/questionnaires/drafts/q_pdf/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "Name", "required": True, "config_json": {}})
+    owner.post("/questionnaires/drafts/q_pdf/publish", json={"published_slug": "pdf-slug"})
+
+    authed = _build_anon_client()
+    start = authed.post("/questionnaires/published/pdf-slug/sessions", json={}, headers={"x-user-sub": "resp-1"})
+    assert start.status_code == 200
+    session_id = start.json()["session"]["response_session_id"]
+
+    submit = authed.post(
+        f"/questionnaires/published/pdf-slug/sessions/{session_id}/submit",
+        json={"answers_by_question_id": {"q1": "Alice"}, "final_submit": True},
+        headers={"x-user-sub": "resp-1"},
+    )
+    assert submit.status_code == 200
+    assert submit.json()["session"]["status"] == "submitted"
+
+    generate = authed.post(
+        f"/questionnaires/published/pdf-slug/sessions/{session_id}/pdf",
+        headers={"x-user-sub": "resp-1"},
+    )
+    assert generate.status_code == 200
+    assert generate.json()["artifact"]["content_type"] == "application/pdf"
+    assert generate.json()["artifact"]["size_bytes"] > 0
+
+    download = authed.get(
+        f"/questionnaires/published/pdf-slug/sessions/{session_id}/pdf",
+        headers={"x-user-sub": "resp-1"},
+    )
+    assert download.status_code == 200
+    assert download.headers["content-type"].startswith("application/pdf")
+    assert b"PDF Survey" in download.content
+    assert b"Alice" in download.content
+
+    forbidden = authed.get(
+        f"/questionnaires/published/pdf-slug/sessions/{session_id}/pdf",
+        headers={"x-user-sub": "resp-2"},
+    )
+    assert forbidden.status_code == 403
+
+
+def test_creator_analytics_reports_funnel_dropoff_and_validation_hotspots() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_analytics", "title": "Q", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_analytics/sections", json={"section_id": "s1", "title": "Section 1"})
+    owner.post("/questionnaires/drafts/q_analytics/sections", json={"section_id": "s2", "title": "Section 2"})
+    owner.post("/questionnaires/drafts/q_analytics/questions", json={"section_id": "s1", "question_id": "q_trigger", "type": "text", "label": "Trigger", "required": False, "config_json": {}})
+    owner.post("/questionnaires/drafts/q_analytics/questions", json={"section_id": "s2", "question_id": "q_required", "type": "text", "label": "Required", "required": True, "config_json": {}})
+    owner.post("/questionnaires/drafts/q_analytics/publish", json={"published_slug": "analytics-slug"})
+
+    anon = _build_anon_client()
+    s1 = anon.post("/questionnaires/published/analytics-slug/sessions", json={}).json()["session"]["response_session_id"]
+    s2 = anon.post("/questionnaires/published/analytics-slug/sessions", json={}).json()["session"]["response_session_id"]
+
+    anon.put(
+        f"/questionnaires/published/analytics-slug/sessions/{s2}",
+        json={"answers_by_question_id": {"q_trigger": "x"}, "current_section_index": 1, "current_question_id": "q_required"},
+    )
+
+    invalid_submit = anon.post(
+        f"/questionnaires/published/analytics-slug/sessions/{s1}/submit",
+        json={"answers_by_question_id": {"q_trigger": "x"}, "form_rules": [{"rule_id": "fr1", "rule_type": "requires_if_answered", "config_json": {"if_question_id": "q_trigger", "required_question_ids": ["q_required"]}, "blocking": True}], "final_submit": True},
+    )
+    assert invalid_submit.status_code == 422
+
+    valid_submit = anon.post(
+        f"/questionnaires/published/analytics-slug/sessions/{s1}/submit",
+        json={"answers_by_question_id": {"q_trigger": "x", "q_required": "ok"}, "final_submit": True},
+    )
+    assert valid_submit.status_code == 200
+
+    analytics = owner.get("/questionnaires/drafts/q_analytics/analytics")
+    assert analytics.status_code == 200
+    data = analytics.json()["analytics"]
+    assert data["totals"]["starts"] == 2
+    assert data["totals"]["completions"] == 1
+    assert data["versions"][0]["funnel"]["starts"] == 2
+    assert data["versions"][0]["funnel"]["completions"] == 1
+    assert data["totals"]["top_dropoffs"][0]["label"].startswith("Section 2")
+    assert any(item["key"].startswith("form:") for item in data["totals"]["top_validation_hotspots"])
+    assert data["freshness_sla_seconds"] == 60
+
+
+def test_session_requires_auth_when_bound_to_authenticated_respondent() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_auth_lock", "title": "Q", "description": "d", "visibility": "private"})
+    owner.post("/questionnaires/drafts/q_auth_lock/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_auth_lock/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}})
+    owner.post("/questionnaires/drafts/q_auth_lock/publish", json={"published_slug": "auth-lock"})
+
+    authed = _build_anon_client()
+    started = authed.post("/questionnaires/published/auth-lock/sessions", json={}, headers={"x-user-sub": "u1"})
+    session_id = started.json()["session"]["response_session_id"]
+
+    anon_get = authed.get(f"/questionnaires/published/auth-lock/sessions/{session_id}")
+    assert anon_get.status_code == 401
+
+
+def test_anonymous_public_submission_rate_limited() -> None:
+    owner = _build_client("owner")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_rl", "title": "Q", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_rl/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_rl/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "config_json": {}})
+    owner.post("/questionnaires/drafts/q_rl/publish", json={"published_slug": "rl-slug"})
+
+    called = {"n": 0}
+
+    def _fake_rl(*args, **kwargs):
+        called["n"] += 1
+        if called["n"] > 1:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=429, detail="Too many recovery attempts; try again later")
+
+    original = questionnaires.rate_limit_password_recovery
+    questionnaires.rate_limit_password_recovery = _fake_rl
+    try:
+        anon = _build_anon_client()
+        first = anon.post("/questionnaires/published/rl-slug/sessions", json={})
+        assert first.status_code == 200
+
+        second = anon.post("/questionnaires/published/rl-slug/sessions", json={})
+        assert second.status_code == 429
+    finally:
+        questionnaires.rate_limit_password_recovery = original

--- a/tests/test_questionnaire_e2e_workflow.py
+++ b/tests/test_questionnaire_e2e_workflow.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.roles import Role
+from app.main import create_app
+from app.routers import questionnaires
+from app.services.sessions import require_ui_session
+
+
+class _FakeTable:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str], dict] = {}
+
+    def reset(self) -> None:
+        self.items.clear()
+
+    def put_item(self, *, Item):
+        self.items[(Item["pk"], Item["sk"])] = deepcopy(Item)
+
+    def get_item(self, *, Key):
+        item = self.items.get((Key["pk"], Key["sk"]))
+        return {"Item": deepcopy(item)} if item else {}
+
+    def update_item(self, *, Key, UpdateExpression, ExpressionAttributeValues, ExpressionAttributeNames=None, ConditionExpression=None):
+        item = self.items[(Key["pk"], Key["sk"])]
+        names = ExpressionAttributeNames or {}
+        assignments = UpdateExpression.replace("SET", "", 1).strip().split(",")
+        for assignment in assignments:
+            left, right = assignment.strip().split("=", 1)
+            left = left.strip()
+            right = right.strip()
+            attr = names.get(left, left)
+            item[attr] = ExpressionAttributeValues[right]
+        self.items[(Key["pk"], Key["sk"])] = item
+
+    def query(self, **kwargs):
+        vals = kwargs.get("ExpressionAttributeValues", {})
+        index_name = kwargs.get("IndexName", "")
+        pk = vals.get(":pk")
+        limit = kwargs.get("Limit", 25)
+        rows = []
+        if "begins_with(sk" in (kwargs.get("KeyConditionExpression") or ""):
+            prefix = vals.get(":sk_prefix", "")
+            for item in self.items.values():
+                if item.get("pk") == pk and item.get("sk", "").startswith(prefix):
+                    rows.append(deepcopy(item))
+            rows.sort(key=lambda r: r.get("sk", ""))
+            return {"Items": rows}
+        for item in self.items.values():
+            if index_name.endswith("owner-updated-index") and item.get("gsi_owner_pk") == pk:
+                rows.append(deepcopy(item))
+            if ("published" in index_name) and item.get("gsi_published_pk") == pk:
+                rows.append(deepcopy(item))
+            if ("response" in index_name) and item.get("gsi_response_status_pk") == pk:
+                rows.append(deepcopy(item))
+        rows.sort(key=lambda r: r.get("sk", ""), reverse=not kwargs.get("ScanIndexForward", True))
+        return {"Items": rows[:limit]}
+
+
+_FAKE_TABLE = _FakeTable()
+questionnaires.REPO._table = _FAKE_TABLE
+
+
+def _build_client(user_sub: str) -> TestClient:
+    app = create_app()
+
+    async def _auth_override():
+        return AuthenticatedUser(sub=user_sub, role=Role.USER)
+
+    async def _session_override():
+        return {"user_sub": user_sub, "session_id": "sess_1", "role": Role.USER.value}
+
+    app.dependency_overrides[get_authenticated_user] = _auth_override
+    app.dependency_overrides[require_ui_session] = _session_override
+    return TestClient(app)
+
+
+def _build_anon_client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
+
+
+def setup_function():
+    _FAKE_TABLE.reset()
+
+
+def test_e2e_core_workflow_draft_to_pdf_download() -> None:
+    owner = _build_client("creator-1")
+
+    created = owner.post(
+        "/questionnaires/drafts",
+        json={"questionnaire_id": "q_e2e", "title": "E2E Survey", "description": "flow", "visibility": "public"},
+    )
+    assert created.status_code == 200
+
+    owner.post("/questionnaires/drafts/q_e2e/sections", json={"section_id": "s1", "title": "Intro"})
+    owner.post("/questionnaires/drafts/q_e2e/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "Name", "required": True, "config_json": {}})
+
+    published = owner.post("/questionnaires/drafts/q_e2e/publish", json={"published_slug": "e2e-survey"})
+    assert published.status_code == 200
+    assert published.json()["version"]["version_number"] == 1
+
+    anon = _build_anon_client()
+    start = anon.post("/questionnaires/published/e2e-survey/sessions", json={})
+    assert start.status_code == 200
+    session_id = start.json()["session"]["response_session_id"]
+
+    saved = anon.put(
+        f"/questionnaires/published/e2e-survey/sessions/{session_id}",
+        json={"answers_by_question_id": {"q1": "Ada"}, "current_section_index": 0, "current_question_id": "q1"},
+    )
+    assert saved.status_code == 200
+
+    validated = anon.post(
+        f"/questionnaires/published/e2e-survey/sessions/{session_id}/validate",
+        json={"answers_by_question_id": {"q1": "Ada"}, "final_submit": False},
+    )
+    assert validated.status_code == 200
+    assert validated.json()["can_submit"] is True
+
+    submitted = anon.post(
+        f"/questionnaires/published/e2e-survey/sessions/{session_id}/submit",
+        json={"answers_by_question_id": {"q1": "Ada"}, "final_submit": True},
+    )
+    assert submitted.status_code == 200
+    assert submitted.json()["session"]["status"] == "submitted"
+    assert submitted.json()["session"]["submitted_at"] is not None
+
+    generated_pdf = anon.post(f"/questionnaires/published/e2e-survey/sessions/{session_id}/pdf")
+    assert generated_pdf.status_code == 200
+    assert generated_pdf.json()["artifact"]["size_bytes"] > 0
+
+    downloaded_pdf = anon.get(f"/questionnaires/published/e2e-survey/sessions/{session_id}/pdf")
+    assert downloaded_pdf.status_code == 200
+    assert downloaded_pdf.headers["content-type"].startswith("application/pdf")
+    assert downloaded_pdf.content.startswith(b"%PDF")
+
+
+def test_regression_session_uses_original_version_after_republish() -> None:
+    owner = _build_client("creator-1")
+    owner.post("/questionnaires/drafts", json={"questionnaire_id": "q_immutable", "title": "Immutable", "description": "d", "visibility": "public"})
+    owner.post("/questionnaires/drafts/q_immutable/sections", json={"section_id": "s1", "title": "S1"})
+    owner.post("/questionnaires/drafts/q_immutable/questions", json={"section_id": "s1", "question_id": "q1", "type": "text", "label": "L1", "required": True, "config_json": {}})
+    first_pub = owner.post("/questionnaires/drafts/q_immutable/publish", json={"published_slug": "immutable-survey"})
+    first_version_id = first_pub.json()["version"]["version_id"]
+
+    anon = _build_anon_client()
+    started = anon.post("/questionnaires/published/immutable-survey/sessions", json={})
+    session_id = started.json()["session"]["response_session_id"]
+
+    _FAKE_TABLE.items[("QNR#q_immutable", "META")]["status"] = "draft"
+    owner.post("/questionnaires/drafts/q_immutable/questions", json={"section_id": "s1", "question_id": "q2", "type": "text", "label": "L2", "required": True, "config_json": {}})
+    second_pub = owner.post("/questionnaires/drafts/q_immutable/publish", json={"published_slug": "immutable-survey"})
+    assert second_pub.json()["version"]["version_id"] != first_version_id
+
+    saved = anon.put(
+        f"/questionnaires/published/immutable-survey/sessions/{session_id}",
+        json={"answers_by_question_id": {"q1": "only-v1-answer"}, "current_section_index": 0, "current_question_id": "q1"},
+    )
+    assert saved.status_code == 200
+
+    submit_v1 = anon.post(
+        f"/questionnaires/published/immutable-survey/sessions/{session_id}/submit",
+        json={"answers_by_question_id": {"q1": "only-v1-answer"}, "final_submit": True},
+    )
+    assert submit_v1.status_code == 200
+    assert submit_v1.json()["session"]["version_id"] == first_version_id

--- a/tests/test_questionnaire_repository.py
+++ b/tests/test_questionnaire_repository.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.questionnaires_repository import DynamoQuestionnaireRepository
+
+
+class _FakeTable:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str], dict] = {}
+
+    def put_item(self, *, Item):
+        self.items[(Item["pk"], Item["sk"])] = dict(Item)
+
+    def get_item(self, *, Key):
+        item = self.items.get((Key["pk"], Key["sk"]))
+        return {"Item": dict(item)} if item else {}
+
+    def update_item(self, *, Key, UpdateExpression, ExpressionAttributeValues, ExpressionAttributeNames=None, ConditionExpression=None):
+        item = self.items[(Key["pk"], Key["sk"])]
+        if ConditionExpression == "#status=:in_progress":
+            assert item["status"] == ExpressionAttributeValues[":in_progress"]
+
+        assignments = UpdateExpression.replace("SET", "", 1).strip().split(",")
+        for assignment in assignments:
+            left, right = assignment.strip().split("=")
+            left = left.strip()
+            right = right.strip()
+            if ExpressionAttributeNames and left in ExpressionAttributeNames:
+                field = ExpressionAttributeNames[left]
+            else:
+                field = left
+            item[field] = ExpressionAttributeValues[right]
+        self.items[(Key["pk"], Key["sk"])] = item
+
+    def query(self, **kwargs):
+        vals = kwargs.get("ExpressionAttributeValues", {})
+        pk = vals.get(":pk")
+        index_name = kwargs.get("IndexName", "")
+        out = []
+        if "begins_with(sk" in (kwargs.get("KeyConditionExpression") or ""):
+            prefix = vals.get(":sk_prefix", "")
+            for item in self.items.values():
+                if item.get("pk") == pk and item.get("sk", "").startswith(prefix):
+                    out.append(item)
+        else:
+            for item in self.items.values():
+                if index_name.endswith("owner-updated-index") and item.get("gsi_owner_pk") == pk:
+                    out.append(item)
+                if index_name.endswith("status-updated-index") and item.get("gsi_status_pk") == pk:
+                    out.append(item)
+                if index_name.endswith("published_slug-index") and item.get("gsi_published_pk") == pk:
+                    out.append(item)
+                if index_name.endswith("response_status-updated-index") and item.get("gsi_response_status_pk") == pk:
+                    out.append(item)
+        return {"Items": out[: kwargs.get("Limit", 25)]}
+
+
+def test_submitted_response_cannot_be_reassigned() -> None:
+    repo = DynamoQuestionnaireRepository(_table=_FakeTable())
+    repo.put_questionnaire(questionnaire_id="q1", owner_id="u1", title="T")
+    repo.put_response_session(response_session_id="r1", questionnaire_id="q1", version_id="v1")
+    repo.mark_response_submitted(questionnaire_id="q1", response_session_id="r1")
+
+    with pytest.raises(ValueError):
+        repo.rebind_response_version(questionnaire_id="q1", response_session_id="r1", new_version_id="v2")
+
+
+def test_published_lookup_indexed_by_slug() -> None:
+    repo = DynamoQuestionnaireRepository(_table=_FakeTable())
+    repo.put_questionnaire(questionnaire_id="q1", owner_id="u1", title="T")
+    repo.put_version(questionnaire_id="q1", version_id="v1", version_number=1, schema_json={}, published_slug="survey-1")
+
+    got = repo.get_published_by_slug("survey-1")
+    assert got is not None
+    assert got["version_id"] == "v1"
+
+
+def test_schema_snapshot_excludes_deleted_questions_and_preserves_order() -> None:
+    repo = DynamoQuestionnaireRepository(_table=_FakeTable())
+    repo.put_questionnaire(questionnaire_id="q1", owner_id="u1", title="T")
+    repo.create_section(questionnaire_id="q1", section_id="s1", title="A", description="", actor_sub="u1")
+    repo.create_section(questionnaire_id="q1", section_id="s2", title="B", description="", actor_sub="u1")
+    repo.reorder_sections(questionnaire_id="q1", ordered_section_ids=["s2", "s1"], actor_sub="u1")
+
+    repo.create_question(
+        questionnaire_id="q1",
+        section_id="s2",
+        question_id="q1",
+        question_type="text",
+        label="L1",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="u1",
+    )
+    repo.create_question(
+        questionnaire_id="q1",
+        section_id="s2",
+        question_id="q2",
+        question_type="text",
+        label="L2",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="u1",
+    )
+    repo.delete_question(questionnaire_id="q1", section_id="s2", question_id="q1", actor_sub="u1")
+
+    snapshot = repo.build_schema_snapshot("q1")
+    assert [s["section_id"] for s in snapshot["sections"]] == ["s2", "s1"]
+    assert [q["question_id"] for q in snapshot["sections"][0]["questions"]] == ["q2"]
+
+
+def test_publish_creates_incrementing_immutable_versions() -> None:
+    repo = DynamoQuestionnaireRepository(_table=_FakeTable())
+    repo.put_questionnaire(questionnaire_id="q1", owner_id="u1", title="T")
+    repo.create_section(questionnaire_id="q1", section_id="s1", title="S1", description="", actor_sub="u1")
+    repo.create_question(
+        questionnaire_id="q1",
+        section_id="s1",
+        question_id="q1",
+        question_type="text",
+        label="Before",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="u1",
+    )
+
+    v1 = repo.publish_draft(questionnaire_id="q1", owner_id="u1", actor_sub="u1")
+    assert v1["version_number"] == 1
+    assert v1["schema_json"]["sections"][0]["questions"][0]["label"] == "Before"
+
+    repo.update_question(
+        questionnaire_id="q1",
+        section_id="s1",
+        question_id="q1",
+        label="After",
+        required=None,
+        hint=None,
+        config_json=None,
+        actor_sub="u1",
+    )
+    v2 = repo.publish_draft(questionnaire_id="q1", owner_id="u1", actor_sub="u1")
+    assert v2["version_number"] == 2
+    assert v1["schema_json"]["sections"][0]["questions"][0]["label"] == "Before"
+    assert v2["schema_json"]["sections"][0]["questions"][0]["label"] == "After"
+
+
+def test_existing_response_stays_on_prior_version_after_republish() -> None:
+    repo = DynamoQuestionnaireRepository(_table=_FakeTable())
+    repo.put_questionnaire(questionnaire_id="q1", owner_id="u1", title="T")
+    repo.create_section(questionnaire_id="q1", section_id="s1", title="S1", description="", actor_sub="u1")
+    repo.create_question(
+        questionnaire_id="q1",
+        section_id="s1",
+        question_id="q1",
+        question_type="text",
+        label="L1",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="u1",
+    )
+    v1 = repo.publish_draft(questionnaire_id="q1", owner_id="u1", actor_sub="u1")
+    session = repo.put_response_session(response_session_id="r1", questionnaire_id="q1", version_id=v1["version_id"])
+
+    repo.create_question(
+        questionnaire_id="q1",
+        section_id="s1",
+        question_id="q2",
+        question_type="text",
+        label="L2",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="u1",
+    )
+    v2 = repo.publish_draft(questionnaire_id="q1", owner_id="u1", actor_sub="u1")
+
+    got = repo._table.get_item(Key={"pk": "QNR#q1", "sk": "RESP#r1"})["Item"]
+    assert session["version_id"] == v1["version_id"]
+    assert got["version_id"] == v1["version_id"]
+    assert got["version_id"] != v2["version_id"]
+
+
+def test_sensitive_answers_are_encrypted_at_rest_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = DynamoQuestionnaireRepository(_table=_FakeTable())
+    repo.put_questionnaire(questionnaire_id="q1", owner_id="u1", title="T")
+    repo.create_section(questionnaire_id="q1", section_id="s1", title="S1", description="", actor_sub="u1")
+    repo.create_question(
+        questionnaire_id="q1",
+        section_id="s1",
+        question_id="q_addr",
+        question_type="address",
+        label="Address",
+        required=False,
+        hint="",
+        config_json={},
+        actor_sub="u1",
+    )
+    v1 = repo.publish_draft(questionnaire_id="q1", owner_id="u1", actor_sub="u1")
+    repo.put_response_session(response_session_id="r1", questionnaire_id="q1", version_id=v1["version_id"])
+
+    from app.core.settings import S
+
+    prev = S.questionnaire_encrypt_sensitive_answers
+    object.__setattr__(S, "questionnaire_encrypt_sensitive_answers", True)
+    monkeypatch.setattr("app.services.questionnaires_repository.kms_encrypt", lambda plaintext: f"enc::{plaintext}")
+    monkeypatch.setattr("app.services.questionnaires_repository.kms_decrypt", lambda ct: ct.replace("enc::", "").encode("utf-8"))
+    try:
+        repo.save_session_answers(questionnaire_id="q1", response_session_id="r1", answers_by_question_id={"q_addr": {"line1": "123 Main"}})
+        raw = repo._table.get_item(Key={"pk": "QNR#q1", "sk": "ANSWER#r1#q_addr"})["Item"]
+        assert raw["value_encrypted"] is True
+        assert raw.get("value") is None
+        assert str(raw.get("value_enc", "")).startswith("enc::")
+
+        hydrated = repo.list_session_answers(questionnaire_id="q1", response_session_id="r1")
+        assert hydrated["q_addr"]["line1"] == "123 Main"
+    finally:
+        object.__setattr__(S, "questionnaire_encrypt_sensitive_answers", prev)

--- a/tests/test_questionnaire_validation.py
+++ b/tests/test_questionnaire_validation.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.questionnaire_validation import (
+    evaluate_form_rules,
+    evaluate_group_rules,
+    validate_form_submission,
+    validate_question_answers,
+    validate_with_group_rules,
+)
+
+
+def _schema_for(question: dict) -> dict:
+    return {"sections": [{"section_id": "s1", "questions": [question]}]}
+
+
+def _codes(errors: dict, qid: str = "q1") -> list[str]:
+    return [e["code"] for e in errors.get(qid, [])]
+
+
+def test_required_validation() -> None:
+    schema = _schema_for({"question_id": "q1", "type": "text", "required": True, "config_json": {}})
+    errors = validate_question_answers(schema, {"q1": ""})
+    assert _codes(errors) == ["required"]
+
+
+def test_text_constraints_min_max_and_pattern() -> None:
+    schema = _schema_for(
+        {
+            "question_id": "q1",
+            "type": "text",
+            "required": True,
+            "config_json": {"minLength": 3, "maxLength": 5, "pattern": r"^[A-Z]+$"},
+        }
+    )
+    assert _codes(validate_question_answers(schema, {"q1": "ab"})) == ["too_short", "pattern_mismatch"]
+    assert _codes(validate_question_answers(schema, {"q1": "ABCDEF"})) == ["too_long"]
+    assert validate_question_answers(schema, {"q1": "ABCD"}) == {}
+
+
+def test_select_and_radio_validation() -> None:
+    base = {"question_id": "q1", "required": True, "config_json": {"options": ["a", "b"]}}
+    select_schema = _schema_for({**base, "type": "select"})
+    radio_schema = _schema_for({**base, "type": "radio"})
+
+    assert _codes(validate_question_answers(select_schema, {"q1": "c"})) == ["invalid_option"]
+    assert _codes(validate_question_answers(radio_schema, {"q1": 2})) == ["invalid_type"]
+    assert validate_question_answers(select_schema, {"q1": "a"}) == {}
+
+
+def test_multiselect_validation_boundaries() -> None:
+    schema = _schema_for(
+        {
+            "question_id": "q1",
+            "type": "multiselect",
+            "required": True,
+            "config_json": {"options": ["x", "y", "z"], "minSelections": 1, "maxSelections": 2},
+        }
+    )
+
+    assert _codes(validate_question_answers(schema, {"q1": []})) == ["required"]
+    assert _codes(validate_question_answers(schema, {"q1": ["x", "bad"]})) == ["invalid_option"]
+    assert _codes(validate_question_answers(schema, {"q1": ["x", "y", "z"]})) == ["too_many_choices"]
+    assert validate_question_answers(schema, {"q1": ["x", "z"]}) == {}
+
+
+def test_slider_validation_min_max_step() -> None:
+    schema = _schema_for(
+        {
+            "question_id": "q1",
+            "type": "slider",
+            "required": True,
+            "config_json": {"min": 0, "max": 10, "step": 2},
+        }
+    )
+
+    assert _codes(validate_question_answers(schema, {"q1": -1})) == ["below_min"]
+    assert _codes(validate_question_answers(schema, {"q1": 11})) == ["above_max"]
+    assert _codes(validate_question_answers(schema, {"q1": 3})) == ["invalid_step"]
+    assert validate_question_answers(schema, {"q1": 4}) == {}
+
+
+def test_date_validation_format_and_value() -> None:
+    schema = _schema_for({"question_id": "q1", "type": "date", "required": True, "config_json": {}})
+    assert _codes(validate_question_answers(schema, {"q1": "2024/01/10"})) == ["invalid_date_format"]
+    assert _codes(validate_question_answers(schema, {"q1": "2024-13-10"})) == ["invalid_date_format"]
+    assert validate_question_answers(schema, {"q1": "2024-01-10"}) == {}
+
+
+def test_time_validation_format_and_value() -> None:
+    schema = _schema_for({"question_id": "q1", "type": "time", "required": True, "config_json": {}})
+    assert _codes(validate_question_answers(schema, {"q1": "7pm"})) == ["invalid_time_format"]
+    assert _codes(validate_question_answers(schema, {"q1": "24:00"})) == ["invalid_time_format"]
+    assert validate_question_answers(schema, {"q1": "23:59"}) == {}
+
+
+def test_timezone_validation() -> None:
+    schema = _schema_for({"question_id": "q1", "type": "timezone", "required": True, "config_json": {}})
+    assert _codes(validate_question_answers(schema, {"q1": "Mars/Olympus"})) == ["invalid_timezone"]
+    assert validate_question_answers(schema, {"q1": "UTC"}) == {}
+
+
+def test_address_validation_required_fields() -> None:
+    schema = _schema_for(
+        {
+            "question_id": "q1",
+            "type": "address",
+            "required": True,
+            "config_json": {"requiredFields": ["line1", "city", "postal_code", "country"]},
+        }
+    )
+
+    errors = validate_question_answers(schema, {"q1": {"line1": "1 Main", "city": "", "country": "US"}})
+    assert _codes(errors) == ["missing_address_field", "missing_address_field"]
+    assert validate_question_answers(
+        schema,
+        {"q1": {"line1": "1 Main", "city": "Springfield", "postal_code": "12345", "country": "US"}},
+    ) == {}
+
+
+def test_errors_are_keyed_by_question_id_and_independent_of_order() -> None:
+    schema = {
+        "sections": [
+            {
+                "section_id": "s1",
+                "questions": [
+                    {"question_id": "q_date", "type": "date", "required": True, "config_json": {}},
+                    {"question_id": "q_slider", "type": "slider", "required": True, "config_json": {"min": 1, "max": 5, "step": 1}},
+                ],
+            }
+        ]
+    }
+
+    answers = {"q_slider": 3, "q_date": "bad"}
+    errors = validate_question_answers(schema, answers)
+    assert set(errors.keys()) == {"q_date"}
+    assert _codes(errors, "q_date") == ["invalid_date_format"]
+
+
+def test_group_min_answered_with_partial_completion() -> None:
+    schema = {
+        "sections": [
+            {
+                "section_id": "employment",
+                "questions": [
+                    {"question_id": "q_role", "type": "text", "required": False, "config_json": {}},
+                    {"question_id": "q_company", "type": "text", "required": False, "config_json": {}},
+                    {"question_id": "q_years", "type": "slider", "required": False, "config_json": {"min": 0, "max": 40, "step": 1}},
+                ],
+            }
+        ]
+    }
+    group_rules = [
+        {
+            "rule_id": "r_min",
+            "group_id": "employment",
+            "rule_type": "min_answered",
+            "question_ids": ["q_role", "q_company", "q_years"],
+            "config_json": {"min_answered": 2},
+        }
+    ]
+
+    errors = validate_with_group_rules(schema, {"q_role": "Engineer"}, group_rules)
+    assert _codes(errors, "group:employment") == ["group_min_answered"]
+
+    no_errors = validate_with_group_rules(schema, {"q_role": "Engineer", "q_company": "Acme"}, group_rules)
+    assert "group:employment" not in no_errors
+
+
+def test_group_dependency_rule() -> None:
+    schema = {
+        "sections": [
+            {
+                "section_id": "preferences",
+                "questions": [
+                    {"question_id": "q_opt_in", "type": "radio", "required": False, "config_json": {"options": ["yes", "no"]}},
+                    {"question_id": "q_email", "type": "text", "required": False, "config_json": {}},
+                ],
+            }
+        ]
+    }
+    rules = [
+        {
+            "rule_id": "r_dep",
+            "group_id": "preferences",
+            "rule_type": "requires_if_answered",
+            "question_ids": ["q_opt_in", "q_email"],
+            "config_json": {"if_question_id": "q_opt_in", "required_question_ids": ["q_email"]},
+        }
+    ]
+
+    errors = validate_with_group_rules(schema, {"q_opt_in": "yes"}, rules)
+    assert _codes(errors, "group:preferences") == ["group_dependency_required"]
+
+    no_errors = validate_with_group_rules(schema, {"q_opt_in": "yes", "q_email": "a@example.com"}, rules)
+    assert "group:preferences" not in no_errors
+
+
+def test_group_mutually_exclusive_constraint() -> None:
+    schema = {
+        "sections": [
+            {
+                "section_id": "contact",
+                "questions": [
+                    {"question_id": "q_phone", "type": "text", "required": False, "config_json": {}},
+                    {"question_id": "q_sms", "type": "text", "required": False, "config_json": {}},
+                ],
+            }
+        ]
+    }
+    rules = [
+        {
+            "rule_id": "r_excl",
+            "group_id": "contact",
+            "rule_type": "mutually_exclusive",
+            "question_ids": ["q_phone", "q_sms"],
+            "config_json": {},
+        }
+    ]
+
+    errors = validate_with_group_rules(schema, {"q_phone": "111", "q_sms": "222"}, rules)
+    assert _codes(errors, "group:contact") == ["group_mutually_exclusive"]
+
+
+def test_group_errors_merge_with_question_errors() -> None:
+    schema = {
+        "sections": [
+            {
+                "section_id": "mix",
+                "questions": [
+                    {"question_id": "q_date", "type": "date", "required": True, "config_json": {}},
+                    {"question_id": "q_other", "type": "text", "required": False, "config_json": {}},
+                ],
+            }
+        ]
+    }
+    rules = [
+        {
+            "rule_id": "r_min",
+            "group_id": "mix",
+            "rule_type": "min_answered",
+            "question_ids": ["q_date", "q_other"],
+            "config_json": {"min_answered": 2},
+        }
+    ]
+
+    errors = validate_with_group_rules(schema, {"q_date": "not-a-date"}, rules)
+    assert _codes(errors, "q_date") == ["invalid_date_format"]
+    assert _codes(errors, "group:mix") == ["group_min_answered"]
+
+
+def test_group_rule_rejects_unknown_references() -> None:
+    questions_by_id = {"q1": {"question_id": "q1", "type": "text", "required": False, "config_json": {}}}
+    rules = [
+        {
+            "rule_id": "r_invalid",
+            "group_id": "g1",
+            "rule_type": "min_answered",
+            "question_ids": ["q1", "missing_q"],
+            "config_json": {"min_answered": 1},
+        }
+    ]
+
+    with pytest.raises(ValueError, match="unknown question IDs"):
+        evaluate_group_rules(rules, answers_by_question_id={}, questions_by_id=questions_by_id)
+
+
+def test_form_rule_cross_section_dependency_and_order() -> None:
+    schema = {
+        "sections": [
+            {
+                "section_id": "personal",
+                "questions": [
+                    {"question_id": "q_country", "type": "select", "required": False, "config_json": {"options": ["US", "CA"]}},
+                ],
+            },
+            {
+                "section_id": "tax",
+                "questions": [
+                    {"question_id": "q_ssn", "type": "text", "required": False, "config_json": {}},
+                ],
+            },
+        ]
+    }
+    form_rules = [
+        {
+            "rule_id": "fr1",
+            "rule_type": "requires_if_answered",
+            "config_json": {"if_question_id": "q_country", "required_question_ids": ["q_ssn"]},
+            "blocking": True,
+        }
+    ]
+
+    result = validate_form_submission(
+        schema_json=schema,
+        answers_by_question_id={"q_country": "US"},
+        group_rules=[],
+        form_rules=form_rules,
+    )
+    assert result["can_submit"] is False
+    assert _codes(result["errors"], "form:fr1") == ["form_dependency_required"]
+
+
+def test_form_level_runs_after_question_and_group_rules() -> None:
+    schema = {
+        "sections": [
+            {
+                "section_id": "s1",
+                "questions": [
+                    {"question_id": "q_date", "type": "date", "required": True, "config_json": {}},
+                    {"question_id": "q_toggle", "type": "radio", "required": False, "config_json": {"options": ["yes", "no"]}},
+                ],
+            },
+            {
+                "section_id": "s2",
+                "questions": [
+                    {"question_id": "q_dep", "type": "text", "required": False, "config_json": {}},
+                ],
+            },
+        ]
+    }
+    group_rules = [
+        {
+            "rule_id": "gr1",
+            "group_id": "s1",
+            "rule_type": "min_answered",
+            "question_ids": ["q_date", "q_toggle", "q_dep"],
+            "config_json": {"min_answered": 3},
+        }
+    ]
+    form_rules = [
+        {
+            "rule_id": "fr2",
+            "rule_type": "requires_if_answered",
+            "config_json": {"if_question_id": "q_toggle", "required_question_ids": ["q_dep"]},
+            "blocking": True,
+        }
+    ]
+
+    result = validate_form_submission(
+        schema_json=schema,
+        answers_by_question_id={"q_date": "bad", "q_toggle": "yes"},
+        group_rules=group_rules,
+        form_rules=form_rules,
+    )
+
+    assert _codes(result["errors"], "q_date") == ["invalid_date_format"]
+    assert _codes(result["errors"], "group:s1") == ["group_min_answered"]
+    assert _codes(result["errors"], "form:fr2") == ["form_dependency_required"]
+    assert result["has_blocking_form_error"] is True
+    assert result["can_submit"] is False
+
+
+def test_form_rule_rejects_unknown_references() -> None:
+    with pytest.raises(ValueError, match="Form rule references unknown question IDs"):
+        evaluate_form_rules(
+            form_rules=[
+                {
+                    "rule_id": "fr_bad",
+                    "rule_type": "mutually_exclusive",
+                    "config_json": {"question_ids": ["missing_a", "missing_b"]},
+                    "blocking": True,
+                }
+            ],
+            answers_by_question_id={},
+            questions_by_id={"q1": {"question_id": "q1", "type": "text"}},
+        )

--- a/tests/test_questionnaire_validation_contract.py
+++ b/tests/test_questionnaire_validation_contract.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.roles import Role
+from app.contracts.questionnaire_validation_contract import VALIDATION_CONTRACT_VERSION, QuestionnaireValidationResponse
+from app.main import create_app
+from app.routers import questionnaires
+from app.services.sessions import require_ui_session
+
+CONTRACT_SCHEMA_PATH = Path("docs/questionnaire-validation-contract-v1.json")
+FRONTEND_TYPES_PATH = Path("frontend/src/api/types.ts")
+
+
+class _FakeTable:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str], dict] = {}
+
+    def put_item(self, *, Item):
+        self.items[(Item["pk"], Item["sk"])] = deepcopy(Item)
+
+    def get_item(self, *, Key):
+        item = self.items.get((Key["pk"], Key["sk"]))
+        return {"Item": deepcopy(item)} if item else {}
+
+    def update_item(self, *, Key, UpdateExpression, ExpressionAttributeValues, ExpressionAttributeNames=None, ConditionExpression=None):
+        item = self.items[(Key["pk"], Key["sk"])]
+        names = ExpressionAttributeNames or {}
+        assignments = UpdateExpression.replace("SET", "", 1).strip().split(",")
+        for assignment in assignments:
+            left, right = assignment.strip().split("=", 1)
+            left = left.strip()
+            right = right.strip()
+            attr = names.get(left, left)
+            item[attr] = ExpressionAttributeValues[right]
+        self.items[(Key["pk"], Key["sk"])] = item
+
+    def query(self, **kwargs):
+        vals = kwargs.get("ExpressionAttributeValues", {})
+        index_name = kwargs.get("IndexName", "")
+        pk = vals.get(":pk")
+        limit = kwargs.get("Limit", 25)
+        rows = []
+        if "begins_with(sk" in (kwargs.get("KeyConditionExpression") or ""):
+            prefix = vals.get(":sk_prefix", "")
+            for item in self.items.values():
+                if item.get("pk") == pk and item.get("sk", "").startswith(prefix):
+                    rows.append(deepcopy(item))
+            rows.sort(key=lambda r: r.get("sk", ""))
+            return {"Items": rows}
+        for item in self.items.values():
+            if index_name.endswith("owner-updated-index") and item.get("gsi_owner_pk") == pk:
+                rows.append(deepcopy(item))
+        return {"Items": rows[:limit]}
+
+
+def _build_client(user_sub: str, fake_table: _FakeTable) -> tuple[TestClient, object]:
+    app = create_app()
+    previous_table = questionnaires.REPO._table
+    questionnaires.REPO._table = fake_table
+
+    async def _auth_override():
+        return AuthenticatedUser(sub=user_sub, role=Role.USER)
+
+    async def _session_override():
+        return {"user_sub": user_sub, "session_id": "sess_1", "role": Role.USER.value}
+
+    app.dependency_overrides[get_authenticated_user] = _auth_override
+    app.dependency_overrides[require_ui_session] = _session_override
+    return TestClient(app), previous_table
+
+
+def test_contract_schema_version_is_stable() -> None:
+    assert CONTRACT_SCHEMA_PATH.exists()
+    schema = json.loads(CONTRACT_SCHEMA_PATH.read_text())
+    assert schema["properties"]["contract_version"]["const"] == VALIDATION_CONTRACT_VERSION
+
+
+def test_frontend_types_include_validation_contract_interfaces() -> None:
+    text = FRONTEND_TYPES_PATH.read_text()
+    assert "QUESTIONNAIRE_VALIDATION_CONTRACT_VERSION" in text
+    assert "QuestionnaireValidationReq" in text
+    assert "QuestionnaireValidationResp" in text
+
+
+def test_validate_endpoint_response_matches_shared_contract() -> None:
+    client, previous_table = _build_client("user-1", _FakeTable())
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_contract", "title": "Q", "description": "d"})
+    client.post("/questionnaires/drafts/q_contract/sections", json={"section_id": "s1", "title": "S1"})
+    client.post(
+        "/questionnaires/drafts/q_contract/questions",
+        json={"section_id": "s1", "question_id": "q1", "type": "date", "label": "D", "required": True, "config_json": {}},
+    )
+
+    res = client.post(
+        "/questionnaires/drafts/q_contract/validate",
+        json={
+            "contract_version": VALIDATION_CONTRACT_VERSION,
+            "answers_by_question_id": {"q1": "bad-date"},
+            "group_rules": [],
+            "form_rules": [],
+            "final_submit": False,
+        },
+    )
+    assert res.status_code == 200
+
+    parsed = QuestionnaireValidationResponse.model_validate(res.json())
+    assert parsed.contract_version == VALIDATION_CONTRACT_VERSION
+    assert "q1" in parsed.errors
+    assert parsed.errors["q1"][0].code == "invalid_date_format"
+    questionnaires.REPO._table = previous_table
+
+
+def test_incompatible_contract_version_is_rejected() -> None:
+    client, previous_table = _build_client("user-1", _FakeTable())
+    client.post("/questionnaires/drafts", json={"questionnaire_id": "q_contract_2", "title": "Q", "description": "d"})
+
+    res = client.post(
+        "/questionnaires/drafts/q_contract_2/validate",
+        json={
+            "contract_version": "2027-01-validation-v2",
+            "answers_by_question_id": {},
+            "group_rules": [],
+            "form_rules": [],
+            "final_submit": False,
+        },
+    )
+    assert res.status_code == 422
+    questionnaires.REPO._table = previous_table

--- a/tests/test_text_sanitizer.py
+++ b/tests/test_text_sanitizer.py
@@ -1,0 +1,11 @@
+from app.services.text_sanitizer import sanitize_user_text
+
+
+def test_sanitize_removes_script_and_markup() -> None:
+    raw = '<b>Hello</b><script>alert(1)</script><i>World</i>'
+    assert sanitize_user_text(raw) == 'HelloWorld'
+
+
+def test_sanitize_handles_none_and_length_limit() -> None:
+    assert sanitize_user_text(None) == ''
+    assert sanitize_user_text('x' * 10, max_length=4) == 'xxxx'


### PR DESCRIPTION
### Motivation
- Introduce a first-class questionnaire creator/respondent workflow with versioned published snapshots and immutable response binding for reliable audits and analytics.
- Provide a shared validation contract so frontend and backend can evaluate the same validation rules (question/group/form) and block submissions on blocking form-level errors.
- Expose respondent features like page-based navigation, autosave, server-side authoritative validation and PDF export for submitted responses.
- Add creator UX (builder, rule editor, preview) and analytics so owners can monitor starts, completions, drop-offs and validation hotspots.

### Description
- Added backend types and contract: `app/contracts/questionnaire_validation_contract.py` and JSON schema `docs/questionnaire-validation-contract-v1.json` with version constant `2026-03-validation-v1`.
- Implemented the questionnaire service layer and persistence: `app/services/questionnaires_repository.py` (Dynamo-backed repository), `app/services/questionnaire_validation.py` (question/group/form validators), `app/services/questionnaire_response_pdf.py` (HTML rendering + minimal PDF generator), and `app/services/text_sanitizer.py` (sanitization utilities).
- Exposed REST API surface in `app/routers/questionnaires.py` and wired routing in `app/main.py`; added models in `app/models_questionnaire.py` and settings/table wiring in `app/core/settings.py` and `app/core/tables.py` plus local/migration tooling (`scripts/local-ddb-init.py`, `scripts/migrations/20260302_questionnaire_schema.py`).
- Frontend additions include types, API endpoints, builder and respondent UI pages and components, and rule/config helpers under `frontend/src/pages/questionnaires/*`, plus integration with the app router and generated TypeScript types in `frontend/src/api/types.ts` and `frontend/src/api/endpoints/questionnaires.ts`.
- Added documentation and launch artifacts: architecture update `docs/architecture.md` ERD, accessibility audit, implementation plan and release checklist plus validation contract/versioning docs.

### Testing
- Added comprehensive backend unit and integration tests and ran `tests/test_questionnaire_validation.py`, `tests/test_questionnaire_repository.py`, `tests/test_questionnaire_draft_routes.py`, `tests/test_questionnaire_e2e_workflow.py`, `tests/test_questionnaire_validation_contract.py`, and `tests/test_text_sanitizer.py`, all of which passed in the test run.
- Added frontend unit/component tests (Vitest) covering the builder/respondent components: `QuestionTypeConfigEditor.test.tsx`, `QuestionnaireBuilderPage.test.tsx`, `QuestionnaireRespondentPage.test.tsx`, `ValidationRuleBuilder.test.tsx`, which were executed and passed in CI.
- Contract compatibility was validated by parsing `docs/questionnaire-validation-contract-v1.json` and validating responses against `QuestionnaireValidationResponse`.
- Local migration and table init scripts were exercised in staging-local flows as part of the migration checklist (index attributes and GSI wiring validated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a459628488832b812e6278599c402c)