### PR TITLE
Add full content moderation subsystem (reporting, tickets, admin board, enforcement)

### DIFF
--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -16,6 +16,7 @@ from app.auth.roles import AdminProfile, Role, normalize_admin_profile, normaliz
 from app.auth.root_invariant import enforce_root_role_invariant
 from app.core.settings import S
 from app.models import UiSessionStartReq
+from app.services.moderation_policy_engine import is_user_currently_banned
 
 _JWKS_CACHE: Optional[Dict[str, Any]] = None
 _JWKS_FETCHED_AT: float = 0.0
@@ -128,6 +129,13 @@ class AuthenticatedUser:
     admin_profile: AdminProfile = AdminProfile()
 
 
+def _enforce_not_banned(*, user_sub: str, role: Role) -> None:
+    if role in {Role.ROOT, Role.ADMIN}:
+        return
+    if is_user_currently_banned(user_sub):
+        raise HTTPException(status_code=403, detail="account is banned")
+
+
 def extract_bearer_token(auth_header: Optional[str]) -> str:
     if not auth_header:
         raise HTTPException(401, "Missing Authorization header")
@@ -201,6 +209,7 @@ async def get_authenticated_user(request: Request) -> AuthenticatedUser:
                     role = _extract_role_from_claims(payload)
                     role = enforce_root_role_invariant(user_sub=str(user_sub), role=role)
                     admin_profile = _extract_admin_profile_from_claims(payload)
+                    _enforce_not_banned(user_sub=str(user_sub), role=role)
                     return AuthenticatedUser(sub=str(user_sub), role=role, admin_profile=admin_profile)
             except jwt.PyJWTError:
                 pass
@@ -218,6 +227,7 @@ async def get_authenticated_user(request: Request) -> AuthenticatedUser:
         role = _extract_role_from_claims(payload)
         role = enforce_root_role_invariant(user_sub=str(user_sub), role=role)
         admin_profile = _extract_admin_profile_from_claims(payload)
+        _enforce_not_banned(user_sub=str(user_sub), role=role)
         return AuthenticatedUser(sub=str(user_sub), role=role, admin_profile=admin_profile)
 
     # 3. Dev-mode fallbacks
@@ -229,6 +239,7 @@ async def get_authenticated_user(request: Request) -> AuthenticatedUser:
         fallback_role = normalize_role(request.headers.get("x-user-role"))
         fallback_role = enforce_root_role_invariant(user_sub=fallback_user, role=fallback_role)
         fallback_admin_profile = normalize_admin_profile(request.headers.get("x-user-admin-profile"))
+        _enforce_not_banned(user_sub=fallback_user, role=fallback_role)
         return AuthenticatedUser(sub=fallback_user, role=fallback_role, admin_profile=fallback_admin_profile)
 
     auth = request.headers.get("authorization", "")
@@ -238,6 +249,7 @@ async def get_authenticated_user(request: Request) -> AuthenticatedUser:
     role = _extract_role_from_claims(payload)
     role = enforce_root_role_invariant(user_sub=sub, role=role)
     admin_profile = _extract_admin_profile_from_claims(payload)
+    _enforce_not_banned(user_sub=sub, role=role)
     return AuthenticatedUser(sub=sub, role=role, admin_profile=admin_profile)
 
 

--- a/app/auth/roles.py
+++ b/app/auth/roles.py
@@ -15,6 +15,7 @@ class AdminScope(str, Enum):
     AUTH_SUPPORT = "auth_support"
     BILLING_SUPPORT = "billing_support"
     CONTENT_MODERATION = "content_moderation"
+    CONTENT_MODERATION_SENIOR = "content_moderation_senior"
 
 
 class AdminProfileType(str, Enum):
@@ -26,6 +27,7 @@ CANONICAL_ADMIN_SCOPES: tuple[AdminScope, ...] = (
     AdminScope.AUTH_SUPPORT,
     AdminScope.BILLING_SUPPORT,
     AdminScope.CONTENT_MODERATION,
+    AdminScope.CONTENT_MODERATION_SENIOR,
 )
 
 

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -300,6 +300,43 @@ class Settings:
         "DDB_MESSAGE_REPORT_CONTEXT",
         "MessageReportContext",
     )
+    content_reports_table_name: str = os.environ.get(
+        "DDB_CONTENT_REPORTS",
+        "ContentReports",
+    )
+    moderation_tickets_table_name: str = os.environ.get(
+        "DDB_MODERATION_TICKETS",
+        "ModerationTickets",
+    )
+    moderation_actions_table_name: str = os.environ.get(
+        "DDB_MODERATION_ACTIONS",
+        "ModerationActions",
+    )
+    moderation_audit_log_table_name: str = os.environ.get(
+        "DDB_MODERATION_AUDIT_LOG",
+        "ModerationAuditLog",
+    )
+    user_enforcement_history_table_name: str = os.environ.get(
+        "DDB_USER_ENFORCEMENT_HISTORY",
+        "UserEnforcementHistory",
+    )
+    moderation_dual_approval_permanent_ban_enabled: bool = os.environ.get(
+        "MODERATION_DUAL_APPROVAL_PERMANENT_BAN_ENABLED",
+        "false",
+    ).lower() in ("1", "true", "yes", "on")
+    moderation_kpi_lookback_hours: int = int(os.environ.get("MODERATION_KPI_LOOKBACK_HOURS", "24"))
+    moderation_kpi_surge_window_minutes: int = int(os.environ.get("MODERATION_KPI_SURGE_WINDOW_MINUTES", "15"))
+    moderation_alert_extortion_criminal_surge_threshold: int = int(
+        os.environ.get("MODERATION_ALERT_EXTORTION_CRIMINAL_SURGE_THRESHOLD", "10")
+    )
+    moderation_alert_sla_open_critical_threshold: int = int(
+        os.environ.get("MODERATION_ALERT_SLA_OPEN_CRITICAL_THRESHOLD", "20")
+    )
+    moderation_alert_sla_oldest_open_minutes_threshold: int = int(
+        os.environ.get("MODERATION_ALERT_SLA_OLDEST_OPEN_MINUTES_THRESHOLD", "120")
+    )
+    moderation_alert_sla_window_minutes: int = int(os.environ.get("MODERATION_ALERT_SLA_WINDOW_MINUTES", "30"))
+    moderation_oncall_user_subs: str = os.environ.get("MODERATION_ONCALL_USER_SUBS", "")
     message_legal_holds_table_name: str = os.environ.get(
         "DDB_MESSAGE_LEGAL_HOLDS",
         "MessageLegalHolds",

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -35,6 +35,11 @@ class Tables:
     conversation_pins: Any
     message_reports: Any
     message_report_context: Any
+    content_reports: Any
+    moderation_tickets: Any
+    moderation_actions: Any
+    moderation_audit_log: Any
+    user_enforcement_history: Any
     message_legal_holds: Any
     message_archive_chain_heads: Any
     message_compliance_exports: Any
@@ -81,6 +86,11 @@ T = Tables(
     conversation_pins=ddb.Table(S.conversation_pins_table_name),
     message_reports=ddb.Table(S.message_reports_table_name),
     message_report_context=ddb.Table(S.message_report_context_table_name),
+    content_reports=ddb.Table(S.content_reports_table_name),
+    moderation_tickets=ddb.Table(S.moderation_tickets_table_name),
+    moderation_actions=ddb.Table(S.moderation_actions_table_name),
+    moderation_audit_log=ddb.Table(S.moderation_audit_log_table_name),
+    user_enforcement_history=ddb.Table(S.user_enforcement_history_table_name),
     message_legal_holds=ddb.Table(S.message_legal_holds_table_name),
     message_archive_chain_heads=ddb.Table(S.message_archive_chain_heads_table_name),
     message_compliance_exports=ddb.Table(S.message_compliance_exports_table_name),

--- a/app/main.py
+++ b/app/main.py
@@ -66,6 +66,8 @@ from app.routers.browser_ssh_terminal import (
     router as browser_ssh_terminal_router,
 )
 from app.routers.questionnaires import router as questionnaires_router
+from app.routers.moderation import router as moderation_router, compat_router as moderation_compat_router
+from app.routers.admin_moderation import router as admin_moderation_router
 from app.services.billing_reconcile import start_billing_reconcile_task
 from app.services.billing_dunning import start_billing_dunning_task
 from app.services.filemanager import start_filemgr_purge_task
@@ -195,6 +197,9 @@ def create_app() -> FastAPI:
     app.include_router(calendar_public_event_router)
     app.include_router(device_trust_router)
     app.include_router(newsfeed_router)
+    app.include_router(moderation_router)
+    app.include_router(moderation_compat_router)
+    app.include_router(admin_moderation_router)
     app.add_event_handler("startup", validate_startup_root_invariant)
     if _S.dev_mode:
         _dev_buckets = [b for b in [

--- a/app/routers/admin_moderation.py
+++ b/app/routers/admin_moderation.py
@@ -1,0 +1,970 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict, Literal
+
+from boto3.dynamodb.conditions import Attr, Key
+from boto3.dynamodb.types import TypeSerializer
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.auth.deps import AuthenticatedUser
+from app.auth.policy import require_admin_scope
+from app.auth.roles import AdminScope, admin_profile_has_scope, normalize_admin_profile
+from app.core.aws import ddb
+from app.core.settings import S
+from app.core.tables import T
+from app.services.moderation_content_removal import apply_content_removal
+from app.services.moderation_audit_log import write_moderation_audit_event
+from app.services.moderation_policy_engine import apply_ban, issue_warning_notification, notify_content_removal
+from app.services.moderation_kpis import compute_moderation_kpis, evaluate_and_dispatch_moderation_alerts
+from app.services.moderation_flags import (
+    ensure_admin_actions_enabled,
+    ensure_admin_board_enabled,
+    ensure_permanent_ban_scope_rollout,
+    get_moderation_feature_flags,
+    set_moderation_feature_flags,
+)
+
+router = APIRouter(prefix="/v1/admin/moderation", tags=["admin-moderation"])
+
+require_content_moderation_admin = require_admin_scope(AdminScope.CONTENT_MODERATION)
+APP_TABLE = os.environ.get("APP_TABLE", "app_single_table")
+MESSAGES_TABLE = os.environ.get("DDB_MESSAGES", "Messages")
+SERIALIZER = TypeSerializer()
+POLICY_CATEGORY_RANK = {"spam": 1, "sexual": 2, "racist": 2, "criminal": 3, "extortion": 4}
+
+
+def _require_senior_moderation_for_permanent_ban(*, admin: AuthenticatedUser) -> None:
+    if admin.role.name == "ROOT":
+        return
+    profile = normalize_admin_profile(getattr(admin, "admin_profile", None))
+    if admin_profile_has_scope(profile, AdminScope.CONTENT_MODERATION_SENIOR):
+        return
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "code": "role_required_scope",
+            "required_scope": AdminScope.CONTENT_MODERATION_SENIOR.value,
+            "actual_role": str(getattr(admin.role, "value", admin.role)),
+            "actual_admin_profile": profile.to_dict(),
+        },
+    )
+
+
+
+
+def _require_dual_approval_for_permanent_ban(*, admin: AuthenticatedUser, second_approver_admin_user_id: str | None) -> None:
+    if not bool(getattr(S, "moderation_dual_approval_permanent_ban_enabled", False)):
+        return
+    approver = str(second_approver_admin_user_id or "").strip()
+    if not approver:
+        raise HTTPException(status_code=403, detail="second approver is required for permanent ban")
+    if approver == admin.sub:
+        raise HTTPException(status_code=403, detail="second approver must be different from acting admin")
+
+def _encode_cursor(cursor: Dict[str, Any] | None) -> str | None:
+    if not cursor:
+        return None
+    payload = json.dumps(cursor).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("utf-8")
+
+
+def _decode_cursor(cursor: str | None) -> Dict[str, Any] | None:
+    if not cursor:
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("utf-8"))
+        data = json.loads(raw.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(status_code=400, detail="invalid cursor") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="invalid cursor")
+    return data
+
+
+class ModerationTicketOut(BaseModel):
+    ticket_id: str
+    content_type: str
+    content_id: str
+    status: str
+    priority: str
+    queue: str
+    assigned_admin_user_id: str | None = None
+    report_count: int = 0
+    aggregated_topics: list[str] = Field(default_factory=list)
+    latest_report_at: int
+    updated_at: int
+    created_at: int
+
+
+class ModerationTicketsListOut(BaseModel):
+    items: list[ModerationTicketOut]
+    next_cursor: str | None = None
+
+
+class LinkedReportOut(BaseModel):
+    report_id: str
+    reporter_user_id: str
+    topics: list[str] = Field(default_factory=list)
+    reason_text: str
+    created_at: int
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+
+
+class UserEnforcementHistoryOut(BaseModel):
+    user_id: str
+    enforcement_id: str
+    enforcement_type: str
+    status: str
+    source_ticket_id: str
+    created_at: int
+    created_by_admin_user_id: str | None = None
+    duration_days: int = 0
+    note: str = ""
+
+
+class UserEnforcementHistoryListOut(BaseModel):
+    items: list[UserEnforcementHistoryOut]
+
+class OffenderHistorySummaryOut(BaseModel):
+    offender_user_id: str | None = None
+    total_tickets: int = 0
+    open_tickets: int = 0
+    total_reports: int = 0
+
+
+class ModerationTicketDetailOut(BaseModel):
+    ticket: ModerationTicketOut
+    content_snapshot: dict[str, Any] = Field(default_factory=dict)
+    linked_reports: list[LinkedReportOut] = Field(default_factory=list)
+    offender_history_summary: OffenderHistorySummaryOut
+    prior_enforcement_history: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class ModerationDecisionIn(BaseModel):
+    decision: Literal["no_violation", "remove", "warn", "ban"]
+    second_approver_admin_user_id: str | None = Field(default=None, max_length=256)
+    note: str | None = Field(default=None, max_length=2000)
+
+
+class ResolveModerationTicketIn(BaseModel):
+    resolution: Literal["no_violation", "content_removed"]
+    enforcement_action: Literal["none", "warn", "ban"] = "none"
+    enforcement_duration_days: int | None = Field(default=None, ge=1, le=3650)
+    second_approver_admin_user_id: str | None = Field(default=None, max_length=256)
+    note: str | None = Field(default=None, max_length=2000)
+
+
+
+class ModerationKpisOut(BaseModel):
+    generated_at: int
+    lookback_hours: int
+    surge_window_minutes: int
+    ticket_volume: int
+    resolution_count: int
+    resolution_latency_avg_seconds: int
+    resolution_latency_p95_seconds: int
+    warning_count: int
+    ban_count: int
+    warning_rate: float
+    ban_rate: float
+    open_ticket_count: int
+    critical_backlog: int
+    oldest_open_age_minutes: int
+    extortion_criminal_reports_window_count: int
+
+
+class ModerationKpiAlertsOut(BaseModel):
+    ok: bool
+    kpis: ModerationKpisOut
+    alerts_fired: list[dict[str, Any]] = Field(default_factory=list)
+    notified_user_subs: list[str] = Field(default_factory=list)
+
+
+
+class ModerationFeatureFlagsOut(BaseModel):
+    enabled: bool
+    report_feed_enabled: bool
+    report_messages_enabled: bool
+    report_profile_enabled: bool
+    admin_board_enabled: bool
+    admin_actions_enabled: bool
+    enforcement_enabled: bool
+    min_scope_for_board: str
+    min_scope_for_actions: str
+    min_scope_for_permanent_ban: str
+
+
+class ModerationFeatureFlagsUpdateIn(BaseModel):
+    enabled: bool | None = None
+    report_feed_enabled: bool | None = None
+    report_messages_enabled: bool | None = None
+    report_profile_enabled: bool | None = None
+    admin_board_enabled: bool | None = None
+    admin_actions_enabled: bool | None = None
+    enforcement_enabled: bool | None = None
+    min_scope_for_board: Literal["content_moderation", "content_moderation_senior"] | None = None
+    min_scope_for_actions: Literal["content_moderation", "content_moderation_senior"] | None = None
+    min_scope_for_permanent_ban: Literal["content_moderation", "content_moderation_senior"] | None = None
+def _parse_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _policy_category_for_notification(ticket_item: dict[str, Any], reports: list[dict[str, Any]]) -> str:
+    topics: list[str] = []
+    raw_ticket_topics = ticket_item.get("aggregated_topics")
+    if isinstance(raw_ticket_topics, (list, set, tuple)):
+        topics.extend(str(v).strip().lower() for v in raw_ticket_topics if str(v).strip())
+    for report in reports:
+        raw_report_topics = report.get("topics")
+        if isinstance(raw_report_topics, (list, set, tuple)):
+            topics.extend(str(v).strip().lower() for v in raw_report_topics if str(v).strip())
+
+    normalized = sorted(set(topics))
+    if not normalized:
+        return "unspecified"
+    return max(normalized, key=lambda topic: (POLICY_CATEGORY_RANK.get(topic, 0), topic))
+
+
+def _to_topic_list(raw: Any) -> list[str]:
+    if isinstance(raw, set):
+        return sorted(str(v) for v in raw)
+    if isinstance(raw, list):
+        return sorted(str(v) for v in raw)
+    return []
+
+
+def _to_ticket_out(item: Dict[str, Any]) -> ModerationTicketOut:
+    return ModerationTicketOut(
+        ticket_id=str(item.get("ticket_id") or ""),
+        content_type=str(item.get("content_type") or ""),
+        content_id=str(item.get("content_id") or ""),
+        status=str(item.get("status") or ""),
+        priority=str(item.get("priority") or "medium"),
+        queue=str(item.get("queue") or "general"),
+        assigned_admin_user_id=str(item.get("assigned_admin_user_id") or "") or None,
+        report_count=_parse_int(item.get("report_count"), default=0),
+        aggregated_topics=_to_topic_list(item.get("aggregated_topics")),
+        latest_report_at=_parse_int(item.get("latest_report_at"), default=0),
+        updated_at=_parse_int(item.get("updated_at"), default=0),
+        created_at=_parse_int(item.get("created_at"), default=0),
+    )
+
+
+def _query_config(*, status: str | None, queue: str | None, assignee: str | None) -> tuple[str, str, str]:
+    if assignee:
+        return ("ByAssignedAdminLatestReportAt", "assigned_admin_user_id", assignee)
+    if queue:
+        return ("ByQueueLatestReportAt", "queue", queue)
+    if status:
+        return ("ByStatusLatestReportAt", "status", status)
+    return ("ByLatestReportAt", "latest_report_scope", "ALL")
+
+
+def _get_ticket_or_404(ticket_id: str) -> dict[str, Any]:
+    item = T.moderation_tickets.get_item(Key={"ticket_id": ticket_id}).get("Item")
+    if not item or item.get("entity_type") != "moderation_ticket":
+        raise HTTPException(status_code=404, detail="ticket not found")
+    return item
+
+
+def _linked_reports(ticket_id: str) -> list[dict[str, Any]]:
+    # No direct ticket-id index yet; query timeline index and filter.
+    cursor = None
+    reports: list[dict[str, Any]] = []
+    for _ in range(8):
+        kwargs: dict[str, Any] = {
+            "IndexName": "ByCreatedAt",
+            "KeyConditionExpression": Key("created_scope").eq("ALL"),
+            "ScanIndexForward": False,
+            "Limit": 200,
+            "FilterExpression": Attr("linked_ticket_id").eq(ticket_id),
+        }
+        if cursor:
+            kwargs["ExclusiveStartKey"] = cursor
+        resp = T.content_reports.query(**kwargs)
+        items = [i for i in resp.get("Items", []) if i.get("entity_type") == "content_report"]
+        reports.extend(items)
+        cursor = resp.get("LastEvaluatedKey")
+        if not cursor:
+            break
+    reports.sort(key=lambda i: _parse_int(i.get("created_at"), 0), reverse=True)
+    return reports
+
+
+def _content_snapshot(ticket: dict[str, Any], reports: list[dict[str, Any]]) -> dict[str, Any]:
+    content_type = str(ticket.get("content_type") or "")
+    content_id = str(ticket.get("content_id") or "")
+    meta = (reports[0].get("metadata") if reports else {}) or {}
+
+    if content_type in {"feed_post", "feed_media"}:
+        post_id = str(meta.get("post_id") or content_id)
+        post = ddb.Table(APP_TABLE).get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item") or {}
+        out = {
+            "kind": content_type,
+            "exists": bool(post),
+            "post_id": post_id,
+            "author_user_id": str(post.get("user_sub") or "") or None,
+            "text": str(post.get("text") or ""),
+            "image_urls": post.get("image_urls") or [],
+            "created_at": _parse_int(post.get("created_at"), 0),
+        }
+        if content_type == "feed_media":
+            out["media_index"] = _parse_int(meta.get("media_index"), -1)
+        return out
+
+    if content_type == "feed_comment":
+        post_id = str(meta.get("post_id") or "")
+        if not post_id:
+            return {"kind": content_type, "exists": False}
+        resp = ddb.Table(APP_TABLE).query(
+            KeyConditionExpression=Key("pk").eq(f"POST#{post_id}#COMMENTS"),
+            FilterExpression=Attr("comment_id").eq(content_id),
+            Limit=1,
+        )
+        row = (resp.get("Items") or [None])[0] or {}
+        return {
+            "kind": content_type,
+            "exists": bool(row),
+            "post_id": post_id,
+            "comment_id": content_id,
+            "author_user_id": str(row.get("user_sub") or "") or None,
+            "text": str(row.get("body") or row.get("text") or ""),
+            "created_at": _parse_int(row.get("created_at"), 0),
+        }
+
+    if content_type in {"message", "message_media"}:
+        conversation_id = str(meta.get("conversation_id") or "")
+        if not conversation_id:
+            return {"kind": content_type, "exists": False}
+        msg = ddb.Table(MESSAGES_TABLE).get_item(Key={"conversation_id": conversation_id, "message_id": content_id}).get("Item") or {}
+        return {
+            "kind": content_type,
+            "exists": bool(msg),
+            "conversation_id": conversation_id,
+            "message_id": content_id,
+            "author_user_id": str(msg.get("sender_user_id") or msg.get("user_id") or "") or None,
+            "text": str(msg.get("text") or msg.get("body") or ""),
+            "attachments": msg.get("attachments") or [],
+            "created_at": _parse_int(msg.get("created_at"), 0),
+        }
+
+    if content_type == "profile_photo":
+        profile = T.profile.get_item(Key={"user_sub": content_id}).get("Item") or {}
+        return {
+            "kind": content_type,
+            "exists": bool((profile.get("profile") or {}).get("profile_photo_url")),
+            "user_id": content_id,
+            "author_user_id": content_id,
+            "profile_photo_url": str((profile.get("profile") or {}).get("profile_photo_url") or "") or None,
+        }
+
+    return {"kind": content_type, "exists": False}
+
+
+def _infer_offender_user_id(ticket: dict[str, Any], content_snapshot: dict[str, Any]) -> str | None:
+    offender = str(content_snapshot.get("author_user_id") or "").strip()
+    if offender:
+        return offender
+    if str(ticket.get("content_type") or "") == "profile_photo":
+        content_id = str(ticket.get("content_id") or "").strip()
+        return content_id or None
+    return None
+
+
+
+
+def _query_enforcement_history(user_id: str, *, limit: int = 25) -> list[dict[str, Any]]:
+    resp = T.user_enforcement_history.query(
+        KeyConditionExpression=Key("user_id").eq(user_id),
+        ScanIndexForward=False,
+        Limit=max(1, min(limit, 100)),
+    )
+    rows = resp.get("Items", [])
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if row.get("entity_type") != "user_enforcement":
+            continue
+        out.append(
+            {
+                "user_id": str(row.get("user_id") or user_id),
+                "enforcement_id": str(row.get("enforcement_id") or ""),
+                "enforcement_type": str(row.get("enforcement_type") or ""),
+                "status": str(row.get("status") or ""),
+                "source_ticket_id": str(row.get("source_ticket_id") or ""),
+                "created_at": _parse_int(row.get("created_at"), 0),
+                "created_by_admin_user_id": str(row.get("created_by_admin_user_id") or "") or None,
+                "duration_days": _parse_int(row.get("duration_days"), 0),
+                "note": str(row.get("note") or ""),
+            }
+        )
+    out.sort(key=lambda i: (int(i.get("created_at") or 0), str(i.get("enforcement_id") or "")), reverse=True)
+    return out[:limit]
+
+
+def _prior_enforcement_history(offender_user_id: str | None) -> list[dict[str, Any]]:
+    if not offender_user_id:
+        return []
+    return _query_enforcement_history(offender_user_id, limit=25)
+
+def _offender_history_summary(offender_user_id: str | None, reports: list[dict[str, Any]]) -> OffenderHistorySummaryOut:
+    if not offender_user_id:
+        return OffenderHistorySummaryOut(offender_user_id=None, total_tickets=0, open_tickets=0, total_reports=len(reports))
+
+    # Best-effort summary from moderation tickets table (future: dedicated offender index).
+    scanned = T.moderation_tickets.scan(FilterExpression=Attr("offender_user_id").eq(offender_user_id)).get("Items", [])
+    ticket_rows = [r for r in scanned if r.get("entity_type") == "moderation_ticket"]
+    open_tickets = sum(1 for r in ticket_rows if str(r.get("status") or "") == "open")
+
+    return OffenderHistorySummaryOut(
+        offender_user_id=offender_user_id,
+        total_tickets=len(ticket_rows),
+        open_tickets=open_tickets,
+        total_reports=len(reports),
+    )
+
+
+
+
+
+
+def _ddb_av_map(payload: dict[str, Any]) -> dict[str, Any]:
+    return {k: SERIALIZER.serialize(v) for k, v in payload.items()}
+
+
+def _validate_resolve_combination(inp: ResolveModerationTicketIn) -> None:
+    if inp.resolution == "no_violation" and inp.enforcement_action != "none":
+        raise HTTPException(status_code=400, detail="invalid resolution/enforcement combination")
+    if inp.enforcement_action != "ban" and inp.enforcement_duration_days is not None:
+        raise HTTPException(status_code=400, detail="enforcement_duration_days is only valid for ban action")
+
+
+def _resolve_action_type(resolution: str) -> str:
+    if resolution == "content_removed":
+        return "content_removed"
+    return "no_violation"
+
+def _persist_moderation_action(*, ticket_id: str, decision: str, note: str, admin_user_id: str, offender_user_id: str | None, now_ts: str) -> None:
+    action_id = f"modact_{uuid.uuid4().hex[:20]}"
+    T.moderation_actions.put_item(
+        Item={
+            "action_id": action_id,
+            "entity_type": "moderation_action",
+            "ticket_id": ticket_id,
+            "action_type": decision,
+            "created_at": now_ts,
+            "admin_user_id": admin_user_id,
+            "target_user_id": str(offender_user_id or ""),
+            "note": note,
+            "source_ticket_id": ticket_id,
+        }
+    )
+
+
+def _persist_enforcement_if_needed(*, decision: str, ticket_id: str, offender_user_id: str | None, admin_user_id: str, note: str, now_ts: str) -> None:
+    if decision not in {"warn", "ban"}:
+        return
+    user_id = str(offender_user_id or "").strip()
+    if not user_id:
+        return
+
+    enforcement_id = f"enf_{uuid.uuid4().hex[:20]}"
+    T.user_enforcement_history.put_item(
+        Item={
+            "user_id": user_id,
+            "enforcement_id": enforcement_id,
+            "entity_type": "user_enforcement",
+            "status": "active" if decision == "ban" else "recorded",
+            "enforcement_type": decision,
+            "source_ticket_id": ticket_id,
+            "created_at": now_ts,
+            "created_by_admin_user_id": admin_user_id,
+            "note": note,
+        }
+    )
+
+
+
+@router.get("/kpis", response_model=ModerationKpisOut)
+def get_moderation_kpis(_admin: AuthenticatedUser = Depends(require_content_moderation_admin)) -> ModerationKpisOut:
+    ensure_admin_board_enabled(_admin)
+    return ModerationKpisOut(**compute_moderation_kpis())
+
+
+@router.post("/kpis/evaluate-alerts", response_model=ModerationKpiAlertsOut)
+def evaluate_moderation_kpi_alerts(admin: AuthenticatedUser = Depends(require_content_moderation_admin)) -> ModerationKpiAlertsOut:
+    ensure_admin_actions_enabled(admin)
+    result = evaluate_and_dispatch_moderation_alerts(actor_user_id=admin.sub)
+    return ModerationKpiAlertsOut(ok=True, **result)
+
+
+
+@router.get("/feature-flags", response_model=ModerationFeatureFlagsOut)
+def get_moderation_feature_flags_endpoint(_admin: AuthenticatedUser = Depends(require_content_moderation_admin)) -> ModerationFeatureFlagsOut:
+    ensure_admin_board_enabled(_admin)
+    return ModerationFeatureFlagsOut(**get_moderation_feature_flags())
+
+
+@router.put("/feature-flags", response_model=ModerationFeatureFlagsOut)
+def update_moderation_feature_flags(
+    body: ModerationFeatureFlagsUpdateIn,
+    admin: AuthenticatedUser = Depends(require_content_moderation_admin),
+) -> ModerationFeatureFlagsOut:
+    if admin.role.name != "ROOT":
+        raise HTTPException(status_code=403, detail="only root can update moderation feature flags")
+    updated = set_moderation_feature_flags(body.model_dump(exclude_none=True))
+    return ModerationFeatureFlagsOut(**updated)
+
+@router.get("/users/{user_id}/history", response_model=UserEnforcementHistoryListOut)
+def get_user_enforcement_history(
+    user_id: str,
+    limit: int = Query(default=25, ge=1, le=100),
+    _admin: AuthenticatedUser = Depends(require_content_moderation_admin),
+) -> UserEnforcementHistoryListOut:
+    ensure_admin_board_enabled(_admin)
+    items = _query_enforcement_history(user_id, limit=limit)
+    return UserEnforcementHistoryListOut(items=[UserEnforcementHistoryOut(**row) for row in items])
+
+
+@router.get("/tickets", response_model=ModerationTicketsListOut)
+def list_moderation_tickets(
+    status: str | None = Query(default=None),
+    queue: str | None = Query(default=None),
+    topic: Literal["sexual", "extortion", "criminal", "spam", "racist"] | None = Query(default=None),
+    assignee: str | None = Query(default=None),
+    limit: int = Query(default=25, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    _admin: AuthenticatedUser = Depends(require_content_moderation_admin),
+) -> ModerationTicketsListOut:
+    ensure_admin_board_enabled(_admin)
+    index_name, partition_key, partition_value = _query_config(status=status, queue=queue, assignee=assignee)
+    exclusive_start_key = _decode_cursor(cursor)
+
+    collected: list[Dict[str, Any]] = []
+    last_evaluated_key: Dict[str, Any] | None = None
+    fetch_limit = min(100, max(limit, 25))
+    scans = 0
+
+    while len(collected) < limit and scans < 8:
+        scans += 1
+        query_kwargs: Dict[str, Any] = {
+            "IndexName": index_name,
+            "KeyConditionExpression": Key(partition_key).eq(partition_value),
+            "ScanIndexForward": False,
+            "Limit": fetch_limit,
+        }
+        if exclusive_start_key:
+            query_kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+        if topic and index_name != "ByLatestReportAt":
+            query_kwargs["FilterExpression"] = Attr("aggregated_topics").contains(topic)
+
+        resp = T.moderation_tickets.query(**query_kwargs)
+        items = [i for i in resp.get("Items", []) if i.get("entity_type") == "moderation_ticket"]
+
+        if topic and index_name == "ByLatestReportAt":
+            items = [i for i in items if topic in set(i.get("aggregated_topics") or [])]
+
+        if status and index_name != "ByStatusLatestReportAt":
+            items = [i for i in items if str(i.get("status") or "") == status]
+        if queue and index_name != "ByQueueLatestReportAt":
+            items = [i for i in items if str(i.get("queue") or "") == queue]
+        if assignee and index_name != "ByAssignedAdminLatestReportAt":
+            items = [i for i in items if str(i.get("assigned_admin_user_id") or "") == assignee]
+
+        collected.extend(items)
+
+        last_evaluated_key = resp.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+        exclusive_start_key = last_evaluated_key
+
+    collected.sort(
+        key=lambda item: (
+            _parse_int(item.get("latest_report_at"), default=0),
+            str(item.get("ticket_id") or ""),
+        ),
+        reverse=True,
+    )
+    page = collected[:limit]
+    next_cursor = _encode_cursor(last_evaluated_key) if last_evaluated_key else None
+
+    return ModerationTicketsListOut(items=[_to_ticket_out(i) for i in page], next_cursor=next_cursor)
+
+
+@router.get("/tickets/{ticket_id}", response_model=ModerationTicketDetailOut)
+def get_moderation_ticket_detail(
+    ticket_id: str,
+    _admin: AuthenticatedUser = Depends(require_content_moderation_admin),
+) -> ModerationTicketDetailOut:
+    ensure_admin_board_enabled(_admin)
+    ticket_item = _get_ticket_or_404(ticket_id)
+    reports = _linked_reports(ticket_id)
+    snapshot = _content_snapshot(ticket_item, reports)
+    offender_user_id = _infer_offender_user_id(ticket_item, snapshot)
+
+    return ModerationTicketDetailOut(
+        ticket=_to_ticket_out(ticket_item),
+        content_snapshot=snapshot,
+        linked_reports=[
+            LinkedReportOut(
+                report_id=str(r.get("report_id") or ""),
+                reporter_user_id=str(r.get("reporter_user_id") or ""),
+                topics=_to_topic_list(r.get("topics")),
+                reason_text=str(r.get("reason_text") or ""),
+                created_at=_parse_int(r.get("created_at"), 0),
+                metadata=(r.get("metadata") if isinstance(r.get("metadata"), dict) else {}),
+            )
+            for r in reports
+        ],
+        offender_history_summary=_offender_history_summary(offender_user_id, reports),
+        prior_enforcement_history=_prior_enforcement_history(offender_user_id),
+    )
+
+
+@router.post("/tickets/{ticket_id}/claim", response_model=ModerationTicketOut)
+def claim_moderation_ticket(
+    ticket_id: str,
+    admin: AuthenticatedUser = Depends(require_content_moderation_admin),
+) -> ModerationTicketOut:
+    ensure_admin_actions_enabled(admin)
+    ticket_item = _get_ticket_or_404(ticket_id)
+    if str(ticket_item.get("status") or "") != "open":
+        raise HTTPException(status_code=409, detail="ticket is not open")
+
+    T.moderation_tickets.update_item(
+        Key={"ticket_id": ticket_id},
+        ConditionExpression="#status = :open",
+        UpdateExpression="SET #assigned_admin_user_id = :admin_sub, #updated_at = :updated_at",
+        ExpressionAttributeNames={
+            "#status": "status",
+            "#assigned_admin_user_id": "assigned_admin_user_id",
+            "#updated_at": "updated_at",
+        },
+        ExpressionAttributeValues={
+            ":open": "open",
+            ":admin_sub": admin.sub,
+            ":updated_at": str(int(time.time())),
+        },
+    )
+
+    write_moderation_audit_event(
+        action="ticket_assigned",
+        actor_user_id=admin.sub,
+        ticket_id=ticket_id,
+        content_type=str(ticket_item.get("content_type") or ""),
+        content_id=str(ticket_item.get("content_id") or ""),
+        metadata={"assigned_admin_user_id": admin.sub},
+    )
+
+    updated = _get_ticket_or_404(ticket_id)
+    return _to_ticket_out(updated)
+
+
+@router.post("/tickets/{ticket_id}/decision", response_model=ModerationTicketOut)
+def decide_moderation_ticket(
+    ticket_id: str,
+    inp: ModerationDecisionIn,
+    admin: AuthenticatedUser = Depends(require_content_moderation_admin),
+) -> ModerationTicketOut:
+    ensure_admin_actions_enabled(admin)
+    ticket_item = _get_ticket_or_404(ticket_id)
+    reports = _linked_reports(ticket_id)
+    snapshot = _content_snapshot(ticket_item, reports)
+    offender_user_id = _infer_offender_user_id(ticket_item, snapshot)
+
+    now = str(int(time.time()))
+    note = str(inp.note or "").strip()
+    policy_category = _policy_category_for_notification(ticket_item, reports)
+
+    if inp.decision == "ban":
+        _require_senior_moderation_for_permanent_ban(admin=admin)
+        ensure_permanent_ban_scope_rollout(admin)
+        _require_dual_approval_for_permanent_ban(
+            admin=admin,
+            second_approver_admin_user_id=inp.second_approver_admin_user_id,
+        )
+
+    _persist_moderation_action(
+        ticket_id=ticket_id,
+        decision=inp.decision,
+        note=note,
+        admin_user_id=admin.sub,
+        offender_user_id=offender_user_id,
+        now_ts=now,
+    )
+    _persist_enforcement_if_needed(
+        decision=inp.decision,
+        ticket_id=ticket_id,
+        offender_user_id=offender_user_id,
+        admin_user_id=admin.sub,
+        note=note,
+        now_ts=now,
+    )
+
+    T.moderation_tickets.update_item(
+        Key={"ticket_id": ticket_id},
+        UpdateExpression=(
+            "SET #status = :status, #updated_at = :updated_at, #moderation_decision = :decision, "
+            "#moderation_note = :note, #decision_at = :decision_at, #decision_by_admin_user_id = :decision_by, "
+            "#offender_user_id = :offender_user_id"
+        ),
+        ExpressionAttributeNames={
+            "#status": "status",
+            "#updated_at": "updated_at",
+            "#moderation_decision": "moderation_decision",
+            "#moderation_note": "moderation_note",
+            "#decision_at": "decision_at",
+            "#decision_by_admin_user_id": "decision_by_admin_user_id",
+            "#offender_user_id": "offender_user_id",
+        },
+        ExpressionAttributeValues={
+            ":status": "closed",
+            ":updated_at": now,
+            ":decision": inp.decision,
+            ":note": note,
+            ":decision_at": now,
+            ":decision_by": admin.sub,
+            ":offender_user_id": str(offender_user_id or ""),
+        },
+    )
+
+    write_moderation_audit_event(
+        action="ticket_decision_recorded",
+        actor_user_id=admin.sub,
+        ticket_id=ticket_id,
+        content_type=str(ticket_item.get("content_type") or ""),
+        content_id=str(ticket_item.get("content_id") or ""),
+        target_user_id=str(offender_user_id or ""),
+        metadata={"decision": inp.decision, "note": note, "second_approver_admin_user_id": inp.second_approver_admin_user_id},
+    )
+
+    updated = _get_ticket_or_404(ticket_id)
+    return _to_ticket_out(updated)
+
+
+@router.post("/tickets/{ticket_id}/resolve", response_model=ModerationTicketOut)
+def resolve_moderation_ticket(
+    ticket_id: str,
+    inp: ResolveModerationTicketIn,
+    admin: AuthenticatedUser = Depends(require_content_moderation_admin),
+) -> ModerationTicketOut:
+    ensure_admin_actions_enabled(admin)
+    _validate_resolve_combination(inp)
+
+    ticket_item = _get_ticket_or_404(ticket_id)
+    reports = _linked_reports(ticket_id)
+    snapshot = _content_snapshot(ticket_item, reports)
+    offender_user_id = _infer_offender_user_id(ticket_item, snapshot)
+
+    now = str(int(time.time()))
+    note = str(inp.note or "").strip()
+    policy_category = _policy_category_for_notification(ticket_item, reports)
+
+    if inp.enforcement_action in {"warn", "ban"} and not str(offender_user_id or "").strip():
+        raise HTTPException(status_code=422, detail="offender_user_id required for enforcement action")
+
+    if inp.enforcement_action == "ban" and int(inp.enforcement_duration_days or 0) <= 0:
+        _require_senior_moderation_for_permanent_ban(admin=admin)
+        ensure_permanent_ban_scope_rollout(admin)
+        _require_dual_approval_for_permanent_ban(
+            admin=admin,
+            second_approver_admin_user_id=inp.second_approver_admin_user_id,
+        )
+
+    action_id = f"modact_{uuid.uuid4().hex[:20]}"
+    transact_items: list[dict[str, Any]] = [
+        {
+            "Update": {
+                "TableName": T.moderation_tickets.name,
+                "Key": _ddb_av_map({"ticket_id": ticket_id}),
+                "ConditionExpression": "#status = :open",
+                "UpdateExpression": (
+                    "SET #status = :closed, #updated_at = :updated_at, #resolved_at = :resolved_at, "
+                    "#resolved_by_admin_user_id = :resolved_by, #resolution = :resolution, "
+                    "#enforcement_action = :enforcement_action, #moderation_note = :note, "
+                    "#offender_user_id = :offender_user_id"
+                ),
+                "ExpressionAttributeNames": {
+                    "#status": "status",
+                    "#updated_at": "updated_at",
+                    "#resolved_at": "resolved_at",
+                    "#resolved_by_admin_user_id": "resolved_by_admin_user_id",
+                    "#resolution": "resolution",
+                    "#enforcement_action": "enforcement_action",
+                    "#moderation_note": "moderation_note",
+                    "#offender_user_id": "offender_user_id",
+                },
+                "ExpressionAttributeValues": _ddb_av_map({
+                    ":open": "open",
+                    ":closed": "closed",
+                    ":updated_at": now,
+                    ":resolved_at": now,
+                    ":resolved_by": admin.sub,
+                    ":resolution": inp.resolution,
+                    ":enforcement_action": inp.enforcement_action,
+                    ":note": note,
+                    ":offender_user_id": str(offender_user_id or ""),
+                }),
+            }
+        },
+        {
+            "Put": {
+                "TableName": T.moderation_actions.name,
+                "Item": _ddb_av_map({
+                    "action_id": action_id,
+                    "entity_type": "moderation_action",
+                    "ticket_id": ticket_id,
+                    "action_type": _resolve_action_type(inp.resolution),
+                    "created_at": now,
+                    "admin_user_id": admin.sub,
+                    "target_user_id": str(offender_user_id or ""),
+                    "note": note,
+                    "source_ticket_id": ticket_id,
+                }),
+            }
+        },
+    ]
+
+    if inp.enforcement_action in {"warn", "ban"}:
+        enforce_action_id = f"modact_{uuid.uuid4().hex[:20]}"
+        transact_items.append(
+            {
+                "Put": {
+                    "TableName": T.moderation_actions.name,
+                    "Item": _ddb_av_map({
+                        "action_id": enforce_action_id,
+                        "entity_type": "moderation_action",
+                        "ticket_id": ticket_id,
+                        "action_type": inp.enforcement_action,
+                        "created_at": now,
+                        "admin_user_id": admin.sub,
+                        "target_user_id": str(offender_user_id or ""),
+                        "note": note,
+                        "source_ticket_id": ticket_id,
+                    }),
+                }
+            }
+        )
+
+        enforcement_id = f"enf_{uuid.uuid4().hex[:20]}"
+        transact_items.append(
+            {
+                "Put": {
+                    "TableName": T.user_enforcement_history.name,
+                    "Item": _ddb_av_map({
+                        "user_id": str(offender_user_id or ""),
+                        "enforcement_id": enforcement_id,
+                        "entity_type": "user_enforcement",
+                        "status": "active" if inp.enforcement_action == "ban" else "recorded",
+                        "enforcement_type": inp.enforcement_action,
+                        "source_ticket_id": ticket_id,
+                        "created_at": now,
+                        "created_by_admin_user_id": admin.sub,
+                        "note": note,
+                        "duration_days": int(inp.enforcement_duration_days or 0),
+                    }),
+                }
+            }
+        )
+
+    try:
+        ddb.meta.client.transact_write_items(TransactItems=transact_items)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        if code in {"TransactionCanceledException", "ConditionalCheckFailedException"}:
+            raise HTTPException(status_code=409, detail="invalid ticket state transition") from exc
+        raise
+
+    if inp.resolution == "content_removed":
+        try:
+            apply_content_removal(ticket=ticket_item, reports=reports, ticket_id=ticket_id, admin_user_id=admin.sub)
+            T.moderation_tickets.update_item(
+                Key={"ticket_id": ticket_id},
+                UpdateExpression="SET content_removal_state = :done, content_removed_at = :ts",
+                ExpressionAttributeValues={":done": "completed", ":ts": now},
+            )
+        except Exception as exc:
+            T.moderation_tickets.update_item(
+                Key={"ticket_id": ticket_id},
+                UpdateExpression="SET content_removal_state = :retry, content_removal_error = :err, updated_at = :updated_at",
+                ExpressionAttributeValues={
+                    ":retry": "retry_required",
+                    ":err": str(exc)[:500],
+                    ":updated_at": str(int(time.time())),
+                },
+            )
+            raise HTTPException(status_code=503, detail="content removal adapter failed; retry required") from exc
+
+        try:
+            notify_content_removal(
+                offender_user_id=str(offender_user_id or ""),
+                ticket_id=ticket_id,
+                content_type=str(ticket_item.get("content_type") or ""),
+                policy_category=policy_category,
+                note=note,
+            )
+        except Exception:
+            # Best effort: notification failures must not rollback moderation resolution.
+            pass
+
+    write_moderation_audit_event(
+        action="ticket_resolved",
+        actor_user_id=admin.sub,
+        ticket_id=ticket_id,
+        content_type=str(ticket_item.get("content_type") or ""),
+        content_id=str(ticket_item.get("content_id") or ""),
+        target_user_id=str(offender_user_id or ""),
+        metadata={
+            "resolution": inp.resolution,
+            "enforcement_action": inp.enforcement_action,
+            "enforcement_duration_days": int(inp.enforcement_duration_days or 0),
+            "second_approver_admin_user_id": inp.second_approver_admin_user_id,
+            "note": note,
+        },
+    )
+
+    if inp.enforcement_action == "warn":
+        issue_warning_notification(
+            offender_user_id=str(offender_user_id or ""),
+            ticket_id=ticket_id,
+            note=note,
+            policy_category=policy_category,
+        )
+        write_moderation_audit_event(
+            action="enforcement_warned",
+            actor_user_id=admin.sub,
+            ticket_id=ticket_id,
+            target_user_id=str(offender_user_id or ""),
+            metadata={"note": note},
+        )
+    elif inp.enforcement_action == "ban":
+        apply_ban(
+            offender_user_id=str(offender_user_id or ""),
+            ticket_id=ticket_id,
+            admin_user_id=admin.sub,
+            note=note,
+            duration_days=inp.enforcement_duration_days,
+            policy_category=policy_category,
+        )
+        write_moderation_audit_event(
+            action="enforcement_banned",
+            actor_user_id=admin.sub,
+            ticket_id=ticket_id,
+            target_user_id=str(offender_user_id or ""),
+            metadata={"duration_days": int(inp.enforcement_duration_days or 0), "second_approver_admin_user_id": inp.second_approver_admin_user_id, "note": note},
+        )
+
+    updated = _get_ticket_or_404(ticket_id)
+    return _to_ticket_out(updated)

--- a/app/routers/messaging.py
+++ b/app/routers/messaging.py
@@ -1964,6 +1964,8 @@ def _filter_message_visible(message_item: dict, user_id: str) -> bool:
     deleted_for = set(message_item.get("deleted_for", []))
     if message_item.get("revoked_at"):
         return False
+    if message_item.get("moderation_hidden") or message_item.get("moderation_removed_at"):
+        return False
     # Scheduled messages are only visible to the sender until delivered
     if message_item.get("status") == "scheduled" and message_item.get("sender_id") != user_id:
         return False

--- a/app/routers/moderation.py
+++ b/app/routers/moderation.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import time
+from typing import Any, Dict, List, Literal, Optional
+
+from boto3.dynamodb.conditions import Attr, Key
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field, field_validator
+
+from app.core.aws import ddb
+from app.core.tables import T
+from app.core.normalize import client_ip_from_request
+from app.services.alerts import audit_event, write_alert
+from app.services.content_reports_store import create_content_report
+from app.services.moderation_audit_log import write_moderation_audit_event
+from app.services.moderation_tickets_store import upsert_open_ticket_for_report
+from app.services.moderation_flags import ensure_reporting_surface_enabled
+from app.services.sessions import require_ui_session
+
+APP_TABLE = os.environ.get("APP_TABLE", "app_single_table")
+MESSAGES_TABLE = os.environ.get("DDB_MESSAGES", "Messages")
+IDEMPOTENCY_WINDOW_SECONDS = 45
+RATE_LIMIT_USER_WINDOW_SECONDS = int(os.environ.get("MODERATION_REPORT_RATE_LIMIT_USER_WINDOW_SECONDS", "60"))
+RATE_LIMIT_USER_MAX = int(os.environ.get("MODERATION_REPORT_RATE_LIMIT_USER_MAX", "8"))
+RATE_LIMIT_IP_WINDOW_SECONDS = int(os.environ.get("MODERATION_REPORT_RATE_LIMIT_IP_WINDOW_SECONDS", "60"))
+RATE_LIMIT_IP_MAX = int(os.environ.get("MODERATION_REPORT_RATE_LIMIT_IP_MAX", "20"))
+ALLOWED_TOPICS = {"sexual", "extortion", "criminal", "spam", "racist"}
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/moderation", tags=["moderation"])
+
+
+class CreateModerationReportIn(BaseModel):
+    content_type: Literal["feed_post", "feed_comment", "feed_media", "message", "message_media", "profile_photo"]
+    content_id: str = Field(min_length=1, max_length=256)
+    topics: List[str] = Field(min_length=1, max_length=5)
+    reason_text: str = Field(min_length=5, max_length=2000)
+    post_id: Optional[str] = Field(default=None, max_length=256)
+    conversation_id: Optional[str] = Field(default=None, max_length=256)
+    media_index: Optional[int] = Field(default=None, ge=0)
+
+    @field_validator("topics")
+    @classmethod
+    def _validate_topics(cls, value: List[str]) -> List[str]:
+        normalized = [v.strip().lower() for v in value if v and v.strip()]
+        if not normalized:
+            raise ValueError("at least one topic is required")
+        for topic in normalized:
+            if topic not in ALLOWED_TOPICS:
+                raise ValueError(f"invalid topic: {topic}")
+        return list(dict.fromkeys(normalized))
+
+
+class CreateModerationReportOut(BaseModel):
+    ok: bool
+    report_id: str
+    ticket_id: str
+    status: Literal["submitted", "deduplicated"]
+    created_at: int
+
+
+# Backward-compatible alias for existing frontend calls.
+compat_router = APIRouter(prefix="/moderation", tags=["moderation"])
+
+
+def _linked_ticket_id(content_type: str, content_id: str) -> str:
+    digest = hashlib.sha256(f"{content_type}:{content_id}".encode("utf-8")).hexdigest()[:20]
+    return f"modtk_{digest}"
+
+
+def _feed_post_exists(post_id: str) -> bool:
+    table = ddb.Table(APP_TABLE)
+    item = table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
+    return bool(item)
+
+
+def _feed_comment_exists(post_id: str, comment_id: str) -> bool:
+    table = ddb.Table(APP_TABLE)
+    resp = table.query(
+        KeyConditionExpression=Key("pk").eq(f"POST#{post_id}#COMMENTS"),
+        FilterExpression=Attr("comment_id").eq(comment_id),
+        Limit=1,
+    )
+    return bool(resp.get("Items"))
+
+
+def _feed_media_exists(post_id: str, media_index: Optional[int]) -> bool:
+    table = ddb.Table(APP_TABLE)
+    post = table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
+    if not post:
+        return False
+    images = post.get("image_urls") or []
+    if not isinstance(images, list) or not images:
+        return False
+    if media_index is None:
+        return True
+    return 0 <= int(media_index) < len(images)
+
+
+def _message_exists(conversation_id: str, message_id: str) -> bool:
+    table = ddb.Table(MESSAGES_TABLE)
+    item = table.get_item(Key={"conversation_id": conversation_id, "message_id": message_id}).get("Item")
+    return bool(item)
+
+
+def _profile_photo_exists(user_id: str) -> bool:
+    item = T.profile.get_item(Key={"user_id": user_id}).get("Item") or {}
+    return bool(item.get("profile_photo_url"))
+
+
+def _validate_content_exists(inp: CreateModerationReportIn) -> None:
+    if inp.content_type == "feed_post":
+        if not _feed_post_exists(inp.content_id):
+            raise HTTPException(status_code=404, detail="content not found")
+        return
+
+    if inp.content_type == "feed_comment":
+        if not inp.post_id:
+            raise HTTPException(status_code=400, detail="post_id is required for feed_comment")
+        if not _feed_comment_exists(inp.post_id, inp.content_id):
+            raise HTTPException(status_code=404, detail="content not found")
+        return
+
+    if inp.content_type == "feed_media":
+        if not inp.post_id:
+            raise HTTPException(status_code=400, detail="post_id is required for feed_media")
+        if not _feed_media_exists(inp.post_id, inp.media_index):
+            raise HTTPException(status_code=404, detail="content not found")
+        return
+
+    if inp.content_type in {"message", "message_media"}:
+        if not inp.conversation_id:
+            raise HTTPException(status_code=400, detail="conversation_id is required for message content")
+        if not _message_exists(inp.conversation_id, inp.content_id):
+            raise HTTPException(status_code=404, detail="content not found")
+        return
+
+    if inp.content_type == "profile_photo":
+        if not _profile_photo_exists(inp.content_id):
+            raise HTTPException(status_code=404, detail="content not found")
+
+
+def _hash_ip(ip: str) -> str:
+    return hashlib.sha256(ip.encode("utf-8")).hexdigest()[:24]
+
+
+def _query_report_count(*, index_name: str, partition_key_name: str, partition_key_value: str, since_ts: int, limit: int) -> int:
+    resp = T.content_reports.query(
+        IndexName=index_name,
+        KeyConditionExpression=Key(partition_key_name).eq(partition_key_value) & Key("created_at").gte(str(since_ts)),
+        ScanIndexForward=False,
+        Limit=max(1, limit),
+        Select="COUNT",
+    )
+    return int(resp.get("Count", 0) or 0)
+
+
+def _query_ip_report_count(*, ip_hash: str, since_ts: int, limit: int) -> int:
+    resp = T.content_reports.query(
+        IndexName="ByCreatedAt",
+        KeyConditionExpression=Key("created_scope").eq("ALL") & Key("created_at").gte(str(since_ts)),
+        FilterExpression=Attr("ip_hash").eq(ip_hash),
+        ScanIndexForward=False,
+        Limit=max(1, limit),
+    )
+    return int(resp.get("Count", 0) or 0)
+
+
+def _enforce_rate_limits(*, reporter_user_id: str, ip_hash: str, now_ts: int, request: Request | None, content_type: str, content_id: str) -> None:
+    user_count = _query_report_count(
+        index_name="ByReporterCreatedAt",
+        partition_key_name="reporter_user_id",
+        partition_key_value=reporter_user_id,
+        since_ts=now_ts - RATE_LIMIT_USER_WINDOW_SECONDS,
+        limit=RATE_LIMIT_USER_MAX,
+    )
+    if user_count >= RATE_LIMIT_USER_MAX:
+        audit_event(
+            "moderation_report_rate_limited",
+            reporter_user_id,
+            request,
+            outcome="rate_limited",
+            scope="user",
+            count=user_count,
+            window_seconds=RATE_LIMIT_USER_WINDOW_SECONDS,
+            content_type=content_type,
+            content_id=content_id,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded for moderation reports",
+            headers={"Retry-After": str(RATE_LIMIT_USER_WINDOW_SECONDS)},
+        )
+
+    ip_count = _query_ip_report_count(
+        ip_hash=ip_hash,
+        since_ts=now_ts - RATE_LIMIT_IP_WINDOW_SECONDS,
+        limit=RATE_LIMIT_IP_MAX,
+    )
+    if ip_count >= RATE_LIMIT_IP_MAX:
+        audit_event(
+            "moderation_report_rate_limited",
+            reporter_user_id,
+            request,
+            outcome="rate_limited",
+            scope="ip",
+            count=ip_count,
+            window_seconds=RATE_LIMIT_IP_WINDOW_SECONDS,
+            content_type=content_type,
+            content_id=content_id,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded for moderation reports",
+            headers={"Retry-After": str(RATE_LIMIT_IP_WINDOW_SECONDS)},
+        )
+
+
+def _run_anti_spam_heuristics(*, reporter_user_id: str, inp: CreateModerationReportIn, request: Request | None) -> None:
+    reason = inp.reason_text.strip().lower()
+    suspicious = []
+    if "http://" in reason or "https://" in reason:
+        suspicious.append("contains_url")
+    if len(set(reason)) <= 3 and len(reason) > 20:
+        suspicious.append("low_entropy_text")
+    if reason.count("!") >= 8:
+        suspicious.append("excessive_punctuation")
+
+    if suspicious:
+        logger.warning(
+            "moderation report anti-spam signal",
+            extra={"reporter_user_id": reporter_user_id, "signals": suspicious, "content_type": inp.content_type, "content_id": inp.content_id},
+        )
+        audit_event(
+            "moderation_report_anti_spam_signal",
+            reporter_user_id,
+            request,
+            outcome="warning",
+            signals=suspicious,
+            content_type=inp.content_type,
+            content_id=inp.content_id,
+        )
+
+
+def _find_recent_duplicate(*, reporter_user_id: str, content_type: str, content_id: str, now_ts: int) -> Dict[str, Any] | None:
+    earliest = str(now_ts - IDEMPOTENCY_WINDOW_SECONDS)
+    resp = T.content_reports.query(
+        IndexName="ByReporterCreatedAt",
+        KeyConditionExpression=Key("reporter_user_id").eq(reporter_user_id) & Key("created_at").gte(earliest),
+        ScanIndexForward=False,
+        Limit=20,
+    )
+    for item in resp.get("Items", []):
+        if item.get("entity_type") != "content_report":
+            continue
+        if item.get("content_type") == content_type and item.get("content_id") == content_id:
+            return item
+    return None
+
+
+def _create_report(inp: CreateModerationReportIn, ctx: Dict[str, str], request: Request | None = None) -> CreateModerationReportOut:
+    reporter_user_id = str(ctx.get("user_sub") or "").strip()
+    if not reporter_user_id:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    ensure_reporting_surface_enabled(inp.content_type)
+    _validate_content_exists(inp)
+    now_ts = int(time.time())
+    ip = client_ip_from_request(request) if request is not None else str(ctx.get("ip") or "")
+    ip_hash = _hash_ip(ip or "unknown")
+
+    _enforce_rate_limits(
+        reporter_user_id=reporter_user_id,
+        ip_hash=ip_hash,
+        now_ts=now_ts,
+        request=request,
+        content_type=inp.content_type,
+        content_id=inp.content_id,
+    )
+    _run_anti_spam_heuristics(reporter_user_id=reporter_user_id, inp=inp, request=request)
+
+    duplicate = _find_recent_duplicate(
+        reporter_user_id=reporter_user_id,
+        content_type=inp.content_type,
+        content_id=inp.content_id,
+        now_ts=now_ts,
+    )
+    if duplicate:
+        ticket_id = str(duplicate.get("ticket_id") or _linked_ticket_id(inp.content_type, inp.content_id))
+        report_id = str(duplicate.get("report_id") or "")
+        write_moderation_audit_event(
+            action="report_deduplicated",
+            actor_user_id=reporter_user_id,
+            ticket_id=ticket_id,
+            report_id=report_id,
+            content_type=inp.content_type,
+            content_id=inp.content_id,
+            metadata={"idempotency_window_seconds": IDEMPOTENCY_WINDOW_SECONDS},
+        )
+        write_alert(
+            reporter_user_id,
+            event="moderation_report_received",
+            outcome="success",
+            title="Report received",
+            details={"report_id": report_id, "ticket_id": ticket_id, "status": "deduplicated"},
+        )
+        return CreateModerationReportOut(
+            ok=True,
+            report_id=report_id,
+            ticket_id=ticket_id,
+            status="deduplicated",
+            created_at=int(str(duplicate.get("created_at") or now_ts)),
+        )
+
+    ticket_result = upsert_open_ticket_for_report(
+        content_type=inp.content_type,
+        content_id=inp.content_id,
+        topics=inp.topics,
+        now_ts=now_ts,
+    )
+    ticket_id = str(ticket_result.get("ticket_id") or _linked_ticket_id(inp.content_type, inp.content_id))
+    try:
+        report_id = create_content_report(
+            reporter_user_id=reporter_user_id,
+            content_type=inp.content_type,
+            content_id=inp.content_id,
+            topics=inp.topics,
+            reason_text=inp.reason_text,
+            linked_ticket_id=ticket_id,
+            metadata={
+                "post_id": inp.post_id,
+                "conversation_id": inp.conversation_id,
+                "media_index": inp.media_index,
+                "ip_hash": ip_hash,
+            },
+        )
+    except ClientError as exc:
+        raise HTTPException(status_code=422, detail="invalid report payload") from exc
+
+    write_moderation_audit_event(
+        action="report_created",
+        actor_user_id=reporter_user_id,
+        ticket_id=ticket_id,
+        report_id=report_id,
+        content_type=inp.content_type,
+        content_id=inp.content_id,
+        metadata={"topics": inp.topics},
+    )
+    write_alert(
+        reporter_user_id,
+        event="moderation_report_received",
+        outcome="success",
+        title="Report received",
+        details={"report_id": report_id, "ticket_id": ticket_id, "status": "submitted"},
+    )
+
+    return CreateModerationReportOut(
+        ok=True,
+        report_id=report_id,
+        ticket_id=ticket_id,
+        status="submitted",
+        created_at=now_ts,
+    )
+
+
+@router.post("/reports", response_model=CreateModerationReportOut)
+def create_moderation_report(inp: CreateModerationReportIn, request: Request, ctx=Depends(require_ui_session)):
+    return _create_report(inp, ctx, request=request)
+
+
+@compat_router.post("/reports", response_model=CreateModerationReportOut)
+def create_moderation_report_compat(inp: CreateModerationReportIn, request: Request, ctx=Depends(require_ui_session)):
+    return _create_report(inp, ctx, request=request)

--- a/app/routers/newsfeed.py
+++ b/app/routers/newsfeed.py
@@ -1690,6 +1690,8 @@ def view_feed(
         post = post_by_id.get(post_id)
         if not post:
             continue
+        if post.get("moderation_removed") or post.get("moderation_removed_at"):
+            continue
 
         if is_hidden(user_id, post_id):
             continue
@@ -1907,7 +1909,11 @@ def list_comments(
         Limit=limit,
         ExclusiveStartKey=eks if eks else None,
     )
-    items = [_comment_to_dict(it) for it in resp.get("Items", [])]
+    items = [
+        _comment_to_dict(it)
+        for it in resp.get("Items", [])
+        if not it.get("moderation_removed") and not it.get("deleted")
+    ]
     return {"items": items, "next_cursor": encode_cursor(resp.get("LastEvaluatedKey"))}
 
 

--- a/app/services/content_reports_store.py
+++ b/app/services/content_reports_store.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Iterable
+
+from app.core.aws import ddb
+from app.core.settings import S
+
+
+def create_content_report(
+    *,
+    reporter_user_id: str,
+    content_type: str,
+    content_id: str,
+    topics: Iterable[str],
+    reason_text: str,
+    linked_ticket_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> str:
+    """Persist a moderation content report with DB-level topic checks via transaction condition checks."""
+    report_id = str(uuid.uuid4())
+    created_at = str(int(time.time()))
+    topics_list = [t.strip().lower() for t in topics if t and t.strip()]
+
+    extra_metadata = {k: v for k, v in (metadata or {}).items() if v is not None}
+
+    transact_items = [
+        {
+            "Put": {
+                "TableName": S.content_reports_table_name,
+                "Item": {
+                    "report_id": {"S": report_id},
+                    "entity_type": {"S": "content_report"},
+                    "reporter_user_id": {"S": reporter_user_id},
+                    "content_type": {"S": content_type},
+                    "content_id": {"S": content_id},
+                    "content_ref": {"S": f"{content_type}#{content_id}"},
+                    "created_scope": {"S": "ALL"},
+                    "created_at": {"S": created_at},
+                    "reason_text": {"S": reason_text},
+                    "topics": {"SS": topics_list},
+                    **({"ticket_id": {"S": linked_ticket_id}} if linked_ticket_id else {}),
+                    **({k: {"S": str(v)} for k, v in extra_metadata.items()}),
+                },
+                "ConditionExpression": "attribute_not_exists(report_id)",
+            }
+        }
+    ]
+
+    for topic in topics_list:
+        transact_items.append(
+            {
+                "ConditionCheck": {
+                    "TableName": S.content_reports_table_name,
+                    "Key": {"report_id": {"S": f"TOPIC#{topic}"}},
+                    "ConditionExpression": "attribute_exists(report_id)",
+                }
+            }
+        )
+
+    ddb.meta.client.transact_write_items(TransactItems=transact_items)
+    return report_id

--- a/app/services/moderation_audit_log.py
+++ b/app/services/moderation_audit_log.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from app.core.tables import T
+
+
+def write_moderation_audit_event(
+    *,
+    action: str,
+    actor_user_id: str,
+    ticket_id: str = "",
+    report_id: str = "",
+    content_type: str = "",
+    content_id: str = "",
+    target_user_id: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> str:
+    now = str(int(time.time()))
+    audit_id = f"modaudit_{uuid.uuid4().hex[:24]}"
+    T.moderation_audit_log.put_item(
+        Item={
+            "audit_id": audit_id,
+            "entity_type": "moderation_audit_event",
+            "action": action,
+            "actor_user_id": actor_user_id,
+            "ticket_id": ticket_id,
+            "report_id": report_id,
+            "content_type": content_type,
+            "content_id": content_id,
+            "target_user_id": target_user_id,
+            "created_at": now,
+            "metadata": metadata or {},
+        }
+    )
+    return audit_id

--- a/app/services/moderation_content_removal.py
+++ b/app/services/moderation_content_removal.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from boto3.dynamodb.conditions import Attr, Key
+from fastapi import HTTPException
+
+from app.core.aws import ddb
+from app.core.tables import T
+
+APP_TABLE = os.environ.get("APP_TABLE", "app_single_table")
+MESSAGES_TABLE = os.environ.get("DDB_MESSAGES", "Messages")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _latest_metadata(reports: list[dict[str, Any]]) -> dict[str, Any]:
+    if not reports:
+        return {}
+    md = reports[0].get("metadata")
+    return md if isinstance(md, dict) else {}
+
+
+def _mark_feed_post_removed(*, post_id: str, ticket_id: str, admin_user_id: str) -> None:
+    if not post_id:
+        return
+    ddb.Table(APP_TABLE).update_item(
+        Key={"pk": f"POST#{post_id}", "sk": "META"},
+        UpdateExpression=(
+            "SET moderation_removed = :t, moderation_removed_at = :ts, "
+            "moderation_removed_by_admin_user_id = :admin, moderation_source_ticket_id = :ticket, updated_at = :updated"
+        ),
+        ExpressionAttributeValues={
+            ":t": True,
+            ":ts": _now_iso(),
+            ":admin": admin_user_id,
+            ":ticket": ticket_id,
+            ":updated": _now_iso(),
+        },
+    )
+
+
+def _mark_feed_comment_removed(*, post_id: str, comment_id: str, ticket_id: str, admin_user_id: str) -> None:
+    if not post_id or not comment_id:
+        return
+    resp = ddb.Table(APP_TABLE).query(
+        KeyConditionExpression=Key("pk").eq(f"POST#{post_id}#COMMENTS"),
+        FilterExpression=Attr("comment_id").eq(comment_id),
+        Limit=1,
+    )
+    row = (resp.get("Items") or [None])[0]
+    if not row:
+        return
+    ddb.Table(APP_TABLE).update_item(
+        Key={"pk": row["pk"], "sk": row["sk"]},
+        UpdateExpression=(
+            "SET deleted = :t, moderation_removed = :t, moderation_removed_at = :ts, "
+            "moderation_removed_by_admin_user_id = :admin, moderation_source_ticket_id = :ticket, updated_at = :updated, "
+            "#body = :null, body_plain = :null, body_markdown = :null, body_markdown_html = :null, body_rich = :null"
+        ),
+        ExpressionAttributeNames={"#body": "body"},
+        ExpressionAttributeValues={
+            ":t": True,
+            ":ts": _now_iso(),
+            ":admin": admin_user_id,
+            ":ticket": ticket_id,
+            ":updated": _now_iso(),
+            ":null": None,
+        },
+    )
+
+
+def _mark_feed_media_removed(*, post_id: str, media_index: int | None, ticket_id: str, admin_user_id: str) -> None:
+    if not post_id:
+        return
+    table = ddb.Table(APP_TABLE)
+    post = table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item") or {}
+    image_urls = list(post.get("image_urls") or [])
+    removed_media: list[str] = list(post.get("moderation_removed_media") or [])
+    if media_index is not None and 0 <= media_index < len(image_urls):
+        removed_media.append(str(image_urls[media_index]))
+        image_urls.pop(media_index)
+
+    table.update_item(
+        Key={"pk": f"POST#{post_id}", "sk": "META"},
+        UpdateExpression=(
+            "SET image_urls = :image_urls, moderation_removed_media = :removed_media, moderation_removed = :t, "
+            "moderation_removed_at = :ts, moderation_removed_by_admin_user_id = :admin, "
+            "moderation_source_ticket_id = :ticket, updated_at = :updated"
+        ),
+        ExpressionAttributeValues={
+            ":image_urls": image_urls,
+            ":removed_media": removed_media,
+            ":t": True,
+            ":ts": _now_iso(),
+            ":admin": admin_user_id,
+            ":ticket": ticket_id,
+            ":updated": _now_iso(),
+        },
+    )
+
+
+def _mark_message_removed(*, conversation_id: str, message_id: str, ticket_id: str, admin_user_id: str, media_only: bool) -> None:
+    if not conversation_id or not message_id:
+        return
+    table = ddb.Table(MESSAGES_TABLE)
+    item = table.get_item(Key={"conversation_id": conversation_id, "message_id": message_id}).get("Item") or {}
+    if not item:
+        return
+
+    expr = (
+        "SET moderation_hidden = :t, moderation_removed_at = :ts, moderation_removed_by_admin_user_id = :admin, "
+        "moderation_source_ticket_id = :ticket, updated_at = :updated"
+    )
+    names: dict[str, str] | None = None
+    values: dict[str, Any] = {
+        ":t": True,
+        ":ts": int(datetime.now(timezone.utc).timestamp()),
+        ":admin": admin_user_id,
+        ":ticket": ticket_id,
+        ":updated": int(datetime.now(timezone.utc).timestamp()),
+    }
+
+    if media_only:
+        expr += ", attachments = :empty_attachments, image = :null, file = :null, audio = :null, video = :null"
+        values[":empty_attachments"] = []
+        values[":null"] = None
+    else:
+        expr += ", #text = :removed_text, attachments = :empty_attachments, image = :null, file = :null, audio = :null, video = :null"
+        names = {"#text": "text"}
+        values[":removed_text"] = "[removed by moderation]"
+        values[":empty_attachments"] = []
+        values[":null"] = None
+
+    kwargs: dict[str, Any] = {
+        "Key": {"conversation_id": conversation_id, "message_id": message_id},
+        "UpdateExpression": expr,
+        "ExpressionAttributeValues": values,
+    }
+    if names:
+        kwargs["ExpressionAttributeNames"] = names
+    table.update_item(**kwargs)
+
+
+def _revert_profile_photo(*, user_sub: str, ticket_id: str, admin_user_id: str) -> None:
+    if not user_sub:
+        return
+    item = T.profile.get_item(Key={"user_sub": user_sub}).get("Item") or {"user_sub": user_sub, "profile": {}, "audit": []}
+    profile = dict(item.get("profile") or {})
+    current = profile.get("profile_photo_url")
+    previous = profile.get("previous_approved_profile_photo_url")
+
+    profile["moderation_last_removed_profile_photo_url"] = current
+    profile["moderation_last_removed_ticket_id"] = ticket_id
+    profile["moderation_last_removed_by_admin_user_id"] = admin_user_id
+    profile["moderation_last_removed_at"] = _now_iso()
+    profile["profile_photo_url"] = previous or None
+
+    T.profile.put_item(
+        Item={
+            **item,
+            "user_sub": user_sub,
+            "profile": profile,
+        }
+    )
+
+
+def apply_content_removal(*, ticket: dict[str, Any], reports: list[dict[str, Any]], ticket_id: str, admin_user_id: str) -> None:
+    content_type = str(ticket.get("content_type") or "")
+    content_id = str(ticket.get("content_id") or "")
+    metadata = _latest_metadata(reports)
+
+    if content_type == "feed_post":
+        post_id = str(metadata.get("post_id") or content_id)
+        _mark_feed_post_removed(post_id=post_id, ticket_id=ticket_id, admin_user_id=admin_user_id)
+        return
+
+    if content_type == "feed_comment":
+        _mark_feed_comment_removed(
+            post_id=str(metadata.get("post_id") or ""),
+            comment_id=content_id,
+            ticket_id=ticket_id,
+            admin_user_id=admin_user_id,
+        )
+        return
+
+    if content_type == "feed_media":
+        post_id = str(metadata.get("post_id") or content_id)
+        media_index_raw = metadata.get("media_index")
+        media_index = int(media_index_raw) if media_index_raw is not None else None
+        _mark_feed_media_removed(post_id=post_id, media_index=media_index, ticket_id=ticket_id, admin_user_id=admin_user_id)
+        return
+
+    if content_type == "message":
+        _mark_message_removed(
+            conversation_id=str(metadata.get("conversation_id") or ""),
+            message_id=content_id,
+            ticket_id=ticket_id,
+            admin_user_id=admin_user_id,
+            media_only=False,
+        )
+        return
+
+    if content_type == "message_media":
+        _mark_message_removed(
+            conversation_id=str(metadata.get("conversation_id") or ""),
+            message_id=content_id,
+            ticket_id=ticket_id,
+            admin_user_id=admin_user_id,
+            media_only=True,
+        )
+        return
+
+    if content_type == "profile_photo":
+        _revert_profile_photo(user_sub=content_id, ticket_id=ticket_id, admin_user_id=admin_user_id)
+        return
+
+    raise HTTPException(status_code=400, detail="unsupported content type for removal")

--- a/app/services/moderation_flags.py
+++ b/app/services/moderation_flags.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import HTTPException
+
+from app.auth.deps import AuthenticatedUser
+from app.auth.roles import AdminScope, admin_profile_has_scope, normalize_admin_profile
+from app.core.tables import T
+
+FLAGS_PK = "__moderation_flags__"
+
+DEFAULT_FLAGS: dict[str, Any] = {
+    "enabled": True,
+    "report_feed_enabled": True,
+    "report_messages_enabled": True,
+    "report_profile_enabled": True,
+    "admin_board_enabled": True,
+    "admin_actions_enabled": True,
+    "enforcement_enabled": True,
+    "min_scope_for_board": "content_moderation",
+    "min_scope_for_actions": "content_moderation",
+    "min_scope_for_permanent_ban": "content_moderation_senior",
+}
+
+
+FlagScope = Literal["content_moderation", "content_moderation_senior"]
+
+
+def _normalize_scope(raw: Any, *, default: FlagScope) -> FlagScope:
+    val = str(raw or "").strip().lower()
+    if val in {"content_moderation", "content_moderation_senior"}:
+        return val  # type: ignore[return-value]
+    return default
+
+
+def get_moderation_feature_flags() -> dict[str, Any]:
+    try:
+        row = T.alert_prefs.get_item(Key={"user_sub": FLAGS_PK}).get("Item") or {}
+    except Exception:
+        row = {}
+    persisted = row.get("moderation_feature_flags") if isinstance(row.get("moderation_feature_flags"), dict) else {}
+    flags = {**DEFAULT_FLAGS, **persisted}
+    flags["min_scope_for_board"] = _normalize_scope(flags.get("min_scope_for_board"), default="content_moderation")
+    flags["min_scope_for_actions"] = _normalize_scope(flags.get("min_scope_for_actions"), default="content_moderation")
+    flags["min_scope_for_permanent_ban"] = _normalize_scope(flags.get("min_scope_for_permanent_ban"), default="content_moderation_senior")
+    return flags
+
+
+def set_moderation_feature_flags(updates: dict[str, Any]) -> dict[str, Any]:
+    cur = get_moderation_feature_flags()
+    merged = {**cur, **(updates or {})}
+    try:
+        T.alert_prefs.put_item(Item={"user_sub": FLAGS_PK, "moderation_feature_flags": merged})
+    except Exception:
+        return merged
+    return get_moderation_feature_flags()
+
+
+def _has_scope(admin: AuthenticatedUser, required_scope: str) -> bool:
+    if getattr(admin.role, "name", "") == "ROOT":
+        return True
+    profile = normalize_admin_profile(getattr(admin, "admin_profile", None))
+    if required_scope == "content_moderation_senior":
+        return admin_profile_has_scope(profile, AdminScope.CONTENT_MODERATION_SENIOR)
+    return admin_profile_has_scope(profile, AdminScope.CONTENT_MODERATION)
+
+
+def ensure_admin_board_enabled(admin: AuthenticatedUser) -> None:
+    flags = get_moderation_feature_flags()
+    if not bool(flags.get("enabled", True)) or not bool(flags.get("admin_board_enabled", True)):
+        raise HTTPException(status_code=403, detail="moderation board is disabled")
+    if not _has_scope(admin, str(flags.get("min_scope_for_board") or "content_moderation")):
+        raise HTTPException(status_code=403, detail="moderation board rollout scope not enabled for role")
+
+
+def ensure_admin_actions_enabled(admin: AuthenticatedUser) -> None:
+    flags = get_moderation_feature_flags()
+    if not bool(flags.get("enabled", True)) or not bool(flags.get("admin_actions_enabled", True)):
+        raise HTTPException(status_code=403, detail="moderation actions are disabled")
+    if not _has_scope(admin, str(flags.get("min_scope_for_actions") or "content_moderation")):
+        raise HTTPException(status_code=403, detail="moderation actions rollout scope not enabled for role")
+
+
+def ensure_reporting_surface_enabled(content_type: str) -> None:
+    flags = get_moderation_feature_flags()
+    if not bool(flags.get("enabled", True)):
+        raise HTTPException(status_code=403, detail="moderation reporting is disabled")
+    ctype = str(content_type or "")
+    if ctype.startswith("feed_") and not bool(flags.get("report_feed_enabled", True)):
+        raise HTTPException(status_code=403, detail="feed reporting is disabled")
+    if ctype.startswith("message") and not bool(flags.get("report_messages_enabled", True)):
+        raise HTTPException(status_code=403, detail="message reporting is disabled")
+    if ctype == "profile_photo" and not bool(flags.get("report_profile_enabled", True)):
+        raise HTTPException(status_code=403, detail="profile reporting is disabled")
+
+
+def ensure_permanent_ban_scope_rollout(admin: AuthenticatedUser) -> None:
+    flags = get_moderation_feature_flags()
+    required = str(flags.get("min_scope_for_permanent_ban") or "content_moderation_senior")
+    if not _has_scope(admin, required):
+        raise HTTPException(status_code=403, detail="permanent ban rollout scope not enabled for role")

--- a/app/services/moderation_kpis.py
+++ b/app/services/moderation_kpis.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from boto3.dynamodb.conditions import Key
+
+from app.core.settings import S
+from app.core.tables import T
+from app.services.alerts import write_alert
+from app.services.moderation_audit_log import write_moderation_audit_event
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _scan_all(table: Any, **kwargs: Any) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    cursor = None
+    while True:
+        req = dict(kwargs)
+        if cursor:
+            req["ExclusiveStartKey"] = cursor
+        resp = table.scan(**req)
+        items.extend(resp.get("Items", []))
+        cursor = resp.get("LastEvaluatedKey")
+        if not cursor:
+            break
+    return items
+
+
+def _percentile(values: list[int], q: float) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    idx = int((len(ordered) - 1) * q)
+    return int(ordered[idx])
+
+
+def _parse_oncall_user_subs(raw: str) -> list[str]:
+    out: list[str] = []
+    for chunk in str(raw or "").split(","):
+        value = chunk.strip()
+        if value and value not in out:
+            out.append(value)
+    return out
+
+
+def compute_moderation_kpis(*, now_ts: int | None = None, lookback_hours: int | None = None, surge_window_minutes: int | None = None) -> dict[str, Any]:
+    now = int(now_ts or time.time())
+    lookback = max(1, int(lookback_hours or S.moderation_kpi_lookback_hours))
+    surge_window = max(1, int(surge_window_minutes or S.moderation_kpi_surge_window_minutes))
+
+    since = now - (lookback * 3600)
+    surge_since = now - (surge_window * 60)
+
+    tickets = [
+        row
+        for row in _scan_all(T.moderation_tickets)
+        if row.get("entity_type") == "moderation_ticket"
+    ]
+    reports = [
+        row
+        for row in _scan_all(T.content_reports)
+        if row.get("entity_type") == "content_report"
+    ]
+    enforcements = [
+        row
+        for row in _scan_all(T.user_enforcement_history)
+        if row.get("entity_type") == "user_enforcement"
+    ]
+
+    tickets_in_window = [row for row in tickets if _to_int(row.get("created_at"), 0) >= since]
+    resolved_in_window = [
+        row
+        for row in tickets
+        if _to_int(row.get("resolved_at"), 0) >= since and str(row.get("status") or "") == "closed"
+    ]
+    latency_values = [
+        max(0, _to_int(row.get("resolved_at"), 0) - _to_int(row.get("created_at"), 0))
+        for row in resolved_in_window
+        if _to_int(row.get("resolved_at"), 0) > 0 and _to_int(row.get("created_at"), 0) > 0
+    ]
+
+    open_tickets = [row for row in tickets if str(row.get("status") or "") == "open"]
+    critical_open = [row for row in open_tickets if str(row.get("priority") or "").lower() == "critical"]
+    oldest_open_age_minutes = 0
+    if open_tickets:
+        oldest_open_created = min(_to_int(row.get("created_at"), now) for row in open_tickets)
+        oldest_open_age_minutes = max(0, (now - oldest_open_created) // 60)
+
+    enforcement_in_window = [row for row in enforcements if _to_int(row.get("created_at"), 0) >= since]
+    warning_count = sum(1 for row in enforcement_in_window if str(row.get("enforcement_type") or "") == "warn")
+    ban_count = sum(1 for row in enforcement_in_window if str(row.get("enforcement_type") or "") == "ban")
+    denom = max(1, len(enforcement_in_window))
+
+    surge_reports = [
+        row
+        for row in reports
+        if _to_int(row.get("created_at"), 0) >= surge_since
+        and any(str(t).strip().lower() in {"extortion", "criminal"} for t in (row.get("topics") or []))
+    ]
+
+    return {
+        "generated_at": now,
+        "lookback_hours": lookback,
+        "surge_window_minutes": surge_window,
+        "ticket_volume": len(tickets_in_window),
+        "resolution_count": len(resolved_in_window),
+        "resolution_latency_avg_seconds": int(sum(latency_values) / len(latency_values)) if latency_values else 0,
+        "resolution_latency_p95_seconds": _percentile(latency_values, 0.95),
+        "warning_count": warning_count,
+        "ban_count": ban_count,
+        "warning_rate": round(warning_count / denom, 4),
+        "ban_rate": round(ban_count / denom, 4),
+        "open_ticket_count": len(open_tickets),
+        "critical_backlog": len(critical_open),
+        "oldest_open_age_minutes": oldest_open_age_minutes,
+        "extortion_criminal_reports_window_count": len(surge_reports),
+    }
+
+
+def _already_fired(*, alert_key: str, marker: str, since_ts: int) -> bool:
+    try:
+        resp = T.moderation_audit_log.query(
+            IndexName="ByActionCreatedAt",
+            KeyConditionExpression=Key("action").eq("kpi_alert_fired") & Key("created_at").gte(str(since_ts)),
+            ScanIndexForward=False,
+            Limit=100,
+        )
+    except Exception:
+        return False
+    for row in resp.get("Items", []):
+        metadata = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
+        if str(metadata.get("alert_key") or "") == alert_key and str(metadata.get("marker") or "") == marker:
+            return True
+    return False
+
+
+def evaluate_and_dispatch_moderation_alerts(*, actor_user_id: str = "system", now_ts: int | None = None) -> dict[str, Any]:
+    now = int(now_ts or time.time())
+    kpis = compute_moderation_kpis(now_ts=now)
+    oncall_user_subs = _parse_oncall_user_subs(S.moderation_oncall_user_subs)
+    fired: list[dict[str, Any]] = []
+
+    if not oncall_user_subs:
+        return {"kpis": kpis, "alerts_fired": fired, "notified_user_subs": []}
+
+    surge_threshold = int(S.moderation_alert_extortion_criminal_surge_threshold)
+    surge_window_seconds = max(60, int(S.moderation_kpi_surge_window_minutes) * 60)
+    surge_marker = str(now // surge_window_seconds)
+    surge_alert_key = "extortion_criminal_surge"
+
+    if int(kpis.get("extortion_criminal_reports_window_count") or 0) >= surge_threshold and not _already_fired(
+        alert_key=surge_alert_key,
+        marker=surge_marker,
+        since_ts=now - surge_window_seconds,
+    ):
+        details = {
+            "alert_key": surge_alert_key,
+            "marker": surge_marker,
+            "threshold": surge_threshold,
+            "observed": int(kpis.get("extortion_criminal_reports_window_count") or 0),
+            "window_minutes": int(kpis.get("surge_window_minutes") or 0),
+        }
+        for user_sub in oncall_user_subs:
+            write_alert(
+                user_sub,
+                event="moderation_extortion_criminal_surge",
+                outcome="warning",
+                title="Moderation surge detected",
+                details=details,
+            )
+        write_moderation_audit_event(action="kpi_alert_fired", actor_user_id=actor_user_id, metadata=details)
+        fired.append({"alert": surge_alert_key, **details})
+
+    critical_threshold = int(S.moderation_alert_sla_open_critical_threshold)
+    oldest_threshold = int(S.moderation_alert_sla_oldest_open_minutes_threshold)
+    sla_breach = (
+        int(kpis.get("critical_backlog") or 0) >= critical_threshold
+        or int(kpis.get("oldest_open_age_minutes") or 0) >= oldest_threshold
+    )
+    sla_window_seconds = max(300, int(S.moderation_alert_sla_window_minutes) * 60)
+    sla_marker = str(now // sla_window_seconds)
+    sla_alert_key = "sla_breach"
+
+    if sla_breach and not _already_fired(
+        alert_key=sla_alert_key,
+        marker=sla_marker,
+        since_ts=now - sla_window_seconds,
+    ):
+        details = {
+            "alert_key": sla_alert_key,
+            "marker": sla_marker,
+            "critical_backlog": int(kpis.get("critical_backlog") or 0),
+            "oldest_open_age_minutes": int(kpis.get("oldest_open_age_minutes") or 0),
+            "critical_backlog_threshold": critical_threshold,
+            "oldest_open_age_threshold_minutes": oldest_threshold,
+        }
+        for user_sub in oncall_user_subs:
+            write_alert(
+                user_sub,
+                event="moderation_sla_breach",
+                outcome="warning",
+                title="Moderation SLA breach",
+                details=details,
+            )
+        write_moderation_audit_event(action="kpi_alert_fired", actor_user_id=actor_user_id, metadata=details)
+        fired.append({"alert": sla_alert_key, **details})
+
+    return {
+        "kpis": kpis,
+        "alerts_fired": fired,
+        "notified_user_subs": oncall_user_subs,
+    }

--- a/app/services/moderation_policy_engine.py
+++ b/app/services/moderation_policy_engine.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.tables import T
+from app.core.time import now_ts
+from app.services.alerts import write_alert
+
+
+BAN_STATUS = "banned"
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def issue_warning_notification(*, offender_user_id: str, ticket_id: str, note: str, policy_category: str = "unspecified") -> None:
+    if not offender_user_id:
+        return
+    write_alert(
+        offender_user_id,
+        event="moderation_warning",
+        outcome="warning",
+        title="Account warning issued",
+        details={
+            "ticket_id": ticket_id,
+            "action": "warn",
+            "policy_category": str(policy_category or "unspecified"),
+            "note": (note or "")[:500],
+        },
+    )
+
+
+def _ban_duration_label(duration_days: int) -> str:
+    return f"{duration_days} day{'s' if duration_days != 1 else ''}" if duration_days > 0 else "permanent"
+
+
+def notify_content_removal(*, offender_user_id: str, ticket_id: str, content_type: str, policy_category: str, note: str) -> None:
+    if not offender_user_id:
+        return
+    write_alert(
+        offender_user_id,
+        event="moderation_content_removed",
+        outcome="warning",
+        title="Content removed",
+        details={
+            "ticket_id": ticket_id,
+            "action": "content_removed",
+            "content_type": str(content_type or ""),
+            "policy_category": str(policy_category or "unspecified"),
+            "note": (note or "")[:500],
+        },
+    )
+
+
+def apply_ban(
+    *,
+    offender_user_id: str,
+    ticket_id: str,
+    admin_user_id: str,
+    note: str,
+    duration_days: int | None,
+    policy_category: str = "unspecified",
+) -> dict[str, Any]:
+    if not offender_user_id:
+        return {"status": "skipped"}
+
+    ts = now_ts()
+    duration = _coerce_int(duration_days, 0)
+    banned_until = ts + duration * 86400 if duration > 0 else 0
+
+    T.account_state.put_item(
+        Item={
+            "user_sub": offender_user_id,
+            "status": BAN_STATUS,
+            "updated_at": ts,
+            "reason": "moderation_ban",
+            "requested_by": admin_user_id,
+            "source_ticket_id": ticket_id,
+            "ban_duration_days": duration,
+            "ban_started_at": ts,
+            "ban_until": banned_until,
+            "ban_note": (note or "")[:500],
+        }
+    )
+
+    write_alert(
+        offender_user_id,
+        event="moderation_ban",
+        outcome="warning",
+        title="Account restricted",
+        details={
+            "ticket_id": ticket_id,
+            "action": "ban",
+            "policy_category": str(policy_category or "unspecified"),
+            "ban_duration_days": duration,
+            "effective_duration": _ban_duration_label(duration),
+            "ban_until": banned_until,
+            "note": (note or "")[:500],
+        },
+    )
+
+    return {
+        "status": BAN_STATUS,
+        "ban_duration_days": duration,
+        "ban_until": banned_until,
+    }
+
+
+def is_user_currently_banned(user_sub: str) -> bool:
+    if not user_sub:
+        return False
+    try:
+        item = T.account_state.get_item(Key={"user_sub": user_sub}).get("Item") or {}
+    except Exception:
+        return False
+    if str(item.get("status") or "") != BAN_STATUS:
+        return False
+
+    ban_until = _coerce_int(item.get("ban_until"), 0)
+    if ban_until > 0 and now_ts() >= ban_until:
+        return False
+    return True

--- a/app/services/moderation_tickets_store.py
+++ b/app/services/moderation_tickets_store.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any, Iterable
+
+from botocore.exceptions import ClientError
+
+from app.core.tables import T
+
+DEFAULT_STATUS = "open"
+DEFAULT_PRIORITY = "medium"
+
+PRIORITY_RANK = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+TOPIC_PRIORITY_RULES = {
+    "extortion": "critical",
+    "criminal": "high",
+    "sexual": "high",
+    "racist": "high",
+    "spam": "medium",
+}
+DEFAULT_QUEUE = "general"
+
+QUEUE_BY_CONTENT_TYPE = {
+    "feed_post": "newsfeed",
+    "feed_comment": "newsfeed",
+    "feed_media": "newsfeed",
+    "message": "messages",
+    "message_media": "messages",
+    "profile_photo": "profile",
+}
+DEFAULT_UNASSIGNED_ADMIN = "UNASSIGNED"
+
+
+def _content_ref(content_type: str, content_id: str) -> str:
+    return f"{content_type}#{content_id}"
+
+
+def score_initial_priority(*, topics: Iterable[str]) -> str:
+    normalized = {str(t).strip().lower() for t in topics if str(t).strip()}
+    if not normalized:
+        return DEFAULT_PRIORITY
+
+    best = DEFAULT_PRIORITY
+    for topic in sorted(normalized):
+        candidate = TOPIC_PRIORITY_RULES.get(topic, DEFAULT_PRIORITY)
+        if PRIORITY_RANK[candidate] > PRIORITY_RANK[best]:
+            best = candidate
+    return best
+
+
+def queue_for_content_type(content_type: str) -> str:
+    return QUEUE_BY_CONTENT_TYPE.get(str(content_type or "").strip().lower(), DEFAULT_QUEUE)
+
+
+def _open_ticket_id(content_type: str, content_id: str) -> str:
+    digest = hashlib.sha256(f"{content_type}:{content_id}".encode("utf-8")).hexdigest()[:20]
+    return f"modtk_{digest}"
+
+
+def upsert_open_ticket_for_report(*, content_type: str, content_id: str, topics: Iterable[str], now_ts: int | None = None) -> dict[str, Any]:
+    """Create or update the open moderation ticket for a piece of content.
+
+    This keeps one open ticket per content reference and performs atomic aggregation
+    updates (`report_count`, `aggregated_topics`, latest timestamps) to reduce
+    race-condition risk under concurrent report submissions.
+    """
+
+    ts = int(now_ts or time.time())
+    ticket_id = _open_ticket_id(content_type, content_id)
+    content_ref = _content_ref(content_type, content_id)
+    topic_set = {str(t).strip().lower() for t in topics if str(t).strip()}
+    if not topic_set:
+        topic_set = {"spam"}
+
+    priority = score_initial_priority(topics=topic_set)
+    queue = queue_for_content_type(content_type)
+
+    item = {
+        "ticket_id": ticket_id,
+        "entity_type": "moderation_ticket",
+        "content_type": content_type,
+        "content_id": content_id,
+        "content_ref": content_ref,
+        "content_ref_status": f"{content_ref}#{DEFAULT_STATUS}",
+        "status": DEFAULT_STATUS,
+        "priority": priority,
+        "queue": queue,
+        "assigned_admin_user_id": DEFAULT_UNASSIGNED_ADMIN,
+        "report_count": 1,
+        "aggregated_topics": topic_set,
+        "latest_report_scope": "ALL",
+        "latest_report_at": str(ts),
+        "created_at": str(ts),
+        "updated_at": str(ts),
+    }
+
+    try:
+        T.moderation_tickets.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(ticket_id)",
+        )
+        return {"ticket_id": ticket_id, "status": DEFAULT_STATUS, "created": True}
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        if code != "ConditionalCheckFailedException":
+            raise
+
+    # Existing ticket path: aggregate only if the ticket is still open.
+    try:
+        T.moderation_tickets.update_item(
+            Key={"ticket_id": ticket_id},
+            ConditionExpression="#status = :open",
+            UpdateExpression=(
+                "SET #updated_at = :updated_at, #latest_report_at = :latest_report_at, "
+                "#latest_report_scope = :latest_report_scope, #content_ref_status = :content_ref_status, "
+                "#priority = if_not_exists(#priority, :priority) "
+                "ADD #report_count :inc, #aggregated_topics :topics"
+            ),
+            ExpressionAttributeNames={
+                "#status": "status",
+                "#updated_at": "updated_at",
+                "#latest_report_at": "latest_report_at",
+                "#latest_report_scope": "latest_report_scope",
+                "#content_ref_status": "content_ref_status",
+                "#report_count": "report_count",
+                "#aggregated_topics": "aggregated_topics",
+                "#priority": "priority",
+            },
+            ExpressionAttributeValues={
+                ":open": DEFAULT_STATUS,
+                ":updated_at": str(ts),
+                ":latest_report_at": str(ts),
+                ":latest_report_scope": "ALL",
+                ":content_ref_status": f"{content_ref}#{DEFAULT_STATUS}",
+                ":inc": 1,
+                ":topics": topic_set,
+                ":priority": priority,
+            },
+        )
+    except ClientError as exc:
+        # If status is no longer open we fall back to a timestamp-suffixed ticket.
+        code = exc.response.get("Error", {}).get("Code")
+        if code != "ConditionalCheckFailedException":
+            raise
+
+        new_ticket_id = f"{ticket_id}_{ts}"
+        item["ticket_id"] = new_ticket_id
+        T.moderation_tickets.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(ticket_id)",
+        )
+        return {"ticket_id": new_ticket_id, "status": DEFAULT_STATUS, "created": True}
+
+    return {"ticket_id": ticket_id, "status": DEFAULT_STATUS, "created": False}

--- a/app/services/sessions.py
+++ b/app/services/sessions.py
@@ -19,6 +19,7 @@ from app.core.tables import T
 from app.core.time import now_ts
 from app.metrics import record_session_created, record_session_revoked
 from app.services.device_trust import ensure_device_cookie, record_device_login
+from app.services.moderation_policy_engine import is_user_currently_banned
 from app.services.ttl import with_ttl
 
 @dataclass(frozen=True)
@@ -290,6 +291,8 @@ async def require_ui_session(
     if not resolved_user_sub:
         raise HTTPException(401, "Missing user")
     role: Role = normalize_role(getattr(auth_user, "role", None))
+    if role not in {Role.ADMIN, Role.ROOT} and is_user_currently_banned(resolved_user_sub):
+        raise HTTPException(403, "account is banned")
     session_id = None
     cookies = getattr(request, "cookies", {}) or {}
     headers = getattr(request, "headers", {}) or {}

--- a/docs/content-moderation-implementation-tickets.md
+++ b/docs/content-moderation-implementation-tickets.md
@@ -1,0 +1,371 @@
+# Content Moderation Implementation Tickets
+
+This document breaks `docs/content-moderation-plan.md` into implementable engineering tickets.
+
+## Conventions
+- **Priority**: P0 (must-have MVP), P1 (post-MVP), P2 (later).
+- **Estimate**: S (<=2 days), M (3-5 days), L (1-2 weeks).
+- **Dependencies**: Ticket IDs that should land first.
+
+---
+
+## Epic A — Reporting Entry Points (User-Facing)
+
+### MOD-001 — Add unified `ReportContentModal` component
+- **Priority**: P0
+- **Estimate**: M
+- **Scope**:
+  - Build reusable modal with:
+    - Topic multi-select: `sexual`, `extortion`, `criminal`, `spam`, `racist`.
+    - Reason textarea.
+    - Client-side validation + error states.
+  - Emit normalized payload for API.
+- **Acceptance criteria**:
+  - Modal can be mounted from feed/message/profile contexts.
+  - Prevent submit without at least one topic.
+  - Displays server validation errors.
+
+### MOD-002 — Add report action to Newsfeed post/comment/media UI
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-001
+- **Scope**:
+  - Add “Report” action in post actions menu, comment actions, media viewer.
+  - Pass correct `content_type` and `content_id` into modal.
+- **Acceptance criteria**:
+  - Report action visible only for eligible content.
+  - Correct content metadata sent for post/comment/media.
+
+### MOD-003 — Add report action to Messages UI
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-001
+- **Scope**:
+  - Add report action for message bubble and message attachments.
+  - Handle DM and group conversation contexts.
+- **Acceptance criteria**:
+  - Reporting works for text + media messages.
+  - UI confirms successful submission.
+
+### MOD-004 — Add report action to Profile photo UI
+- **Priority**: P0
+- **Estimate**: S
+- **Dependencies**: MOD-001
+- **Scope**:
+  - Add report entry point on profile photo view.
+- **Acceptance criteria**:
+  - Profile-photo report submits with `content_type=profile_photo`.
+
+---
+
+## Epic B — Report Intake API + Persistence
+
+### MOD-005 — Create DB schema for `content_reports`
+- **Priority**: P0
+- **Estimate**: M
+- **Scope**:
+  - Migration for `content_reports` table.
+  - Enum/check constraint for topic taxonomy.
+  - Indices: `content_type+content_id`, `reporter_user_id`, `created_at`.
+- **Acceptance criteria**:
+  - Migration applies cleanly in local/test env.
+  - Invalid topic values rejected at DB boundary.
+
+### MOD-006 — Implement `POST /v1/moderation/reports`
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-005
+- **Scope**:
+  - Request validation.
+  - Content existence + reportability checks.
+  - Insert report record.
+  - Return report ID + linked ticket ID.
+- **Acceptance criteria**:
+  - 2xx on valid payload.
+  - 4xx on invalid content/topic.
+  - Idempotency guard for repeated rapid submissions from same user/content.
+
+### MOD-007 — Add abuse controls on report endpoint
+- **Priority**: P0
+- **Estimate**: S
+- **Dependencies**: MOD-006
+- **Scope**:
+  - Rate limiting per user/IP.
+  - Basic anti-spam heuristics/logging.
+- **Acceptance criteria**:
+  - Requests beyond threshold return controlled error.
+  - Security events logged.
+
+---
+
+## Epic C — Ticket Creation + Queueing
+
+### MOD-008 — Create DB schema for `moderation_tickets`
+- **Priority**: P0
+- **Estimate**: M
+- **Scope**:
+  - Migration for ticket table + status/priority fields.
+  - Indexes on `status`, `queue`, `assigned_admin_user_id`, `latest_report_at`.
+- **Acceptance criteria**:
+  - Tickets queryable by board filters with performant index plan.
+
+### MOD-009 — Implement dedup/aggregation service (report → ticket)
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-006, MOD-008
+- **Scope**:
+  - Map report to existing open ticket by `content_type+content_id` or create new.
+  - Increment `report_count`, aggregate topics, update timestamps.
+- **Acceptance criteria**:
+  - Multiple reports on same content map to one open ticket.
+  - Race conditions handled (transaction/locking/upsert).
+
+### MOD-010 — Priority scoring rules for initial SLA
+- **Priority**: P1
+- **Estimate**: S
+- **Dependencies**: MOD-009
+- **Scope**:
+  - Encode first-pass priority rules (e.g., extortion/criminal → high/critical).
+- **Acceptance criteria**:
+  - Priority set deterministically from report metadata.
+
+---
+
+## Epic D — Admin Moderation Board
+
+### MOD-011 — Build admin tickets list endpoint
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-008, MOD-009
+- **Scope**:
+  - `GET /v1/admin/moderation/tickets` with filters: status/queue/topic/assignee.
+- **Acceptance criteria**:
+  - Supports pagination + stable ordering.
+  - Unauthorized roles blocked.
+
+### MOD-012 — Build admin ticket detail endpoint
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-011
+- **Scope**:
+  - `GET /v1/admin/moderation/tickets/{ticket_id}`.
+  - Include content snapshot + linked reports + offender history summary.
+- **Acceptance criteria**:
+  - Returns all data required for moderation decision in one response.
+
+### MOD-013 — Create moderation board UI (list + filters + assignment)
+- **Priority**: P0
+- **Estimate**: L
+- **Dependencies**: MOD-011
+- **Scope**:
+  - New admin page with queues (newsfeed/messages/profile), filters, and assignment.
+- **Acceptance criteria**:
+  - Moderator can browse and claim tickets.
+  - Empty/loading/error states implemented.
+
+### MOD-014 — Build ticket detail UI with decision panel
+- **Priority**: P0
+- **Estimate**: L
+- **Dependencies**: MOD-012, MOD-013
+- **Scope**:
+  - Show reported content, topics, reasons, prior enforcement history.
+  - Decision controls for no-violation/remove/warn/ban.
+- **Acceptance criteria**:
+  - Admin can complete full moderation workflow from ticket detail.
+
+---
+
+## Epic E — Resolution + Enforcement Actions
+
+### MOD-015 — Create schema for `moderation_actions` and `user_enforcement_history`
+- **Priority**: P0
+- **Estimate**: M
+- **Scope**:
+  - Migrations and indexes for action audit + enforcement history queries.
+- **Acceptance criteria**:
+  - Warning/ban actions persist with source ticket reference.
+
+### MOD-016 — Implement resolve endpoint with transactional action pipeline
+- **Priority**: P0
+- **Estimate**: L
+- **Dependencies**: MOD-012, MOD-015
+- **Scope**:
+  - `POST /v1/admin/moderation/tickets/{ticket_id}/resolve`.
+  - Support combinations:
+    - no_violation + none
+    - content_removed + none/warn/ban
+  - Ensure atomic writes or compensating retry logic.
+- **Acceptance criteria**:
+  - Ticket status/resolution/action records always consistent.
+  - Reject invalid state transitions.
+
+### MOD-017 — Implement content removal adapters by content type
+- **Priority**: P0
+- **Estimate**: L
+- **Dependencies**: MOD-016
+- **Scope**:
+  - Feed: soft-remove post/comment/media.
+  - Messages: hide/remove from UI; preserve compliance storage as configured.
+  - Profile: revert photo to previous approved/default avatar.
+- **Acceptance criteria**:
+  - Removed content no longer appears in user-facing surfaces.
+  - Evidence retention behavior documented and verified.
+
+### MOD-018 — Implement warning/ban policy engine integration
+- **Priority**: P1
+- **Estimate**: M
+- **Dependencies**: MOD-016
+- **Scope**:
+  - Issue warning notifications.
+  - Apply temporary/permanent ban with duration support.
+- **Acceptance criteria**:
+  - Banned user restrictions enforced system-wide.
+
+---
+
+## Epic F — History, Auditability, and Admin Safety Controls
+
+### MOD-019 — Add `GET /v1/admin/moderation/users/{user_id}/history`
+- **Priority**: P0
+- **Estimate**: S
+- **Dependencies**: MOD-015
+- **Scope**:
+  - Query warning/ban timeline for user.
+- **Acceptance criteria**:
+  - Ticket detail can fetch and render prior enforcement quickly.
+
+### MOD-020 — Implement `moderation_audit_log` write path
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-006, MOD-016
+- **Scope**:
+  - Log report creation, assignment, resolution, enforcement actions.
+- **Acceptance criteria**:
+  - Every moderation action has an immutable audit record.
+
+### MOD-021 — Role-based permissions for moderation capabilities
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-011, MOD-016
+- **Scope**:
+  - Moderator vs senior-admin gates (e.g., permanent ban).
+- **Acceptance criteria**:
+  - Unauthorized actions return 403.
+  - Permission checks covered by tests.
+
+### MOD-022 — Optional dual-approval flow for permanent bans
+- **Priority**: P2
+- **Estimate**: M
+- **Dependencies**: MOD-021
+- **Scope**:
+  - Feature flag for requiring second approver.
+- **Acceptance criteria**:
+  - Permanent ban cannot finalize without second approver when enabled.
+
+---
+
+## Epic G — Notifications + User Communication
+
+### MOD-023 — Reporter acknowledgement notification
+- **Priority**: P1
+- **Estimate**: S
+- **Dependencies**: MOD-006
+- **Scope**:
+  - In-app/toast confirmation and optional inbox event.
+- **Acceptance criteria**:
+  - Reporter sees “report received” confirmation.
+
+### MOD-024 — Offender moderation outcome notifications
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-016, MOD-018
+- **Scope**:
+  - Notify on content removal, warning, or ban.
+- **Acceptance criteria**:
+  - Notification templates include policy category and effective duration for bans.
+
+---
+
+## Epic H — QA, Observability, and Rollout
+
+### MOD-025 — Add backend unit/integration tests for report + ticket lifecycle
+- **Priority**: P0
+- **Estimate**: L
+- **Dependencies**: MOD-006, MOD-009, MOD-016
+- **Scope**:
+  - Validate happy path + invalid payloads + race conditions + permission errors.
+- **Acceptance criteria**:
+  - CI test coverage for core moderation workflows.
+
+### MOD-026 — Add frontend tests for reporting and admin moderation workflows
+- **Priority**: P0
+- **Estimate**: M
+- **Dependencies**: MOD-001, MOD-014
+- **Scope**:
+  - Component tests for modal validation.
+  - UI tests for ticket resolution decision panel.
+- **Acceptance criteria**:
+  - Key moderation UX paths covered by automated tests.
+
+### MOD-027 — Dashboard + alerts for moderation KPIs
+- **Priority**: P1
+- **Estimate**: M
+- **Dependencies**: MOD-020
+- **Scope**:
+  - Metrics: ticket volume, resolution latency, warning/ban rates, critical backlog.
+  - Alerts: extortion/criminal surge, SLA breach.
+- **Acceptance criteria**:
+  - On-call receives alerts for configured thresholds.
+
+### MOD-028 — Feature flags and staged rollout plan
+- **Priority**: P0
+- **Estimate**: S
+- **Dependencies**: MOD-002, MOD-003, MOD-004, MOD-013
+- **Scope**:
+  - Gradual enablement by surface and role.
+- **Acceptance criteria**:
+  - Moderation features can be toggled without redeploy.
+
+---
+
+## Suggested Delivery Slices
+
+### Slice 1 (MVP Core)
+- MOD-001, MOD-002, MOD-003, MOD-004
+- MOD-005, MOD-006, MOD-008, MOD-009
+- MOD-011, MOD-012, MOD-013, MOD-014
+- MOD-015, MOD-016, MOD-017, MOD-019, MOD-020, MOD-021
+- MOD-024, MOD-025, MOD-026, MOD-028
+
+### Slice 2 (Operational hardening)
+- MOD-007, MOD-010, MOD-023, MOD-027
+
+### Slice 3 (Advanced governance)
+- MOD-018, MOD-022
+
+---
+
+## Jira/Linear Ticket Template (copy/paste)
+
+**Title**: `[MOD-XXX] <short action-oriented title>`
+
+**Problem**
+- What user/admin pain this ticket solves.
+
+**Scope**
+- In scope bullets.
+- Out of scope bullets.
+
+**Implementation notes**
+- Data model/API/UI details.
+- Dependency tickets.
+
+**Acceptance criteria**
+- Testable Given/When/Then outcomes.
+
+**Testing**
+- Unit/integration/e2e coverage required.
+
+**Rollout**
+- Feature flag name.
+- Metrics to monitor post-release.

--- a/docs/content-moderation-plan.md
+++ b/docs/content-moderation-plan.md
@@ -1,0 +1,296 @@
+# Content Moderation Plan (Newsfeed, Messages, Profile Photos)
+
+## 1. Goals
+
+Implementation breakdown: see `docs/content-moderation-implementation-tickets.md`.
+- Let users report problematic content in **newsfeed posts/comments**, **direct/group messages**, and **profile photos**.
+- Route every report into a centralized **moderation ticket board**.
+- Give admins a consistent decision workflow: **approve/no action**, **reject content (remove)**, **warn user**, or **ban user**.
+- Preserve an auditable moderation trail, including prior bans/warnings history.
+- Capture structured report context, including a free-text reason and topic tags:
+  - `sexual`
+  - `extortion`
+  - `criminal`
+  - `spam`
+  - `racist`
+
+---
+
+## 2. Scope and Content Types
+### In scope
+1. Newsfeed
+   - Post
+   - Comment
+   - Attached image/video
+2. Messaging
+   - Message text
+   - Image/video/file attachment
+3. Profile
+   - Profile photo
+
+### Out of scope (phase 1)
+- Automated ML moderation decisions (allowed later as recommendations only).
+- Appeals portal for end users (tracked as phase 2 enhancement).
+
+---
+
+## 3. High-Level Workflow
+1. User clicks **Report** on a piece of content.
+2. Client opens report modal:
+   - Select one or more topics (`sexual`, `extortion`, `criminal`, `spam`, `racist`).
+   - Enter optional/required reason text.
+3. Backend validates report and creates a **Moderation Ticket**.
+4. Ticket appears on moderator board with content snapshot and metadata.
+5. Admin reviews and chooses disposition:
+   - **No violation** (close ticket, keep content).
+   - **Violation – remove content**.
+   - Optional enforcement: **warn user** or **ban user**.
+6. System executes action atomically (or with compensating retry):
+   - Content hidden/removed.
+   - Enforcement record created.
+   - Ticket status/resolution updated.
+   - Audit log entry written.
+7. Admin can view offender history (prior warnings/bans) from the ticket before finalizing.
+
+---
+
+## 4. Data Model Proposal
+
+### 4.1 `content_reports`
+Represents user-submitted reports (many reports can map to one moderation ticket if deduplicated).
+
+Fields:
+- `id` (uuid)
+- `reporter_user_id`
+- `content_type` (`feed_post`, `feed_comment`, `feed_media`, `message`, `message_media`, `profile_photo`)
+- `content_id`
+- `content_owner_user_id`
+- `topics` (array enum: sexual/extortion/criminal/spam/racist)
+- `reason_text`
+- `status` (`submitted`, `linked_to_ticket`, `dismissed`)
+- `created_at`
+
+### 4.2 `moderation_tickets`
+Single moderator work item.
+
+Fields:
+- `id` (uuid)
+- `queue` (`newsfeed`, `messages`, `profile`)
+- `priority` (`low`, `medium`, `high`, `critical`)
+- `status` (`open`, `in_review`, `resolved`, `closed`)
+- `content_type`
+- `content_id`
+- `content_owner_user_id`
+- `report_count`
+- `aggregated_topics` (set)
+- `latest_report_at`
+- `assigned_admin_user_id` (nullable)
+- `resolution` (`no_violation`, `content_removed`, `content_removed_warned`, `content_removed_banned`)
+- `resolution_notes`
+- `resolved_by_admin_user_id`
+- `resolved_at`
+- `created_at`
+- `updated_at`
+
+### 4.3 `moderation_actions`
+Immutable action log for each decision/action.
+
+Fields:
+- `id` (uuid)
+- `ticket_id`
+- `action_type` (`remove_content`, `warn_user`, `ban_user`, `no_action`)
+- `target_user_id`
+- `target_content_type`
+- `target_content_id`
+- `metadata` (json; e.g., ban duration, warning template id)
+- `performed_by_admin_user_id`
+- `created_at`
+
+### 4.4 `user_enforcement_history`
+Queryable summary (can be a table or materialized view).
+
+Fields:
+- `id`
+- `user_id`
+- `enforcement_type` (`warning`, `ban`)
+- `reason_code/topics`
+- `source_ticket_id`
+- `active` (for bans)
+- `starts_at`
+- `ends_at` (nullable for permanent)
+- `created_by_admin_user_id`
+- `created_at`
+
+### 4.5 `moderation_audit_log`
+Security/audit event stream for compliance and incident review.
+
+Fields:
+- `id`
+- `actor_user_id`
+- `actor_role`
+- `event_type`
+- `entity_type`
+- `entity_id`
+- `before_state` (json)
+- `after_state` (json)
+- `ip_hash`
+- `user_agent_hash`
+- `created_at`
+
+---
+
+## 5. API Contract (Draft)
+
+### User-facing
+- `POST /v1/moderation/reports`
+  - Input: `content_type`, `content_id`, `topics[]`, `reason_text`.
+  - Validations:
+    - Content exists and is reportable.
+    - Topics subset of allowed taxonomy.
+    - Reporter cannot report own content? (product decision; often allowed for compromised-account handling).
+  - Output: report + ticket reference.
+
+### Admin-facing board
+- `GET /v1/admin/moderation/tickets?status=&queue=&topic=&assigned=`
+- `GET /v1/admin/moderation/tickets/{ticket_id}`
+  - Includes content preview/snapshot + offender enforcement history.
+- `POST /v1/admin/moderation/tickets/{ticket_id}/assign`
+- `POST /v1/admin/moderation/tickets/{ticket_id}/resolve`
+  - Payload:
+    - `resolution` (`no_violation` | `content_removed`)
+    - `enforcement` (`none` | `warn` | `ban`)
+    - `ban_duration_days` (optional)
+    - `resolution_notes`
+
+### Enforcement history
+- `GET /v1/admin/moderation/users/{user_id}/history`
+
+---
+
+## 6. Ticketing & Board Behavior
+- Default queues: `newsfeed`, `messages`, `profile`.
+- Deduplication rule: reports on the same `content_type + content_id` within active window map to one open ticket; `report_count` increments.
+- SLA indicators:
+  - `critical`: extortion/criminal + repeated reports.
+  - `high`: sexual/racist with media evidence.
+- Board views:
+  - Unassigned
+  - Assigned to me
+  - Escalated
+  - Recently resolved
+- Bulk actions (later phase): close as no violation for clear spam waves.
+
+---
+
+## 7. Admin Decision Tree
+1. Review content snapshot and context.
+2. Review report topics and reason text.
+3. Review prior warnings/bans for the content owner.
+4. Choose outcome:
+   - **No violation** → close ticket, keep content.
+   - **Violation** → remove content.
+5. Optional enforcement:
+   - First/low severity: warning.
+   - Repeat/high severity: temporary or permanent ban.
+6. Enter required moderation notes.
+7. Confirm action; system commits all records and logs.
+
+Guardrails:
+- Require second-review for permanent bans (optional policy toggle).
+- Prevent resolving already-resolved ticket unless using explicit override workflow.
+
+---
+
+## 8. Content Removal Semantics
+- Use **soft delete/hide** first for reversibility:
+  - `visibility = removed_by_moderation`
+  - Preserve original bytes/text for legal retention policies.
+- Message removal behavior:
+  - Remove from active conversation UI.
+  - Preserve in compliance archive if legal policy requires.
+- Profile photo rejection:
+  - Revert to previous approved photo or default avatar.
+
+---
+
+## 9. User Notifications
+- Reporter:
+  - Optional confirmation: “Thanks, your report was received.”
+  - Do not expose detailed moderation outcome.
+- Offending user:
+  - If content removed: notify with policy reason category.
+  - If warned: include warning message and next-step guidance.
+  - If banned: include duration and appeal/contact route (if enabled).
+
+---
+
+## 10. Permissions & Security
+- Only users with moderation/admin roles can access board endpoints.
+- Action authorization split:
+  - Moderator: remove + warn.
+  - Senior admin: permanent bans.
+- Full audit logging for every read/write on moderation entities.
+- Rate limit report endpoint to reduce abuse.
+- Anti-brigading heuristics:
+  - Cap weight of duplicate reports from tightly linked accounts.
+
+---
+
+## 11. Analytics & Monitoring
+Track:
+- Tickets created/day by queue and topic.
+- Median time to first review and time to resolution.
+- Removal rate, warning rate, ban rate.
+- Repeat offender rate (warned/banned users reoffending).
+- False report ratio (no_violation outcomes).
+
+Alerts:
+- Surge in `extortion` or `criminal` topics.
+- Backlog threshold exceeded for high/critical tickets.
+
+---
+
+
+## 12.1 Evidence Retention and Removal Behavior
+- **Feed removals** are soft removals: post/comment records stay in storage with moderation metadata and source ticket reference, while user-facing feed/comment APIs exclude moderated items.
+- **Message removals** set moderation-hidden flags and clear user-facing payload fields for removed content/media, but message records remain stored for compliance/legal workflows.
+- **Profile-photo removals** revert active profile photo to the previous approved/default value and retain last-removed metadata linked to the source moderation ticket.
+- Each removal path writes moderation provenance (`moderation_source_ticket_id`, actor, timestamp) to support audit and replay.
+
+---
+
+## 12. Rollout Plan
+### Phase 1 (MVP)
+- Report UI for all 3 content surfaces.
+- Ticket creation and admin moderation board.
+- Remove/warn/ban actions.
+- Basic offender history panel.
+- Audit logs.
+
+### Phase 2
+- Smarter deduplication and auto-priority scoring.
+- Appeals workflow.
+- Moderator QA sampling and calibration reports.
+
+### Phase 3
+- ML-assisted triage recommendations.
+- Policy simulation / what-if tooling.
+
+---
+
+## 13. Acceptance Criteria
+- Users can report newsfeed posts/messages/profile photos with reason + topics.
+- Every report creates or updates a moderation ticket visible on board.
+- Admin can reject content and remove it successfully.
+- Admin can choose warn or ban during resolution.
+- Admin can view previous warnings and bans for the reported user.
+- All decisions/actions are captured in auditable logs.
+
+---
+
+## 14. Open Product/Policy Decisions
+- Should users be able to report their own content?
+- Is `reason_text` required or optional?
+- Ban policy matrix by topic/severity/repeat count.
+- Whether permanent bans require dual control.
+- Retention period for removed content evidence.

--- a/docs/moderation-feature-flags-rollout.md
+++ b/docs/moderation-feature-flags-rollout.md
@@ -1,0 +1,46 @@
+# Moderation Feature Flags and Staged Rollout (MOD-028)
+
+This rollout plan is backed by runtime feature flags stored server-side and editable via admin API (root-only updates), so moderation behavior can be toggled without redeploy.
+
+## Runtime flags
+
+- `enabled`
+- `report_feed_enabled`
+- `report_messages_enabled`
+- `report_profile_enabled`
+- `admin_board_enabled`
+- `admin_actions_enabled`
+- `enforcement_enabled`
+- `min_scope_for_board` (`content_moderation` | `content_moderation_senior`)
+- `min_scope_for_actions` (`content_moderation` | `content_moderation_senior`)
+- `min_scope_for_permanent_ban` (`content_moderation` | `content_moderation_senior`)
+
+## API
+
+- `GET /v1/admin/moderation/feature-flags`
+- `PUT /v1/admin/moderation/feature-flags` (root only)
+
+## Suggested staged rollout
+
+1. **Dark launch**
+   - `enabled=true`
+   - `report_*_enabled=true`
+   - `admin_board_enabled=true`
+   - `admin_actions_enabled=false`
+2. **Board-only for senior admins**
+   - `min_scope_for_board=content_moderation_senior`
+3. **Operational rollout**
+   - `admin_actions_enabled=true`
+   - `min_scope_for_actions=content_moderation_senior`
+4. **Broaden to moderators**
+   - `min_scope_for_board=content_moderation`
+   - `min_scope_for_actions=content_moderation`
+5. **Permanent-ban control**
+   - Keep `min_scope_for_permanent_ban=content_moderation_senior`
+
+## Behavior summary
+
+- Report intake checks per-surface flags before persistence.
+- Admin board/ticket reads check board flag + minimum scope.
+- Admin actions (claim/decision/resolve/KPI alert evaluation) check actions flag + minimum scope.
+- Permanent-ban flow also checks `min_scope_for_permanent_ban`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ const SettingsPage = lazy(() => import("@/pages/settings/SettingsPage"));
 const PurchasesPage = lazy(() => import("@/pages/purchases/PurchasesPage"));
 const SubscriptionsPage = lazy(() => import("@/pages/subscriptions/SubscriptionsPage"));
 const RootRoleManagementPage = lazy(() => import("@/pages/admin/RootRoleManagementPage"));
+const ModerationBoardPage = lazy(() => import("@/pages/admin/ModerationBoardPage"));
 const PublicEventPage = lazy(() => import("@/pages/calendar/PublicEventPage"));
 const ContactsPage = lazy(() => import("@/pages/contacts/ContactsPage"));
 const HelpdeskPage = lazy(() => import("@/pages/helpdesk/HelpdeskPage"));
@@ -93,6 +94,7 @@ export default function App() {
           <Route path="purchases/:txnId" element={<PurchasesPage />} />
           <Route path="subscriptions" element={<SubscriptionsPage />} />
           <Route path="root/roles" element={<RootRoleManagementPage />} />
+          <Route path="admin/moderation" element={<ModerationBoardPage />} />
           {showDevtoolsLogUi && <Route path="dev-tools/log-ui" element={<DevToolsLogUiPage />} />}
           <Route path="*" element={<ErrorPage status={404} />} />
         </Route>

--- a/frontend/src/api/endpoints/moderation.ts
+++ b/frontend/src/api/endpoints/moderation.ts
@@ -1,0 +1,104 @@
+import { api } from "@/api/client";
+
+export interface CreateModerationReportReq {
+  content_type: "feed_post" | "feed_comment" | "feed_media" | "message" | "message_media" | "profile_photo";
+  content_id: string;
+  topics: string[];
+  reason_text: string;
+  post_id?: string;
+  comment_id?: string;
+  media_index?: number;
+  conversation_id?: string;
+  message_id?: string;
+  profile_user_id?: string;
+}
+
+export interface ModerationTicket {
+  ticket_id: string;
+  content_type: string;
+  content_id: string;
+  status: string;
+  priority: string;
+  queue: string;
+  assigned_admin_user_id?: string | null;
+  report_count: number;
+  aggregated_topics: string[];
+  latest_report_at: number;
+  updated_at: number;
+  created_at: number;
+}
+
+export interface ModerationTicketListResp {
+  items: ModerationTicket[];
+  next_cursor?: string | null;
+}
+
+export interface ModerationLinkedReport {
+  report_id: string;
+  reporter_user_id: string;
+  topics: string[];
+  reason_text: string;
+  created_at: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface ModerationTicketDetailResp {
+  ticket: ModerationTicket;
+  content_snapshot: Record<string, unknown>;
+  linked_reports: ModerationLinkedReport[];
+  offender_history_summary: {
+    offender_user_id?: string | null;
+    total_tickets: number;
+    open_tickets: number;
+    total_reports: number;
+  };
+  prior_enforcement_history: Array<{
+    ticket_id: string;
+    decision: string;
+    note: string;
+    decided_at: number;
+    decided_by: string;
+  }>;
+}
+
+export const createModerationReport = (body: CreateModerationReportReq) =>
+  api.post<{ ok: boolean; report_id: string }>("/moderation/reports", body);
+
+export const listModerationTickets = (params?: {
+  status?: string;
+  queue?: string;
+  topic?: "sexual" | "extortion" | "criminal" | "spam" | "racist";
+  assignee?: string;
+  limit?: number;
+  cursor?: string;
+}) => {
+  const q: Record<string, string> = {};
+  if (!params) return api.get<ModerationTicketListResp>("/v1/admin/moderation/tickets", q);
+  if (params.status) q.status = params.status;
+  if (params.queue) q.queue = params.queue;
+  if (params.topic) q.topic = params.topic;
+  if (params.assignee) q.assignee = params.assignee;
+  if (typeof params.limit === "number") q.limit = String(params.limit);
+  if (params.cursor) q.cursor = params.cursor;
+  return api.get<ModerationTicketListResp>("/v1/admin/moderation/tickets", q);
+};
+
+export const getModerationTicketDetail = (ticketId: string) =>
+  api.get<ModerationTicketDetailResp>(`/v1/admin/moderation/tickets/${encodeURIComponent(ticketId)}`);
+
+export const claimModerationTicket = (ticketId: string) =>
+  api.post<ModerationTicket>(`/v1/admin/moderation/tickets/${encodeURIComponent(ticketId)}/claim`, {});
+
+export const decideModerationTicket = (
+  ticketId: string,
+  body: { decision: "no_violation" | "remove" | "warn" | "ban"; note?: string },
+) => api.post<ModerationTicket>(`/v1/admin/moderation/tickets/${encodeURIComponent(ticketId)}/decision`, body);
+
+export const resolveModerationTicket = (
+  ticketId: string,
+  body: {
+    resolution: "no_violation" | "content_removed";
+    enforcement_action: "none" | "warn" | "ban";
+    note?: string;
+  },
+) => api.post<ModerationTicket>(`/v1/admin/moderation/tickets/${encodeURIComponent(ticketId)}/resolve`, body);

--- a/frontend/src/api/endpoints/newsfeed.ts
+++ b/frontend/src/api/endpoints/newsfeed.ts
@@ -96,3 +96,17 @@ export const removePostReaction = (postId: string, emoji: string) =>
 
 /** SSE stream URL for real-time feed updates */
 export const feedSseUrl = "/sse";
+
+
+export interface ReportFeedContentReq {
+  content_type: "feed_post" | "feed_comment" | "feed_media";
+  content_id: string;
+  topics: string[];
+  reason_text: string;
+  post_id?: string;
+  comment_id?: string;
+  media_index?: number;
+}
+
+export const reportFeedContent = (body: ReportFeedContentReq) =>
+  api.post<{ ok: boolean; report_id: string }>("/moderation/reports", body);

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -80,11 +80,12 @@ import {
   Bell,
   LifeBuoy,
   UsersRound,
+  Scale,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Separator } from "@/components/ui/separator";
 import { useAuthStore } from "@/stores/authStore";
-import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
+import { canAccessModerationBoard, canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 
 const MOBILE_NAV_GROUPS = [
   {
@@ -122,6 +123,7 @@ const MOBILE_NAV_GROUPS = [
   { label: "Ticket Spaces", path: "/tickets/spaces", icon: LifeBuoy },
       { label: "Settings", path: "/settings", icon: Settings },
       { label: "Role Mgmt", path: "/root/roles", icon: UsersRound },
+      { label: "Moderation Board", path: "/admin/moderation", icon: Scale },
     ],
   },
 ];
@@ -130,6 +132,7 @@ function MobileSidebar({ onNavigate }: { onNavigate: () => void }) {
   const location = useLocation();
   const accessToken = useAuthStore((s) => s.accessToken);
   const showRootRoleManagement = canSeeRootRoleManagement(accessToken);
+  const showModerationBoard = canAccessModerationBoard(accessToken);
 
   const isActive = (path: string) => {
     if (path === "/") return location.pathname === "/";
@@ -151,7 +154,11 @@ function MobileSidebar({ onNavigate }: { onNavigate: () => void }) {
       {/* Nav */}
       <nav className="flex-1 overflow-y-auto px-2 py-3">
         {MOBILE_NAV_GROUPS.map((group, gi) => {
-          const items = group.items.filter((item) => item.path !== "/root/roles" || showRootRoleManagement);
+          const items = group.items.filter((item) => {
+            if (item.path === "/root/roles") return showRootRoleManagement;
+            if (item.path === "/admin/moderation") return showModerationBoard;
+            return true;
+          });
           if (items.length === 0) return null;
           return (
           <div key={group.title}>

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -17,6 +17,7 @@ import {
   Settings,
   UsersRound,
   Bug,
+  Scale,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -28,7 +29,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useAuthStore } from "@/stores/authStore";
-import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
+import { canAccessModerationBoard, canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 import { isDevtoolsLogUiEnabled } from "@/lib/featureFlags";
 
 // ─── Tab config ─────────────────────────────────────────────────
@@ -53,6 +54,7 @@ const MORE_LINKS = [
   { label: "Settings", path: "/settings", icon: Settings },
   { label: "Dev Tools", path: "/dev-tools/log-ui", icon: Bug },
   { label: "Role Mgmt", path: "/root/roles", icon: UsersRound },
+  { label: "Moderation Board", path: "/admin/moderation", icon: Scale },
 ];
 
 // ─── MobileNav Component ────────────────────────────────────────
@@ -62,10 +64,12 @@ export default function MobileNav() {
   const navigate = useNavigate();
   const accessToken = useAuthStore((s) => s.accessToken);
   const showRootRoleManagement = canSeeRootRoleManagement(accessToken);
+  const showModerationBoard = canAccessModerationBoard(accessToken);
 
   const moreLinks = MORE_LINKS.filter((item) => {
     if (item.path === "/root/roles") return showRootRoleManagement;
     if (item.path === "/dev-tools/log-ui") return isDevtoolsLogUiEnabled();
+    if (item.path === "/admin/moderation") return showModerationBoard;
     return true;
   });
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   PanelLeftClose,
   PanelLeft,
   Bug,
+  Scale,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -29,7 +30,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { Separator } from "@/components/ui/separator";
 import { useUiStore } from "@/stores/uiStore";
 import { useAuthStore } from "@/stores/authStore";
-import { canSeeRootRoleManagement } from "@/lib/adminCapabilities";
+import { canAccessModerationBoard, canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 import { useQuery } from "@tanstack/react-query";
 import { getConversations } from "@/api/endpoints/messaging";
 import { isDevtoolsLogUiEnabled } from "@/lib/featureFlags";
@@ -88,6 +89,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Settings", path: "/settings", icon: <Settings className="h-5 w-5" /> },
       { label: "Dev Tools Log UI", path: "/dev-tools/log-ui", icon: <Bug className="h-5 w-5" /> },
       { label: "Role Management", path: "/root/roles", icon: <UsersRound className="h-5 w-5" /> },
+      { label: "Moderation Board", path: "/admin/moderation", icon: <Scale className="h-5 w-5" /> },
     ],
   },
 ];
@@ -100,6 +102,7 @@ export default function Sidebar() {
   const location = useLocation();
   const accessToken = useAuthStore((s) => s.accessToken);
   const showRootRoleManagement = canSeeRootRoleManagement(accessToken);
+  const showModerationBoard = canAccessModerationBoard(accessToken);
 
   const { data: convoData } = useQuery({
     queryKey: ["conversations"],
@@ -146,6 +149,7 @@ export default function Sidebar() {
           const items = group.items.filter((item) => {
             if (item.path === "/root/roles") return showRootRoleManagement;
             if (item.path === "/dev-tools/log-ui") return isDevtoolsLogUiEnabled();
+            if (item.path === "/admin/moderation") return showModerationBoard;
             return true;
           });
           if (items.length === 0) return null;

--- a/frontend/src/components/shared/ReportContentModal.test.tsx
+++ b/frontend/src/components/shared/ReportContentModal.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ReportContentModal } from "./ReportContentModal";
+
+describe("ReportContentModal", () => {
+  it("requires at least one topic", async () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <ReportContentModal
+        open
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Reason"), "A valid report reason.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Select at least one topic.");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows server error message", () => {
+    render(
+      <ReportContentModal
+        open
+        onOpenChange={vi.fn()}
+        serverError="Server rejected request"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Server rejected request");
+  });
+
+
+
+  it("validates minimum reason length and trims payload", async () => {
+    const onSubmit = vi.fn(async () => {});
+
+    render(
+      <ReportContentModal
+        open
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText("Spam"));
+    await userEvent.type(screen.getByLabelText("Reason"), " no ");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Reason must be at least 5 characters.");
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await userEvent.clear(screen.getByLabelText("Reason"));
+    await userEvent.type(screen.getByLabelText("Reason"), "   valid reason   ");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        topics: ["spam"],
+        reason_text: "valid reason",
+      });
+    });
+  });
+  it("emits normalized payload", async () => {
+    const onSubmit = vi.fn(async () => {});
+
+    render(
+      <ReportContentModal
+        open
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText("Criminal"));
+    await userEvent.click(screen.getByLabelText("Spam"));
+    await userEvent.type(screen.getByLabelText("Reason"), "Suspicious criminal spam content.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        topics: ["criminal", "spam"],
+        reason_text: "Suspicious criminal spam content.",
+      });
+    });
+  });
+});

--- a/frontend/src/components/shared/ReportContentModal.tsx
+++ b/frontend/src/components/shared/ReportContentModal.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+export const MODERATION_TOPICS = ["sexual", "extortion", "criminal", "spam", "racist"] as const;
+
+export type ModerationTopic = (typeof MODERATION_TOPICS)[number];
+
+export interface ReportContentPayload {
+  topics: ModerationTopic[];
+  reason_text: string;
+}
+
+interface ReportContentModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  description?: string;
+  submitLabel?: string;
+  cancelLabel?: string;
+  isSubmitting?: boolean;
+  serverError?: string | null;
+  onSubmit: (payload: ReportContentPayload) => Promise<void> | void;
+}
+
+const TOPIC_LABELS: Record<ModerationTopic, string> = {
+  sexual: "Sexual",
+  extortion: "Extortion",
+  criminal: "Criminal",
+  spam: "Spam",
+  racist: "Racist",
+};
+
+export function ReportContentModal({
+  open,
+  onOpenChange,
+  title = "Report content",
+  description = "Select at least one topic and explain why this content should be reviewed.",
+  submitLabel = "Submit report",
+  cancelLabel = "Cancel",
+  isSubmitting,
+  serverError,
+  onSubmit,
+}: ReportContentModalProps) {
+  const [selectedTopics, setSelectedTopics] = useState<ModerationTopic[]>([]);
+  const [reasonText, setReasonText] = useState("");
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedTopics([]);
+      setReasonText("");
+      setClientError(null);
+    }
+  }, [open]);
+
+  const trimmedReasonText = useMemo(() => reasonText.trim(), [reasonText]);
+
+  const toggleTopic = (topic: ModerationTopic, checked: boolean) => {
+    setClientError(null);
+    setSelectedTopics((prev) => {
+      if (checked) {
+        if (prev.includes(topic)) return prev;
+        return [...prev, topic];
+      }
+      return prev.filter((item) => item !== topic);
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedTopics.length) {
+      setClientError("Select at least one topic.");
+      return;
+    }
+
+    if (trimmedReasonText.length < 5) {
+      setClientError("Reason must be at least 5 characters.");
+      return;
+    }
+
+    setClientError(null);
+    try {
+      await onSubmit({ topics: selectedTopics, reason_text: trimmedReasonText });
+    } catch {
+      // server-side error is surfaced by parent via `serverError`
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !isSubmitting && onOpenChange(next)}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium">Topics</legend>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2" role="group" aria-label="Report topics">
+              {MODERATION_TOPICS.map((topic) => {
+                const checked = selectedTopics.includes(topic);
+                return (
+                  <label
+                    key={topic}
+                    htmlFor={`report-topic-${topic}`}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 rounded-md border p-2 text-sm transition-colors",
+                      checked ? "border-primary bg-primary/5" : "border-border",
+                    )}
+                  >
+                    <Checkbox
+                      id={`report-topic-${topic}`}
+                      checked={checked}
+                      onCheckedChange={(value) => toggleTopic(topic, value === true)}
+                    />
+                    {TOPIC_LABELS[topic]}
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="space-y-1.5">
+            <label htmlFor="report-reason-text" className="text-sm font-medium">Reason</label>
+            <Textarea
+              id="report-reason-text"
+              value={reasonText}
+              onChange={(event) => {
+                setReasonText(event.target.value);
+                setClientError(null);
+              }}
+              placeholder="Describe why this should be reviewed."
+              rows={4}
+              minLength={5}
+              maxLength={2000}
+              aria-describedby="report-reason-help"
+            />
+            <p id="report-reason-help" className="text-xs text-muted-foreground">
+              Required (5–2000 characters).
+            </p>
+          </div>
+
+          {(clientError || serverError) && (
+            <p role="alert" className="text-sm text-red-600">{clientError ?? serverError}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+            {cancelLabel}
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={isSubmitting}>
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/adminCapabilities.test.ts
+++ b/frontend/src/lib/adminCapabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   canAccessGeneralAdminControls,
+  canAccessModerationBoard,
   canSeeRootRoleManagement,
   getAdminProfileFromAccessToken,
   getRoleFromAccessToken,
@@ -50,3 +51,16 @@ describe("adminCapabilities", () => {
     expect(canSeeRootRoleManagement(tokenFor({ role: "user" }))).toBe(false);
   });
 });
+
+
+  it("gates moderation board visibility", () => {
+    expect(canAccessModerationBoard(tokenFor({ role: "root" }))).toBe(true);
+    expect(canAccessModerationBoard(tokenFor({ role: "admin" }))).toBe(true);
+    expect(
+      canAccessModerationBoard(tokenFor({ role: "admin", admin_profile: { type: "scoped", scopes: ["content_moderation"] } })),
+    ).toBe(true);
+    expect(
+      canAccessModerationBoard(tokenFor({ role: "admin", admin_profile: { type: "scoped", scopes: ["billing_support"] } })),
+    ).toBe(false);
+    expect(canAccessModerationBoard(tokenFor({ role: "user" }))).toBe(false);
+  });

--- a/frontend/src/lib/adminCapabilities.ts
+++ b/frontend/src/lib/adminCapabilities.ts
@@ -54,3 +54,13 @@ export function canAccessGeneralAdminControls(token: string | null): boolean {
 export function canSeeRootRoleManagement(token: string | null): boolean {
   return getRoleFromAccessToken(token) === "root";
 }
+
+
+export function canAccessModerationBoard(token: string | null): boolean {
+  const role = getRoleFromAccessToken(token);
+  if (role === "root") return true;
+  if (role !== "admin") return false;
+  const profile = getAdminProfileFromAccessToken(token);
+  if (!profile) return false;
+  return profile.type === "general" || profile.scopes.includes("content_moderation");
+}

--- a/frontend/src/pages/admin/ModerationBoardPage.tsx
+++ b/frontend/src/pages/admin/ModerationBoardPage.tsx
@@ -1,0 +1,301 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { PageHeader } from "@/components/shared/PageHeader";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuthStore } from "@/stores/authStore";
+import { canAccessModerationBoard } from "@/lib/adminCapabilities";
+import {
+  claimModerationTicket,
+  resolveModerationTicket,
+  getModerationTicketDetail,
+  listModerationTickets,
+  type ModerationTicket,
+} from "@/api/endpoints/moderation";
+
+const QUEUES = ["newsfeed", "messages", "profile"] as const;
+
+function fmt(ts?: number) {
+  if (!ts) return "—";
+  return new Date(ts * 1000).toLocaleString();
+}
+
+export default function ModerationBoardPage() {
+  const token = useAuthStore((s) => s.accessToken);
+  const currentUserSub = useAuthStore((s) => s.userId);
+  const canAccess = canAccessModerationBoard(token);
+
+  const [queue, setQueue] = useState<string>("newsfeed");
+  const [status, setStatus] = useState<string>("open");
+  const [topic, setTopic] = useState<string>("");
+  const [assignee, setAssignee] = useState<string>("");
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
+  const [resolution, setResolution] = useState<"no_violation" | "content_removed">("no_violation");
+  const [enforcementAction, setEnforcementAction] = useState<"none" | "warn" | "ban">("none");
+  const [decisionNote, setDecisionNote] = useState<string>("");
+
+  const listQuery = useQuery({
+    queryKey: ["moderation-board", queue, status, topic, assignee, cursor],
+    queryFn: () =>
+      listModerationTickets({
+        queue,
+        status: status || undefined,
+        topic: (topic || undefined) as "sexual" | "extortion" | "criminal" | "spam" | "racist" | undefined,
+        assignee: assignee || undefined,
+        cursor,
+        limit: 20,
+      }),
+    enabled: canAccess,
+  });
+
+  const selectedId = selectedTicketId || listQuery.data?.items?.[0]?.ticket_id || null;
+
+  const detailQuery = useQuery({
+    queryKey: ["moderation-board", "detail", selectedId],
+    queryFn: () => getModerationTicketDetail(selectedId!),
+    enabled: canAccess && !!selectedId,
+  });
+
+  const claimMutation = useMutation({
+    mutationFn: (ticketId: string) => claimModerationTicket(ticketId),
+    onSuccess: () => {
+      toast.success("Ticket claimed");
+      void listQuery.refetch();
+      void detailQuery.refetch();
+    },
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : "Unable to claim ticket"),
+  });
+
+
+  const decisionMutation = useMutation({
+    mutationFn: (input: { ticketId: string; resolution: "no_violation" | "content_removed"; enforcement_action: "none" | "warn" | "ban"; note?: string }) =>
+      resolveModerationTicket(input.ticketId, { resolution: input.resolution, enforcement_action: input.enforcement_action, note: input.note }),
+    onSuccess: () => {
+      toast.success("Decision recorded");
+      setDecisionNote("");
+      void listQuery.refetch();
+      void detailQuery.refetch();
+    },
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : "Unable to apply decision"),
+  });
+
+  const tickets = listQuery.data?.items ?? [];
+
+  const queueCounts = useMemo(() => {
+    const out: Record<string, number> = { newsfeed: 0, messages: 0, profile: 0 };
+    for (const t of tickets) out[t.queue] = (out[t.queue] || 0) + 1;
+    return out;
+  }, [tickets]);
+
+  if (!canAccess) {
+    return (
+      <div className="space-y-6 p-4 md:p-6 lg:p-8">
+        <PageHeader title="Moderation Board" description="Review and assign moderation tickets." />
+        <Card>
+          <CardHeader><CardTitle>Unauthorized</CardTitle></CardHeader>
+          <CardContent className="text-sm text-muted-foreground">You need content moderation admin permissions to access this board.</CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4 md:p-6 lg:p-8">
+      <PageHeader title="Moderation Board" description="Browse queues, filter tickets, and claim work." />
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {QUEUES.map((q) => (
+          <Button key={q} variant={queue === q ? "default" : "outline"} onClick={() => { setQueue(q); setCursor(undefined); }}>
+            {q} <span className="ml-2 text-xs opacity-80">{queueCounts[q] ?? 0}</span>
+          </Button>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+          <CardDescription>Refine by status/topic/assignee.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-4">
+          <div className="space-y-1">
+            <Label htmlFor="mod-status">Status</Label>
+            <select id="mod-status" className="h-9 w-full rounded-md border bg-background px-3 text-sm" value={status} onChange={(e) => setStatus(e.target.value)}>
+              <option value="">All</option>
+              <option value="open">open</option>
+              <option value="in_review">in_review</option>
+              <option value="closed">closed</option>
+            </select>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="mod-topic">Topic</Label>
+            <select id="mod-topic" className="h-9 w-full rounded-md border bg-background px-3 text-sm" value={topic} onChange={(e) => setTopic(e.target.value)}>
+              <option value="">All</option>
+              <option value="sexual">sexual</option>
+              <option value="extortion">extortion</option>
+              <option value="criminal">criminal</option>
+              <option value="spam">spam</option>
+              <option value="racist">racist</option>
+            </select>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="mod-assignee">Assignee</Label>
+            <Input id="mod-assignee" value={assignee} onChange={(e) => setAssignee(e.target.value)} placeholder="admin_user_sub" />
+          </div>
+          <div className="flex items-end gap-2">
+            <Button variant="secondary" onClick={() => { setCursor(undefined); void listQuery.refetch(); }}>Apply</Button>
+            <Button variant="outline" onClick={() => { setStatus("open"); setTopic(""); setAssignee(""); setCursor(undefined); }}>Reset</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-[1.1fr,1.3fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tickets</CardTitle>
+            <CardDescription>{listQuery.isLoading ? "Loading moderation tickets..." : "Select a ticket to review."}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {listQuery.isError && <div className="text-sm text-destructive">Failed to load tickets.</div>}
+            {!listQuery.isLoading && tickets.length === 0 && <div className="text-sm text-muted-foreground">No tickets found for current filters.</div>}
+            <div className="max-h-[460px] space-y-2 overflow-auto">
+              {tickets.map((t: ModerationTicket) => (
+                <button key={t.ticket_id} className={`w-full rounded-md border p-2 text-left text-sm ${selectedId === t.ticket_id ? "border-primary bg-primary/5" : "hover:bg-muted/30"}`} onClick={() => setSelectedTicketId(t.ticket_id)}>
+                  <div className="flex items-center justify-between">
+                    <div className="font-medium">{t.ticket_id}</div>
+                    <Badge variant="outline">{t.status}</Badge>
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">{t.queue} • {t.content_type} • reports {t.report_count}</div>
+                </button>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => void listQuery.refetch()} disabled={listQuery.isFetching}>Refresh</Button>
+              <Button variant="outline" onClick={() => setCursor(listQuery.data?.next_cursor || undefined)} disabled={!listQuery.data?.next_cursor}>Next page</Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Ticket Detail</CardTitle>
+            <CardDescription>{selectedId || "No ticket selected"}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {detailQuery.isLoading && <div className="text-sm text-muted-foreground">Loading ticket detail...</div>}
+            {detailQuery.isError && <div className="text-sm text-destructive">Failed to load ticket detail.</div>}
+            {detailQuery.data && (
+              <>
+                <div className="flex flex-wrap gap-2 text-xs">
+                  <Badge variant="secondary">{detailQuery.data.ticket.priority}</Badge>
+                  <span>Queue: {detailQuery.data.ticket.queue}</span>
+                  <span>Assigned: {detailQuery.data.ticket.assigned_admin_user_id || "unassigned"}</span>
+                  <span>Updated: {fmt(detailQuery.data.ticket.updated_at)}</span>
+                </div>
+                <div className="rounded-md border p-3 text-sm">
+                  <div className="mb-1 font-medium">Content snapshot</div>
+                  <pre className="overflow-auto text-xs">{JSON.stringify(detailQuery.data.content_snapshot, null, 2)}</pre>
+                </div>
+                <div className="rounded-md border p-3">
+                  <div className="mb-2 font-medium text-sm">Linked reports</div>
+                  <div className="max-h-[180px] space-y-2 overflow-auto">
+                    {detailQuery.data.linked_reports.map((r) => (
+                      <div key={r.report_id} className="rounded bg-muted/40 p-2 text-xs">
+                        <div className="font-medium">{r.report_id} • {r.reporter_user_id}</div>
+                        <div>topics: {r.topics.join(", ") || "—"}</div>
+                        <div>{r.reason_text}</div>
+                      </div>
+                    ))}
+                    {detailQuery.data.linked_reports.length === 0 && <div className="text-xs text-muted-foreground">No linked reports.</div>}
+                  </div>
+                </div>
+                <div className="rounded-md border p-3 text-xs">
+                  <div>Offender: {detailQuery.data.offender_history_summary.offender_user_id || "unknown"}</div>
+                  <div>Total tickets: {detailQuery.data.offender_history_summary.total_tickets}</div>
+                  <div>Open tickets: {detailQuery.data.offender_history_summary.open_tickets}</div>
+                  <div>Total reports: {detailQuery.data.offender_history_summary.total_reports}</div>
+                </div>
+                <div className="rounded-md border p-3 text-xs">
+                  <div className="mb-2 font-medium text-sm">Prior enforcement history</div>
+                  <div className="max-h-[120px] space-y-1 overflow-auto">
+                    {detailQuery.data.prior_enforcement_history.length === 0 && (
+                      <div className="text-muted-foreground">No prior enforcement actions.</div>
+                    )}
+                    {detailQuery.data.prior_enforcement_history.map((h) => (
+                      <div key={`${h.ticket_id}-${h.decided_at}`} className="rounded bg-muted/40 p-2">
+                        <div>{h.ticket_id} • {h.decision} • {h.decided_by || "unknown"}</div>
+                        <div className="text-muted-foreground">{h.note || "—"}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-md border p-3 space-y-2">
+                  <div className="font-medium text-sm">Decision panel</div>
+                  <select
+                    className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                    value={resolution}
+                    onChange={(e) => {
+                      const v = e.target.value as "no_violation" | "content_removed";
+                      setResolution(v);
+                      if (v === "no_violation") setEnforcementAction("none");
+                    }}
+                  >
+                    <option value="no_violation">no_violation</option>
+                    <option value="content_removed">content_removed</option>
+                  </select>
+                  <select
+                    className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                    value={enforcementAction}
+                    onChange={(e) => setEnforcementAction(e.target.value as "none" | "warn" | "ban")}
+                    disabled={resolution === "no_violation"}
+                  >
+                    <option value="none">none</option>
+                    <option value="warn">warn</option>
+                    <option value="ban">ban</option>
+                  </select>
+                  <Input
+                    value={decisionNote}
+                    onChange={(e) => setDecisionNote(e.target.value)}
+                    placeholder="Decision note (optional)"
+                  />
+                  <div className="flex gap-2">
+                    <Button
+                      onClick={() =>
+                        selectedId &&
+                        decisionMutation.mutate({
+                          ticketId: selectedId,
+                          resolution,
+                          enforcement_action: resolution === "no_violation" ? "none" : enforcementAction,
+                          note: decisionNote.trim() || undefined,
+                        })
+                      }
+                      disabled={!selectedId || decisionMutation.isPending}
+                    >
+                      Apply decision
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => selectedId && claimMutation.mutate(selectedId)}
+                      disabled={!selectedId || claimMutation.isPending || detailQuery.data.ticket.assigned_admin_user_id === currentUserSub}
+                    >
+                      {detailQuery.data.ticket.assigned_admin_user_id === currentUserSub ? "Claimed by you" : "Claim ticket"}
+                    </Button>
+                  </div>
+                </div>
+              </>
+            )}
+            {!detailQuery.isLoading && !detailQuery.data && !detailQuery.isError && (
+              <div className="text-sm text-muted-foreground">Select a ticket from the list to begin moderation.</div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/__tests__/ModerationBoardPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ModerationBoardPage.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import ModerationBoardPage from "../ModerationBoardPage";
+
+const listModerationTickets = vi.fn();
+const getModerationTicketDetail = vi.fn();
+const resolveModerationTicket = vi.fn();
+const claimModerationTicket = vi.fn();
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/api/endpoints/moderation", () => ({
+  listModerationTickets: (...args: unknown[]) => listModerationTickets(...args),
+  getModerationTicketDetail: (...args: unknown[]) => getModerationTicketDetail(...args),
+  resolveModerationTicket: (...args: unknown[]) => resolveModerationTicket(...args),
+  claimModerationTicket: (...args: unknown[]) => claimModerationTicket(...args),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (selector: (s: { accessToken: string | null; userId: string | null }) => unknown) =>
+    selector({ accessToken: "token", userId: "admin_1" }),
+}));
+
+vi.mock("@/lib/adminCapabilities", () => ({
+  canAccessModerationBoard: vi.fn(() => true),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+const ticket = {
+  ticket_id: "modtk_1",
+  content_type: "feed_post",
+  content_id: "post_1",
+  status: "open",
+  priority: "high",
+  queue: "newsfeed",
+  assigned_admin_user_id: "UNASSIGNED",
+  report_count: 1,
+  aggregated_topics: ["criminal"],
+  latest_report_at: 1700000010,
+  updated_at: 1700000010,
+  created_at: 1700000000,
+};
+
+const detail = {
+  ticket,
+  content_snapshot: { exists: true, author_user_id: "u_offender" },
+  linked_reports: [
+    {
+      report_id: "rpt_1",
+      reporter_user_id: "u_reporter",
+      topics: ["criminal"],
+      reason_text: "Threat",
+      created_at: 1700000010,
+      metadata: {},
+    },
+  ],
+  offender_history_summary: {
+    offender_user_id: "u_offender",
+    total_tickets: 2,
+    open_tickets: 1,
+    total_reports: 3,
+  },
+  prior_enforcement_history: [],
+};
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ModerationBoardPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ModerationBoardPage decision panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listModerationTickets.mockResolvedValue({ items: [ticket], next_cursor: null });
+    getModerationTicketDetail.mockResolvedValue(detail);
+    resolveModerationTicket.mockResolvedValue({ ...ticket, status: "closed" });
+    claimModerationTicket.mockResolvedValue({ ...ticket, assigned_admin_user_id: "admin_1" });
+  });
+
+  it("applies no_violation with enforced none action", async () => {
+    renderPage();
+
+    expect(await screen.findByText("Decision panel")).toBeInTheDocument();
+
+    const selects = screen.getAllByRole("combobox");
+    const [resolutionSelect, enforcementSelect] = selects.slice(-2) as HTMLSelectElement[];
+
+    await userEvent.selectOptions(resolutionSelect, "no_violation");
+    expect(enforcementSelect).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Apply decision" }));
+
+    await waitFor(() => {
+      expect(resolveModerationTicket).toHaveBeenCalledWith("modtk_1", {
+        resolution: "no_violation",
+        enforcement_action: "none",
+        note: undefined,
+      });
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Decision recorded");
+  });
+
+  it("submits content_removed + warn decision with trimmed note", async () => {
+    renderPage();
+
+    expect(await screen.findByText("Decision panel")).toBeInTheDocument();
+
+    const selects = screen.getAllByRole("combobox");
+    const [resolutionSelect, enforcementSelect] = selects.slice(-2) as HTMLSelectElement[];
+
+    await userEvent.selectOptions(resolutionSelect, "content_removed");
+    await userEvent.selectOptions(enforcementSelect, "warn");
+
+    const note = screen.getByPlaceholderText("Decision note (optional)");
+    await userEvent.type(note, "  enforce warning please  ");
+    await userEvent.click(screen.getByRole("button", { name: "Apply decision" }));
+
+    await waitFor(() => {
+      expect(resolveModerationTicket).toHaveBeenCalledWith("modtk_1", {
+        resolution: "content_removed",
+        enforcement_action: "warn",
+        note: "enforce warning please",
+      });
+    });
+  });
+});

--- a/frontend/src/pages/contacts/ContactsPage.report.test.tsx
+++ b/frontend/src/pages/contacts/ContactsPage.report.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import ContactsPage from "./ContactsPage";
+
+const createModerationReport = vi.fn();
+
+vi.mock("@/api/endpoints/contacts", () => ({
+  getContacts: vi.fn(async () => ([
+    {
+      contact_id: "u2",
+      display_name: "Alex",
+      profile_photo_url: "https://example.com/photo.jpg",
+      is_favorite: false,
+      is_blocked: false,
+    },
+  ])),
+  addContact: vi.fn(async () => ({})),
+  removeContact: vi.fn(async () => ({})),
+  updateContact: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/api/endpoints/messaging", () => ({
+  findOrCreateDm: vi.fn(async () => ({ conversation_id: "c1" })),
+  sendFileShareMessage: vi.fn(async () => ({})),
+  sendCalendarShareMessage: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/api/endpoints/moderation", () => ({
+  createModerationReport: (...args: unknown[]) => createModerationReport(...args),
+}));
+
+vi.mock("@/pages/messages/UserSearch", () => ({ UserSearch: () => null }));
+vi.mock("@/pages/messages/FilePickerDialog", () => ({ FilePickerDialog: () => null }));
+vi.mock("@/pages/messages/CalendarPickerDialog", () => ({ CalendarPickerDialog: () => null }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <ContactsPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Contacts profile photo reporting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits report with content_type=profile_photo", async () => {
+    createModerationReport.mockResolvedValue({ ok: true, report_id: "r1" });
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Open Alex profile photo/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /Report profile photo/i }));
+
+    await userEvent.click(screen.getByLabelText("Spam"));
+    await userEvent.type(screen.getByLabelText("Reason"), "This photo is spam.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => {
+      expect(createModerationReport).toHaveBeenCalledWith({
+        content_type: "profile_photo",
+        content_id: "u2",
+        profile_user_id: "u2",
+        topics: ["spam"],
+        reason_text: "This photo is spam.",
+      });
+    });
+  });
+});

--- a/frontend/src/pages/contacts/ContactsPage.tsx
+++ b/frontend/src/pages/contacts/ContactsPage.tsx
@@ -9,6 +9,7 @@ import {
   MoreVertical,
   UserPlus,
   User,
+  Flag,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -18,6 +19,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import {
   DropdownMenu,
@@ -27,10 +29,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import { ApiError } from "@/api/client";
 
 import { getContacts, addContact, removeContact, updateContact } from "@/api/endpoints/contacts";
 import { findOrCreateDm, sendFileShareMessage, sendCalendarShareMessage } from "@/api/endpoints/messaging";
+import { createModerationReport } from "@/api/endpoints/moderation";
 import type { ContactEntry, FileEntry, SendCalendarShareReq } from "@/api/types";
+import { ReportContentModal, type ReportContentPayload } from "@/components/shared/ReportContentModal";
 
 import { UserSearch } from "@/pages/messages/UserSearch";
 import { FilePickerDialog } from "@/pages/messages/FilePickerDialog";
@@ -38,14 +43,21 @@ import { CalendarPickerDialog } from "@/pages/messages/CalendarPickerDialog";
 
 // ── Avatar ─────────────────────────────────────────────────────────────────
 
-function ContactAvatar({ contact }: { contact: ContactEntry }) {
+function ContactAvatar({ contact, onOpenPhoto }: { contact: ContactEntry; onOpenPhoto: () => void }) {
   if (contact.profile_photo_url) {
     return (
-      <img
-        src={contact.profile_photo_url}
-        alt={contact.display_name}
-        className="h-9 w-9 rounded-full object-cover shrink-0"
-      />
+      <button
+        type="button"
+        onClick={onOpenPhoto}
+        className="shrink-0"
+        aria-label={`Open ${contact.display_name} profile photo`}
+      >
+        <img
+          src={contact.profile_photo_url}
+          alt={contact.display_name}
+          className="h-9 w-9 rounded-full object-cover"
+        />
+      </button>
     );
   }
   return (
@@ -76,6 +88,7 @@ interface ContactRowProps {
   onBlock: () => void;
   onUnblock: () => void;
   onRemove: () => void;
+  onOpenPhoto: () => void;
 }
 
 function ContactRow({
@@ -87,10 +100,11 @@ function ContactRow({
   onBlock,
   onUnblock,
   onRemove,
+  onOpenPhoto,
 }: ContactRowProps) {
   return (
     <div className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-accent/40 transition-colors">
-      <ContactAvatar contact={contact} />
+      <ContactAvatar contact={contact} onOpenPhoto={onOpenPhoto} />
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium">{contact.display_name}</p>
@@ -182,6 +196,9 @@ export default function ContactsPage() {
   const [addOpen, setAddOpen] = React.useState(false);
   const [fileShareConvoId, setFileShareConvoId] = React.useState<string | null>(null);
   const [calShareConvoId, setCalShareConvoId] = React.useState<string | null>(null);
+  const [profilePhotoContact, setProfilePhotoContact] = React.useState<ContactEntry | null>(null);
+  const [reportOpen, setReportOpen] = React.useState(false);
+  const [reportServerError, setReportServerError] = React.useState<string | null>(null);
 
   // ── Data ────────────────────────────────────────────────────────────────
 
@@ -215,6 +232,33 @@ export default function ContactsPage() {
       updateContact(id, patch),
     onSuccess: invalidateContacts,
     onError: () => toast.error("Failed to update contact"),
+  });
+
+
+  const reportMut = useMutation({
+    mutationFn: ({ topics, reason_text }: ReportContentPayload) => {
+      if (!profilePhotoContact) throw new Error("No profile selected");
+      return createModerationReport({
+        content_type: "profile_photo",
+        content_id: profilePhotoContact.contact_id,
+        profile_user_id: profilePhotoContact.contact_id,
+        topics,
+        reason_text,
+      });
+    },
+    onSuccess: () => {
+      toast.success("Report received");
+      setReportOpen(false);
+      setReportServerError(null);
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && typeof error.message === "string" && error.message.trim()) {
+        setReportServerError(error.message);
+      } else {
+        setReportServerError("Could not submit report. Please try again.");
+      }
+      toast.error("Could not submit report. Please try again.");
+    },
   });
 
   // ── Action handlers ──────────────────────────────────────────────────────
@@ -312,6 +356,7 @@ export default function ContactsPage() {
               onBlock={() => handleBlock(c)}
               onUnblock={() => handleUnblock(c)}
               onRemove={() => handleRemove(c)}
+              onOpenPhoto={() => setProfilePhotoContact(c)}
             />
           ))}
         </div>
@@ -382,6 +427,63 @@ export default function ContactsPage() {
         onClose={() => setCalShareConvoId(null)}
         onSelect={handleCalendarSelect}
       />
+
+
+      <Dialog
+        open={profilePhotoContact !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setProfilePhotoContact(null);
+            if (!reportMut.isPending) setReportServerError(null);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{profilePhotoContact?.display_name ?? "Profile photo"}</DialogTitle>
+            <DialogDescription>View and report this profile photo.</DialogDescription>
+          </DialogHeader>
+          {profilePhotoContact?.profile_photo_url ? (
+            <div className="space-y-3">
+              <img
+                src={profilePhotoContact.profile_photo_url}
+                alt={profilePhotoContact.display_name}
+                className="w-full max-h-[70vh] rounded-lg object-contain"
+              />
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setReportOpen(true)}
+                  className="gap-1.5"
+                >
+                  <Flag className="h-4 w-4" /> Report profile photo
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      {profilePhotoContact && (
+        <ReportContentModal
+          open={reportOpen}
+          onOpenChange={(open) => {
+            setReportOpen(open);
+            if (!open && !reportMut.isPending) {
+              setReportServerError(null);
+            }
+          }}
+          title="Report profile photo"
+          description="Share why this profile photo should be reviewed."
+          serverError={reportServerError}
+          isSubmitting={reportMut.isPending}
+          onSubmit={async (payload) => {
+            setReportServerError(null);
+            await reportMut.mutateAsync(payload);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/feed/CommentsThread.tsx
+++ b/frontend/src/pages/feed/CommentsThread.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Send, MoreHorizontal, Pencil, Trash2, X, Check, DollarSign } from "lucide-react";
+import { Send, MoreHorizontal, Pencil, Trash2, X, Check, DollarSign, Flag } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -12,13 +12,16 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { ReportContentModal, type ReportContentPayload } from "@/components/shared/ReportContentModal";
 import {
   getComments,
   createComment,
   editComment,
   deleteComment,
+  reportFeedContent,
 } from "@/api/endpoints/newsfeed";
 import { useAuthStore } from "@/stores/authStore";
+import { ApiError } from "@/api/client";
 import type { FeedComment } from "@/api/types";
 import { TipDialog } from "./TipDialog";
 import { MarkdownComposer, type EditorMode, type RichDoc, richDocToPlain, buildContentPayload } from "./MarkdownComposer";
@@ -171,6 +174,8 @@ function CommentRow({ comment, postId, isOwn }: CommentRowProps) {
   const [editRichDoc, setEditRichDoc] = useState<RichDoc | null>((comment.body_rich as RichDoc | undefined) ?? null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [tipOpen, setTipOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reportServerError, setReportServerError] = useState<string | null>(null);
 
   const editMut = useMutation({
     mutationFn: () => editComment(postId, comment.comment_id, buildContentPayload(editBody, editMode, editRichDoc)),
@@ -180,6 +185,31 @@ function CommentRow({ comment, postId, isOwn }: CommentRowProps) {
       setEditing(false);
     },
     onError: (err: unknown) => toast.error(err instanceof Error ? err.message : "Failed to update comment"),
+  });
+
+
+  const reportMut = useMutation({
+    mutationFn: ({ topics, reason_text }: ReportContentPayload) => reportFeedContent({
+      content_type: "feed_comment",
+      content_id: comment.comment_id,
+      topics,
+      reason_text,
+      post_id: postId,
+      comment_id: comment.comment_id,
+    }),
+    onSuccess: () => {
+      toast.success("Report received");
+      setReportOpen(false);
+      setReportServerError(null);
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && typeof error.message === "string" && error.message.trim()) {
+        setReportServerError(error.message);
+      } else {
+        setReportServerError("Could not submit report. Please try again.");
+      }
+      toast.error("Could not submit report. Please try again.");
+    },
   });
 
   const deleteMut = useMutation({
@@ -302,28 +332,37 @@ function CommentRow({ comment, postId, isOwn }: CommentRowProps) {
           )}
         </div>
 
-        {/* Actions menu — own comments only, when not editing */}
-        {isOwn && !editing && (
+        {/* Actions menu */}
+        {!editing && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
                 className="h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                aria-label="Comment actions"
               >
                 <MoreHorizontal className="h-3.5 w-3.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={startEdit}>
-                <Pencil className="mr-2 h-3.5 w-3.5" /> Edit
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="text-destructive focus:text-destructive"
-                onClick={() => setDeleteOpen(true)}
-              >
-                <Trash2 className="mr-2 h-3.5 w-3.5" /> Delete
-              </DropdownMenuItem>
+              {isOwn ? (
+                <>
+                  <DropdownMenuItem onClick={startEdit}>
+                    <Pencil className="mr-2 h-3.5 w-3.5" /> Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => setDeleteOpen(true)}
+                  >
+                    <Trash2 className="mr-2 h-3.5 w-3.5" /> Delete
+                  </DropdownMenuItem>
+                </>
+              ) : (
+                <DropdownMenuItem onClick={() => setReportOpen(true)}>
+                  <Flag className="mr-2 h-3.5 w-3.5" /> Report comment
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}
@@ -339,6 +378,26 @@ function CommentRow({ comment, postId, isOwn }: CommentRowProps) {
         onConfirm={() => deleteMut.mutate()}
         loading={deleteMut.isPending}
       />
+
+      {!isOwn && (
+        <ReportContentModal
+          open={reportOpen}
+          onOpenChange={(open) => {
+            setReportOpen(open);
+            if (!open && !reportMut.isPending) {
+              setReportServerError(null);
+            }
+          }}
+          title="Report comment"
+          description="Share why this comment should be reviewed."
+          serverError={reportServerError}
+          isSubmitting={reportMut.isPending}
+          onSubmit={async (payload) => {
+            setReportServerError(null);
+            await reportMut.mutateAsync(payload);
+          }}
+        />
+      )}
 
       {!isOwn && (
         <TipDialog

--- a/frontend/src/pages/feed/PostActions.tsx
+++ b/frontend/src/pages/feed/PostActions.tsx
@@ -11,7 +11,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
-import { deletePost, hidePost } from "@/api/endpoints/newsfeed";
+import { ReportContentModal, type ReportContentPayload } from "@/components/shared/ReportContentModal";
+import { deletePost, hidePost, reportFeedContent } from "@/api/endpoints/newsfeed";
+import { ApiError } from "@/api/client";
 
 interface PostActionsProps {
   postId: string;
@@ -22,6 +24,8 @@ interface PostActionsProps {
 export function PostActions({ postId, isOwn, onEdit }: PostActionsProps) {
   const queryClient = useQueryClient();
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reportServerError, setReportServerError] = useState<string | null>(null);
 
   const deleteMut = useMutation({
     mutationFn: () => deletePost(postId),
@@ -40,6 +44,29 @@ export function PostActions({ postId, isOwn, onEdit }: PostActionsProps) {
       void queryClient.invalidateQueries({ queryKey: ["feed"] });
     },
     onError: () => toast.error("Failed to hide post"),
+  });
+
+  const reportMut = useMutation({
+    mutationFn: ({ topics, reason_text }: ReportContentPayload) => reportFeedContent({
+      content_type: "feed_post",
+      content_id: postId,
+      topics,
+      reason_text,
+      post_id: postId,
+    }),
+    onSuccess: () => {
+      toast.success("Report received");
+      setReportOpen(false);
+      setReportServerError(null);
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && typeof error.message === "string" && error.message.trim()) {
+        setReportServerError(error.message);
+      } else {
+        setReportServerError("Could not submit report. Please try again.");
+      }
+      toast.error("Could not submit report. Please try again.");
+    },
   });
 
   return (
@@ -78,9 +105,7 @@ export function PostActions({ postId, isOwn, onEdit }: PostActionsProps) {
               <DropdownMenuItem onClick={() => hideMut.mutate()}>
                 <EyeOff className="mr-2 h-4 w-4" /> Hide
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => toast.info("Report submitted")}
-              >
+              <DropdownMenuItem onClick={() => setReportOpen(true)}>
                 <Flag className="mr-2 h-4 w-4" /> Report
               </DropdownMenuItem>
             </>
@@ -98,6 +123,26 @@ export function PostActions({ postId, isOwn, onEdit }: PostActionsProps) {
         onConfirm={() => deleteMut.mutate()}
         loading={deleteMut.isPending}
       />
+
+      {!isOwn && (
+        <ReportContentModal
+          open={reportOpen}
+          onOpenChange={(open) => {
+            setReportOpen(open);
+            if (!open && !reportMut.isPending) {
+              setReportServerError(null);
+            }
+          }}
+          title="Report post"
+          description="Share why this post should be reviewed."
+          serverError={reportServerError}
+          isSubmitting={reportMut.isPending}
+          onSubmit={async (payload) => {
+            setReportServerError(null);
+            await reportMut.mutateAsync(payload);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/feed/PostCard.tsx
+++ b/frontend/src/pages/feed/PostCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Heart, MessageCircle, Lock, DollarSign, X, ChevronLeft, ChevronRight, CreditCard, Check, Loader2, Share2, FileText } from "lucide-react";
+import { Heart, MessageCircle, Lock, DollarSign, X, ChevronLeft, ChevronRight, CreditCard, Check, Loader2, Share2, FileText, Flag } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -15,8 +15,9 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { likePost, unlikePost, unlockPost, addPostReaction, removePostReaction } from "@/api/endpoints/newsfeed";
+import { likePost, unlikePost, unlockPost, addPostReaction, removePostReaction, reportFeedContent } from "@/api/endpoints/newsfeed";
 import { getPaymentMethods } from "@/api/endpoints/billing";
+import { ApiError } from "@/api/client";
 import { useAuthStore } from "@/stores/authStore";
 import { CommentsThread } from "./CommentsThread";
 import { PostActions } from "./PostActions";
@@ -25,6 +26,7 @@ import { RichContentRenderer } from "./RichContentRenderer";
 import { TipDialog } from "./TipDialog";
 import { SharePostDialog } from "./SharePostDialog";
 import { FilePreview } from "@/pages/files/FilePreview";
+import { ReportContentModal, type ReportContentPayload } from "@/components/shared/ReportContentModal";
 import type { FeedPost, PaymentMethod, PostFileAttachment } from "@/api/types";
 import type { FileEntry } from "@/api/types";
 
@@ -65,6 +67,7 @@ function PostImageGrid({ urls, onClickImage }: PostImageGridProps) {
       <button
         type="button"
         className="mt-3 block w-full overflow-hidden rounded-lg"
+        aria-label="Open image 1"
         onClick={() => onClickImage(0)}
       >
         <img
@@ -84,6 +87,7 @@ function PostImageGrid({ urls, onClickImage }: PostImageGridProps) {
             key={i}
             type="button"
             className="aspect-square overflow-hidden"
+            aria-label={`Open image ${i + 1}`}
             onClick={() => onClickImage(i)}
           >
             <img src={url} alt="" className="h-full w-full object-cover transition-transform hover:scale-[1.02]" />
@@ -100,6 +104,7 @@ function PostImageGrid({ urls, onClickImage }: PostImageGridProps) {
         <button
           type="button"
           className="col-span-2 aspect-video overflow-hidden"
+          aria-label="Open image 1"
           onClick={() => onClickImage(0)}
         >
           <img src={urls[0]} alt="" className="h-full w-full object-cover transition-transform hover:scale-[1.02]" />
@@ -110,6 +115,7 @@ function PostImageGrid({ urls, onClickImage }: PostImageGridProps) {
             key={i + 1}
             type="button"
             className="aspect-square overflow-hidden"
+            aria-label={`Open image ${i + 2}`}
             onClick={() => onClickImage(i + 1)}
           >
             <img src={url} alt="" className="h-full w-full object-cover transition-transform hover:scale-[1.02]" />
@@ -127,6 +133,7 @@ function PostImageGrid({ urls, onClickImage }: PostImageGridProps) {
             key={i}
             type="button"
             className="aspect-square overflow-hidden"
+            aria-label={`Open image ${i + 1}`}
             onClick={() => onClickImage(i)}
           >
             <img src={url} alt="" className="h-full w-full object-cover transition-transform hover:scale-[1.02]" />
@@ -145,6 +152,7 @@ function PostImageGrid({ urls, onClickImage }: PostImageGridProps) {
           key={i}
           type="button"
           className="relative aspect-square overflow-hidden"
+          aria-label={`Open image ${i + 1}`}
           onClick={() => onClickImage(i)}
         >
           <img src={url} alt="" className="h-full w-full object-cover transition-transform hover:scale-[1.02]" />
@@ -175,6 +183,9 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
   const [unlockDialogOpen, setUnlockDialogOpen] = useState(false);
   const [unlockPaymentMethodId, setUnlockPaymentMethodId] = useState<string | null>(null);
   const [filePreviewTarget, setFilePreviewTarget] = useState<PostFileAttachment | null>(null);
+  const [reportMediaOpen, setReportMediaOpen] = useState(false);
+  const [reportMediaIndex, setReportMediaIndex] = useState<number | null>(null);
+  const [reportMediaServerError, setReportMediaServerError] = useState<string | null>(null);
 
   const imageUrls = post.image_urls ?? [];
   const isOwn = post.author_id === userId;
@@ -205,6 +216,31 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
     },
     onError: () => {
       toast.error("Failed to unlock post");
+    },
+  });
+
+
+  const reportMediaMut = useMutation({
+    mutationFn: ({ topics, reason_text }: ReportContentPayload) => reportFeedContent({
+      content_type: "feed_media",
+      content_id: `${post.post_id}:${reportMediaIndex ?? 0}` ,
+      topics,
+      reason_text,
+      post_id: post.post_id,
+      media_index: reportMediaIndex ?? undefined,
+    }),
+    onSuccess: () => {
+      toast.success("Report received");
+      setReportMediaOpen(false);
+      setReportMediaServerError(null);
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && typeof error.message === "string" && error.message.trim()) {
+        setReportMediaServerError(error.message);
+      } else {
+        setReportMediaServerError("Could not submit report. Please try again.");
+      }
+      toast.error("Could not submit report. Please try again.");
     },
   });
 
@@ -549,6 +585,26 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
         />
       )}
 
+      {!isOwn && (
+        <ReportContentModal
+          open={reportMediaOpen}
+          onOpenChange={(open) => {
+            setReportMediaOpen(open);
+            if (!open && !reportMediaMut.isPending) {
+              setReportMediaServerError(null);
+            }
+          }}
+          title="Report image"
+          description="Share why this image should be reviewed."
+          serverError={reportMediaServerError}
+          isSubmitting={reportMediaMut.isPending}
+          onSubmit={async (payload) => {
+            setReportMediaServerError(null);
+            await reportMediaMut.mutateAsync(payload);
+          }}
+        />
+      )}
+
       {/* Image lightbox */}
       {lightboxIdx !== null && imageUrls[lightboxIdx] && (
         <div
@@ -557,6 +613,21 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
           role="dialog"
           aria-label="Image preview"
         >
+          {!isOwn && (
+            <button
+              className="absolute left-4 top-4 inline-flex items-center gap-1 rounded-full bg-white/10 px-3 py-1.5 text-xs text-white transition-colors hover:bg-white/20"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (lightboxIdx === null) return;
+                setReportMediaIndex(lightboxIdx);
+                setReportMediaServerError(null);
+                setReportMediaOpen(true);
+              }}
+            >
+              <Flag className="h-3.5 w-3.5" /> Report image
+            </button>
+          )}
+
           <button
             className="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
             onClick={closeLightbox}

--- a/frontend/src/pages/feed/__tests__/CommentsThread.report.test.tsx
+++ b/frontend/src/pages/feed/__tests__/CommentsThread.report.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { CommentsThread } from "../CommentsThread";
+
+const reportFeedContent = vi.fn();
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (selector: (s: { userId: string }) => string) => selector({ userId: "viewer" }),
+}));
+
+vi.mock("@/api/endpoints/newsfeed", () => ({
+  getComments: vi.fn(async () => ({
+    items: [
+      {
+        comment_id: "c1",
+        post_id: "p1",
+        author_id: "author2",
+        body: "test",
+        created_at: new Date().toISOString(),
+      },
+    ],
+  })),
+  createComment: vi.fn(async () => ({})),
+  editComment: vi.fn(async () => ({})),
+  deleteComment: vi.fn(async () => ({ ok: true })),
+  reportFeedContent: (...args: unknown[]) => reportFeedContent(...args),
+}));
+
+vi.mock("../MarkdownComposer", () => ({
+  MarkdownComposer: () => null,
+  richDocToPlain: () => "",
+  buildContentPayload: () => ({ body: "x" }),
+}));
+vi.mock("../RichContentRenderer", () => ({ RichContentRenderer: () => <div>body</div> }));
+vi.mock("../TipDialog", () => ({ TipDialog: () => null }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderThread() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <CommentsThread postId="p1" />
+    </QueryClientProvider>,
+  );
+}
+
+describe("CommentsThread report", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits report with feed_comment metadata", async () => {
+    reportFeedContent.mockResolvedValue({ ok: true, report_id: "r1" });
+    renderThread();
+
+    await screen.findByText("body");
+    await userEvent.click(screen.getByRole("button", { name: "Comment actions" }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /report comment/i }));
+
+    await userEvent.click(screen.getByLabelText("Racist"));
+    await userEvent.type(screen.getByLabelText("Reason"), "Racist slur in comment.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => {
+      expect(reportFeedContent).toHaveBeenCalledWith({
+        content_type: "feed_comment",
+        content_id: "c1",
+        topics: ["racist"],
+        reason_text: "Racist slur in comment.",
+        post_id: "p1",
+        comment_id: "c1",
+      });
+    });
+  });
+});

--- a/frontend/src/pages/feed/__tests__/PostActions.report.test.tsx
+++ b/frontend/src/pages/feed/__tests__/PostActions.report.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PostActions } from "../PostActions";
+
+const reportFeedContent = vi.fn();
+
+vi.mock("@/api/endpoints/newsfeed", () => ({
+  deletePost: vi.fn(async () => ({ ok: true })),
+  hidePost: vi.fn(async () => ({ ok: true })),
+  reportFeedContent: (...args: unknown[]) => reportFeedContent(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function renderActions() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <PostActions postId="p1" isOwn={false} onEdit={vi.fn()} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("PostActions report", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits report with feed_post metadata", async () => {
+    reportFeedContent.mockResolvedValue({ ok: true, report_id: "r1" });
+    renderActions();
+
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /report/i }));
+
+    await userEvent.click(screen.getByLabelText("Spam"));
+    await userEvent.type(screen.getByLabelText("Reason"), "Spam post content.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => {
+      expect(reportFeedContent).toHaveBeenCalledWith({
+        content_type: "feed_post",
+        content_id: "p1",
+        topics: ["spam"],
+        reason_text: "Spam post content.",
+        post_id: "p1",
+      });
+    });
+  });
+});

--- a/frontend/src/pages/feed/__tests__/PostCard.report.test.tsx
+++ b/frontend/src/pages/feed/__tests__/PostCard.report.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PostCard } from "../PostCard";
+
+const reportFeedContent = vi.fn();
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (selector: (s: { userId: string }) => string) => selector({ userId: "viewer" }),
+}));
+
+vi.mock("@/api/endpoints/newsfeed", () => ({
+  likePost: vi.fn(async () => ({ ok: true })),
+  unlikePost: vi.fn(async () => ({ ok: true })),
+  unlockPost: vi.fn(async () => ({ ok: true })),
+  addPostReaction: vi.fn(async () => ({ ok: true })),
+  removePostReaction: vi.fn(async () => ({ ok: true })),
+  reportFeedContent: (...args: unknown[]) => reportFeedContent(...args),
+}));
+
+vi.mock("@/api/endpoints/billing", () => ({ getPaymentMethods: vi.fn(async () => []) }));
+vi.mock("../CommentsThread", () => ({ CommentsThread: () => null }));
+vi.mock("../PostActions", () => ({ PostActions: () => null }));
+vi.mock("../EditPostDialog", () => ({ EditPostDialog: () => null }));
+vi.mock("../TipDialog", () => ({ TipDialog: () => null }));
+vi.mock("../SharePostDialog", () => ({ SharePostDialog: () => null }));
+vi.mock("../RichContentRenderer", () => ({ RichContentRenderer: () => <div>post body</div> }));
+vi.mock("@/pages/files/FilePreview", () => ({ FilePreview: () => null }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderCard() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <PostCard
+        post={{
+          post_id: "p1",
+          author_id: "author2",
+          body: "hello",
+          created_at: new Date().toISOString(),
+          image_urls: ["https://example.com/a.jpg"],
+        } as never}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("PostCard media reporting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits report with feed_media metadata", async () => {
+    reportFeedContent.mockResolvedValue({ ok: true, report_id: "r1" });
+    renderCard();
+
+    await userEvent.click(screen.getByRole("button", { name: "Open image 1" }));
+    await userEvent.click(await screen.findByRole("button", { name: /report image/i }));
+
+    await userEvent.click(screen.getByLabelText("Criminal"));
+    await userEvent.type(screen.getByLabelText("Reason"), "Criminal activity shown.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => {
+      expect(reportFeedContent).toHaveBeenCalledWith({
+        content_type: "feed_media",
+        content_id: "p1:0",
+        topics: ["criminal"],
+        reason_text: "Criminal activity shown.",
+        post_id: "p1",
+        media_index: 0,
+      });
+    });
+  });
+});

--- a/frontend/src/pages/messages/MessageBubble.report.test.tsx
+++ b/frontend/src/pages/messages/MessageBubble.report.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/api/endpoints/messaging", () => ({
   getMeetingPoll: vi.fn(),
   voteMeetingPoll: vi.fn(),
   confirmMeetingPoll: vi.fn(),
-  markViewed: vi.fn(),
+  markViewed: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("sonner", () => ({
@@ -61,6 +61,30 @@ if (!HTMLElement.prototype.releasePointerCapture) {
   });
 }
 
+
+
+function renderImageBubble() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <MessageBubble
+          conversationId="c1"
+          isOwn={false}
+          message={{
+            message_id: "m2",
+            conversation_id: "c1",
+            sender_id: "u2",
+            kind: "image",
+            created_at: 1,
+            image: { url: "https://example.com/img.jpg" },
+          }}
+        />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
 function renderBubble() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   return render(
@@ -88,7 +112,6 @@ describe("MessageBubble report action", () => {
     vi.clearAllMocks();
   });
 
-
   it("renders accessible report dialog copy and controls", async () => {
     renderBubble();
 
@@ -97,27 +120,23 @@ describe("MessageBubble report action", () => {
 
     expect(await screen.findByRole("heading", { name: "Report message" })).toBeInTheDocument();
     expect(screen.getByText(/Recent conversation context will be included automatically/i)).toBeInTheDocument();
-    expect(screen.getByLabelText("Report reason")).toBeInTheDocument();
-    expect(screen.getByLabelText("Statement")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Report topics" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Reason")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Submit report" })).toBeInTheDocument();
   });
-  it("blocks submit until reason and statement are valid", async () => {
+
+  it("prevents submit without topics", async () => {
     renderBubble();
 
     await userEvent.click(screen.getByRole("button", { name: "Message actions" }));
     await userEvent.click(await screen.findByRole("menuitem", { name: /Report message/i }));
 
-    const submit = await screen.findByRole("button", { name: "Submit report" });
-    expect(submit).toBeDisabled();
+    await userEvent.type(screen.getByLabelText("Reason"), "This should be reviewed.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
 
-    await userEvent.type(screen.getByLabelText("Statement"), "Too short");
-    expect(submit).toBeDisabled();
-
-    await userEvent.click(screen.getByLabelText("Report reason"));
-    await userEvent.click(await screen.findByText("Spam or scam"));
-
-    expect(submit).toBeEnabled();
+    expect(screen.getByRole("alert")).toHaveTextContent("Select at least one topic.");
+    expect(reportMessage).not.toHaveBeenCalled();
   });
 
   it("submits report and shows success toast", async () => {
@@ -127,19 +146,40 @@ describe("MessageBubble report action", () => {
     await userEvent.click(screen.getByRole("button", { name: "Message actions" }));
     await userEvent.click(await screen.findByRole("menuitem", { name: /Report message/i }));
 
-    await userEvent.click(screen.getByLabelText("Report reason"));
-    await userEvent.click(await screen.findByText("Harassment or bullying"));
-    await userEvent.type(screen.getByLabelText("Statement"), "This message includes targeted harassment.");
-
+    await userEvent.click(screen.getByLabelText("Sexual"));
+    await userEvent.type(screen.getByLabelText("Reason"), "This message includes sexual content.");
     await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
 
     await waitFor(() => {
       expect(reportMessage).toHaveBeenCalledWith("c1", "m1", {
-        reason_code: "harassment",
-        statement: "This message includes targeted harassment.",
+        reason_code: "sexual",
+        statement: "This message includes sexual content.",
       });
     });
-    expect(toastSuccess).toHaveBeenCalledWith("Report submitted");
+    expect(toastSuccess).toHaveBeenCalledWith("Report received");
+  });
+
+
+
+  it("supports reporting image attachments from lightbox", async () => {
+    reportMessage.mockResolvedValue({ ok: true, report_id: "r2" });
+    renderImageBubble();
+
+    await userEvent.click(screen.getByRole("button", { name: "Open message image" }));
+    await userEvent.click(await screen.findByRole("button", { name: /Report image/i }));
+
+    expect(await screen.findByRole("heading", { name: "Report attachment" })).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Criminal"));
+    await userEvent.type(screen.getByLabelText("Reason"), "This attachment appears criminal.");
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => {
+      expect(reportMessage).toHaveBeenCalledWith("c1", "m2", {
+        reason_code: "criminal",
+        statement: "This attachment appears criminal.",
+      });
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Report received");
   });
 
   it("shows recoverable error when report submission fails", async () => {
@@ -149,9 +189,8 @@ describe("MessageBubble report action", () => {
     await userEvent.click(screen.getByRole("button", { name: "Message actions" }));
     await userEvent.click(await screen.findByRole("menuitem", { name: /Report message/i }));
 
-    await userEvent.click(screen.getByLabelText("Report reason"));
-    await userEvent.click(await screen.findByText("Other"));
-    await userEvent.type(screen.getByLabelText("Statement"), "Report details for moderators.");
+    await userEvent.click(screen.getByLabelText("Spam"));
+    await userEvent.type(screen.getByLabelText("Reason"), "Spam content to review.");
     await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
 
     await waitFor(() => expect(toastError).toHaveBeenCalledWith("Could not submit report. Please try again."));

--- a/frontend/src/pages/messages/MessageBubble.tsx
+++ b/frontend/src/pages/messages/MessageBubble.tsx
@@ -64,6 +64,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { FilePreview } from "@/pages/files/FilePreview";
 import { downloadUrl, sharedPreviewUrl } from "@/api/endpoints/files";
 import type { FileEntry } from "@/api/types";
+import { ReportContentModal, type ReportContentPayload } from "@/components/shared/ReportContentModal";
 
 const QUICK_EMOJIS = ["👍", "❤️", "😂", "😮", "😢", "🙏"];
 
@@ -305,8 +306,8 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
   const [fileSharePreviewOpen, setFileSharePreviewOpen] = useState(false);
   const [filePreviewOpen, setFilePreviewOpen] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
-  const [reportReason, setReportReason] = useState("");
-  const [reportStatement, setReportStatement] = useState("");
+  const [reportServerError, setReportServerError] = useState<string | null>(null);
+  const [reportTarget, setReportTarget] = useState<"message" | "attachment">("message");
 
   const viewOnceTextRevealed = viewedOnceIds?.has(message.message_id) ?? false;
 
@@ -408,18 +409,23 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
     },
   });
 
-  const reportStatementTrimmed = reportStatement.trim();
-  const reportCanSubmit = reportReason.length >= 2 && reportStatementTrimmed.length >= 5 && reportStatementTrimmed.length <= 2000;
-
   const reportMut = useMutation({
-    mutationFn: () => reportMessage(conversationId, message.message_id, { reason_code: reportReason, statement: reportStatementTrimmed }),
+    mutationFn: ({ topics, reason_text }: ReportContentPayload) => reportMessage(conversationId, message.message_id, {
+      reason_code: topics[0],
+      statement: reason_text,
+    }),
     onSuccess: () => {
-      toast.success("Report submitted");
+      toast.success("Report received");
       setReportOpen(false);
-      setReportReason("");
-      setReportStatement("");
+      setReportServerError(null);
+      setReportTarget("message");
     },
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ApiError && typeof error.message === "string" && error.message.trim()) {
+        setReportServerError(error.message);
+      } else {
+        setReportServerError("Could not submit report. Please try again.");
+      }
       toast.error("Could not submit report. Please try again.");
     },
   });
@@ -648,7 +654,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                   {hideMut.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <EyeOff className="mr-2 h-4 w-4" />} Hide for me
                 </DropdownMenuItem>
                 {!isOwn && (
-                  <DropdownMenuItem onClick={() => setReportOpen(true)}>
+                  <DropdownMenuItem onClick={() => { setReportTarget("message"); setReportOpen(true); }}>
                     <Flag className="mr-2 h-4 w-4" /> Report message
                   </DropdownMenuItem>
                 )}
@@ -915,6 +921,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
             ) : (
               <button
                 type="button"
+                aria-label="Open message image"
                 onClick={() => {
                   onViewOnce?.(message.message_id);
                   if (!message.message_id.startsWith("optimistic-")) {
@@ -984,6 +991,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
               // Normal image or own view-once: show actual image
               <button
                 type="button"
+                aria-label="Open message image"
                 onClick={() => {
                   if (message.consumption_policy && !isOwn) {
                     void handleOpenOnceAttachment();
@@ -1141,6 +1149,18 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                   setFilePreviewOpen(true);
                 }}
               />
+              {!isOwn && (
+                <button
+                  type="button"
+                  className="mt-1 text-xs text-muted-foreground hover:text-destructive"
+                  onClick={() => {
+                    setReportTarget("attachment");
+                    setReportOpen(true);
+                  }}
+                >
+                  Report attachment
+                </button>
+              )}
               {filePreviewOpen && message.file?.url && (
                 <FilePreview
                   file={{
@@ -1466,73 +1486,26 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
         conversationId={conversationId}
       />
 
-      <Dialog
+      <ReportContentModal
         open={reportOpen}
         onOpenChange={(open) => {
           setReportOpen(open);
           if (!open && !reportMut.isPending) {
-            setReportReason("");
-            setReportStatement("");
+            setReportServerError(null);
+            setReportTarget("message");
           }
         }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Flag className="h-4 w-4" />
-              Report message
-            </DialogTitle>
-            <DialogDescription>
-              Share why this message should be reviewed. Recent conversation context will be included automatically.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            <div className="space-y-1.5">
-              <label htmlFor={`report-reason-${message.message_id}`} className="text-sm font-medium">Reason</label>
-              <Select value={reportReason} onValueChange={setReportReason}>
-                <SelectTrigger id={`report-reason-${message.message_id}`} aria-label="Report reason">
-                  <SelectValue placeholder="Select a reason" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="harassment">Harassment or bullying</SelectItem>
-                  <SelectItem value="hate_speech">Hate speech</SelectItem>
-                  <SelectItem value="threat_or_violence">Threat or violence</SelectItem>
-                  <SelectItem value="sexual_content">Sexual content</SelectItem>
-                  <SelectItem value="spam">Spam or scam</SelectItem>
-                  <SelectItem value="other">Other</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <label htmlFor={`report-statement-${message.message_id}`} className="text-sm font-medium">Statement</label>
-              <Textarea
-                id={`report-statement-${message.message_id}`}
-                placeholder="Describe what happened and why you are reporting this message."
-                value={reportStatement}
-                onChange={(e) => setReportStatement(e.target.value)}
-                minLength={5}
-                maxLength={2000}
-                rows={4}
-                aria-describedby={`report-statement-help-${message.message_id}`}
-              />
-              <p id={`report-statement-help-${message.message_id}`} className="text-xs text-muted-foreground">
-                Required (5–2000 characters). Context from nearby messages is included for reviewers.
-              </p>
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setReportOpen(false)} disabled={reportMut.isPending}>
-              Cancel
-            </Button>
-            <Button onClick={() => reportMut.mutate()} disabled={!reportCanSubmit || reportMut.isPending}>
-              {reportMut.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Submit report"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        title={reportTarget === "attachment" ? "Report attachment" : "Report message"}
+        description={reportTarget === "attachment"
+          ? "Share why this attachment should be reviewed. Recent conversation context will be included automatically."
+          : "Share why this message should be reviewed. Recent conversation context will be included automatically."}
+        isSubmitting={reportMut.isPending}
+        serverError={reportServerError}
+        onSubmit={async (payload) => {
+          setReportServerError(null);
+          await reportMut.mutateAsync(payload);
+        }}
+      />
 
       <Dialog
         open={tipStep !== null}
@@ -1725,6 +1698,19 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
         <Dialog open={lightboxOpen} onOpenChange={setLightboxOpen}>
           <DialogContent className="max-w-4xl p-0 overflow-hidden bg-black/90 border-none">
             <DialogHeader className="absolute top-0 right-0 z-10 flex flex-row items-center gap-2 p-3">
+              {!isOwn && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setReportTarget("attachment");
+                    setReportOpen(true);
+                  }}
+                  className="inline-flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1.5 text-xs text-white hover:bg-white/20"
+                >
+                  <Flag className="h-3.5 w-3.5" /> Report image
+                </button>
+              )}
               <a
                 href={message.image.url}
                 download

--- a/scripts/local-ddb-init.py
+++ b/scripts/local-ddb-init.py
@@ -269,6 +269,117 @@ def _table_defs() -> List[TableDef]:
             "message_id",
         ),
         TableDef(
+            _resolve_table_name(S.content_reports_table_name, "ContentReports"),
+            "report_id",
+            gsi=[
+                {
+                    "index_name": "ByContentCreatedAt",
+                    "partition_key": "content_ref",
+                    "sort_key": "created_at",
+                },
+                {
+                    "index_name": "ByReporterCreatedAt",
+                    "partition_key": "reporter_user_id",
+                    "sort_key": "created_at",
+                },
+                {
+                    "index_name": "ByCreatedAt",
+                    "partition_key": "created_scope",
+                    "sort_key": "created_at",
+                },
+            ],
+        ),
+        TableDef(
+            _resolve_table_name(S.moderation_tickets_table_name, "ModerationTickets"),
+            "ticket_id",
+            gsi=[
+                {
+                    "index_name": "ByStatusLatestReportAt",
+                    "partition_key": "status",
+                    "sort_key": "latest_report_at",
+                },
+                {
+                    "index_name": "ByQueueLatestReportAt",
+                    "partition_key": "queue",
+                    "sort_key": "latest_report_at",
+                },
+                {
+                    "index_name": "ByAssignedAdminLatestReportAt",
+                    "partition_key": "assigned_admin_user_id",
+                    "sort_key": "latest_report_at",
+                },
+                {
+                    "index_name": "ByLatestReportAt",
+                    "partition_key": "latest_report_scope",
+                    "sort_key": "latest_report_at",
+                },
+                {
+                    "index_name": "ByContentStatusLatestReportAt",
+                    "partition_key": "content_ref_status",
+                    "sort_key": "latest_report_at",
+                },
+            ],
+        ),
+        TableDef(
+            _resolve_table_name(S.moderation_actions_table_name, "ModerationActions"),
+            "action_id",
+            gsi=[
+                {
+                    "index_name": "ByTicketCreatedAt",
+                    "partition_key": "ticket_id",
+                    "sort_key": "created_at",
+                },
+                {
+                    "index_name": "ByActionTypeCreatedAt",
+                    "partition_key": "action_type",
+                    "sort_key": "created_at",
+                },
+                {
+                    "index_name": "ByTargetUserCreatedAt",
+                    "partition_key": "target_user_id",
+                    "sort_key": "created_at",
+                },
+            ],
+        ),
+        TableDef(
+            _resolve_table_name(S.moderation_audit_log_table_name, "ModerationAuditLog"),
+            "audit_id",
+            gsi=[
+                {
+                    "index_name": "ByTicketCreatedAt",
+                    "partition_key": "ticket_id",
+                    "sort_key": "created_at",
+                },
+                {
+                    "index_name": "ByActorCreatedAt",
+                    "partition_key": "actor_user_id",
+                    "sort_key": "created_at",
+                },
+                {
+                    "index_name": "ByActionCreatedAt",
+                    "partition_key": "action",
+                    "sort_key": "created_at",
+                },
+            ],
+        ),
+        TableDef(
+            _resolve_table_name(S.user_enforcement_history_table_name, "UserEnforcementHistory"),
+            "user_id",
+            "enforcement_id",
+            gsi=[
+                {
+                    "index_name": "ByStatusCreatedAt",
+                    "partition_key": "status",
+                    "sort_key": "created_at",
+                },
+                {
+                    "index_name": "BySourceTicketCreatedAt",
+                    "partition_key": "source_ticket_id",
+                    "sort_key": "created_at",
+                },
+            ],
+        ),
+        TableDef(
             _resolve_table_name(S.message_legal_holds_table_name, "MessageLegalHolds"),
             "hold_id",
             gsi=[

--- a/scripts/migrations/20260305_content_reports_schema.py
+++ b/scripts/migrations/20260305_content_reports_schema.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from botocore.exceptions import ClientError
+
+from app.core.aws import ddb
+from app.core.settings import S
+
+ALLOWED_TOPICS = ("sexual", "extortion", "criminal", "spam", "racist")
+
+
+def _ensure_table() -> None:
+    client = ddb.meta.client
+    existing = set(client.list_tables().get("TableNames", []))
+    if S.content_reports_table_name in existing:
+        return
+
+    client.create_table(
+        TableName=S.content_reports_table_name,
+        AttributeDefinitions=[
+            {"AttributeName": "report_id", "AttributeType": "S"},
+            {"AttributeName": "content_ref", "AttributeType": "S"},
+            {"AttributeName": "reporter_user_id", "AttributeType": "S"},
+            {"AttributeName": "created_scope", "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "S"},
+        ],
+        KeySchema=[
+            {"AttributeName": "report_id", "KeyType": "HASH"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "ByContentCreatedAt",
+                "KeySchema": [
+                    {"AttributeName": "content_ref", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ByReporterCreatedAt",
+                "KeySchema": [
+                    {"AttributeName": "reporter_user_id", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ByCreatedAt",
+                "KeySchema": [
+                    {"AttributeName": "created_scope", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )
+
+
+def _seed_topic_constraints() -> None:
+    """Seed allowed-topic sentinel rows used for DB-level condition checks in transact writes."""
+    table = ddb.Table(S.content_reports_table_name)
+    for topic in ALLOWED_TOPICS:
+        try:
+            table.put_item(
+                Item={
+                    "report_id": f"TOPIC#{topic}",
+                    "entity_type": "content_report_topic",
+                    "topic": topic,
+                },
+                ConditionExpression="attribute_not_exists(report_id)",
+            )
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code != "ConditionalCheckFailedException":
+                raise
+
+
+def _backfill_index_attributes() -> None:
+    table = ddb.Table(S.content_reports_table_name)
+    items = table.scan().get("Items", [])
+    for item in items:
+        if item.get("entity_type") == "content_report_topic":
+            continue
+        content_type = item.get("content_type")
+        content_id = item.get("content_id")
+        created_at = item.get("created_at")
+        if not content_type or not content_id or not created_at:
+            continue
+
+        updates = {
+            "content_ref": f"{content_type}#{content_id}",
+            "created_scope": "ALL",
+        }
+
+        update_expr = []
+        attr_names = {}
+        attr_values = {}
+        for idx, (k, v) in enumerate(updates.items(), start=1):
+            nk = f"#k{idx}"
+            vk = f":v{idx}"
+            attr_names[nk] = k
+            attr_values[vk] = v
+            update_expr.append(f"{nk} = {vk}")
+
+        table.update_item(
+            Key={"report_id": item["report_id"]},
+            UpdateExpression="SET " + ", ".join(update_expr),
+            ExpressionAttributeNames=attr_names,
+            ExpressionAttributeValues=attr_values,
+        )
+
+
+def migrate() -> None:
+    _ensure_table()
+    _seed_topic_constraints()
+    _backfill_index_attributes()
+
+
+if __name__ == "__main__":
+    migrate()
+    print("content_reports schema migration complete")

--- a/scripts/migrations/20260306_moderation_tickets_schema.py
+++ b/scripts/migrations/20260306_moderation_tickets_schema.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from app.core.aws import ddb
+from app.core.settings import S
+
+DEFAULT_STATUS = "open"
+DEFAULT_PRIORITY = "medium"
+DEFAULT_QUEUE = "general"
+
+TICKET_GSIS = [
+    {
+        "IndexName": "ByStatusLatestReportAt",
+        "PartitionKey": "status",
+        "SortKey": "latest_report_at",
+    },
+    {
+        "IndexName": "ByQueueLatestReportAt",
+        "PartitionKey": "queue",
+        "SortKey": "latest_report_at",
+    },
+    {
+        "IndexName": "ByAssignedAdminLatestReportAt",
+        "PartitionKey": "assigned_admin_user_id",
+        "SortKey": "latest_report_at",
+    },
+    {
+        "IndexName": "ByLatestReportAt",
+        "PartitionKey": "latest_report_scope",
+        "SortKey": "latest_report_at",
+    },
+    {
+        "IndexName": "ByContentStatusLatestReportAt",
+        "PartitionKey": "content_ref_status",
+        "SortKey": "latest_report_at",
+    },
+]
+
+
+def _ensure_table() -> None:
+    client = ddb.meta.client
+    existing = set(client.list_tables().get("TableNames", []))
+    if S.moderation_tickets_table_name in existing:
+        _ensure_missing_gsis()
+        return
+
+    attrs = [{"AttributeName": "ticket_id", "AttributeType": "S"}]
+    for gsi in TICKET_GSIS:
+        attrs.append({"AttributeName": gsi["PartitionKey"], "AttributeType": "S"})
+        attrs.append({"AttributeName": gsi["SortKey"], "AttributeType": "S"})
+
+    # unique while preserving order
+    seen = set()
+    attr_defs = []
+    for item in attrs:
+        name = item["AttributeName"]
+        if name in seen:
+            continue
+        seen.add(name)
+        attr_defs.append(item)
+
+    client.create_table(
+        TableName=S.moderation_tickets_table_name,
+        AttributeDefinitions=attr_defs,
+        KeySchema=[{"AttributeName": "ticket_id", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": gsi["IndexName"],
+                "KeySchema": [
+                    {"AttributeName": gsi["PartitionKey"], "KeyType": "HASH"},
+                    {"AttributeName": gsi["SortKey"], "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+            for gsi in TICKET_GSIS
+        ],
+    )
+
+
+def _ensure_missing_gsis() -> None:
+    client = ddb.meta.client
+    desc = client.describe_table(TableName=S.moderation_tickets_table_name).get("Table", {})
+    existing_indexes = {idx.get("IndexName") for idx in desc.get("GlobalSecondaryIndexes", [])}
+    existing_attributes = {attr.get("AttributeName") for attr in desc.get("AttributeDefinitions", [])}
+
+    for gsi in TICKET_GSIS:
+        if gsi["IndexName"] in existing_indexes:
+            continue
+
+        attr_defs = []
+        for attr_name in (gsi["PartitionKey"], gsi["SortKey"]):
+            if attr_name not in existing_attributes:
+                attr_defs.append({"AttributeName": attr_name, "AttributeType": "S"})
+
+        kwargs = {
+            "TableName": S.moderation_tickets_table_name,
+            "GlobalSecondaryIndexUpdates": [
+                {
+                    "Create": {
+                        "IndexName": gsi["IndexName"],
+                        "KeySchema": [
+                            {"AttributeName": gsi["PartitionKey"], "KeyType": "HASH"},
+                            {"AttributeName": gsi["SortKey"], "KeyType": "RANGE"},
+                        ],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        }
+        if attr_defs:
+            kwargs["AttributeDefinitions"] = attr_defs
+
+        client.update_table(**kwargs)
+        waiter = client.get_waiter("table_exists")
+        waiter.wait(TableName=S.moderation_tickets_table_name)
+
+
+def _backfill_defaults() -> None:
+    table = ddb.Table(S.moderation_tickets_table_name)
+    items = table.scan().get("Items", [])
+    for item in items:
+        ticket_id = item.get("ticket_id")
+        if not ticket_id:
+            continue
+
+        content_type = str(item.get("content_type") or "").strip()
+        content_id = str(item.get("content_id") or "").strip()
+        content_ref = str(item.get("content_ref") or "").strip()
+
+        updates = {}
+        if not item.get("status"):
+            updates["status"] = DEFAULT_STATUS
+        if not item.get("priority"):
+            updates["priority"] = DEFAULT_PRIORITY
+        if not item.get("queue"):
+            updates["queue"] = DEFAULT_QUEUE
+        if not item.get("latest_report_at"):
+            updates["latest_report_at"] = str(item.get("created_at") or "0")
+        if not item.get("latest_report_scope"):
+            updates["latest_report_scope"] = "ALL"
+        if not content_ref and content_type and content_id:
+            content_ref = f"{content_type}#{content_id}"
+            updates["content_ref"] = content_ref
+        if content_ref and not item.get("content_ref_status"):
+            updates["content_ref_status"] = f"{content_ref}#{str(item.get('status') or DEFAULT_STATUS)}"
+
+        if not updates:
+            continue
+
+        names = {}
+        values = {}
+        expr = []
+        for i, (k, v) in enumerate(updates.items(), start=1):
+            nk = f"#k{i}"
+            vk = f":v{i}"
+            names[nk] = k
+            values[vk] = v
+            expr.append(f"{nk} = {vk}")
+
+        table.update_item(
+            Key={"ticket_id": ticket_id},
+            UpdateExpression="SET " + ", ".join(expr),
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+
+
+def migrate() -> None:
+    _ensure_table()
+    _backfill_defaults()
+
+
+if __name__ == "__main__":
+    migrate()
+    print("moderation_tickets schema migration complete")

--- a/scripts/migrations/20260307_moderation_actions_enforcement_schema.py
+++ b/scripts/migrations/20260307_moderation_actions_enforcement_schema.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from app.core.aws import ddb
+from app.core.settings import S
+
+
+def _ensure_table(
+    *,
+    table_name: str,
+    partition_key: str,
+    sort_key: str | None,
+    gsi: list[dict[str, str]],
+) -> None:
+    client = ddb.meta.client
+    existing = set(client.list_tables().get("TableNames", []))
+    if table_name in existing:
+        return
+
+    attrs = [{"AttributeName": partition_key, "AttributeType": "S"}]
+    if sort_key:
+        attrs.append({"AttributeName": sort_key, "AttributeType": "S"})
+    for idx in gsi:
+        attrs.append({"AttributeName": idx["partition_key"], "AttributeType": "S"})
+        if idx.get("sort_key"):
+            attrs.append({"AttributeName": idx["sort_key"], "AttributeType": "S"})
+
+    dedup = []
+    seen = set()
+    for a in attrs:
+        k = a["AttributeName"]
+        if k in seen:
+            continue
+        seen.add(k)
+        dedup.append(a)
+
+    client.create_table(
+        TableName=table_name,
+        AttributeDefinitions=dedup,
+        KeySchema=[
+            {"AttributeName": partition_key, "KeyType": "HASH"},
+            *([{"AttributeName": sort_key, "KeyType": "RANGE"}] if sort_key else []),
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": idx["index_name"],
+                "KeySchema": [
+                    {"AttributeName": idx["partition_key"], "KeyType": "HASH"},
+                    *([{"AttributeName": idx["sort_key"], "KeyType": "RANGE"}] if idx.get("sort_key") else []),
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+            for idx in gsi
+        ],
+    )
+
+
+def migrate() -> None:
+    _ensure_table(
+        table_name=S.moderation_actions_table_name,
+        partition_key="action_id",
+        sort_key=None,
+        gsi=[
+            {"index_name": "ByTicketCreatedAt", "partition_key": "ticket_id", "sort_key": "created_at"},
+            {"index_name": "ByActionTypeCreatedAt", "partition_key": "action_type", "sort_key": "created_at"},
+            {"index_name": "ByTargetUserCreatedAt", "partition_key": "target_user_id", "sort_key": "created_at"},
+        ],
+    )
+    _ensure_table(
+        table_name=S.user_enforcement_history_table_name,
+        partition_key="user_id",
+        sort_key="enforcement_id",
+        gsi=[
+            {"index_name": "ByStatusCreatedAt", "partition_key": "status", "sort_key": "created_at"},
+            {"index_name": "BySourceTicketCreatedAt", "partition_key": "source_ticket_id", "sort_key": "created_at"},
+        ],
+    )
+
+
+if __name__ == "__main__":
+    migrate()
+    print("moderation actions + enforcement history schema migration complete")

--- a/scripts/migrations/20260308_moderation_audit_log_schema.py
+++ b/scripts/migrations/20260308_moderation_audit_log_schema.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from app.core.aws import ddb
+from app.core.settings import S
+
+
+def _ensure_table() -> None:
+    client = ddb.meta.client
+    table_name = S.moderation_audit_log_table_name
+    if table_name in set(client.list_tables().get("TableNames", [])):
+        return
+
+    client.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[
+            {"AttributeName": "audit_id", "AttributeType": "S"},
+            {"AttributeName": "ticket_id", "AttributeType": "S"},
+            {"AttributeName": "actor_user_id", "AttributeType": "S"},
+            {"AttributeName": "action", "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "S"},
+        ],
+        KeySchema=[{"AttributeName": "audit_id", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "ByTicketCreatedAt",
+                "KeySchema": [
+                    {"AttributeName": "ticket_id", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ByActorCreatedAt",
+                "KeySchema": [
+                    {"AttributeName": "actor_user_id", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ByActionCreatedAt",
+                "KeySchema": [
+                    {"AttributeName": "action", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )
+
+
+def migrate() -> None:
+    _ensure_table()
+
+
+if __name__ == "__main__":
+    migrate()
+    print("moderation audit log schema migration complete")

--- a/tests/test_admin_moderation_tickets_router.py
+++ b/tests/test_admin_moderation_tickets_router.py
@@ -1,0 +1,1009 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
+from app.routers.admin_moderation import router
+
+
+def _client(user: AuthenticatedUser) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_authenticated_user] = lambda: user
+    return TestClient(app)
+
+
+def test_list_tickets_blocks_unauthorized_role() -> None:
+    client = _client(AuthenticatedUser(sub="u1", role=Role.USER))
+    resp = client.get("/v1/admin/moderation/tickets")
+    assert resp.status_code == 403
+
+
+
+
+def test_get_user_history_blocks_unauthorized_role() -> None:
+    client = _client(AuthenticatedUser(sub="u1", role=Role.USER))
+    resp = client.get("/v1/admin/moderation/users/u1/history")
+    assert resp.status_code == 403
+
+
+def test_get_user_history_returns_timeline(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    monkeypatch.setattr(
+        admin_moderation.T.user_enforcement_history,
+        "query",
+        lambda **kwargs: {
+            "Items": [
+                {
+                    "entity_type": "user_enforcement",
+                    "user_id": "u_target",
+                    "enforcement_id": "enf_b",
+                    "enforcement_type": "ban",
+                    "status": "active",
+                    "source_ticket_id": "modtk_2",
+                    "created_at": "1700000002",
+                    "created_by_admin_user_id": "admin_1",
+                    "duration_days": 30,
+                    "note": "repeat abuse",
+                },
+                {
+                    "entity_type": "user_enforcement",
+                    "user_id": "u_target",
+                    "enforcement_id": "enf_a",
+                    "enforcement_type": "warn",
+                    "status": "recorded",
+                    "source_ticket_id": "modtk_1",
+                    "created_at": "1700000001",
+                    "created_by_admin_user_id": "admin_1",
+                    "duration_days": 0,
+                    "note": "first strike",
+                },
+            ]
+        },
+    )
+
+    admin_user = AuthenticatedUser(sub="root_1", role=Role.ROOT)
+    client = _client(admin_user)
+    resp = client.get("/v1/admin/moderation/users/u_target/history", params={"limit": 10})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [i["enforcement_id"] for i in body["items"]] == ["enf_b", "enf_a"]
+    assert body["items"][0]["enforcement_type"] == "ban"
+    assert body["items"][0]["duration_days"] == 30
+
+
+def test_list_tickets_returns_filtered_paginated_results(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    items = [
+        {
+            "ticket_id": "modtk_b",
+            "entity_type": "moderation_ticket",
+            "content_type": "feed_post",
+            "content_id": "post_2",
+            "status": "open",
+            "priority": "critical",
+            "queue": "safety",
+            "assigned_admin_user_id": "admin_1",
+            "report_count": 2,
+            "aggregated_topics": {"extortion", "spam"},
+            "latest_report_at": "1700000002",
+            "updated_at": "1700000002",
+            "created_at": "1700000000",
+        },
+        {
+            "ticket_id": "modtk_a",
+            "entity_type": "moderation_ticket",
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "status": "open",
+            "priority": "high",
+            "queue": "safety",
+            "assigned_admin_user_id": "admin_1",
+            "report_count": 1,
+            "aggregated_topics": {"criminal"},
+            "latest_report_at": "1700000001",
+            "updated_at": "1700000001",
+            "created_at": "1700000000",
+        },
+    ]
+
+    calls = {"count": 0}
+
+    def _query(**kwargs):
+        calls["count"] += 1
+        assert kwargs["IndexName"] == "ByAssignedAdminLatestReportAt"
+        return {
+            "Items": items,
+            "LastEvaluatedKey": {"ticket_id": "modtk_a"},
+        }
+
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "query", _query)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.get(
+        "/v1/admin/moderation/tickets",
+        params={"assignee": "admin_1", "topic": "extortion", "limit": 1},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["ticket_id"] == "modtk_b"
+    assert body["items"][0]["priority"] == "critical"
+    assert body["next_cursor"] is not None
+    assert calls["count"] == 1
+
+
+def test_list_tickets_has_stable_ordering_by_latest_then_ticket(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    def _query(**kwargs):
+        return {
+            "Items": [
+                {
+                    "ticket_id": "modtk_a",
+                    "entity_type": "moderation_ticket",
+                    "content_type": "feed_post",
+                    "content_id": "post_1",
+                    "status": "open",
+                    "priority": "high",
+                    "queue": "general",
+                    "assigned_admin_user_id": "",
+                    "report_count": 1,
+                    "aggregated_topics": ["criminal"],
+                    "latest_report_at": "1700000001",
+                    "updated_at": "1700000001",
+                    "created_at": "1700000000",
+                },
+                {
+                    "ticket_id": "modtk_b",
+                    "entity_type": "moderation_ticket",
+                    "content_type": "feed_post",
+                    "content_id": "post_2",
+                    "status": "open",
+                    "priority": "high",
+                    "queue": "general",
+                    "assigned_admin_user_id": "",
+                    "report_count": 1,
+                    "aggregated_topics": ["criminal"],
+                    "latest_report_at": "1700000001",
+                    "updated_at": "1700000001",
+                    "created_at": "1700000000",
+                },
+            ]
+        }
+
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "query", _query)
+
+    admin_user = AuthenticatedUser(sub="root_1", role=Role.ROOT)
+    client = _client(admin_user)
+    resp = client.get("/v1/admin/moderation/tickets", params={"limit": 10})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [i["ticket_id"] for i in body["items"]] == ["modtk_b", "modtk_a"]
+
+
+def test_get_ticket_detail_blocks_unauthorized_role() -> None:
+    client = _client(AuthenticatedUser(sub="u1", role=Role.USER))
+    resp = client.get("/v1/admin/moderation/tickets/modtk_1")
+    assert resp.status_code == 403
+
+
+def test_get_ticket_detail_returns_snapshot_reports_and_offender_summary(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_1",
+        "entity_type": "moderation_ticket",
+        "content_type": "profile_photo",
+        "content_id": "user_target",
+        "status": "open",
+        "priority": "high",
+        "queue": "safety",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["sexual", "spam"],
+        "latest_report_at": "1700000100",
+        "updated_at": "1700000100",
+        "created_at": "1700000000",
+    }
+
+    linked_reports = [
+        {
+            "report_id": "rpt_2",
+            "entity_type": "content_report",
+            "reporter_user_id": "u_reporter_2",
+            "topics": ["sexual"],
+            "reason_text": "unsafe image",
+            "created_at": "1700000100",
+            "metadata": {},
+        },
+        {
+            "report_id": "rpt_1",
+            "entity_type": "content_report",
+            "reporter_user_id": "u_reporter_1",
+            "topics": ["spam"],
+            "reason_text": "bad image",
+            "created_at": "1700000001",
+            "metadata": {},
+        },
+    ]
+
+    profile_item = {"user_sub": "user_target", "profile": {"profile_photo_url": "https://cdn.example/p.jpg"}}
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: linked_reports)
+    monkeypatch.setattr(admin_moderation.T.profile, "get_item", lambda Key: {"Item": profile_item})
+    monkeypatch.setattr(
+        admin_moderation.T.moderation_tickets,
+        "scan",
+        lambda **kwargs: {"Items": [{"entity_type": "moderation_ticket", "status": "open"}, {"entity_type": "moderation_ticket", "status": "closed"}]},
+    )
+    monkeypatch.setattr(
+        admin_moderation.T.user_enforcement_history,
+        "query",
+        lambda **kwargs: {
+            "Items": [
+                {
+                    "entity_type": "user_enforcement",
+                    "user_id": "user_target",
+                    "enforcement_id": "enf_1",
+                    "enforcement_type": "warn",
+                    "status": "recorded",
+                    "source_ticket_id": "modtk_prev",
+                    "created_at": "1700000002",
+                    "created_by_admin_user_id": "admin_1",
+                    "note": "prior warning",
+                }
+            ]
+        },
+    )
+
+    admin_user = AuthenticatedUser(sub="root_1", role=Role.ROOT)
+    client = _client(admin_user)
+    resp = client.get("/v1/admin/moderation/tickets/modtk_1")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ticket"]["ticket_id"] == "modtk_1"
+    assert body["content_snapshot"]["kind"] == "profile_photo"
+    assert body["content_snapshot"]["author_user_id"] == "user_target"
+    assert [r["report_id"] for r in body["linked_reports"]] == ["rpt_2", "rpt_1"]
+    assert body["offender_history_summary"]["offender_user_id"] == "user_target"
+    assert body["offender_history_summary"]["total_tickets"] == 2
+    assert body["offender_history_summary"]["open_tickets"] == 1
+    assert body["offender_history_summary"]["total_reports"] == 2
+    assert body["prior_enforcement_history"][0]["enforcement_type"] == "warn"
+
+
+def test_claim_ticket_assigns_to_admin(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    monkeypatch.setattr(admin_moderation, "write_moderation_audit_event", lambda **kwargs: "audit_1")
+
+    item = {
+        "ticket_id": "modtk_claim",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": None,
+        "report_count": 1,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    calls = {"updated": False}
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: item)
+
+    def _update_item(**kwargs):
+        calls["updated"] = True
+        assert kwargs["ExpressionAttributeValues"][":admin_sub"] == "admin_1"
+        return {}
+
+    action_calls = []
+    enforcement_calls = []
+
+    def _put_action(**kwargs):
+        action_calls.append(kwargs["Item"])
+        return {}
+
+    def _put_enforcement(**kwargs):
+        enforcement_calls.append(kwargs["Item"])
+        return {}
+
+    monkeypatch.setattr(admin_moderation.T.moderation_actions, "put_item", _put_action)
+    monkeypatch.setattr(admin_moderation.T.user_enforcement_history, "put_item", _put_enforcement)
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "update_item", _update_item)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post("/v1/admin/moderation/tickets/modtk_claim/claim")
+    assert resp.status_code == 200
+    assert resp.json()["ticket_id"] == "modtk_claim"
+    assert calls["updated"] is True
+
+
+def test_decide_ticket_closes_and_records_decision(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    monkeypatch.setattr(admin_moderation, "write_moderation_audit_event", lambda **kwargs: "audit_1")
+
+    ticket_item = {
+        "ticket_id": "modtk_decide",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    updates = {"called": False}
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+
+    def _update_item(**kwargs):
+        updates["called"] = True
+        values = kwargs["ExpressionAttributeValues"]
+        assert values[":status"] == "closed"
+        assert values[":decision"] == "ban"
+        assert values[":offender_user_id"] == "u_target"
+        return {}
+
+    action_calls = []
+    enforcement_calls = []
+
+    def _put_action(**kwargs):
+        action_calls.append(kwargs["Item"])
+        return {}
+
+    def _put_enforcement(**kwargs):
+        enforcement_calls.append(kwargs["Item"])
+        return {}
+
+    monkeypatch.setattr(admin_moderation.T.moderation_actions, "put_item", _put_action)
+    monkeypatch.setattr(admin_moderation.T.user_enforcement_history, "put_item", _put_enforcement)
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "update_item", _update_item)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION, AdminScope.CONTENT_MODERATION_SENIOR)),
+    )
+    client = _client(admin_user)
+    resp = client.post("/v1/admin/moderation/tickets/modtk_decide/decision", json={"decision": "ban", "note": "repeat abuse"})
+
+    assert resp.status_code == 200
+    assert resp.json()["ticket_id"] == "modtk_decide"
+    assert updates["called"] is True
+    assert action_calls and action_calls[0]["source_ticket_id"] == "modtk_decide"
+    assert action_calls[0]["action_type"] == "ban"
+    assert enforcement_calls and enforcement_calls[0]["source_ticket_id"] == "modtk_decide"
+    assert enforcement_calls[0]["enforcement_type"] == "ban"
+
+
+def test_warn_decision_persists_enforcement_history(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    monkeypatch.setattr(admin_moderation, "write_moderation_audit_event", lambda **kwargs: "audit_1")
+
+    ticket_item = {
+        "ticket_id": "modtk_warn",
+        "entity_type": "moderation_ticket",
+        "content_type": "message",
+        "content_id": "m1",
+        "status": "open",
+        "priority": "high",
+        "queue": "messages",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 1,
+        "aggregated_topics": ["spam"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_warned"})
+
+    action_calls = []
+    enforcement_calls = []
+
+    monkeypatch.setattr(admin_moderation.T.moderation_actions, "put_item", lambda **kwargs: action_calls.append(kwargs["Item"]) or {})
+    monkeypatch.setattr(admin_moderation.T.user_enforcement_history, "put_item", lambda **kwargs: enforcement_calls.append(kwargs["Item"]) or {})
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "update_item", lambda **kwargs: {})
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+    resp = client.post("/v1/admin/moderation/tickets/modtk_warn/decision", json={"decision": "warn", "note": "first warning"})
+
+    assert resp.status_code == 200
+    assert action_calls[0]["source_ticket_id"] == "modtk_warn"
+    assert action_calls[0]["action_type"] == "warn"
+    assert enforcement_calls[0]["source_ticket_id"] == "modtk_warn"
+    assert enforcement_calls[0]["enforcement_type"] == "warn"
+
+
+def test_resolve_ticket_rejects_invalid_combination(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_resolve_invalid",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 1,
+        "aggregated_topics": ["spam"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_resolve_invalid/resolve",
+        json={"resolution": "no_violation", "enforcement_action": "warn", "note": "invalid combo"},
+    )
+    assert resp.status_code == 400
+
+
+def test_resolve_ticket_transactional_pipeline(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    monkeypatch.setattr(admin_moderation, "write_moderation_audit_event", lambda **kwargs: "audit_1")
+
+    ticket_item = {
+        "ticket_id": "modtk_resolve",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+    removal_calls = {"called": False}
+    monkeypatch.setattr(
+        admin_moderation,
+        "apply_content_removal",
+        lambda **kwargs: removal_calls.__setitem__("called", True),
+    )
+    ban_calls = {"called": False, "duration": None, "policy_category": None}
+    monkeypatch.setattr(
+        admin_moderation,
+        "apply_ban",
+        lambda **kwargs: (
+            ban_calls.__setitem__("called", True),
+            ban_calls.__setitem__("duration", kwargs.get("duration_days")),
+            ban_calls.__setitem__("policy_category", kwargs.get("policy_category")),
+            {"status": "banned"},
+        )[-1],
+    )
+    monkeypatch.setattr(admin_moderation, "issue_warning_notification", lambda **kwargs: {})
+    content_remove_notifications = []
+    monkeypatch.setattr(admin_moderation, "notify_content_removal", lambda **kwargs: content_remove_notifications.append(kwargs) or None)
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "update_item", lambda **kwargs: {})
+
+    tx_calls = {}
+
+    def _tx(*, TransactItems):
+        tx_calls["items"] = TransactItems
+        return {}
+
+    monkeypatch.setattr(admin_moderation.ddb.meta.client, "transact_write_items", _tx)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_resolve/resolve",
+        json={"resolution": "content_removed", "enforcement_action": "ban", "enforcement_duration_days": 30, "note": "severe abuse"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ticket_id"] == "modtk_resolve"
+    assert removal_calls["called"] is True
+    assert ban_calls["called"] is True
+    assert ban_calls["duration"] == 30
+    assert ban_calls["policy_category"] == "criminal"
+    assert content_remove_notifications
+    assert content_remove_notifications[0]["policy_category"] == "criminal"
+    items = tx_calls["items"]
+    assert len(items) == 4
+    update = items[0]["Update"]
+    assert update["ConditionExpression"] == "#status = :open"
+
+    action_items = [i["Put"]["Item"] for i in items[1:3]]
+    action_types = {next(iter(i["action_type"].values())) for i in action_items}
+    assert "content_removed" in action_types
+    assert "ban" in action_types
+
+    enforcement_item = items[3]["Put"]["Item"]
+    assert next(iter(enforcement_item["source_ticket_id"].values())) == "modtk_resolve"
+    assert next(iter(enforcement_item["enforcement_type"].values())) == "ban"
+    assert next(iter(enforcement_item["duration_days"].values())) == "30"
+
+
+def test_resolve_ticket_rejects_invalid_state_transition(monkeypatch) -> None:
+    from app.routers import admin_moderation
+    from botocore.exceptions import ClientError
+
+    ticket_item = {
+        "ticket_id": "modtk_transition",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "closed",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 1,
+        "aggregated_topics": ["spam"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+
+    def _tx(*, TransactItems):
+        raise ClientError({"Error": {"Code": "TransactionCanceledException", "Message": "conditional failed"}}, "TransactWriteItems")
+
+    monkeypatch.setattr(admin_moderation.ddb.meta.client, "transact_write_items", _tx)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_transition/resolve",
+        json={"resolution": "content_removed", "enforcement_action": "none"},
+    )
+    assert resp.status_code == 409
+
+
+def test_resolve_ticket_rejects_duration_for_non_ban(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_duration_invalid",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 1,
+        "aggregated_topics": ["spam"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_duration_invalid/resolve",
+        json={"resolution": "content_removed", "enforcement_action": "warn", "enforcement_duration_days": 7},
+    )
+    assert resp.status_code == 400
+
+
+def test_decide_ticket_ban_requires_senior_scope(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_decide_perm_ban",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_decide_perm_ban/decision",
+        json={"decision": "ban", "note": "perm ban should require senior"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["required_scope"] == "content_moderation_senior"
+
+
+def test_resolve_ticket_permanent_ban_requires_senior_scope(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_resolve_perm_ban",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_resolve_perm_ban/resolve",
+        json={"resolution": "content_removed", "enforcement_action": "ban", "note": "perm ban should require senior"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["required_scope"] == "content_moderation_senior"
+
+
+def test_resolve_ticket_permanent_ban_allowed_for_senior_scope(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_resolve_perm_ban_senior",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+    monkeypatch.setattr(admin_moderation, "apply_content_removal", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation, "apply_ban", lambda **kwargs: {"status": "banned"})
+    monkeypatch.setattr(admin_moderation, "issue_warning_notification", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation, "write_moderation_audit_event", lambda **kwargs: "audit_1")
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "update_item", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation.ddb.meta.client, "transact_write_items", lambda **kwargs: {})
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION, AdminScope.CONTENT_MODERATION_SENIOR)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_resolve_perm_ban_senior/resolve",
+        json={"resolution": "content_removed", "enforcement_action": "ban", "note": "senior perm ban"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ticket_id"] == "modtk_resolve_perm_ban_senior"
+
+
+def test_resolve_ticket_permanent_ban_requires_second_approver_when_flag_enabled(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_resolve_perm_ban_dual",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "S", type("_S", (), {"moderation_dual_approval_permanent_ban_enabled": True})())
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION, AdminScope.CONTENT_MODERATION_SENIOR)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_resolve_perm_ban_dual/resolve",
+        json={"resolution": "content_removed", "enforcement_action": "ban", "note": "perm ban requires dual"},
+    )
+
+    assert resp.status_code == 403
+    assert "second approver" in str(resp.json()["detail"]).lower()
+
+
+def test_resolve_ticket_permanent_ban_allows_second_approver_when_flag_enabled(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_resolve_perm_ban_dual_ok",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "S", type("_S", (), {"moderation_dual_approval_permanent_ban_enabled": True})())
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+    monkeypatch.setattr(admin_moderation, "apply_content_removal", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation, "apply_ban", lambda **kwargs: {"status": "banned"})
+    monkeypatch.setattr(admin_moderation, "issue_warning_notification", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation, "write_moderation_audit_event", lambda **kwargs: "audit_1")
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "update_item", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation.ddb.meta.client, "transact_write_items", lambda **kwargs: {})
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION, AdminScope.CONTENT_MODERATION_SENIOR)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_resolve_perm_ban_dual_ok/resolve",
+        json={
+            "resolution": "content_removed",
+            "enforcement_action": "ban",
+            "second_approver_admin_user_id": "admin_2",
+            "note": "dual approved perm ban",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ticket_id"] == "modtk_resolve_perm_ban_dual_ok"
+
+
+def test_decide_ticket_permanent_ban_requires_second_approver_when_flag_enabled(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    ticket_item = {
+        "ticket_id": "modtk_decide_perm_ban_dual",
+        "entity_type": "moderation_ticket",
+        "content_type": "feed_post",
+        "content_id": "p1",
+        "status": "open",
+        "priority": "high",
+        "queue": "newsfeed",
+        "assigned_admin_user_id": "admin_1",
+        "report_count": 2,
+        "aggregated_topics": ["criminal"],
+        "latest_report_at": "1700000001",
+        "updated_at": "1700000001",
+        "created_at": "1700000000",
+    }
+
+    monkeypatch.setattr(admin_moderation, "S", type("_S", (), {"moderation_dual_approval_permanent_ban_enabled": True})())
+    monkeypatch.setattr(admin_moderation, "_get_ticket_or_404", lambda ticket_id: ticket_item)
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: [])
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_target"})
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION, AdminScope.CONTENT_MODERATION_SENIOR)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_decide_perm_ban_dual/decision",
+        json={"decision": "ban", "note": "perm ban requires dual"},
+    )
+
+    assert resp.status_code == 403
+    assert "second approver" in str(resp.json()["detail"]).lower()
+
+
+def test_list_tickets_respects_feature_flag_gate(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    def _deny_board(_admin):
+        raise HTTPException(status_code=403, detail="moderation board is disabled")
+
+    monkeypatch.setattr(admin_moderation, "ensure_admin_board_enabled", _deny_board)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.get("/v1/admin/moderation/tickets")
+    assert resp.status_code == 403
+
+
+def test_resolve_ticket_respects_feature_flag_gate(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    def _deny_actions(_admin):
+        raise HTTPException(status_code=403, detail="moderation actions are disabled")
+
+    monkeypatch.setattr(admin_moderation, "ensure_admin_actions_enabled", _deny_actions)
+
+    admin_user = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin_user)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_feature_gate/resolve",
+        json={"resolution": "no_violation", "enforcement_action": "none"},
+    )
+    assert resp.status_code == 403
+
+
+def test_feature_flags_endpoint_root_can_update_and_admin_cannot(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    monkeypatch.setattr(admin_moderation, "ensure_admin_board_enabled", lambda admin: None)
+    monkeypatch.setattr(
+        admin_moderation,
+        "get_moderation_feature_flags",
+        lambda: {
+            "enabled": True,
+            "report_feed_enabled": True,
+            "report_messages_enabled": True,
+            "report_profile_enabled": True,
+            "admin_board_enabled": True,
+            "admin_actions_enabled": True,
+            "enforcement_enabled": True,
+            "min_scope_for_board": "content_moderation",
+            "min_scope_for_actions": "content_moderation",
+            "min_scope_for_permanent_ban": "content_moderation_senior",
+        },
+    )
+    monkeypatch.setattr(
+        admin_moderation,
+        "set_moderation_feature_flags",
+        lambda updates: {
+            "enabled": bool(updates.get("enabled", True)),
+            "report_feed_enabled": True,
+            "report_messages_enabled": True,
+            "report_profile_enabled": True,
+            "admin_board_enabled": True,
+            "admin_actions_enabled": True,
+            "enforcement_enabled": True,
+            "min_scope_for_board": "content_moderation",
+            "min_scope_for_actions": "content_moderation",
+            "min_scope_for_permanent_ban": "content_moderation_senior",
+        },
+    )
+
+    scoped_admin = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(scoped_admin)
+    deny = client.put("/v1/admin/moderation/feature-flags", json={"enabled": False})
+    assert deny.status_code == 403
+
+    root_client = _client(AuthenticatedUser(sub="root_1", role=Role.ROOT))
+    ok = root_client.put("/v1/admin/moderation/feature-flags", json={"enabled": False})
+    assert ok.status_code == 200
+    assert ok.json()["enabled"] is False

--- a/tests/test_admin_roles.py
+++ b/tests/test_admin_roles.py
@@ -314,7 +314,7 @@ def test_grant_role_rejects_unknown_admin_scope_values() -> None:
         "code": "invalid_admin_scopes",
         "reason": "unknown_scope_values",
         "invalid_scopes": ["nope"],
-        "allowed_scopes": ["auth_support", "billing_support", "content_moderation"],
+        "allowed_scopes": ["auth_support", "billing_support", "content_moderation", "content_moderation_senior"],
     }
 
 

--- a/tests/test_auth_deps.py
+++ b/tests/test_auth_deps.py
@@ -53,3 +53,16 @@ class TestAuthDeps(unittest.TestCase):
                 run_async(deps.get_authenticated_user_sub(req))
         self.assertEqual(ctx.exception.status_code, 401)
         self.assertIn("Authentication not configured", str(ctx.exception.detail))
+
+
+    def test_get_authenticated_user_sub_blocks_banned_user(self):
+        req = SimpleNamespace(headers={"authorization": "Bearer user-1"})
+        fake_settings = SimpleNamespace(
+            cognito_user_pool_id="",
+            cognito_app_client_id="",
+            dev_mode=True,
+        )
+        with patch.object(deps, "S", fake_settings), patch.object(deps, "is_user_currently_banned", return_value=True):
+            with self.assertRaises(HTTPException) as ctx:
+                run_async(deps.get_authenticated_user_sub(req))
+        self.assertEqual(ctx.exception.status_code, 403)

--- a/tests/test_content_reports_store.py
+++ b/tests/test_content_reports_store.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from botocore.exceptions import ClientError
+import pytest
+
+from app.services.content_reports_store import create_content_report
+from app.core.aws import ddb
+
+
+def test_create_content_report_includes_topic_condition_checks(monkeypatch):
+    captured = {}
+
+    def _fake_transact_write_items(*, TransactItems):
+        captured["items"] = TransactItems
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    monkeypatch.setattr(ddb.meta.client, "transact_write_items", _fake_transact_write_items)
+
+    report_id = create_content_report(
+        reporter_user_id="u1",
+        content_type="profile_photo",
+        content_id="u2",
+        topics=["spam", "racist"],
+        reason_text="Bad content",
+    )
+
+    assert report_id
+    items = captured["items"]
+    assert items[0]["Put"]["ConditionExpression"] == "attribute_not_exists(report_id)"
+
+    topic_checks = [item["ConditionCheck"]["Key"]["report_id"]["S"] for item in items[1:]]
+    assert "TOPIC#spam" in topic_checks
+    assert "TOPIC#racist" in topic_checks
+
+
+def test_create_content_report_invalid_topic_rejected_by_db_condition(monkeypatch):
+    def _raise_on_transact(*, TransactItems):
+        raise ClientError(
+            {
+                "Error": {
+                    "Code": "TransactionCanceledException",
+                    "Message": "ConditionalCheckFailed",
+                }
+            },
+            "TransactWriteItems",
+        )
+
+    monkeypatch.setattr(ddb.meta.client, "transact_write_items", _raise_on_transact)
+
+    with pytest.raises(ClientError) as exc:
+        create_content_report(
+            reporter_user_id="u1",
+            content_type="profile_photo",
+            content_id="u2",
+            topics=["not_allowed"],
+            reason_text="Bad content",
+        )
+
+    assert exc.value.response["Error"]["Code"] == "TransactionCanceledException"

--- a/tests/test_local_ddb_init_content_reports.py
+++ b/tests/test_local_ddb_init_content_reports.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    path = Path("scripts/local-ddb-init.py").resolve()
+    spec = importlib.util.spec_from_file_location("local_ddb_init_content_reports", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _table_for(mod, table_name: str, fallback_name: str):
+    for t in mod._table_defs():
+        if t.name in {table_name, fallback_name}:
+            return t
+    raise AssertionError(f"table not found: {table_name} / {fallback_name}")
+
+
+def test_content_reports_table_schema_and_indexes() -> None:
+    mod = _load_module()
+    table = _table_for(mod, mod.S.content_reports_table_name, "ContentReports")
+
+    assert table.partition_key == "report_id"
+    assert table.sort_key is None
+
+    gsis = {g["index_name"]: g for g in table.gsi}
+    assert gsis["ByContentCreatedAt"]["partition_key"] == "content_ref"
+    assert gsis["ByContentCreatedAt"]["sort_key"] == "created_at"
+
+    assert gsis["ByReporterCreatedAt"]["partition_key"] == "reporter_user_id"
+    assert gsis["ByReporterCreatedAt"]["sort_key"] == "created_at"
+
+    assert gsis["ByCreatedAt"]["partition_key"] == "created_scope"
+    assert gsis["ByCreatedAt"]["sort_key"] == "created_at"

--- a/tests/test_local_ddb_init_moderation_actions_enforcement.py
+++ b/tests/test_local_ddb_init_moderation_actions_enforcement.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    path = Path("scripts/local-ddb-init.py").resolve()
+    spec = importlib.util.spec_from_file_location("local_ddb_init_moderation_actions_enforcement", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _table_for(mod, table_name: str, fallback_name: str):
+    for t in mod._table_defs():
+        if t.name in {table_name, fallback_name}:
+            return t
+    raise AssertionError(f"table not found: {table_name} / {fallback_name}")
+
+
+def test_moderation_actions_table_schema_and_indexes() -> None:
+    mod = _load_module()
+    table = _table_for(mod, mod.S.moderation_actions_table_name, "ModerationActions")
+
+    assert table.partition_key == "action_id"
+    assert table.sort_key is None
+
+    gsis = {g["index_name"]: g for g in table.gsi}
+    assert gsis["ByTicketCreatedAt"]["partition_key"] == "ticket_id"
+    assert gsis["ByTicketCreatedAt"]["sort_key"] == "created_at"
+    assert gsis["ByActionTypeCreatedAt"]["partition_key"] == "action_type"
+    assert gsis["ByActionTypeCreatedAt"]["sort_key"] == "created_at"
+    assert gsis["ByTargetUserCreatedAt"]["partition_key"] == "target_user_id"
+    assert gsis["ByTargetUserCreatedAt"]["sort_key"] == "created_at"
+
+
+def test_user_enforcement_history_table_schema_and_indexes() -> None:
+    mod = _load_module()
+    table = _table_for(mod, mod.S.user_enforcement_history_table_name, "UserEnforcementHistory")
+
+    assert table.partition_key == "user_id"
+    assert table.sort_key == "enforcement_id"
+
+    gsis = {g["index_name"]: g for g in table.gsi}
+    assert gsis["ByStatusCreatedAt"]["partition_key"] == "status"
+    assert gsis["ByStatusCreatedAt"]["sort_key"] == "created_at"
+    assert gsis["BySourceTicketCreatedAt"]["partition_key"] == "source_ticket_id"
+    assert gsis["BySourceTicketCreatedAt"]["sort_key"] == "created_at"

--- a/tests/test_local_ddb_init_moderation_audit_log.py
+++ b/tests/test_local_ddb_init_moderation_audit_log.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    path = Path("scripts/local-ddb-init.py").resolve()
+    spec = importlib.util.spec_from_file_location("local_ddb_init_moderation_audit_log", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _table_for(mod, table_name: str, fallback_name: str):
+    for t in mod._table_defs():
+        if t.name in {table_name, fallback_name}:
+            return t
+    raise AssertionError(f"table not found: {table_name} / {fallback_name}")
+
+
+def test_moderation_audit_log_table_schema_and_indexes() -> None:
+    mod = _load_module()
+    table = _table_for(mod, mod.S.moderation_audit_log_table_name, "ModerationAuditLog")
+
+    assert table.partition_key == "audit_id"
+    assert table.sort_key is None
+
+    gsis = {g["index_name"]: g for g in table.gsi}
+    assert gsis["ByTicketCreatedAt"]["partition_key"] == "ticket_id"
+    assert gsis["ByTicketCreatedAt"]["sort_key"] == "created_at"
+    assert gsis["ByActorCreatedAt"]["partition_key"] == "actor_user_id"
+    assert gsis["ByActorCreatedAt"]["sort_key"] == "created_at"
+    assert gsis["ByActionCreatedAt"]["partition_key"] == "action"
+    assert gsis["ByActionCreatedAt"]["sort_key"] == "created_at"

--- a/tests/test_local_ddb_init_moderation_tickets.py
+++ b/tests/test_local_ddb_init_moderation_tickets.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    path = Path("scripts/local-ddb-init.py").resolve()
+    spec = importlib.util.spec_from_file_location("local_ddb_init_moderation_tickets", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _table_for(mod, table_name: str, fallback_name: str):
+    for t in mod._table_defs():
+        if t.name in {table_name, fallback_name}:
+            return t
+    raise AssertionError(f"table not found: {table_name} / {fallback_name}")
+
+
+def test_moderation_tickets_table_schema_and_indexes() -> None:
+    mod = _load_module()
+    table = _table_for(mod, mod.S.moderation_tickets_table_name, "ModerationTickets")
+
+    assert table.partition_key == "ticket_id"
+    assert table.sort_key is None
+
+    gsis = {g["index_name"]: g for g in table.gsi}
+    assert gsis["ByStatusLatestReportAt"]["partition_key"] == "status"
+    assert gsis["ByStatusLatestReportAt"]["sort_key"] == "latest_report_at"
+
+    assert gsis["ByQueueLatestReportAt"]["partition_key"] == "queue"
+    assert gsis["ByQueueLatestReportAt"]["sort_key"] == "latest_report_at"
+
+    assert gsis["ByAssignedAdminLatestReportAt"]["partition_key"] == "assigned_admin_user_id"
+    assert gsis["ByAssignedAdminLatestReportAt"]["sort_key"] == "latest_report_at"
+
+    assert gsis["ByLatestReportAt"]["partition_key"] == "latest_report_scope"
+    assert gsis["ByLatestReportAt"]["sort_key"] == "latest_report_at"
+
+
+    assert gsis["ByContentStatusLatestReportAt"]["partition_key"] == "content_ref_status"
+    assert gsis["ByContentStatusLatestReportAt"]["sort_key"] == "latest_report_at"

--- a/tests/test_moderation_audit_log.py
+++ b/tests/test_moderation_audit_log.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from app.services import moderation_audit_log
+
+
+def test_write_moderation_audit_event_puts_immutable_row(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(moderation_audit_log.T.moderation_audit_log, "put_item", lambda **kwargs: calls.append(kwargs) or {})
+
+    audit_id = moderation_audit_log.write_moderation_audit_event(
+        action="ticket_resolved",
+        actor_user_id="admin_1",
+        ticket_id="modtk_1",
+        report_id="rpt_1",
+        content_type="feed_post",
+        content_id="post_1",
+        target_user_id="user_1",
+        metadata={"resolution": "content_removed"},
+    )
+
+    assert audit_id.startswith("modaudit_")
+    assert calls
+    item = calls[0]["Item"]
+    assert item["entity_type"] == "moderation_audit_event"
+    assert item["action"] == "ticket_resolved"
+    assert item["ticket_id"] == "modtk_1"
+    assert item["metadata"]["resolution"] == "content_removed"

--- a/tests/test_moderation_content_removal.py
+++ b/tests/test_moderation_content_removal.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from app.services import moderation_content_removal
+
+
+def test_apply_content_removal_feed_post_marks_removed(monkeypatch) -> None:
+    updates = []
+
+    class _Table:
+        def update_item(self, **kwargs):
+            updates.append(kwargs)
+            return {}
+
+    class _DDB:
+        def Table(self, _name):
+            return _Table()
+
+    monkeypatch.setattr(moderation_content_removal, "ddb", _DDB())
+
+    moderation_content_removal.apply_content_removal(
+        ticket={"content_type": "feed_post", "content_id": "post_1"},
+        reports=[{"metadata": {"post_id": "post_1"}}],
+        ticket_id="modtk_1",
+        admin_user_id="admin_1",
+    )
+
+    assert updates
+    assert updates[0]["Key"] == {"pk": "POST#post_1", "sk": "META"}
+    assert updates[0]["ExpressionAttributeValues"][":ticket"] == "modtk_1"
+
+
+def test_apply_content_removal_message_hides_message(monkeypatch) -> None:
+    update_calls = []
+
+    class _Table:
+        def get_item(self, **kwargs):
+            return {"Item": {"conversation_id": "c1", "message_id": "m1", "text": "hello"}}
+
+        def update_item(self, **kwargs):
+            update_calls.append(kwargs)
+            return {}
+
+    class _DDB:
+        def Table(self, _name):
+            return _Table()
+
+    monkeypatch.setattr(moderation_content_removal, "ddb", _DDB())
+
+    moderation_content_removal.apply_content_removal(
+        ticket={"content_type": "message", "content_id": "m1"},
+        reports=[{"metadata": {"conversation_id": "c1"}}],
+        ticket_id="modtk_2",
+        admin_user_id="admin_2",
+    )
+
+    assert update_calls
+    values = update_calls[0]["ExpressionAttributeValues"]
+    assert values[":t"] is True
+    assert values[":removed_text"] == "[removed by moderation]"
+
+
+def test_apply_content_removal_profile_photo_reverts(monkeypatch) -> None:
+    put_calls = []
+
+    def _get_item(**kwargs):
+        return {
+            "Item": {
+                "user_sub": "u1",
+                "profile": {
+                    "profile_photo_url": "https://cdn/new.jpg",
+                    "previous_approved_profile_photo_url": "https://cdn/old.jpg",
+                },
+            }
+        }
+
+    def _put_item(**kwargs):
+        put_calls.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(moderation_content_removal.T.profile, "get_item", _get_item)
+    monkeypatch.setattr(moderation_content_removal.T.profile, "put_item", _put_item)
+
+    moderation_content_removal.apply_content_removal(
+        ticket={"content_type": "profile_photo", "content_id": "u1"},
+        reports=[{"metadata": {}}],
+        ticket_id="modtk_3",
+        admin_user_id="admin_3",
+    )
+
+    assert put_calls
+    profile = put_calls[0]["Item"]["profile"]
+    assert profile["profile_photo_url"] == "https://cdn/old.jpg"
+    assert profile["moderation_last_removed_ticket_id"] == "modtk_3"

--- a/tests/test_moderation_kpis.py
+++ b/tests/test_moderation_kpis.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
+from app.routers.admin_moderation import router
+from app.services import moderation_kpis
+
+
+def _client(user: AuthenticatedUser) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_authenticated_user] = lambda: user
+    return TestClient(app)
+
+
+def test_compute_moderation_kpis_aggregates_expected_fields(monkeypatch) -> None:
+    tickets = [
+        {
+            "entity_type": "moderation_ticket",
+            "status": "open",
+            "priority": "critical",
+            "created_at": "1700000000",
+        },
+        {
+            "entity_type": "moderation_ticket",
+            "status": "closed",
+            "priority": "high",
+            "created_at": "1700000100",
+            "resolved_at": "1700000700",
+        },
+    ]
+    reports = [
+        {
+            "entity_type": "content_report",
+            "created_at": "1700001000",
+            "topics": ["criminal"],
+        },
+        {
+            "entity_type": "content_report",
+            "created_at": "1700001000",
+            "topics": ["spam"],
+        },
+    ]
+    enforcements = [
+        {"entity_type": "user_enforcement", "created_at": "1700001000", "enforcement_type": "warn"},
+        {"entity_type": "user_enforcement", "created_at": "1700001000", "enforcement_type": "ban"},
+    ]
+
+    monkeypatch.setattr(moderation_kpis, "_scan_all", lambda table, **kwargs: tickets if table is moderation_kpis.T.moderation_tickets else reports if table is moderation_kpis.T.content_reports else enforcements)
+
+    out = moderation_kpis.compute_moderation_kpis(now_ts=1700001200, lookback_hours=24, surge_window_minutes=30)
+
+    assert out["ticket_volume"] == 2
+    assert out["resolution_count"] == 1
+    assert out["resolution_latency_avg_seconds"] == 600
+    assert out["critical_backlog"] == 1
+    assert out["warning_count"] == 1
+    assert out["ban_count"] == 1
+    assert out["extortion_criminal_reports_window_count"] == 1
+
+
+def test_evaluate_and_dispatch_moderation_alerts_notifies_oncall_and_dedupes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        moderation_kpis,
+        "compute_moderation_kpis",
+        lambda **kwargs: {
+            "surge_window_minutes": 15,
+            "extortion_criminal_reports_window_count": 25,
+            "critical_backlog": 30,
+            "oldest_open_age_minutes": 200,
+        },
+    )
+    monkeypatch.setattr(
+        moderation_kpis,
+        "S",
+        type(
+            "_S",
+            (),
+            {
+                "moderation_oncall_user_subs": "oncall_1,oncall_2",
+                "moderation_alert_extortion_criminal_surge_threshold": 10,
+                "moderation_kpi_surge_window_minutes": 15,
+                "moderation_alert_sla_open_critical_threshold": 20,
+                "moderation_alert_sla_oldest_open_minutes_threshold": 120,
+                "moderation_alert_sla_window_minutes": 30,
+            },
+        )(),
+    )
+
+    alerts: list[tuple] = []
+    audit_calls: list[dict] = []
+    monkeypatch.setattr(moderation_kpis, "write_alert", lambda *args, **kwargs: alerts.append((args, kwargs)) or {"alert_id": "a1"})
+    monkeypatch.setattr(moderation_kpis, "write_moderation_audit_event", lambda **kwargs: audit_calls.append(kwargs) or "audit_1")
+    monkeypatch.setattr(moderation_kpis, "_already_fired", lambda **kwargs: False)
+
+    out = moderation_kpis.evaluate_and_dispatch_moderation_alerts(actor_user_id="admin_1", now_ts=1700001200)
+
+    assert len(out["alerts_fired"]) == 2
+    assert out["notified_user_subs"] == ["oncall_1", "oncall_2"]
+    assert len(alerts) == 4  # 2 alert types x 2 recipients
+    assert len(audit_calls) == 2
+
+
+def test_moderation_kpis_router_requires_permissions() -> None:
+    client = _client(AuthenticatedUser(sub="u1", role=Role.USER))
+
+    resp = client.get("/v1/admin/moderation/kpis")
+    assert resp.status_code == 403
+
+
+def test_moderation_kpis_router_returns_data_and_eval(monkeypatch) -> None:
+    from app.routers import admin_moderation
+
+    monkeypatch.setattr(
+        admin_moderation,
+        "compute_moderation_kpis",
+        lambda: {
+            "generated_at": 1700001200,
+            "lookback_hours": 24,
+            "surge_window_minutes": 15,
+            "ticket_volume": 10,
+            "resolution_count": 8,
+            "resolution_latency_avg_seconds": 100,
+            "resolution_latency_p95_seconds": 180,
+            "warning_count": 2,
+            "ban_count": 1,
+            "warning_rate": 0.6667,
+            "ban_rate": 0.3333,
+            "open_ticket_count": 2,
+            "critical_backlog": 1,
+            "oldest_open_age_minutes": 25,
+            "extortion_criminal_reports_window_count": 3,
+        },
+    )
+    monkeypatch.setattr(
+        admin_moderation,
+        "evaluate_and_dispatch_moderation_alerts",
+        lambda actor_user_id: {
+            "kpis": {
+                "generated_at": 1700001200,
+                "lookback_hours": 24,
+                "surge_window_minutes": 15,
+                "ticket_volume": 10,
+                "resolution_count": 8,
+                "resolution_latency_avg_seconds": 100,
+                "resolution_latency_p95_seconds": 180,
+                "warning_count": 2,
+                "ban_count": 1,
+                "warning_rate": 0.6667,
+                "ban_rate": 0.3333,
+                "open_ticket_count": 2,
+                "critical_backlog": 1,
+                "oldest_open_age_minutes": 25,
+                "extortion_criminal_reports_window_count": 3,
+            },
+            "alerts_fired": [{"alert": "sla_breach"}],
+            "notified_user_subs": ["oncall_1"],
+        },
+    )
+
+    admin = AuthenticatedUser(
+        sub="admin_1",
+        role=Role.ADMIN,
+        admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+    )
+    client = _client(admin)
+
+    summary = client.get("/v1/admin/moderation/kpis")
+    assert summary.status_code == 200
+    assert summary.json()["ticket_volume"] == 10
+
+    eval_resp = client.post("/v1/admin/moderation/kpis/evaluate-alerts")
+    assert eval_resp.status_code == 200
+    assert eval_resp.json()["ok"] is True
+    assert eval_resp.json()["alerts_fired"][0]["alert"] == "sla_breach"

--- a/tests/test_moderation_lifecycle_integration.py
+++ b/tests/test_moderation_lifecycle_integration.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import threading
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.roles import AdminProfile, AdminProfileType, AdminScope, Role
+from app.routers.admin_moderation import router as admin_router
+from app.routers.moderation import compat_router, router as moderation_router
+from app.services.sessions import require_ui_session
+
+
+class _AdminRef:
+    def __init__(self, value: AuthenticatedUser) -> None:
+        self.value = value
+
+
+def _client(admin_ref: _AdminRef) -> TestClient:
+    app = FastAPI()
+    app.include_router(moderation_router)
+    app.include_router(compat_router)
+    app.include_router(admin_router)
+    app.dependency_overrides[require_ui_session] = lambda: {"user_sub": "u_reporter", "ip": "127.0.0.1"}
+    app.dependency_overrides[get_authenticated_user] = lambda: admin_ref.value
+    return TestClient(app)
+
+
+def test_report_to_resolve_warn_lifecycle(monkeypatch) -> None:
+    from app.routers import admin_moderation, moderation
+
+    reports_by_ticket: dict[str, list[dict]] = {}
+    report_counter = {"n": 0}
+    warning_calls: list[dict] = []
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", lambda inp: None)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "_find_recent_duplicate", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "upsert_open_ticket_for_report", lambda **kwargs: {"ticket_id": "modtk_lifecycle"})
+
+    def _create_content_report(**kwargs):
+        report_counter["n"] += 1
+        report_id = f"rpt_{report_counter['n']}"
+        reports_by_ticket.setdefault(kwargs["linked_ticket_id"], []).append(
+            {
+                "report_id": report_id,
+                "topics": list(kwargs.get("topics") or []),
+                "metadata": kwargs.get("metadata") or {},
+                "content_type": kwargs.get("content_type"),
+                "content_id": kwargs.get("content_id"),
+            }
+        )
+        return report_id
+
+    monkeypatch.setattr(moderation, "create_content_report", _create_content_report)
+    monkeypatch.setattr(moderation, "write_moderation_audit_event", lambda **kwargs: "audit_mod")
+    monkeypatch.setattr(moderation, "write_alert", lambda *args, **kwargs: {"alert_id": "a1"})
+
+    monkeypatch.setattr(
+        admin_moderation,
+        "_get_ticket_or_404",
+        lambda ticket_id: {
+            "ticket_id": ticket_id,
+            "entity_type": "moderation_ticket",
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "status": "open",
+            "priority": "high",
+            "queue": "newsfeed",
+            "assigned_admin_user_id": "admin_1",
+            "report_count": 1,
+            "aggregated_topics": ["criminal"],
+            "latest_report_at": "1700000002",
+            "updated_at": "1700000002",
+            "created_at": "1700000001",
+        },
+    )
+    monkeypatch.setattr(admin_moderation, "_linked_reports", lambda ticket_id: reports_by_ticket.get(ticket_id, []))
+    monkeypatch.setattr(admin_moderation, "_content_snapshot", lambda ticket_item, reports: {"author_user_id": "u_offender"})
+    monkeypatch.setattr(admin_moderation.ddb.meta.client, "transact_write_items", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation.T.moderation_tickets, "update_item", lambda **kwargs: {})
+    monkeypatch.setattr(admin_moderation, "apply_content_removal", lambda **kwargs: None)
+    monkeypatch.setattr(admin_moderation, "notify_content_removal", lambda **kwargs: None)
+    monkeypatch.setattr(admin_moderation, "apply_ban", lambda **kwargs: {"status": "skipped"})
+    monkeypatch.setattr(admin_moderation, "issue_warning_notification", lambda **kwargs: warning_calls.append(kwargs) or None)
+    monkeypatch.setattr(admin_moderation, "write_moderation_audit_event", lambda **kwargs: "audit_admin")
+
+    admin_ref = _AdminRef(
+        AuthenticatedUser(
+            sub="admin_1",
+            role=Role.ADMIN,
+            admin_profile=AdminProfile(type=AdminProfileType.SCOPED, scopes=(AdminScope.CONTENT_MODERATION,)),
+        )
+    )
+    client = _client(admin_ref)
+
+    report_resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["criminal"],
+            "reason_text": "Threat content",
+        },
+    )
+    assert report_resp.status_code == 200
+    assert report_resp.json()["ticket_id"] == "modtk_lifecycle"
+
+    resolve_resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_lifecycle/resolve",
+        json={"resolution": "content_removed", "enforcement_action": "warn", "note": "policy violation"},
+    )
+    assert resolve_resp.status_code == 200
+    assert resolve_resp.json()["ticket_id"] == "modtk_lifecycle"
+    assert warning_calls
+    assert warning_calls[0]["policy_category"] == "criminal"
+
+
+def test_report_invalid_payload_rejected() -> None:
+    admin_ref = _AdminRef(AuthenticatedUser(sub="admin_1", role=Role.ADMIN))
+    client = _client(admin_ref)
+
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["not_allowed"],
+            "reason_text": "Invalid topic payload",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_report_race_condition_two_submissions_share_ticket(monkeypatch) -> None:
+    from app.routers import moderation
+
+    calls = {"upsert": 0, "reports": 0}
+    lock = threading.Lock()
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", lambda inp: None)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "_find_recent_duplicate", lambda **kwargs: None)
+
+    def _upsert(**kwargs):
+        with lock:
+            calls["upsert"] += 1
+        return {"ticket_id": "modtk_race"}
+
+    def _create_report(**kwargs):
+        with lock:
+            calls["reports"] += 1
+            return f"rpt_{calls['reports']}"
+
+    monkeypatch.setattr(moderation, "upsert_open_ticket_for_report", _upsert)
+    monkeypatch.setattr(moderation, "create_content_report", _create_report)
+    monkeypatch.setattr(moderation, "write_moderation_audit_event", lambda **kwargs: "audit")
+    monkeypatch.setattr(moderation, "write_alert", lambda *args, **kwargs: {"alert_id": "a1"})
+
+    admin_ref = _AdminRef(AuthenticatedUser(sub="admin_1", role=Role.ADMIN))
+    client = _client(admin_ref)
+
+    payload = {
+        "content_type": "feed_post",
+        "content_id": "post_race",
+        "topics": ["spam"],
+        "reason_text": "Concurrent report",
+    }
+
+    responses: list[dict] = []
+
+    def _submit() -> None:
+        responses.append(client.post("/v1/moderation/reports", json=payload).json())
+
+    t1 = threading.Thread(target=_submit)
+    t2 = threading.Thread(target=_submit)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert len(responses) == 2
+    assert {r["ticket_id"] for r in responses} == {"modtk_race"}
+    assert len({r["report_id"] for r in responses}) == 2
+    assert calls["upsert"] == 2
+
+
+def test_permission_error_for_admin_resolve() -> None:
+    admin_ref = _AdminRef(AuthenticatedUser(sub="u1", role=Role.USER))
+    client = _client(admin_ref)
+
+    resp = client.post(
+        "/v1/admin/moderation/tickets/modtk_denied/resolve",
+        json={"resolution": "no_violation", "enforcement_action": "none"},
+    )
+    assert resp.status_code == 403

--- a/tests/test_moderation_policy_engine.py
+++ b/tests/test_moderation_policy_engine.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from app.services import moderation_policy_engine
+
+
+def test_issue_warning_notification_writes_alert(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(moderation_policy_engine, "write_alert", lambda *args, **kwargs: calls.append((args, kwargs)) or {"alert_id": "a1"})
+
+    moderation_policy_engine.issue_warning_notification(
+        offender_user_id="u1",
+        ticket_id="t1",
+        note="watch it",
+        policy_category="criminal",
+    )
+
+    assert calls
+    args, kwargs = calls[0]
+    assert args[0] == "u1"
+    assert kwargs["event"] == "moderation_warning"
+    assert kwargs["details"]["ticket_id"] == "t1"
+    assert kwargs["details"]["policy_category"] == "criminal"
+
+
+def test_notify_content_removal_writes_alert(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(moderation_policy_engine, "write_alert", lambda *args, **kwargs: calls.append((args, kwargs)) or {"alert_id": "a1"})
+
+    moderation_policy_engine.notify_content_removal(
+        offender_user_id="u1",
+        ticket_id="t1",
+        content_type="feed_post",
+        policy_category="sexual",
+        note="removed after review",
+    )
+
+    assert calls
+    args, kwargs = calls[0]
+    assert args[0] == "u1"
+    assert kwargs["event"] == "moderation_content_removed"
+    assert kwargs["details"]["policy_category"] == "sexual"
+    assert kwargs["details"]["content_type"] == "feed_post"
+
+
+def test_apply_ban_updates_account_state_and_alert(monkeypatch) -> None:
+    put_calls = []
+    alert_calls = []
+
+    monkeypatch.setattr(moderation_policy_engine, "now_ts", lambda: 1700000000)
+    monkeypatch.setattr(moderation_policy_engine.T.account_state, "put_item", lambda **kwargs: put_calls.append(kwargs) or {})
+    monkeypatch.setattr(moderation_policy_engine, "write_alert", lambda *args, **kwargs: alert_calls.append((args, kwargs)) or {"alert_id": "a2"})
+
+    out = moderation_policy_engine.apply_ban(
+        offender_user_id="u2",
+        ticket_id="t2",
+        admin_user_id="admin_1",
+        note="policy violation",
+        duration_days=7,
+        policy_category="extortion",
+    )
+
+    assert out["status"] == "banned"
+    assert out["ban_until"] == 1700000000 + (7 * 86400)
+    assert put_calls
+    item = put_calls[0]["Item"]
+    assert item["status"] == "banned"
+    assert item["source_ticket_id"] == "t2"
+    assert item["ban_duration_days"] == 7
+    assert alert_calls
+    _args, kwargs = alert_calls[0]
+    assert kwargs["details"]["policy_category"] == "extortion"
+    assert kwargs["details"]["effective_duration"] == "7 days"
+
+
+def test_is_user_currently_banned_honors_expiry(monkeypatch) -> None:
+    monkeypatch.setattr(moderation_policy_engine, "now_ts", lambda: 1700000500)
+    monkeypatch.setattr(
+        moderation_policy_engine.T.account_state,
+        "get_item",
+        lambda Key: {"Item": {"user_sub": "u3", "status": "banned", "ban_until": 1700000400}},
+    )
+
+    assert moderation_policy_engine.is_user_currently_banned("u3") is False

--- a/tests/test_moderation_reports_router.py
+++ b/tests/test_moderation_reports_router.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.routers.moderation import router, compat_router
+from app.services.sessions import require_ui_session
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.include_router(compat_router)
+    app.dependency_overrides[require_ui_session] = lambda: {"user_sub": "u_reporter"}
+    return TestClient(app)
+
+
+def test_create_report_returns_2xx_for_valid_payload(monkeypatch) -> None:
+    from app.routers import moderation
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", lambda inp: None)
+    monkeypatch.setattr(moderation, "_find_recent_duplicate", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "upsert_open_ticket_for_report", lambda **kwargs: {"ticket_id": "modtk_abc"})
+    monkeypatch.setattr(moderation, "create_content_report", lambda **kwargs: "rpt_123")
+    audit_calls = []
+    alert_calls = []
+    monkeypatch.setattr(moderation, "write_moderation_audit_event", lambda **kwargs: audit_calls.append(kwargs) or "a1")
+    monkeypatch.setattr(moderation, "write_alert", lambda *args, **kwargs: alert_calls.append((args, kwargs)) or {"alert_id": "a1"})
+
+    client = _client()
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["spam"],
+            "reason_text": "This is spam content",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["report_id"] == "rpt_123"
+    assert body["ticket_id"].startswith("modtk_")
+    assert body["status"] == "submitted"
+    assert audit_calls and audit_calls[0]["action"] == "report_created"
+    assert alert_calls and alert_calls[0][1]["title"] == "Report received"
+
+
+def test_create_report_returns_4xx_for_invalid_topic() -> None:
+    client = _client()
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["unknown_topic"],
+            "reason_text": "This should fail",
+        },
+    )
+
+    assert resp.status_code == 422
+
+
+def test_create_report_returns_4xx_for_invalid_content(monkeypatch) -> None:
+    from app.routers import moderation
+
+    def _raise_not_found(inp):
+        raise HTTPException(status_code=404, detail="content not found")
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", _raise_not_found)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+
+    client = _client()
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "profile_photo",
+            "content_id": "user_missing",
+            "topics": ["spam"],
+            "reason_text": "Missing content",
+        },
+    )
+
+    assert resp.status_code == 404
+
+
+def test_create_report_idempotency_guard_deduplicates(monkeypatch) -> None:
+    from app.routers import moderation
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", lambda inp: None)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+    audit_calls = []
+    alert_calls = []
+    monkeypatch.setattr(moderation, "write_moderation_audit_event", lambda **kwargs: audit_calls.append(kwargs) or "a1")
+    monkeypatch.setattr(moderation, "write_alert", lambda *args, **kwargs: alert_calls.append((args, kwargs)) or {"alert_id": "a1"})
+    monkeypatch.setattr(
+        moderation,
+        "_find_recent_duplicate",
+        lambda **kwargs: {
+            "report_id": "rpt_existing",
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "ticket_id": "modtk_existing",
+            "created_at": "1700000000",
+            "entity_type": "content_report",
+        },
+    )
+
+    client = _client()
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["spam"],
+            "reason_text": "Repeated report",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["report_id"] == "rpt_existing"
+    assert body["ticket_id"] == "modtk_existing"
+    assert body["status"] == "deduplicated"
+    assert audit_calls and audit_calls[0]["action"] == "report_deduplicated"
+    assert alert_calls and alert_calls[0][1]["details"]["status"] == "deduplicated"
+
+
+def test_compat_route_matches_same_contract(monkeypatch) -> None:
+    from app.routers import moderation
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", lambda inp: None)
+    monkeypatch.setattr(moderation, "_find_recent_duplicate", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "upsert_open_ticket_for_report", lambda **kwargs: {"ticket_id": "modtk_abc"})
+    monkeypatch.setattr(moderation, "create_content_report", lambda **kwargs: "rpt_compat")
+    monkeypatch.setattr(moderation, "write_moderation_audit_event", lambda **kwargs: "a1")
+    monkeypatch.setattr(moderation, "write_alert", lambda *args, **kwargs: {"alert_id": "a1"})
+
+    client = _client()
+    resp = client.post(
+        "/moderation/reports",
+        json={
+            "content_type": "message",
+            "content_id": "m1",
+            "conversation_id": "c1",
+            "topics": ["criminal"],
+            "reason_text": "Criminal threat",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["report_id"] == "rpt_compat"
+
+
+def test_rate_limit_returns_controlled_error(monkeypatch) -> None:
+    from app.routers import moderation
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", lambda inp: None)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+    monkeypatch.setattr(
+        moderation,
+        "_enforce_rate_limits",
+        lambda **kwargs: (_ for _ in ()).throw(HTTPException(status_code=429, detail="Rate limit exceeded for moderation reports", headers={"Retry-After": "60"})),
+    )
+
+    client = _client()
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["spam"],
+            "reason_text": "Repeated report payload",
+        },
+    )
+
+    assert resp.status_code == 429
+    assert resp.json()["detail"] == "Rate limit exceeded for moderation reports"
+    assert resp.headers.get("retry-after") == "60"
+
+
+def test_anti_spam_security_event_is_logged(monkeypatch) -> None:
+    from app.routers import moderation
+
+    calls: list[tuple] = []
+
+    monkeypatch.setattr(moderation, "_validate_content_exists", lambda inp: None)
+    monkeypatch.setattr(moderation, "_find_recent_duplicate", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "_enforce_rate_limits", lambda **kwargs: None)
+    monkeypatch.setattr(moderation, "upsert_open_ticket_for_report", lambda **kwargs: {"ticket_id": "modtk_abc"})
+    monkeypatch.setattr(moderation, "create_content_report", lambda **kwargs: "rpt_anti_spam")
+    monkeypatch.setattr(moderation, "write_moderation_audit_event", lambda **kwargs: "a1")
+    monkeypatch.setattr(moderation, "write_alert", lambda *args, **kwargs: {"alert_id": "a1"})
+
+    def _capture_audit(event, user_sub, request=None, **fields):
+        calls.append((event, user_sub, fields))
+
+    monkeypatch.setattr(moderation, "audit_event", _capture_audit)
+
+    client = _client()
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["spam"],
+            "reason_text": "https://example.com scam scam scam!!!",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert any(event == "moderation_report_anti_spam_signal" for event, _user, _fields in calls)
+
+
+def test_create_report_blocks_disabled_surface_flag(monkeypatch) -> None:
+    from app.routers import moderation
+
+    monkeypatch.setattr(moderation, "ensure_reporting_surface_enabled", lambda content_type: (_ for _ in ()).throw(HTTPException(status_code=403, detail="feed reporting is disabled")))
+
+    client = _client()
+    resp = client.post(
+        "/v1/moderation/reports",
+        json={
+            "content_type": "feed_post",
+            "content_id": "post_1",
+            "topics": ["spam"],
+            "reason_text": "report blocked by flag",
+        },
+    )
+
+    assert resp.status_code == 403
+    assert "disabled" in resp.json()["detail"]

--- a/tests/test_moderation_tickets_store.py
+++ b/tests/test_moderation_tickets_store.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from botocore.exceptions import ClientError
+
+from app.services.moderation_tickets_store import score_initial_priority, upsert_open_ticket_for_report
+
+
+def test_score_initial_priority_is_deterministic() -> None:
+    assert score_initial_priority(topics=["spam"]) == "medium"
+    assert score_initial_priority(topics=["criminal"]) == "high"
+    assert score_initial_priority(topics=["extortion"]) == "critical"
+    assert score_initial_priority(topics=["spam", "extortion"]) == "critical"
+    assert score_initial_priority(topics=[" extortion ", "SPAM"]) == "critical"
+
+
+def _conditional_check_failed(operation: str = "PutItem") -> ClientError:
+    return ClientError({"Error": {"Code": "ConditionalCheckFailedException", "Message": "conditional failed"}}, operation)
+
+
+def test_upsert_open_ticket_creates_new_ticket(monkeypatch) -> None:
+    from app.services import moderation_tickets_store as store
+
+    calls = {}
+
+    def _put_item(**kwargs):
+        calls["put"] = kwargs
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    monkeypatch.setattr(store.T.moderation_tickets, "put_item", _put_item)
+
+    out = upsert_open_ticket_for_report(content_type="feed_post", content_id="post_1", topics=["spam", "racist"], now_ts=1700000000)
+
+    assert out["created"] is True
+    assert out["status"] == "open"
+    assert out["ticket_id"].startswith("modtk_")
+    item = calls["put"]["Item"]
+    assert item["content_ref"] == "feed_post#post_1"
+    assert item["content_ref_status"] == "feed_post#post_1#open"
+    assert item["report_count"] == 1
+    assert item["aggregated_topics"] == {"spam", "racist"}
+    assert item["priority"] == "high"
+
+
+def test_upsert_open_ticket_updates_existing_open_ticket(monkeypatch) -> None:
+    from app.services import moderation_tickets_store as store
+
+    def _put_item(**kwargs):
+        raise _conditional_check_failed("PutItem")
+
+    captured = {}
+
+    def _update_item(**kwargs):
+        captured.update(kwargs)
+        return {"Attributes": {}}
+
+    monkeypatch.setattr(store.T.moderation_tickets, "put_item", _put_item)
+    monkeypatch.setattr(store.T.moderation_tickets, "update_item", _update_item)
+
+    out = upsert_open_ticket_for_report(content_type="message", content_id="msg_9", topics=["criminal"], now_ts=1700000001)
+
+    assert out == {"ticket_id": out["ticket_id"], "status": "open", "created": False}
+    assert captured["ConditionExpression"] == "#status = :open"
+    assert captured["ExpressionAttributeValues"][":inc"] == 1
+    assert captured["ExpressionAttributeValues"][":topics"] == {"criminal"}
+    assert captured["ExpressionAttributeValues"][":priority"] == "high"
+
+
+def test_upsert_open_ticket_creates_new_when_existing_is_not_open(monkeypatch) -> None:
+    from app.services import moderation_tickets_store as store
+
+    put_calls = []
+
+    def _put_item(**kwargs):
+        put_calls.append(kwargs)
+        if len(put_calls) == 1:
+            raise _conditional_check_failed("PutItem")
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def _update_item(**kwargs):
+        raise _conditional_check_failed("UpdateItem")
+
+    monkeypatch.setattr(store.T.moderation_tickets, "put_item", _put_item)
+    monkeypatch.setattr(store.T.moderation_tickets, "update_item", _update_item)
+
+    out = upsert_open_ticket_for_report(content_type="profile_photo", content_id="u_2", topics=["sexual"], now_ts=1700000002)
+
+    assert out["created"] is True
+    assert out["ticket_id"].endswith("_1700000002")
+    assert len(put_calls) == 2

--- a/tests/test_moderation_visibility_filters.py
+++ b/tests/test_moderation_visibility_filters.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from app.routers import messaging
+
+
+def test_filter_message_visible_hides_moderation_hidden() -> None:
+    assert messaging._filter_message_visible({"moderation_hidden": True, "deleted_for": []}, "u1") is False
+
+
+def test_filter_message_visible_hides_moderation_removed_at() -> None:
+    assert messaging._filter_message_visible({"moderation_removed_at": 1700000000, "deleted_for": []}, "u1") is False

--- a/tests/test_newsfeed_moderation_visibility.py
+++ b/tests/test_newsfeed_moderation_visibility.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from app.routers import newsfeed
+
+
+def test_list_comments_excludes_deleted_and_moderation_removed(monkeypatch) -> None:
+    monkeypatch.setattr(newsfeed, "ddb_get_item", lambda key: {"post_id": "p1", "locked": False, "user_id": "owner"})
+    monkeypatch.setattr(
+        newsfeed,
+        "ddb_query",
+        lambda **kwargs: {
+            "Items": [
+                {"comment_id": "c1", "post_id": "p1", "deleted": False, "moderation_removed": False, "body": "ok", "body_format": "plain", "body_version": 1},
+                {"comment_id": "c2", "post_id": "p1", "deleted": True, "body": "gone", "body_format": "plain", "body_version": 1},
+                {"comment_id": "c3", "post_id": "p1", "deleted": False, "moderation_removed": True, "body": "gone", "body_format": "plain", "body_version": 1},
+            ]
+        },
+    )
+    monkeypatch.setattr(newsfeed, "has_unlocked", lambda user_id, post_id: True)
+
+    out = newsfeed.list_comments("p1", cursor=None, user_id="viewer")
+    assert [i["comment_id"] for i in out["items"]] == ["c1"]


### PR DESCRIPTION
### Motivation
- Implement a first-class content moderation workflow so users can report feed/messages/profile photos and moderators can triage, remove content, warn, or ban offenders.
- Provide operational tools: ticket aggregation, priority scoring, KPI alerts, audit logging, feature flags and staged rollouts.
- Enforce bans system-wide by blocking banned users from UI sessions and requests.

### Description
- Add a user-facing reporting API and compatibility route with `POST /v1/moderation/reports` and client helpers, including anti-spam heuristics, rate limits, idempotency, and content existence checks via `app/routers/moderation.py` and `app/services/content_reports_store.py`.
- Implement moderation ticket lifecycle and admin board endpoints under `app/routers/admin_moderation.py` with claim/decision/resolve flows, enforcement recording, audit events, and content removal adapters in `app/services/moderation_*` (tickets store, content removal, policy engine, audit log, kpis, flags).
- Persist new moderation tables and wiring: add settings for table names and feature flags in `app/core/settings.py`, expose tables in `app/core/tables.py`, add local DDB init entries and multiple migrations under `scripts/migrations/*` to create `content_reports`, `moderation_tickets`, `moderation_actions`, `user_enforcement_history`, and `moderation_audit_log` schemas.
- Integrate moderation into the app: include routers in `app/main.py`, add frontend components and pages (`ReportContentModal`, `ModerationBoardPage`, feed/message/report actions), API endpoints in frontend, capability gating in `frontend/src/lib/adminCapabilities.*`, and wire up UI changes to hide moderated content in `newsfeed` and message visibility filters.
- Add role/permission updates: new `AdminScope.CONTENT_MODERATION_SENIOR` scope and feature-flag gated checks for permanent bans and admin actions; require senior scope for permanent bans and optional dual-approval gating.
- Enforce bans during auth/session resolution by consulting `app/services/moderation_policy_engine.is_user_currently_banned` in `app/auth/deps.py` and `app/services/sessions.py` to block non-admin banned users.

### Testing
- Added extensive unit and integration tests covering report intake, ticket upsert/aggregation, admin ticket APIs (claim/decision/resolve), enforcement persistence, content removal adapters, policy engine, KPI alerts, and local DDB init expectations; key test files include `tests/test_moderation_*`, `tests/test_admin_moderation_tickets_router.py`, `tests/test_moderation_lifecycle_integration.py`, `tests/test_moderation_policy_engine.py`, and new frontend component tests (e.g. `ReportContentModal.test.tsx`, moderation page tests).
- Ran the new and existing automated test suites (Python unit tests and frontend Jest/Vitest component tests) against the changes; all new tests passed locally in the CI run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99818a6f8832ba1d52ea489105eb0)