### PR TITLE
Fix missing page.goto() in mock backend + WebRTC E2E specs

### DIFF
--- a/frontend/e2e/google-drive-mock.spec.ts
+++ b/frontend/e2e/google-drive-mock.spec.ts
@@ -84,6 +84,7 @@ async function injectAuth(page: Page, identity = "alice") {
   const session = getSessions()[identity];
   if (!session) throw new Error(`No session for ${identity}`);
   await page.context().addCookies(session.cookies);
+  await page.goto(`${BASE}/login`, { waitUntil: "domcontentloaded" });
 }
 
 // ─── API helpers (via Vite proxy so session cookies are forwarded) ─────────────

--- a/frontend/e2e/jira-mock.spec.ts
+++ b/frontend/e2e/jira-mock.spec.ts
@@ -80,6 +80,7 @@ async function injectAuth(page: Page, identity: string): Promise<void> {
   const session = getSessions()[identity];
   if (!session) throw new Error(`No session for identity: ${identity}`);
   await page.context().addCookies(session.cookies);
+  await page.goto(`${BASE}/login`, { waitUntil: "domcontentloaded" });
 }
 
 // ─── API helpers ──────────────────────────────────────────────────────────────

--- a/frontend/e2e/webrtc-calls.spec.ts
+++ b/frontend/e2e/webrtc-calls.spec.ts
@@ -39,6 +39,7 @@ async function injectAuth(page: Page, identity: string) {
   const session = getSessions()[identity];
   if (!session) throw new Error(`No session for ${identity}`);
   await page.context().addCookies(session.cookies);
+  await page.goto("http://localhost:3000/login", { waitUntil: "domcontentloaded" });
 }
 
 async function apiPost(


### PR DESCRIPTION
## Summary

- Three E2E specs (`google-drive-mock.spec.ts`, `jira-mock.spec.ts`, `webrtc-calls.spec.ts`) were missing the `page.goto()` call in their `injectAuth()` helpers.
- Without navigating the Playwright browser page to `localhost:3000/login` first, `page.request` doesn't attach session cookies to direct requests to `localhost:8000`. All three specs were getting 401 "Missing bearer token" — the backend cookie-auth path (HS256 JWT decode) was never reached; the request fell through to Cognito Bearer auth.
- Root cause of the backend staleness: the running backend had been started from a prior session with a different `UI_ACCESS_TOKEN_SECRET` than `.env.local`; two uvicorn processes were alive and the old one was answering on port 8000.

## Fix

Add `await page.goto(BASE + "/login", { waitUntil: "domcontentloaded" })` to `injectAuth()` in each affected spec — matching the pattern already used by `messaging-features.spec.ts` and `signing-inbox.spec.ts`.

## Test plan
- [ ] `npx playwright test e2e/google-calendar-mock.spec.ts e2e/google-drive-mock.spec.ts e2e/apple-caldav-mock.spec.ts e2e/jira-mock.spec.ts e2e/webrtc-calls.spec.ts` → **68/68 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)