### PR TITLE
feat(SHP-004..017): Shipping carriers, rate estimation, shipment lifecycle + admin UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ const Checkout = lazy(() => import("@/pages/shop/Checkout"));
 const InventoryAdmin = lazy(() => import("@/pages/shop/admin/InventoryAdmin"));
 const ShopCatalogDepthPage = lazy(() => import("@/pages/shop/admin/CatalogDepthPage"));
 const ShopOrderLifecyclePage = lazy(() => import("@/pages/shop/admin/OrderLifecyclePage"));
+const ShopShippingAdminPage = lazy(() => import("@/pages/shop/admin/ShippingAdminPage"));
 const FeedPage = lazy(() => import("@/pages/feed/FeedPage"));
 const PostDetailPage = lazy(() => import("@/pages/feed/PostDetailPage"));
 const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
@@ -703,6 +704,7 @@ export default function App() {
           <Route path="shop/:categoryId/:itemId" element={<ProductDetail />} />
           <Route path="shop/admin/catalog/depth/:itemId" element={<ShopCatalogDepthPage />} />
           <Route path="shop/admin/orders/:orderId/lifecycle" element={<ShopOrderLifecyclePage />} />
+          <Route path="shop/admin/shipping" element={<ShopShippingAdminPage />} />
           <Route path="cart" element={<CartPage />} />
           <Route path="cart/checkout" element={<Checkout />} />
           <Route path="feed" element={<FeedPage />} />

--- a/frontend/src/pages/shop/admin/ShippingAdminPage.tsx
+++ b/frontend/src/pages/shop/admin/ShippingAdminPage.tsx
@@ -1,0 +1,828 @@
+/**
+ * ShippingAdminPage (SHP-016 / SHP-017)
+ *
+ * Admin UI for the Shipping Logistics module.
+ * Route: /shop/admin/shipping
+ *
+ * Tabs:
+ *   Carriers      — list + toggle carriers, add new carrier, view per-carrier methods
+ *   Rate Estimate — enter destination & weight, preview available rate options
+ *   Shipments     — search by order id, view status, advance shipment state
+ */
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Loader2,
+  Truck,
+  DollarSign,
+  Package,
+  Plus,
+  ChevronRight,
+  AlertTriangle,
+  RefreshCw,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { EmptyState } from "@/components/shared/EmptyState";
+
+import {
+  listCarriers,
+  createCarrier,
+  updateCarrier,
+  listMethods,
+  estimateRates,
+  listOrderShipments,
+  advanceShipment,
+  type CarrierCode,
+  type MethodCode,
+  type ShipmentStatus,
+} from "@/api/endpoints/shipping";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const CARRIER_CODES: CarrierCode[] = ["ups", "fedex", "usps", "dhl", "manual"];
+
+const STATUS_COLORS: Record<string, string> = {
+  pending_fulfillment: "bg-slate-100 text-slate-700",
+  label_created: "bg-blue-100 text-blue-700",
+  picked_up: "bg-indigo-100 text-indigo-700",
+  in_transit: "bg-amber-100 text-amber-700",
+  out_for_delivery: "bg-orange-100 text-orange-700",
+  delivered: "bg-emerald-100 text-emerald-700",
+  exception: "bg-red-100 text-red-700",
+  returned: "bg-purple-100 text-purple-700",
+  cancelled: "bg-gray-100 text-gray-500",
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const cls = STATUS_COLORS[status] ?? "bg-gray-100 text-gray-500";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}
+    >
+      {status.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+function fmtCents(cents: number) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+// ─── Carriers tab ─────────────────────────────────────────────────────────────
+
+function CarriersTab() {
+  const qc = useQueryClient();
+
+  const [showAdd, setShowAdd] = useState(false);
+  const [newDisplayName, setNewDisplayName] = useState("");
+  const [newCode, setNewCode] = useState<CarrierCode>("manual");
+  const [newTracking, setNewTracking] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const carriersQuery = useQuery({
+    queryKey: ["shipping", "carriers", "all"],
+    queryFn: () => listCarriers(false), // include disabled
+  });
+
+  const methodsQuery = useQuery({
+    queryKey: ["shipping", "methods", expandedId],
+    queryFn: () => listMethods(expandedId!, false),
+    enabled: !!expandedId,
+  });
+
+  const createMut = useMutation({
+    mutationFn: () =>
+      createCarrier({ carrier_code: newCode, display_name: newDisplayName }),
+    onSuccess: () => {
+      toast.success("Carrier created");
+      setShowAdd(false);
+      setNewDisplayName("");
+      setNewCode("manual");
+      setNewTracking(false);
+      qc.invalidateQueries({ queryKey: ["shipping", "carriers"] });
+    },
+    onError: () => toast.error("Failed to create carrier"),
+  });
+
+  const toggleMut = useMutation({
+    mutationFn: ({
+      carrierId,
+      enabled,
+    }: {
+      carrierId: string;
+      enabled: boolean;
+    }) => updateCarrier(carrierId, { enabled }),
+    onSuccess: () => {
+      toast.success("Carrier updated");
+      qc.invalidateQueries({ queryKey: ["shipping", "carriers"] });
+    },
+    onError: () => toast.error("Failed to update carrier"),
+  });
+
+  const carriers = carriersQuery.data ?? [];
+
+  return (
+    <div className="space-y-4">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Manage shipping carriers and their methods.
+        </p>
+        <Button size="sm" onClick={() => setShowAdd((v) => !v)}>
+          <Plus className="mr-1 h-4 w-4" />
+          Add carrier
+        </Button>
+      </div>
+
+      {/* Add carrier form */}
+      {showAdd && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">New carrier</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div>
+                <Label htmlFor="carrier-name">Display name</Label>
+                <Input
+                  id="carrier-name"
+                  value={newDisplayName}
+                  onChange={(e) => setNewDisplayName(e.target.value)}
+                  placeholder="e.g. FedEx Ground"
+                />
+              </div>
+              <div>
+                <Label htmlFor="carrier-code">Carrier code</Label>
+                <Select
+                  value={newCode}
+                  onValueChange={(v) => setNewCode(v as CarrierCode)}
+                >
+                  <SelectTrigger id="carrier-code">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CARRIER_CODES.map((c) => (
+                      <SelectItem key={c} value={c}>
+                        {c}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col justify-end">
+                <div className="flex items-center gap-2 pb-1">
+                  <Checkbox
+                    id="online-tracking"
+                    checked={newTracking}
+                    onCheckedChange={(v) => setNewTracking(!!v)}
+                  />
+                  <Label htmlFor="online-tracking">Online tracking</Label>
+                </div>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                disabled={!newDisplayName.trim() || createMut.isPending}
+                onClick={() => createMut.mutate()}
+              >
+                {createMut.isPending && (
+                  <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                )}
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setShowAdd(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Carriers list */}
+      {carriersQuery.isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading carriers…
+        </div>
+      ) : carriers.length === 0 ? (
+        <EmptyState
+          icon={<Truck className="h-10 w-10" />}
+          title="No carriers configured"
+          description="Add a carrier above to get started."
+        />
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Display name</TableHead>
+                <TableHead>Code</TableHead>
+                <TableHead>Online tracking</TableHead>
+                <TableHead>Enabled</TableHead>
+                <TableHead>Methods</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {carriers.map((c) => (
+                <>
+                  <TableRow key={c.carrier_id}>
+                    <TableCell className="font-medium">
+                      {c.display_name}
+                    </TableCell>
+                    <TableCell>
+                      <span className="font-mono text-xs">{c.carrier_code}</span>
+                    </TableCell>
+                    <TableCell>
+                      {c.online_tracking ? (
+                        <Badge
+                          variant="outline"
+                          className="border-emerald-500 text-emerald-600"
+                        >
+                          Yes
+                        </Badge>
+                      ) : (
+                        <Badge
+                          variant="outline"
+                          className="text-muted-foreground"
+                        >
+                          No
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Switch
+                        checked={c.enabled}
+                        disabled={toggleMut.isPending}
+                        onCheckedChange={(checked) =>
+                          toggleMut.mutate({
+                            carrierId: c.carrier_id,
+                            enabled: checked,
+                          })
+                        }
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() =>
+                          setExpandedId((prev) =>
+                            prev === c.carrier_id ? null : c.carrier_id,
+                          )
+                        }
+                      >
+                        <ChevronRight
+                          className={`h-4 w-4 transition-transform ${
+                            expandedId === c.carrier_id ? "rotate-90" : ""
+                          }`}
+                        />
+                        {expandedId === c.carrier_id ? "Hide" : "View"}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+
+                  {/* Methods sub-table */}
+                  {expandedId === c.carrier_id && (
+                    <TableRow key={`${c.carrier_id}-methods`}>
+                      <TableCell colSpan={5} className="bg-muted/30 p-0">
+                        <div className="px-6 py-3">
+                          {methodsQuery.isLoading ? (
+                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                              <Loader2 className="h-4 w-4 animate-spin" />{" "}
+                              Loading methods…
+                            </div>
+                          ) : (methodsQuery.data ?? []).length === 0 ? (
+                            <p className="text-sm text-muted-foreground">
+                              No methods configured for this carrier.
+                            </p>
+                          ) : (
+                            <Table>
+                              <TableHeader>
+                                <TableRow>
+                                  <TableHead>Method</TableHead>
+                                  <TableHead>Label</TableHead>
+                                  <TableHead>Base rate</TableHead>
+                                  <TableHead>Transit (days)</TableHead>
+                                  <TableHead>Enabled</TableHead>
+                                </TableRow>
+                              </TableHeader>
+                              <TableBody>
+                                {(methodsQuery.data ?? []).map((m) => (
+                                  <TableRow key={m.method_code}>
+                                    <TableCell className="font-mono text-xs">
+                                      {m.method_code}
+                                    </TableCell>
+                                    <TableCell>{m.method_label}</TableCell>
+                                    <TableCell>
+                                      {fmtCents(m.base_rate_cents)}
+                                    </TableCell>
+                                    <TableCell>
+                                      {m.transit_days_min != null &&
+                                      m.transit_days_max != null
+                                        ? `${m.transit_days_min}–${m.transit_days_max}`
+                                        : (m.transit_days_min ??
+                                          m.transit_days_max ??
+                                          "—")}
+                                    </TableCell>
+                                    <TableCell>
+                                      {m.enabled ? (
+                                        <Badge
+                                          variant="outline"
+                                          className="border-emerald-500 text-emerald-600"
+                                        >
+                                          Yes
+                                        </Badge>
+                                      ) : (
+                                        <Badge
+                                          variant="outline"
+                                          className="text-muted-foreground"
+                                        >
+                                          No
+                                        </Badge>
+                                      )}
+                                    </TableCell>
+                                  </TableRow>
+                                ))}
+                              </TableBody>
+                            </Table>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Rate Estimate tab ────────────────────────────────────────────────────────
+
+const METHOD_CODES: MethodCode[] = [
+  "ground",
+  "express",
+  "overnight",
+  "economy",
+  "flat_rate",
+];
+
+function RateEstimateTab() {
+  const [carrierCode, setCarrierCode] = useState<CarrierCode>("usps");
+  const [methodCode, setMethodCode] = useState<MethodCode>("ground");
+  const [weightOz, setWeightOz] = useState("16");
+  const [destZip, setDestZip] = useState("");
+
+  const estimateQuery = useQuery({
+    queryKey: [
+      "shipping",
+      "estimate",
+      carrierCode,
+      methodCode,
+      weightOz,
+      destZip,
+    ],
+    queryFn: () =>
+      estimateRates({
+        carrier_code: carrierCode,
+        method_code: methodCode,
+        weight_oz: Number(weightOz),
+        destination_zip: destZip,
+      }),
+    enabled: false, // only runs on explicit user action
+  });
+
+  const options = estimateQuery.data?.options ?? [];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Preview shipping costs for a carrier + method + destination combination.
+      </p>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Rate parameters</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div>
+              <Label>Carrier</Label>
+              <Select
+                value={carrierCode}
+                onValueChange={(v) => setCarrierCode(v as CarrierCode)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CARRIER_CODES.map((c) => (
+                    <SelectItem key={c} value={c}>
+                      {c}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Method</Label>
+              <Select
+                value={methodCode}
+                onValueChange={(v) => setMethodCode(v as MethodCode)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {METHOD_CODES.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {m}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="weight-oz">Weight (oz)</Label>
+              <Input
+                id="weight-oz"
+                type="number"
+                min={0.1}
+                step={0.1}
+                value={weightOz}
+                onChange={(e) => setWeightOz(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="dest-zip">Destination zip</Label>
+              <Input
+                id="dest-zip"
+                value={destZip}
+                onChange={(e) => setDestZip(e.target.value)}
+                placeholder="e.g. 90210"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && destZip.trim())
+                    estimateQuery.refetch();
+                }}
+              />
+            </div>
+          </div>
+          <Button
+            size="sm"
+            disabled={!destZip.trim() || estimateQuery.isFetching}
+            onClick={() => estimateQuery.refetch()}
+          >
+            {estimateQuery.isFetching ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <DollarSign className="mr-1 h-4 w-4" />
+            )}
+            Get estimate
+          </Button>
+        </CardContent>
+      </Card>
+
+      {estimateQuery.isError && (
+        <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          Failed to fetch rate estimate. Check that the carrier and method are
+          configured.
+        </div>
+      )}
+
+      {estimateQuery.isSuccess && options.length === 0 && (
+        <EmptyState
+          icon={<DollarSign className="h-10 w-10" />}
+          title="No rate options returned"
+          description="The carrier/method may not have a base rate configured."
+        />
+      )}
+
+      {options.length > 0 && (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Carrier</TableHead>
+                <TableHead>Method</TableHead>
+                <TableHead>Rate</TableHead>
+                <TableHead>Currency</TableHead>
+                <TableHead>Transit (days)</TableHead>
+                <TableHead>Est. delivery</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {options.map((opt, i) => (
+                <TableRow key={i}>
+                  <TableCell className="font-mono text-xs">
+                    {opt.carrier_code}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {opt.method_code}
+                  </TableCell>
+                  <TableCell className="tabular-nums font-semibold">
+                    {fmtCents(opt.rate_cents)}
+                  </TableCell>
+                  <TableCell>{opt.currency}</TableCell>
+                  <TableCell>
+                    {opt.transit_days_min != null && opt.transit_days_max != null
+                      ? `${opt.transit_days_min}–${opt.transit_days_max}`
+                      : (opt.transit_days_min ?? opt.transit_days_max ?? "—")}
+                  </TableCell>
+                  <TableCell>{opt.estimated_delivery ?? "—"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Shipments tab ────────────────────────────────────────────────────────────
+
+const ADVANCE_TARGETS: ShipmentStatus[] = [
+  "label_created",
+  "picked_up",
+  "in_transit",
+  "out_for_delivery",
+  "delivered",
+  "exception",
+  "returned",
+  "cancelled",
+];
+
+function ShipmentsTab() {
+  const qc = useQueryClient();
+
+  const [orderId, setOrderId] = useState("");
+  const [searchedOrderId, setSearchedOrderId] = useState<string | null>(null);
+  const [advanceTarget, setAdvanceTarget] = useState<
+    Record<string, ShipmentStatus>
+  >({});
+  const [advanceReason, setAdvanceReason] = useState<Record<string, string>>(
+    {},
+  );
+
+  const shipmentsQuery = useQuery({
+    queryKey: ["shipping", "order-shipments", searchedOrderId],
+    queryFn: () => listOrderShipments(searchedOrderId!),
+    enabled: !!searchedOrderId,
+    retry: false,
+  });
+
+  const advanceMut = useMutation({
+    mutationFn: ({
+      shipmentId,
+      target,
+      reason,
+    }: {
+      shipmentId: string;
+      target: ShipmentStatus;
+      reason?: string;
+    }) =>
+      advanceShipment(shipmentId, {
+        target_status: target,
+        reason: reason || undefined,
+      }),
+    onSuccess: (updated) => {
+      toast.success(
+        `Shipment advanced to "${updated.status.replace(/_/g, " ")}"`,
+      );
+      qc.invalidateQueries({
+        queryKey: ["shipping", "order-shipments", searchedOrderId],
+      });
+    },
+    onError: () => toast.error("Failed to advance shipment"),
+  });
+
+  const shipments = shipmentsQuery.data?.shipments ?? [];
+
+  return (
+    <div className="space-y-4">
+      {/* Search bar */}
+      <div className="flex items-end gap-2">
+        <div className="flex-1">
+          <Label htmlFor="order-search">Order ID</Label>
+          <Input
+            id="order-search"
+            value={orderId}
+            onChange={(e) => setOrderId(e.target.value)}
+            placeholder="Enter order id to search shipments"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && orderId.trim())
+                setSearchedOrderId(orderId.trim());
+            }}
+          />
+        </div>
+        <Button
+          disabled={!orderId.trim() || shipmentsQuery.isFetching}
+          onClick={() => setSearchedOrderId(orderId.trim())}
+        >
+          {shipmentsQuery.isFetching ? (
+            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-1 h-4 w-4" />
+          )}
+          Search
+        </Button>
+      </div>
+
+      {!searchedOrderId && (
+        <EmptyState
+          icon={<Package className="h-10 w-10" />}
+          title="Enter an order ID to view shipments"
+          description="Shipments are scoped to a single order."
+        />
+      )}
+
+      {shipmentsQuery.isError && (
+        <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          Order not found or no shipments for that order ID.
+        </div>
+      )}
+
+      {shipmentsQuery.isSuccess && shipments.length === 0 && (
+        <EmptyState
+          icon={<Package className="h-10 w-10" />}
+          title="No shipments for this order"
+          description="Create a shipment from the order lifecycle page."
+        />
+      )}
+
+      {shipments.length > 0 && (
+        <div className="space-y-3">
+          {shipments.map((s) => (
+            <Card key={s.shipment_id}>
+              <CardContent className="pt-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  {/* Info */}
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {s.shipment_id}
+                      </span>
+                      <StatusBadge status={s.status} />
+                    </div>
+                    <div className="text-sm">
+                      <span className="font-medium">{s.carrier_code}</span>{" "}
+                      <span className="text-muted-foreground">/</span>{" "}
+                      {s.method_code}
+                    </div>
+                    {s.tracking_number && (
+                      <div className="font-mono text-xs text-muted-foreground">
+                        Tracking: {s.tracking_number}
+                      </div>
+                    )}
+                    <div className="text-xs text-muted-foreground">
+                      Created:{" "}
+                      {new Date(s.created_at * 1000).toLocaleString()}
+                    </div>
+                  </div>
+
+                  {/* Advance controls */}
+                  <div className="flex flex-wrap items-end gap-2">
+                    <div>
+                      <Label className="text-xs">Advance to</Label>
+                      <Select
+                        value={advanceTarget[s.shipment_id] ?? ""}
+                        onValueChange={(v) =>
+                          setAdvanceTarget((prev) => ({
+                            ...prev,
+                            [s.shipment_id]: v as ShipmentStatus,
+                          }))
+                        }
+                      >
+                        <SelectTrigger className="h-8 w-44">
+                          <SelectValue placeholder="Select status…" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {ADVANCE_TARGETS.map((t) => (
+                            <SelectItem key={t} value={t}>
+                              {t.replace(/_/g, " ")}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label className="text-xs">Reason (optional)</Label>
+                      <Input
+                        value={advanceReason[s.shipment_id] ?? ""}
+                        onChange={(e) =>
+                          setAdvanceReason((prev) => ({
+                            ...prev,
+                            [s.shipment_id]: e.target.value,
+                          }))
+                        }
+                        placeholder="e.g. manual update"
+                        className="h-8 w-44"
+                      />
+                    </div>
+                    <Button
+                      size="sm"
+                      disabled={
+                        !advanceTarget[s.shipment_id] || advanceMut.isPending
+                      }
+                      onClick={() =>
+                        advanceMut.mutate({
+                          shipmentId: s.shipment_id,
+                          target: advanceTarget[s.shipment_id],
+                          reason: advanceReason[s.shipment_id],
+                        })
+                      }
+                    >
+                      {advanceMut.isPending ? (
+                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Truck className="mr-1 h-4 w-4" />
+                      )}
+                      Advance
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Page root ────────────────────────────────────────────────────────────────
+
+export function ShippingAdminPage() {
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Truck className="h-6 w-6" />
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Shipping Administration
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Manage carriers, estimate rates, and track shipments.
+          </p>
+        </div>
+      </div>
+
+      <Tabs defaultValue="carriers">
+        <TabsList>
+          <TabsTrigger value="carriers">Carriers</TabsTrigger>
+          <TabsTrigger value="estimate">Rate Estimate</TabsTrigger>
+          <TabsTrigger value="shipments">Shipments</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="carriers" className="mt-4">
+          <CarriersTab />
+        </TabsContent>
+
+        <TabsContent value="estimate" className="mt-4">
+          <RateEstimateTab />
+        </TabsContent>
+
+        <TabsContent value="shipments" className="mt-4">
+          <ShipmentsTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+export default ShippingAdminPage;

--- a/tests/test_shp_carriers_rates_shipments.py
+++ b/tests/test_shp_carriers_rates_shipments.py
@@ -1,0 +1,530 @@
+"""Hermetic pytest suite for SHP-004..SHP-011.
+
+Covers carrier management (SHP-004/005), rate estimation (SHP-006/007),
+and shipment lifecycle (SHP-008/009/010/011).
+
+Pattern: moto in-memory DynamoDB tables, T/S patched via object.__setattr__
+in a module-scoped autouse fixture.  No real AWS, no network.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+# ---------------------------------------------------------------------------
+# Module-scope fixture: moto tables + freeze T/S
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def _shp_tables():
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+
+        # shipping_carriers: PK=carrier_id, SK=sk
+        carriers_tbl = ddb.create_table(
+            TableName="shp_test_carriers",
+            KeySchema=[
+                {"AttributeName": "carrier_id", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "carrier_id", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+                {"AttributeName": "carrier_code", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[{
+                "IndexName": "GSI_CODE",
+                "KeySchema": [
+                    {"AttributeName": "carrier_code", "KeyType": "HASH"},
+                    {"AttributeName": "sk", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # shipments: PK=shipment_id, GSI_ORDER on order_id+created_at
+        shipments_tbl = ddb.create_table(
+            TableName="shp_test_shipments",
+            KeySchema=[{"AttributeName": "shipment_id", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "shipment_id", "AttributeType": "S"},
+                {"AttributeName": "order_id", "AttributeType": "S"},
+                {"AttributeName": "status", "AttributeType": "S"},
+                {"AttributeName": "created_at", "AttributeType": "N"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "GSI_ORDER",
+                    "KeySchema": [
+                        {"AttributeName": "order_id", "KeyType": "HASH"},
+                        {"AttributeName": "created_at", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": "GSI_STATUS",
+                    "KeySchema": [
+                        {"AttributeName": "status", "KeyType": "HASH"},
+                        {"AttributeName": "created_at", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # shipment_items: PK=shipment_id, SK=item_id
+        items_tbl = ddb.create_table(
+            TableName="shp_test_items",
+            KeySchema=[
+                {"AttributeName": "shipment_id", "KeyType": "HASH"},
+                {"AttributeName": "item_id", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "shipment_id", "AttributeType": "S"},
+                {"AttributeName": "item_id", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # shipment_packages: PK=shipment_id, SK=package_seq
+        pkgs_tbl = ddb.create_table(
+            TableName="shp_test_packages",
+            KeySchema=[
+                {"AttributeName": "shipment_id", "KeyType": "HASH"},
+                {"AttributeName": "package_seq", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "shipment_id", "AttributeType": "S"},
+                {"AttributeName": "package_seq", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # billing: for shipping-refund cancel tests
+        billing_tbl = ddb.create_table(
+            TableName="shp_test_billing",
+            KeySchema=[
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # orders: for attach_ship_group
+        orders_tbl = ddb.create_table(
+            TableName="shp_test_orders",
+            KeySchema=[{"AttributeName": "order_id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "order_id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        from app.core import tables as tables_mod, settings as settings_mod
+
+        # Save originals
+        orig_t = {
+            "shipping_carriers": tables_mod.T.shipping_carriers,
+            "shipments": tables_mod.T.shipments,
+            "shipment_items": tables_mod.T.shipment_items,
+            "shipment_packages": tables_mod.T.shipment_packages,
+            "billing": tables_mod.T.billing,
+            "orders": tables_mod.T.orders,
+        }
+        orig_s = {
+            "shipping_enabled": settings_mod.S.shipping_enabled,
+            "shipping_rate_estimation_enabled": settings_mod.S.shipping_rate_estimation_enabled,
+            "shipping_default_currency": getattr(settings_mod.S, "shipping_default_currency", "usd"),
+            "shipping_default_item_weight_oz": getattr(settings_mod.S, "shipping_default_item_weight_oz", 16),
+            "shipping_dim_divisor": getattr(settings_mod.S, "shipping_dim_divisor", 139),
+        }
+
+        # Inject moto tables
+        object.__setattr__(tables_mod.T, "shipping_carriers", carriers_tbl)
+        object.__setattr__(tables_mod.T, "shipments", shipments_tbl)
+        object.__setattr__(tables_mod.T, "shipment_items", items_tbl)
+        object.__setattr__(tables_mod.T, "shipment_packages", pkgs_tbl)
+        object.__setattr__(tables_mod.T, "billing", billing_tbl)
+        object.__setattr__(tables_mod.T, "orders", orders_tbl)
+
+        object.__setattr__(settings_mod.S, "shipping_enabled", True)
+        object.__setattr__(settings_mod.S, "shipping_rate_estimation_enabled", True)
+        object.__setattr__(settings_mod.S, "shipping_default_currency", "usd")
+        object.__setattr__(settings_mod.S, "shipping_default_item_weight_oz", 16)
+        object.__setattr__(settings_mod.S, "shipping_dim_divisor", 139)
+
+        yield {
+            "carriers_tbl": carriers_tbl,
+            "shipments_tbl": shipments_tbl,
+            "items_tbl": items_tbl,
+            "pkgs_tbl": pkgs_tbl,
+            "billing_tbl": billing_tbl,
+            "orders_tbl": orders_tbl,
+        }
+
+        # Restore
+        for attr, val in orig_t.items():
+            object.__setattr__(tables_mod.T, attr, val)
+        for attr, val in orig_s.items():
+            object.__setattr__(settings_mod.S, attr, val)
+
+
+# ---------------------------------------------------------------------------
+# SHP-004: Carrier management
+# ---------------------------------------------------------------------------
+
+class TestCarrierManagement:
+    """SHP-004: create, read, update carriers and shipping methods."""
+
+    def test_carrier_id_is_deterministic(self):
+        """sha256(carrier_code)[:16] must be stable across calls."""
+        from app.services.shipping_carriers import _carrier_id
+        assert _carrier_id("ups") == _carrier_id("ups")
+        assert len(_carrier_id("ups")) == 16
+
+    def test_create_carrier_success(self):
+        """create_carrier writes a CARRIER# row with correct fields."""
+        from app.services.shipping_carriers import create_carrier, get_carrier, _carrier_id
+        item = create_carrier("fedex", "FedEx Corp")
+        assert item["carrier_code"] == "fedex"
+        assert item["enabled"] is True
+        # fedex appears in CARRIER_TRACKING_URLS
+        assert item["online_tracking"] is True
+        fetched = get_carrier(_carrier_id("fedex"))
+        assert fetched is not None
+        assert fetched["display_name"] == "FedEx Corp"
+
+    def test_create_carrier_duplicate_raises_409(self):
+        """Second create_carrier for the same code raises HTTP 409."""
+        from app.services.shipping_carriers import create_carrier
+        from fastapi import HTTPException
+        try:
+            create_carrier("usps", "USPS First")
+        except Exception:
+            pass
+        with pytest.raises(HTTPException) as exc_info:
+            create_carrier("usps", "USPS Second")
+        assert exc_info.value.status_code == 409
+
+    def test_manual_carrier_has_no_online_tracking(self):
+        """'manual' carrier_code does not appear in carrier tracking URLs."""
+        from app.services.shipping_carriers import create_carrier, get_carrier, _carrier_id
+        try:
+            item = create_carrier("manual", "Manual Carrier")
+        except Exception:
+            item = get_carrier(_carrier_id("manual"))
+        assert item is not None
+        assert item["online_tracking"] is False
+
+    def test_add_method_and_list_methods(self):
+        """add_method writes a METHOD# row; list_methods returns it."""
+        from app.services.shipping_carriers import create_carrier, add_method, list_methods, _carrier_id
+        try:
+            create_carrier("dhl", "DHL Express Inc")
+        except Exception:
+            pass
+        cid = _carrier_id("dhl")
+        try:
+            add_method(cid, "express", "DHL Express",
+                       base_rate_cents=2200,
+                       transit_days_min=1, transit_days_max=3)
+        except Exception:
+            pass  # already exists
+        methods = list_methods(cid)
+        assert any(m["method_code"] == "express" for m in methods)
+
+    def test_add_method_duplicate_raises_409(self):
+        """Second add_method for same carrier+method raises HTTP 409."""
+        from app.services.shipping_carriers import create_carrier, add_method, _carrier_id
+        from fastapi import HTTPException
+        try:
+            create_carrier("ups", "UPS Inc")
+        except Exception:
+            pass
+        cid = _carrier_id("ups")
+        try:
+            add_method(cid, "ground", "UPS Ground", base_rate_cents=899)
+        except Exception:
+            pass  # already exists
+        with pytest.raises(HTTPException) as exc_info:
+            add_method(cid, "ground", "UPS Ground Duplicate", base_rate_cents=999)
+        assert exc_info.value.status_code == 409
+
+    def test_update_carrier_display_name(self):
+        """update_carrier can patch display_name."""
+        from app.services.shipping_carriers import create_carrier, update_carrier, _carrier_id
+        try:
+            create_carrier("fedex", "FedEx Corp")
+        except Exception:
+            pass
+        cid = _carrier_id("fedex")
+        updated = update_carrier(cid, patch={"display_name": "FedEx Renamed"})
+        assert updated["display_name"] == "FedEx Renamed"
+
+    def test_seed_default_carriers_idempotent(self):
+        """seed_default_carriers run twice produces the same carrier count."""
+        from app.services.shipping_carriers import seed_default_carriers, list_carriers
+        seed_default_carriers()
+        count_first = len(list_carriers(enabled_only=False))
+        seed_default_carriers()
+        count_second = len(list_carriers(enabled_only=False))
+        assert count_first == count_second
+        assert count_first >= 5
+
+    def test_seed_default_carriers_creates_all_five(self):
+        """After seed, all five canonical carrier codes must be present."""
+        from app.services.shipping_carriers import seed_default_carriers, list_carriers
+        seed_default_carriers()
+        carriers = list_carriers(enabled_only=False)
+        codes = {c["carrier_code"] for c in carriers}
+        assert {"ups", "fedex", "usps", "dhl", "manual"}.issubset(codes)
+
+    def test_list_all_enabled_methods_returns_methods(self):
+        """list_enabled_methods_all_carriers returns METHOD# rows after seed."""
+        from app.services.shipping_carriers import seed_default_carriers, list_enabled_methods_all_carriers
+        seed_default_carriers()
+        methods = list_enabled_methods_all_carriers()
+        assert len(methods) > 0
+        for m in methods:
+            assert m["sk"].startswith("METHOD#")
+
+
+# ---------------------------------------------------------------------------
+# SHP-006: Rate estimation
+# ---------------------------------------------------------------------------
+
+class TestRateEstimation:
+    """SHP-006: estimate_rates returns correctly computed rate options."""
+
+    def test_estimate_rates_returns_single_option_for_specific_method(self):
+        """estimate_rates filtered to one carrier+method returns exactly one option."""
+        from app.services.shipping_carriers import seed_default_carriers
+        from app.services.shipping_rates import estimate_rates
+        seed_default_carriers()
+        result = estimate_rates(
+            carrier_code="ups",
+            method_code="ground",
+            weight_oz=16,
+            destination_zip="10001",
+        )
+        assert "options" in result
+        assert len(result["options"]) == 1
+        opt = result["options"][0]
+        assert opt["rate_cents"] >= 0
+        assert opt["carrier_code"] == "ups"
+        assert opt["method_code"] == "ground"
+
+    def test_estimate_rates_all_carriers_when_no_filter(self):
+        """Without carrier/method filter, returns options from all enabled carriers."""
+        from app.services.shipping_carriers import seed_default_carriers
+        from app.services.shipping_rates import estimate_rates
+        seed_default_carriers()
+        result = estimate_rates(weight_oz=16, destination_zip="10001")
+        assert len(result["options"]) > 1
+
+    def test_rate_increases_with_weight(self):
+        """Heavier shipments cost at least as much as lighter ones."""
+        from app.services.shipping_carriers import seed_default_carriers
+        from app.services.shipping_rates import estimate_rates
+        seed_default_carriers()
+        light = estimate_rates(carrier_code="ups", method_code="ground",
+                               weight_oz=16, destination_zip="10001")
+        heavy = estimate_rates(carrier_code="ups", method_code="ground",
+                               weight_oz=320, destination_zip="10001")
+        assert heavy["options"][0]["rate_cents"] >= light["options"][0]["rate_cents"]
+
+    def test_flat_rate_method_ignores_weight(self):
+        """manual/flat_rate has no per-lb increment — weight does not change cost."""
+        from app.services.shipping_carriers import seed_default_carriers
+        from app.services.shipping_rates import estimate_rates
+        seed_default_carriers()
+        r0 = estimate_rates(carrier_code="manual", method_code="flat_rate",
+                            weight_oz=0, destination_zip="99501")
+        r_heavy = estimate_rates(carrier_code="manual", method_code="flat_rate",
+                                 weight_oz=1000, destination_zip="99501")
+        assert r0["options"][0]["rate_cents"] == r_heavy["options"][0]["rate_cents"]
+
+    def test_estimate_empty_when_no_enabled_methods_for_carrier(self):
+        """Disabling all methods for a carrier produces no options for that carrier."""
+        from app.services.shipping_carriers import (
+            seed_default_carriers, disable_method, list_methods, _carrier_id,
+        )
+        from app.services.shipping_rates import estimate_rates
+        seed_default_carriers()
+        cid = _carrier_id("manual")
+        # Disable the only manual method (flat_rate)
+        for m in list_methods(cid):
+            disable_method(cid, m["method_code"])
+        result = estimate_rates(carrier_code="manual", method_code="flat_rate",
+                                weight_oz=0, destination_zip="10001")
+        # No enabled method → empty options
+        assert result["options"] == []
+        # Re-enable for subsequent tests
+        from app.services.shipping_carriers import update_method
+        update_method(cid, "flat_rate", patch={"enabled": True})
+
+
+# ---------------------------------------------------------------------------
+# SHP-008 / SHP-010: Shipment lifecycle
+# ---------------------------------------------------------------------------
+
+class TestShipmentLifecycle:
+    """SHP-008/010: full create → advance state machine tests."""
+
+    def _create(self, suffix: str, user_id: str = "usr_test") -> Dict[str, Any]:
+        from app.services.shipments import create_shipment
+        return create_shipment(
+            order_id=f"ORD_CRS_{suffix}",
+            user_id=user_id,
+            carrier_code="ups",
+            method_code="ground",
+            ship_to_address={"line1": "1 Main St", "country": "US"},
+            line_items=[{"item_id": "item_1", "sku": "SKU-A", "quantity": 1}],
+        )
+
+    def test_create_shipment_initial_status(self):
+        """Newly created shipment is 'pending_fulfillment'."""
+        result = self._create("INIT")
+        assert result["status"] == "pending_fulfillment"
+        assert result["carrier_code"] == "ups"
+
+    def test_create_shipment_idempotent(self):
+        """Creating the same order+seq twice returns the same shipment_id."""
+        r1 = self._create("IDEM")
+        r2 = self._create("IDEM")
+        assert r1["shipment_id"] == r2["shipment_id"]
+
+    def test_full_happy_path_to_delivered(self):
+        """Walk pending → label_created → picked_up → in_transit → out_for_delivery → delivered."""
+        from app.services.shipments import advance_shipment_status
+        r = self._create("HAPPY")
+        sid = r["shipment_id"]
+        advance_shipment_status(sid, "label_created")
+        advance_shipment_status(sid, "picked_up")
+        advance_shipment_status(sid, "in_transit")
+        advance_shipment_status(sid, "out_for_delivery")
+        final = advance_shipment_status(sid, "delivered")
+        assert final["status"] == "delivered"
+        assert final.get("delivered_at") is not None
+
+    def test_cancel_from_pending(self):
+        """Cancellation is allowed from 'pending_fulfillment'."""
+        from app.services.shipments import advance_shipment_status
+        r = self._create("CANCEL_PENDING")
+        sid = r["shipment_id"]
+        final = advance_shipment_status(sid, "cancelled")
+        assert final["status"] == "cancelled"
+
+    def test_cancel_from_label_created(self):
+        """Cancellation is allowed after label is created."""
+        from app.services.shipments import advance_shipment_status
+        r = self._create("CANCEL_LABEL")
+        sid = r["shipment_id"]
+        advance_shipment_status(sid, "label_created")
+        final = advance_shipment_status(sid, "cancelled")
+        assert final["status"] == "cancelled"
+
+    def test_cannot_cancel_after_in_transit(self):
+        """'in_transit' → 'cancelled' is not a valid transition."""
+        from app.services.shipments import advance_shipment_status
+        from fastapi import HTTPException
+        r = self._create("NO_CANCEL_INTRANSIT")
+        sid = r["shipment_id"]
+        advance_shipment_status(sid, "label_created")
+        advance_shipment_status(sid, "picked_up")
+        advance_shipment_status(sid, "in_transit")
+        with pytest.raises(HTTPException) as exc_info:
+            advance_shipment_status(sid, "cancelled")
+        assert exc_info.value.status_code == 409
+
+    def test_invalid_skip_transition_raises_409(self):
+        """Jumping from 'pending_fulfillment' straight to 'delivered' is rejected."""
+        from app.services.shipments import advance_shipment_status
+        from fastapi import HTTPException
+        r = self._create("SKIP_TRANS")
+        sid = r["shipment_id"]
+        with pytest.raises(HTTPException) as exc_info:
+            advance_shipment_status(sid, "delivered")
+        assert exc_info.value.status_code == 409
+
+    def test_list_shipments_for_order(self):
+        """list_shipments_for_order returns all shipments for a given order_id."""
+        from app.services.shipments import create_shipment, list_shipments_for_order
+        oid = "ORD_LIST_CRS_001"
+        create_shipment(
+            order_id=oid, user_id="usr1",
+            carrier_code="ups", method_code="ground",
+            ship_to_address={"line1": "1 A St", "country": "US"},
+            line_items=[{"item_id": "1", "sku": "A", "quantity": 1}],
+            ship_group_seq=1,
+        )
+        create_shipment(
+            order_id=oid, user_id="usr1",
+            carrier_code="fedex", method_code="ground",
+            ship_to_address={"line1": "1 B St", "country": "US"},
+            line_items=[{"item_id": "2", "sku": "B", "quantity": 1}],
+            ship_group_seq=2,
+        )
+        shipments = list_shipments_for_order(oid)
+        assert len(shipments) >= 2
+
+    def test_get_shipment_ownership_enforcement(self):
+        """Owner can read; non-owner gets None; admin=True bypasses ownership."""
+        from app.services.shipments import get_shipment
+        r = self._create("OWN_ACCESS", user_id="alice")
+        sid = r["shipment_id"]
+        assert get_shipment(sid, user_id="alice") is not None
+        assert get_shipment(sid, user_id="bob") is None
+        assert get_shipment(sid, user_id="bob", admin=True) is not None
+
+
+# ---------------------------------------------------------------------------
+# Flag-off parity
+# ---------------------------------------------------------------------------
+
+class TestFlagOffParity:
+    """When shipping_enabled=False all service functions must raise."""
+
+    def test_carrier_service_disabled_raises(self):
+        from app.core import settings as settings_mod
+        from app.services.shipping_carriers import list_carriers
+        from fastapi import HTTPException
+        orig = settings_mod.S.shipping_enabled
+        object.__setattr__(settings_mod.S, "shipping_enabled", False)
+        try:
+            with pytest.raises(HTTPException):
+                list_carriers()
+        finally:
+            object.__setattr__(settings_mod.S, "shipping_enabled", orig)
+
+    def test_shipment_service_disabled_raises(self):
+        from app.core import settings as settings_mod
+        from app.services.shipments import get_shipment
+        from fastapi import HTTPException
+        orig = settings_mod.S.shipping_enabled
+        object.__setattr__(settings_mod.S, "shipping_enabled", False)
+        try:
+            with pytest.raises(HTTPException):
+                get_shipment("any-id", admin=True)
+        finally:
+            object.__setattr__(settings_mod.S, "shipping_enabled", orig)
+
+    def test_rate_service_disabled_raises(self):
+        from app.core import settings as settings_mod
+        from app.services.shipping_rates import estimate_rates
+        from fastapi import HTTPException
+        orig = settings_mod.S.shipping_enabled
+        object.__setattr__(settings_mod.S, "shipping_enabled", False)
+        try:
+            with pytest.raises(HTTPException):
+                estimate_rates(weight_oz=16, destination_zip="10001")
+        finally:
+            object.__setattr__(settings_mod.S, "shipping_enabled", orig)


### PR DESCRIPTION
## Summary

- **SHP-004..011**: Shipping carriers CRUD, rate estimation engine, shipment lifecycle (create/ship/deliver/cancel) — backend service layer + routes already implemented; added hermetic test suite (27 tests, all passing)
- **SHP-016/017**: Frontend shipping admin page (3 tabs: Carriers | Rate Estimate | Shipments) with full TypeScript API wrappers and lazy-loaded route at `/shop/admin/shipping`

## Test plan
- [ ] `pytest tests/test_shp_carriers_rates_shipments.py` → 27 passed
- [ ] `npx tsc --noEmit` in frontend → 0 errors
- [ ] `/shop/admin/shipping` renders Carriers | Rate Estimate | Shipments tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)