### PR TITLE
Group-call web video: wire LiveKit media leg

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,7 @@
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^4.0.0",
         "leaflet": "^1.9.4",
+        "livekit-client": "2.15.16",
         "lucide-react": "^0.468.0",
         "mammoth": "^1.11.0",
         "react": "^18.3.1",
@@ -398,6 +399,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1087,6 +1094,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.42.2.tgz",
+      "integrity": "sha512-0jeCwoMJKcwsZICg5S6RZM4xhJoF78qMvQELjACJQn6/VB+jmiySQKOSELTXvPBVafHfEbMlqxUw2UR1jTXs2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -3359,6 +3381,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4587,6 +4616,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -5186,6 +5224,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5533,6 +5580,40 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/livekit-client": {
+      "version": "2.15.16",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.15.16.tgz",
+      "integrity": "sha512-i4cDjlI7W5a7hiBjt3WeOzWwxRNx0ej2spq/JFQarXuvC1t3BbIAY5oOi61VIOHyU5nEQa83YAcKfoP6AeVUJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.42.2",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/loose-envify": {
@@ -6803,6 +6884,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6836,6 +6927,21 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
       }
     },
     "node_modules/semver": {
@@ -7271,6 +7377,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7288,6 +7400,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typescript": {
@@ -8630,6 +8751,19 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^4.0.0",
     "leaflet": "^1.9.4",
+    "livekit-client": "2.15.16",
     "lucide-react": "^0.468.0",
     "mammoth": "^1.11.0",
     "react": "^18.3.1",

--- a/frontend/src/hooks/useGroupCall.ts
+++ b/frontend/src/hooks/useGroupCall.ts
@@ -40,6 +40,10 @@ import {
   getGroupCallLiveKitToken,
 } from "@/api/endpoints/groupCalls";
 import { acquireLocalMedia } from "@/lib/webrtc";
+import {
+  connectGroupCallLiveKit,
+  type GroupCallLiveKitSession,
+} from "@/lib/groupCallLiveKit";
 import type { GroupCallOut, GroupCallParticipant } from "@/api/types";
 
 export type GroupCallMode = "mesh" | "sfu";
@@ -68,11 +72,11 @@ export interface UseGroupCallReturn {
   livekit: { url: string; token: string; room: string } | null;
   /**
    * SFU media status. "na" (mesh path), "connecting" (fetching token),
-   * "seam" (token minted but browser media connect is not wired — needs the
-   * livekit-client SDK), "unavailable" (LiveKit not configured/failed → the
-   * server returned mesh or 503).
+   * "seam" (token minted but not yet connecting), "connected" (LiveKit Room
+   * connected — real media flowing), "unavailable" (LiveKit not configured/
+   * failed → the server returned mesh or 503).
    */
-  sfuStatus: "na" | "connecting" | "seam" | "unavailable";
+  sfuStatus: "na" | "connecting" | "connected" | "seam" | "unavailable";
   isCreator: boolean;
   participants: GroupCallParticipant[];
   activeParticipants: GroupCallParticipant[];
@@ -118,7 +122,7 @@ export function useGroupCall(options: UseGroupCallOptions): UseGroupCallReturn {
   const [sfuProvider, setSfuProvider] = React.useState<string | null>(null);
   const [livekit, setLivekit] = React.useState<{ url: string; token: string; room: string } | null>(null);
   const [sfuStatus, setSfuStatus] = React.useState<
-    "na" | "connecting" | "seam" | "unavailable"
+    "na" | "connecting" | "connected" | "seam" | "unavailable"
   >("na");
 
   // Stable callback ref so effects don't re-run when the caller passes a new fn.
@@ -128,6 +132,15 @@ export function useGroupCall(options: UseGroupCallOptions): UseGroupCallReturn {
   // One RTCPeerConnection per remote peer (mesh), or a single SFU peer.
   const peersRef = React.useRef<Map<string, RTCPeerConnection>>(new Map());
   const localStreamRef = React.useRef<MediaStream | null>(null);
+  // Live LiveKit session (SFU path). null on the mesh path.
+  const livekitSessionRef = React.useRef<GroupCallLiveKitSession | null>(null);
+  // Current local media intent (audio/video on?). Seeded from callMode and
+  // kept in sync by updateMedia so a LiveKit connect publishes the right
+  // tracks and toggles route to the SFU session.
+  const mediaStateRef = React.useRef<{ audio: boolean; video: boolean }>({
+    audio: true,
+    video: callMode === "video",
+  });
 
   // ── Call-state polling ─────────────────────────────────────────────
   const { data: callData } = useQuery({
@@ -260,6 +273,11 @@ export function useGroupCall(options: UseGroupCallOptions): UseGroupCallReturn {
       local.getTracks().forEach((t) => t.stop());
       localStreamRef.current = null;
     }
+    // Disconnect the LiveKit session (SFU path) if one is live.
+    if (livekitSessionRef.current) {
+      void livekitSessionRef.current.disconnect();
+      livekitSessionRef.current = null;
+    }
     setLocalStream(null);
     setRemoteStreams({});
     setLivekit(null);
@@ -288,29 +306,64 @@ export function useGroupCall(options: UseGroupCallOptions): UseGroupCallReturn {
           const tok = await getGroupCallLiveKitToken(callId);
           if (tok?.token && tok?.url) {
             setLivekit({ url: tok.url, token: tok.token, room: tok.room_name });
-            // Token minted, but connecting the browser media engine needs the
-            // livekit-client SDK (not yet a web dependency). SEAM-NOT-LIVE.
-            setSfuStatus("seam");
+            // Real browser media leg: connect the LiveKit Room and publish
+            // mic/camera honoring the current mute/camera state. Remote
+            // tracks arrive keyed by participant identity (== user_id) and
+            // merge into remoteStreams, reusing the mesh render contract.
+            const session = await connectGroupCallLiveKit(
+              tok.url,
+              tok.token,
+              { audio: mediaStateRef.current.audio, video: mediaStateRef.current.video },
+              {
+                onRemoteStream: (identity, stream) => {
+                  if (identity === userId) return; // never overwrite self-tile
+                  if (stream) setRemoteStream(identity, stream);
+                  else removeRemoteStream(identity);
+                },
+                onPhase: (phase) => {
+                  if (phase === "connected") setSfuStatus("connected");
+                  else if (phase === "connecting" || phase === "reconnecting")
+                    setSfuStatus("connecting");
+                  else if (phase === "failed") setSfuStatus("unavailable");
+                  // "disconnected" during an active call: leave/teardown owns
+                  // the terminal state; a transient drop is followed by
+                  // "reconnecting"/"connected" above.
+                },
+              },
+            );
+            livekitSessionRef.current = session;
+            if (import.meta.env.DEV) {
+              (window as unknown as Record<string, unknown>).__groupCallLiveKit = session;
+            }
           } else {
             setSfuStatus("unavailable");
           }
         } catch {
-          // 503 LIVEKIT_NOT_CONFIGURED / SDK unavailable, or transient error.
+          // 503 LIVEKIT_NOT_CONFIGURED / SDK unavailable / connect failed.
+          // Do NOT fabricate media: surface the honest unavailable state.
           setLivekit(null);
+          if (livekitSessionRef.current) {
+            void livekitSessionRef.current.disconnect();
+            livekitSessionRef.current = null;
+          }
           setSfuStatus("unavailable");
         }
       } else {
         setSfuStatus("na");
       }
 
-      // Acquire local media once. Failures (no camera, denied permission) are
-      // non-fatal — the call still proceeds receive-only.
-      try {
-        const stream = await acquireLocalMedia(callMode);
-        localStreamRef.current = stream;
-        setLocalStream(stream);
-      } catch {
-        localStreamRef.current = null;
+      // Acquire local media for the MESH path. On the LiveKit path the SFU
+      // session acquires + publishes its own devices, so we skip this to
+      // avoid grabbing the camera twice. Failures (no camera, denied
+      // permission) are non-fatal — the call still proceeds receive-only.
+      if (!(resolvedMode === "sfu" && provider === "livekit")) {
+        try {
+          const stream = await acquireLocalMedia(callMode);
+          localStreamRef.current = stream;
+          setLocalStream(stream);
+        } catch {
+          localStreamRef.current = null;
+        }
       }
 
       if (import.meta.env.DEV) {
@@ -343,8 +396,22 @@ export function useGroupCall(options: UseGroupCallOptions): UseGroupCallReturn {
     mutationFn: (update: { audio?: boolean; video?: boolean; screen?: boolean }) =>
       updateGroupCallMedia(callId, update),
     onSuccess: (_data, update) => {
-      // Reflect mute/unmute on the local upstream tracks so peers stop/resume
-      // receiving immediately (the REST call only updates server-side status).
+      // Track the current intent for a (re)publish / late LiveKit connect.
+      if (typeof update.audio === "boolean") mediaStateRef.current.audio = update.audio;
+      if (typeof update.video === "boolean") mediaStateRef.current.video = update.video;
+
+      // SFU (LiveKit) path: toggle publish on the live session.
+      const session = livekitSessionRef.current;
+      if (session) {
+        if (typeof update.audio === "boolean") void session.setMicrophoneEnabled(update.audio);
+        if (typeof update.video === "boolean") void session.setCameraEnabled(update.video);
+        if (typeof update.screen === "boolean") void session.setScreenShareEnabled(update.screen);
+        return;
+      }
+
+      // MESH path: reflect mute/unmute on the local upstream tracks so peers
+      // stop/resume receiving immediately (the REST call only updates
+      // server-side status).
       const local = localStreamRef.current;
       if (local) {
         if (typeof update.audio === "boolean") {

--- a/frontend/src/lib/groupCallLiveKit.ts
+++ b/frontend/src/lib/groupCallLiveKit.ts
@@ -1,0 +1,207 @@
+/**
+ * groupCallLiveKit — browser LiveKit media leg for group calls (GAP-0017-sfu).
+ *
+ * The group-call BACKEND mints a real LiveKit video-grant JWT
+ * (`GET /ui/calls/group/{id}/livekit-token`); `useGroupCall` fetches it and,
+ * when `sfu_provider==="livekit"`, hands the {url,token} to this helper which
+ * owns the real `Room.connect` + publish + subscribe against the SAME LiveKit
+ * SFU the audio rooms use. This replaces the SEAM (token-real, media-not-wired)
+ * with real media flow.
+ *
+ * The LiveKit participant *identity* is the platform `user_id` (see the token
+ * endpoint `.with_identity(str(uid))`), so remote tracks map 1:1 onto the
+ * participant tiles the overlay renders (keyed by user_id).
+ *
+ * We expose remote media as plain `MediaStream`s keyed by user_id so the LiveKit
+ * path reuses the exact same {localStream, remoteStreams} contract the mesh path
+ * already exposes — the overlay renders both identically. The mesh
+ * RTCPeerConnection path is untouched and remains the fallback when LiveKit is
+ * not configured (mode:mesh / 503 token).
+ */
+import {
+  Room,
+  RoomEvent,
+  Track,
+  ConnectionState,
+  type RemoteParticipant,
+  type RemoteTrack,
+  type RemoteTrackPublication,
+} from "livekit-client";
+
+export type LiveKitPhase =
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected"
+  | "failed";
+
+export interface LiveKitCallbacks {
+  /** Remote participant media changed — stream is keyed by participant identity (user_id). */
+  onRemoteStream: (identity: string, stream: MediaStream | null) => void;
+  /** Connection phase changed (drives sfuStatus connecting→connected). */
+  onPhase: (phase: LiveKitPhase) => void;
+}
+
+export interface LiveKitInitialMedia {
+  audio: boolean;
+  video: boolean;
+}
+
+/**
+ * Connect to the LiveKit room, publish local mic/camera per the current
+ * mute/camera state, and forward remote tracks to the caller. Returns a handle
+ * to toggle media / screen-share and disconnect.
+ */
+export async function connectGroupCallLiveKit(
+  url: string,
+  token: string,
+  initial: LiveKitInitialMedia,
+  cb: LiveKitCallbacks,
+): Promise<GroupCallLiveKitSession> {
+  const room = new Room({
+    adaptiveStream: true,
+    dynacast: true,
+  });
+
+  // Per-remote-participant MediaStream, keyed by identity (== user_id).
+  const remoteStreams = new Map<string, MediaStream>();
+
+  const streamFor = (identity: string): MediaStream => {
+    let s = remoteStreams.get(identity);
+    if (!s) {
+      s = new MediaStream();
+      remoteStreams.set(identity, s);
+    }
+    return s;
+  };
+
+  const attach = (
+    track: RemoteTrack,
+    participant: RemoteParticipant,
+  ) => {
+    const mt = track.mediaStreamTrack;
+    if (!mt) return;
+    const stream = streamFor(participant.identity);
+    // Replace any existing track of the same kind (camera swap, republish).
+    for (const existing of stream.getTracks()) {
+      if (existing.kind === mt.kind) stream.removeTrack(existing);
+    }
+    stream.addTrack(mt);
+    cb.onRemoteStream(participant.identity, stream);
+  };
+
+  const detach = (
+    track: RemoteTrack,
+    participant: RemoteParticipant,
+  ) => {
+    const stream = remoteStreams.get(participant.identity);
+    if (!stream) return;
+    const mt = track.mediaStreamTrack;
+    if (mt) stream.removeTrack(mt);
+    if (stream.getTracks().length === 0) {
+      remoteStreams.delete(participant.identity);
+      cb.onRemoteStream(participant.identity, null);
+    } else {
+      cb.onRemoteStream(participant.identity, stream);
+    }
+  };
+
+  const dropParticipant = (participant: RemoteParticipant) => {
+    if (remoteStreams.has(participant.identity)) {
+      remoteStreams.delete(participant.identity);
+      cb.onRemoteStream(participant.identity, null);
+    }
+  };
+
+  room
+    .on(RoomEvent.TrackSubscribed, (track, _pub: RemoteTrackPublication, participant) => {
+      if (track.kind === Track.Kind.Audio || track.kind === Track.Kind.Video) {
+        attach(track, participant);
+      }
+    })
+    .on(RoomEvent.TrackUnsubscribed, (track, _pub, participant) => {
+      detach(track, participant);
+    })
+    .on(RoomEvent.ParticipantDisconnected, (participant) => {
+      dropParticipant(participant);
+    })
+    .on(RoomEvent.ConnectionStateChanged, (state) => {
+      switch (state) {
+        case ConnectionState.Connecting:
+          cb.onPhase("connecting");
+          break;
+        case ConnectionState.Connected:
+          cb.onPhase("connected");
+          break;
+        case ConnectionState.Reconnecting:
+          cb.onPhase("reconnecting");
+          break;
+        case ConnectionState.Disconnected:
+          cb.onPhase("disconnected");
+          break;
+        default:
+          break;
+      }
+    })
+    .on(RoomEvent.Disconnected, () => {
+      cb.onPhase("disconnected");
+    });
+
+  await room.connect(url, token);
+
+  // Publish local media honoring the call's current mute/camera state.
+  try {
+    if (initial.audio) await room.localParticipant.setMicrophoneEnabled(true);
+    if (initial.video) await room.localParticipant.setCameraEnabled(true);
+  } catch {
+    // Publish failure (no devices / denied permission) is non-fatal — the
+    // participant stays receive-only, mirroring the mesh path's tolerance.
+  }
+
+  return new GroupCallLiveKitSession(room);
+}
+
+/** Live handle over a connected LiveKit room. */
+export class GroupCallLiveKitSession {
+  constructor(private readonly room: Room) {}
+
+  async setMicrophoneEnabled(enabled: boolean): Promise<void> {
+    try {
+      await this.room.localParticipant.setMicrophoneEnabled(enabled);
+    } catch {
+      /* device/permission errors are non-fatal */
+    }
+  }
+
+  async setCameraEnabled(enabled: boolean): Promise<void> {
+    try {
+      await this.room.localParticipant.setCameraEnabled(enabled);
+    } catch {
+      /* device/permission errors are non-fatal */
+    }
+  }
+
+  async setScreenShareEnabled(enabled: boolean): Promise<void> {
+    try {
+      await this.room.localParticipant.setScreenShareEnabled(enabled);
+    } catch {
+      /* screen-share grant/cancel errors are non-fatal */
+    }
+  }
+
+  /** Local camera stream for the self-tile (null when camera is off). */
+  localCameraStream(): MediaStream | null {
+    const pub = this.room.localParticipant.getTrackPublication(Track.Source.Camera);
+    const mt = pub?.track?.mediaStreamTrack;
+    if (!mt) return null;
+    return new MediaStream([mt]);
+  }
+
+  async disconnect(): Promise<void> {
+    try {
+      await this.room.disconnect();
+    } catch {
+      /* already disconnected */
+    }
+  }
+}

--- a/frontend/src/pages/messages/GroupCallOverlay.tsx
+++ b/frontend/src/pages/messages/GroupCallOverlay.tsx
@@ -199,6 +199,8 @@ function GroupCallOverlay({ callId, userId, conversationId, mode: callKind, onCl
     mode,
     isCreator,
     activeParticipants,
+    localStream,
+    remoteStreams,
     join,
     leave,
     end,
@@ -270,6 +272,17 @@ function GroupCallOverlay({ callId, userId, conversationId, mode: callKind, onCl
   const screenSharer = activeParticipants.find((p) => p.media_status.screen);
   const effectiveLayout = screenSharer ? "presentation" as const : layout;
 
+  // Resolve the MediaStream for a tile: the local publish for self, the
+  // per-participant remote stream (mesh RTCPeerConnection OR LiveKit SFU —
+  // both key streams by user_id) for everyone else. null → avatar fallback.
+  const streamFor = React.useCallback(
+    (participantUserId: string, isLocal: boolean): MediaStream | null => {
+      if (isLocal) return localStream ?? null;
+      return remoteStreams[participantUserId] ?? null;
+    },
+    [localStream, remoteStreams],
+  );
+
   // Grid column class based on participant count
   const gridCols =
     activeParticipants.length <= 2
@@ -340,6 +353,7 @@ function GroupCallOverlay({ callId, userId, conversationId, mode: callKind, onCl
                   key={p.user_id}
                   participant={p}
                   isLocal={p.user_id === userId}
+                  stream={streamFor(p.user_id, p.user_id === userId)}
                 />
               ))}
             </div>
@@ -347,7 +361,12 @@ function GroupCallOverlay({ callId, userId, conversationId, mode: callKind, onCl
         ) : effectiveLayout === "grid" || layout === "grid" ? (
           <div className={cn("grid gap-3 h-full", gridCols)}>
             {activeParticipants.map((p) => (
-              <ParticipantTile key={p.user_id} participant={p} isLocal={p.user_id === userId} />
+              <ParticipantTile
+                key={p.user_id}
+                participant={p}
+                isLocal={p.user_id === userId}
+                stream={streamFor(p.user_id, p.user_id === userId)}
+              />
             ))}
           </div>
         ) : (
@@ -358,6 +377,7 @@ function GroupCallOverlay({ callId, userId, conversationId, mode: callKind, onCl
                 <ParticipantTile
                   participant={activeParticipants[0]}
                   isLocal={activeParticipants[0].user_id === userId}
+                  stream={streamFor(activeParticipants[0].user_id, activeParticipants[0].user_id === userId)}
                   large
                 />
               </div>
@@ -367,7 +387,11 @@ function GroupCallOverlay({ callId, userId, conversationId, mode: callKind, onCl
               <div className="flex gap-2 overflow-x-auto pb-2">
                 {activeParticipants.slice(1).map((p) => (
                   <div key={p.user_id} className="w-36 shrink-0">
-                    <ParticipantTile participant={p} isLocal={p.user_id === userId} />
+                    <ParticipantTile
+                      participant={p}
+                      isLocal={p.user_id === userId}
+                      stream={streamFor(p.user_id, p.user_id === userId)}
+                    />
                   </div>
                 ))}
               </div>
@@ -451,38 +475,98 @@ function GroupCallOverlay({ callId, userId, conversationId, mode: callKind, onCl
 }
 
 
+// ─── Media renderers ──────────────────────────────────────────────
+
+/** Attach a MediaStream to a <video> element (same pattern as direct calls). */
+function TileVideo({
+  stream,
+  muted,
+  mirror,
+}: {
+  stream: MediaStream;
+  muted?: boolean;
+  mirror?: boolean;
+}) {
+  const videoRef = React.useRef<HTMLVideoElement>(null);
+  React.useEffect(() => {
+    if (!videoRef.current) return;
+    videoRef.current.srcObject = stream;
+    return () => {
+      if (videoRef.current) videoRef.current.srcObject = null;
+    };
+  }, [stream]);
+  return (
+    <video
+      ref={videoRef}
+      autoPlay
+      playsInline
+      muted={muted}
+      className={cn("absolute inset-0 h-full w-full object-cover", mirror && "[transform:scaleX(-1)]")}
+    />
+  );
+}
+
+/** Attach a MediaStream's audio to a hidden <audio> element. */
+function TileAudio({ stream }: { stream: MediaStream }) {
+  const audioRef = React.useRef<HTMLAudioElement>(null);
+  React.useEffect(() => {
+    if (!audioRef.current) return;
+    audioRef.current.srcObject = stream;
+    return () => {
+      if (audioRef.current) audioRef.current.srcObject = null;
+    };
+  }, [stream]);
+  return <audio ref={audioRef} autoPlay className="hidden" />;
+}
+
 // ─── Participant Tile ─────────────────────────────────────────────
 
 interface ParticipantTileProps {
   participant: GroupCallParticipant;
   isLocal?: boolean;
   large?: boolean;
+  /** Live media for this tile (local publish or remote mesh/SFU stream). */
+  stream?: MediaStream | null;
 }
 
-function ParticipantTile({ participant, isLocal, large }: ParticipantTileProps) {
+function ParticipantTile({ participant, isLocal, large, stream }: ParticipantTileProps) {
   const name = participant.display_name || participant.user_id;
   const initials = name.slice(0, 2).toUpperCase();
+
+  // A live stream with a video track drives the real <video>. When video is
+  // off (or no track yet) we fall back to the avatar. This is the same for
+  // both media paths: mesh RTCPeerConnection streams and LiveKit SFU streams
+  // are both plain MediaStreams keyed by user_id.
+  const hasVideo =
+    !!participant.media_status.video &&
+    !!stream &&
+    stream.getVideoTracks().length > 0;
 
   return (
     <div
       className={cn(
-        "relative flex items-center justify-center rounded-lg bg-gray-800",
+        "relative flex items-center justify-center overflow-hidden rounded-lg bg-gray-800",
         large ? "min-h-[300px]" : "aspect-video min-h-[120px]",
       )}
       data-testid={`participant-tile-${participant.user_id}`}
     >
-      {/* Avatar (shown when video is off) */}
-      {!participant.media_status.video && (
+      {/* Avatar (shown when there is no live video for the tile) */}
+      {!hasVideo && (
         <Avatar className={cn("border-2 border-gray-600", large ? "h-24 w-24" : "h-16 w-16")}>
           <AvatarFallback className="bg-gray-700 text-white text-lg">{initials}</AvatarFallback>
         </Avatar>
       )}
 
-      {/* Video placeholder (would be <video> element in real impl) */}
-      {participant.media_status.video && (
-        <div className="flex items-center justify-center text-gray-500">
-          <Video className={cn(large ? "h-12 w-12" : "h-8 w-8")} />
-        </div>
+      {/* Real video (mesh or LiveKit SFU). Muted for the local tile to avoid
+          echo; the remote audio tracks in the stream still play. */}
+      {hasVideo && (
+        <TileVideo stream={stream!} muted={!!isLocal} mirror={!!isLocal} />
+      )}
+
+      {/* Remote audio: attach the stream so audio plays even when video is
+          off (avatar shown). Local audio is never played back (no echo). */}
+      {!isLocal && stream && stream.getAudioTracks().length > 0 && (
+        <TileAudio stream={stream} />
       )}
 
       {/* Name overlay */}


### PR DESCRIPTION
## Summary

Wires the actual media transport leg for group calls on the web frontend using LiveKit.

- Adds `livekit-client` dependency (package.json / package-lock.json).
- New `frontend/src/lib/groupCallLiveKit.ts`: connects to the LiveKit room, publishes local audio/video, subscribes to remote participant tracks, and exposes lifecycle/track callbacks.
- `useGroupCall.ts`: drives the LiveKit connection alongside the existing signaling, managing local/remote track state.
- `GroupCallOverlay.tsx`: renders real remote participant media tiles instead of placeholder UI.

## Verification

The media path was proven end-to-end against a real LiveKit v1.13.2 server (connect, publish, subscribe, remote track render).

## Go-live

Operator sets the `LIVEKIT_*` env vars to point at the production LiveKit deployment. No further code change required to flip on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>