### PR TITLE
frontend UX polish + easier document signing (wizard, viewer, drafts)

### DIFF
--- a/app/routers/signature_packets.py
+++ b/app/routers/signature_packets.py
@@ -577,27 +577,44 @@ def list_awaiting_my_signature(limit: int = 100, user_sub: str = Depends(_curren
     return {"items": items, "count": len(items)}
 
 
+def _sender_inbox_item(packet: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "packet_id": str(packet.get("packet_id") or ""),
+        "owner_user_id": packet.get("owner_user_id"),
+        "source_name": packet.get("source_name"),
+        "status": str(packet.get("status") or ""),
+        "status_chip": None,
+        "status_text": None,
+        "role": "sender",
+        "created_at": packet.get("created_at"),
+        "sent_at": packet.get("sent_at"),
+        "completed_at": packet.get("completed_at"),
+    }
+
+
 @router.get("/sent", response_model=SigningInboxListOut)
 def list_sent_by_me(limit: int = 100, user_sub: str = Depends(_current_user)) -> Dict[str, Any]:
-    """Packets the caller owns/sent, newest first (OWNER_CREATED_INDEX GSI)."""
+    """Packets the caller has SENT (excludes unsent drafts), newest first."""
     limit = max(1, min(int(limit), 200))
     packets = list_packets_by_sender(user_sub, limit=limit)
-    items: list[Dict[str, Any]] = []
-    for packet in packets:
-        items.append(
-            {
-                "packet_id": str(packet.get("packet_id") or ""),
-                "owner_user_id": packet.get("owner_user_id"),
-                "source_name": packet.get("source_name"),
-                "status": str(packet.get("status") or ""),
-                "status_chip": None,
-                "status_text": None,
-                "role": "sender",
-                "created_at": packet.get("created_at"),
-                "sent_at": packet.get("sent_at"),
-                "completed_at": packet.get("completed_at"),
-            }
-        )
+    items = [
+        _sender_inbox_item(p)
+        for p in packets
+        if str(p.get("status") or "") != SignaturePacketStatus.DRAFT.value
+    ]
+    return {"items": items, "count": len(items)}
+
+
+@router.get("/drafts", response_model=SigningInboxListOut)
+def list_my_drafts(limit: int = 100, user_sub: str = Depends(_current_user)) -> Dict[str, Any]:
+    """Unsent draft packets the caller owns, newest first — resumable in the composer."""
+    limit = max(1, min(int(limit), 200))
+    packets = list_packets_by_sender(user_sub, limit=limit)
+    items = [
+        _sender_inbox_item(p)
+        for p in packets
+        if str(p.get("status") or "") == SignaturePacketStatus.DRAFT.value
+    ]
     return {"items": items, "count": len(items)}
 
 

--- a/frontend/e2e/signing-inbox.spec.ts
+++ b/frontend/e2e/signing-inbox.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * E2E for the Signing inbox document viewer (SUX-* + drafts).
+ *
+ * Covers the four buckets a user expects — Awaiting me / Sent by me / Completed /
+ * Drafts — plus the new Drafts tab and "Resume" (reopens a draft in the composer).
+ *
+ * Auth: Alice session cookies (e2e_session_setup.py). Creates a real draft packet
+ * via the API (after injecting a fake PDF node into DynamoDB so create resolves).
+ * Requires SIGNATURE_PDF_ENABLED=true.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import * as path from "path";
+
+const REPO_ROOT = process.env.E2E_REPO_ROOT || path.resolve(process.cwd(), "..");
+const BASE = "http://localhost:3000";
+const ALICE_ID = "e2e_alice@test.local";
+const TS = Date.now();
+
+interface SessionData {
+  user_sub: string;
+  csrf_token: string;
+  cookies: Array<{
+    name: string; value: string; domain: string; path: string;
+    httpOnly: boolean; secure: boolean; sameSite: "Lax" | "Strict" | "None"; expires: number;
+  }>;
+}
+
+let _sessions: Record<string, SessionData> | null = null;
+function getSessions(): Record<string, SessionData> {
+  if (!_sessions) {
+    const raw = execSync("python3 " + REPO_ROOT + "/e2e_session_setup.py", {
+      cwd: REPO_ROOT, timeout: 30_000,
+    }).toString();
+    _sessions = JSON.parse(raw);
+  }
+  return _sessions!;
+}
+
+async function injectAuth(page: Page, userId = ALICE_ID) {
+  const session = getSessions()[userId];
+  if (!session) throw new Error(`No session for ${userId}`);
+  await page.context().addCookies(session.cookies);
+  await page.goto(`${BASE}/login`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((uid: string) => {
+    const state = { userId: uid, accessToken: null, isAuthenticated: true };
+    localStorage.setItem("auth-store", JSON.stringify({ state, version: 0 }));
+  }, userId);
+}
+
+async function apiGet(page: Page, p: string) {
+  const s = getSessions()[ALICE_ID];
+  return page.request.get(`${BASE}${p}`, { headers: { "x-csrf-token": s.csrf_token } });
+}
+async function apiPost(page: Page, p: string, body: object) {
+  const s = getSessions()[ALICE_ID];
+  return page.request.post(`${BASE}${p}`, { data: body, headers: { "x-csrf-token": s.csrf_token } });
+}
+
+const DDB_PRELUDE = `
+import boto3, os, time
+from pathlib import Path
+env_file = Path('${REPO_ROOT}/.env.local')
+if env_file.exists():
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith('#') and '=' in line:
+            k, v = line.split('=', 1)
+            os.environ.setdefault(k.strip(), v.strip())
+ddb = boto3.resource('dynamodb', endpoint_url=os.environ.get('DDB_ENDPOINT_URL', 'http://localhost:8001'),
+    region_name='us-east-1', aws_access_key_id='test', aws_secret_access_key='test')
+`;
+
+function injectPdfNode(userSub: string, pdfPath: string): void {
+  const name = pdfPath.split("/").pop()!;
+  const parent = pdfPath.substring(0, pdfPath.lastIndexOf("/")) || "/";
+  execSync(
+    `python3 -c "${DDB_PRELUDE}
+tbl = ddb.Table('file_manager')
+tbl.put_item(Item={'PK':'USER#${userSub}','SK':'NODE#${pdfPath}','type':'file','path':'${pdfPath}',
+ 'name':'${name}','name_lc':'${name.toLowerCase()}','parent':'${parent}','content_type':'application/pdf',
+ 'size':1024,'created_at':str(int(time.time())),'updated_at':str(int(time.time())),
+ 's3_key':'e2e/fake/${name}','s3_bucket':'test-bucket'})
+print('ok')
+"`,
+    { timeout: 10_000 },
+  );
+}
+
+test.describe("Signing inbox document viewer", () => {
+  let page: Page;
+  let aliceSub: string;
+  let draftId = "";
+  const PDF_PATH = `/e2e/inbox_${TS}.pdf`;
+  const SRC_NAME = `inbox_${TS}.pdf`;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await injectAuth(page);
+    aliceSub = getSessions()[ALICE_ID].user_sub;
+    injectPdfNode(aliceSub, PDF_PATH);
+    const resp = await apiPost(page, "/v1/signature-packets", {
+      source_path: PDF_PATH,
+      origin_channel: "share",
+    });
+    expect(resp.status()).toBe(200);
+    draftId = ((await resp.json()) as { packet_id: string }).packet_id;
+    expect(draftId).toBeTruthy();
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
+  });
+
+  test("inbox shows the four document buckets", async () => {
+    await page.goto(`${BASE}/signing/inbox`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("tab-awaiting")).toBeVisible();
+    await expect(page.getByTestId("tab-sent")).toBeVisible();
+    await expect(page.getByTestId("tab-completed")).toBeVisible();
+    await expect(page.getByTestId("tab-drafts")).toBeVisible();
+  });
+
+  test("API: draft appears in /drafts and NOT in /sent", async () => {
+    const drafts = await (await apiGet(page, "/v1/signature-packets/drafts")).json();
+    const sent = await (await apiGet(page, "/v1/signature-packets/sent")).json();
+    const draftIds = (drafts.items as Array<{ packet_id: string }>).map((i) => i.packet_id);
+    const sentIds = (sent.items as Array<{ packet_id: string }>).map((i) => i.packet_id);
+    expect(draftIds).toContain(draftId);
+    expect(sentIds).not.toContain(draftId);
+  });
+
+  test("Drafts tab lists the draft with a Resume action", async () => {
+    await page.goto(`${BASE}/signing/inbox`, { waitUntil: "domcontentloaded" });
+    await page.getByTestId("tab-drafts").click();
+    const panel = page.getByTestId("panel-drafts");
+    await expect(panel.getByText(SRC_NAME)).toBeVisible({ timeout: 8000 });
+    await expect(panel.getByRole("button", { name: "Resume" }).first()).toBeVisible();
+  });
+
+  test("Resume reopens the draft in the composer", async () => {
+    await page.goto(`${BASE}/signing/inbox`, { waitUntil: "domcontentloaded" });
+    await page.getByTestId("tab-drafts").click();
+    const row = page
+      .getByTestId("signing-inbox-row")
+      .filter({ hasText: SRC_NAME })
+      .first();
+    await row.getByRole("button", { name: "Resume" }).click();
+    await expect(page).toHaveURL(new RegExp(`/signing/new\\?packet=${draftId}`));
+    // composer auto-loads the draft → status line reflects it, Step 2 appears
+    await expect(page.getByTestId("signature-status")).toContainText(draftId, { timeout: 10_000 });
+    await expect(page.getByText("Step 2 · Place signature fields")).toBeVisible();
+  });
+});

--- a/frontend/src/api/endpoints/signaturePackets.ts
+++ b/frontend/src/api/endpoints/signaturePackets.ts
@@ -154,6 +154,9 @@ export const listSentPackets = (limit = 100) =>
 export const listCompletedForMe = (limit = 100) =>
   api.get<SigningInboxList>("/v1/signature-packets/completed-for-me", { limit: String(limit) });
 
+export const listDraftPackets = (limit = 100) =>
+  api.get<SigningInboxList>("/v1/signature-packets/drafts", { limit: String(limit) });
+
 // ─── SUX-005: owner mint/revoke per-signer public signing link ───────────────
 
 export interface CreateSigningLinkResp {

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -165,7 +165,7 @@ export default function MobileNav() {
             }
           >
             <tab.icon className="h-5 w-5" />
-            {tab.i18nKey ? t(tab.i18nKey) : tab.label}
+            {tab.i18nKey ? t(tab.i18nKey, { defaultValue: tab.label }) : tab.label}
           </NavLink>
         ))}
         <button
@@ -196,7 +196,7 @@ export default function MobileNav() {
                 }}
               >
                 <link.icon className="h-5 w-5" />
-                <span className="text-[10px]">{link.i18nKey ? t(link.i18nKey) : link.label}</span>
+                <span className="text-[10px]">{link.i18nKey ? t(link.i18nKey, { defaultValue: link.label }) : link.label}</span>
               </Button>
             ))}
           </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -490,7 +490,7 @@ export default function Sidebar() {
             {gi > 0 && <Separator className="my-2" />}
             {!collapsed && (
               <span className="mb-1 block px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {group.i18nKey ? t(group.i18nKey) : group.title}
+                {group.i18nKey ? t(group.i18nKey, { defaultValue: group.title }) : group.title}
               </span>
             )}
             <ul className="space-y-0.5">
@@ -518,7 +518,7 @@ export default function Sidebar() {
                       )}
                     </span>
                     {!collapsed && (
-                      <span className="truncate">{item.i18nKey ? t(item.i18nKey) : item.label}</span>
+                      <span className="truncate">{item.i18nKey ? t(item.i18nKey, { defaultValue: item.label }) : item.label}</span>
                     )}
                     {!collapsed && badge > 0 && (
                       <span className="ml-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-semibold text-primary-foreground">
@@ -534,7 +534,7 @@ export default function Sidebar() {
                       <Tooltip>
                         <TooltipTrigger asChild>{link}</TooltipTrigger>
                         <TooltipContent side="right" sideOffset={8}>
-                          {item.i18nKey ? t(item.i18nKey) : item.label}
+                          {item.i18nKey ? t(item.i18nKey, { defaultValue: item.label }) : item.label}
                         </TooltipContent>
                       </Tooltip>
                     </li>

--- a/frontend/src/pages/dashboard/TopContentList.tsx
+++ b/frontend/src/pages/dashboard/TopContentList.tsx
@@ -1,4 +1,6 @@
+import { BarChart3 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/shared/EmptyState";
 import type { DashboardTopContentItem } from "@/api/types";
 
 interface TopContentListProps {
@@ -13,7 +15,12 @@ export default function TopContentList({ items }: TopContentListProps) {
       </CardHeader>
       <CardContent>
         {items.length === 0 && (
-          <p className="text-sm text-muted-foreground">No content data yet</p>
+          <EmptyState
+            icon={<BarChart3 className="h-7 w-7" />}
+            title="No content data yet"
+            description="Your top-performing posts and videos will appear here once they start getting views."
+            className="py-8"
+          />
         )}
         <ul className="space-y-2">
           {items.slice(0, 5).map((item, idx) => (

--- a/frontend/src/pages/discover/DiscoverPage.tsx
+++ b/frontend/src/pages/discover/DiscoverPage.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { FollowButton } from "@/components/shared/FollowButton";
+import { EmptyState } from "@/components/shared/EmptyState";
 import { Compass, Hash, Search, TrendingUp, Users } from "lucide-react";
 import {
   searchDiscoverUsers,
@@ -179,7 +180,12 @@ export default function DiscoverPage() {
                   ))}
                 </div>
               ) : (
-                <p className="text-sm text-muted-foreground">No suggestions yet</p>
+                <EmptyState
+                  icon={<Users className="h-7 w-7" />}
+                  title="No suggestions yet"
+                  description="Follow creators and engage with posts to get personalized suggestions."
+                  className="py-10"
+                />
               )}
             </CardContent>
           </Card>
@@ -199,7 +205,12 @@ export default function DiscoverPage() {
                   ))}
                 </div>
               ) : (
-                <p className="text-sm text-muted-foreground">No trending creators yet</p>
+                <EmptyState
+                  icon={<TrendingUp className="h-7 w-7" />}
+                  title="No trending creators yet"
+                  description="Trending creators appear here as the community grows — check back soon."
+                  className="py-10"
+                />
               )}
             </CardContent>
           </Card>

--- a/frontend/src/pages/files/SignaturePacketComposer.tsx
+++ b/frontend/src/pages/files/SignaturePacketComposer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { FilePen } from "lucide-react";
+import { FilePen, FolderOpen } from "lucide-react";
 import { toast } from "sonner";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SignatureDrawCanvas } from "@/components/SignatureDrawCanvas";
+import { FilePickerDialog } from "@/pages/messages/FilePickerDialog";
 import {
   Select,
   SelectContent,
@@ -135,6 +136,7 @@ function formatTs(ts?: string): string {
 
 export function SignaturePacketComposer() {
   const [sourcePath, setSourcePath] = React.useState("");
+  const [pickerOpen, setPickerOpen] = React.useState(false);
   const [originChannel, setOriginChannel] = React.useState<SignatureOriginChannel>("share");
   const [packetId, setPacketId] = React.useState("");
   const [packet, setPacket] = React.useState<SignaturePacketDetail | null>(null);
@@ -421,20 +423,29 @@ export function SignaturePacketComposer() {
         )}
       </div>
 
-      <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
-        <Input
-          placeholder="Source PDF path (e.g. /contracts/nda.pdf)"
-          value={sourcePath}
-          onChange={(e) => setSourcePath(e.target.value)}
-        />
-        <Select value={originChannel} onValueChange={(v) => setOriginChannel(v as SignatureOriginChannel)}>
-          <SelectTrigger className="w-[160px]"><SelectValue /></SelectTrigger>
-          <SelectContent>
-            <SelectItem value="share">share</SelectItem>
-            <SelectItem value="message">message</SelectItem>
-          </SelectContent>
-        </Select>
-        <Button onClick={createDraft} disabled={busy}>Create draft</Button>
+      <div className="space-y-1">
+        <Label className="text-sm font-medium">Step 1 · Choose the PDF to sign</Label>
+        <div className="grid gap-3 md:grid-cols-[auto_1fr_auto_auto]">
+          <Button type="button" variant="outline" onClick={() => setPickerOpen(true)} className="gap-2">
+            <FolderOpen className="h-4 w-4" /> Choose PDF
+          </Button>
+          <Input
+            placeholder="Source PDF path — or click Choose PDF"
+            value={sourcePath}
+            onChange={(e) => setSourcePath(e.target.value)}
+          />
+          <Select value={originChannel} onValueChange={(v) => setOriginChannel(v as SignatureOriginChannel)}>
+            <SelectTrigger className="w-[160px]"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="share">Share link</SelectItem>
+              <SelectItem value="message">In a message</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button onClick={createDraft} disabled={busy || !sourcePath.trim()}>Create draft</Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Pick a PDF from your files, then “Create draft” to add signer fields and send.
+        </p>
       </div>
 
       <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
@@ -721,6 +732,16 @@ export function SignaturePacketComposer() {
           </div>
         </div>
       </div>
+
+      <FilePickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        showPermission={false}
+        onSelect={(entry) => {
+          setSourcePath(entry.path);
+          setPickerOpen(false);
+        }}
+      />
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/files/SignaturePacketComposer.tsx
+++ b/frontend/src/pages/files/SignaturePacketComposer.tsx
@@ -134,7 +134,7 @@ function formatTs(ts?: string): string {
   return d.toLocaleString();
 }
 
-export function SignaturePacketComposer() {
+export function SignaturePacketComposer({ initialPacketId }: { initialPacketId?: string } = {}) {
   const [sourcePath, setSourcePath] = React.useState("");
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const [originChannel, setOriginChannel] = React.useState<SignatureOriginChannel>("share");
@@ -205,6 +205,14 @@ export function SignaturePacketComposer() {
       setBusy(false);
     }
   }, [defaultCaptureMode]);
+
+  // Resume a draft passed in via ?packet= (from the Drafts tab in the signing inbox).
+  React.useEffect(() => {
+    if (initialPacketId) {
+      void loadPacket(initialPacketId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialPacketId]);
 
   const createDraft = React.useCallback(async () => {
     if (!sourcePath.trim()) {

--- a/frontend/src/pages/files/SignaturePacketComposer.tsx
+++ b/frontend/src/pages/files/SignaturePacketComposer.tsx
@@ -408,7 +408,7 @@ export function SignaturePacketComposer() {
       <div>
         <h3 className="text-base font-semibold">Create signature form</h3>
         <p className="text-sm text-muted-foreground">
-          Sender composer + signer fill workflow for signature packets.
+          Send a PDF for signature in three steps: choose the document, place signer fields, then send.
         </p>
       </div>
 
@@ -448,28 +448,34 @@ export function SignaturePacketComposer() {
         </p>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
-        <Input
-          placeholder="Packet ID"
-          value={packetId}
-          onChange={(e) => setPacketId(e.target.value)}
-        />
-        <Button variant="outline" onClick={() => void loadPacket(packetId)} disabled={busy}>Load</Button>
-        <Button onClick={() => void sendPacket()} disabled={busy || !packet || !packet.capabilities?.can_send}>Send packet</Button>
-      </div>
+      <details className="rounded-md border bg-muted/10 px-3 py-2">
+        <summary className="cursor-pointer select-none text-sm text-muted-foreground">
+          Resume an existing draft
+        </summary>
+        <div className="mt-2 grid gap-3 md:grid-cols-[1fr_auto]">
+          <Input
+            placeholder="Packet ID"
+            value={packetId}
+            onChange={(e) => setPacketId(e.target.value)}
+          />
+          <Button variant="outline" onClick={() => void loadPacket(packetId)} disabled={busy}>Load</Button>
+        </div>
+      </details>
 
       <div className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground" data-testid="signature-status">
-        {statusMsg || "Load a packet to compose or fill assigned fields."}
+        {statusMsg || "Choose a PDF and create a draft to get started."}
       </div>
 
-      <div className="rounded-md border p-3" data-testid="packet-timeline">
-        <div className="text-sm font-medium mb-2">Packet timeline</div>
-        <ul className="space-y-1 text-xs text-muted-foreground">
-          <li>Draft created: {formatTs(packet?.created_at)}</li>
-          <li>Sent: {formatTs(packet?.sent_at)}</li>
-          <li>Completed: {formatTs(packet?.completed_at)}</li>
-        </ul>
-      </div>
+      {packet && (
+        <div className="rounded-md border p-3" data-testid="packet-timeline">
+          <div className="text-sm font-medium mb-2">Progress</div>
+          <ul className="space-y-1 text-xs text-muted-foreground">
+            <li>Draft created: {formatTs(packet?.created_at)}</li>
+            <li>Sent: {formatTs(packet?.sent_at)}</li>
+            <li>Completed: {formatTs(packet?.completed_at)}</li>
+          </ul>
+        </div>
+      )}
 
       {signerCanFill && (
         <div className="rounded-md border p-3 space-y-2" data-testid="signer-fill-panel">
@@ -519,6 +525,16 @@ export function SignaturePacketComposer() {
         </div>
       )}
 
+      {packet && (
+      <div className="space-y-3">
+        {packet.role !== "signer" && (
+          <div className="space-y-1">
+            <Label className="text-sm font-medium">Step 2 · Place signature fields</Label>
+            <p className="text-xs text-muted-foreground">
+              Pick a field type and signer, then click on the document to drop the field.
+            </p>
+          </div>
+        )}
       <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
         <div className="space-y-3">
           <div className="space-y-2">
@@ -646,8 +662,8 @@ export function SignaturePacketComposer() {
 
         <div className="space-y-2">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span>PDF editor canvas</span>
-            <span>status: {packet?.status ?? "none"}</span>
+            <span>Document preview — click to place a field</span>
+            <span>Status: {packet?.status ?? "draft"}</span>
           </div>
           <div
             ref={canvasRef}
@@ -732,6 +748,20 @@ export function SignaturePacketComposer() {
           </div>
         </div>
       </div>
+
+      {packet.role !== "signer" && packet.capabilities?.can_send && (
+        <div className="space-y-1 border-t pt-3">
+          <Label className="text-sm font-medium">Step 3 · Send for signature</Label>
+          <p className="text-xs text-muted-foreground">
+            When your fields are placed, send the document to the signers.
+          </p>
+          <Button onClick={() => void sendPacket()} disabled={busy || !packet.capabilities?.can_send}>
+            Send packet
+          </Button>
+        </div>
+      )}
+      </div>
+      )}
 
       <FilePickerDialog
         open={pickerOpen}

--- a/frontend/src/pages/signing/CreateSignatureRequestPage.tsx
+++ b/frontend/src/pages/signing/CreateSignatureRequestPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { ArrowLeft, Copy, Link2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,8 @@ import { createSignerSigningLink } from "@/api/endpoints/signaturePackets";
  * affordance (SUX-005) with copy-to-clipboard.
  */
 export default function CreateSignatureRequestPage() {
+  const [searchParams] = useSearchParams();
+  const resumePacketId = searchParams.get("packet") ?? undefined;
   const [linkPacketId, setLinkPacketId] = React.useState("");
   const [linkSignerId, setLinkSignerId] = React.useState("");
   const [generatedUrl, setGeneratedUrl] = React.useState("");
@@ -71,7 +73,7 @@ export default function CreateSignatureRequestPage() {
         Pick a source PDF, add signer fields, then send. After sending you can mint a per-signer public link below.
       </p>
 
-      <SignaturePacketComposer />
+      <SignaturePacketComposer initialPacketId={resumePacketId} />
 
       <Card>
         <CardHeader>

--- a/frontend/src/pages/signing/SigningInboxPage.tsx
+++ b/frontend/src/pages/signing/SigningInboxPage.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, FilePen, Inbox, Send, CheckCircle2 } from "lucide-react";
+import { ArrowLeft, FilePen, Inbox, Send, CheckCircle2, FileEdit } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,6 +11,7 @@ import {
   listAwaitingSignature,
   listSentPackets,
   listCompletedForMe,
+  listDraftPackets,
   type SigningInboxItem,
 } from "@/api/endpoints/signaturePackets";
 
@@ -87,10 +88,21 @@ export default function SigningInboxPage() {
     queryKey: ["signing", "completed-for-me"],
     queryFn: () => listCompletedForMe(),
   });
+  const drafts = useQuery({
+    queryKey: ["signing", "drafts"],
+    queryFn: () => listDraftPackets(),
+  });
 
   const openToSign = React.useCallback(
     (item: SigningInboxItem) => {
       navigate(`/signing/inbox/${encodeURIComponent(item.packet_id)}`);
+    },
+    [navigate],
+  );
+
+  const resumeDraft = React.useCallback(
+    (item: SigningInboxItem) => {
+      navigate(`/signing/new?packet=${encodeURIComponent(item.packet_id)}`);
     },
     [navigate],
   );
@@ -145,6 +157,14 @@ export default function SigningInboxPage() {
           <TabsTrigger value="completed" data-testid="tab-completed">
             <CheckCircle2 className="mr-1 h-4 w-4" /> Completed
           </TabsTrigger>
+          <TabsTrigger value="drafts" data-testid="tab-drafts">
+            <FileEdit className="mr-1 h-4 w-4" /> Drafts
+            {(drafts.data?.count ?? 0) > 0 && (
+              <Badge className="ml-2" variant="secondary">
+                {drafts.data?.count}
+              </Badge>
+            )}
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="awaiting" className="space-y-2 pt-3" data-testid="panel-awaiting">
@@ -183,6 +203,18 @@ export default function SigningInboxPage() {
           )}
           {completed.data?.items.map((item) => (
             <InboxRow key={item.packet_id} item={item} />
+          ))}
+        </TabsContent>
+
+        <TabsContent value="drafts" className="space-y-2 pt-3" data-testid="panel-drafts">
+          {drafts.isLoading && <div className="text-sm text-muted-foreground">Loading…</div>}
+          {!drafts.isLoading && (drafts.data?.items.length ?? 0) === 0 && (
+            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No drafts yet. Start a new signature request to create one.
+            </div>
+          )}
+          {drafts.data?.items.map((item) => (
+            <InboxRow key={item.packet_id} item={item} actionLabel="Resume" onAction={resumeDraft} />
           ))}
         </TabsContent>
       </Tabs>

--- a/frontend/src/pages/signing/SigningWidget.tsx
+++ b/frontend/src/pages/signing/SigningWidget.tsx
@@ -70,7 +70,7 @@ function validateFieldInput(
       return null;
     }
     const strokes = parseDrawnStrokes(drawnRaw);
-    if (strokes.length < 2) return "Drawn mode needs JSON points, e.g. [[0.1,0.2],[0.2,0.3]]";
+    if (strokes.length < 2) return "Please draw your signature in the box above.";
     if (strokes.length > 20) return "Max points is 20";
     for (const point of strokes) {
       if (!Array.isArray(point) || point.length !== 2) return "Each point must be [x,y]";
@@ -314,7 +314,7 @@ export function SigningWidget({
       <div className="space-y-2">
         <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>Document preview</span>
-          <span>status: {packet.status}</span>
+          <span>Status: {packet.status}</span>
         </div>
         <div
           data-testid="signing-canvas"
@@ -416,7 +416,7 @@ export function SigningWidget({
               </span>
             </div>
             <div className="flex items-center gap-2 text-xs">
-              <span>Default signature input:</span>
+              <span>Signature style:</span>
               <Select
                 value={defaultCaptureMode}
                 onValueChange={(v) => {
@@ -429,8 +429,8 @@ export function SigningWidget({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="typed">typed</SelectItem>
-                  <SelectItem value="drawn">drawn</SelectItem>
+                  <SelectItem value="typed">Type</SelectItem>
+                  <SelectItem value="drawn">Draw</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -464,8 +464,8 @@ export function SigningWidget({
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="typed">typed</SelectItem>
-                              <SelectItem value="drawn">drawn</SelectItem>
+                              <SelectItem value="typed">Type</SelectItem>
+                              <SelectItem value="drawn">Draw</SelectItem>
                             </SelectContent>
                           </Select>
                         )}


### PR DESCRIPTION
## Summary
First fix from a UX/visual audit. The sidebar + mobile nav rendered `t(item.i18nKey)` unconditionally, so nav entries lacking an `en.json` key showed the **raw key** (`nav.callHistory`, `nav.activity`, `nav.saved`, `nav.achievements`, `nav.invoices`, `nav.taxDocuments`, `nav.taxForms1099`, `nav.vodRentals`, …) — the whole left nav looked half-finished. Every item already has a human `label`; pass it as the i18next `defaultValue` so missing translations fall back to the label (real translations still win).

Applied to `Sidebar` (group titles, items, collapsed tooltips) and `MobileNav` (tabs + "More" sheet).

## Before / after
Raw `nav.callHistory` etc. → **Call History, Activity, Saved, Achievements, Invoices, Tax Documents, Tax Forms (1099), My Rentals** (verified via screenshot, desktop + mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)