### PR TITLE
merge: PR #133 branch — DDB init fix, alerts E2E, CI fixes, address map + UPS validation

### DIFF
--- a/scripts/local-ddb-init.py
+++ b/scripts/local-ddb-init.py
@@ -245,27 +245,6 @@ def _table_defs() -> List[TableDef]:
             ],
         ),
         TableDef(
-            _resolve_table_name(S.message_reports_table_name, "MessageReports"),
-            "report_id",
-            gsi=[
-                {
-                    "index_name": "ByConversationCreatedAt",
-                    "partition_key": "conversation_id",
-                    "sort_key": "created_at",
-                },
-                {
-                    "index_name": "ByStatusCreatedAt",
-                    "partition_key": "status",
-                    "sort_key": "created_at",
-                },
-                {
-                    "index_name": "ByReporterCreatedAt",
-                    "partition_key": "reported_by_user_id",
-                    "sort_key": "created_at",
-                },
-            ],
-        ),
-        TableDef(
             _resolve_table_name(S.message_report_context_table_name, "MessageReportContext"),
             "report_id",
             "message_id",
@@ -382,40 +361,8 @@ def _table_defs() -> List[TableDef]:
             ],
         ),
         TableDef(
-            _resolve_table_name(S.message_legal_holds_table_name, "MessageLegalHolds"),
-            "hold_id",
-            gsi=[
-                {
-                    "index_name": "ByConversationStatusCreatedAt",
-                    "partition_key": "conversation_status",
-                    "sort_key": "created_at",
-                },
-                {
-                    "index_name": "ByStatusCreatedAt",
-                    "partition_key": "status",
-                    "sort_key": "created_at",
-                },
-            ],
-        ),
-        TableDef(
             _resolve_table_name(S.message_archive_chain_heads_table_name, "MessageArchiveChainHeads"),
             "partition_key",
-        ),
-        TableDef(
-            _resolve_table_name(S.message_compliance_exports_table_name, "MessageComplianceExports"),
-            "export_id",
-            gsi=[
-                {
-                    "index_name": "ByCaseCreatedAt",
-                    "partition_key": "case_id",
-                    "sort_key": "created_at",
-                },
-                {
-                    "index_name": "ByStatusCreatedAt",
-                    "partition_key": "status",
-                    "sort_key": "created_at",
-                },
-            ],
         ),
         TableDef(
             os.getenv("DDB_MESSAGE_CONSUMPTION", "MessageConsumption"),
@@ -459,29 +406,41 @@ def _table_defs() -> List[TableDef]:
             gsi=[{"index_name": "ByConversationUserUpdatedAt", "partition_key": "conversation_user", "sort_key": "updated_at"}],
             attr_types={"updated_at": "N"},
         ),
-        # MessageReports: pk=report_id, GSIs ByConversationCreatedAt + ByReporterCreatedAt
+        # MessageReports: pk=report_id, GSIs ByConversationCreatedAt + ByStatusCreatedAt + ByReporterCreatedAt
         TableDef(
             _resolve_table_name(S.message_reports_table_name, "MessageReports"),
             "report_id",
             gsi=[
                 {"index_name": "ByConversationCreatedAt", "partition_key": "conversation_id", "sort_key": "created_at"},
+                {"index_name": "ByStatusCreatedAt", "partition_key": "status", "sort_key": "created_at"},
                 {"index_name": "ByReporterCreatedAt", "partition_key": "reported_by_user_id", "sort_key": "created_at"},
             ],
             attr_types={"created_at": "N"},
         ),
         # MessageReportContext: pk=(report_id, message_id)
         TableDef(_resolve_table_name(S.message_report_context_table_name, "MessageReportContext"), "report_id", "message_id"),
-        # MessageLegalHolds: pk=hold_id, GSI ByConversationStatusCreatedAt
+        # MessageLegalHolds: pk=hold_id, GSIs ByConversationStatusCreatedAt + ByStatusCreatedAt
         TableDef(
             _resolve_table_name(S.message_legal_holds_table_name, "MessageLegalHolds"),
             "hold_id",
-            gsi=[{"index_name": "ByConversationStatusCreatedAt", "partition_key": "conversation_status", "sort_key": "created_at"}],
+            gsi=[
+                {"index_name": "ByConversationStatusCreatedAt", "partition_key": "conversation_status", "sort_key": "created_at"},
+                {"index_name": "ByStatusCreatedAt", "partition_key": "status", "sort_key": "created_at"},
+            ],
             attr_types={"created_at": "N"},
         ),
         # MessageArchiveChainHeads: pk=conversation_id
         TableDef(_resolve_table_name(S.message_archive_chain_heads_table_name, "MessageArchiveChainHeads"), "conversation_id"),
-        # MessageComplianceExports: pk=export_id
-        TableDef(_resolve_table_name(S.message_compliance_exports_table_name, "MessageComplianceExports"), "export_id"),
+        # MessageComplianceExports: pk=export_id, GSIs ByCaseCreatedAt + ByStatusCreatedAt
+        TableDef(
+            _resolve_table_name(S.message_compliance_exports_table_name, "MessageComplianceExports"),
+            "export_id",
+            gsi=[
+                {"index_name": "ByCaseCreatedAt", "partition_key": "case_id", "sort_key": "created_at"},
+                {"index_name": "ByStatusCreatedAt", "partition_key": "status", "sort_key": "created_at"},
+            ],
+            attr_types={"created_at": "N"},
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary
- **fix(ddb-init)**: Remove duplicate `TableDef` entries for `MessageReports`, `MessageLegalHolds`, and `MessageComplianceExports` that caused `ValidationException` (type mismatch) on compliance endpoints — consolidated into single definitions with `attr_types={"created_at": "N"}` and all required GSIs
- **feat(alerts)**: Fix prefs API field names (`sms_event_types`, `toast_event_types`) and add 35-test E2E suite (`alerts-delivery.spec.ts`, sections 97–101)
- **fix(ci)**: Update all three GitHub Actions workflows to Python 3.12, add missing env vars, test files, health checks, and artifact uploads
- **feat**: Address map preview (Leaflet/Nominatim) + UPS Address Validation button with click-to-fill suggestions in Add/Edit address dialog
- **chore**: Untrack generated/runtime directories from git; restore `.github` to version control

## Test plan
- [x] Full E2E suite: **1067 passed, 3 skipped, 0 failed** (1070 tests)
- [x] `messaging-compliance.spec.ts` all 30 pass after DDB init fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)