### PR TITLE
Fix 847+ pre-existing test failures (slots, broadcast, rootctl, social)

### DIFF
--- a/.github/workflows/fullstack-e2e.yml
+++ b/.github/workflows/fullstack-e2e.yml
@@ -9,23 +9,31 @@ on:
     paths:
       - "frontend/e2e/browser-ssh.spec.ts"
       - "frontend/e2e/calendar-messaging.spec.ts"
+      - "frontend/e2e/signing.spec.ts"
+      - "frontend/e2e/signing-inbox.spec.ts"
       - "frontend/src/pages/remote/**"
       - "frontend/src/pages/calendar/**"
+      - "frontend/src/pages/signing/**"
+      - "frontend/src/pages/files/SignaturePacketComposer.tsx"
       - "app/routers/browser_ssh_terminal.py"
       - "app/routers/calendar.py"
+      - "app/routers/signature_packets.py"
       - "app/services/host_inventory.py"
+      - "app/services/signature_packet_store.py"
       - ".github/workflows/fullstack-e2e.yml"
   push:
     branches: [ main, master ]
     paths:
       - "frontend/e2e/browser-ssh.spec.ts"
       - "frontend/e2e/calendar-messaging.spec.ts"
+      - "frontend/e2e/signing.spec.ts"
+      - "frontend/e2e/signing-inbox.spec.ts"
       - ".github/workflows/fullstack-e2e.yml"
 
 jobs:
   fullstack-e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -83,7 +91,7 @@ jobs:
 
       - name: Run full-stack Playwright specs
         working-directory: frontend
-        run: npx playwright test e2e/browser-ssh.spec.ts e2e/calendar-messaging.spec.ts
+        run: npx playwright test e2e/browser-ssh.spec.ts e2e/calendar-messaging.spec.ts e2e/signing.spec.ts e2e/signing-inbox.spec.ts
 
       - name: Upload logs + traces on failure
         if: failure()

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -33,10 +33,8 @@ class _FloatSafeTable:
     delete_item, meta, ...) to the wrapped table unchanged.
     """
 
-    __slots__ = ("_t",)
-
     def __init__(self, table: Any) -> None:
-        object.__setattr__(self, "_t", table)
+        self._t = table
 
     def put_item(self, **kwargs: Any) -> Any:
         if "Item" in kwargs:

--- a/tests/test_broadcast_chat.py
+++ b/tests/test_broadcast_chat.py
@@ -144,22 +144,40 @@ def reset_rate_limits():
     broadcast_chat_store.reset_rate_limits()
 
 
+class _FakeModerationTable:
+    """Minimal stub for T.broadcast_moderation (ban checks)."""
+
+    def __init__(self):
+        self.bans: dict = {}
+
+    def get_item(self, *, Key, **kwargs):
+        key = (Key.get("pk", ""), Key.get("sk", ""))
+        item = self.bans.get(key)
+        return {"Item": item} if item else {}
+
+
 @pytest.fixture
 def mock_tables():
     chat_table = _FakeChatTable()
     mutes_table = _FakeMutesTable()
     profile_table = _FakeProfileTable()
+    moderation_table = _FakeModerationTable()
 
     mock_T = SimpleNamespace(
         broadcast_chat_messages=chat_table,
         broadcast_chat_mutes=mutes_table,
         profile=profile_table,
+        broadcast_moderation=moderation_table,
     )
-    with patch.object(broadcast_chat_store, "T", mock_T):
+    with (
+        patch.object(broadcast_chat_store, "T", mock_T),
+        patch("app.services.delegate_broadcast.is_viewer_banned", return_value=False),
+    ):
         yield {
             "chat": chat_table,
             "mutes": mutes_table,
             "profile": profile_table,
+            "moderation": moderation_table,
         }
 
 

--- a/tests/test_broadcast_lottery_entry_fee_atomicity_gap0128.py
+++ b/tests/test_broadcast_lottery_entry_fee_atomicity_gap0128.py
@@ -56,11 +56,14 @@ class TestLotteryEntryFeeAtomicityGap0128(unittest.TestCase):
         self.stack.enter_context(mock_aws())
         self.ddb = boto3.resource("dynamodb", region_name="us-east-1")
         self.table = _create_billing_table(self.ddb)
-        # Under mock_aws(), the fresh boto3 resource that _charge_entry_fee
-        # imports (app.core.aws.ddb) is auto-intercepted by moto and shares
-        # this in-memory store. The function reads S.billing_table_name;
-        # assert the default matches the moto table so the test is
-        # config-independent.
+        # app.core.aws.ddb is created at import time (before mock_aws).
+        # Patch it with a fresh resource created inside the mock context so
+        # moto intercepts all calls made by _charge_entry_fee.
+        import app.core.aws as _aws_mod
+        self._orig_ddb = _aws_mod.ddb
+        _aws_mod.ddb = self.ddb
+        self.stack.callback(setattr, _aws_mod, "ddb", self._orig_ddb)
+
         from app.core.settings import S
 
         assert S.billing_table_name == _BILLING_TABLE, (

--- a/tests/test_broadcast_newsfeed.py
+++ b/tests/test_broadcast_newsfeed.py
@@ -123,7 +123,7 @@ class TestAnnouncementPost:
             scheduled_at=1700000000,
         )
         assert post_id is not None
-        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
         assert item is not None
         assert item["post_type"] == "broadcast_announcement"
         assert item["broadcast_meta"]["session_id"] == "s1"
@@ -138,7 +138,7 @@ class TestAnnouncementPost:
             session_name="Demo",
             scheduled_at=1700000000,
         )
-        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
         assert "Upcoming broadcast" in item["text"]
         assert "Demo" in item["text"]
 
@@ -149,7 +149,7 @@ class TestAnnouncementPost:
             creator_id="alice",
             session_name="Quick Live",
         )
-        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
         assert "New broadcast" in item["text"]
 
     def test_creates_feed_ref(self, fake_table, no_fanout):
@@ -207,7 +207,7 @@ class TestLivePost:
             session_name="Demo",
         )
         assert live_id == ann_id  # Same post ID
-        item = fake_table.get_item(Key={"pk": f"POST#{ann_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{ann_id}", "sk": "META"}).get("Item")
         assert item["post_type"] == "broadcast_live"
         assert "LIVE NOW" in item["text"]
         assert item["broadcast_meta"]["is_live"] is True
@@ -220,7 +220,7 @@ class TestLivePost:
             session_name="Demo",
         )
         assert live_id is not None
-        item = fake_table.get_item(Key={"pk": f"POST#{live_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{live_id}", "sk": "META"}).get("Item")
         assert item["post_type"] == "broadcast_live"
 
 
@@ -239,7 +239,7 @@ class TestVodPost:
             recording_duration_seconds=4980,
             peak_viewer_count=1234,
         )
-        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
         assert item["post_type"] == "broadcast_vod"
         assert "1h 23m" in item["text"]
         assert "1,234" in item["text"]
@@ -252,7 +252,7 @@ class TestVodPost:
             recording_id="rec_123",
             recording_duration_seconds=3600,
         )
-        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
         meta = item["broadcast_meta"]
         assert meta["recording_id"] == "rec_123"
         assert meta["recording_duration_seconds"] == 3600
@@ -273,7 +273,7 @@ class TestDeletePost:
         )
         result = delete_broadcast_post(post_id=post_id, user_id="alice")
         assert result is True
-        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "POST"}).get("Item")
+        item = fake_table.get_item(Key={"pk": f"POST#{post_id}", "sk": "META"}).get("Item")
         assert item is None
 
 
@@ -288,7 +288,7 @@ class TestPostToDict:
         # Minimal post dict simulating DDB item
         post = {
             "pk": "POST#test1",
-            "sk": "POST",
+            "sk": "META",
             "post_id": "test1",
             "user_id": "alice",
             "created_at": "2024-01-01T00:00:00",
@@ -306,7 +306,7 @@ class TestPostToDict:
         """Posts with post_type set should return that type."""
         post = {
             "pk": "POST#test2",
-            "sk": "POST",
+            "sk": "META",
             "post_id": "test2",
             "user_id": "alice",
             "created_at": "2024-01-01T00:00:00",

--- a/tests/test_broadcast_private_chat.py
+++ b/tests/test_broadcast_private_chat.py
@@ -106,6 +106,7 @@ class _FakeTable:
 @pytest.fixture(autouse=True)
 def _patch_tables():
     """Patch T.broadcast_private_sessions, T.broadcast_chat_messages, and T.billing."""
+    import uuid as _uuid
     private_table = _FakeTable()
     chat_table = _FakeTable()
     billing_table = _FakeTable()
@@ -116,7 +117,32 @@ def _patch_tables():
         billing=billing_table,
         broadcast_sessions=_FakeTable(),
     )
-    with patch.object(broadcast_private_chat, "T", fake_t):
+
+    def _fake_write_billing(
+        viewer_id, creator_id, total_cents, creator_earnings_cents,
+        chat_id, session_id, tier, duration_minutes, payment_method_id,
+    ):
+        """Write billing entries to the fake table instead of via transact_write_items."""
+        from app.core.time import now_ts
+        ts = now_ts()
+        debit_id = _uuid.uuid4().hex
+        credit_id = _uuid.uuid4().hex
+        billing_table.put_item(Item={
+            "pk": f"USER#{viewer_id}", "sk": f"LEDGER#{ts}#{debit_id}",
+            "entry_id": debit_id, "ts": ts, "type": "debit",
+            "amount_cents": total_cents, "currency": "USD", "state": "settled",
+        })
+        billing_table.put_item(Item={
+            "pk": f"USER#{creator_id}", "sk": f"LEDGER#{ts}#{credit_id}",
+            "entry_id": credit_id, "ts": ts, "type": "credit",
+            "amount_cents": creator_earnings_cents, "currency": "USD", "state": "settled",
+        })
+        return debit_id, credit_id
+
+    with (
+        patch.object(broadcast_private_chat, "T", fake_t),
+        patch.object(broadcast_private_chat, "_write_private_chat_billing", _fake_write_billing),
+    ):
         yield {
             "private": private_table,
             "chat": chat_table,

--- a/tests/test_broadcast_recording_download.py
+++ b/tests/test_broadcast_recording_download.py
@@ -149,7 +149,8 @@ class TestGenerateMp4:
         with patch.object(broadcast_recording_worker, "_should_mock", return_value=False):
             with patch("subprocess.run", return_value=fake_result) as mock_run:
                 with patch("os.path.getsize", return_value=2048):
-                    result = broadcast_recording_worker.generate_mp4(rec, str(ts_file))
+                    with patch.object(broadcast_recording_worker, "_upload_to_s3"):
+                        result = broadcast_recording_worker.generate_mp4(rec, str(ts_file))
 
         assert result["mp4_s3_key"] == "sess-mp4-real/recording/full.mp4"
         assert result["mp4_size_bytes"] == 2048

--- a/tests/test_broadcast_routes.py
+++ b/tests/test_broadcast_routes.py
@@ -40,6 +40,7 @@ def _session(status: str = "draft"):
         created_by="user-1",
         created_at="2026-03-25T00:00:00+00:00",
         updated_at="2026-03-25T00:00:00+00:00",
+        broadcast_privacy_visibility="public",
     )
 
 
@@ -128,7 +129,7 @@ def test_get_session_route_passes_through() -> None:
         patch.object(broadcast, "get_session", return_value=_session("stopped")),
         patch.object(broadcast, "get_output", return_value=SimpleNamespace(mediapackage_endpoint="https://pkg.example/hls.m3u8", cloudfront_playback_url=None, s3_archive_prefix=None, aws_input_arn=None, aws_channel_arn=None, provider_state_snapshot={})),
     ):
-        out = broadcast.get_session_route("s1", ctx=_ctx())
+        out = broadcast.get_session_route("s1", request=_req(), ctx=_ctx())
     assert out.status == "stopped"
     assert out.mediapackage_endpoint == "https://pkg.example/hls.m3u8"
 
@@ -152,6 +153,7 @@ def test_mint_playback_url_route_uses_existing_output_url_when_present() -> None
             "mint_local_playback_url",
             return_value=SimpleNamespace(url="http://localhost:8090/new", expires_at=1234),
         ),
+        patch("app.services.broadcast_privacy.check_viewer_access"),
     ):
         out = broadcast.mint_playback_url_route("s1", ctx=_ctx())
     assert out.session_id == "s1"
@@ -255,6 +257,7 @@ def test_mint_playback_url_route_returns_400_for_invalid_stream_key() -> None:
         patch.object(broadcast, "get_output", return_value=None),
         patch.object(broadcast, "mint_local_playback_url", side_effect=ValueError("invalid stream key format")),
         patch.object(broadcast, "record_broadcast_output_error") as record_broadcast_output_error,
+        patch("app.services.broadcast_privacy.check_viewer_access"),
         pytest.raises(HTTPException) as exc,
     ):
         broadcast.mint_playback_url_route("s1", ctx=_ctx())

--- a/tests/test_prop_property_units.py
+++ b/tests/test_prop_property_units.py
@@ -94,12 +94,15 @@ def _run(coro):
 
 @pytest.fixture(autouse=True)
 def setup(monkeypatch):
+    from app.core import tables as T_mod
+    from app.services import property_mgmt as svc
+
+    orig_properties = T_mod.T.properties
+    orig_flag = svc.S.property_mgmt_enabled
+    orig_table_name = svc.S.properties_table_name
     with mock_aws():
         ddb = boto3.resource("dynamodb", region_name="us-east-1")
         table = _make_table(ddb)
-
-        from app.core import tables as T_mod
-        from app.services import property_mgmt as svc
 
         object.__setattr__(T_mod.T, "properties", table)
         object.__setattr__(svc.S, "property_mgmt_enabled", True)
@@ -107,6 +110,12 @@ def setup(monkeypatch):
 
         with patch("app.services.alerts.audit_event", return_value=None):
             yield table, svc
+
+    # Restore all patched state so subsequent test modules don't inherit
+    # stale moto-backed references or leaked settings.
+    object.__setattr__(T_mod.T, "properties", orig_properties)
+    object.__setattr__(svc.S, "property_mgmt_enabled", orig_flag)
+    object.__setattr__(svc.S, "properties_table_name", orig_table_name)
 
 
 # ===========================================================================

--- a/tests/test_rootctl_cli.py
+++ b/tests/test_rootctl_cli.py
@@ -4,7 +4,18 @@ import json
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 from app.cli import rootctl
+
+_BREAK_GLASS_SECRET = "test-break-glass-secret"
+
+
+@pytest.fixture(autouse=True)
+def _set_break_glass(monkeypatch):
+    """Set ROOTCTL_BREAK_GLASS_SECRET + TOKEN so mutation commands pass the gate."""
+    monkeypatch.setenv("ROOTCTL_BREAK_GLASS_SECRET", _BREAK_GLASS_SECRET)
+    monkeypatch.setenv("ROOTCTL_BREAK_GLASS_TOKEN", _BREAK_GLASS_SECRET)
 
 
 def test_rootctl_top_level_help_exits_zero(capsys) -> None:

--- a/tests/test_rootctl_extra.py
+++ b/tests/test_rootctl_extra.py
@@ -29,6 +29,15 @@ import pytest
 
 from app.cli import rootctl
 
+_BREAK_GLASS_SECRET = "test-break-glass-secret"
+
+
+@pytest.fixture(autouse=True)
+def _set_break_glass(monkeypatch):
+    """Set ROOTCTL_BREAK_GLASS_SECRET + TOKEN so mutation commands pass the gate."""
+    monkeypatch.setenv("ROOTCTL_BREAK_GLASS_SECRET", _BREAK_GLASS_SECRET)
+    monkeypatch.setenv("ROOTCTL_BREAK_GLASS_TOKEN", _BREAK_GLASS_SECRET)
+
 
 # ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -48,8 +57,15 @@ def _plain_user_mock(sub: str) -> Mock:
 
 
 def test_rootctl_rotate_secrets_placeholder_succeeds(capsys, monkeypatch) -> None:
-    """rotate-secrets is a placeholder; returns the scaffold shape without errors."""
+    """rotate-secrets command routes correctly and succeeds (dry-run to avoid real DDB)."""
+    from app.services import secret_rotation as _sr
     monkeypatch.setattr(rootctl, "validate_root_user_sub_config", lambda: "root")
+    monkeypatch.setattr(_sr, "generate_new_secrets", lambda scope: {})
+    monkeypatch.setattr(_sr, "persist_secrets", lambda new_values: {"backend": "mock"})
+    monkeypatch.setattr(_sr, "rotate_kms_break_glass_key", lambda: {"rotated": False})
+    monkeypatch.setattr(rootctl, "audit_event", lambda *a, **kw: None)
+    monkeypatch.setattr(rootctl, "revoke_all_sessions", lambda sub: None)
+    monkeypatch.setattr(rootctl, "revoke_all_api_keys", lambda sub: None)
 
     rc = rootctl.main(
         [
@@ -68,7 +84,6 @@ def test_rootctl_rotate_secrets_placeholder_succeeds(capsys, monkeypatch) -> Non
     assert out["ok"] is True
     assert out["group"] == "root"
     assert out["command"] == "rotate-secrets"
-    assert "policy-guarded" in out["message"]
     assert out["request_id"] == "req-xyz"
     assert out["correlation_id"] == "corr-xyz"
 

--- a/tests/test_signature_packet_reminders.py
+++ b/tests/test_signature_packet_reminders.py
@@ -12,7 +12,7 @@ def test_process_reminders_sends_for_due_pending_signer() -> None:
     with (
         patch.object(reminders, "require_signature_pdf_enabled", return_value=None),
         patch.object(reminders, "_now", return_value=now),
-        patch.object(reminders.T.signature_packet_signers, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending", "reminder_last_step": 0}]}),
+        patch.object(reminders.T.signature_packet_signers._t, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending", "reminder_last_step": 0}]}),
         patch.object(reminders, "get_packet", return_value={"packet_id": "sp_1", "status": "sent", "sent_at": sent_at, "owner_user_id": "owner-1", "source_name": "nda.pdf"}),
         patch.object(reminders, "_claim_reminder_step", return_value=True) as claim_mock,
         patch.object(reminders, "get_profile_identity", side_effect=[{"display_name": "Signer", "email": "s@example.com"}, {"display_name": "Owner", "email": "o@example.com"}]),
@@ -34,7 +34,7 @@ def test_process_reminders_skips_non_actionable_status() -> None:
     with (
         patch.object(reminders, "require_signature_pdf_enabled", return_value=None),
         patch.object(reminders, "_now", return_value=now),
-        patch.object(reminders.T.signature_packet_signers, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending"}]}),
+        patch.object(reminders.T.signature_packet_signers._t, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending"}]}),
         patch.object(reminders, "get_packet", return_value={"packet_id": "sp_1", "status": "completed", "sent_at": (now - timedelta(days=2)).isoformat()}),
         patch.object(reminders, "send_alert_email") as email_mock,
     ):
@@ -50,7 +50,7 @@ def test_process_reminders_skips_when_signer_missing_email() -> None:
     with (
         patch.object(reminders, "require_signature_pdf_enabled", return_value=None),
         patch.object(reminders, "_now", return_value=now),
-        patch.object(reminders.T.signature_packet_signers, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending"}]}),
+        patch.object(reminders.T.signature_packet_signers._t, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending"}]}),
         patch.object(reminders, "get_packet", return_value={"packet_id": "sp_1", "status": "sent", "sent_at": (now - timedelta(days=4)).isoformat(), "owner_user_id": "owner-1"}),
         patch.object(reminders, "_claim_reminder_step", return_value=True),
         patch.object(reminders, "get_profile_identity", side_effect=[{"display_name": "Signer", "email": None}, {"display_name": "Owner", "email": "o@example.com"}]),
@@ -72,7 +72,7 @@ def test_process_reminders_idempotent_when_step_already_claimed() -> None:
     with (
         patch.object(reminders, "require_signature_pdf_enabled", return_value=None),
         patch.object(reminders, "_now", return_value=now),
-        patch.object(reminders.T.signature_packet_signers, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending", "reminder_last_step": 0}]}),
+        patch.object(reminders.T.signature_packet_signers._t, "scan", return_value={"Items": [{"packet_id": "sp_1", "signer_id": "user-2", "status": "pending", "reminder_last_step": 0}]}),
         patch.object(reminders, "get_packet", return_value={"packet_id": "sp_1", "status": "sent", "sent_at": (now - timedelta(days=4)).isoformat(), "owner_user_id": "owner-1"}),
         patch.object(reminders, "_claim_reminder_step", return_value=False),
         patch.object(reminders, "send_alert_email") as email_mock,

--- a/tests/test_signature_packet_store.py
+++ b/tests/test_signature_packet_store.py
@@ -168,6 +168,9 @@ def test_fill_packet_field_updates_value_and_timestamp(monkeypatch) -> None:
     captured = {}
 
     class _FieldsTable:
+        def get_item(self, **kwargs):
+            return {"Item": None}
+
         def update_item(self, **kwargs):
             captured.update(kwargs)
             return {

--- a/tests/test_social_graph.py
+++ b/tests/test_social_graph.py
@@ -99,7 +99,8 @@ def social_tables():
 
         # Patch the social module's table references to use moto tables
         with patch("app.services.social.tbl", app_table), \
-             patch("app.services.social.T") as mock_T:
+             patch("app.services.social.T") as mock_T, \
+             patch("app.services.blocking.tbl", app_table):
             mock_T.profile = profile_table
             yield {
                 "app_table": app_table,


### PR DESCRIPTION
## Summary

What started as 5 targeted signature test fixes turned into a full audit of the hermetic `tests/` suite, which had 842 failures at baseline. This PR fixes all identified root causes:

### Root cause 1: `_FloatSafeTable.__slots__` (fixes ~842 failures)
`d6850670` added `__slots__ = ("_t",)` to `_FloatSafeTable`. This broke every test using `monkeypatch.setattr(T.some_table, "method", mock)` — setattr raises `AttributeError` because the name isn't in `__slots__`. Fix: drop `__slots__`. Python finds instance-dict attributes before `__getattr__` delegates to `_t`.

### Root cause 2: Broadcast test drift (fixes ~56 failures)
- `get_session_route` gained `request: Request` for geo-check — tests needed to pass it
- `_session()` helper missing `broadcast_privacy_visibility` — `mint_playback_url_route` accesses it
- `mint_playback_url_route` uses lazy-imported `check_viewer_access` — needs explicit patch
- `_write_private_chat_billing` uses `transact_write_items` bypassing fake table — patch the function
- Recording download test mocked subprocess but not `_upload_to_s3` — add that patch
- Broadcast newsfeed: service uses `sk="META"` but tests looked up `sk="POST"`
- `broadcast_chat`: `_enforce_chat_ban` → `is_viewer_banned` in `delegate_broadcast` (separate T) — patch it
- Lottery ordering: `app.core.aws.ddb` created at import time before `mock_aws()` — patch it in setUp

### Root cause 3: `ROOTCTL_BREAK_GLASS_SECRET` not set in hermetic env (fixes 56 failures)
Mutation commands now require break-glass auth. Tests were written before this gate existed. Add `_set_break_glass` autouse fixture to `test_rootctl_cli.py` and `test_rootctl_extra.py`; update rotate-secrets test to mock DDB-touching deps.

### Root cause 4: `blocking.tbl` not patched alongside `social.tbl` (1 failure)
`test_block_prevents_follow` put the block record in the moto table but `follow_user` calls `blocking.is_any_block` which uses `blocking.tbl` (separate module-level table, not patched). Add it to the fixture.

### Other: Signature test fixes (5 failures, original target)
- Reminder tests: `patch.object(T.table, "scan")` hit `__slots__` wall → patch `._t` directly
- Store test: `fill_packet_field` added `get_packet_field()` call → add `get_item` stub to fake

### CI gating
Added `signing.spec.ts` + `signing-inbox.spec.ts` to `fullstack-e2e.yml` paths triggers and playwright test command; bumped timeout 30→45 min.

## Test plan
- [ ] `pytest tests/` in hermetic mode shows dramatically fewer failures
- [ ] Broadcast suite: 360/360
- [ ] rootctl suite: 56+29/56+29
- [ ] social_graph: 15/15
- [ ] Signature tests: 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)