### PR TITLE
Gate mock backend + WebRTC specs in CI

### DIFF
--- a/.github/workflows/fullstack-e2e.yml
+++ b/.github/workflows/fullstack-e2e.yml
@@ -11,6 +11,11 @@ on:
       - "frontend/e2e/calendar-messaging.spec.ts"
       - "frontend/e2e/signing.spec.ts"
       - "frontend/e2e/signing-inbox.spec.ts"
+      - "frontend/e2e/webrtc-calls.spec.ts"
+      - "frontend/e2e/google-calendar-mock.spec.ts"
+      - "frontend/e2e/google-drive-mock.spec.ts"
+      - "frontend/e2e/apple-caldav-mock.spec.ts"
+      - "frontend/e2e/jira-mock.spec.ts"
       - "frontend/src/pages/remote/**"
       - "frontend/src/pages/calendar/**"
       - "frontend/src/pages/signing/**"
@@ -18,8 +23,14 @@ on:
       - "app/routers/browser_ssh_terminal.py"
       - "app/routers/calendar.py"
       - "app/routers/signature_packets.py"
+      - "app/routers/messaging.py"
+      - "app/routers/google_calendar_mock.py"
+      - "app/routers/google_drive_mock.py"
+      - "app/routers/apple_caldav_mock.py"
+      - "app/routers/jira_mock.py"
       - "app/services/host_inventory.py"
       - "app/services/signature_packet_store.py"
+      - "app/services/messaging_call_lifecycle.py"
       - ".github/workflows/fullstack-e2e.yml"
   push:
     branches: [ main, master ]
@@ -28,12 +39,17 @@ on:
       - "frontend/e2e/calendar-messaging.spec.ts"
       - "frontend/e2e/signing.spec.ts"
       - "frontend/e2e/signing-inbox.spec.ts"
+      - "frontend/e2e/webrtc-calls.spec.ts"
+      - "frontend/e2e/google-calendar-mock.spec.ts"
+      - "frontend/e2e/google-drive-mock.spec.ts"
+      - "frontend/e2e/apple-caldav-mock.spec.ts"
+      - "frontend/e2e/jira-mock.spec.ts"
       - ".github/workflows/fullstack-e2e.yml"
 
 jobs:
   fullstack-e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +107,17 @@ jobs:
 
       - name: Run full-stack Playwright specs
         working-directory: frontend
-        run: npx playwright test e2e/browser-ssh.spec.ts e2e/calendar-messaging.spec.ts e2e/signing.spec.ts e2e/signing-inbox.spec.ts
+        run: >
+          npx playwright test
+          e2e/browser-ssh.spec.ts
+          e2e/calendar-messaging.spec.ts
+          e2e/signing.spec.ts
+          e2e/signing-inbox.spec.ts
+          e2e/webrtc-calls.spec.ts
+          e2e/google-calendar-mock.spec.ts
+          e2e/google-drive-mock.spec.ts
+          e2e/apple-caldav-mock.spec.ts
+          e2e/jira-mock.spec.ts
 
       - name: Upload logs + traces on failure
         if: failure()

--- a/scripts/ci-e2e-feature-flags.env
+++ b/scripts/ci-e2e-feature-flags.env
@@ -96,3 +96,20 @@ TICKET_ATTACHMENTS_ENABLED=1
 TICKET_BOUNTIES_ENABLED=1
 TXN_REQUESTS_ENABLED=1
 WEB_PUSH_ENABLED=1
+
+# Mock backend API URLs (required for mock-backend + WebRTC E2E specs)
+GOOGLE_CALENDAR_API_BASE_URL=http://localhost:8000/mock/google-calendar/calendar/v3
+GOOGLE_CALENDAR_OAUTH_TOKEN_URL=http://localhost:8000/mock/google-calendar/oauth/token
+GOOGLE_CALENDAR_OAUTH_USERINFO_URL=http://localhost:8000/mock/google-calendar/oauth/userinfo
+GOOGLE_CALENDAR_OAUTH_REVOKE_URL=http://localhost:8000/mock/google-calendar/oauth/revoke
+GOOGLE_CALENDAR_OAUTH_CLIENT_ID=e2e-test-client-id
+GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET=e2e-test-secret
+GOOGLE_CALENDAR_OAUTH_REDIRECT_URI=http://localhost:3000/calendar/integrations/google/callback
+GOOGLE_DRIVE_API_BASE_URL=http://localhost:8000/mock/google-drive/drive/v3
+GOOGLE_DRIVE_UPLOAD_API_BASE_URL=http://localhost:8000/mock/google-drive/upload/drive/v3
+APPLE_CALDAV_BASE_URL=http://localhost:8000/mock/apple-caldav
+JIRA_API_BASE_URL=http://localhost:8000/mock/jira
+JIRA_SYNC_OAUTH_TOKEN_URL=http://localhost:8000/mock/jira/oauth/token
+JIRA_SYNC_OAUTH_RESOURCES_URL=http://localhost:8000/mock/jira/oauth/accessible-resources
+JIRA_SYNC_OAUTH_CLIENT_ID=e2e-test-jira-client-id
+JIRA_SYNC_OAUTH_CLIENT_SECRET=e2e-test-jira-secret


### PR DESCRIPTION
## Summary

- Added `webrtc-calls.spec.ts`, `google-calendar-mock.spec.ts`, `google-drive-mock.spec.ts`, `apple-caldav-mock.spec.ts`, `jira-mock.spec.ts` to `fullstack-e2e.yml` — both paths triggers and the `npx playwright test` command.
- Bumped timeout 45→60 min (68 additional tests across 5 specs).
- Added mock API base URL settings to `ci-e2e-feature-flags.env` — the `MOCK_ENABLED` flags were already there but the URL vars (`GOOGLE_CALENDAR_API_BASE_URL`, `GOOGLE_DRIVE_API_BASE_URL`, `APPLE_CALDAV_BASE_URL`, `JIRA_API_BASE_URL`, OAuth endpoints) were missing, meaning mock backends would start but not be wired to the right endpoints.

## Test plan
- [ ] All 68 tests in the 5 new specs verified locally: 68/68 passed
- [ ] Existing 4 specs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)