### PR TITLE
feat(devtools): move dev tools UI to standalone server on port 3001

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ See `justfile` for all available commands.
 | Service | Port | Notes |
 |---------|------|-------|
 | Frontend (Vite) | 3000 | React app; proxies `/api`, `/ui`, `/mock`, `/internal`, etc. to backend |
+| Dev Tools UI | 3001 | Standalone React app; no auth needed; proxies `/internal` to backend |
 | Backend (uvicorn) | 8000 | FastAPI; `GET /openapi.json` for full API spec, `/docs` for Swagger UI |
 | DynamoDB Local | 8001 | Persistent across backend restarts; data in `.local/tools/dynamodb-local/data/` |
 | Moto (S3 + Cognito mock) | 4566 | LocalStack-compatible AWS mock |

--- a/docs/internal-dev-log-ui.md
+++ b/docs/internal-dev-log-ui.md
@@ -15,15 +15,21 @@ It helps developers inspect mock artifacts produced by the local stack in one pl
 1. Start the local stack:
 
 ```bash
-scripts/run_dev.sh
+just up
 ```
 
-2. Open the frontend app:
+2. Open the Dev Tools UI:
 
-- Main app: `http://localhost:5173`
-- Dev Log UI: `http://localhost:5173/dev-tools/log-ui`
+- Dev Tools: `http://localhost:3001`
 
-`run_dev.sh` auto-enables the route by exporting `VITE_ENABLE_DEVTOOLS_LOG_UI=1` for local runs.
+The Dev Tools UI is a standalone Vite server on port 3001. No auth is required.
+Start it independently with:
+
+```bash
+just devtools
+```
+
+The main app runs on port 3000 as usual. The devtools server is started automatically by `just up` / `scripts/dev.sh start`.
 
 ## Data inputs and defaults
 
@@ -48,15 +54,15 @@ The only interactive write-like action is in-memory/local browser handling for t
 
 ## Troubleshooting
 
-### Dev Log route returns 404
+### Dev Tools page not loading
 
-- Confirm frontend flag is enabled: `VITE_ENABLE_DEVTOOLS_LOG_UI=1`
-- If using local flow, prefer `scripts/run_dev.sh` (it sets this automatically).
+- Confirm the devtools server is running on port 3001: `just devtools` or check `scripts/dev.sh status`.
+- The devtools server is started automatically by `just up` / `scripts/dev.sh start`.
 
 ### Page loads but no records appear
 
 - Confirm logs exist at the configured `DEVTOOLS_*` paths.
-- Check backend/frontend logs printed by `run_dev.sh` startup output.
+- Check backend/frontend logs printed by `scripts/dev.sh start` startup output.
 - If you used `--no-clean`, old logs may be retained; verify file timestamps and active path values.
 
 ### Billing tab is empty

--- a/frontend/devtools.html
+++ b/frontend/devtools.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dev Tools</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/devtools-main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "lint": "tsc --noEmit",
     "test": "vitest",
     "test:e2e": "playwright test",
-    "test:e2e:vnc": "playwright test e2e/vnc-remote-desktop.spec.ts"
+    "test:e2e:vnc": "playwright test e2e/vnc-remote-desktop.spec.ts",
+    "dev:devtools": "vite --config vite.devtools.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import AppShell from "@/components/layout/AppShell";
 import { ErrorPage } from "@/components/shared/ErrorPage";
-import { isDevtoolsLogUiEnabled, isVncRemoteDesktopEnabled } from "@/lib/featureFlags";
+import { isVncRemoteDesktopEnabled } from "@/lib/featureFlags";
 
 // ─── Lazy-loaded pages (code-split per route) ───────────────────
 const Login = lazy(() => import("@/pages/Login"));
@@ -40,7 +40,6 @@ const TicketsPage = lazy(() => import("@/pages/tickets/TicketsPage"));
 const TicketSpacesPage = lazy(() => import("@/pages/tickets/TicketSpacesPage"));
 const TicketSpaceDetailPage = lazy(() => import("@/pages/tickets/TicketSpaceDetailPage"));
 const RemoteDesktopPage = lazy(() => import("@/pages/remote/RemoteDesktopPage"));
-const DevToolsLogUiPage = lazy(() => import("@/pages/devtools/DevToolsLogUiPage"));
 const SigningPage = lazy(() => import("@/pages/signing/SigningPage"));
 const QuestionnaireBuilderPage = lazy(() => import("@/pages/questionnaires/QuestionnaireBuilderPage"));
 const QuestionnaireRespondentPage = lazy(() => import("@/pages/questionnaires/QuestionnaireRespondentPage"));
@@ -54,7 +53,6 @@ function PageSpinner() {
 }
 
 export default function App() {
-  const showDevtoolsLogUi = isDevtoolsLogUiEnabled();
   const showVncRemoteDesktop = isVncRemoteDesktopEnabled();
 
   return (
@@ -100,7 +98,6 @@ export default function App() {
           <Route path="subscriptions" element={<SubscriptionsPage />} />
           <Route path="root/roles" element={<RootRoleManagementPage />} />
           <Route path="admin/moderation" element={<ModerationBoardPage />} />
-          {showDevtoolsLogUi && <Route path="dev-tools/log-ui" element={<DevToolsLogUiPage />} />}
           <Route path="*" element={<ErrorPage status={404} />} />
         </Route>
 

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -17,7 +17,6 @@ import {
   FilePen,
   Settings,
   UsersRound,
-  Bug,
   MonitorSmartphone,
   Scale,
 } from "lucide-react";
@@ -32,7 +31,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useAuthStore } from "@/stores/authStore";
 import { canAccessModerationBoard, canSeeRootRoleManagement } from "@/lib/adminCapabilities";
-import { isDevtoolsLogUiEnabled, isVncRemoteDesktopEnabled } from "@/lib/featureFlags";
+import { isVncRemoteDesktopEnabled } from "@/lib/featureFlags";
 
 // ─── Tab config ─────────────────────────────────────────────────
 
@@ -56,7 +55,6 @@ const MORE_LINKS = [
   { label: "Ticket Spaces", path: "/tickets/spaces", icon: LifeBuoy },
   { label: "Remote Desktop", path: "/remote-desktop", icon: MonitorSmartphone },
   { label: "Settings", path: "/settings", icon: Settings },
-  { label: "Dev Tools", path: "/dev-tools/log-ui", icon: Bug },
   { label: "Role Mgmt", path: "/root/roles", icon: UsersRound },
   { label: "Moderation Board", path: "/admin/moderation", icon: Scale },
 ];
@@ -72,7 +70,6 @@ export default function MobileNav() {
 
   const moreLinks = MORE_LINKS.filter((item) => {
     if (item.path === "/root/roles") return showRootRoleManagement;
-    if (item.path === "/dev-tools/log-ui") return isDevtoolsLogUiEnabled();
     if (item.path === "/remote-desktop") return isVncRemoteDesktopEnabled();
     if (item.path === "/admin/moderation") return showModerationBoard;
     return true;

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -22,7 +22,6 @@ import {
   Headphones,
   PanelLeftClose,
   PanelLeft,
-  Bug,
   MonitorSmartphone,
   Scale,
 } from "lucide-react";
@@ -35,7 +34,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { canAccessModerationBoard, canSeeRootRoleManagement } from "@/lib/adminCapabilities";
 import { useQuery } from "@tanstack/react-query";
 import { getConversations } from "@/api/endpoints/messaging";
-import { isDevtoolsLogUiEnabled, isVncRemoteDesktopEnabled } from "@/lib/featureFlags";
+import { isVncRemoteDesktopEnabled } from "@/lib/featureFlags";
 
 // ─── Navigation Config ──────────────────────────────────────────
 
@@ -91,7 +90,6 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Ticket Spaces", path: "/tickets/spaces", icon: <LifeBuoy className="h-5 w-5" /> },
       { label: "Remote Desktop", path: "/remote-desktop", icon: <MonitorSmartphone className="h-5 w-5" /> },
       { label: "Settings", path: "/settings", icon: <Settings className="h-5 w-5" /> },
-      { label: "Dev Tools Log UI", path: "/dev-tools/log-ui", icon: <Bug className="h-5 w-5" /> },
       { label: "Role Management", path: "/root/roles", icon: <UsersRound className="h-5 w-5" /> },
       { label: "Moderation Board", path: "/admin/moderation", icon: <Scale className="h-5 w-5" /> },
     ],
@@ -152,7 +150,6 @@ export default function Sidebar() {
         {NAV_GROUPS.map((group, gi) => {
           const items = group.items.filter((item) => {
             if (item.path === "/root/roles") return showRootRoleManagement;
-            if (item.path === "/dev-tools/log-ui") return isDevtoolsLogUiEnabled();
             if (item.path === "/remote-desktop") return isVncRemoteDesktopEnabled();
             if (item.path === "/admin/moderation") return showModerationBoard;
             return true;

--- a/frontend/src/devtools-main.tsx
+++ b/frontend/src/devtools-main.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import DevToolsLogUiPage from "@/pages/devtools/DevToolsLogUiPage";
+import { ThemeProvider } from "@/components/ThemeProvider";
+import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: 1, staleTime: 10_000 },
+  },
+});
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <div className="min-h-screen bg-background">
+          <div className="mx-auto max-w-7xl p-6">
+            <DevToolsLogUiPage />
+          </div>
+        </div>
+      </QueryClientProvider>
+    </ThemeProvider>
+  </React.StrictMode>,
+);

--- a/frontend/vite.devtools.config.ts
+++ b/frontend/vite.devtools.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+    dedupe: ["react", "react-dom"],
+  },
+  server: {
+    host: "0.0.0.0",
+    port: 3001,
+    strictPort: true,
+    hmr: {
+      clientPort: 3001,
+    },
+    proxy: {
+      "/internal": "http://localhost:8000",
+    },
+  },
+  build: {
+    outDir: "dist-devtools",
+    rollupOptions: {
+      input: path.resolve(__dirname, "devtools.html"),
+    },
+  },
+});

--- a/justfile
+++ b/justfile
@@ -43,6 +43,10 @@ status:
 e2e *args:
     cd frontend && npx playwright test {{args}}
 
+# Start the devtools UI server (standalone, port 3001)
+devtools:
+    npm --prefix frontend run dev:devtools
+
 # Run backend unit tests
 test *args:
     .venv/bin/pytest {{args}}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -13,6 +13,8 @@ BACKEND_LOG="${DEV_LOG_DIR}/backend.log"
 FRONTEND_LOG="${DEV_LOG_DIR}/frontend.log"
 BACKEND_PID_FILE="${LOCAL_RUN_DIR}/backend.pid"
 FRONTEND_PID_FILE="${LOCAL_RUN_DIR}/frontend.pid"
+DEVTOOLS_LOG="${DEV_LOG_DIR}/devtools.log"
+DEVTOOLS_PID_FILE="${LOCAL_RUN_DIR}/devtools.pid"
 DDB_BOOTSTRAP_MARKER="${LOCAL_RUN_DIR}/ddb-bootstrap.done"
 
 # ---------------------------------------------------------------------------
@@ -123,6 +125,7 @@ cmd_start() {
   echo "Dev logs will be written to:"
   echo "  backend : ${BACKEND_LOG}"
   echo "  frontend: ${FRONTEND_LOG}"
+  echo "  devtools : ${DEVTOOLS_LOG}"
 
   # Start mock infrastructure (moto, DynamoDB Local, Stripe mock, KMS mock)
   echo "Starting local mock infrastructure..."
@@ -161,11 +164,19 @@ cmd_start() {
     echo "Frontend started (pid $(cat "$FRONTEND_PID_FILE")) → log: ${FRONTEND_LOG}"
   fi
 
+  # Start devtools frontend (standalone, port 3001)
+  if [[ -f "frontend/package.json" ]]; then
+    echo "Starting devtools UI..."
+    npm --prefix frontend run dev:devtools >>"$DEVTOOLS_LOG" 2>&1 &
+    echo $! > "$DEVTOOLS_PID_FILE"
+    echo "Devtools UI started (pid $(cat "$DEVTOOLS_PID_FILE")) → log: ${DEVTOOLS_LOG}"
+  fi
+
   echo ""
   echo "Waiting up to 30s for backend and frontend..."
   local deadline=$((SECONDS + 30))
   while ((SECONDS < deadline)); do
-    _probe_http "http://localhost:8000/openapi.json" && _probe_http "http://localhost:3000/" && break
+    _probe_http "http://localhost:8000/openapi.json" && _probe_http "http://localhost:3000/" && _probe_http "http://localhost:3001/" && break
     sleep 2
   done
 
@@ -178,10 +189,12 @@ cmd_stop() {
   for arg in "$@"; do [[ "$arg" == "--quiet" ]] && quiet=1; done
 
   _stop_pid_file "$FRONTEND_PID_FILE" "frontend"
+  _stop_pid_file "$DEVTOOLS_PID_FILE" "devtools"
   _stop_pid_file "$BACKEND_PID_FILE"  "backend"
   # Belt-and-suspenders: kill any orphaned processes
   pkill -f "uvicorn app.main:app" 2>/dev/null || true
   pkill -f "vite"                 2>/dev/null || true
+  pkill -f "vite.*devtools.config" 2>/dev/null || true
   scripts/local-stack-down.sh
 
   [[ "$quiet" == "0" ]] && echo "Dev stack stopped."
@@ -205,9 +218,11 @@ cmd_status() {
   _probe_http "http://localhost:8000/openapi.json" && be_ok=true  || be_ok=false
   _probe_http "http://localhost:3000/"          && fe_ok=true     || fe_ok=false
 
-  local be_proc fe_proc
+  local be_proc fe_proc dt_ok dt_proc
   _is_running "$BACKEND_PID_FILE"  && be_proc=true || be_proc=false
   _is_running "$FRONTEND_PID_FILE" && fe_proc=true || fe_proc=false
+  _probe_http "http://localhost:3001/"          && dt_ok=true     || dt_ok=false
+  _is_running "$DEVTOOLS_PID_FILE"              && dt_proc=true   || dt_proc=false
 
   echo "Dev stack status:"
   printf "  %-34s [%s]\n" "S3/Moto (LocalStack)"            "$(_status_icon $s3_ok)"
@@ -217,6 +232,7 @@ cmd_status() {
   printf "  %-34s [%s]\n" "KMS mock"                        "$(_status_icon $kms_ok)"
   printf "  %-34s [%s]  process=%s\n" "Backend  (localhost:8000)" "$(_status_icon $be_ok)" "$($be_proc && echo running || echo stopped)"
   printf "  %-34s [%s]  process=%s\n" "Frontend (localhost:3000)" "$(_status_icon $fe_ok)" "$($fe_proc && echo running || echo stopped)"
+  printf "  %-34s [%s]  process=%s\n" "Devtools (localhost:3001)" "$(_status_icon $dt_ok)" "$($dt_proc && echo running || echo stopped)"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Dev tools (email/SMS/MFA TOTP/billing log viewer) now runs as its **own standalone Vite process** on port 3001, separate from the main app
- Removed from the main React app — no longer a route behind a feature flag, no longer in the sidebar/mobile nav
- Starts automatically with `just up` / `just restart` alongside backend and main frontend
- Or start on its own with `just devtools`

## New files
- `frontend/devtools.html` — HTML entry point
- `frontend/src/devtools-main.tsx` — minimal React mount: `ThemeProvider` + `QueryClientProvider` + `DevToolsLogUiPage`, no AppShell or auth
- `frontend/vite.devtools.config.ts` — Vite config for port 3001; proxies `/internal` → `http://localhost:8000`

## What changed
- `frontend/package.json` — added `dev:devtools` npm script
- `frontend/src/App.tsx` — removed devtools route + lazy import
- `frontend/src/components/layout/Sidebar.tsx` — removed Dev Tools nav item
- `frontend/src/components/layout/MobileNav.tsx` — removed Dev Tools link
- `scripts/dev.sh` — starts devtools as 3rd frontend process; own PID file (`.local/run/devtools.pid`), own log (`.logs/dev/devtools.log`), own status line, included in stop/restart
- `justfile` — added `just devtools` recipe
- `docs/internal-dev-log-ui.md` — updated URL to `http://localhost:3001`
- `CLAUDE.md` — port 3001 added to services table

## Access
`http://localhost:3001` — no login required

🤖 Generated with [Claude Code](https://claude.com/claude-code)