### PR TITLE
[THROWAWAY] CI P3 gate validation (do not merge)

### DIFF
--- a/ops/ci-p3-validate-throwaway.md
+++ b/ops/ci-p3-validate-throwaway.md
@@ -1,0 +1,4 @@
+# CI P3 validation throwaway
+
+Throwaway PR to observe which status checks trigger on a docs-only PR to main
+(path-filter behaviour for branch protection). Safe to delete.


### PR DESCRIPTION
Throwaway PR to observe which status checks trigger on a docs-only PR to main and to validate branch-protection posture. Will be closed. Touches only ops/ci-p3-validate-throwaway.md.