### PR TITLE
Add tip_lottery newsfeed lock strategy with validation, backfill, UI and tests

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -832,6 +832,7 @@ class Settings:
     newsfeed_unlock_attempt_stale_seconds: int = int(os.environ.get("NEWSFEED_UNLOCK_ATTEMPT_STALE_SECONDS", "300"))
     newsfeed_unlock_throttle_window_seconds: int = int(os.environ.get("NEWSFEED_UNLOCK_THROTTLE_WINDOW_SECONDS", "10"))
     newsfeed_unlock_throttle_max_attempts: int = int(os.environ.get("NEWSFEED_UNLOCK_THROTTLE_MAX_ATTEMPTS", "6"))
+    newsfeed_tip_lottery_enabled: bool = os.environ.get("NEWSFEED_TIP_LOTTERY_ENABLED", "true").lower() in ("1", "true", "yes", "on")
 
     # Messaging feature flags
     messaging_encrypted_messages_enabled: bool = os.environ.get("MESSAGING_ENCRYPTED_MESSAGES_ENABLED", "false").lower() == "true"

--- a/app/routers/newsfeed.py
+++ b/app/routers/newsfeed.py
@@ -235,6 +235,25 @@ def _unlock_attempt_throttled_error(*, retry_after_seconds: int) -> HTTPExceptio
     )
 
 
+def _emit_newsfeed_lock_validation_reject(
+    reason_code: str,
+    *,
+    lock_type: Optional[str],
+    has_unlock_price: bool,
+    has_lottery_fields: bool,
+) -> None:
+    logger.warning(
+        "newsfeed lock validation reject",
+        extra={
+            "event": "newsfeed_lock_validation_reject",
+            "reason_code": reason_code,
+            "lock_type": lock_type or "none",
+            "has_unlock_price": has_unlock_price,
+            "has_lottery_fields": has_lottery_fields,
+        },
+    )
+
+
 def _enforce_unlock_attempt_throttle(user_id: str, post_id: str) -> None:
     window_seconds = max(1, int(getattr(S, "newsfeed_unlock_throttle_window_seconds", 10) or 10))
     max_attempts = max(1, int(getattr(S, "newsfeed_unlock_throttle_max_attempts", 6) or 6))
@@ -1171,8 +1190,17 @@ def _content_from_payload(req: ContentFieldsMixin) -> Dict[str, Any]:
 class CreatePostRequest(ContentFieldsMixin):
     image_urls: List[str] = Field(default_factory=list)
     visibility: Literal["followers", "public"] = "followers"
+    lock_type: Optional[Literal["fixed_price", "tip_lottery"]] = None
     unlock_price_cents: Optional[int] = Field(default=None, ge=0)
     unlock_limit: Optional[int] = Field(default=None, ge=1)
+    lottery_tip_cents: Optional[int] = Field(default=None, ge=1)
+    lottery_quiet_period_seconds: Optional[int] = Field(default=None, ge=1)
+    lottery_state: Optional[Literal["open", "won", "closed"]] = None
+    lottery_last_tip_at: Optional[str] = None
+    lottery_last_tipper_user_id: Optional[str] = None
+    lottery_winner_user_id: Optional[str] = None
+    lottery_won_at: Optional[str] = None
+    lottery_version: Optional[int] = Field(default=None, ge=0)
     file_paths: List[str] = Field(default_factory=list)
     publish_at: Optional[int] = Field(
         default=None,
@@ -1239,10 +1267,19 @@ class PostResponse(BaseModel):
     visibility: str
     locked: bool
     lock_expired: bool = False
+    lock_type: Optional[Literal["fixed_price", "tip_lottery"]] = None
     unlock_price_cents: Optional[int] = None
     unlock_limit: Optional[int] = None
     unlock_count: int = 0
     unlock_limit_reached: bool = False
+    lottery_tip_cents: Optional[int] = None
+    lottery_quiet_period_seconds: Optional[int] = None
+    lottery_state: Optional[Literal["open", "won", "closed"]] = None
+    lottery_last_tip_at: Optional[str] = None
+    lottery_last_tipper_user_id: Optional[str] = None
+    lottery_winner_user_id: Optional[str] = None
+    lottery_won_at: Optional[str] = None
+    lottery_version: Optional[int] = None
     like_count: int = 0
     comment_count: int = 0
 
@@ -1703,6 +1740,25 @@ def _write_scheduled_post_ref(
     ddb_put_item(scheduled_ref)
 
 
+def _normalized_post_lock_type(post: Dict[str, Any]) -> Optional[str]:
+    raw_lock_type = post.get("lock_type")
+    if raw_lock_type in {"fixed_price", "tip_lottery"}:
+        return raw_lock_type
+    if raw_lock_type is None:
+        unlock_price = int(post["unlock_price_cents"]) if post.get("unlock_price_cents") is not None else 0
+        if unlock_price > 0:
+            logger.info(
+                "newsfeed lock_type fallback",
+                extra={
+                    "event": "newsfeed_lock_type_fallback",
+                    "post_id": post.get("post_id"),
+                    "derived_lock_type": "fixed_price",
+                },
+            )
+            return "fixed_price"
+    return None
+
+
 def _post_to_dict(post: Dict[str, Any], locked_body: bool = False, liked_by_me: bool = False, unlocked: bool = False, viewer_id: Optional[str] = None) -> Dict[str, Any]:
     """Map a raw DDB post item to the FeedPost shape expected by the frontend."""
     body, body_plain, body_markdown, body_markdown_html, body_rich, body_format, body_version = _resolve_read_body_fields(post)
@@ -1739,6 +1795,11 @@ def _post_to_dict(post: Dict[str, Any], locked_body: bool = False, liked_by_me: 
     unlock_count = (_coerce_optional_int(post.get("unlock_count"), minimum=0) or 0) if unlock_limit_feature_on else 0
     lock_expired = _is_lock_expired(post)
     unlock_limit_reached = unlock_limit_feature_on and (not lock_expired) and unlock_limit is not None and unlock_count >= unlock_limit
+    lock_type = _normalized_post_lock_type(post)
+    unlock_price_cents = int(post["unlock_price_cents"]) if post.get("unlock_price_cents") is not None else None
+    lottery_tip_cents = int(post["lottery_tip_cents"]) if post.get("lottery_tip_cents") is not None else None
+    lottery_quiet_period_seconds = int(post["lottery_quiet_period_seconds"]) if post.get("lottery_quiet_period_seconds") is not None else None
+    lottery_version = int(post["lottery_version"]) if post.get("lottery_version") is not None else None
     return {
         "post_id": post_id,
         "author_id": post.get("user_id", ""),
@@ -1761,10 +1822,19 @@ def _post_to_dict(post: Dict[str, Any], locked_body: bool = False, liked_by_me: 
         "visibility": post.get("visibility", "followers"),
         "locked": bool(post.get("locked")),
         "lock_expired": lock_expired,
-        "unlock_price_cents": post.get("unlock_price_cents"),
+        "lock_type": lock_type,
+        "unlock_price_cents": unlock_price_cents,
         "unlock_limit": unlock_limit,
         "unlock_count": unlock_count,
         "unlock_limit_reached": unlock_limit_reached,
+        "lottery_tip_cents": lottery_tip_cents,
+        "lottery_quiet_period_seconds": lottery_quiet_period_seconds,
+        "lottery_state": post.get("lottery_state"),
+        "lottery_last_tip_at": post.get("lottery_last_tip_at"),
+        "lottery_last_tipper_user_id": post.get("lottery_last_tipper_user_id"),
+        "lottery_winner_user_id": post.get("lottery_winner_user_id"),
+        "lottery_won_at": post.get("lottery_won_at"),
+        "lottery_version": lottery_version,
         "unlocked": unlocked,
         "like_count": int(post.get("like_count", 0)),
         "comment_count": int(post.get("comment_count", 0)),
@@ -2835,8 +2905,103 @@ def create_post(req: CreatePostRequest, user_id: UserIdDep):
                 message="scheduled_at_local must use format YYYY-MM-DDTHH:mm",
                 operation="create",
             )
+
+    requested_lock_type = req.lock_type
+    unlock_price_cents = req.unlock_price_cents if req.unlock_price_cents and req.unlock_price_cents > 0 else None
+    has_lottery_fields = any(
+        value is not None
+        for value in (
+            req.lottery_tip_cents,
+            req.lottery_quiet_period_seconds,
+            req.lottery_state,
+            req.lottery_last_tip_at,
+            req.lottery_last_tipper_user_id,
+            req.lottery_winner_user_id,
+            req.lottery_won_at,
+            req.lottery_version,
+        )
+    )
+    lock_type: Optional[str] = None
+    lottery_tip_cents: Optional[int] = None
+    lottery_quiet_period_seconds: Optional[int] = None
+    lottery_state: Optional[str] = None
+    lottery_last_tip_at: Optional[str] = None
+    lottery_last_tipper_user_id: Optional[str] = None
+    lottery_winner_user_id: Optional[str] = None
+    lottery_won_at: Optional[str] = None
+    lottery_version: Optional[int] = None
+
+    if requested_lock_type == "tip_lottery":
+        if not bool(getattr(S, "newsfeed_tip_lottery_enabled", True)):
+            _emit_newsfeed_lock_validation_reject(
+                "tip_lottery_feature_disabled",
+                lock_type=requested_lock_type,
+                has_unlock_price=unlock_price_cents is not None,
+                has_lottery_fields=has_lottery_fields,
+            )
+            raise HTTPException(status_code=403, detail="tip_lottery lock strategy is disabled")
+        if unlock_price_cents is not None:
+            _emit_newsfeed_lock_validation_reject(
+                "tip_lottery_with_unlock_price",
+                lock_type=requested_lock_type,
+                has_unlock_price=True,
+                has_lottery_fields=has_lottery_fields,
+            )
+            raise HTTPException(status_code=400, detail="unlock_price_cents is not allowed for tip_lottery lock type")
+        if req.lottery_tip_cents is None or req.lottery_quiet_period_seconds is None:
+            _emit_newsfeed_lock_validation_reject(
+                "tip_lottery_missing_required_fields",
+                lock_type=requested_lock_type,
+                has_unlock_price=False,
+                has_lottery_fields=has_lottery_fields,
+            )
+            raise HTTPException(status_code=400, detail="lottery_tip_cents and lottery_quiet_period_seconds are required for tip_lottery")
+        lock_type = "tip_lottery"
+        lottery_tip_cents = int(req.lottery_tip_cents)
+        lottery_quiet_period_seconds = int(req.lottery_quiet_period_seconds)
+        lottery_state = req.lottery_state or "open"
+        lottery_last_tip_at = req.lottery_last_tip_at
+        lottery_last_tipper_user_id = req.lottery_last_tipper_user_id
+        lottery_winner_user_id = req.lottery_winner_user_id
+        lottery_won_at = req.lottery_won_at
+        lottery_version = int(req.lottery_version or 0)
+    elif requested_lock_type == "fixed_price":
+        if unlock_price_cents is None:
+            _emit_newsfeed_lock_validation_reject(
+                "fixed_price_missing_unlock_price",
+                lock_type=requested_lock_type,
+                has_unlock_price=False,
+                has_lottery_fields=has_lottery_fields,
+            )
+            raise HTTPException(status_code=400, detail="unlock_price_cents must be positive when lock_type is fixed_price")
+        if has_lottery_fields:
+            _emit_newsfeed_lock_validation_reject(
+                "fixed_price_with_lottery_fields",
+                lock_type=requested_lock_type,
+                has_unlock_price=True,
+                has_lottery_fields=has_lottery_fields,
+            )
+            raise HTTPException(status_code=400, detail="lottery_* fields are not allowed when lock_type is fixed_price")
+        lock_type = "fixed_price"
+    elif requested_lock_type is None and has_lottery_fields:
+        _emit_newsfeed_lock_validation_reject(
+            "lottery_fields_without_lock_type",
+            lock_type=requested_lock_type,
+            has_unlock_price=unlock_price_cents is not None,
+            has_lottery_fields=True,
+        )
+        raise HTTPException(status_code=400, detail="lock_type must be tip_lottery when lottery_* fields are provided")
+    elif unlock_price_cents is not None:
+        lock_type = "fixed_price"
+
+    locked = lock_type is not None
     content = _content_from_payload(req)
-    _emit_newsfeed_content_metric("create_post", surface="post", body_format=content.get("body_format", "plain"))
+    _emit_newsfeed_content_metric(
+        "create_post",
+        surface="post",
+        body_format=content.get("body_format", "plain"),
+        lock_type=lock_type or "none",
+    )
 
     # Validate and collect file attachment metadata (max 5)
     file_attachments = _build_file_attachments_for_post(user_id=user_id, file_paths=req.file_paths)
@@ -2859,7 +3024,16 @@ def create_post(req: CreatePostRequest, user_id: UserIdDep):
         "image_urls": req.image_urls,
         "visibility": req.visibility,
         "locked": locked,
+        "lock_type": lock_type,
         "unlock_price_cents": unlock_price_cents,
+        "lottery_tip_cents": lottery_tip_cents,
+        "lottery_quiet_period_seconds": lottery_quiet_period_seconds,
+        "lottery_state": lottery_state,
+        "lottery_last_tip_at": lottery_last_tip_at,
+        "lottery_last_tipper_user_id": lottery_last_tipper_user_id,
+        "lottery_winner_user_id": lottery_winner_user_id,
+        "lottery_won_at": lottery_won_at,
+        "lottery_version": lottery_version,
         "like_count": 0,
         "comment_count": 0,
         "file_attachments": file_attachments,
@@ -2904,10 +3078,19 @@ def create_post(req: CreatePostRequest, user_id: UserIdDep):
         image_urls=req.image_urls,
         visibility=req.visibility,
         locked=locked,
+        lock_type=lock_type,
         unlock_price_cents=unlock_price_cents,
         unlock_limit=unlock_limit,
         unlock_count=0,
         unlock_limit_reached=False,
+        lottery_tip_cents=lottery_tip_cents,
+        lottery_quiet_period_seconds=lottery_quiet_period_seconds,
+        lottery_state=lottery_state,
+        lottery_last_tip_at=lottery_last_tip_at,
+        lottery_last_tipper_user_id=lottery_last_tipper_user_id,
+        lottery_winner_user_id=lottery_winner_user_id,
+        lottery_won_at=lottery_won_at,
+        lottery_version=lottery_version,
         like_count=0,
         comment_count=0,
     )

--- a/docs/newsfeed_tip_lottery_rollout_runbook.md
+++ b/docs/newsfeed_tip_lottery_rollout_runbook.md
@@ -1,0 +1,173 @@
+# Newsfeed Tip-Lottery Rollout Runbook (LOT-012)
+
+## Scope
+
+This runbook covers production rollout for the `tip_lottery` lock strategy on newsfeed posts, including:
+
+- schema-safe backend deploy sequencing,
+- legacy data backfill,
+- post-deploy validation,
+- rollback and lottery-create disable procedures.
+
+---
+
+## Prerequisites
+
+- Backend release with:
+  - `CreatePostRequest` / `PostResponse` support for `lock_type` + `lottery_*` fields.
+  - read-path normalization for legacy rows (`unlock_price_cents` -> `lock_type=fixed_price` inference).
+  - `scripts/backfill_newsfeed_lock_type.py`.
+- Access to application logs, API metrics, and DynamoDB read/write dashboards.
+- Operator access to run backfill script in each environment.
+
+---
+
+## Rollout Order (Required)
+
+1. **Deploy backend read/write support first**
+   - Deploy API servers containing lottery schema support and legacy read normalization.
+   - Do **not** run backfill before this deploy.
+
+2. **Smoke test API behavior in target environment**
+   - Create fixed-price post and verify existing unlock flow still works.
+   - Create `tip_lottery` post and verify response includes:
+     - `lock_type=tip_lottery`
+     - `lottery_tip_cents`
+     - `lottery_quiet_period_seconds`
+     - `lottery_state=open`
+     - `lottery_version=0`
+
+3. **Run backfill in dry-run mode**
+   - Command:
+     - `python scripts/backfill_newsfeed_lock_type.py --dry-run --page-limit 200`
+   - Capture output values:
+     - `scanned`
+     - `eligible`
+     - `planned_updates`
+     - `applied_updates` (should be `0` in dry-run)
+
+4. **Run backfill in apply mode**
+   - Command:
+     - `python scripts/backfill_newsfeed_lock_type.py --page-limit 200`
+   - Record output values and runtime.
+   - Re-run once to confirm idempotency (`planned_updates=0`, `applied_updates=0` expected on second run).
+
+5. **Verify metrics and error rates**
+   - Monitor for at least 30–60 minutes after rollout/backfill:
+     - 4xx/5xx rates on `POST /posts`, `GET /posts/{id}`, `GET /feed`
+     - DynamoDB throttling / error rates
+     - app logs containing `invalid_lock_configuration` and serialization errors
+
+6. **Enable by environment using feature flag**
+   - Backend toggle: `NEWSFEED_TIP_LOTTERY_ENABLED`
+   - Frontend toggle: `VITE_NEWSFEED_TIP_LOTTERY_ENABLED`
+   - Recommended staged values:
+     - Dev: backend `true`, frontend `true`
+     - Staging: backend `true`, frontend `true` after QA sign-off
+     - Prod canary: backend `true`, frontend `false` (observe create-path protections)
+     - Prod full rollout: backend `true`, frontend `true`
+
+---
+
+## Post-Deploy Validation Checklist
+
+- [ ] `POST /posts` with fixed-price payload still succeeds.
+- [ ] `POST /posts` with lottery payload succeeds and returns lottery defaults (`open`, `0` version).
+- [ ] `GET /posts/{id}` returns lottery fields for lottery posts.
+- [ ] `GET /feed` shows lottery fields for lottery posts.
+- [ ] Legacy post without `lock_type` but with positive `unlock_price_cents` reads as `lock_type=fixed_price`.
+- [ ] Backfill dry-run completes without write errors.
+- [ ] Backfill apply completes and idempotent re-run is clean.
+
+---
+
+## Suggested Validation Queries
+
+Use DynamoDB PartiQL (or equivalent table inspection tooling) after apply run:
+
+1. **Legacy rows still missing lock_type with positive unlock price** (should trend to zero):
+   ```sql
+   SELECT post_id, unlock_price_cents
+   FROM "app_single_table"
+   WHERE Entity='Post'
+     AND unlock_price_cents > 0
+     AND (lock_type IS MISSING OR lock_type IS NULL)
+   LIMIT 100;
+   ```
+
+2. **Lottery rows sanity check**:
+   ```sql
+   SELECT post_id, lock_type, lottery_tip_cents, lottery_quiet_period_seconds, lottery_state, lottery_version
+   FROM "app_single_table"
+   WHERE Entity='Post'
+     AND lock_type='tip_lottery'
+   LIMIT 100;
+   ```
+
+3. **Invalid lock combinations** (should be zero):
+   ```sql
+   SELECT post_id, lock_type, unlock_price_cents, lottery_tip_cents, lottery_quiet_period_seconds
+   FROM "app_single_table"
+   WHERE Entity='Post'
+     AND (
+       (lock_type='tip_lottery' AND unlock_price_cents > 0) OR
+       (lock_type='fixed_price' AND (lottery_tip_cents IS NOT MISSING OR lottery_quiet_period_seconds IS NOT MISSING))
+     )
+   LIMIT 100;
+   ```
+
+---
+
+## Dashboards / Alerts to Watch
+
+Minimum recommended monitors during rollout window:
+
+- **API availability**
+  - `POST /posts` 5xx rate
+  - `GET /posts/{id}` 5xx rate
+  - `GET /feed` 5xx rate
+- **Validation drift**
+  - count of 400 responses for lock configuration errors
+  - sudden spikes in `invalid_lock_configuration` messages
+- **Data-store health**
+  - DynamoDB throttles
+  - DynamoDB conditional/check failures (if any)
+  - elevated latency on read/write operations
+
+---
+
+## Rollback and Disable Plan
+
+### Safe behavior when `lock_type` is absent
+
+Read paths remain safe because legacy rows with positive `unlock_price_cents` are normalized to `lock_type=fixed_price` at serialization time. This allows rollback without requiring immediate data rewrites.
+
+### Disable lottery create path
+
+If lottery create traffic must be halted immediately:
+
+1. **Preferred operational action:** set `NEWSFEED_TIP_LOTTERY_ENABLED=false` and redeploy API.
+2. **Emergency edge control:** apply API gateway/WAF rule that blocks requests where body contains `lock_type":"tip_lottery"` for `POST /posts`.
+3. Set `VITE_NEWSFEED_TIP_LOTTERY_ENABLED=false` for frontend to hide lottery controls/metadata.
+4. Keep read-path support active so existing lottery posts remain readable while create is disabled.
+
+### Full rollback
+
+1. Roll back API to previous stable build.
+2. Keep backfilled data (safe; additional `lock_type` field is additive).
+3. Validate fixed-price create/read paths and feed rendering.
+4. Track and remediate any client retries targeting `tip_lottery` create payloads.
+
+---
+
+## Environment Progression
+
+- **Dev**: run full checklist + dry-run/apply backfill on small dataset.
+- **Staging**: repeat and validate dashboards/alerts + smoke tests from web UI.
+- **Prod**: canary deploy backend, then run dry-run/apply backfill, then full rollout.
+
+## Toggle Ownership
+
+- **Backend toggle owner:** Backend Platform / API on-call.
+- **Frontend toggle owner:** Web Platform / Frontend on-call.
+- **Approval authority for prod enablement:** Release Manager + Service Owner.

--- a/frontend/e2e/feed.spec.ts
+++ b/frontend/e2e/feed.spec.ts
@@ -617,6 +617,48 @@ test.describe("8. Locked posts", () => {
     await feedDelete(page, `/posts/${data.post_id}`);
   });
 
+  test("lottery lock metadata appears on create and subsequent reads", async () => {
+    const lotteryResp = await feedPost(page, "/posts", {
+      body: `Lottery lock post ${Date.now()}`,
+      lock_type: "tip_lottery",
+      lottery_tip_cents: 125,
+      lottery_quiet_period_seconds: 90,
+    });
+    expect(lotteryResp.ok()).toBe(true);
+    const lotteryData = await lotteryResp.json() as {
+      post_id: string;
+      lock_type: string;
+      lottery_tip_cents: number;
+      lottery_quiet_period_seconds: number;
+      lottery_state: string;
+    };
+    expect(lotteryData.lock_type).toBe("tip_lottery");
+    expect(lotteryData.lottery_tip_cents).toBe(125);
+    expect(lotteryData.lottery_quiet_period_seconds).toBe(90);
+    expect(lotteryData.lottery_state).toBe("open");
+
+    const getResp = await feedGet(page, `/posts/${lotteryData.post_id}`);
+    expect(getResp.ok()).toBe(true);
+    const fromGet = await getResp.json() as {
+      lock_type: string;
+      lottery_tip_cents: number;
+      lottery_quiet_period_seconds: number;
+    };
+    expect(fromGet.lock_type).toBe("tip_lottery");
+    expect(fromGet.lottery_tip_cents).toBe(125);
+    expect(fromGet.lottery_quiet_period_seconds).toBe(90);
+
+    const feedResp = await feedGet(page, "/feed");
+    expect(feedResp.ok()).toBe(true);
+    const feedData = await feedResp.json() as { items: Array<{ post_id: string; lock_type?: string; lottery_tip_cents?: number }> };
+    const found = (feedData.items ?? []).find((p) => p.post_id === lotteryData.post_id);
+    expect(found).toBeTruthy();
+    expect(found?.lock_type).toBe("tip_lottery");
+    expect(found?.lottery_tip_cents).toBe(125);
+
+    await feedDelete(page, `/posts/${lotteryData.post_id}`);
+  });
+
   test("owner (Alice) sees full content in feed — unlocked=true", async () => {
     const resp = await feedGet(page, "/feed");
     expect(resp.ok()).toBe(true);
@@ -767,6 +809,28 @@ test.describe("8. Locked posts", () => {
     await expect(priceInput).toBeVisible({ timeout: 3000 });
 
     await uiPage.close();
+  });
+
+  test("UI: lottery lock post shows metadata banner", async ({ browser }) => {
+    const createResp = await feedPost(page, "/posts", {
+      body: `Lottery lock UI post ${Date.now()}`,
+      lock_type: "tip_lottery",
+      lottery_tip_cents: 175,
+      lottery_quiet_period_seconds: 45,
+    });
+    expect(createResp.ok()).toBe(true);
+    const created = await createResp.json() as { post_id: string };
+
+    const uiPage = await browser.newPage();
+    await gotoFeed(uiPage);
+    await expect(uiPage.getByText(/Lottery lock UI post/i)).toBeVisible({ timeout: 5000 });
+    await expect(uiPage.getByText(/lottery lock/i)).toBeVisible({ timeout: 5000 });
+    await expect(uiPage.getByText(/tip \$1\.75/i)).toBeVisible({ timeout: 5000 });
+    await expect(uiPage.getByText(/quiet period 45s/i)).toBeVisible({ timeout: 5000 });
+    await expect(uiPage.getByText(/state open/i)).toBeVisible({ timeout: 5000 });
+
+    await uiPage.close();
+    await feedDelete(page, `/posts/${created.post_id}`);
   });
 });
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1706,10 +1706,19 @@ export interface FeedPost {
   image_urls?: string[];
   file_attachments?: PostFileAttachment[];
   lock_expired?: boolean | null;
+  lock_type?: "fixed_price" | "tip_lottery";
   unlock_price_cents?: number | null;
   unlock_limit?: number | null;
   unlock_count?: number | null;
   unlock_limit_reached?: boolean | null;
+  lottery_tip_cents?: number;
+  lottery_quiet_period_seconds?: number;
+  lottery_state?: "open" | "won" | "closed";
+  lottery_last_tip_at?: string;
+  lottery_last_tipper_user_id?: string;
+  lottery_winner_user_id?: string;
+  lottery_won_at?: string;
+  lottery_version?: number;
   like_count: number;
   comment_count: number;
   tip_total_cents?: number;
@@ -1758,11 +1767,20 @@ export interface CreatePostReq {
   body_version?: number;
   image_urls?: string[];
   file_paths?: string[];
+  lock_type?: "fixed_price" | "tip_lottery";
   unlock_price_cents?: number;
   publish_at?: number;
   schedule_timezone?: string;
   scheduled_at_local?: string;
   unlock_limit?: number | null;
+  lottery_tip_cents?: number;
+  lottery_quiet_period_seconds?: number;
+  lottery_state?: "open" | "won" | "closed";
+  lottery_last_tip_at?: string;
+  lottery_last_tipper_user_id?: string;
+  lottery_winner_user_id?: string;
+  lottery_won_at?: string;
+  lottery_version?: number;
 }
 
 export interface CreateCommentReq {

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -1,0 +1,9 @@
+const FALSEY_FLAG_VALUES = new Set(["0", "false", "no", "off"]);
+
+export function isTipLotteryEnabled(): boolean {
+  const envRaw = ((import.meta as any).env?.VITE_NEWSFEED_TIP_LOTTERY_ENABLED ?? "true").toString().trim().toLowerCase();
+  if (typeof window !== "undefined" && (window as any).__TIP_LOTTERY_ENABLED__ !== undefined) {
+    return Boolean((window as any).__TIP_LOTTERY_ENABLED__);
+  }
+  return !FALSEY_FLAG_VALUES.has(envRaw);
+}

--- a/frontend/src/pages/feed/PostCard.tsx
+++ b/frontend/src/pages/feed/PostCard.tsx
@@ -30,6 +30,7 @@ import { ReportContentModal, type ReportContentPayload } from "@/components/shar
 import { resolveCanonicalProfilePath } from "@/components/shared/UserProfileLink";
 import type { FeedPost, PaymentMethod, PostFileAttachment } from "@/api/types";
 import type { FileEntry } from "@/api/types";
+import { isTipLotteryEnabled } from "@/config/featureFlags";
 
 function formatBytes(bytes?: number): string {
   if (bytes == null) return "";
@@ -272,7 +273,13 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
     },
   });
 
-  const isLocked = !!post.unlock_price_cents && !post.unlocked;
+  const lotteryFeatureEnabled = isTipLotteryEnabled();
+  const isLotteryLock = lotteryFeatureEnabled && post.lock_type === "tip_lottery";
+  const isFixedPriceLock = post.lock_type === "fixed_price" || (!!post.unlock_price_cents && post.lock_type !== "tip_lottery");
+  const isLocked = !!post.locked && !post.unlocked;
+  const lotteryTipText = post.lottery_tip_cents != null ? `$${(post.lottery_tip_cents / 100).toFixed(2)}` : "N/A";
+  const lotteryQuietText = post.lottery_quiet_period_seconds != null ? `${post.lottery_quiet_period_seconds}s` : "N/A";
+  const lotteryStateText = post.lottery_state ?? "open";
   const initials = post.author_id.slice(0, 2).toUpperCase();
   const authorProfilePath = resolveCanonicalProfilePath({ userId: post.author_id, displayName: post.author_id });
 
@@ -380,6 +387,14 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
               </span>
             </div>
           )}
+          {isLotteryLock && (
+            <div className="mb-2 rounded-md border border-amber-300/40 bg-amber-50/40 px-2.5 py-1.5 text-xs text-amber-900 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-200">
+              <span className="font-medium">Lottery lock</span>
+              <span>{` • Tip ${lotteryTipText}`}</span>
+              <span>{` • Quiet period ${lotteryQuietText}`}</span>
+              <span>{` • State ${lotteryStateText}`}</span>
+            </div>
+          )}
           {isLocked ? (
             <div className="relative">
               <div className="blur-sm select-none">
@@ -402,21 +417,31 @@ export function PostCard({ post, defaultShowComments = false }: PostCardProps) {
                   <p className="text-xs text-destructive px-4 text-center">
                     Sold out — no unlock slots remaining.
                   </p>
-                ) : paymentMethods.length === 0 ? (
+                ) : isFixedPriceLock ? (
+                  paymentMethods.length === 0 ? (
+                    <p className="text-xs text-muted-foreground px-4 text-center">
+                      Add a payment method in Billing to unlock this post
+                    </p>
+                  ) : (
+                    <Button
+                      size="sm"
+                      onClick={() => {
+                        const def = paymentMethods.find((m) => m.is_default) ?? paymentMethods[0];
+                        setUnlockPaymentMethodId(def?.payment_method_id ?? null);
+                        setUnlockDialogOpen(true);
+                      }}
+                    >
+                      {`Unlock for $${((post.unlock_price_cents ?? 0) / 100).toFixed(2)}`}
+                    </Button>
+                  )
+                ) : isLotteryLock ? (
                   <p className="text-xs text-muted-foreground px-4 text-center">
-                    Add a payment method in Billing to unlock this post
+                    Lottery lock: tip {lotteryTipText} and stay uncontested for {lotteryQuietText} to unlock.
                   </p>
                 ) : (
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      const def = paymentMethods.find((m) => m.is_default) ?? paymentMethods[0];
-                      setUnlockPaymentMethodId(def?.payment_method_id ?? null);
-                      setUnlockDialogOpen(true);
-                    }}
-                  >
-                    {`Unlock for $${((post.unlock_price_cents ?? 0) / 100).toFixed(2)}`}
-                  </Button>
+                  <p className="text-xs text-muted-foreground px-4 text-center">
+                    This post is locked.
+                  </p>
                 )}
               </div>
             </div>

--- a/frontend/src/pages/feed/__tests__/PostCard.report.test.tsx
+++ b/frontend/src/pages/feed/__tests__/PostCard.report.test.tsx
@@ -29,18 +29,19 @@ vi.mock("../RichContentRenderer", () => ({ RichContentRenderer: () => <div>post 
 vi.mock("@/pages/files/FilePreview", () => ({ FilePreview: () => null }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
-function renderCard() {
+function renderCard(postOverrides?: Partial<Record<string, unknown>>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const basePost = {
+    post_id: "p1",
+    author_id: "author2",
+    body: "hello",
+    created_at: new Date().toISOString(),
+    image_urls: ["https://example.com/a.jpg"],
+  };
   return render(
     <QueryClientProvider client={client}>
       <PostCard
-        post={{
-          post_id: "p1",
-          author_id: "author2",
-          body: "hello",
-          created_at: new Date().toISOString(),
-          image_urls: ["https://example.com/a.jpg"],
-        } as never}
+        post={{ ...basePost, ...(postOverrides ?? {}) } as never}
       />
     </QueryClientProvider>,
   );
@@ -49,6 +50,7 @@ function renderCard() {
 describe("PostCard media reporting", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (window as any).__TIP_LOTTERY_ENABLED__ = true;
   });
 
   it("submits report with feed_media metadata", async () => {
@@ -81,5 +83,62 @@ describe("PostCard media reporting", () => {
     for (const link of links) {
       expect(link).toHaveAttribute("href", "/u/author2");
     }
+  });
+
+  it("renders lottery lock strategy metadata safely", async () => {
+    renderCard({
+      locked: true,
+      unlocked: false,
+      lock_type: "tip_lottery",
+      lottery_tip_cents: 175,
+      lottery_quiet_period_seconds: 90,
+      lottery_state: "open",
+    });
+
+    expect(await screen.findByText(/lottery lock/i)).toBeInTheDocument();
+    expect(screen.getByText(/tip \$1\.75/i)).toBeInTheDocument();
+    expect(screen.getByText(/quiet period 90s/i)).toBeInTheDocument();
+    expect(screen.getByText(/state open/i)).toBeInTheDocument();
+  });
+
+  it("renders lottery lock fallback values safely when metadata is missing", async () => {
+    renderCard({
+      locked: true,
+      unlocked: false,
+      lock_type: "tip_lottery",
+    });
+
+    expect(await screen.findByText(/lottery lock/i)).toBeInTheDocument();
+    expect(screen.getByText(/tip n\/a/i)).toBeInTheDocument();
+    expect(screen.getByText(/quiet period n\/a/i)).toBeInTheDocument();
+    expect(screen.getByText(/state open/i)).toBeInTheDocument();
+  });
+
+  it("keeps fixed-price lock display unchanged", async () => {
+    renderCard({
+      locked: true,
+      unlocked: false,
+      lock_type: "fixed_price",
+      unlock_price_cents: 250,
+    });
+
+    expect(await screen.findByRole("button", { name: /unlock for \$2\.50/i })).toBeInTheDocument();
+    expect(screen.queryByText(/lottery lock/i)).not.toBeInTheDocument();
+  });
+
+  it("hides lottery metadata when tip-lottery feature flag is disabled", async () => {
+    (window as any).__TIP_LOTTERY_ENABLED__ = false;
+    renderCard({
+      locked: true,
+      unlocked: false,
+      lock_type: "tip_lottery",
+      lottery_tip_cents: 175,
+      lottery_quiet_period_seconds: 90,
+      lottery_state: "open",
+    });
+
+    expect(await screen.findByText(/this post is locked\./i)).toBeInTheDocument();
+    expect(screen.queryByText(/lottery lock/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tip \$1\.75/i)).not.toBeInTheDocument();
   });
 });

--- a/scripts/backfill_newsfeed_lock_type.py
+++ b/scripts/backfill_newsfeed_lock_type.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from typing import Any, Dict, Optional, Tuple
+
+from app.core.aws import ddb
+
+APP_TABLE = os.environ.get("APP_TABLE", "app_single_table")
+VALID_LOCK_TYPES = {"fixed_price", "tip_lottery"}
+
+
+def _table():
+    return ddb.Table(APP_TABLE)
+
+
+def is_post_row(item: Dict[str, Any]) -> bool:
+    return item.get("Entity") == "Post" and bool(item.get("post_id"))
+
+
+def infer_lock_type(item: Dict[str, Any]) -> Optional[str]:
+    raw = item.get("lock_type")
+    if raw in VALID_LOCK_TYPES:
+        return raw
+    unlock_price = int(item.get("unlock_price_cents") or 0)
+    if unlock_price > 0:
+        return "fixed_price"
+    return None
+
+
+def plan_update(item: Dict[str, Any]) -> Tuple[bool, Dict[str, Any]]:
+    if not is_post_row(item):
+        return False, {}
+    desired = infer_lock_type(item)
+    current = item.get("lock_type")
+    if desired == current:
+        return False, {}
+    if desired is None:
+        return False, {}
+    return True, {":lt": desired}
+
+
+def run(*, page_limit: int, dry_run: bool) -> Dict[str, int | bool]:
+    started_at = time.time()
+    tbl = _table()
+    scanned = 0
+    eligible = 0
+    planned_updates = 0
+    applied_updates = 0
+    start_key = None
+
+    while True:
+        kwargs: Dict[str, Any] = {"Limit": page_limit}
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+        resp = tbl.scan(**kwargs)
+        items = resp.get("Items", [])
+        scanned += len(items)
+
+        for item in items:
+            if not is_post_row(item):
+                continue
+            eligible += 1
+            should_update, values = plan_update(item)
+            if not should_update:
+                continue
+            planned_updates += 1
+            if dry_run:
+                continue
+            tbl.update_item(
+                Key={"pk": item["pk"], "sk": item["sk"]},
+                UpdateExpression="SET lock_type = :lt",
+                ExpressionAttributeValues=values,
+            )
+            applied_updates += 1
+
+        start_key = resp.get("LastEvaluatedKey")
+        if not start_key:
+            break
+
+    finished_at = time.time()
+    return {
+        "dry_run": dry_run,
+        "scanned": scanned,
+        "eligible": eligible,
+        "planned_updates": planned_updates,
+        "applied_updates": applied_updates,
+        "duration_seconds": round(finished_at - started_at, 3),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill newsfeed post lock_type=fixed_price for legacy posts with unlock_price_cents.",
+    )
+    parser.add_argument("--page-limit", type=int, default=200, help="DynamoDB scan page size")
+    parser.add_argument("--dry-run", action="store_true", help="Plan changes without writing updates")
+    args = parser.parse_args()
+    report = run(page_limit=args.page_limit, dry_run=args.dry_run)
+    print(json.dumps(report, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_newsfeed_api_lottery_integration.py
+++ b/tests/test_newsfeed_api_lottery_integration.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.routers import newsfeed
+from app.services.sessions import require_ui_session
+
+
+class _FakeNewsfeedTable:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str], Dict[str, Any]] = {}
+
+    def put_item(self, *, Item: Dict[str, Any]) -> None:
+        self.items[(Item["pk"], Item["sk"])] = deepcopy(Item)
+
+    def get_item(self, *, Key: Dict[str, Any]) -> Dict[str, Any]:
+        item = self.items.get((Key["pk"], Key["sk"]))
+        return {"Item": deepcopy(item)} if item else {}
+
+    def query(self, **kwargs) -> Dict[str, Any]:
+        vals = kwargs.get("ExpressionAttributeValues", {})
+        pk = vals.get(":pk")
+        items = [deepcopy(item) for item in self.items.values() if item.get("GSI1PK") == pk]
+        items.sort(key=lambda it: it.get("GSI1SK", ""), reverse=not kwargs.get("ScanIndexForward", True))
+        limit = kwargs.get("Limit")
+        if limit is not None:
+            items = items[: int(limit)]
+        return {"Items": items}
+
+
+class _FakeDDB:
+    def __init__(self, table: _FakeNewsfeedTable) -> None:
+        self._table = table
+
+    def batch_get_item(self, *, RequestItems: Dict[str, Any]) -> Dict[str, Any]:
+        req = next(iter(RequestItems.values()))
+        keys = req.get("Keys", [])
+        rows = []
+        for key in keys:
+            item = self._table.items.get((key["pk"], key["sk"]))
+            if item:
+                rows.append(deepcopy(item))
+        return {"Responses": {newsfeed.APP_TABLE: rows}}
+
+
+def _build_client(user_sub: str, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, _FakeNewsfeedTable]:
+    fake_table = _FakeNewsfeedTable()
+    app = create_app()
+
+    async def _session_override():
+        return {"user_sub": user_sub, "session_id": "sess_1", "role": "user"}
+
+    app.dependency_overrides[require_ui_session] = _session_override
+
+    monkeypatch.setattr(newsfeed, "tbl", fake_table)
+    monkeypatch.setattr(newsfeed, "ddb", _FakeDDB(fake_table))
+    monkeypatch.setattr(newsfeed, "_enforce_newsfeed_post_quota_precheck", lambda user_id: None)
+    monkeypatch.setattr(newsfeed, "_meter_newsfeed_post_publish", lambda user_id, post_id: None)
+
+    return TestClient(app), fake_table
+
+
+def test_api_create_get_and_feed_include_tip_lottery_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = _build_client("user-lottery", monkeypatch)
+
+    created = client.post(
+        "/posts",
+        json={
+            "body": "lottery post",
+            "lock_type": "tip_lottery",
+            "lottery_tip_cents": 125,
+            "lottery_quiet_period_seconds": 90,
+        },
+    )
+    assert created.status_code == 200
+    body = created.json()
+    assert body["lock_type"] == "tip_lottery"
+    assert body["lottery_tip_cents"] == 125
+    assert body["lottery_quiet_period_seconds"] == 90
+    assert body["lottery_state"] == "open"
+    assert body["lottery_version"] == 0
+
+    post_id = body["post_id"]
+    fetched = client.get(f"/posts/{post_id}")
+    assert fetched.status_code == 200
+    fetched_body = fetched.json()
+    assert fetched_body["lock_type"] == "tip_lottery"
+    assert fetched_body["lottery_tip_cents"] == 125
+    assert fetched_body["lottery_quiet_period_seconds"] == 90
+
+    feed = client.get("/feed")
+    assert feed.status_code == 200
+    items = feed.json().get("items", [])
+    assert any(item["post_id"] == post_id and item["lock_type"] == "tip_lottery" for item in items)
+
+
+def test_api_legacy_fixed_price_reads_infer_lock_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    client, table = _build_client("user-legacy", monkeypatch)
+
+    post_id = "post_legacy_1"
+    created_at = "2026-01-01T00:00:00+00:00"
+    table.put_item(
+        Item={
+            "pk": newsfeed.pk_post(post_id),
+            "sk": newsfeed.sk_post(),
+            "Entity": "Post",
+            "post_id": post_id,
+            "user_id": "user-legacy",
+            "created_at": created_at,
+            "body": "legacy fixed body",
+            "locked": True,
+            "unlock_price_cents": 250,
+        },
+    )
+    table.put_item(
+        Item={
+            "pk": newsfeed.pk_post(post_id),
+            "sk": "FEEDREF#user-legacy",
+            "Entity": "FeedRef",
+            "post_id": post_id,
+            "owner_user_id": "user-legacy",
+            "created_at": created_at,
+            "GSI1PK": "FEED#user-legacy",
+            "GSI1SK": f"{created_at}#POST#{post_id}",
+        },
+    )
+
+    fetched = client.get(f"/posts/{post_id}")
+    assert fetched.status_code == 200
+    assert fetched.json()["lock_type"] == "fixed_price"
+
+    feed = client.get("/feed")
+    assert feed.status_code == 200
+    item = next(i for i in feed.json()["items"] if i["post_id"] == post_id)
+    assert item["lock_type"] == "fixed_price"
+
+    stored = table.items[(newsfeed.pk_post(post_id), newsfeed.sk_post())]
+    assert "lock_type" not in stored

--- a/tests/test_newsfeed_backfill_script.py
+++ b/tests/test_newsfeed_backfill_script.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from unittest.mock import Mock, patch
+
 from scripts.backfill_newsfeed_plain_fields import (
     infer_body_format,
     infer_body_plain,
     is_newsfeed_content_row,
     plan_update,
+)
+from scripts.backfill_newsfeed_lock_type import (
+    infer_lock_type,
+    is_post_row,
+    plan_update as plan_lock_type_update,
+    run as run_lock_type_backfill,
 )
 
 
@@ -69,3 +77,136 @@ def test_plan_update_sets_plain_and_default_format_for_legacy_row() -> None:
     assert reason is None
     assert values[":bp"] == "legacy body"
     assert values[":bf"] == "plain"
+
+
+def test_infer_lock_type_defaults_to_fixed_price_for_legacy_unlock_posts() -> None:
+    assert infer_lock_type({"unlock_price_cents": 250}) == "fixed_price"
+    assert infer_lock_type({"unlock_price_cents": "500"}) == "fixed_price"
+    assert infer_lock_type({"lock_type": "fixed_price", "unlock_price_cents": 500}) == "fixed_price"
+    assert infer_lock_type({"lock_type": "tip_lottery", "unlock_price_cents": 0}) == "tip_lottery"
+    assert infer_lock_type({"unlock_price_cents": 0}) is None
+
+
+def test_backfill_is_post_row_filters_only_post_entities() -> None:
+    assert is_post_row({"Entity": "Post", "post_id": "p1"}) is True
+    assert is_post_row({"Entity": "Post", "post_id": ""}) is False
+    assert is_post_row({"Entity": "Comment", "comment_id": "c1"}) is False
+    assert is_post_row({"Entity": "FeedRef", "post_id": "p1"}) is False
+
+
+def test_plan_lock_type_update_updates_only_posts_missing_derived_lock_type() -> None:
+    should_update, values = plan_lock_type_update(
+        {
+            "Entity": "Post",
+            "post_id": "p1",
+            "pk": "POST#p1",
+            "sk": "META",
+            "unlock_price_cents": 700,
+        },
+    )
+    assert should_update is True
+    assert values[":lt"] == "fixed_price"
+
+    should_update, values = plan_lock_type_update(
+        {
+            "Entity": "Post",
+            "post_id": "p2",
+            "pk": "POST#p2",
+            "sk": "META",
+            "unlock_price_cents": 900,
+            "lock_type": "fixed_price",
+        },
+    )
+    assert should_update is False
+    assert values == {}
+
+    should_update, values = plan_lock_type_update(
+        {
+            "Entity": "Post",
+            "post_id": "p3",
+            "pk": "POST#p3",
+            "sk": "META",
+            "lock_type": "tip_lottery",
+            "unlock_price_cents": 900,
+        },
+    )
+    assert should_update is False
+    assert values == {}
+
+
+def test_plan_lock_type_update_non_post_rows_are_noop() -> None:
+    should_update, values = plan_lock_type_update(
+        {
+            "Entity": "Comment",
+            "comment_id": "c1",
+            "pk": "POST#p1",
+            "sk": "COMMENT#1",
+            "unlock_price_cents": 100,
+        },
+    )
+    assert should_update is False
+    assert values == {}
+
+
+def test_lock_type_backfill_run_dry_run_plans_without_writes() -> None:
+    table = Mock()
+    table.scan.side_effect = [
+        {
+            "Items": [
+                {"Entity": "Post", "post_id": "p1", "pk": "POST#p1", "sk": "META", "unlock_price_cents": 100},
+                {"Entity": "Comment", "comment_id": "c1", "pk": "POST#p1", "sk": "COMMENT#1"},
+                {"Entity": "Post", "post_id": "p2", "pk": "POST#p2", "sk": "META", "lock_type": "fixed_price", "unlock_price_cents": 250},
+            ],
+            "LastEvaluatedKey": {"pk": "NEXT", "sk": "NEXT"},
+        },
+        {
+            "Items": [
+                {"Entity": "Post", "post_id": "p3", "pk": "POST#p3", "sk": "META", "unlock_price_cents": 0},
+            ],
+        },
+    ]
+    with patch("scripts.backfill_newsfeed_lock_type._table", return_value=table):
+        report = run_lock_type_backfill(page_limit=2, dry_run=True)
+
+    assert report["dry_run"] is True
+    assert report["scanned"] == 4
+    assert report["eligible"] == 3
+    assert report["planned_updates"] == 1
+    assert report["applied_updates"] == 0
+    assert isinstance(report["duration_seconds"], float)
+    table.update_item.assert_not_called()
+
+
+def test_lock_type_backfill_run_apply_mode_is_idempotent() -> None:
+    table = Mock()
+    first_pass_items = [
+        {"Entity": "Post", "post_id": "p1", "pk": "POST#p1", "sk": "META", "unlock_price_cents": 100},
+        {"Entity": "Post", "post_id": "p2", "pk": "POST#p2", "sk": "META", "lock_type": "fixed_price", "unlock_price_cents": 250},
+    ]
+    second_pass_items = [
+        {"Entity": "Post", "post_id": "p1", "pk": "POST#p1", "sk": "META", "lock_type": "fixed_price", "unlock_price_cents": 100},
+        {"Entity": "Post", "post_id": "p2", "pk": "POST#p2", "sk": "META", "lock_type": "fixed_price", "unlock_price_cents": 250},
+    ]
+
+    table.scan.return_value = {"Items": first_pass_items}
+    with patch("scripts.backfill_newsfeed_lock_type._table", return_value=table):
+        first_report = run_lock_type_backfill(page_limit=50, dry_run=False)
+
+    assert first_report["planned_updates"] == 1
+    assert first_report["applied_updates"] == 1
+    assert isinstance(first_report["duration_seconds"], float)
+    table.update_item.assert_called_once_with(
+        Key={"pk": "POST#p1", "sk": "META"},
+        UpdateExpression="SET lock_type = :lt",
+        ExpressionAttributeValues={":lt": "fixed_price"},
+    )
+
+    table.reset_mock()
+    table.scan.return_value = {"Items": second_pass_items}
+    with patch("scripts.backfill_newsfeed_lock_type._table", return_value=table):
+        second_report = run_lock_type_backfill(page_limit=50, dry_run=False)
+
+    assert second_report["planned_updates"] == 0
+    assert second_report["applied_updates"] == 0
+    assert isinstance(second_report["duration_seconds"], float)
+    table.update_item.assert_not_called()

--- a/tests/test_newsfeed_content_envelope.py
+++ b/tests/test_newsfeed_content_envelope.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
+from decimal import Decimal
 
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from app.routers import newsfeed
@@ -732,6 +734,300 @@ class TestNewsfeedContentEnvelope(unittest.TestCase):
         self.assertEqual([it["post_id"] for it in out["items"]], ["p-published"])
         self.assertEqual(out["items"][0]["status"], "published")
 
+    def test_create_post_with_tip_lottery_persists_lottery_schema_fields(self):
+        req = newsfeed.CreatePostRequest(
+            body_plain="Lottery post",
+            body_format="plain",
+            visibility="followers",
+            lock_type="tip_lottery",
+            lottery_tip_cents=125,
+            lottery_quiet_period_seconds=90,
+        )
+
+        with (
+            patch.object(newsfeed, "new_id", return_value="post_lottery_1"),
+            patch.object(newsfeed, "now_iso", return_value="2026-01-01T00:00:00+00:00"),
+            patch.object(newsfeed, "ddb_put_item") as put_item,
+            patch.object(newsfeed, "_meter_newsfeed_post_publish"),
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            resp = newsfeed.create_post(req, user_id="u1")
+
+        self.assertEqual(resp.lock_type, "tip_lottery")
+        self.assertTrue(resp.locked)
+        self.assertEqual(resp.lottery_tip_cents, 125)
+        self.assertEqual(resp.lottery_quiet_period_seconds, 90)
+        self.assertEqual(resp.lottery_state, "open")
+        self.assertEqual(resp.lottery_version, 0)
+
+        post_item = put_item.call_args_list[0].args[0]
+        self.assertEqual(post_item["lock_type"], "tip_lottery")
+        self.assertEqual(post_item["lottery_tip_cents"], 125)
+        self.assertEqual(post_item["lottery_quiet_period_seconds"], 90)
+        self.assertEqual(post_item["lottery_state"], "open")
+        self.assertEqual(post_item["lottery_version"], 0)
+
+    def test_create_post_rejects_tip_lottery_with_unlock_price(self):
+        req = newsfeed.CreatePostRequest(
+            body="invalid",
+            lock_type="tip_lottery",
+            unlock_price_cents=100,
+            lottery_tip_cents=50,
+            lottery_quiet_period_seconds=60,
+        )
+        with (
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+            patch.object(newsfeed.logger, "warning") as warn_log,
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                newsfeed.create_post(req, user_id="u1")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("unlock_price_cents", str(ctx.exception.detail))
+        warn_log.assert_called()
+        self.assertEqual(
+            warn_log.call_args.kwargs["extra"]["reason_code"],
+            "tip_lottery_with_unlock_price",
+        )
+
+    def test_create_post_rejects_tip_lottery_when_feature_flag_disabled(self):
+        req = newsfeed.CreatePostRequest(
+            body="invalid",
+            lock_type="tip_lottery",
+            lottery_tip_cents=50,
+            lottery_quiet_period_seconds=60,
+        )
+        original_flag = getattr(newsfeed.S, "newsfeed_tip_lottery_enabled", True)
+        object.__setattr__(newsfeed.S, "newsfeed_tip_lottery_enabled", False)
+        try:
+            with (
+                patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+                patch.object(newsfeed.logger, "warning") as warn_log,
+            ):
+                with self.assertRaises(HTTPException) as ctx:
+                    newsfeed.create_post(req, user_id="u1")
+            self.assertEqual(ctx.exception.status_code, 403)
+            self.assertIn("disabled", str(ctx.exception.detail))
+            self.assertEqual(
+                warn_log.call_args.kwargs["extra"]["reason_code"],
+                "tip_lottery_feature_disabled",
+            )
+        finally:
+            object.__setattr__(newsfeed.S, "newsfeed_tip_lottery_enabled", original_flag)
+
+    def test_create_post_rejects_tip_lottery_when_tip_amount_missing(self):
+        req = newsfeed.CreatePostRequest(
+            body="invalid",
+            lock_type="tip_lottery",
+            lottery_quiet_period_seconds=60,
+        )
+        with (
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                newsfeed.create_post(req, user_id="u1")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("lottery_tip_cents", str(ctx.exception.detail))
+
+    def test_create_post_rejects_tip_lottery_when_quiet_period_missing(self):
+        req = newsfeed.CreatePostRequest(
+            body="invalid",
+            lock_type="tip_lottery",
+            lottery_tip_cents=75,
+        )
+        with (
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                newsfeed.create_post(req, user_id="u1")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("lottery_quiet_period_seconds", str(ctx.exception.detail))
+
+    def test_create_post_rejects_fixed_price_with_lottery_fields(self):
+        req = newsfeed.CreatePostRequest(
+            body="invalid",
+            lock_type="fixed_price",
+            unlock_price_cents=200,
+            lottery_tip_cents=25,
+        )
+        with (
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                newsfeed.create_post(req, user_id="u1")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("lottery_*", str(ctx.exception.detail))
+
+    def test_create_post_rejects_fixed_price_without_unlock_price(self):
+        req = newsfeed.CreatePostRequest(
+            body="invalid",
+            lock_type="fixed_price",
+        )
+        with (
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                newsfeed.create_post(req, user_id="u1")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("unlock_price_cents", str(ctx.exception.detail))
+
+    def test_create_post_rejects_lottery_fields_without_tip_lottery_lock_type(self):
+        req = newsfeed.CreatePostRequest(
+            body="invalid",
+            lottery_tip_cents=30,
+            lottery_quiet_period_seconds=45,
+        )
+        with (
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                newsfeed.create_post(req, user_id="u1")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("lock_type", str(ctx.exception.detail))
+
+    def test_create_post_non_locked_still_allowed(self):
+        req = newsfeed.CreatePostRequest(body="plain post")
+        with (
+            patch.object(newsfeed, "new_id", return_value="post_unlocked_1"),
+            patch.object(newsfeed, "now_iso", return_value="2026-01-01T00:00:00+00:00"),
+            patch.object(newsfeed, "ddb_put_item"),
+            patch.object(newsfeed, "_meter_newsfeed_post_publish"),
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            resp = newsfeed.create_post(req, user_id="u1")
+        self.assertFalse(resp.locked)
+        self.assertIsNone(resp.lock_type)
+
+    def test_create_post_fixed_price_still_allowed_without_explicit_lock_type(self):
+        req = newsfeed.CreatePostRequest(body="fixed post", unlock_price_cents=299)
+        with (
+            patch.object(newsfeed, "new_id", return_value="post_fixed_1"),
+            patch.object(newsfeed, "now_iso", return_value="2026-01-01T00:00:00+00:00"),
+            patch.object(newsfeed, "ddb_put_item") as put_item,
+            patch.object(newsfeed, "_meter_newsfeed_post_publish"),
+            patch.object(newsfeed, "_enforce_newsfeed_post_quota_precheck"),
+        ):
+            resp = newsfeed.create_post(req, user_id="u1")
+        self.assertTrue(resp.locked)
+        self.assertEqual(resp.lock_type, "fixed_price")
+        self.assertEqual(resp.unlock_price_cents, 299)
+        post_item = put_item.call_args_list[0].args[0]
+        self.assertEqual(post_item["lock_type"], "fixed_price")
+        self.assertEqual(post_item["unlock_price_cents"], 299)
+        self.assertIsNone(post_item["lottery_tip_cents"])
+        self.assertIsNone(post_item["lottery_quiet_period_seconds"])
+        self.assertIsNone(post_item["lottery_state"])
+        self.assertIsNone(post_item["lottery_version"])
+
+    def test_post_serializer_coerces_lottery_numeric_fields_to_int(self):
+        post = {
+            "post_id": "p_decimal_1",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "lottery body",
+            "locked": True,
+            "lock_type": "tip_lottery",
+            "lottery_tip_cents": Decimal("150"),
+            "lottery_quiet_period_seconds": Decimal("45"),
+            "lottery_version": Decimal("2"),
+            "unlock_price_cents": Decimal("0"),
+        }
+        out = newsfeed._post_to_dict(post)
+        self.assertEqual(out["lottery_tip_cents"], 150)
+        self.assertEqual(out["lottery_quiet_period_seconds"], 45)
+        self.assertEqual(out["lottery_version"], 2)
+        self.assertEqual(out["unlock_price_cents"], 0)
+
+    def test_post_serializer_infers_fixed_price_lock_type_for_legacy_rows(self):
+        post = {
+            "post_id": "p_fixed_1",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "legacy body",
+            "locked": True,
+            "unlock_price_cents": 333,
+        }
+
+        with patch.object(newsfeed.logger, "info") as info_log:
+            out = newsfeed._post_to_dict(post, locked_body=False)
+        self.assertEqual(out["lock_type"], "fixed_price")
+        self.assertEqual(out["unlock_price_cents"], 333)
+        self.assertNotIn("lock_type", post)
+        info_log.assert_called()
+        self.assertEqual(
+            info_log.call_args.kwargs["extra"]["event"],
+            "newsfeed_lock_type_fallback",
+        )
+
+    def test_post_serializer_preserves_explicit_valid_lock_type(self):
+        fixed_post = {
+            "post_id": "p_fixed_explicit",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "fixed body",
+            "locked": True,
+            "lock_type": "fixed_price",
+            "unlock_price_cents": 125,
+        }
+        lottery_post = {
+            "post_id": "p_lottery_explicit",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "lottery body",
+            "locked": True,
+            "lock_type": "tip_lottery",
+            "lottery_tip_cents": 50,
+            "lottery_quiet_period_seconds": 30,
+        }
+
+        fixed_out = newsfeed._post_to_dict(fixed_post)
+        lottery_out = newsfeed._post_to_dict(lottery_post)
+
+        self.assertEqual(fixed_out["lock_type"], "fixed_price")
+        self.assertEqual(lottery_out["lock_type"], "tip_lottery")
+        self.assertEqual(lottery_out["lottery_tip_cents"], 50)
+        self.assertEqual(lottery_out["lottery_quiet_period_seconds"], 30)
+
+    def test_post_serializer_passthrough_for_modern_tip_lottery_metadata(self):
+        post = {
+            "post_id": "p_modern_lottery",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "lottery body",
+            "locked": True,
+            "lock_type": "tip_lottery",
+            "lottery_tip_cents": 175,
+            "lottery_quiet_period_seconds": 90,
+            "lottery_state": "won",
+            "lottery_last_tip_at": "2026-01-01T01:00:00+00:00",
+            "lottery_last_tipper_user_id": "u_last",
+            "lottery_winner_user_id": "u_winner",
+            "lottery_won_at": "2026-01-01T01:03:00+00:00",
+            "lottery_version": 7,
+        }
+        out = newsfeed._post_to_dict(post, locked_body=False)
+        self.assertEqual(out["lock_type"], "tip_lottery")
+        self.assertEqual(out["lottery_tip_cents"], 175)
+        self.assertEqual(out["lottery_quiet_period_seconds"], 90)
+        self.assertEqual(out["lottery_state"], "won")
+        self.assertEqual(out["lottery_last_tip_at"], "2026-01-01T01:00:00+00:00")
+        self.assertEqual(out["lottery_last_tipper_user_id"], "u_last")
+        self.assertEqual(out["lottery_winner_user_id"], "u_winner")
+        self.assertEqual(out["lottery_won_at"], "2026-01-01T01:03:00+00:00")
+        self.assertEqual(out["lottery_version"], 7)
+
+    def test_post_serializer_non_locked_rows_remain_backward_compatible(self):
+        post = {
+            "post_id": "p_open_1",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "plain body",
+            "locked": False,
+        }
+        out = newsfeed._post_to_dict(post, locked_body=False)
+        self.assertFalse(out["locked"])
+        self.assertIsNone(out["lock_type"])
+        self.assertEqual(out["body"], "plain body")
+
 
     def test_post_serializer_masks_all_format_fields_when_locked(self):
         post = {
@@ -759,6 +1055,34 @@ class TestNewsfeedContentEnvelope(unittest.TestCase):
         self.assertEqual(out["body_format"], "plain")
         self.assertEqual(out["body_version"], 1)
         self.assertEqual(out["image_urls"], [])
+
+    def test_post_serializer_locked_content_masking_unchanged_for_tip_lottery(self):
+        post = {
+            "post_id": "p1",
+            "user_id": "author_1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "body": "secret body",
+            "body_plain": "secret body",
+            "body_markdown": "## secret",
+            "body_markdown_html": "<h2>secret</h2>",
+            "body_rich": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "secret"}]}]},
+            "body_format": "rich",
+            "body_version": 3,
+            "image_urls": ["https://cdn.example.com/private.png"],
+            "locked": True,
+            "lock_type": "tip_lottery",
+            "lottery_tip_cents": 99,
+            "lottery_quiet_period_seconds": 45,
+        }
+        out = newsfeed._post_to_dict(post, locked_body=True)
+        self.assertEqual(out["body"], "[Locked content]")
+        self.assertEqual(out["body_plain"], "[Locked content]")
+        self.assertIsNone(out["body_markdown"])
+        self.assertIsNone(out["body_markdown_html"])
+        self.assertIsNone(out["body_rich"])
+        self.assertEqual(out["body_format"], "plain")
+        self.assertEqual(out["image_urls"], [])
+        self.assertEqual(out["lock_type"], "tip_lottery")
 
     def test_get_post_masks_locked_content_without_format_bypass(self):
         locked_post = {

--- a/tests/test_newsfeed_lottery_contracts.py
+++ b/tests/test_newsfeed_lottery_contracts.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from app.routers import newsfeed
+
+
+def test_post_serializer_emits_lottery_contract_fields_when_present() -> None:
+    post = {
+        "post_id": "p1",
+        "user_id": "author_1",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "body": "lottery body",
+        "locked": True,
+        "lock_type": "tip_lottery",
+        "lottery_tip_cents": 150,
+        "lottery_quiet_period_seconds": 120,
+        "lottery_state": "open",
+        "lottery_last_tip_at": "2026-01-01T00:00:00+00:00",
+        "lottery_last_tipper_user_id": "u2",
+        "lottery_winner_user_id": None,
+        "lottery_won_at": None,
+        "lottery_version": 3,
+    }
+
+    out = newsfeed._post_to_dict(post, viewer_id="u3")
+    assert out["lock_type"] == "tip_lottery"
+    assert out["lottery_tip_cents"] == 150
+    assert out["lottery_quiet_period_seconds"] == 120
+    assert out["lottery_state"] == "open"
+    assert out["lottery_last_tip_at"] == "2026-01-01T00:00:00+00:00"
+    assert out["lottery_last_tipper_user_id"] == "u2"
+    assert out["lottery_winner_user_id"] is None
+    assert out["lottery_won_at"] is None
+    assert out["lottery_version"] == 3
+
+
+def test_create_post_request_preserves_fixed_price_contract() -> None:
+    req = newsfeed.CreatePostRequest(
+        body="fixed-price post",
+        unlock_price_cents=299,
+    )
+    assert req.unlock_price_cents == 299
+    assert req.lock_type is None
+    assert req.lottery_tip_cents is None

--- a/tickets-phase2.md
+++ b/tickets-phase2.md
@@ -2352,3 +2352,122 @@
 **Acceptance criteria:**
 - Monthly review template and owners are documented.
 - Action items from each review are tracked to closure.
+### LOT-101: Introduce explicit lottery participation endpoint contract
+**Description:** Add a dedicated `POST /posts/{post_id}/lottery/enter` API contract (request/response schemas, route docs, error model) instead of overloading generic tipping behavior.
+**Acceptance criteria:**
+- Endpoint contract clearly separates lottery entry from fixed-price unlock and generic tips.
+- API docs and typed client contracts include success, rejected, and already-won response shapes.
+
+### LOT-102: Implement atomic lottery entry writes with idempotency keys
+**Description:** Add idempotent participation writes that prevent duplicate entry charges and duplicate participation records during retries/timeouts.
+**Acceptance criteria:**
+- Replayed requests with same idempotency key do not create duplicate charges or entries.
+- Storage and ledger state remain consistent under retry storms.
+
+### LOT-103: Build quiet-period resolver service
+**Description:** Create a scheduled resolver that finalizes `open` lotteries after quiet period expiry and determines winner deterministically.
+**Acceptance criteria:**
+- Resolver transitions qualifying posts from `open` to `won` using deterministic ordering rules.
+- Resolver is safe to run concurrently across multiple workers.
+
+### LOT-104: Enforce single-winner invariants with conditional updates
+**Description:** Add strict DynamoDB conditional expressions/version checks so only one winner can ever be committed for a post.
+**Acceptance criteria:**
+- Race conditions cannot produce multiple winners.
+- Conflicting updates produce controlled conflict outcomes and retry guidance.
+
+### LOT-105: Add loser/winner settlement policy and ledger mapping
+**Description:** Define and implement explicit settlement semantics for participant funds and creator payouts (winner only unlocks, losers pay tip).
+**Acceptance criteria:**
+- Ledger entries clearly identify lottery participation, lottery win unlock, and payout settlement reasons.
+- Finance reconciliation checks can distinguish lottery events from fixed-price unlock events.
+
+### LOT-106: Add anti-fraud controls for lottery participation
+**Description:** Add protections against self-dealing, bot bursts, and abusive repeated entries (velocity limits, anomaly flags, payment risk signals).
+**Acceptance criteria:**
+- Per-user and per-post rate limits are enforced on lottery entry endpoints.
+- Suspicious patterns emit structured security events for moderation/risk workflows.
+
+### LOT-107: Add moderation and policy enforcement hooks for lottery posts
+**Description:** Ensure moderation actions (post removal, user suspension, content restrictions) halt participation and resolution safely.
+**Acceptance criteria:**
+- Removed/suspended content cannot continue accepting lottery entries.
+- Resolver skips or closes moderated lotteries with auditable state transitions.
+
+### LOT-108: Add entitlement/subscription gating parity for lottery visibility
+**Description:** Ensure lottery-locked posts respect creator access policies in every read path (feed, post detail, attachments, comments).
+**Acceptance criteria:**
+- Access checks for lottery posts match fixed-price policy behavior.
+- Unauthorized users never receive unlockable lottery details that bypass entitlement gates.
+
+### LOT-109: Add complete API lifecycle integration tests (state machine)
+**Description:** Build integration tests that exercise full lifecycle: create → entries → contested updates → quiet expiry → winner commit → read consistency.
+**Acceptance criteria:**
+- Tests assert state transitions and invariants at each lifecycle stage.
+- Tests include retry/race scenarios to validate idempotency and conditional write handling.
+
+### LOT-110: Add deterministic time-travel test utility for quiet-period logic
+**Description:** Introduce a controllable clock abstraction so resolver and lifecycle tests avoid wall-clock sleeps.
+**Acceptance criteria:**
+- Resolver tests run with deterministic clock control.
+- CI runtime and flakiness are improved versus sleep-based timing.
+
+### LOT-111: Add frontend composer controls for lottery configuration
+**Description:** Implement post composer UI to select lock strategy (`fixed_price` vs `tip_lottery`) and enter lottery-specific parameters.
+**Acceptance criteria:**
+- Users can configure tip amount and quiet period with inline validation and helpful errors.
+- Composer respects feature flag and hides lottery controls when disabled.
+
+### LOT-112: Add participant-facing lottery status UX
+**Description:** Expand post card/detail UX for states (`open`, `won`, `closed`) including who is leading, time remaining, and final winner context.
+**Acceptance criteria:**
+- UI updates status text and CTAs based on current server-provided lottery state.
+- Missing/legacy fields degrade gracefully without runtime errors.
+
+### LOT-113: Add frontend polling/SSE updates for live lottery state
+**Description:** Wire feed/post detail to receive near-real-time lottery state changes via SSE/polling refresh strategy.
+**Acceptance criteria:**
+- UI refreshes when lottery state changes (new entry, winner selected, closed).
+- Refresh strategy has bounded request volume and backoff behavior.
+
+### LOT-114: Add Playwright multi-user contested winner scenarios
+**Description:** Expand E2E tests to include two+ participants competing within quiet period and verifying only one winner unlock outcome.
+**Acceptance criteria:**
+- E2E validates contested case (new entrant before expiry) and uncontested case (quiet-period winner).
+- Existing fixed-price unlock E2E paths remain green.
+
+### LOT-115: Add production dashboards and SLOs for lottery flows
+**Description:** Build dashboards/SLOs for adoption and reliability: creation volume, entry success, resolver lag, invalid config rejects, winner finalization latency.
+**Acceptance criteria:**
+- Metrics are split by lock strategy and environment (dev/stage/prod).
+- SLOs and alert thresholds are defined for resolver lag and elevated error rates.
+
+### LOT-116: Add structured tracing/correlation across create→entry→resolve
+**Description:** Propagate correlation IDs through API logs, payment calls, resolver actions, and notifications for incident debugging.
+**Acceptance criteria:**
+- Engineers can reconstruct complete lifecycle for a post using a single correlation key.
+- Tracing fields are present in both success and failure logs.
+
+### LOT-117: Add performance and cost benchmark suite
+**Description:** Benchmark resolver throughput, hot-partition risk, and DynamoDB RCU/WCU cost under production-like lottery traffic.
+**Acceptance criteria:**
+- Benchmark report includes scaling limits and projected monthly cost at target traffic.
+- Actionable optimization tasks are captured for bottlenecks.
+
+### LOT-118: Add security threat-model extension and penetration checklist
+**Description:** Extend threat model for lottery-specific abuse (economic manipulation, replay, race exploitation, payment spoofing) and define validation checklist.
+**Acceptance criteria:**
+- Threat scenarios are documented with mapped controls and residual risk ratings.
+- Security checklist is executable pre-prod and results are stored with release artifacts.
+
+### LOT-119: Add rollback automation and kill-switch drills
+**Description:** Automate backend/frontend flag rollback procedures and run recurring gameday drills for rapid disable/recovery.
+**Acceptance criteria:**
+- One-command disable path exists for backend and frontend lottery exposure.
+- Drill evidence captures time-to-disable and time-to-stable metrics.
+
+### LOT-120: Add customer support and dispute operations playbook
+**Description:** Create SOP for support teams handling contested outcomes, delayed resolver cases, duplicate charge claims, and refund/escalation flow.
+**Acceptance criteria:**
+- SOP includes decision trees for support, billing, and engineering escalation.
+- Playbook links to dashboards, trace lookup steps, and incident runbook references.

--- a/tickets.md
+++ b/tickets.md
@@ -1522,3 +1522,100 @@ Create deployment plan covering migration order, feature-flag enablement, canary
 **Acceptance criteria:**
 - `frontend/e2e/feed-unlock-limit.spec.ts` is included in nightly CI lane.
 - Failures page the designated QA/engineering owner for triage.
+### LOT-001: Add lottery lock fields to post API contracts
+**Description:** Extend backend request/response models and frontend TypeScript types to support lock strategy and lottery metadata (`lock_type`, `lottery_tip_cents`, `lottery_quiet_period_seconds`, lifecycle state, winner metadata, and versioning fields) while preserving fixed-price fields.
+**Acceptance criteria:**
+- Backend post create/read payloads include the new lottery fields when provided.
+- Frontend API typings compile with the new fields for `FeedPost` and create post requests.
+- Existing fixed-price `unlock_price_cents` payloads remain valid and unchanged.
+
+### LOT-002: Implement lock strategy validation for post creation
+**Description:** Add backend validation logic for lock strategy combinations, including required lottery configuration for `tip_lottery` and compatibility rules versus fixed-price unlocks.
+**Acceptance criteria:**
+- `tip_lottery` posts require positive `lottery_tip_cents` and `lottery_quiet_period_seconds`.
+- Invalid combinations (for example fixed-price unlock amount combined with lottery lock type) return a 400 error with clear detail.
+- Non-locked posts and fixed-price posts continue to be creatable with existing behavior.
+
+### LOT-003: Persist lottery configuration on post records
+**Description:** Update post persistence logic to store lottery fields on post entities, initialize defaults (`lottery_state=open`, `lottery_version=0`), and ensure consistent lock status derivation.
+**Acceptance criteria:**
+- Creating a `tip_lottery` post writes all configured lottery attributes to DynamoDB post rows.
+- Creating a fixed-price post writes `lock_type=fixed_price` and keeps existing unlock fields.
+- Read-back of persisted rows returns the same values without schema coercion errors.
+
+### LOT-004: Add serializer normalization for legacy rows
+**Description:** Enhance post serialization to infer lock strategy for legacy rows that have `unlock_price_cents` but no `lock_type`, returning a normalized API shape.
+**Acceptance criteria:**
+- Legacy fixed-price rows are returned as `lock_type=fixed_price` without mutating the original record.
+- Rows already carrying valid `lock_type` values are returned unchanged.
+- Serialization of unlocked/non-locked rows remains backward compatible.
+
+### LOT-005: Add backfill script for legacy lock type normalization
+**Description:** Create an operational script to scan post rows and set `lock_type=fixed_price` where legacy rows contain positive `unlock_price_cents` but lack a valid lock type.
+**Acceptance criteria:**
+- Script supports dry-run and apply modes.
+- Script only updates eligible `Post` entities and is idempotent on repeated runs.
+- Script emits summary stats for scanned, eligible, and updated rows.
+
+### LOT-006: Add unit tests for lottery schema and validation
+**Description:** Add backend unit tests for request validation and persistence behavior across lock strategies.
+**Acceptance criteria:**
+- Tests cover successful `tip_lottery` create with required fields.
+- Tests cover invalid combinations and missing required fields with 400 responses.
+- Tests verify fixed-price and unlocked creation flows remain green.
+
+### LOT-007: Add unit tests for serializer legacy compatibility
+**Description:** Add/extend serializer tests to verify inferred `lock_type` behavior for legacy rows and passthrough behavior for modern rows.
+**Acceptance criteria:**
+- Legacy rows with `unlock_price_cents` and missing lock type serialize as `fixed_price`.
+- Modern rows with explicit `tip_lottery` serialize all lottery metadata.
+- Existing locked-content masking behavior remains unchanged in test coverage.
+
+### LOT-008: Add unit tests for backfill planner logic
+**Description:** Add tests for lock-type backfill helper functions and update planning.
+**Acceptance criteria:**
+- Tests validate eligibility filtering (`Post` rows only).
+- Tests validate inference rules for valid existing lock types and legacy unlock rows.
+- Tests validate no-op behavior when target value is already present.
+
+### LOT-009: Add API integration tests for post create/get schema
+**Description:** Extend API-level tests to verify end-to-end create/get behavior for `tip_lottery` posts and legacy lock-type read compatibility.
+**Acceptance criteria:**
+- Integration tests assert lottery fields are returned after create and on subsequent get/list reads.
+- Integration tests assert fixed-price legacy-style reads include inferred lock type.
+- Integration tests run in CI alongside existing newsfeed suites.
+
+### LOT-010: Add frontend UI support for lock strategy display
+**Description:** Update feed/post UI components to render lock strategy metadata (fixed price vs tip lottery) and show lottery parameters/status safely.
+**Acceptance criteria:**
+- Post cards show lottery tip amount and quiet-period details for `tip_lottery` posts.
+- Existing fixed-price lock UI remains unchanged for non-lottery posts.
+- UI handles missing/legacy fields gracefully without runtime errors.
+
+### LOT-011: Add frontend component and e2e tests for lottery metadata rendering
+**Description:** Add UI test coverage for rendering and state handling of lottery metadata in post views.
+**Acceptance criteria:**
+- Component tests assert correct rendering of lottery fields and fallback behavior.
+- E2E/newsfeed tests verify lottery-configured posts are visible with expected metadata.
+- Tests do not regress existing fixed-price unlock scenarios.
+
+### LOT-012: Add migration runbook and deployment rollout checklist
+**Description:** Provide deployment guidance for schema rollout, backfill execution, and rollback planning across environments.
+**Acceptance criteria:**
+- Runbook documents order: deploy read/write support, run backfill dry-run, execute backfill, verify metrics.
+- Rollback notes cover safe behavior when `lock_type` is absent and how to disable lottery create path.
+- Checklist includes post-deploy validation queries and dashboards/alerts for errors.
+
+### LOT-013: Add observability for lottery schema adoption and failures
+**Description:** Instrument metrics/logs to track lottery post creation volume, validation failures, serializer fallback usage, and backfill progress.
+**Acceptance criteria:**
+- Metrics distinguish fixed-price vs lottery post creation counts.
+- Validation failure logs include structured reason codes.
+- Backfill run outputs are collectable for operational reporting.
+
+### LOT-014: Add feature-flag gating and staged rollout controls
+**Description:** Introduce a feature flag to gate lottery lock creation and UI visibility, enabling phased rollout and quick disable.
+**Acceptance criteria:**
+- Backend rejects `tip_lottery` creates when flag is disabled.
+- Frontend hides lottery configuration controls when flag is disabled.
+- Staged rollout plan supports dev/staging/prod enablement with clear toggle ownership.


### PR DESCRIPTION
### Motivation
- Introduce a new `tip_lottery` lock strategy for newsfeed posts to support lottery-style tipping unlocks alongside existing fixed-price unlocks. 
- Preserve backward compatibility for legacy rows that only have `unlock_price_cents` by inferring `lock_type=fixed_price` at read time. 
- Provide an operational backfill to populate `lock_type` for legacy fixed-price posts and a rollout runbook for safe deployment. 
- Surface lottery metadata in the frontend behind a feature flag and add tests and instrumentation for safe rollout.

### Description
- Add a backend feature flag `NEWSFEED_TIP_LOTTERY_ENABLED` to `Settings` and emit structured warnings via `_emit_newsfeed_lock_validation_reject` for invalid lock configurations.  
- Extend request/response shapes in `app/routers/newsfeed.py` (`CreatePostRequest`, `PostResponse`) and implement `create_post` validation and persistence for `lock_type=tip_lottery`, including required `lottery_tip_cents`, `lottery_quiet_period_seconds`, default `lottery_state=open`, and `lottery_version` initialization.  
- Add read-path normalization `_normalized_post_lock_type` and enrich `_post_to_dict` to include `lock_type` and `lottery_*` fields while maintaining backward compatibility for legacy `unlock_price_cents`.  
- Add an idempotent backfill script `scripts/backfill_newsfeed_lock_type.py`, documentation `docs/newsfeed_tip_lottery_rollout_runbook.md`, frontend feature-flag helper `frontend/src/config/featureFlags.ts`, TypeScript type updates, UI updates to `PostCard.tsx` to render lottery metadata safely, and planning/ticket docs (`tickets*.md`).

### Testing
- Backend unit tests and integration tests were added/updated (`tests/test_newsfeed_api_lottery_integration.py`, `tests/test_newsfeed_backfill_script.py`, `tests/test_newsfeed_content_envelope.py`, `tests/test_newsfeed_lottery_contracts.py`) and run with `pytest`, passing locally/CI.  
- Backfill script behavior covered by unit tests exercising dry-run and apply modes, and these tests passed under `pytest`.  
- Frontend unit and component tests for `PostCard` were added/updated (`frontend/src/pages/feed/__tests__/PostCard.report.test.tsx`) and run with the frontend test runner (vitest), passing locally/CI.  
- Playwright E2E scenarios in `frontend/e2e/feed.spec.ts` were extended to exercise lottery creation and UI rendering and were executed against the test environment, passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ae51be0510832b9bd66dbc692ae487)