### PR TITLE
Contacts hub + device sync + Picture-in-Picture (contacts & PiP program)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -34,6 +34,10 @@ android {
         buildConfigField("String", "HELPDESK_GROUP_ID", "\"e2e-helpdesk\"")
         // Diagnostic: when true, forces ICE to use ONLY TURN relay candidates (skips host/srflx).
         // Defaults false (normal ICE — direct path with TURN as fallback); useful on restrictive networks.
+        // Contacts Feature 2 — the app pepper for privacy-safe contact-hash matching. MUST stay
+        // byte-identical to the backend APP_CONTACT_MATCH_SALT (app/services/contact_match.py) or
+        // client hashes stop matching server hashes. Non-secret (see that module's docstring).
+        buildConfigField("String", "CONTACT_MATCH_SALT", "\"tl_contact_match_v1\"")
         buildConfigField("boolean", "WEBRTC_FORCE_RELAY", "false")
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
     <!-- AND-107: runtime notification permission (requested at runtime on Android 13+ / API 33). -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Contacts Feature 2: read the device address book to privacy-safely match contacts
+         against platform users. Requested at RUNTIME behind an explicit "Find people you know"
+         action; emails/phones are hashed on-device and NEVER uploaded (only hashes are sent). -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
     <!-- AND-297: full-screen incoming-call notification (CATEGORY_CALL qualifies on API 34+). The
          notifier still degrades to a heads-up call notification when canUseFullScreenIntent() is false. -->
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />

--- a/android/app/src/main/java/com/testlogon/android/MainActivity.kt
+++ b/android/app/src/main/java/com/testlogon/android/MainActivity.kt
@@ -38,6 +38,7 @@ import com.testlogon.android.testseam.TestHooks
 import androidx.compose.runtime.mutableStateOf
 import com.testlogon.android.feature.player.ActivityPipController
 import com.testlogon.android.feature.player.LocalPipController
+import com.testlogon.android.feature.player.PipSourceLogic
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.graphics.Color
@@ -165,8 +166,27 @@ class MainActivity : FragmentActivity() {
                     // the floating window shows the VIDEO (not the messaging thread / news feed behind
                     // an inline player). This mirrors the VOD detail player, whose PlayerView already
                     // fills the window. Outside PiP we render the normal app shell.
+                    // CALL-PiP — pick the PiP SOURCE: a live video call (native WebRTC SurfaceViewRenderer)
+                    // takes precedence over a media3 player, else the media3 player branch (unchanged), else
+                    // the normal app shell. Selection is the pure PipSourceLogic so it is unit-tested.
                     val activePlayer = pipController.pipPlayerState.value
-                    if (inPipMode.value && activePlayer != null) {
+                    val callSource = pipController.callSourceState.value
+                    val source = PipSourceLogic.selectSource(
+                        callActive = callSource != null,
+                        media3Active = activePlayer != null,
+                    )
+                    if (inPipMode.value && source == PipSourceLogic.PipSourceKind.CALL && callSource != null) {
+                        // CALL branch: collapse to the remote participant's live WebRTC surface. The
+                        // ConnectionService keeps audio + the peer connection alive; this View is only a
+                        // display sink, built by the call feature's factory and released cleanly on swap-out.
+                        Box(Modifier.fillMaxSize().background(Color.Black)) {
+                            AndroidView(
+                                modifier = Modifier.fillMaxSize(),
+                                factory = { ctx -> callSource.makeView(ctx) },
+                                onRelease = { view -> callSource.releaseView(view) },
+                            )
+                        }
+                    } else if (inPipMode.value && source == PipSourceLogic.PipSourceKind.MEDIA3 && activePlayer != null) {
                         Box(Modifier.fillMaxSize().background(Color.Black)) {
                             AndroidView(
                                 modifier = Modifier.fillMaxSize(),
@@ -220,7 +240,9 @@ class MainActivity : FragmentActivity() {
      */
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
-        if (pipController.videoActive && pipController.isPipSupported) {
+        // Auto-enter PiP when leaving with EITHER a playing media3 video OR a connected VIDEO call
+        // active (API 26-30 manual fallback; API 31+ the system auto-enters via setAutoEnterEnabled).
+        if ((pipController.videoActive || pipController.callActive) && pipController.isPipSupported) {
             pipController.enterPip()
         }
     }

--- a/android/app/src/main/java/com/testlogon/android/core/webrtc/ui/CallPipRenderer.kt
+++ b/android/app/src/main/java/com/testlogon/android/core/webrtc/ui/CallPipRenderer.kt
@@ -1,0 +1,102 @@
+package com.testlogon.android.core.webrtc.ui
+
+import android.content.Context
+import android.view.View
+import com.testlogon.android.data.webrtc.CallMediaHolder
+import com.testlogon.android.feature.player.CallPipSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import livekit.org.webrtc.EglBase
+import livekit.org.webrtc.RendererCommon
+import livekit.org.webrtc.SurfaceViewRenderer
+import livekit.org.webrtc.VideoTrack
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * CALL-PiP — factory seam for building the live-call [CallPipSource]. Injected into the in-call view model
+ * so it can register the call as a PiP source WITHOUT the view model depending on the EglBase-backed
+ * [CallPipRenderer] directly (keeps the view model JVM-unit-constructible with a trivial fake).
+ */
+interface CallPipSourceFactory {
+    fun source(aspectWidth: Int = 16, aspectHeight: Int = 9): CallPipSource
+}
+
+/**
+ * CALL-PiP — builds the [com.testlogon.android.feature.player.CallPipSource] used to render a LIVE video
+ * call inside the system Picture-in-Picture window.
+ *
+ * This is the NON-media3 render branch: the PiP window shows the remote participant's LiveKit
+ * [VideoTrack] via a native `SurfaceViewRenderer` (NOT an ExoPlayer/PlayerView). The renderer is created
+ * fresh when PiP is entered (factory), inits against the shared [EglBase] context (the SAME context the
+ * in-call `RealVideoRenderer` uses, so both surfaces share the GL context), and subscribes to
+ * [CallMediaHolder.remoteVideo] so it (re)binds the track as a sink whenever it is (re)created or the
+ * remote track swaps mid-call. On teardown it removes the sink and releases the SurfaceView — no leak,
+ * no black frame retained.
+ *
+ * The ConnectionService keeps audio + the WebRTC session alive independent of any View, so tearing down /
+ * rebuilding this render View across PiP-enter / config-change / return-to-fullscreen never affects the
+ * call itself; it only re-attaches a display sink to the already-live remote track.
+ */
+@Singleton
+class CallPipRenderer @Inject constructor(
+    private val eglBase: EglBase,
+    private val mediaHolder: CallMediaHolder,
+) : CallPipSourceFactory {
+
+    // Per-View scope + last-bound track, so releaseView can remove the exact sink and cancel the collector.
+    private data class Binding(val scope: CoroutineScope, @Volatile var boundTrack: VideoTrack?)
+
+    private val bindings = ConcurrentHashMap<View, Binding>()
+
+    /**
+     * Build a [CallPipSource] whose [CallPipSource.makeView] hosts a SurfaceViewRenderer bound to the live
+     * remote track, and whose [CallPipSource.releaseView] cleanly detaches + releases it. [aspectWidth]/
+     * [aspectHeight] size the floating window (defaults 16:9; the caller may pass the real negotiated size).
+     */
+    override fun source(aspectWidth: Int, aspectHeight: Int): CallPipSource = CallPipSource(
+        makeView = { ctx -> makeRenderer(ctx) },
+        releaseView = { view -> release(view) },
+        aspectWidth = aspectWidth,
+        aspectHeight = aspectHeight,
+    )
+
+    private fun makeRenderer(context: Context): View {
+        val view = SurfaceViewRenderer(context).apply {
+            init(eglBase.eglBaseContext, null)
+            setEnableHardwareScaler(true)
+            setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL)
+            setMirror(false) // remote participant is never mirrored
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val binding = Binding(scope, null)
+        bindings[view] = binding
+        // Rebind the remote track as a sink whenever it appears/changes; detach the previous one.
+        mediaHolder.remoteVideo.onEach { track ->
+            val prev = binding.boundTrack
+            if (prev !== track) {
+                if (prev != null) runCatching { prev.removeSink(view) }
+                if (track != null) runCatching { track.addSink(view) }
+                binding.boundTrack = track
+            }
+        }.launchIn(scope)
+        return view
+    }
+
+    private fun release(view: View) {
+        val binding = bindings.remove(view) ?: return
+        // Stop the track collector first so no new sink is attached during teardown.
+        binding.scope.coroutineContext[Job]?.cancel()
+        // Detach the current sink + release the SurfaceView SYNCHRONOUSLY on the calling (main) thread —
+        // releaseView is invoked from the Activity/Compose main thread when leaving PiP / ending the call.
+        val renderer = view as? SurfaceViewRenderer
+        binding.boundTrack?.let { t -> if (renderer != null) runCatching { t.removeSink(renderer) } }
+        binding.boundTrack = null
+        runCatching { renderer?.release() }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/ContactMatchHasher.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/ContactMatchHasher.kt
@@ -1,0 +1,77 @@
+package com.testlogon.android.data.contacts
+
+import java.security.MessageDigest
+import java.util.Locale
+
+/**
+ * Contacts Feature 2 — on-device normalize + hash for privacy-safe contact matching.
+ *
+ * This is the byte-for-byte mirror of the server scheme
+ * (app/services/contact_match.py + app/core/normalize.py):
+ *
+ *     id_hash = sha256( CONTACT_MATCH_SALT + ":" + normalized_identifier )   (lowercase hex)
+ *
+ *   - email: lowercased + trimmed.
+ *   - phone: E.164 (default region +1), matching the server's normalize_phone:
+ *       * strip spaces / - / ( ) / .
+ *       * a leading '+' is kept, remaining non-digits stripped -> "+<digits>"
+ *       * exactly 10 digits           -> "+1<digits>"
+ *       * 11 digits starting with '1' -> "+<digits>"
+ *       * anything else               -> INVALID (dropped)
+ *
+ * PURE Kotlin (no Android imports) so it is directly JVM-unit-testable and provably
+ * produces the same hash the server computes for the same raw input.
+ *
+ * The salt is injected (from BuildConfig.CONTACT_MATCH_SALT) so tests can pin a fixed
+ * vector without depending on the Android build config.
+ */
+class ContactMatchHasher(private val salt: String) {
+
+    /** sha256(salt + ":" + normalized) -> lowercase hex. */
+    fun hash(normalized: String): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        val digest = md.digest("$salt:$normalized".toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    /** Normalize + hash an email; null if the value is not a plausible email. */
+    fun hashEmail(raw: String?): String? {
+        val n = normalizeEmail(raw) ?: return null
+        return hash(n)
+    }
+
+    /** Normalize (E.164) + hash a phone; null if it cannot be normalized. */
+    fun hashPhone(raw: String?): String? {
+        val n = normalizePhone(raw) ?: return null
+        return hash(n)
+    }
+
+    companion object {
+        /** Lowercase + trim; must contain '@' and be <= 254 chars (mirrors normalize_email). */
+        fun normalizeEmail(raw: String?): String? {
+            val s = raw?.trim()?.lowercase(Locale.ROOT) ?: return null
+            if (s.isEmpty() || !s.contains('@') || s.length > 254) return null
+            return s
+        }
+
+        private val SEPARATORS = Regex("""[\s\-().]""")
+
+        /** Best-effort E.164 with default region +1 — mirrors server normalize_phone. */
+        fun normalizePhone(raw: String?): String? {
+            val trimmed = raw?.trim().orEmpty()
+            if (trimmed.isEmpty()) return null
+            val s2 = trimmed.replace(SEPARATORS, "")
+            if (s2.startsWith("+")) {
+                val digits = s2.substring(1).filter { it.isDigit() }
+                if (digits.isEmpty()) return null
+                return "+$digits"
+            }
+            val digits = s2.filter { it.isDigit() }
+            return when {
+                digits.length == 10 -> "+1$digits"
+                digits.length == 11 && digits.startsWith("1") -> "+$digits"
+                else -> null
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsApi.kt
@@ -1,0 +1,89 @@
+package com.testlogon.android.data.contacts
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * Feature 1 (Contacts hub) — the saved-contacts address book + "people you may know"
+ * suggestions, backed by the mounted backend router `app/routers/contacts.py`.
+ *
+ * All paths are RELATIVE (no leading slash) so the shared authenticated Retrofit's
+ * base URL + cookie/CSRF interceptors apply, exactly like every other *Api in the app.
+ */
+interface ContactsApi {
+
+    /** GET /ui/contacts — favorites-first saved contacts for the signed-in user. */
+    @GET("ui/contacts")
+    suspend fun listContacts(): ContactsListDto
+
+    /** POST /ui/contacts — save a user by id; server fills display_name/photo from their profile. */
+    @POST("ui/contacts")
+    suspend fun addContact(@Body body: AddContactDto): ContactEntryDto
+
+    /** PATCH /ui/contacts/{contactId} — toggle is_favorite / is_blocked. */
+    @PATCH("ui/contacts/{contactId}")
+    suspend fun updateContact(
+        @Path("contactId") contactId: String,
+        @Body body: UpdateContactDto,
+    ): ContactEntryDto
+
+    /** DELETE /ui/contacts/{contactId} — remove a saved contact (204). */
+    @DELETE("ui/contacts/{contactId}")
+    suspend fun deleteContact(@Path("contactId") contactId: String): Response<Unit>
+
+    /**
+     * GET /ui/contacts/suggestions — "people you may know": mutuals + follow graph +
+     * recent DM peers, excluding already-saved contacts and self. Read-only.
+     */
+    @GET("ui/contacts/suggestions")
+    suspend fun suggestions(): SuggestionsListDto
+}
+
+@JsonClass(generateAdapter = true)
+data class AddContactDto(
+    @Json(name = "user_id") val userId: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdateContactDto(
+    @Json(name = "is_favorite") val isFavorite: Boolean? = null,
+    @Json(name = "is_blocked") val isBlocked: Boolean? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ContactsListDto(
+    @Json(name = "contacts") val contacts: List<ContactEntryDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class ContactEntryDto(
+    @Json(name = "owner_id") val ownerId: String,
+    @Json(name = "contact_id") val contactId: String,
+    @Json(name = "display_name") val displayName: String,
+    @Json(name = "profile_photo_url") val profilePhotoUrl: String? = null,
+    @Json(name = "is_favorite") val isFavorite: Boolean = false,
+    @Json(name = "is_blocked") val isBlocked: Boolean = false,
+    @Json(name = "added_at") val addedAt: String = "",
+)
+
+@JsonClass(generateAdapter = true)
+data class SuggestionsListDto(
+    @Json(name = "suggestions") val suggestions: List<SuggestionCardDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class SuggestionCardDto(
+    @Json(name = "user_id") val userId: String,
+    @Json(name = "display_name") val displayName: String,
+    @Json(name = "profile_photo_url") val profilePhotoUrl: String? = null,
+    @Json(name = "hint") val hint: String = "",
+    @Json(name = "mutual_count") val mutualCount: Int = 0,
+    @Json(name = "source") val source: String = "",
+)

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsApi.kt
@@ -44,6 +44,14 @@ interface ContactsApi {
      */
     @GET("ui/contacts/suggestions")
     suspend fun suggestions(): SuggestionsListDto
+
+    /**
+     * POST /ui/contacts/match — Contacts Feature 2. Body carries ONLY hashes
+     * (sha256(salt + ":" + normalized identifier)); raw emails/phones never leave the
+     * device. Returns matched public profile cards, excluding self / already-saved / blocked.
+     */
+    @POST("ui/contacts/match")
+    suspend fun matchContacts(@Body body: ContactMatchDto): ContactMatchResultDto
 }
 
 @JsonClass(generateAdapter = true)
@@ -86,4 +94,23 @@ data class SuggestionCardDto(
     @Json(name = "hint") val hint: String = "",
     @Json(name = "mutual_count") val mutualCount: Int = 0,
     @Json(name = "source") val source: String = "",
+)
+
+@JsonClass(generateAdapter = true)
+data class ContactMatchDto(
+    @Json(name = "email_hashes") val emailHashes: List<String> = emptyList(),
+    @Json(name = "phone_hashes") val phoneHashes: List<String> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class ContactMatchResultDto(
+    @Json(name = "matches") val matches: List<ContactMatchCardDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class ContactMatchCardDto(
+    @Json(name = "user_id") val userId: String,
+    @Json(name = "display_name") val displayName: String,
+    @Json(name = "profile_photo_url") val profilePhotoUrl: String? = null,
+    @Json(name = "matched_by") val matchedBy: String = "",
 )

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsDataModule.kt
@@ -1,0 +1,35 @@
+package com.testlogon.android.data.contacts
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Provides the contacts + follow Retrofit services on the shared authenticated Retrofit. */
+@Module
+@InstallIn(SingletonComponent::class)
+object ContactsApiModule {
+
+    @Provides
+    @Singleton
+    fun provideContactsApi(retrofit: Retrofit): ContactsApi =
+        retrofit.create(ContactsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideFollowApi(retrofit: Retrofit): FollowApi =
+        retrofit.create(FollowApi::class.java)
+}
+
+/** Binds the contacts repository to its implementation. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ContactsDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindContactsRepository(impl: ContactsRepositoryImpl): ContactsRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsDataModule.kt
@@ -22,6 +22,15 @@ object ContactsApiModule {
     @Singleton
     fun provideFollowApi(retrofit: Retrofit): FollowApi =
         retrofit.create(FollowApi::class.java)
+
+    /**
+     * Feature 2 — the on-device contact-match hasher, pinned to the compile-time
+     * CONTACT_MATCH_SALT (must stay byte-identical to the backend APP_CONTACT_MATCH_SALT).
+     */
+    @Provides
+    @Singleton
+    fun provideContactMatchHasher(): ContactMatchHasher =
+        ContactMatchHasher(com.testlogon.android.BuildConfig.CONTACT_MATCH_SALT)
 }
 
 /** Binds the contacts repository to its implementation. */
@@ -32,4 +41,8 @@ abstract class ContactsDataModule {
     @Binds
     @Singleton
     abstract fun bindContactsRepository(impl: ContactsRepositoryImpl): ContactsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDeviceContactsReader(impl: DeviceContactsReaderImpl): DeviceContactsReader
 }

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsRepository.kt
@@ -1,0 +1,148 @@
+package com.testlogon.android.data.contacts
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// ── Domain models (surface-facing; DTOs stay in the Api file) ────────────────
+
+/** A saved address-book contact. */
+data class SavedContact(
+    val userId: String,
+    val displayName: String,
+    val photoUrl: String?,
+    val isFavorite: Boolean,
+    val isBlocked: Boolean,
+)
+
+/** A "people you may know" suggestion card. */
+data class ContactSuggestion(
+    val userId: String,
+    val displayName: String,
+    val photoUrl: String?,
+    val hint: String,
+    val mutualCount: Int,
+    val source: String,
+)
+
+/** Bidirectional follow relationship snapshot for the contact card. */
+data class FollowRelationship(
+    val isFollowing: Boolean,
+    val isFollowedBy: Boolean,
+    val isMutual: Boolean,
+)
+
+/**
+ * Feature 1 — Contacts data layer over [ContactsApi] + [FollowApi]. Every method returns
+ * [ApiResult] so ViewModels get a uniform success / server-failure / offline split (and a
+ * distinct offline retry affordance).
+ */
+interface ContactsRepository {
+    suspend fun listContacts(): ApiResult<List<SavedContact>>
+    suspend fun suggestions(): ApiResult<List<ContactSuggestion>>
+    suspend fun addContact(userId: String): ApiResult<SavedContact>
+    suspend fun removeContact(userId: String): ApiResult<Unit>
+    suspend fun setFavorite(userId: String, favorite: Boolean): ApiResult<SavedContact>
+
+    // Follow graph (existing social routes, newly wired on Android).
+    suspend fun follow(userId: String): ApiResult<Unit>
+    suspend fun unfollow(userId: String): ApiResult<Unit>
+    suspend fun followStatus(userId: String): ApiResult<FollowRelationship>
+}
+
+@Singleton
+class ContactsRepositoryImpl @Inject constructor(
+    private val contactsApi: ContactsApi,
+    private val followApi: FollowApi,
+    private val errorParser: ApiErrorParser,
+) : ContactsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun listContacts(): ApiResult<List<SavedContact>> = withContext(io) {
+        call { contactsApi.listContacts().contacts.map { it.toDomain() } }
+    }
+
+    override suspend fun suggestions(): ApiResult<List<ContactSuggestion>> = withContext(io) {
+        call { contactsApi.suggestions().suggestions.map { it.toDomain() } }
+    }
+
+    override suspend fun addContact(userId: String): ApiResult<SavedContact> = withContext(io) {
+        call { contactsApi.addContact(AddContactDto(userId = userId)).toDomain() }
+    }
+
+    override suspend fun removeContact(userId: String): ApiResult<Unit> = withContext(io) {
+        call { unitFrom(contactsApi.deleteContact(userId)) }
+    }
+
+    override suspend fun setFavorite(userId: String, favorite: Boolean): ApiResult<SavedContact> =
+        withContext(io) {
+            call { contactsApi.updateContact(userId, UpdateContactDto(isFavorite = favorite)).toDomain() }
+        }
+
+    override suspend fun follow(userId: String): ApiResult<Unit> = withContext(io) {
+        call { followApi.follow(FollowTargetDto(userId)); Unit }
+    }
+
+    override suspend fun unfollow(userId: String): ApiResult<Unit> = withContext(io) {
+        call { followApi.unfollow(FollowTargetDto(userId)); Unit }
+    }
+
+    override suspend fun followStatus(userId: String): ApiResult<FollowRelationship> = withContext(io) {
+        call {
+            val s = followApi.followStatus(userId)
+            FollowRelationship(
+                isFollowing = s.isFollowing,
+                isFollowedBy = s.isFollowedBy,
+                isMutual = s.isMutual,
+            )
+        }
+    }
+
+    // ── helpers (mirror BlockingRepositoryImpl's uniform error mapping) ──────
+
+    private fun unitFrom(response: Response<*>) {
+        if (!response.isSuccessful) throw HttpException(response)
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    } catch (e: IllegalArgumentException) {
+        ApiResult.Failure(ApiError(status = ApiError.STATUS_PARSE, message = "Malformed response", raw = e.message))
+    }
+}
+
+private fun ContactEntryDto.toDomain() = SavedContact(
+    userId = contactId,
+    displayName = displayName,
+    photoUrl = profilePhotoUrl,
+    isFavorite = isFavorite,
+    isBlocked = isBlocked,
+)
+
+private fun SuggestionCardDto.toDomain() = ContactSuggestion(
+    userId = userId,
+    displayName = displayName,
+    photoUrl = profilePhotoUrl,
+    hint = hint,
+    mutualCount = mutualCount,
+    source = source,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/ContactsRepository.kt
@@ -35,6 +35,15 @@ data class ContactSuggestion(
     val source: String,
 )
 
+/** A device-address-book match (Feature 2). */
+data class ContactMatch(
+    val userId: String,
+    val displayName: String,
+    val photoUrl: String?,
+    /** Which identifier matched: "email" or "phone" (for the UI label). */
+    val matchedBy: String,
+)
+
 /** Bidirectional follow relationship snapshot for the contact card. */
 data class FollowRelationship(
     val isFollowing: Boolean,
@@ -54,6 +63,13 @@ interface ContactsRepository {
     suspend fun removeContact(userId: String): ApiResult<Unit>
     suspend fun setFavorite(userId: String, favorite: Boolean): ApiResult<SavedContact>
 
+    /**
+     * Feature 2 — read the device address book, hash every email/phone ON-DEVICE, and match
+     * against platform users. Raw contacts NEVER leave the device (only hashes are sent).
+     * Requires READ_CONTACTS to already be granted.
+     */
+    suspend fun matchDeviceContacts(): ApiResult<List<ContactMatch>>
+
     // Follow graph (existing social routes, newly wired on Android).
     suspend fun follow(userId: String): ApiResult<Unit>
     suspend fun unfollow(userId: String): ApiResult<Unit>
@@ -64,6 +80,8 @@ interface ContactsRepository {
 class ContactsRepositoryImpl @Inject constructor(
     private val contactsApi: ContactsApi,
     private val followApi: FollowApi,
+    private val deviceContactsReader: DeviceContactsReader,
+    private val hasher: ContactMatchHasher,
     private val errorParser: ApiErrorParser,
 ) : ContactsRepository {
 
@@ -89,6 +107,43 @@ class ContactsRepositoryImpl @Inject constructor(
         withContext(io) {
             call { contactsApi.updateContact(userId, UpdateContactDto(isFavorite = favorite)).toDomain() }
         }
+
+    override suspend fun matchDeviceContacts(): ApiResult<List<ContactMatch>> = withContext(io) {
+        call {
+            val ids = deviceContactsReader.read()
+            // Hash on-device; drop un-normalizable values; dedupe.
+            val emailHashes = ids.emails.mapNotNull { hasher.hashEmail(it) }.distinct()
+            val phoneHashes = ids.phones.mapNotNull { hasher.hashPhone(it) }.distinct()
+            if (emailHashes.isEmpty() && phoneHashes.isEmpty()) {
+                emptyList()
+            } else {
+                // Cap/batch so a huge address book never exceeds the server's per-field cap.
+                val cap = MATCH_HASH_BATCH
+                val seen = LinkedHashMap<String, ContactMatch>()
+                val emailBatches = emailHashes.chunked(cap)
+                val phoneBatches = phoneHashes.chunked(cap)
+                val rounds = maxOf(emailBatches.size, phoneBatches.size, 1)
+                for (i in 0 until rounds) {
+                    val body = ContactMatchDto(
+                        emailHashes = emailBatches.getOrElse(i) { emptyList() },
+                        phoneHashes = phoneBatches.getOrElse(i) { emptyList() },
+                    )
+                    if (body.emailHashes.isEmpty() && body.phoneHashes.isEmpty()) continue
+                    val res = contactsApi.matchContacts(body)
+                    for (c in res.matches) {
+                        // First occurrence wins; email label preferred if it appears.
+                        val existing = seen[c.userId]
+                        if (existing == null) {
+                            seen[c.userId] = c.toDomain()
+                        } else if (existing.matchedBy != "email" && c.matchedBy == "email") {
+                            seen[c.userId] = c.toDomain()
+                        }
+                    }
+                }
+                seen.values.sortedBy { it.displayName.lowercase() }
+            }
+        }
+    }
 
     override suspend fun follow(userId: String): ApiResult<Unit> = withContext(io) {
         call { followApi.follow(FollowTargetDto(userId)); Unit }
@@ -129,6 +184,15 @@ class ContactsRepositoryImpl @Inject constructor(
         ApiResult.Failure(ApiError(status = ApiError.STATUS_PARSE, message = "Malformed response", raw = e.message))
     }
 }
+
+private const val MATCH_HASH_BATCH = 1000
+
+private fun ContactMatchCardDto.toDomain() = ContactMatch(
+    userId = userId,
+    displayName = displayName,
+    photoUrl = profilePhotoUrl,
+    matchedBy = matchedBy,
+)
 
 private fun ContactEntryDto.toDomain() = SavedContact(
     userId = contactId,

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/DeviceContactsReader.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/DeviceContactsReader.kt
@@ -1,0 +1,67 @@
+package com.testlogon.android.data.contacts
+
+import android.content.Context
+import android.provider.ContactsContract
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Raw identifiers read from the device address book (stays ON the device). */
+data class DeviceContactIdentifiers(
+    val emails: Set<String>,
+    val phones: Set<String>,
+)
+
+/**
+ * Contacts Feature 2 — reads the native Android address book via ContactsContract and
+ * returns the raw email + phone strings. Callers MUST hash these on-device (via
+ * [ContactMatchHasher]) before anything leaves the device; the raw strings are never
+ * uploaded.
+ *
+ * Behind an interface so the sync ViewModel is JVM-unit-testable with a fake reader.
+ */
+interface DeviceContactsReader {
+    /** Requires READ_CONTACTS to already be granted; runs off the main thread. */
+    suspend fun read(): DeviceContactIdentifiers
+}
+
+@Singleton
+class DeviceContactsReaderImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : DeviceContactsReader {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun read(): DeviceContactIdentifiers = withContext(io) {
+        val emails = LinkedHashSet<String>()
+        val phones = LinkedHashSet<String>()
+        val resolver = context.contentResolver
+
+        resolver.query(
+            ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+            arrayOf(ContactsContract.CommonDataKinds.Email.ADDRESS),
+            null, null, null,
+        )?.use { c ->
+            val col = c.getColumnIndex(ContactsContract.CommonDataKinds.Email.ADDRESS)
+            if (col >= 0) while (c.moveToNext()) {
+                c.getString(col)?.trim()?.takeIf { it.isNotEmpty() }?.let { emails += it }
+            }
+        }
+
+        resolver.query(
+            ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+            arrayOf(ContactsContract.CommonDataKinds.Phone.NUMBER),
+            null, null, null,
+        )?.use { c ->
+            val col = c.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER)
+            if (col >= 0) while (c.moveToNext()) {
+                c.getString(col)?.trim()?.takeIf { it.isNotEmpty() }?.let { phones += it }
+            }
+        }
+
+        DeviceContactIdentifiers(emails = emails, phones = phones)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/contacts/FollowApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/contacts/FollowApi.kt
@@ -1,0 +1,56 @@
+package com.testlogon.android.data.contacts
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * Thin client for the EXISTING social follow graph (`app/routers/social.py`):
+ * follow / unfollow + bidirectional follow-status. The Android app already had
+ * BlockApi but no follow wiring — this closes that gap for the Contacts card.
+ */
+interface FollowApi {
+
+    /** POST /ui/social/follow */
+    @POST("ui/social/follow")
+    suspend fun follow(@Body body: FollowTargetDto): FollowActionDto
+
+    /** POST /ui/social/unfollow */
+    @POST("ui/social/unfollow")
+    suspend fun unfollow(@Body body: FollowTargetDto): UnfollowActionDto
+
+    /** GET /ui/social/status/{targetUserId} — is_following / is_followed_by / is_mutual (+block). */
+    @GET("ui/social/status/{targetUserId}")
+    suspend fun followStatus(@Path("targetUserId") targetUserId: String): FollowStatusDto
+}
+
+@JsonClass(generateAdapter = true)
+data class FollowTargetDto(
+    @Json(name = "target_user_id") val targetUserId: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class FollowActionDto(
+    @Json(name = "ok") val ok: Boolean = false,
+    @Json(name = "status") val status: String = "",
+    @Json(name = "follower_count") val followerCount: Int = 0,
+    @Json(name = "following_count") val followingCount: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class UnfollowActionDto(
+    @Json(name = "ok") val ok: Boolean = false,
+    @Json(name = "status") val status: String = "",
+)
+
+@JsonClass(generateAdapter = true)
+data class FollowStatusDto(
+    @Json(name = "is_following") val isFollowing: Boolean = false,
+    @Json(name = "is_followed_by") val isFollowedBy: Boolean = false,
+    @Json(name = "is_mutual") val isMutual: Boolean = false,
+    @Json(name = "is_blocked_by_me") val isBlockedByMe: Boolean = false,
+    @Json(name = "is_blocking_me") val isBlockingMe: Boolean = false,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/webrtc/WebRtcDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/webrtc/WebRtcDataModule.kt
@@ -54,6 +54,13 @@ object WebRtcApiModule {
 @InstallIn(SingletonComponent::class)
 abstract class WebRtcDataModule {
 
+    /** CALL-PiP — the live-call PiP source factory is the real [CallPipRenderer]. */
+    @Binds
+    abstract fun bindCallPipSourceFactory(
+        impl: com.testlogon.android.core.webrtc.ui.CallPipRenderer,
+    ): com.testlogon.android.core.webrtc.ui.CallPipSourceFactory
+
+
     // ── Implementable (real backend endpoints) ──────────────────────────────────────────────────
 
     @Binds

--- a/android/app/src/main/java/com/testlogon/android/feature/call/incall/InCallScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/call/incall/InCallScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,6 +82,8 @@ import com.testlogon.android.feature.messaging.thread.ThreadRoute
 import com.testlogon.android.feature.messaging.thread.ThreadViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.R
+import com.testlogon.android.feature.player.LocalPipController
+import com.testlogon.android.feature.player.PipSourceLogic
 import com.testlogon.android.core.webrtc.ui.LocalVideoPreview
 import com.testlogon.android.core.webrtc.ui.RemoteVideoView
 import com.testlogon.android.core.webrtc.ui.VideoRenderer
@@ -111,8 +114,38 @@ fun InCallRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val recording by viewModel.recordingState.collectAsStateWithLifecycle()
     val chatState by chatViewModel.state.collectAsStateWithLifecycle()
+    // CALL-PiP — resolved up front so the terminal effect can also leave PiP on end.
+    val pipController = LocalPipController.current
     LaunchedEffect(viewModel) {
-        viewModel.callEnded.collect { onCallEnded() }
+        viewModel.callEnded.collect {
+            // If the call ends while floating in PiP, leave PiP so the user returns to the app cleanly.
+            pipController.exitPip()
+            onCallEnded()
+        }
+    }
+
+    // CALL-PiP — register the ACTIVE VIDEO CALL as the PiP source so leaving the app (Home) floats the
+    // live remote video FaceTime-style. Guarded on a CONNECTED VIDEO call (audio-only / not-yet-connected
+    // never register — nothing to show, so PiP stays a no-op and the call keeps running in the
+    // ConnectionService). The source is unregistered when the call ends or the screen leaves composition.
+    val callPipEligible = PipSourceLogic.isCallPipEligible(
+        isVideoCall = state.isVideoCall,
+        isConnected = state.lifecycle == InCallLifecycle.Connected,
+    )
+    DisposableEffect(callPipEligible) {
+        if (callPipEligible) {
+            pipController.setCallSource(viewModel.buildCallPipSource())
+            pipController.setCallActive(true)
+        } else {
+            pipController.setCallActive(false)
+            pipController.setCallSource(null)
+        }
+        onDispose {
+            // Leaving the in-call screen (nav pop / process teardown) must always drop the call source so
+            // a later media3 PiP is not shadowed by a stale call surface.
+            pipController.setCallActive(false)
+            pipController.setCallSource(null)
+        }
     }
 
     // AND-302: RECORD_AUDIO is requested just-in-time on the requester side; only kick off the record

--- a/android/app/src/main/java/com/testlogon/android/feature/call/incall/InCallViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/call/incall/InCallViewModel.kt
@@ -48,6 +48,7 @@ class InCallViewModel @Inject constructor(
     private val statsSampler: CallStatsSampler,
     private val recordingController: RecordingController,
     private val callMediaHolder: com.testlogon.android.data.webrtc.CallMediaHolder,
+    private val callPipSourceFactory: com.testlogon.android.core.webrtc.ui.CallPipSourceFactory,
     private val clock: com.testlogon.android.core.data.cache.Clock,
     private val savedState: SavedStateHandle,
     // The real native-WebRTC renderer (RealVideoRenderer) bound in WebRtcApiModule; the screen passes it
@@ -203,6 +204,16 @@ class InCallViewModel @Inject constructor(
     }
 
     private fun isVideoCall(): Boolean = callManager.state.value.call?.mode == CallMode.VIDEO
+
+    /**
+     * CALL-PiP — build the [com.testlogon.android.feature.player.CallPipSource] for the active video call.
+     * The renderer factory (in [callPipRenderer]) hosts a SurfaceViewRenderer bound to the live remote
+     * track; the ConnectionService owns audio + the peer connection, so this View is a pure display sink.
+     * Registered by the in-call screen while the call is a CONNECTED VIDEO call. 16:9 default aspect (a
+     * real negotiated size can be threaded through once the remote track reports one).
+     */
+    fun buildCallPipSource(): com.testlogon.android.feature.player.CallPipSource =
+        callPipSourceFactory.source()
 
     private fun hasMultipleCameras(): Boolean = true
 

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactCardScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactCardScreen.kt
@@ -1,0 +1,300 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.contacts
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.filled.VolunteerActivism
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+
+/** Feature 1 — stable test tags for the contact card. */
+object ContactCardTestTags {
+    const val SCREEN = "contact_card_screen"
+    const val MESSAGE = "contact_card_message"
+    const val CALL_AUDIO = "contact_card_call_audio"
+    const val CALL_VIDEO = "contact_card_call_video"
+    const val FOLLOW = "contact_card_follow"
+    const val TIP = "contact_card_tip"
+    const val SAVE = "contact_card_save"
+    const val FAVORITE = "contact_card_favorite"
+    const val PROFILE = "contact_card_profile"
+}
+
+/**
+ * Feature 1 — the contact detail card. Reachable from the Contacts hub, from a suggestion, and
+ * (via "View contact") from a conversation. Actions: Message, Audio/Video call, Follow/unfollow,
+ * Tip, Save/Remove + favorite, View full profile.
+ */
+@Composable
+fun ContactCardRoute(
+    onOpenThread: (conversationId: String) -> Unit,
+    onPlaceCall: (route: String) -> Unit,
+    onOpenFullProfile: (userId: String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ContactCardViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is ContactCardEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.message)
+                is ContactCardEvent.OpenThread -> onOpenThread(event.conversationId)
+                is ContactCardEvent.PlaceCall -> onPlaceCall(event.route)
+                is ContactCardEvent.OpenFullProfile -> onOpenFullProfile(event.userId)
+            }
+        }
+    }
+
+    ContactCardScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onRetry = viewModel::load,
+        onMessage = viewModel::onMessage,
+        onAudioCall = { viewModel.onCall(video = false) },
+        onVideoCall = { viewModel.onCall(video = true) },
+        onToggleFollow = viewModel::onToggleFollow,
+        onTip = viewModel::onViewFullProfile,
+        onToggleSaved = viewModel::onToggleSaved,
+        onToggleFavorite = viewModel::onToggleFavorite,
+        onViewProfile = viewModel::onViewFullProfile,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ContactCardScreen(
+    state: ContactCardUiState,
+    snackbarHostState: androidx.compose.material3.SnackbarHostState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onMessage: () -> Unit,
+    onAudioCall: () -> Unit,
+    onVideoCall: () -> Unit,
+    onToggleFollow: () -> Unit,
+    onTip: () -> Unit,
+    onToggleSaved: () -> Unit,
+    onToggleFavorite: () -> Unit,
+    onViewProfile: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(ContactCardTestTags.SCREEN),
+        topBar = {
+            androidx.compose.material3.TopAppBar(
+                title = { Text("Contact") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { androidx.compose.material3.SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        when (state) {
+            is ContactCardUiState.Loading ->
+                LoadingState(modifier = Modifier.padding(padding).fillMaxSize())
+
+            is ContactCardUiState.Error ->
+                ErrorState(message = state.message, onRetry = onRetry, modifier = Modifier.padding(padding).fillMaxSize())
+
+            is ContactCardUiState.Content -> {
+                val data = state.data
+                val enabled = !state.actionInFlight
+                Column(
+                    modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    BigAvatar(data.displayName)
+                    Text(
+                        text = data.displayName,
+                        style = MaterialTheme.typography.headlineSmall,
+                        textAlign = TextAlign.Center,
+                    )
+                    val relationship = when {
+                        data.isMutual -> "You follow each other"
+                        data.isFollowing -> "You follow them"
+                        else -> null
+                    }
+                    if (relationship != null) {
+                        Text(
+                            text = relationship,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    // Primary: Message.
+                    Button(
+                        onClick = onMessage,
+                        enabled = enabled,
+                        modifier = Modifier.fillMaxWidth().testTag(ContactCardTestTags.MESSAGE),
+                    ) {
+                        Icon(Icons.Filled.Chat, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Text("Message", modifier = Modifier.padding(start = 8.dp))
+                    }
+
+                    // Calls (audio + video) side by side.
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        OutlinedButton(
+                            onClick = onAudioCall,
+                            enabled = enabled,
+                            modifier = Modifier.weight(1f).testTag(ContactCardTestTags.CALL_AUDIO),
+                        ) {
+                            Icon(Icons.Filled.Call, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Text("Call", modifier = Modifier.padding(start = 8.dp))
+                        }
+                        OutlinedButton(
+                            onClick = onVideoCall,
+                            enabled = enabled,
+                            modifier = Modifier.weight(1f).testTag(ContactCardTestTags.CALL_VIDEO),
+                        ) {
+                            Icon(Icons.Filled.Videocam, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Text("Video", modifier = Modifier.padding(start = 8.dp))
+                        }
+                    }
+
+                    // Follow / unfollow.
+                    OutlinedButton(
+                        onClick = onToggleFollow,
+                        enabled = enabled,
+                        modifier = Modifier.fillMaxWidth().testTag(ContactCardTestTags.FOLLOW),
+                    ) {
+                        Text(if (data.isFollowing) "Unfollow" else "Follow")
+                    }
+
+                    // Tip (routes into the full profile's tip surface).
+                    OutlinedButton(
+                        onClick = onTip,
+                        enabled = enabled,
+                        modifier = Modifier.fillMaxWidth().testTag(ContactCardTestTags.TIP),
+                    ) {
+                        Icon(Icons.Filled.VolunteerActivism, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Text("Tip", modifier = Modifier.padding(start = 8.dp))
+                    }
+
+                    // Save / remove contact + favorite.
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        OutlinedButton(
+                            onClick = onToggleSaved,
+                            enabled = enabled,
+                            modifier = Modifier.weight(1f).testTag(ContactCardTestTags.SAVE),
+                        ) {
+                            Icon(
+                                if (data.isSaved) Icons.Filled.PersonRemove else Icons.Filled.PersonAdd,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(
+                                if (data.isSaved) "Remove" else "Save",
+                                modifier = Modifier.padding(start = 8.dp),
+                            )
+                        }
+                        if (data.isSaved) {
+                            IconButton(
+                                onClick = onToggleFavorite,
+                                enabled = enabled,
+                                modifier = Modifier.testTag(ContactCardTestTags.FAVORITE),
+                            ) {
+                                if (data.isFavorite) {
+                                    Icon(Icons.Filled.Star, contentDescription = "Unfavorite", tint = MaterialTheme.colorScheme.primary)
+                                } else {
+                                    Icon(Icons.Outlined.StarBorder, contentDescription = "Favorite")
+                                }
+                            }
+                        }
+                    }
+
+                    // View full profile (deep-links to the public profile surface).
+                    OutlinedButton(
+                        onClick = onViewProfile,
+                        enabled = enabled,
+                        modifier = Modifier.fillMaxWidth().testTag(ContactCardTestTags.PROFILE),
+                    ) {
+                        Icon(Icons.Filled.OpenInNew, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Text("View full profile", modifier = Modifier.padding(start = 8.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BigAvatar(displayName: String) {
+    val initials = displayName.trim()
+        .split(Regex("\\s+"))
+        .filter { it.isNotEmpty() }
+        .take(2)
+        .joinToString("") { it.first().uppercase() }
+        .ifBlank { "?" }
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = Modifier.size(96.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = initials,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactCardViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactCardViewModel.kt
@@ -1,0 +1,251 @@
+package com.testlogon.android.feature.contacts
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.contacts.ContactsRepository
+import com.testlogon.android.data.profile.ProfileApi
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** Loaded contact-card data + the live relationship flags that drive the action buttons. */
+data class ContactCardData(
+    val userId: String,
+    val displayName: String,
+    val photoUrl: String?,
+    val isFollowing: Boolean,
+    val isMutual: Boolean,
+    val isSaved: Boolean,
+    val isFavorite: Boolean,
+)
+
+sealed interface ContactCardUiState {
+    data object Loading : ContactCardUiState
+    data class Content(val data: ContactCardData, val actionInFlight: Boolean = false) : ContactCardUiState
+    data class Error(val message: String, val offline: Boolean) : ContactCardUiState
+}
+
+sealed interface ContactCardEvent {
+    data class ShowSnackbar(val message: String) : ContactCardEvent
+    data class OpenThread(val conversationId: String) : ContactCardEvent
+    data class PlaceCall(val route: String) : ContactCardEvent
+    data class OpenFullProfile(val userId: String) : ContactCardEvent
+}
+
+/**
+ * Feature 1 — the contact detail card. Loads the peer's public identity + follow relationship +
+ * whether they're already saved, then wires the action set: Message, Audio/Video call, Follow/
+ * unfollow, Save/Remove + favorite, and (delegated to the full profile surface) Tip + View profile.
+ *
+ * Message/Call resolve a conversation via the messaging DM find-or-create rail so the same
+ * conversation backs both the thread and the 1:1 call — reusing the app's existing money/call paths
+ * rather than duplicating them.
+ */
+@HiltViewModel
+class ContactCardViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val contactsRepository: ContactsRepository,
+    private val messagingRepository: com.testlogon.android.data.messaging.MessagingRepository,
+    private val profileApi: ProfileApi,
+) : ViewModel() {
+
+    val userId: String = requireNotNull(savedStateHandle.get<String>(ARG_USER_ID)) {
+        "ContactCard requires a $ARG_USER_ID argument"
+    }
+
+    private val _state = MutableStateFlow<ContactCardUiState>(ContactCardUiState.Loading)
+    val state: StateFlow<ContactCardUiState> = _state.asStateFlow()
+
+    private val _events = Channel<ContactCardEvent>(Channel.BUFFERED)
+    val events: Flow<ContactCardEvent> = _events.receiveAsFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _state.value = ContactCardUiState.Loading
+
+            // Identity (name + photo) — best-effort; the card still works if this 404s.
+            var displayName = userId
+            var photoUrl: String? = null
+            runCatching { profileApi.getProfileByIdentifier(userId) }.getOrNull()?.let { dto ->
+                displayName = dto.profile.displayName
+                    ?: listOfNotNull(dto.profile.firstName, dto.profile.lastName)
+                        .joinToString(" ").ifBlank { null }
+                    ?: dto.identifier
+                photoUrl = dto.profile.profilePhotoUrl
+            }
+
+            // Follow relationship (authoritative for the Follow button).
+            var following = false
+            var mutual = false
+            when (val rel = contactsRepository.followStatus(userId)) {
+                is ApiResult.Success -> {
+                    following = rel.data.isFollowing
+                    mutual = rel.data.isMutual
+                }
+                is ApiResult.Failure -> Unit
+                is ApiResult.NetworkError -> {
+                    _state.value = ContactCardUiState.Error("You appear to be offline.", offline = true)
+                    return@launch
+                }
+            }
+
+            // Saved / favorite state (from the address book).
+            var saved = false
+            var favorite = false
+            when (val list = contactsRepository.listContacts()) {
+                is ApiResult.Success -> list.data.firstOrNull { it.userId == userId }?.let {
+                    saved = true
+                    favorite = it.isFavorite
+                }
+                is ApiResult.Failure -> Unit
+                is ApiResult.NetworkError -> Unit
+            }
+
+            _state.value = ContactCardUiState.Content(
+                ContactCardData(
+                    userId = userId,
+                    displayName = displayName,
+                    photoUrl = photoUrl,
+                    isFollowing = following,
+                    isMutual = mutual,
+                    isSaved = saved,
+                    isFavorite = favorite,
+                ),
+            )
+        }
+    }
+
+    fun onMessage() {
+        val data = content()?.data ?: return
+        withInFlight {
+            when (val result = messagingRepository.findOrCreateDm(data.userId)) {
+                is ApiResult.Success -> _events.trySend(ContactCardEvent.OpenThread(result.data.id))
+                is ApiResult.Failure -> emitSnack(result.error.message)
+                is ApiResult.NetworkError -> emitSnack("Couldn't open chat — you're offline.")
+            }
+        }
+    }
+
+    fun onCall(video: Boolean) {
+        val data = content()?.data ?: return
+        withInFlight {
+            when (val result = messagingRepository.findOrCreateDm(data.userId)) {
+                is ApiResult.Success -> {
+                    val route = com.testlogon.android.feature.call.nav.CallRoutes.outgoing(
+                        conversationId = result.data.id,
+                        calleeUserId = data.userId,
+                        mode = if (video) com.testlogon.android.data.call.CallMode.VIDEO.wire
+                        else com.testlogon.android.data.call.CallMode.AUDIO.wire,
+                        peerName = data.displayName,
+                    )
+                    _events.trySend(ContactCardEvent.PlaceCall(route))
+                }
+                is ApiResult.Failure -> emitSnack(result.error.message)
+                is ApiResult.NetworkError -> emitSnack("Couldn't start call — you're offline.")
+            }
+        }
+    }
+
+    fun onToggleFollow() {
+        val data = content()?.data ?: return
+        val wantFollow = !data.isFollowing
+        // Optimistic flip.
+        updateData { it.copy(isFollowing = wantFollow, isMutual = if (wantFollow) it.isMutual else false) }
+        viewModelScope.launch {
+            val result = if (wantFollow) contactsRepository.follow(data.userId)
+            else contactsRepository.unfollow(data.userId)
+            when (result) {
+                is ApiResult.Success -> emitSnack(if (wantFollow) "Following" else "Unfollowed")
+                is ApiResult.Failure -> {
+                    updateData { it.copy(isFollowing = data.isFollowing, isMutual = data.isMutual) }
+                    emitSnack(result.error.message)
+                }
+                is ApiResult.NetworkError -> {
+                    updateData { it.copy(isFollowing = data.isFollowing, isMutual = data.isMutual) }
+                    emitSnack("Couldn't update — you're offline.")
+                }
+            }
+        }
+    }
+
+    fun onToggleSaved() {
+        val data = content()?.data ?: return
+        if (data.isSaved) {
+            updateData { it.copy(isSaved = false, isFavorite = false) }
+            viewModelScope.launch {
+                when (val result = contactsRepository.removeContact(data.userId)) {
+                    is ApiResult.Success -> emitSnack("Removed from contacts")
+                    is ApiResult.Failure -> { updateData { it.copy(isSaved = true, isFavorite = data.isFavorite) }; emitSnack(result.error.message) }
+                    is ApiResult.NetworkError -> { updateData { it.copy(isSaved = true, isFavorite = data.isFavorite) }; emitSnack("Couldn't remove — you're offline.") }
+                }
+            }
+        } else {
+            updateData { it.copy(isSaved = true) }
+            viewModelScope.launch {
+                when (val result = contactsRepository.addContact(data.userId)) {
+                    is ApiResult.Success -> emitSnack("Added to contacts")
+                    is ApiResult.Failure -> { updateData { it.copy(isSaved = false) }; emitSnack(result.error.message) }
+                    is ApiResult.NetworkError -> { updateData { it.copy(isSaved = false) }; emitSnack("Couldn't add — you're offline.") }
+                }
+            }
+        }
+    }
+
+    fun onToggleFavorite() {
+        val data = content()?.data ?: return
+        if (!data.isSaved) return // can only favorite a saved contact
+        val want = !data.isFavorite
+        updateData { it.copy(isFavorite = want) }
+        viewModelScope.launch {
+            when (val result = contactsRepository.setFavorite(data.userId, want)) {
+                is ApiResult.Success -> Unit
+                is ApiResult.Failure -> { updateData { it.copy(isFavorite = data.isFavorite) }; emitSnack(result.error.message) }
+                is ApiResult.NetworkError -> { updateData { it.copy(isFavorite = data.isFavorite) }; emitSnack("Couldn't update favorite — you're offline.") }
+            }
+        }
+    }
+
+    fun onViewFullProfile() {
+        _events.trySend(ContactCardEvent.OpenFullProfile(userId))
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private fun content(): ContactCardUiState.Content? = _state.value as? ContactCardUiState.Content
+
+    private fun updateData(transform: (ContactCardData) -> ContactCardData) {
+        _state.update { s -> if (s is ContactCardUiState.Content) s.copy(data = transform(s.data)) else s }
+    }
+
+    private fun withInFlight(block: suspend () -> Unit) {
+        _state.update { if (it is ContactCardUiState.Content) it.copy(actionInFlight = true) else it }
+        viewModelScope.launch {
+            try {
+                block()
+            } finally {
+                _state.update { if (it is ContactCardUiState.Content) it.copy(actionInFlight = false) else it }
+            }
+        }
+    }
+
+    private fun emitSnack(message: String) {
+        _events.trySend(ContactCardEvent.ShowSnackbar(message))
+    }
+
+    companion object {
+        const val ARG_USER_ID = "userId"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubScreen.kt
@@ -1,0 +1,284 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.contacts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+
+/** Feature 1 — stable test tags for the Contacts hub. */
+object ContactsHubTestTags {
+    const val SCREEN = "contacts_hub_screen"
+    const val CONTACTS_SECTION = "contacts_hub_saved"
+    const val SUGGESTIONS_SECTION = "contacts_hub_suggestions"
+    fun contactRow(userId: String) = "contacts_hub_contact_$userId"
+    fun suggestionRow(userId: String) = "contacts_hub_suggestion_$userId"
+    fun favorite(userId: String) = "contacts_hub_fav_$userId"
+    fun addSuggestion(userId: String) = "contacts_hub_add_$userId"
+}
+
+/**
+ * Feature 1 — route-level Contacts hub: a favorites-first saved address book PLUS a
+ * "people you may know" section. Reached from the More hub and from the conversation list.
+ */
+@Composable
+fun ContactsHubRoute(
+    onOpenContactCard: (userId: String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ContactsHubViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is ContactsHubEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.message)
+                is ContactsHubEvent.OpenContactCard -> onOpenContactCard(event.userId)
+            }
+        }
+    }
+
+    ContactsHubScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onRetry = { viewModel.refresh() },
+        onOpenContact = viewModel::onOpenContact,
+        onToggleFavorite = viewModel::onToggleFavorite,
+        onSaveSuggestion = viewModel::onSaveSuggestion,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ContactsHubScreen(
+    state: ContactsHubUiState,
+    snackbarHostState: androidx.compose.material3.SnackbarHostState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onOpenContact: (String) -> Unit,
+    onToggleFavorite: (String, Boolean) -> Unit,
+    onSaveSuggestion: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(ContactsHubTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Contacts") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { androidx.compose.material3.SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        when (state) {
+            is ContactsHubUiState.Loading ->
+                LoadingState(modifier = Modifier.padding(padding).fillMaxSize())
+
+            is ContactsHubUiState.Error ->
+                ErrorState(
+                    message = state.message,
+                    onRetry = onRetry,
+                    modifier = Modifier.padding(padding).fillMaxSize(),
+                )
+
+            is ContactsHubUiState.Content -> {
+                if (state.isFullyEmpty) {
+                    EmptyState(
+                        title = "No contacts yet",
+                        body = "Save people you message or follow to build your address book.",
+                        modifier = Modifier.padding(padding).fillMaxSize(),
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.padding(padding).fillMaxSize(),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 8.dp),
+                    ) {
+                        if (state.contacts.isNotEmpty()) {
+                            item { SectionHeader("Saved contacts", ContactsHubTestTags.CONTACTS_SECTION) }
+                            items(state.contacts, key = { it.userId }) { row ->
+                                ContactRowItem(
+                                    row = row,
+                                    onOpen = { onOpenContact(row.userId) },
+                                    onToggleFavorite = { onToggleFavorite(row.userId, !row.isFavorite) },
+                                )
+                            }
+                        }
+                        if (state.suggestions.isNotEmpty()) {
+                            item { SectionHeader("People you may know", ContactsHubTestTags.SUGGESTIONS_SECTION) }
+                            items(state.suggestions, key = { it.userId }) { row ->
+                                SuggestionRowItem(
+                                    row = row,
+                                    onOpen = { onOpenContact(row.userId) },
+                                    onAdd = { onSaveSuggestion(row.userId) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String, tag: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag(tag),
+    )
+}
+
+@Composable
+private fun ContactRowItem(
+    row: ContactRow,
+    onOpen: () -> Unit,
+    onToggleFavorite: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onOpen)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .testTag(ContactsHubTestTags.contactRow(row.userId)),
+    ) {
+        InitialsAvatar(row.displayName)
+        Column(modifier = Modifier.weight(1f).padding(start = 12.dp)) {
+            Text(
+                text = row.displayName,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        IconButton(
+            onClick = onToggleFavorite,
+            modifier = Modifier.testTag(ContactsHubTestTags.favorite(row.userId)),
+        ) {
+            if (row.isFavorite) {
+                Icon(Icons.Filled.Star, contentDescription = "Unfavorite", tint = MaterialTheme.colorScheme.primary)
+            } else {
+                Icon(Icons.Outlined.StarBorder, contentDescription = "Favorite")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuggestionRowItem(
+    row: SuggestionRow,
+    onOpen: () -> Unit,
+    onAdd: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onOpen)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .testTag(ContactsHubTestTags.suggestionRow(row.userId)),
+    ) {
+        InitialsAvatar(row.displayName)
+        Column(modifier = Modifier.weight(1f).padding(start = 12.dp)) {
+            Text(
+                text = row.displayName,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (row.hint.isNotBlank()) {
+                Text(
+                    text = row.hint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        if (row.adding) {
+            CircularProgressIndicator(modifier = Modifier.size(20.dp))
+        } else {
+            TextButton(
+                onClick = onAdd,
+                modifier = Modifier.testTag(ContactsHubTestTags.addSuggestion(row.userId)),
+            ) {
+                Icon(Icons.Filled.PersonAdd, contentDescription = null, modifier = Modifier.size(18.dp))
+                Text("Add", modifier = Modifier.padding(start = 6.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun InitialsAvatar(displayName: String) {
+    val initials = displayName.trim()
+        .split(Regex("\\s+"))
+        .filter { it.isNotEmpty() }
+        .take(2)
+        .joinToString("") { it.first().uppercase() }
+        .ifBlank { "?" }
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = Modifier.size(40.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = initials,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubScreen.kt
@@ -2,6 +2,23 @@
 
 package com.testlogon.android.feature.contacts
 
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.filled.PersonSearch
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,6 +70,13 @@ object ContactsHubTestTags {
     fun suggestionRow(userId: String) = "contacts_hub_suggestion_$userId"
     fun favorite(userId: String) = "contacts_hub_fav_$userId"
     fun addSuggestion(userId: String) = "contacts_hub_add_$userId"
+
+    // Feature 2 — device contact sync.
+    const val FIND_PEOPLE_BUTTON = "contacts_hub_find_people"
+    const val MATCH_SECTION = "contacts_hub_matches"
+    const val SYNC_PROGRESS = "contacts_hub_sync_progress"
+    fun matchRow(userId: String) = "contacts_hub_match_$userId"
+    fun addMatch(userId: String) = "contacts_hub_addmatch_$userId"
 }
 
 /**
@@ -67,7 +91,9 @@ fun ContactsHubRoute(
     viewModel: ContactsHubViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val matchState by viewModel.matchState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -78,14 +104,57 @@ fun ContactsHubRoute(
         }
     }
 
+    // Feature 2 — runtime READ_CONTACTS request behind the explicit "Find people you know" action.
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            viewModel.onPermissionGranted()
+        } else {
+            val activity = context as? Activity
+            // If we can no longer show a rationale after a denial, it's permanently denied.
+            val permanently = activity != null &&
+                !ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_CONTACTS)
+            viewModel.onPermissionDenied(permanentlyDenied = permanently)
+        }
+    }
+
+    val requestFindPeople: () -> Unit = {
+        val already = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.READ_CONTACTS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (already) viewModel.onPermissionGranted()
+        else permissionLauncher.launch(Manifest.permission.READ_CONTACTS)
+    }
+
     ContactsHubScreen(
         state = state,
+        matchState = matchState,
         snackbarHostState = snackbarHostState,
         onBack = onBack,
         onRetry = { viewModel.refresh() },
         onOpenContact = viewModel::onOpenContact,
         onToggleFavorite = viewModel::onToggleFavorite,
         onSaveSuggestion = viewModel::onSaveSuggestion,
+        onFindPeople = requestFindPeople,
+        onRetrySync = requestFindPeople,
+        onDismissSync = viewModel::onDismissSync,
+        onAddMatch = viewModel::onAddMatch,
+        onOpenAppSettings = {
+            val intent = Intent(
+                android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                android.net.Uri.fromParts("package", context.packageName, null),
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        },
+        onInvite = {
+            // Optional v1 invite: OS share-sheet with a join link (no fake SMS pipeline).
+            val share = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, "Join me on TestLogon: https://tl-api.bitbazaar.cc/")
+            }
+            context.startActivity(Intent.createChooser(share, "Invite to TestLogon"))
+        },
         modifier = modifier,
     )
 }
@@ -93,12 +162,19 @@ fun ContactsHubRoute(
 @Composable
 private fun ContactsHubScreen(
     state: ContactsHubUiState,
+    matchState: MatchSyncState,
     snackbarHostState: androidx.compose.material3.SnackbarHostState,
     onBack: () -> Unit,
     onRetry: () -> Unit,
     onOpenContact: (String) -> Unit,
     onToggleFavorite: (String, Boolean) -> Unit,
     onSaveSuggestion: (String) -> Unit,
+    onFindPeople: () -> Unit,
+    onRetrySync: () -> Unit,
+    onDismissSync: () -> Unit,
+    onAddMatch: (String) -> Unit,
+    onOpenAppSettings: () -> Unit,
+    onInvite: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -127,39 +203,211 @@ private fun ContactsHubScreen(
                 )
 
             is ContactsHubUiState.Content -> {
-                if (state.isFullyEmpty) {
-                    EmptyState(
-                        title = "No contacts yet",
-                        body = "Save people you message or follow to build your address book.",
-                        modifier = Modifier.padding(padding).fillMaxSize(),
-                    )
-                } else {
-                    LazyColumn(
-                        modifier = Modifier.padding(padding).fillMaxSize(),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 8.dp),
-                    ) {
-                        if (state.contacts.isNotEmpty()) {
-                            item { SectionHeader("Saved contacts", ContactsHubTestTags.CONTACTS_SECTION) }
-                            items(state.contacts, key = { it.userId }) { row ->
-                                ContactRowItem(
-                                    row = row,
-                                    onOpen = { onOpenContact(row.userId) },
-                                    onToggleFavorite = { onToggleFavorite(row.userId, !row.isFavorite) },
-                                )
-                            }
+                LazyColumn(
+                    modifier = Modifier.padding(padding).fillMaxSize(),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 8.dp),
+                ) {
+                    // Feature 2 - always-visible "Find people you know" entry (device contact sync).
+                    item { FindPeopleCta(onFindPeople = onFindPeople) }
+
+                    // Feature 2 - matched-from-your-address-book results (when a sync produced any).
+                    val results = matchState as? MatchSyncState.Results
+                    if (results != null && results.matches.isNotEmpty()) {
+                        item { SectionHeader("From your contacts", ContactsHubTestTags.MATCH_SECTION) }
+                        items(results.matches, key = { "match_" + it.userId }) { row ->
+                            MatchRowItem(
+                                row = row,
+                                onOpen = { onOpenContact(row.userId) },
+                                onAdd = { onAddMatch(row.userId) },
+                            )
                         }
-                        if (state.suggestions.isNotEmpty()) {
-                            item { SectionHeader("People you may know", ContactsHubTestTags.SUGGESTIONS_SECTION) }
-                            items(state.suggestions, key = { it.userId }) { row ->
-                                SuggestionRowItem(
-                                    row = row,
-                                    onOpen = { onOpenContact(row.userId) },
-                                    onAdd = { onSaveSuggestion(row.userId) },
-                                )
-                            }
+                        item { HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp)) }
+                    }
+
+                    if (state.isFullyEmpty && (results == null || results.matches.isEmpty())) {
+                        item {
+                            EmptyState(
+                                title = "No contacts yet",
+                                body = "Find people you know, or save people you message or follow.",
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                            )
+                        }
+                    }
+                    if (state.contacts.isNotEmpty()) {
+                        item { SectionHeader("Saved contacts", ContactsHubTestTags.CONTACTS_SECTION) }
+                        items(state.contacts, key = { it.userId }) { row ->
+                            ContactRowItem(
+                                row = row,
+                                onOpen = { onOpenContact(row.userId) },
+                                onToggleFavorite = { onToggleFavorite(row.userId, !row.isFavorite) },
+                            )
+                        }
+                    }
+                    if (state.suggestions.isNotEmpty()) {
+                        item { SectionHeader("People you may know", ContactsHubTestTags.SUGGESTIONS_SECTION) }
+                        items(state.suggestions, key = { it.userId }) { row ->
+                            SuggestionRowItem(
+                                row = row,
+                                onOpen = { onOpenContact(row.userId) },
+                                onAdd = { onSaveSuggestion(row.userId) },
+                            )
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // Feature 2 - sync-phase overlays (progress / permission / empty / failure) as dialogs.
+    ContactSyncOverlay(
+        matchState = matchState,
+        onRetrySync = onRetrySync,
+        onDismiss = onDismissSync,
+        onOpenAppSettings = onOpenAppSettings,
+        onInvite = onInvite,
+    )
+}
+
+@Composable
+private fun FindPeopleCta(onFindPeople: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Button(
+            onClick = onFindPeople,
+            modifier = Modifier.fillMaxWidth().testTag(ContactsHubTestTags.FIND_PEOPLE_BUTTON),
+        ) {
+            Icon(Icons.Filled.PersonSearch, contentDescription = null, modifier = Modifier.size(18.dp))
+            Text("Find people you know", modifier = Modifier.padding(start = 8.dp))
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "We hash your contacts on your device and never upload them.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ContactSyncOverlay(
+    matchState: MatchSyncState,
+    onRetrySync: () -> Unit,
+    onDismiss: () -> Unit,
+    onOpenAppSettings: () -> Unit,
+    onInvite: () -> Unit,
+) {
+    when (matchState) {
+        is MatchSyncState.Idle -> Unit
+        is MatchSyncState.Results -> {
+            // Non-empty results render inline in the list; only the EMPTY result shows a dialog.
+            if (matchState.isEmpty) {
+                AlertDialog(
+                    onDismissRequest = onDismiss,
+                    title = { Text("No matches found") },
+                    text = { Text("None of your contacts are on TestLogon yet. Invite them to connect.") },
+                    confirmButton = { TextButton(onClick = { onInvite() }) { Text("Invite") } },
+                    dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+                )
+            }
+        }
+        is MatchSyncState.Syncing -> {
+            AlertDialog(
+                onDismissRequest = { },
+                title = { Text("Finding people you know") },
+                text = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp).testTag(ContactsHubTestTags.SYNC_PROGRESS),
+                        )
+                        Text(
+                            "Hashing your contacts on-device...",
+                            modifier = Modifier.padding(start = 12.dp),
+                        )
+                    }
+                },
+                confirmButton = { },
+            )
+        }
+        is MatchSyncState.PermissionNeeded -> {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text("Contacts permission needed") },
+                text = {
+                    Text(
+                        if (matchState.permanentlyDenied) {
+                            "To find people you know, allow Contacts access in Settings. " +
+                                "Your contacts are hashed on-device and never uploaded."
+                        } else {
+                            "We need Contacts access to match people you know. " +
+                                "Your contacts are hashed on-device and never uploaded."
+                        },
+                    )
+                },
+                confirmButton = {
+                    if (matchState.permanentlyDenied) {
+                        TextButton(onClick = { onOpenAppSettings() }) { Text("Open settings") }
+                    } else {
+                        TextButton(onClick = { onRetrySync() }) { Text("Allow") }
+                    }
+                },
+                dismissButton = { TextButton(onClick = onDismiss) { Text("Not now") } },
+            )
+        }
+        is MatchSyncState.Failed -> {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text("Could not find people") },
+                text = { Text(matchState.message) },
+                confirmButton = { TextButton(onClick = { onRetrySync() }) { Text("Retry") } },
+                dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MatchRowItem(
+    row: MatchRow,
+    onOpen: () -> Unit,
+    onAdd: () -> Unit,
+) {
+    val label = when (row.matchedBy) {
+        "phone" -> "In your contacts by phone"
+        "email" -> "In your contacts by email"
+        else -> "In your contacts"
+    }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onOpen)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .testTag(ContactsHubTestTags.matchRow(row.userId)),
+    ) {
+        InitialsAvatar(row.displayName)
+        Column(modifier = Modifier.weight(1f).padding(start = 12.dp)) {
+            Text(
+                text = row.displayName,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (row.adding) {
+            CircularProgressIndicator(modifier = Modifier.size(20.dp))
+        } else {
+            TextButton(
+                onClick = onAdd,
+                modifier = Modifier.testTag(ContactsHubTestTags.addMatch(row.userId)),
+            ) {
+                Icon(Icons.Filled.PersonAdd, contentDescription = null, modifier = Modifier.size(18.dp))
+                Text("Add", modifier = Modifier.padding(start = 6.dp))
             }
         }
     }

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubUiState.kt
@@ -1,0 +1,118 @@
+package com.testlogon.android.feature.contacts
+
+import com.testlogon.android.data.contacts.ContactSuggestion
+import com.testlogon.android.data.contacts.SavedContact
+
+/** A saved-contact row in the address book (favorites-first). */
+data class ContactRow(
+    val userId: String,
+    val displayName: String,
+    val photoUrl: String?,
+    val isFavorite: Boolean,
+)
+
+/** A "people you may know" suggestion row. */
+data class SuggestionRow(
+    val userId: String,
+    val displayName: String,
+    val photoUrl: String?,
+    val hint: String,
+    /** True while an add-to-contacts request for this suggestion is in flight. */
+    val adding: Boolean = false,
+)
+
+/**
+ * Feature 1 — Contacts hub screen state. The screen has TWO sections (saved contacts +
+ * suggestions); either can be empty independently, so the top-level state is Content whenever
+ * the initial load succeeded and Error/Loading only gate the first paint.
+ */
+sealed interface ContactsHubUiState {
+    data object Loading : ContactsHubUiState
+
+    data class Content(
+        val contacts: List<ContactRow>,
+        val suggestions: List<SuggestionRow>,
+        val isRefreshing: Boolean = false,
+    ) : ContactsHubUiState {
+        val isFullyEmpty: Boolean get() = contacts.isEmpty() && suggestions.isEmpty()
+    }
+
+    data class Error(val message: String, val offline: Boolean) : ContactsHubUiState
+}
+
+/**
+ * Pure reducers — no Android/coroutine deps, so they are directly JVM-unit-testable
+ * (the ViewModel delegates all list-shaping to these).
+ */
+object ContactsHubReducer {
+
+    /** Build the initial Content from a successful load of both sections. */
+    fun content(
+        contacts: List<SavedContact>,
+        suggestions: List<ContactSuggestion>,
+    ): ContactsHubUiState.Content = ContactsHubUiState.Content(
+        // Sort favorites-first defensively (matches the toggle/promote paths); the backend already
+        // returns favorites-first, but re-sorting keeps the UI invariant local + testable.
+        contacts = contacts.map { it.toRow() }.sortedFavoritesFirst(),
+        // Defensively drop any suggestion that is already a saved contact (belt-and-braces;
+        // the backend already excludes saved ids, but the two calls are not transactional).
+        suggestions = suggestions
+            .filter { s -> contacts.none { it.userId == s.userId } }
+            .map { it.toRow() },
+    )
+
+    /** Optimistically remove a contact row after a delete. */
+    fun removeContact(state: ContactsHubUiState.Content, userId: String): ContactsHubUiState.Content =
+        state.copy(contacts = state.contacts.filterNot { it.userId == userId })
+
+    /** Optimistically flip a favorite flag and re-sort favorites-first. */
+    fun toggleFavorite(
+        state: ContactsHubUiState.Content,
+        userId: String,
+        favorite: Boolean,
+    ): ContactsHubUiState.Content = state.copy(
+        contacts = state.contacts
+            .map { if (it.userId == userId) it.copy(isFavorite = favorite) else it }
+            .sortedFavoritesFirst(),
+    )
+
+    /** Mark a suggestion as "adding" (in-flight) or clear the flag. */
+    fun markSuggestionAdding(
+        state: ContactsHubUiState.Content,
+        userId: String,
+        adding: Boolean,
+    ): ContactsHubUiState.Content = state.copy(
+        suggestions = state.suggestions.map {
+            if (it.userId == userId) it.copy(adding = adding) else it
+        },
+    )
+
+    /**
+     * Move a just-added suggestion into the saved-contacts section (favorites-first) and drop it
+     * from suggestions — the optimistic result of tapping "Add" on a suggestion card.
+     */
+    fun promoteSuggestion(
+        state: ContactsHubUiState.Content,
+        added: SavedContact,
+    ): ContactsHubUiState.Content = state.copy(
+        contacts = (state.contacts + added.toRow()).sortedFavoritesFirst(),
+        suggestions = state.suggestions.filterNot { it.userId == added.userId },
+    )
+}
+
+private fun SavedContact.toRow() = ContactRow(
+    userId = userId,
+    displayName = displayName,
+    photoUrl = photoUrl,
+    isFavorite = isFavorite,
+)
+
+private fun ContactSuggestion.toRow() = SuggestionRow(
+    userId = userId,
+    displayName = displayName,
+    photoUrl = photoUrl,
+    hint = hint,
+)
+
+private fun List<ContactRow>.sortedFavoritesFirst(): List<ContactRow> =
+    sortedWith(compareByDescending<ContactRow> { it.isFavorite }.thenBy { it.displayName.lowercase() })

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubUiState.kt
@@ -1,5 +1,6 @@
 package com.testlogon.android.feature.contacts
 
+import com.testlogon.android.data.contacts.ContactMatch
 import com.testlogon.android.data.contacts.ContactSuggestion
 import com.testlogon.android.data.contacts.SavedContact
 
@@ -20,6 +21,36 @@ data class SuggestionRow(
     /** True while an add-to-contacts request for this suggestion is in flight. */
     val adding: Boolean = false,
 )
+
+/** Feature 2 — a device-address-book match row. */
+data class MatchRow(
+    val userId: String,
+    val displayName: String,
+    val photoUrl: String?,
+    /** "In your contacts by email" / "...by phone" label source. */
+    val matchedBy: String,
+    val adding: Boolean = false,
+)
+
+/**
+ * Feature 2 — the device contact-sync phase, an OVERLAY on the hub (permission gate ->
+ * hashing/matching progress -> results). Idle until the user taps "Find people you know".
+ */
+sealed interface MatchSyncState {
+    data object Idle : MatchSyncState
+
+    /** Permission denied (soft: can re-ask) or permanently denied (must go to Settings). */
+    data class PermissionNeeded(val permanentlyDenied: Boolean) : MatchSyncState
+
+    /** Reading + hashing on-device, then calling the match endpoint. */
+    data object Syncing : MatchSyncState
+
+    data class Results(val matches: List<MatchRow>) : MatchSyncState {
+        val isEmpty: Boolean get() = matches.isEmpty()
+    }
+
+    data class Failed(val message: String, val offline: Boolean) : MatchSyncState
+}
 
 /**
  * Feature 1 — Contacts hub screen state. The screen has TWO sections (saved contacts +
@@ -98,6 +129,25 @@ object ContactsHubReducer {
         contacts = (state.contacts + added.toRow()).sortedFavoritesFirst(),
         suggestions = state.suggestions.filterNot { it.userId == added.userId },
     )
+
+    // ── Feature 2: device-match reducers ────────────────────────────────────
+
+    /** Build match results, dropping anyone already saved (belt-and-braces vs the server). */
+    fun matchResults(
+        matches: List<ContactMatch>,
+        contacts: List<ContactRow>,
+    ): MatchSyncState.Results = MatchSyncState.Results(
+        matches = matches
+            .filter { m -> contacts.none { it.userId == m.userId } }
+            .map { it.toRow() },
+    )
+
+    fun markMatchAdding(state: MatchSyncState.Results, userId: String, adding: Boolean): MatchSyncState.Results =
+        state.copy(matches = state.matches.map { if (it.userId == userId) it.copy(adding = adding) else it })
+
+    /** Drop a just-added match from the results overlay. */
+    fun removeMatch(state: MatchSyncState.Results, userId: String): MatchSyncState.Results =
+        state.copy(matches = state.matches.filterNot { it.userId == userId })
 }
 
 private fun SavedContact.toRow() = ContactRow(
@@ -105,6 +155,13 @@ private fun SavedContact.toRow() = ContactRow(
     displayName = displayName,
     photoUrl = photoUrl,
     isFavorite = isFavorite,
+)
+
+private fun ContactMatch.toRow() = MatchRow(
+    userId = userId,
+    displayName = displayName,
+    photoUrl = photoUrl,
+    matchedBy = matchedBy,
 )
 
 private fun ContactSuggestion.toRow() = SuggestionRow(

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubViewModel.kt
@@ -38,6 +38,10 @@ class ContactsHubViewModel @Inject constructor(
     private val _events = Channel<ContactsHubEvent>(Channel.BUFFERED)
     val events: Flow<ContactsHubEvent> = _events.receiveAsFlow()
 
+    // Feature 2 — the device contact-sync overlay (idle until "Find people you know").
+    private val _matchState = MutableStateFlow<MatchSyncState>(MatchSyncState.Idle)
+    val matchState: StateFlow<MatchSyncState> = _matchState.asStateFlow()
+
     init {
         refresh(initial = true)
     }
@@ -126,6 +130,69 @@ class ContactsHubViewModel @Inject constructor(
 
     fun onOpenContact(userId: String) {
         _events.trySend(ContactsHubEvent.OpenContactCard(userId))
+    }
+
+    // ── Feature 2: device contact sync ──────────────────────────────────────
+
+    /** Called after READ_CONTACTS is GRANTED: read+hash on-device, then match. */
+    fun onPermissionGranted() {
+        _matchState.value = MatchSyncState.Syncing
+        viewModelScope.launch {
+            when (val result = repository.matchDeviceContacts()) {
+                is ApiResult.Success -> {
+                    val savedContacts = (_state.value as? ContactsHubUiState.Content)?.contacts ?: emptyList()
+                    _matchState.value = ContactsHubReducer.matchResults(result.data, savedContacts)
+                }
+                is ApiResult.Failure ->
+                    _matchState.value = MatchSyncState.Failed(result.error.message, offline = false)
+                is ApiResult.NetworkError ->
+                    _matchState.value = MatchSyncState.Failed("You appear to be offline.", offline = true)
+            }
+        }
+    }
+
+    /** Called when the runtime permission request comes back DENIED. */
+    fun onPermissionDenied(permanentlyDenied: Boolean) {
+        _matchState.value = MatchSyncState.PermissionNeeded(permanentlyDenied)
+    }
+
+    /** Dismiss the sync overlay back to the hub. */
+    fun onDismissSync() {
+        _matchState.value = MatchSyncState.Idle
+    }
+
+    /** Add a matched person to contacts (optimistic; promotes into the saved list too). */
+    fun onAddMatch(userId: String) {
+        val results = _matchState.value as? MatchSyncState.Results ?: return
+        _matchState.value = ContactsHubReducer.markMatchAdding(results, userId, adding = true)
+        viewModelScope.launch {
+            when (val result = repository.addContact(userId)) {
+                is ApiResult.Success -> {
+                    (_matchState.value as? MatchSyncState.Results)?.let {
+                        _matchState.value = ContactsHubReducer.removeMatch(it, userId)
+                    }
+                    // Reflect the new contact in the underlying hub list too.
+                    (_state.value as? ContactsHubUiState.Content)?.let {
+                        _state.value = ContactsHubReducer.promoteSuggestion(it, result.data)
+                    }
+                    _events.trySend(ContactsHubEvent.ShowSnackbar("Added to contacts"))
+                }
+                is ApiResult.Failure -> {
+                    clearMatchAdding(userId)
+                    _events.trySend(ContactsHubEvent.ShowSnackbar(result.error.message))
+                }
+                is ApiResult.NetworkError -> {
+                    clearMatchAdding(userId)
+                    _events.trySend(ContactsHubEvent.ShowSnackbar("Couldn't add contact — you're offline."))
+                }
+            }
+        }
+    }
+
+    private fun clearMatchAdding(userId: String) {
+        (_matchState.value as? MatchSyncState.Results)?.let {
+            _matchState.value = ContactsHubReducer.markMatchAdding(it, userId, adding = false)
+        }
     }
 
     private fun clearAdding(userId: String) {

--- a/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/contacts/ContactsHubViewModel.kt
@@ -1,0 +1,153 @@
+package com.testlogon.android.feature.contacts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.contacts.ContactsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed interface ContactsHubEvent {
+    data class ShowSnackbar(val message: String) : ContactsHubEvent
+
+    /** Navigate to the contact detail card for [userId]. */
+    data class OpenContactCard(val userId: String) : ContactsHubEvent
+}
+
+/**
+ * Feature 1 — Contacts hub ViewModel. Loads the saved address book + "people you may know"
+ * suggestions on entry, and drives add / remove / favorite mutations with optimistic UI +
+ * rollback on server failure. All list-shaping is delegated to [ContactsHubReducer] (pure,
+ * unit-tested).
+ */
+@HiltViewModel
+class ContactsHubViewModel @Inject constructor(
+    private val repository: ContactsRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<ContactsHubUiState>(ContactsHubUiState.Loading)
+    val state: StateFlow<ContactsHubUiState> = _state.asStateFlow()
+
+    private val _events = Channel<ContactsHubEvent>(Channel.BUFFERED)
+    val events: Flow<ContactsHubEvent> = _events.receiveAsFlow()
+
+    init {
+        refresh(initial = true)
+    }
+
+    fun refresh(initial: Boolean = false) {
+        viewModelScope.launch {
+            if (!initial) markRefreshing(true)
+            val contactsResult = repository.listContacts()
+            val suggestionsResult = repository.suggestions()
+
+            when (contactsResult) {
+                is ApiResult.Success -> {
+                    val suggestions = (suggestionsResult as? ApiResult.Success)?.data ?: emptyList()
+                    _state.value = ContactsHubReducer.content(contactsResult.data, suggestions)
+                }
+                is ApiResult.Failure ->
+                    reduceError(contactsResult.error.message, offline = false, initial = initial)
+                is ApiResult.NetworkError ->
+                    reduceError("You appear to be offline.", offline = true, initial = initial)
+            }
+        }
+    }
+
+    fun onSaveSuggestion(userId: String) {
+        val content = _state.value as? ContactsHubUiState.Content ?: return
+        _state.value = ContactsHubReducer.markSuggestionAdding(content, userId, adding = true)
+        viewModelScope.launch {
+            when (val result = repository.addContact(userId)) {
+                is ApiResult.Success -> {
+                    (_state.value as? ContactsHubUiState.Content)?.let {
+                        _state.value = ContactsHubReducer.promoteSuggestion(it, result.data)
+                    }
+                    _events.trySend(ContactsHubEvent.ShowSnackbar("Added to contacts"))
+                }
+                is ApiResult.Failure -> {
+                    clearAdding(userId)
+                    _events.trySend(ContactsHubEvent.ShowSnackbar(result.error.message))
+                }
+                is ApiResult.NetworkError -> {
+                    clearAdding(userId)
+                    _events.trySend(ContactsHubEvent.ShowSnackbar("Couldn't add contact — you're offline."))
+                }
+            }
+        }
+    }
+
+    fun onRemoveContact(userId: String) {
+        val content = _state.value as? ContactsHubUiState.Content ?: return
+        val snapshot = content
+        // Optimistic remove.
+        _state.value = ContactsHubReducer.removeContact(content, userId)
+        viewModelScope.launch {
+            when (val result = repository.removeContact(userId)) {
+                is ApiResult.Success ->
+                    _events.trySend(ContactsHubEvent.ShowSnackbar("Removed from contacts"))
+                is ApiResult.Failure -> {
+                    _state.value = snapshot // rollback
+                    _events.trySend(ContactsHubEvent.ShowSnackbar(result.error.message))
+                }
+                is ApiResult.NetworkError -> {
+                    _state.value = snapshot
+                    _events.trySend(ContactsHubEvent.ShowSnackbar("Couldn't remove — you're offline."))
+                }
+            }
+        }
+    }
+
+    fun onToggleFavorite(userId: String, favorite: Boolean) {
+        val content = _state.value as? ContactsHubUiState.Content ?: return
+        val snapshot = content
+        _state.value = ContactsHubReducer.toggleFavorite(content, userId, favorite)
+        viewModelScope.launch {
+            when (val result = repository.setFavorite(userId, favorite)) {
+                is ApiResult.Success -> Unit
+                is ApiResult.Failure -> {
+                    _state.value = snapshot
+                    _events.trySend(ContactsHubEvent.ShowSnackbar(result.error.message))
+                }
+                is ApiResult.NetworkError -> {
+                    _state.value = snapshot
+                    _events.trySend(ContactsHubEvent.ShowSnackbar("Couldn't update favorite — you're offline."))
+                }
+            }
+        }
+    }
+
+    fun onOpenContact(userId: String) {
+        _events.trySend(ContactsHubEvent.OpenContactCard(userId))
+    }
+
+    private fun clearAdding(userId: String) {
+        (_state.value as? ContactsHubUiState.Content)?.let {
+            _state.value = ContactsHubReducer.markSuggestionAdding(it, userId, adding = false)
+        }
+    }
+
+    private fun markRefreshing(refreshing: Boolean) {
+        (_state.value as? ContactsHubUiState.Content)?.let {
+            _state.value = it.copy(isRefreshing = refreshing)
+        }
+    }
+
+    private fun reduceError(message: String, offline: Boolean, initial: Boolean) {
+        val current = _state.value
+        if (current is ContactsHubUiState.Content) {
+            // Keep showing cached content; just surface the failure + stop the spinner.
+            _state.value = current.copy(isRefreshing = false)
+            _events.trySend(ContactsHubEvent.ShowSnackbar(message))
+        } else {
+            _state.value = ContactsHubUiState.Error(message, offline)
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.GroupAdd
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.material.icons.outlined.Contacts
 import androidx.compose.material3.Badge
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -79,6 +80,7 @@ fun ConversationListRoute(
     modifier: Modifier = Modifier,
     onOpenSearch: () -> Unit = {},
     onNewGroup: () -> Unit = {},
+    onOpenContacts: () -> Unit = {},
     viewModel: ConversationListViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -100,6 +102,7 @@ fun ConversationListRoute(
         onOpenConversation = onOpenConversation,
         onOpenSearch = onOpenSearch,
         onNewGroup = onNewGroup,
+        onOpenContacts = onOpenContacts,
         onBack = onBack,
         modifier = modifier,
     )
@@ -117,6 +120,7 @@ fun ConversationListScreen(
     modifier: Modifier = Modifier,
     onOpenSearch: () -> Unit = {},
     onNewGroup: () -> Unit = {},
+    onOpenContacts: () -> Unit = {},
 ) {
     Scaffold(
         modifier = modifier.testTag(ConversationListTestTags.SCREEN),
@@ -143,6 +147,16 @@ fun ConversationListScreen(
                     }
                 },
                 actions = {
+                    // Feature 1 — jump to the Contacts hub (address book + suggestions).
+                    IconButton(
+                        onClick = onOpenContacts,
+                        modifier = Modifier.testTag("conv_list_contacts"),
+                    ) {
+                        Icon(
+                            Icons.Outlined.Contacts,
+                            contentDescription = "Contacts",
+                        )
+                    }
                     // AND-152 — open global (cross-conversation) message search.
                     IconButton(
                         onClick = onOpenSearch,

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/nav/MessagingNav.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/nav/MessagingNav.kt
@@ -8,6 +8,9 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
 import com.testlogon.android.feature.messaging.contacts.ContactsRoute
+import com.testlogon.android.feature.contacts.ContactCardRoute
+import com.testlogon.android.feature.contacts.ContactCardViewModel
+import com.testlogon.android.feature.contacts.ContactsHubRoute
 import com.testlogon.android.feature.messaging.dm.StartDmRoute
 import com.testlogon.android.data.messaging.helpdesk.ClaimState
 import com.testlogon.android.feature.messaging.helpdesk.HelpdeskDashboardScreen
@@ -42,6 +45,16 @@ object MessagingRoutes {
 
     /** AND-153/AND-154 — contacts (people-search) screen; tapping a contact opens its DM thread. */
     const val CONTACTS = "messaging/contacts"
+
+    /** Feature 1 — the saved-contacts address book + "people you may know" hub. */
+    const val CONTACTS_HUB = "messaging/contacts/hub"
+
+    /** Feature 1 — the contact detail card for a single peer user id. */
+    const val ARG_CONTACT_USER_ID = ContactCardViewModel.ARG_USER_ID
+    const val CONTACT_CARD = "messaging/contacts/card/{$ARG_CONTACT_USER_ID}"
+
+    fun contactCard(userId: String): String =
+        "messaging/contacts/card/${Uri.encode(userId)}"
 
     /** AND-127 — start-DM entry: resolves a peer user id to a conversation, then opens the thread. */
     const val ARG_PEER_USER_ID = "peerUserId"
@@ -108,6 +121,9 @@ fun NavGraphBuilder.messagingGraph(navController: NavHostController) {
             onNewGroup = {
                 navController.navigate(MessagingRoutes.GROUP_CREATE) { launchSingleTop = true }
             },
+            onOpenContacts = {
+                navController.navigate(MessagingRoutes.CONTACTS_HUB) { launchSingleTop = true }
+            },
             onBack = { navController.popBackStack() },
         )
     }
@@ -127,6 +143,9 @@ fun NavGraphBuilder.messagingGraph(navController: NavHostController) {
         ThreadRoute(
             onBack = { navController.popBackStack() },
             onPlaceCall = { route -> navController.navigate(route) },
+            onViewContact = { peerUserId ->
+                navController.navigate(MessagingRoutes.contactCard(peerUserId)) { launchSingleTop = true }
+            },
             onOpenGroupDetails = {
                 if (conversationId.isNotBlank()) {
                     navController.navigate(MessagingRoutes.groupDetails(conversationId)) {
@@ -152,6 +171,35 @@ fun NavGraphBuilder.messagingGraph(navController: NavHostController) {
                 navController.navigate(MessagingRoutes.thread(conversationId)) {
                     launchSingleTop = true // FR-5: don't stack duplicate thread destinations
                 }
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    // Feature 1 — the saved-contacts address book + suggestions hub.
+    composable(MessagingRoutes.CONTACTS_HUB) {
+        ContactsHubRoute(
+            onOpenContactCard = { userId ->
+                navController.navigate(MessagingRoutes.contactCard(userId)) { launchSingleTop = true }
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    // Feature 1 — the contact detail card (message / call / follow / tip / save / profile).
+    composable(
+        route = MessagingRoutes.CONTACT_CARD,
+        arguments = listOf(
+            navArgument(MessagingRoutes.ARG_CONTACT_USER_ID) { type = NavType.StringType },
+        ),
+    ) {
+        ContactCardRoute(
+            onOpenThread = { conversationId ->
+                navController.navigate(MessagingRoutes.thread(conversationId)) { launchSingleTop = true }
+            },
+            onPlaceCall = { route -> navController.navigate(route) },
+            onOpenFullProfile = { userId ->
+                navController.navigate(
+                    com.testlogon.android.navigation.PublicProfileDest.build(userId),
+                ) { launchSingleTop = true }
             },
             onBack = { navController.popBackStack() },
         )

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
@@ -148,6 +148,7 @@ import com.testlogon.android.feature.messaging.voice.RecordingOverlay
 import com.testlogon.android.feature.messaging.voice.VoiceMessageBubble
 import com.testlogon.android.feature.messaging.voice.VoicePreviewCard
 import com.testlogon.android.feature.messaging.voice.VoiceTestTags
+import androidx.compose.material.icons.filled.Person
 import kotlinx.coroutines.launch
 
 /** Stable testTags for the thread screen (AND-123 / AND-124). */
@@ -192,6 +193,7 @@ object ThreadTestTags {
 fun ThreadRoute(
     onBack: () -> Unit,
     onPlaceCall: (String) -> Unit = {},
+    onViewContact: (userId: String) -> Unit = {},
     modifier: Modifier = Modifier,
     onOpenGroupDetails: () -> Unit = {},
     viewModel: ThreadViewModel = hiltViewModel(),
@@ -343,6 +345,7 @@ fun ThreadRoute(
         typingUsers = typingUsers,
         onBack = onBack,
         onPlaceCall = onPlaceCall,
+        onViewContact = onViewContact,
         onOpenGroupDetails = onOpenGroupDetails,
         onRetry = viewModel::retry,
         onDraftChange = viewModel::onDraftChange,
@@ -1051,6 +1054,7 @@ fun ThreadScreen(
     onOpenSearch: () -> Unit = {},
     onOpenScheduled: () -> Unit = {},
     onPlaceCall: (String) -> Unit = {},
+    onViewContact: (userId: String) -> Unit = {},
     searchBar: @Composable () -> Unit = {},
     // FULL-PARITY (delegate) — an optional banner slot rendered directly under the top app bar. The
     // ThreadRoute passes the "Managing @creator" DelegationBannerHost here so the reused thread makes it
@@ -1188,6 +1192,15 @@ fun ThreadScreen(
                                     )
                                 },
                                 modifier = Modifier.testTag("thread_call_video"),
+                            )
+                        }
+                        // Feature 1 — jump from a conversation to the peer's contact card.
+                        if (state.isDm) state.peerUserSub?.let { peer ->
+                            androidx.compose.material3.DropdownMenuItem(
+                                text = { Text("View contact") },
+                                leadingIcon = { Icon(Icons.Filled.Person, contentDescription = null) },
+                                onClick = { menuOpen = false; onViewContact(peer) },
+                                modifier = Modifier.testTag("thread_view_contact"),
                             )
                         }
                         // P0-BLOCK: block / unblock the DM peer (1:1 only, resolved peer).

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.outlined.AddBusiness
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.CardMembership
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.material.icons.outlined.Contacts
 import androidx.compose.material.icons.outlined.CreditCard
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Memory
@@ -117,6 +118,14 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_messages,
             icon = Icons.Outlined.ChatBubbleOutline,
             route = MoreRoutes.MESSAGES,
+            hub = MoreHub.INBOX,
+            section = MoreSection.ACCOUNT,
+        ),
+        MoreEntry(
+            id = "contacts",
+            labelRes = R.string.more_entry_contacts,
+            icon = Icons.Outlined.Contacts,
+            route = MoreRoutes.CONTACTS_HUB,
             hub = MoreHub.INBOX,
             section = MoreSection.ACCOUNT,
         ),

--- a/android/app/src/main/java/com/testlogon/android/feature/player/PipController.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/player/PipController.kt
@@ -158,6 +158,7 @@ class ActivityPipController(private val activity: Activity) : PipController {
         activeAspectW = aspectWidth
         activeAspectH = aspectHeight
         videoActive = true
+        refreshAutoEnterParams()
         return enterPip(aspectWidth, aspectHeight)
     }
 
@@ -180,6 +181,8 @@ class ActivityPipController(private val activity: Activity) : PipController {
                 activePlayerState.value = null
             }
         }
+        // Arm/disarm API 31+ auto-enter to match the current playing state (no-op below S).
+        refreshAutoEnterParams()
     }
 
     /**
@@ -209,16 +212,41 @@ class ActivityPipController(private val activity: Activity) : PipController {
     }
 
     private fun buildParams(aspectWidth: Int, aspectHeight: Int): PictureInPictureParams {
-        // Android rejects aspect ratios outside ~[1:2.39, 2.39:1]; clamp to a safe landscape default.
-        val w = aspectWidth.coerceAtLeast(1)
-        val h = aspectHeight.coerceAtLeast(1)
-        val ratio = w.toFloat() / h.toFloat()
-        val safe = when {
-            ratio > 2.39f -> Rational(239, 100)
-            ratio < 1f / 2.39f -> Rational(100, 239)
-            else -> Rational(w, h)
+        // Prefer the active player's REAL reported video size so the floating window matches the actual
+        // stream (live HLS broadcast, VOD, inline clip); fall back to the caller-supplied aspect. Clamp
+        // to the Android-permitted ~[1:2.39, 2.39:1] window. All pure -> PipParamsLogic (JVM-tested).
+        val size = runCatching { activePlayerState.value?.videoSize }.getOrNull()
+        val (num, den) = PipParamsLogic.resolveAspect(
+            videoWidth = size?.width ?: 0,
+            videoHeight = size?.height ?: 0,
+            fallbackW = aspectWidth,
+            fallbackH = aspectHeight,
+        )
+        val builder = PictureInPictureParams.Builder().setAspectRatio(Rational(num, den))
+        // AND-287 — API 31+ (S) auto-enter + seamless resize for a smoother, tap-free float on Home.
+        // On 26-30 we keep the onUserLeaveHint manual-enter fallback (see MainActivity.onUserLeaveHint).
+        if (PipParamsLogic.supportsAutoEnter(Build.VERSION.SDK_INT) &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        ) {
+            builder.setAutoEnterEnabled(videoActive)
+            builder.setSeamlessResizeEnabled(true)
         }
-        return PictureInPictureParams.Builder().setAspectRatio(safe).build()
+        return builder.build()
+    }
+
+    /**
+     * AND-287 — proactively push the current [PictureInPictureParams] to the system so API 31+
+     * setAutoEnterEnabled is armed (or disarmed) as the active video / aspect changes, without waiting
+     * for an explicit enterPip call. No-op below S (manual onUserLeaveHint path) or when PiP is
+     * unsupported. Best-effort; never throws into the caller.
+     */
+    fun refreshAutoEnterParams() {
+        if (!isPipSupported) return
+        if (!PipParamsLogic.supportsAutoEnter(Build.VERSION.SDK_INT)) return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        runCatching {
+            activity.setPictureInPictureParams(buildParams(activeAspectW, activeAspectH))
+        }
     }
 }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/player/PipController.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/player/PipController.kt
@@ -3,10 +3,12 @@ package com.testlogon.android.feature.player
 import android.app.Activity
 import android.app.PictureInPictureParams
 import android.content.Context
+import android.content.Intent
 import android.content.ContextWrapper
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Rational
+import android.view.View
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.media3.common.Player
@@ -28,6 +30,27 @@ import androidx.media3.common.Player
  * Activity's onUserLeaveHint can AUTO-enter PiP (the recommended UX) when the user presses Home while
  * a video is up. A player marks itself active via [setVideoActive] while it is on-screen/playing.
  */
+/**
+ * CALL-PiP — descriptor for rendering a LIVE video call in the Picture-in-Picture window. Unlike the
+ * media3 branch (which hands the controller a [Player] and lets a PlayerView render it), a call renders
+ * native WebRTC frames, so the controller is given:
+ *  - [makeView]: a factory that builds the call's render [View] (a LiveKit SurfaceViewRenderer bound to
+ *    the remote participant's VideoTrack). Invoked by the Activity when it enters PiP and swaps content
+ *    to the call surface; the returned View is added to the PiP window. The factory owns init()/bind.
+ *  - [releaseView]: releases exactly the View produced by [makeView] (remove the track sink + SurfaceView
+ *    release) so returning to full screen / config-change / end does not leak the renderer or black-frame.
+ *  - [aspectWidth]/[aspectHeight]: the call video aspect for the PiP params (clamped by PipParamsLogic).
+ *
+ * The factory indirection keeps org.webrtc / LiveKit types OUT of this SDK-free controller: the call
+ * feature supplies the concrete SurfaceViewRenderer wiring.
+ */
+data class CallPipSource(
+    val makeView: (Context) -> View,
+    val releaseView: (View) -> Unit,
+    val aspectWidth: Int = 16,
+    val aspectHeight: Int = 9,
+)
+
 interface PipController {
 
     /** True if this device/OS supports PiP at all (API 26+ and FEATURE_PICTURE_IN_PICTURE). */
@@ -70,6 +93,30 @@ interface PipController {
      * elsewhere (e.g. the VOD detail controller) never call this, so the controller never releases them.
      */
     fun deferPipRelease(player: Player)
+
+    /**
+     * CALL-PiP — register the ACTIVE VIDEO CALL as the current PiP source. When set, PiP collapses the
+     * Activity to a live WebRTC [android.view.View] (a SurfaceViewRenderer bound to the remote track)
+     * instead of a media3 PlayerView. [source] carries a renderer-view factory + the remote-track binder
+     * + the call aspect; pass null to UNREGISTER the call (on end / audio-only / leaving the call screen).
+     * A registered call takes precedence over any media3 player for source selection. Guarded on
+     * video-call-connected by the caller (audio-only calls never register — nothing to show).
+     */
+    fun setCallSource(source: CallPipSource?)
+
+    /**
+     * CALL-PiP — mark whether the active call is currently PiP-eligible (a CONNECTED VIDEO call). When
+     * true, the Activity may auto-enter PiP on user-leave (Home) exactly like [setVideoActive] does for
+     * media3. False on audio-only / not-yet-connected / ended.
+     */
+    fun setCallActive(active: Boolean)
+
+    /**
+     * CALL-PiP — request the hosting Activity LEAVE Picture-in-Picture and return to full screen. Used
+     * when a call ends while floating in PiP so the user is not stranded with a dead/last-frame window.
+     * No-op when not in PiP / unsupported. Best-effort.
+     */
+    fun exitPip()
 }
 
 /**
@@ -83,6 +130,9 @@ object NoOpPipController : PipController {
     override fun setVideoActive(active: Boolean, player: Player?, aspectWidth: Int, aspectHeight: Int) { /* no-op */ }
     override fun isPipRetained(player: Player): Boolean = false
     override fun deferPipRelease(player: Player) { /* no-op */ }
+    override fun setCallSource(source: CallPipSource?) { /* no-op */ }
+    override fun setCallActive(active: Boolean) { /* no-op */ }
+    override fun exitPip() { /* no-op */ }
 }
 
 /** CompositionLocal carrying the active [PipController] (provided by MainActivity). */
@@ -130,6 +180,18 @@ class ActivityPipController(private val activity: Activity) : PipController {
 
     @Volatile
     var activeAspectH: Int = 9
+        private set
+
+    /**
+     * CALL-PiP — the active video call's PiP descriptor (or null). Observable so the PiP-mode composable
+     * recomposes to (un)mount the call render surface when a call registers/ends. Read by MainActivity
+     * while in PiP to build the SurfaceViewRenderer branch.
+     */
+    val callSourceState = mutableStateOf<CallPipSource?>(null)
+
+    /** CALL-PiP — true when a CONNECTED VIDEO call is registered (arms call auto-enter). */
+    @Volatile
+    var callActive: Boolean = false
         private set
 
     override val isPipSupported: Boolean
@@ -185,6 +247,40 @@ class ActivityPipController(private val activity: Activity) : PipController {
         refreshAutoEnterParams()
     }
 
+    override fun setCallSource(source: CallPipSource?) {
+        callSourceState.value = source
+        if (source != null) {
+            activeAspectW = source.aspectWidth
+            activeAspectH = source.aspectHeight
+        }
+        refreshAutoEnterParams()
+    }
+
+    override fun setCallActive(active: Boolean) {
+        callActive = active
+        if (!active) {
+            // Leaving eligibility (call ended / audio-only / left the screen): drop the render source so a
+            // subsequent forced PiP does not show a stale call surface. Never clears mid-PiP-entry latch
+            // used by the media3 path (call source is independent of pipPlayerState).
+            if (!enteringPip) callSourceState.value = null
+        }
+        refreshAutoEnterParams()
+    }
+
+    override fun exitPip() {
+        if (!isPipSupported) return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        // Standard way to leave PiP programmatically: bring the Activity's own task back to the front via
+        // a singleTask launch intent. The system collapses the PiP window and restores full-screen.
+        runCatching {
+            val intent = activity.packageManager.getLaunchIntentForPackage(activity.packageName)
+            if (intent != null) {
+                intent.flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NEW_TASK
+                activity.startActivity(intent)
+            }
+        }
+    }
+
     /**
      * Called by the hosting Activity from onPictureInPictureModeChanged. On EXIT we release the stable
      * pip snapshot + latch so normal disposal semantics resume.
@@ -215,20 +311,26 @@ class ActivityPipController(private val activity: Activity) : PipController {
         // Prefer the active player's REAL reported video size so the floating window matches the actual
         // stream (live HLS broadcast, VOD, inline clip); fall back to the caller-supplied aspect. Clamp
         // to the Android-permitted ~[1:2.39, 2.39:1] window. All pure -> PipParamsLogic (JVM-tested).
+        val call = callSourceState.value
         val size = runCatching { activePlayerState.value?.videoSize }.getOrNull()
-        val (num, den) = PipParamsLogic.resolveAspect(
-            videoWidth = size?.width ?: 0,
-            videoHeight = size?.height ?: 0,
-            fallbackW = aspectWidth,
-            fallbackH = aspectHeight,
-        )
+        val (num, den) = if (call != null) {
+            // CALL-PiP — a live call has no media3 videoSize; use the call's reported aspect (clamped).
+            PipParamsLogic.resolveAspect(0, 0, call.aspectWidth, call.aspectHeight)
+        } else {
+            PipParamsLogic.resolveAspect(
+                videoWidth = size?.width ?: 0,
+                videoHeight = size?.height ?: 0,
+                fallbackW = aspectWidth,
+                fallbackH = aspectHeight,
+            )
+        }
         val builder = PictureInPictureParams.Builder().setAspectRatio(Rational(num, den))
         // AND-287 — API 31+ (S) auto-enter + seamless resize for a smoother, tap-free float on Home.
         // On 26-30 we keep the onUserLeaveHint manual-enter fallback (see MainActivity.onUserLeaveHint).
         if (PipParamsLogic.supportsAutoEnter(Build.VERSION.SDK_INT) &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
         ) {
-            builder.setAutoEnterEnabled(videoActive)
+            builder.setAutoEnterEnabled(videoActive || callActive)
             builder.setSeamlessResizeEnabled(true)
         }
         return builder.build()

--- a/android/app/src/main/java/com/testlogon/android/feature/player/PipParamsLogic.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/player/PipParamsLogic.kt
@@ -1,0 +1,65 @@
+package com.testlogon.android.feature.player
+
+/**
+ * AND-287 — pure, JVM-testable Picture-in-Picture params logic shared by [ActivityPipController].
+ *
+ * Keeps the two decisions that must be correct — the (clamped) aspect ratio and the API-level
+ * capability gates for the smoother auto-enter path — out of the Android-touching controller so they
+ * can be unit-tested without an emulator. The controller just constructs [android.util.Rational] /
+ * [android.app.PictureInPictureParams] from these results.
+ *
+ * Android rejects PiP aspect ratios outside ~[1:2.39, 2.39:1]; [safeAspect] clamps to that window.
+ * The broadcast viewer (live HLS) reuses the same [ActivityPipController] path as VOD/messaging/feed,
+ * so getting the aspect right here fixes the floating-window shape for every caller at once.
+ */
+object PipParamsLogic {
+
+    /** Android's documented PiP aspect bound: width/height must be within [1/MAX .. MAX]. */
+    const val MAX_RATIO: Float = 2.39f
+
+    /**
+     * Clamp [width]:[height] to the Android-permitted PiP aspect window, returned as a normalized
+     * (num, den) pair suitable for [android.util.Rational]. Non-positive inputs fall back to a safe
+     * 16:9 landscape default (mirrors the old inline default), never a crash.
+     */
+    fun safeAspect(width: Int, height: Int): Pair<Int, Int> {
+        if (width <= 0 || height <= 0) return 16 to 9
+        val ratio = width.toFloat() / height.toFloat()
+        return when {
+            ratio > MAX_RATIO -> 239 to 100
+            ratio < 1f / MAX_RATIO -> 100 to 239
+            else -> width to height
+        }
+    }
+
+    /**
+     * Resolve the aspect to use for PiP: prefer the player's real reported video size ([videoWidth]
+     * :[videoHeight]) when known (> 0), else the caller-supplied fallback ([fallbackW]:[fallbackH]).
+     * Then clamp to the safe window. This lets the live broadcast (and any player) size the floating
+     * window to the actual stream instead of a hardcoded 16:9 when the size is available.
+     */
+    fun resolveAspect(
+        videoWidth: Int,
+        videoHeight: Int,
+        fallbackW: Int,
+        fallbackH: Int,
+    ): Pair<Int, Int> =
+        if (videoWidth > 0 && videoHeight > 0) safeAspect(videoWidth, videoHeight)
+        else safeAspect(fallbackW, fallbackH)
+
+    /**
+     * True on API 31+ (Android S), where [android.app.PictureInPictureParams.Builder.setAutoEnterEnabled]
+     * and setSeamlessResizeEnabled exist. Below S the controller keeps the onUserLeaveHint manual-enter
+     * fallback. Parameterized on [sdkInt] so it is pure/testable.
+     */
+    fun supportsAutoEnter(sdkInt: Int): Boolean = sdkInt >= 31
+
+    /**
+     * Whether the Activity should auto-enter PiP on user-leave (Home press) given the current
+     * [videoActive] state and PiP [pipSupported]. On API 31+ the system does this via
+     * setAutoEnterEnabled; on 26–30 the Activity calls this from onUserLeaveHint. Same predicate either
+     * way so behavior is consistent and testable.
+     */
+    fun shouldAutoEnterOnLeave(videoActive: Boolean, pipSupported: Boolean): Boolean =
+        videoActive && pipSupported
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/player/PipSourceLogic.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/player/PipSourceLogic.kt
@@ -1,0 +1,56 @@
+package com.testlogon.android.feature.player
+
+/**
+ * AND-PIP-CALL — pure, JVM-testable Picture-in-Picture SOURCE selection + call-eligibility logic.
+ *
+ * PiP now supports TWO kinds of floating content:
+ *  - [PipSourceKind.MEDIA3]  — the existing media3 [androidx.media3.common.Player] surface (VOD,
+ *    broadcast viewer, messaging video, newsfeed video). Rendered by a video-only PlayerView.
+ *  - [PipSourceKind.CALL]    — a LIVE WebRTC video call: the remote participant's LiveKit VideoTrack
+ *    rendered by a SurfaceViewRenderer. NOT a media3 Player, so it needs its own render branch.
+ *
+ * This object keeps the two decisions that must be correct — WHICH source the Activity collapses to in
+ * PiP, and WHETHER an active call is even PiP-eligible — out of the Android-touching controller so they
+ * are unit-testable without an emulator. All Android/PiP-param math continues to live in [PipParamsLogic].
+ */
+object PipSourceLogic {
+
+    /** Which kind of content the PiP window should render, or none. */
+    enum class PipSourceKind { NONE, MEDIA3, CALL }
+
+    /**
+     * Decide which PiP source is active given the two independent registrations. A CALL takes
+     * precedence over a media3 player when both are somehow registered (you cannot be watching a VOD
+     * and be in a live video call rendering into the same window; the call is the higher-intent
+     * foreground activity). Media3 is selected whenever a player is active and no call is. NONE means
+     * nothing is eligible — the Activity keeps the normal app shell even if the system forces PiP.
+     *
+     * @param callActive   true when a CONNECTED VIDEO call is registered (see [isCallPipEligible]).
+     * @param media3Active true when a media3 player is registered as the active/PiP video.
+     */
+    fun selectSource(callActive: Boolean, media3Active: Boolean): PipSourceKind = when {
+        callActive -> PipSourceKind.CALL
+        media3Active -> PipSourceKind.MEDIA3
+        else -> PipSourceKind.NONE
+    }
+
+    /**
+     * A call is PiP-eligible ONLY when it is a VIDEO call that is CONNECTED. An audio-only call has
+     * nothing to show in the floating window (it just keeps running in the ConnectionService), and a
+     * not-yet-connected / ended call must never arm auto-enter. Parameterized (no Android types) so it
+     * is pure/testable.
+     *
+     * @param isVideoCall true when the active call's mode is VIDEO.
+     * @param isConnected true when the call has reached the Connected phase (media flowing) and is not terminal.
+     */
+    fun isCallPipEligible(isVideoCall: Boolean, isConnected: Boolean): Boolean =
+        isVideoCall && isConnected
+
+    /**
+     * Whether the Activity should auto-enter PiP on user-leave (Home press) for a CALL. Same predicate
+     * as [isCallPipEligible] gated on PiP support — mirrors [PipParamsLogic.shouldAutoEnterOnLeave] for
+     * the media3 path so both branches behave consistently and are testable.
+     */
+    fun shouldAutoEnterCallOnLeave(callPipEligible: Boolean, pipSupported: Boolean): Boolean =
+        callPipEligible && pipSupported
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -25,6 +25,9 @@ object MoreRoutes {
     // AND-120..124: the messaging conversation list (inbox), first M3 two-user feature.
     val MESSAGES: String get() = MessagingRoutes.LIST
 
+    // Feature 1 — the saved-contacts address book + "people you may know" hub.
+    val CONTACTS_HUB: String get() = MessagingRoutes.CONTACTS_HUB
+
     // AND-160: mass messages (broadcast campaigns). Screen self-gates on the mass-send capability.
     val MASS_MESSAGES: String get() = MessagingRoutes.MASS_MESSAGES
 
@@ -504,6 +507,7 @@ object MoreRoutes {
         get() = setOf(
             PROFILE,
             MESSAGES,
+            CONTACTS_HUB,
             MASS_MESSAGES,
             CALL_HISTORY,
             BROADCASTS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="more_entry_notification_center">Notification center</string>
     <string name="more_entry_settings">Settings</string>
     <string name="more_entry_messages">Messages</string>
+    <string name="more_entry_contacts">Contacts</string>
     <string name="more_entry_activity">Activity</string>
     <string name="more_entry_saved">Saved</string>
     <string name="more_entry_achievements">Achievements</string>

--- a/android/app/src/test/java/com/testlogon/android/data/contacts/ContactMatchHasherTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/contacts/ContactMatchHasherTest.kt
@@ -1,0 +1,80 @@
+package com.testlogon.android.data.contacts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Contacts Feature 2 — proves the on-device normalize + hash produces BYTE-IDENTICAL
+ * hashes to the server scheme (app/services/contact_match.py + app/core/normalize.py).
+ *
+ * The expected hashes below were computed on the SERVER with the same fixed salt
+ * ("tl_contact_match_v1") over the same raw inputs (a shared test vector). If the
+ * client scheme drifts from the server, these assertions fail — which is exactly the
+ * regression we want to catch, since mismatched hashes = silent match failures.
+ */
+class ContactMatchHasherTest {
+
+    private val salt = "tl_contact_match_v1"
+    private val hasher = ContactMatchHasher(salt)
+
+    // ── Shared client==server hash vectors ──────────────────────────────────
+
+    @Test
+    fun email_matches_server_hash() {
+        // server: normalize_email("  Alice.Smith@Example.COM ") -> "alice.smith@example.com"
+        assertEquals(
+            "0a83af565c0afaa2eddfb243381f4877e872c94a4d377957f6ed8f29a087c73e",
+            hasher.hashEmail("  Alice.Smith@Example.COM "),
+        )
+    }
+
+    @Test
+    fun phone_us_10digit_matches_server_hash() {
+        val expected = "f25d3883c7b730fae325a77e88891a2870f8f26b1a20d5384a4d639a7241bcf0"
+        // All of these normalize to +14155550142 on both client and server.
+        assertEquals(expected, hasher.hashPhone("(415) 555-0142"))
+        assertEquals(expected, hasher.hashPhone("+1 415-555-0142"))
+        assertEquals(expected, hasher.hashPhone("4155550142"))
+    }
+
+    @Test
+    fun phone_international_e164_matches_server_hash() {
+        // A +44 number keeps its country code (no default-region rewrite).
+        assertEquals(
+            "69dc7ecba32f7775b1a0407a260a9f27d68c991381bfc051e1b7478c570e50db",
+            hasher.hashPhone("+442071838750"),
+        )
+    }
+
+    // ── Normalization edge cases (must mirror the server exactly) ────────────
+
+    @Test
+    fun email_without_at_is_rejected() {
+        assertNull(hasher.hashEmail("not-an-email"))
+        assertNull(hasher.hashEmail("   "))
+        assertNull(hasher.hashEmail(null))
+    }
+
+    @Test
+    fun phone_too_short_or_junk_is_rejected() {
+        assertNull(hasher.hashPhone("12345"))       // 5 digits, no + -> invalid
+        assertNull(hasher.hashPhone("abc"))
+        assertNull(hasher.hashPhone(""))
+        assertNull(hasher.hashPhone(null))
+    }
+
+    @Test
+    fun phone_11digit_leading_one_normalizes() {
+        // "1 415 555 0142" -> +14155550142 (same as the 10-digit case).
+        assertEquals(hasher.hashPhone("4155550142"), hasher.hashPhone("1-415-555-0142"))
+    }
+
+    @Test
+    fun normalize_helpers_are_pure_and_deterministic() {
+        assertEquals("alice.smith@example.com", ContactMatchHasher.normalizeEmail("  Alice.Smith@Example.COM "))
+        assertEquals("+14155550142", ContactMatchHasher.normalizePhone("(415) 555-0142"))
+        assertEquals("+442071838750", ContactMatchHasher.normalizePhone("+44 20 7183 8750"))
+        assertNull(ContactMatchHasher.normalizePhone("12345"))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/call/incall/InCallViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/call/incall/InCallViewModelTest.kt
@@ -19,7 +19,6 @@ import com.testlogon.android.feature.call.domain.CallManager
 import com.testlogon.android.feature.call.domain.CallTiming
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
@@ -95,6 +94,13 @@ class InCallViewModelTest {
             CallStatsSampler(),
             recordingController(),
             com.testlogon.android.data.webrtc.CallMediaHolder(),
+            object : com.testlogon.android.core.webrtc.ui.CallPipSourceFactory {
+                override fun source(aspectWidth: Int, aspectHeight: Int) =
+                    com.testlogon.android.feature.player.CallPipSource(
+                        makeView = { throw UnsupportedOperationException() },
+                        releaseView = {},
+                    )
+            },
             com.testlogon.android.core.data.cache.Clock { 0L },
             SavedStateHandle(),
             com.testlogon.android.core.webrtc.ui.PlaceholderVideoRenderer,
@@ -149,36 +155,39 @@ class InCallViewModelTest {
     }
 
     @Test
-    fun connectedVideo_mapsLifecycleAndIsVideo_withDuration() = runTest {
-        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    fun connectedVideo_mapsLifecycleAndIsVideo_withDuration() = runTest(mainDispatcher.dispatcher.scheduler) {
+        // A child of backgroundScope (so runTest cancels it before its end-of-test idle check, stopping the
+        // CallManager heartbeat while-loop + the uiState durationTicker), but UNCONFINED so the eager
+        // placeCall/onConnected + stateIn collector run inline and uiState.value is settled after runCurrent().
+        val scope = CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
         val repo = CountingRepo()
         val callManager = manager(scope, repo)
         callManager.placeCall("conv", "peer", CallMode.VIDEO, "Alex")
         callManager.onConnected()
 
         val viewModel = vm(callManager)
-        val job = launch { viewModel.uiState.collect {} }
+        scope.launch { viewModel.uiState.collect {} }
         runCurrent()
 
         val state = viewModel.uiState.value
         assertEquals(InCallLifecycle.Connected, state.lifecycle)
         assertTrue(state.isVideoCall)
         assertTrue(state.durationLabel.isNotEmpty())
-
-        job.cancel()
-        scope.coroutineContext[Job]?.cancel()
     }
 
     @Test
-    fun endCall_isIdempotent_callsEndExactlyOnce() = runTest {
-        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    fun endCall_isIdempotent_callsEndExactlyOnce() = runTest(mainDispatcher.dispatcher.scheduler) {
+        // A child of backgroundScope (so runTest cancels it before its end-of-test idle check, stopping the
+        // CallManager heartbeat while-loop + the uiState durationTicker), but UNCONFINED so the eager
+        // placeCall/onConnected + stateIn collector run inline and uiState.value is settled after runCurrent().
+        val scope = CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
         val repo = CountingRepo()
         val callManager = manager(scope, repo)
         callManager.placeCall("conv", "peer", CallMode.AUDIO, "Alex")
         callManager.onConnected()
 
         val viewModel = vm(callManager)
-        val job = launch { viewModel.uiState.collect {} }
+        scope.launch { viewModel.uiState.collect {} }
         runCurrent()
 
         viewModel.onAction(InCallAction.EndCall)
@@ -186,61 +195,57 @@ class InCallViewModelTest {
         runCurrent()
 
         assertEquals(1, repo.endCount)
-
-        job.cancel()
-        scope.coroutineContext[Job]?.cancel()
     }
 
     @Test
-    fun toggleMic_flipsMicEnabled() = runTest {
-        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    fun toggleMic_flipsMicEnabled() = runTest(mainDispatcher.dispatcher.scheduler) {
+        // A child of backgroundScope (so runTest cancels it before its end-of-test idle check, stopping the
+        // CallManager heartbeat while-loop + the uiState durationTicker), but UNCONFINED so the eager
+        // placeCall/onConnected + stateIn collector run inline and uiState.value is settled after runCurrent().
+        val scope = CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
         val callManager = manager(scope, CountingRepo())
         callManager.placeCall("conv", "peer", CallMode.AUDIO, "Alex")
         callManager.onConnected()
 
         val viewModel = vm(callManager)
-        val job = launch { viewModel.uiState.collect {} }
+        scope.launch { viewModel.uiState.collect {} }
         runCurrent()
 
         assertTrue(viewModel.uiState.value.micEnabled)
         viewModel.onAction(InCallAction.ToggleMic)
         runCurrent()
         assertFalse(viewModel.uiState.value.micEnabled)
-
-        job.cancel()
-        scope.coroutineContext[Job]?.cancel()
     }
 
     @Test
-    fun toggleCamera_flipsInVideo_butNoOpInAudioOnly() = runTest {
-        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    fun toggleCamera_flipsInVideo_butNoOpInAudioOnly() = runTest(mainDispatcher.dispatcher.scheduler) {
+        // A child of backgroundScope (so runTest cancels it before its end-of-test idle check, stopping the
+        // CallManager heartbeat while-loop + the uiState durationTicker), but UNCONFINED so the eager
+        // placeCall/onConnected + stateIn collector run inline and uiState.value is settled after runCurrent().
+        val scope = CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
 
         // Video call: camera toggles.
         val videoManager = manager(scope, CountingRepo())
         videoManager.placeCall("conv", "peer", CallMode.VIDEO, "Alex")
         videoManager.onConnected()
         val videoVm = vm(videoManager)
-        val videoJob = launch { videoVm.uiState.collect {} }
+        scope.launch { videoVm.uiState.collect {} }
         runCurrent()
         assertTrue(videoVm.uiState.value.cameraEnabled)
         videoVm.onAction(InCallAction.ToggleCamera)
         runCurrent()
         assertFalse(videoVm.uiState.value.cameraEnabled)
-        videoJob.cancel()
 
         // Audio-only call (a separate manager instance, so the single-active guard does not interfere).
         val audioManager = manager(scope, CountingRepo())
         audioManager.placeCall("conv2", "peer2", CallMode.AUDIO, "Bo")
         audioManager.onConnected()
         val audioVm = vm(audioManager)
-        val audioJob = launch { audioVm.uiState.collect {} }
+        scope.launch { audioVm.uiState.collect {} }
         runCurrent()
         assertTrue(audioVm.uiState.value.cameraEnabled)
         audioVm.onAction(InCallAction.ToggleCamera)
         runCurrent()
         assertTrue(audioVm.uiState.value.cameraEnabled)
-        audioJob.cancel()
-
-        scope.coroutineContext[Job]?.cancel()
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/contacts/ContactsHubMatchReducerTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/contacts/ContactsHubMatchReducerTest.kt
@@ -1,0 +1,65 @@
+package com.testlogon.android.feature.contacts
+
+import com.testlogon.android.data.contacts.ContactMatch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Contacts Feature 2 — pure reducer tests for the device-match overlay:
+ * matchResults (drops already-saved), markMatchAdding, removeMatch.
+ */
+class ContactsHubMatchReducerTest {
+
+    private fun match(id: String, by: String = "email") =
+        ContactMatch(userId = id, displayName = "Name $id", photoUrl = null, matchedBy = by)
+
+    private fun contact(id: String) =
+        ContactRow(userId = id, displayName = "Name $id", photoUrl = null, isFavorite = false)
+
+    @Test
+    fun matchResults_drops_already_saved_and_maps_labels() {
+        val result = ContactsHubReducer.matchResults(
+            matches = listOf(match("a", "email"), match("b", "phone"), match("c", "email")),
+            contacts = listOf(contact("b")), // b is already saved
+        )
+        val ids = result.matches.map { it.userId }
+        assertEquals(listOf("a", "c"), ids)                       // b filtered out
+        assertEquals("email", result.matches.first { it.userId == "a" }.matchedBy)
+        assertFalse(result.isEmpty)
+    }
+
+    @Test
+    fun matchResults_empty_when_all_saved() {
+        val result = ContactsHubReducer.matchResults(
+            matches = listOf(match("a"), match("b")),
+            contacts = listOf(contact("a"), contact("b")),
+        )
+        assertTrue(result.isEmpty)
+    }
+
+    @Test
+    fun markMatchAdding_flips_only_the_target() {
+        val base = ContactsHubReducer.matchResults(
+            matches = listOf(match("a"), match("b")),
+            contacts = emptyList(),
+        )
+        val adding = ContactsHubReducer.markMatchAdding(base, "a", adding = true)
+        assertTrue(adding.matches.first { it.userId == "a" }.adding)
+        assertFalse(adding.matches.first { it.userId == "b" }.adding)
+
+        val cleared = ContactsHubReducer.markMatchAdding(adding, "a", adding = false)
+        assertFalse(cleared.matches.first { it.userId == "a" }.adding)
+    }
+
+    @Test
+    fun removeMatch_drops_the_added_row() {
+        val base = ContactsHubReducer.matchResults(
+            matches = listOf(match("a"), match("b")),
+            contacts = emptyList(),
+        )
+        val after = ContactsHubReducer.removeMatch(base, "a")
+        assertEquals(listOf("b"), after.matches.map { it.userId })
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/contacts/ContactsHubViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/contacts/ContactsHubViewModelTest.kt
@@ -3,6 +3,7 @@ package com.testlogon.android.feature.contacts
 import com.testlogon.android.MainDispatcherRule
 import com.testlogon.android.core.model.ApiError
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.contacts.ContactMatch
 import com.testlogon.android.data.contacts.ContactSuggestion
 import com.testlogon.android.data.contacts.ContactsRepository
 import com.testlogon.android.data.contacts.FollowRelationship
@@ -43,6 +44,9 @@ class ContactsHubViewModelTest {
             addResult ?: ApiResult.Success(
                 SavedContact(userId, "Name $userId", null, isFavorite = false, isBlocked = false),
             )
+
+        var matchResult: ApiResult<List<ContactMatch>> = ApiResult.Success(emptyList())
+        override suspend fun matchDeviceContacts(): ApiResult<List<ContactMatch>> = matchResult
 
         override suspend fun removeContact(userId: String): ApiResult<Unit> = removeResult
 

--- a/android/app/src/test/java/com/testlogon/android/feature/contacts/ContactsHubViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/contacts/ContactsHubViewModelTest.kt
@@ -1,0 +1,218 @@
+package com.testlogon.android.feature.contacts
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.contacts.ContactSuggestion
+import com.testlogon.android.data.contacts.ContactsRepository
+import com.testlogon.android.data.contacts.FollowRelationship
+import com.testlogon.android.data.contacts.SavedContact
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContactsHubViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    // ── Fake repository ──────────────────────────────────────────────────────
+
+    private class FakeContactsRepository : ContactsRepository {
+        var contacts: MutableList<SavedContact> = mutableListOf()
+        var suggestionsList: List<ContactSuggestion> = emptyList()
+        var listResult: ApiResult<List<SavedContact>>? = null
+        var suggestionsResult: ApiResult<List<ContactSuggestion>>? = null
+        var addResult: ApiResult<SavedContact>? = null
+        var removeResult: ApiResult<Unit> = ApiResult.Success(Unit)
+        var favoriteResult: ((Boolean) -> ApiResult<SavedContact>)? = null
+
+        override suspend fun listContacts(): ApiResult<List<SavedContact>> =
+            listResult ?: ApiResult.Success(contacts.toList())
+
+        override suspend fun suggestions(): ApiResult<List<ContactSuggestion>> =
+            suggestionsResult ?: ApiResult.Success(suggestionsList)
+
+        override suspend fun addContact(userId: String): ApiResult<SavedContact> =
+            addResult ?: ApiResult.Success(
+                SavedContact(userId, "Name $userId", null, isFavorite = false, isBlocked = false),
+            )
+
+        override suspend fun removeContact(userId: String): ApiResult<Unit> = removeResult
+
+        override suspend fun setFavorite(userId: String, favorite: Boolean): ApiResult<SavedContact> =
+            favoriteResult?.invoke(favorite)
+                ?: ApiResult.Success(
+                    SavedContact(userId, "Name $userId", null, isFavorite = favorite, isBlocked = false),
+                )
+
+        override suspend fun follow(userId: String): ApiResult<Unit> = ApiResult.Success(Unit)
+        override suspend fun unfollow(userId: String): ApiResult<Unit> = ApiResult.Success(Unit)
+        override suspend fun followStatus(userId: String): ApiResult<FollowRelationship> =
+            ApiResult.Success(FollowRelationship(false, false, false))
+    }
+
+    private fun saved(id: String, favorite: Boolean = false) =
+        SavedContact(id, "Name $id", null, isFavorite = favorite, isBlocked = false)
+
+    private fun suggestion(id: String, hint: String = "Follows you") =
+        ContactSuggestion(id, "Name $id", null, hint = hint, mutualCount = 0, source = "follower")
+
+    private fun failure(status: Int) = ApiResult.Failure(ApiError(status = status, message = "boom"))
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun load_success_populatesBothSections_favoritesFirst() = runTest {
+        val repo = FakeContactsRepository().apply {
+            contacts = mutableListOf(saved("b"), saved("a", favorite = true))
+            suggestionsList = listOf(suggestion("s1"), suggestion("s2"))
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertTrue(state is ContactsHubUiState.Content)
+        val content = state as ContactsHubUiState.Content
+        // Favorite ("a") sorts before non-favorite ("b").
+        assertEquals(listOf("a", "b"), content.contacts.map { it.userId })
+        assertEquals(listOf("s1", "s2"), content.suggestions.map { it.userId })
+    }
+
+    @Test
+    fun load_suggestionAlreadySaved_isExcludedDefensively() = runTest {
+        val repo = FakeContactsRepository().apply {
+            contacts = mutableListOf(saved("dup"))
+            // Server *should* exclude it, but assert the reducer also filters it out.
+            suggestionsList = listOf(suggestion("dup"), suggestion("fresh"))
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+
+        val content = vm.state.value as ContactsHubUiState.Content
+        assertEquals(listOf("fresh"), content.suggestions.map { it.userId })
+    }
+
+    @Test
+    fun load_emptyBoth_isFullyEmptyContent() = runTest {
+        val repo = FakeContactsRepository()
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+        val content = vm.state.value as ContactsHubUiState.Content
+        assertTrue(content.isFullyEmpty)
+    }
+
+    @Test
+    fun load_serverFailure_emitsError_notOffline() = runTest {
+        val repo = FakeContactsRepository().apply { listResult = failure(500) }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+        val state = vm.state.value
+        assertTrue(state is ContactsHubUiState.Error)
+        assertFalse((state as ContactsHubUiState.Error).offline)
+    }
+
+    @Test
+    fun load_networkError_emitsOfflineError() = runTest {
+        val repo = FakeContactsRepository().apply {
+            listResult = ApiResult.NetworkError(java.io.IOException("x"), isTimeout = true)
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+        val state = vm.state.value
+        assertTrue(state is ContactsHubUiState.Error)
+        assertTrue((state as ContactsHubUiState.Error).offline)
+    }
+
+    @Test
+    fun saveSuggestion_movesItIntoContacts_andDropsFromSuggestions() = runTest {
+        val repo = FakeContactsRepository().apply {
+            suggestionsList = listOf(suggestion("s1"))
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+
+        vm.onSaveSuggestion("s1")
+        advanceUntilIdle()
+
+        val content = vm.state.value as ContactsHubUiState.Content
+        assertTrue(content.suggestions.isEmpty())
+        assertEquals(listOf("s1"), content.contacts.map { it.userId })
+    }
+
+    @Test
+    fun saveSuggestion_failure_clearsAddingFlag_keepsSuggestion() = runTest {
+        val repo = FakeContactsRepository().apply {
+            suggestionsList = listOf(suggestion("s1"))
+            addResult = failure(409)
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+
+        vm.onSaveSuggestion("s1")
+        advanceUntilIdle()
+
+        val content = vm.state.value as ContactsHubUiState.Content
+        assertEquals(listOf("s1"), content.suggestions.map { it.userId })
+        assertFalse(content.suggestions.first().adding)
+        assertTrue(content.contacts.isEmpty())
+    }
+
+    @Test
+    fun removeContact_optimisticThenRollbackOnFailure() = runTest {
+        val repo = FakeContactsRepository().apply {
+            contacts = mutableListOf(saved("c1"))
+            removeResult = failure(500)
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+
+        vm.onRemoveContact("c1")
+        advanceUntilIdle()
+
+        // Rolled back — contact is restored.
+        val content = vm.state.value as ContactsHubUiState.Content
+        assertEquals(listOf("c1"), content.contacts.map { it.userId })
+    }
+
+    @Test
+    fun toggleFavorite_success_reSortsFavoritesFirst() = runTest {
+        val repo = FakeContactsRepository().apply {
+            contacts = mutableListOf(saved("a"), saved("b"))
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+
+        // Favorite "b" -> it should jump to the top.
+        vm.onToggleFavorite("b", favorite = true)
+        advanceUntilIdle()
+
+        val content = vm.state.value as ContactsHubUiState.Content
+        assertEquals(listOf("b", "a"), content.contacts.map { it.userId })
+        assertTrue(content.contacts.first { it.userId == "b" }.isFavorite)
+    }
+
+    @Test
+    fun toggleFavorite_failure_rollsBack() = runTest {
+        val repo = FakeContactsRepository().apply {
+            contacts = mutableListOf(saved("a"), saved("b"))
+            favoriteResult = { failure(500) }
+        }
+        val vm = ContactsHubViewModel(repo)
+        advanceUntilIdle()
+
+        vm.onToggleFavorite("b", favorite = true)
+        advanceUntilIdle()
+
+        val content = vm.state.value as ContactsHubUiState.Content
+        // Original order + no favorite flip.
+        assertEquals(listOf("a", "b"), content.contacts.map { it.userId })
+        assertFalse(content.contacts.first { it.userId == "b" }.isFavorite)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/player/PipParamsLogicTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/player/PipParamsLogicTest.kt
@@ -1,0 +1,96 @@
+package com.testlogon.android.feature.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * AND-287 — pure JVM tests for the Picture-in-Picture params decisions shared by the live-broadcast
+ * viewer and the existing VOD/messaging/feed callers: aspect clamping, real-video-size preference,
+ * the API-31 auto-enter capability gate, and the auto-enter-on-leave predicate. No Android runtime.
+ */
+class PipParamsLogicTest {
+
+    // --- safeAspect: clamp to Android's permitted [1:2.39 .. 2.39:1] window ------------------------
+
+    @Test
+    fun safeAspect_passesThroughInRangeRatios() {
+        assertEquals(16 to 9, PipParamsLogic.safeAspect(16, 9))
+        assertEquals(9 to 16, PipParamsLogic.safeAspect(9, 16)) // portrait, still within 1:2.39
+        assertEquals(1 to 1, PipParamsLogic.safeAspect(1, 1))
+    }
+
+    @Test
+    fun safeAspect_clampsUltraWideLandscape() {
+        // 32:9 (~3.56) exceeds 2.39 -> clamp to 239:100.
+        assertEquals(239 to 100, PipParamsLogic.safeAspect(32, 9))
+    }
+
+    @Test
+    fun safeAspect_clampsUltraTallPortrait() {
+        // 9:32 (~0.28) is below 1/2.39 -> clamp to 100:239.
+        assertEquals(100 to 239, PipParamsLogic.safeAspect(9, 32))
+    }
+
+    @Test
+    fun safeAspect_nonPositiveFallsBackTo16by9() {
+        assertEquals(16 to 9, PipParamsLogic.safeAspect(0, 0))
+        assertEquals(16 to 9, PipParamsLogic.safeAspect(-5, 10))
+        assertEquals(16 to 9, PipParamsLogic.safeAspect(10, 0))
+    }
+
+    // --- resolveAspect: prefer real player video size, else caller fallback -----------------------
+
+    @Test
+    fun resolveAspect_prefersRealVideoSizeWhenKnown() {
+        // Live HLS reports 1920x1080 -> that (in-range) wins over a 1:1 fallback.
+        assertEquals(1920 to 1080, PipParamsLogic.resolveAspect(1920, 1080, 1, 1))
+    }
+
+    @Test
+    fun resolveAspect_fallsBackWhenVideoSizeUnknown() {
+        // Broadcast not yet sized (0x0) -> use the caller-supplied 16:9 default.
+        assertEquals(16 to 9, PipParamsLogic.resolveAspect(0, 0, 16, 9))
+    }
+
+    @Test
+    fun resolveAspect_clampsRealVideoSizeTooo() {
+        // A bizarre ultra-wide stream still gets clamped, never rejected by the system.
+        assertEquals(239 to 100, PipParamsLogic.resolveAspect(4000, 500, 16, 9))
+    }
+
+    // --- supportsAutoEnter: API 31 (S) capability gate --------------------------------------------
+
+    @Test
+    fun supportsAutoEnter_trueOnApi31Plus() {
+        assertTrue(PipParamsLogic.supportsAutoEnter(31))
+        assertTrue(PipParamsLogic.supportsAutoEnter(34))
+    }
+
+    @Test
+    fun supportsAutoEnter_falseBelow31() {
+        assertFalse(PipParamsLogic.supportsAutoEnter(30)) // R — manual onUserLeaveHint path
+        assertFalse(PipParamsLogic.supportsAutoEnter(26)) // O — PiP supported but manual-enter only
+        assertFalse(PipParamsLogic.supportsAutoEnter(24)) // pre-PiP
+    }
+
+    // --- shouldAutoEnterOnLeave: broadcast-active + PiP-supported ---------------------------------
+
+    @Test
+    fun shouldAutoEnterOnLeave_trueWhenBroadcastActiveAndSupported() {
+        // Broadcast playing on a PiP-capable device -> leaving the app floats the live stream.
+        assertTrue(PipParamsLogic.shouldAutoEnterOnLeave(videoActive = true, pipSupported = true))
+    }
+
+    @Test
+    fun shouldAutoEnterOnLeave_falseWhenNoActiveVideo() {
+        // Left the broadcast (video inactive) -> no PiP on Home.
+        assertFalse(PipParamsLogic.shouldAutoEnterOnLeave(videoActive = false, pipSupported = true))
+    }
+
+    @Test
+    fun shouldAutoEnterOnLeave_falseWhenPipUnsupported() {
+        assertFalse(PipParamsLogic.shouldAutoEnterOnLeave(videoActive = true, pipSupported = false))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/player/PipSourceLogicTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/player/PipSourceLogicTest.kt
@@ -1,0 +1,94 @@
+package com.testlogon.android.feature.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * CALL-PiP — pure JVM tests for the Picture-in-Picture SOURCE-selection + call-eligibility decisions
+ * that gate the new live-video-call PiP branch. No Android runtime; complements PipParamsLogicTest.
+ */
+class PipSourceLogicTest {
+
+    // --- selectSource: which content the PiP window collapses to -----------------------------------
+
+    @Test
+    fun selectSource_videoCallConnected_selectsCall() {
+        // A connected video call is registered as active -> the CALL branch is chosen (native WebRTC surface).
+        assertEquals(
+            PipSourceLogic.PipSourceKind.CALL,
+            PipSourceLogic.selectSource(callActive = true, media3Active = false),
+        )
+    }
+
+    @Test
+    fun selectSource_media3Active_stillSelectsPlayerBranch_noRegression() {
+        // VOD / broadcast / messaging / feed player active + no call -> the existing MEDIA3 branch (unchanged).
+        assertEquals(
+            PipSourceLogic.PipSourceKind.MEDIA3,
+            PipSourceLogic.selectSource(callActive = false, media3Active = true),
+        )
+    }
+
+    @Test
+    fun selectSource_callTakesPrecedenceOverMedia3() {
+        // If both are somehow registered, the live call wins (higher-intent foreground activity).
+        assertEquals(
+            PipSourceLogic.PipSourceKind.CALL,
+            PipSourceLogic.selectSource(callActive = true, media3Active = true),
+        )
+    }
+
+    @Test
+    fun selectSource_nothingActive_isNone() {
+        assertEquals(
+            PipSourceLogic.PipSourceKind.NONE,
+            PipSourceLogic.selectSource(callActive = false, media3Active = false),
+        )
+    }
+
+    // --- isCallPipEligible: only a CONNECTED VIDEO call floats -------------------------------------
+
+    @Test
+    fun isCallPipEligible_videoConnected_true() {
+        assertTrue(PipSourceLogic.isCallPipEligible(isVideoCall = true, isConnected = true))
+    }
+
+    @Test
+    fun isCallPipEligible_audioOnly_false() {
+        // Audio-only call: nothing to show -> NOT eligible; it keeps running in the ConnectionService.
+        assertFalse(PipSourceLogic.isCallPipEligible(isVideoCall = false, isConnected = true))
+    }
+
+    @Test
+    fun isCallPipEligible_videoNotYetConnected_false() {
+        // Connecting/ringing video call: no remote frames yet -> not eligible (do not arm auto-enter).
+        assertFalse(PipSourceLogic.isCallPipEligible(isVideoCall = true, isConnected = false))
+    }
+
+    // --- shouldAutoEnterCallOnLeave: mirrors the media3 predicate ----------------------------------
+
+    @Test
+    fun shouldAutoEnterCallOnLeave_requiresEligibleAndSupported() {
+        assertTrue(PipSourceLogic.shouldAutoEnterCallOnLeave(callPipEligible = true, pipSupported = true))
+        assertFalse(PipSourceLogic.shouldAutoEnterCallOnLeave(callPipEligible = true, pipSupported = false))
+        assertFalse(PipSourceLogic.shouldAutoEnterCallOnLeave(callPipEligible = false, pipSupported = true))
+    }
+
+    // --- call-ends-in-PiP: source clears -> selection falls back off the call branch ---------------
+
+    @Test
+    fun callEnds_sourceCleared_selectionLeavesCallBranch() {
+        // While connected: CALL. After the call ends and the source unregisters (callActive=false), the
+        // selection returns to NONE (or MEDIA3 if a player is up) so PiP exits the call branch.
+        assertEquals(
+            PipSourceLogic.PipSourceKind.CALL,
+            PipSourceLogic.selectSource(callActive = true, media3Active = false),
+        )
+        assertEquals(
+            PipSourceLogic.PipSourceKind.NONE,
+            PipSourceLogic.selectSource(callActive = false, media3Active = false),
+        )
+    }
+}

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -545,6 +545,19 @@ class Settings:
     # Contacts
     contacts_table_name: str = os.environ.get("DDB_CONTACTS_TABLE", "Contacts")
 
+    # Contacts Feature 2 — privacy-safe device contact sync (hash -> user_id match index).
+    # APP_CONTACT_MATCH_SALT is a FIXED, NON-SECRET app pepper (see
+    # app/services/contact_match.py). It is shared byte-for-byte with the Android client
+    # (BuildConfig.CONTACT_MATCH_SALT); if you change it you MUST rebuild the app AND
+    # re-run the backfill, or existing hashes stop matching.
+    contact_match_salt: str = os.environ.get("APP_CONTACT_MATCH_SALT", "tl_contact_match_v1")
+    contact_match_index_table_name: str = os.environ.get("DDB_CONTACT_MATCH_INDEX_TABLE", "ContactMatchIndex")
+    # Rate limit for POST /ui/contacts/match (per-user token bucket).
+    contact_match_max_per_window: int = int(os.environ.get("CONTACT_MATCH_MAX_PER_WINDOW", "30"))
+    contact_match_window_seconds: int = int(os.environ.get("CONTACT_MATCH_WINDOW_SECONDS", "3600"))
+    # Max hashes accepted per field per request (email_hashes / phone_hashes).
+    contact_match_max_hashes: int = int(os.environ.get("CONTACT_MATCH_MAX_HASHES", "2000"))
+
     # Sales pipeline (OPP-001)
     sales_pipeline_enabled: bool = os.environ.get(
         "SALES_PIPELINE_ENABLED", "false"

--- a/app/core/tables.py
+++ b/app/core/tables.py
@@ -98,6 +98,7 @@ class Tables:
     subscriptions: Any
     projects: Any
     contacts: Any
+    contact_match_index: Any  # Contacts Feature 2 — hash->user_id device-sync index
     sales_opportunities: Any
     sales_quotas: Any
     leads: Any  # CRM Leads (LED-001)
@@ -494,6 +495,7 @@ T = Tables(
     subscriptions=_safe_table(S.subscriptions_table_name),
     projects=_safe_table(S.projects_table_name),
     contacts=_safe_table(S.contacts_table_name),
+    contact_match_index=_safe_table(S.contact_match_index_table_name),
     sales_opportunities=_safe_table(S.sales_opportunities_table_name),
     sales_quotas=_safe_table(S.sales_quotas_table_name),
     leads=_safe_table(S.leads_table_name),  # CRM Leads (LED-001)

--- a/app/routers/contacts.py
+++ b/app/routers/contacts.py
@@ -181,3 +181,227 @@ def update_contact(contact_id: str, inp: UpdateContactIn, ctx: Dict = Depends(re
     except Exception:
         pass
     return contact_out
+
+
+# ── People-you-may-know suggestions ─────────────────────────────────────────
+
+class SuggestionCard(BaseModel):
+    user_id: str
+    display_name: str
+    profile_photo_url: Optional[str] = None
+    # Relationship hint for the UI, e.g. "Follows you", "You follow", "Mutual",
+    # "Recent chat", "2 mutual connections".
+    hint: str
+    mutual_count: int = 0
+    source: str  # one of: mutual | follower | following | dm_peer
+
+
+def _load_saved_contact_ids(owner_id: str) -> set:
+    saved: set = set()
+    last_key = None
+    while True:
+        kwargs: Dict[str, Any] = {
+            "KeyConditionExpression": Key("owner_id").eq(owner_id),
+            "ProjectionExpression": "contact_id",
+            "Limit": 500,
+        }
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = T.contacts.query(**kwargs)
+        for it in resp.get("Items", []):
+            cid = it.get("contact_id")
+            if cid:
+                saved.add(cid)
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+    return saved
+
+
+def _recent_dm_peer_ids(user_sub: str, *, limit: int = 40) -> List[str]:
+    """Best-effort: recent 1:1 DM peers, most-recent-first, de-duplicated.
+
+    Reuses the messaging Participants/Conversations tables. Isolated so a
+    messaging-side change or missing table never breaks the contacts hub.
+    """
+    peers: List[str] = []
+    seen: set = set()
+    try:
+        from boto3.dynamodb.conditions import Key as _Key
+        from app.routers.messaging import (
+            tbl_parts as _tbl_parts,
+            tbl_convos as _tbl_convos,
+        )
+
+        parts: List[Dict[str, Any]] = []
+        last_key = None
+        while True:
+            kwargs: Dict[str, Any] = {
+                "KeyConditionExpression": _Key("user_id").eq(user_sub),
+                "Limit": 500,
+            }
+            if last_key:
+                kwargs["ExclusiveStartKey"] = last_key
+            resp = _tbl_parts.query(**kwargs)
+            parts.extend(resp.get("Items", []))
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key or len(parts) >= 2000:
+                break
+
+        cids = [p.get("conversation_id") for p in parts if p.get("conversation_id")]
+
+        # Enrich conversations for recency + type; cap the fan-out.
+        convo_map: Dict[str, Dict[str, Any]] = {}
+        for cid in cids:
+            try:
+                convo = _tbl_convos.get_item(Key={"conversation_id": cid}).get("Item")
+                if convo:
+                    convo_map[cid] = convo
+            except Exception:
+                continue
+
+        def _recency(cid: str) -> int:
+            c = convo_map.get(cid, {})
+            return int(c.get("last_message_at", 0) or c.get("created_at", 0) or 0)
+
+        for cid in sorted(cids, key=_recency, reverse=True):
+            convo = convo_map.get(cid, {})
+            ctype = str(convo.get("type") or "").lower()
+            if ctype and ctype != "dm":
+                continue
+            try:
+                other = _tbl_parts.query(
+                    IndexName="GSI1",
+                    KeyConditionExpression=_Key("GSI1PK").eq(cid),
+                    Limit=10,
+                ).get("Items", [])
+            except Exception:
+                other = []
+            for op in other:
+                pid = op.get("user_id")
+                if pid and pid != user_sub and pid not in seen:
+                    seen.add(pid)
+                    peers.append(pid)
+            if len(peers) >= limit:
+                break
+    except Exception:
+        return peers
+    return peers[:limit]
+
+
+@router.get("/suggestions", response_model=Dict[str, List[SuggestionCard]])
+def contact_suggestions(ctx: Dict = Depends(require_ui_session)):
+    """People-you-may-know: mutuals + follow graph + recent DM peers, minus
+    self, already-saved contacts, and blocked/blocking users. Read-only."""
+    from app.services import social as _social
+    from app.services import blocking as _blocking
+
+    user_sub = ctx["user_sub"]
+
+    saved = _load_saved_contact_ids(user_sub)
+    try:
+        blocked = _blocking.get_blocked_set(user_sub)
+    except Exception:
+        blocked = set()
+    try:
+        blocked_by = _blocking.get_blocked_by_set(user_sub)
+    except Exception:
+        blocked_by = set()
+
+    excluded = set(saved) | set(blocked) | set(blocked_by) | {user_sub}
+
+    # candidate_id -> {source, mutual_count}
+    candidates: Dict[str, Dict[str, Any]] = {}
+    rank = {"mutual": 0, "follower": 1, "following": 2, "dm_peer": 3}
+
+    def _consider(cid: str, source: str, mutual_count: int = 0) -> None:
+        if not cid or cid in excluded:
+            return
+        cur = candidates.get(cid)
+        # Priority: mutual > follower(follows-you) > following > dm_peer.
+        if cur is None or rank.get(source, 9) < rank.get(cur["source"], 9):
+            candidates[cid] = {"source": source, "mutual_count": mutual_count}
+        elif source == cur["source"] and mutual_count > cur["mutual_count"]:
+            cur["mutual_count"] = mutual_count
+
+    # 1) People who follow me but I haven't saved -> "Follows you" (strong signal)
+    try:
+        followers, _ = _social.get_followers(user_sub, limit=100)
+        for it in followers:
+            _consider(it.get("user_id", ""), "follower")
+    except Exception:
+        pass
+
+    # 2) People I follow -> "You follow"
+    try:
+        following, _ = _social.get_following(user_sub, limit=100)
+        for it in following:
+            _consider(it.get("target_user_id", "") or it.get("user_id", ""), "following")
+    except Exception:
+        pass
+
+    # 3) Mutual connections: friends-of-friends. For each person I follow, pull
+    #    who THEY follow and surface non-excluded ones with a mutual count.
+    try:
+        following2, _ = _social.get_following(user_sub, limit=50)
+        fof_counts: Dict[str, int] = {}
+        for it in following2:
+            fid = it.get("target_user_id", "") or it.get("user_id", "")
+            if not fid:
+                continue
+            try:
+                their_following, _ = _social.get_following(fid, limit=50)
+            except Exception:
+                continue
+            for jt in their_following:
+                cand = jt.get("target_user_id", "") or jt.get("user_id", "")
+                if cand and cand not in excluded:
+                    fof_counts[cand] = fof_counts.get(cand, 0) + 1
+        for cand, cnt in fof_counts.items():
+            _consider(cand, "mutual", mutual_count=cnt)
+    except Exception:
+        pass
+
+    # 4) Recent DM peers I haven't saved.
+    try:
+        for pid in _recent_dm_peer_ids(user_sub, limit=40):
+            _consider(pid, "dm_peer")
+    except Exception:
+        pass
+
+    # Rank: mutual (by count desc) first, then follower, following, dm_peer.
+    ordered = sorted(
+        candidates.items(),
+        key=lambda kv: (rank.get(kv[1]["source"], 9), -kv[1]["mutual_count"]),
+    )[:50]
+
+    cards: List[SuggestionCard] = []
+    for cid, meta in ordered:
+        try:
+            identity = get_profile_identity(cid)
+            display_name = identity.get("display_name") or cid
+            photo = identity.get("profile_photo_url") or None
+        except Exception:
+            display_name, photo = cid, None
+
+        source = meta["source"]
+        mc = int(meta["mutual_count"])
+        if source == "mutual":
+            hint = f"{mc} mutual connection{'s' if mc != 1 else ''}" if mc else "Mutual connection"
+        elif source == "follower":
+            hint = "Follows you"
+        elif source == "following":
+            hint = "You follow"
+        else:
+            hint = "Recent chat"
+
+        cards.append(SuggestionCard(
+            user_id=cid,
+            display_name=display_name,
+            profile_photo_url=photo,
+            hint=hint,
+            mutual_count=mc,
+            source=source,
+        ))
+
+    return {"suggestions": cards}

--- a/app/routers/contacts.py
+++ b/app/routers/contacts.py
@@ -7,6 +7,7 @@ from boto3.dynamodb.conditions import Key
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from app.core.settings import S as S_settings
 from app.core.tables import T
 from app.services.profile import get_profile_identity
 from app.services.sessions import require_ui_session
@@ -405,3 +406,86 @@ def contact_suggestions(ctx: Dict = Depends(require_ui_session)):
         ))
 
     return {"suggestions": cards}
+
+
+
+# ── Contacts Feature 2: privacy-safe device contact match ────────────────────
+
+class ContactMatchIn(BaseModel):
+    # Client sends ONLY hashes (sha256(salt + ":" + normalized identifier)); raw
+    # emails/phones never leave the device and are never received here.
+    email_hashes: List[str] = []
+    phone_hashes: List[str] = []
+
+
+class ContactMatchCard(BaseModel):
+    user_id: str
+    display_name: str
+    profile_photo_url: Optional[str] = None
+    # Which identifier kind matched this card, so the client can label it
+    # ("In your contacts by email/phone"). One of: email | phone.
+    matched_by: str
+
+
+@router.post("/match", response_model=Dict[str, List[ContactMatchCard]])
+def match_contacts(inp: ContactMatchIn, ctx: Dict = Depends(require_ui_session)):
+    """Match a device address book (hashed on-device) against platform users.
+
+    Body: {email_hashes: [...], phone_hashes: [...]} — hashes ONLY. Resolves each
+    hash via the ContactMatchIndex, returns public profile cards for matched
+    users, excluding self, already-saved contacts, and blocked/blocking users
+    (Phase-1 exclusion logic). Raw identifiers are NEVER persisted or logged —
+    only ephemeral hash get_item lookups happen. Own-scoped + rate-limited.
+    """
+    from app.services import blocking as _blocking
+    from app.services import contact_match as _cm
+    from app.services.rate_limit import rate_limit_contact_match
+
+    user_sub = ctx["user_sub"]
+    rate_limit_contact_match(user_sub)
+
+    cap = int(getattr(S_settings, "contact_match_max_hashes", 2000) or 2000)
+    email_hashes = _cm.clamp_hash_list(inp.email_hashes, cap=cap)
+    phone_hashes = _cm.clamp_hash_list(inp.phone_hashes, cap=cap)
+
+    # Resolve hashes -> user_ids (email preferred as the match label when both hit).
+    email_map = _cm.lookup_hashes(email_hashes)   # {hash: (user_id, kind)}
+    phone_map = _cm.lookup_hashes(phone_hashes)
+
+    matched_by: Dict[str, str] = {}
+    for _h, (uid, _kind) in phone_map.items():
+        matched_by.setdefault(uid, "phone")
+    for _h, (uid, _kind) in email_map.items():
+        matched_by[uid] = "email"  # email wins the label if both matched
+
+    # Phase-1 exclusion: self + already-saved + blocked/blocking.
+    saved = _load_saved_contact_ids(user_sub)
+    try:
+        blocked = _blocking.get_blocked_set(user_sub)
+    except Exception:
+        blocked = set()
+    try:
+        blocked_by = _blocking.get_blocked_by_set(user_sub)
+    except Exception:
+        blocked_by = set()
+    excluded = set(saved) | set(blocked) | set(blocked_by) | {user_sub}
+
+    cards: List[ContactMatchCard] = []
+    for uid, kind in matched_by.items():
+        if not uid or uid in excluded:
+            continue
+        try:
+            identity = get_profile_identity(uid)
+            display_name = identity.get("display_name") or uid
+            photo = identity.get("profile_photo_url") or None
+        except Exception:
+            display_name, photo = uid, None
+        cards.append(ContactMatchCard(
+            user_id=uid,
+            display_name=display_name,
+            profile_photo_url=photo,
+            matched_by=kind,
+        ))
+
+    cards.sort(key=lambda c: c.display_name.lower())
+    return {"matches": cards}

--- a/app/services/contact_match.py
+++ b/app/services/contact_match.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+"""Privacy-safe contact matching (Contacts Feature 2).
+
+Overview
+--------
+The device contact-sync feature matches a user's native address book against
+platform users WITHOUT ever receiving raw contacts. The Android client
+normalizes every email/phone locally, hashes each one, and sends ONLY the
+hashes. The server keeps a hash -> user_id lookup index built at registration
+(email always) and when a profile phone is added/changed (phone).
+
+Hashing scheme (documented, shared byte-for-byte with the client)
+-----------------------------------------------------------------
+    id_hash = sha256( APP_CONTACT_MATCH_SALT + ":" + normalized_identifier )
+              (hex, lowercase)
+
+  - email:  lowercased + trimmed  (reuses app.core.normalize.normalize_email)
+  - phone:  E.164, default region +1 (reuses app.core.normalize.normalize_phone)
+
+APP_CONTACT_MATCH_SALT is a FIXED, NON-SECRET application pepper. It is NOT a
+security boundary: the platform already holds every user's email (it is the
+account primary key) and any phone the user chose to share, so a matching hash
+reveals nothing the platform does not already know. The salt only raises the
+bar against trivial precomputed-rainbow-table lookups of the raw hashes and
+keeps our hashes from colliding with any other system's sha256(identifier).
+Because it must be identical on the client and server, it is shipped as a
+compile-time BuildConfig constant on Android and an env-overridable setting here
+(both default to the same literal).
+
+Index table
+-----------
+A dedicated lookup table (S.contact_match_index_table_name, default
+"ContactMatchIndex"), partition key ``id_hash`` (S). Each item is::
+
+    {"id_hash": <hex>, "user_id": <user_sub>, "kind": "email"|"phone",
+     "updated_at": <epoch>}
+
+Only the HASH is stored — never the raw email/phone. Lookups are direct
+get_item calls (O(1), no scan, no GSI).
+"""
+
+import hashlib
+from typing import Dict, List, Optional, Tuple
+
+from fastapi import HTTPException
+
+from app.core.normalize import normalize_email, normalize_phone
+from app.core.settings import S
+from app.core.tables import T
+from app.core.time import now_ts
+
+EMAIL = "email"
+PHONE = "phone"
+
+
+# ── Hashing ──────────────────────────────────────────────────────────────────
+
+def hash_identifier(normalized: str) -> str:
+    """sha256(salt + ':' + normalized) -> lowercase hex. Shared with the client."""
+    salt = S.contact_match_salt or ""
+    return hashlib.sha256(f"{salt}:{normalized}".encode("utf-8")).hexdigest()
+
+
+def hash_email(raw_email: str) -> Optional[str]:
+    """Normalize + hash an email. Returns None on invalid input (never raises)."""
+    try:
+        return hash_identifier(normalize_email(raw_email))
+    except Exception:
+        return None
+
+
+def hash_phone(raw_phone: str) -> Optional[str]:
+    """Normalize (E.164, default +1) + hash a phone. None on invalid input."""
+    if not raw_phone:
+        return None
+    try:
+        return hash_identifier(normalize_phone(raw_phone))
+    except Exception:
+        return None
+
+
+# ── Index maintenance (write path — hooked at registration + profile update) ─
+
+def _put_index(id_hash: str, user_id: str, kind: str) -> None:
+    if not id_hash or not user_id:
+        return
+    try:
+        T.contact_match_index.put_item(Item={
+            "id_hash": id_hash,
+            "user_id": user_id,
+            "kind": kind,
+            "updated_at": now_ts(),
+        })
+    except Exception:
+        # Best-effort: an index write must NEVER break registration / profile save.
+        pass
+
+
+def index_user_email(user_sub: str) -> bool:
+    """Index a user's email hash. user_sub IS the normalized email (users PK).
+
+    Returns True if a hash was written. Best-effort — never raises.
+    """
+    h = hash_email(user_sub)
+    if not h:
+        return False
+    _put_index(h, user_sub, EMAIL)
+    return True
+
+
+def index_user_phone(user_sub: str, raw_phone: Optional[str]) -> bool:
+    """Index a user's phone hash (E.164). No-op when phone is absent/invalid.
+
+    Best-effort — never raises. Returns True if a hash was written.
+    """
+    if not raw_phone:
+        return False
+    h = hash_phone(raw_phone)
+    if not h:
+        return False
+    _put_index(h, user_sub, PHONE)
+    return True
+
+
+def index_user(user_sub: str, raw_phone: Optional[str] = None) -> Dict[str, bool]:
+    """Index both email (always) and phone (when present) for a user."""
+    return {
+        "email": index_user_email(user_sub),
+        "phone": index_user_phone(user_sub, raw_phone),
+    }
+
+
+# ── Lookup (read path — used by POST /ui/contacts/match) ─────────────────────
+
+def lookup_hashes(hashes: List[str]) -> Dict[str, Tuple[str, str]]:
+    """Resolve a list of id_hashes to {id_hash: (user_id, kind)}.
+
+    Direct get_item per hash (deduped). Missing hashes are simply absent from
+    the result — a non-match returns nothing, never an error.
+    """
+    out: Dict[str, Tuple[str, str]] = {}
+    for h in {x for x in hashes if x}:
+        try:
+            item = T.contact_match_index.get_item(Key={"id_hash": h}).get("Item")
+        except Exception:
+            item = None
+        if item and item.get("user_id"):
+            out[h] = (str(item["user_id"]), str(item.get("kind") or ""))
+    return out
+
+
+# ── Request caps ─────────────────────────────────────────────────────────────
+
+def clamp_hash_list(hashes: Optional[List[str]], *, cap: int) -> List[str]:
+    """Validate + cap a hash list. Drops blanks; rejects oversized payloads."""
+    if hashes is None:
+        return []
+    if not isinstance(hashes, list):
+        raise HTTPException(400, "hashes must be a list")
+    cleaned = [str(h).strip().lower() for h in hashes if isinstance(h, str) and h.strip()]
+    if len(cleaned) > cap:
+        raise HTTPException(413, f"Too many hashes (max {cap} per field)")
+    # Defensive: reject anything that is not a plausible hex sha256 (64 hex chars).
+    return [h for h in cleaned if len(h) == 64 and all(c in "0123456789abcdef" for c in h)]

--- a/app/services/profile.py
+++ b/app/services/profile.py
@@ -343,6 +343,7 @@ def apply_profile_update(user_sub: str, updates: Dict[str, Any], *, replace: boo
     ts = now_ts()
     address_changed = False
     discovery_changed = False
+    phone_changed = False
     for field in PROFILE_FIELDS:
         if current.get(field) != updated.get(field):
             audit_entries.append({
@@ -355,6 +356,8 @@ def apply_profile_update(user_sub: str, updates: Dict[str, Any], *, replace: boo
                 address_changed = True
             if field in DISCOVERY_FIELDS:
                 discovery_changed = True
+            if field == "displayed_telephone_number":
+                phone_changed = True
 
     save_profile(user_sub, updated, audit_entries)
 
@@ -374,6 +377,16 @@ def apply_profile_update(user_sub: str, updates: Dict[str, Any], *, replace: boo
     # profile update, and the import is lazy to avoid any circular-import risk.
     if discovery_changed:
         _reindex_user_for_discovery(user_sub)
+
+    # Contacts Feature 2: (re)index this user's phone hash when the displayed phone
+    # changes, so devices can privacy-safely match by phone. Best-effort — never
+    # rolls back the (already committed) profile write.
+    if phone_changed:
+        try:
+            from app.services.contact_match import index_user_phone
+            index_user_phone(user_sub, updated.get("displayed_telephone_number"))
+        except Exception:
+            pass
 
     # PTY-010: re-sync party EMAIL/PHONE contact mechs when those fields change
     # (best-effort, doubly flag-gated, never rolls back the profile write).

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -224,6 +224,24 @@ def rate_limit_profile_lookup(requester_user_sub: Optional[str], ip: str) -> Non
             headers={"Retry-After": str(window_seconds)},
         )
 
+def rate_limit_contact_match(user_sub: str) -> None:
+    """Contacts Feature 2 — cap POST /ui/contacts/match per user (token bucket)."""
+    cap = max(1, int(getattr(S, "contact_match_max_per_window", 30) or 30))
+    window = max(1, int(getattr(S, "contact_match_window_seconds", 3600) or 3600))
+    sid = "rl#contact_match"
+    if not _bucket_limit(user_sub, sid, cap, window):
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "contact_match_rate_limited",
+                "message": "Too many contact-match requests; try again later",
+                "limit": cap,
+                "window_seconds": window,
+            },
+            headers={"Retry-After": str(window)},
+        )
+
+
 def rate_limit_feed_query(user_sub: str, mode: str) -> None:
     cap = max(1, int(getattr(S, "newsfeed_feed_query_max_per_window", 180) or 180))
     window = max(1, int(getattr(S, "newsfeed_feed_query_window_seconds", 60) or 60))

--- a/app/services/registration.py
+++ b/app/services/registration.py
@@ -145,6 +145,16 @@ def create_user_record(
         requested_by=user_sub,
         ttl_epoch=pending_ttl if verification_required else None,
     )
+
+    # Contacts Feature 2 — index this user's email hash so devices can privacy-safely
+    # match their address book to this account. user_sub IS the normalized email.
+    # Best-effort: an index failure must never fail registration.
+    try:
+        from app.services.contact_match import index_user_email
+        index_user_email(user_sub)
+    except Exception:
+        pass
+
     return {"user_sub": user_sub}
 
 

--- a/ops/backfill_contact_match.py
+++ b/ops/backfill_contact_match.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Contacts Feature 2 — backfill the ContactMatchIndex for EXISTING users.
+
+Iterates every user, computes:
+  - email_hash from the user's PK (user_sub == normalized email), always
+  - phone_hash from profile.displayed_telephone_number (E.164), when present
+and writes them into the hash -> user_id lookup index. Only HASHES are stored
+(never the raw email/phone). Idempotent + re-runnable (put_item upserts).
+
+Run (dev or prod, from the repo root, with the backend env loaded)::
+
+    PYTHONPATH=. python ops/backfill_contact_match.py            # apply
+    PYTHONPATH=. python ops/backfill_contact_match.py --dry-run  # count only
+"""
+from __future__ import annotations
+
+import sys
+
+from app.core.tables import T
+from app.services import contact_match as cm
+from app.services.profile import get_profile
+
+
+def _iter_users():
+    last_key = None
+    while True:
+        kwargs = {"Limit": 500}
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        resp = T.users.scan(**kwargs)
+        for it in resp.get("Items", []):
+            yield it
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+
+def main() -> None:
+    dry = "--dry-run" in sys.argv
+    n_users = n_email = n_phone = 0
+    for it in _iter_users():
+        user_sub = it.get("user_sub") or it.get("email")
+        if not user_sub:
+            continue
+        n_users += 1
+
+        eh = cm.hash_email(user_sub)
+        phone = None
+        try:
+            phone = get_profile(user_sub).get("displayed_telephone_number")
+        except Exception:
+            phone = None
+        ph = cm.hash_phone(phone) if phone else None
+
+        if dry:
+            if eh:
+                n_email += 1
+            if ph:
+                n_phone += 1
+            continue
+
+        if cm.index_user_email(user_sub):
+            n_email += 1
+        if phone and cm.index_user_phone(user_sub, phone):
+            n_phone += 1
+
+    mode = "DRY-RUN" if dry else "APPLIED"
+    print(f"[{mode}] users={n_users} email_hashes={n_email} phone_hashes={n_phone}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/prod-hotfixes/contact-sync/README.md
+++ b/ops/prod-hotfixes/contact-sync/README.md
@@ -1,0 +1,79 @@
+# Contacts Feature 2 — Device contact sync (privacy-safe match) — prod hotfix
+
+Match a user's native Android address book against platform users by EMAIL + PHONE,
+privacy-safely (only hashes ever leave the device), and let them add matches to the
+Phase-1 Contacts hub.
+
+## Hashing scheme (shared byte-for-byte client<->server)
+
+    id_hash = sha256( APP_CONTACT_MATCH_SALT + ":" + normalized_identifier )   (lowercase hex)
+
+- email: lowercased + trimmed (`app.core.normalize.normalize_email`)
+- phone: E.164, default region +1 (`app.core.normalize.normalize_phone`)
+- `APP_CONTACT_MATCH_SALT` is a FIXED, NON-SECRET app pepper (default `tl_contact_match_v1`),
+  shipped to Android as `BuildConfig.CONTACT_MATCH_SALT`. It is NOT a security boundary — the
+  platform already holds every user's email (account PK) and any shared phone, so a matching
+  hash reveals nothing new. The salt only raises the bar against precomputed rainbow tables.
+  Changing it requires an app rebuild AND a backfill re-run.
+
+## Backend changes
+
+- NEW `app/services/contact_match.py` — hashing + the `ContactMatchIndex` (hash -> user_id)
+  read/write helpers. Only HASHES are stored, never raw identifiers.
+- NEW table `ContactMatchIndex`, PK `id_hash` (S). Direct get_item lookups (no scan/GSI).
+- NEW `POST /ui/contacts/match` on `app/routers/contacts.py` — own-scoped (require_ui_session),
+  RATE-LIMITED (`rate_limit_contact_match`, 30/hour), caps hashes/field (413), body is hashes
+  only. Excludes self / already-saved / blocked (Phase-1 exclusion logic). Returns match cards
+  `{user_id, display_name, profile_photo_url, matched_by}`. No api_key registry entry needed
+  (the contacts router carries no api-key policy dependency — boot never RuntimeErrors).
+- Registration hook: `create_user_record` indexes the email hash (user_sub IS the email).
+- Profile hook: `apply_profile_update` (re)indexes the phone hash when `displayed_telephone_number`
+  changes. Both hooks best-effort (never fail the write).
+- Settings: `contact_match_salt`, `contact_match_index_table_name`, rate/cap knobs.
+
+## IMPORTANT: prod runs DEV_MODE=1 (DDB-Local at localhost:8001 on the instance)
+
+The running prod uvicorn is launched by `scripts/run_local_mock_backend.sh`, which sources
+`.env.local` (DEV_MODE=1, `DDB_ENDPOINT_URL=http://localhost:8001`). So the app's REAL data
+store — including `Contacts` (Phase 1) and this feature's `ContactMatchIndex` — lives in the
+instance's DDB-Local, NOT real AWS. The EC2 instance role has NO DDB Scan/control-plane perms,
+so all table create/verify MUST be done ON the instance against localhost:8001 (source
+`.env.local`, use the `.venv` python). Do NOT create the table in real AWS us-east-1.
+
+## Runbook (SSM, instance i-08f937fc705ebea75, us-east-2; runs from the dev host)
+
+1. `prod_inspect_cs.py`          — snapshot prod md5s / route / workers.
+2. `prod_apply_cs.py`            — byte-mirror `contacts.py` (md5 == dev
+   `f50b07792542db463cc8f84d7e676f0c`) + upload `contact_match.py` + `ops/backfill_contact_match.py`,
+   then apply IDEMPOTENT targeted patches to the 5 shared files (settings/tables/registration/
+   profile/rate_limit) IN PLACE (those carry prod-only divergence — never byte-clobbered).
+   Keeps `.bak_contactsync_*` of every touched file. AST-verifies + marker-checks after.
+3. `prod_restart_verify_cs.py`   — restart via absolute `/home/ubuntu/restart_backend.sh`
+   (self-detaches; do NOT pkill inside SSM). Polls openapi 200 + single worker + match route.
+4. `prod_run_create_backfill.py` — create `ContactMatchIndex` in DDB-Local (localhost:8001,
+   sourcing `.env.local`) + run the backfill against the same store.
+5. `prod_run_verify.py`          — index count + raw-never-stored inspection + a LIVE match
+   over prod HTTP (`POST /ui/contacts/match`).
+6. `prod_final_health.py`        — openapi 200 / WORKERS=1 / match + suggestions routes present.
+
+### Applied result (verified)
+
+- Files byte-mirrored/patched, AST OK, markers present. Restart: openapi 200, WORKERS=1,
+  `/ui/contacts/match` present.
+- Backfill: `users=197 email_hashes=195 phone_hashes=0` (phone is sparsely populated on prod,
+  as scoped). `ContactMatchIndex` = 195 items; each item has only `id_hash/user_id/kind/updated_at`
+  (no raw email/phone). LIVE match over HTTP returned 200 with the correct matched card.
+
+## Backfill (dev or prod, idempotent + re-runnable)
+
+    # from repo root, with the app env loaded (prod: source .env.local; use .venv python):
+    PYTHONPATH=. python ops/backfill_contact_match.py            # apply
+    PYTHONPATH=. python ops/backfill_contact_match.py --dry-run  # count only
+
+## Deferred / flagged
+
+- On-device address-book READ is out of the build-gate (Android runtime). The read+hash path is
+  covered by the shared client==server hash-vector unit test (proves byte-identical hashes).
+- Phone coverage is sparse on prod (0 phone hashes today) because `displayed_telephone_number`
+  is optional at signup. New/updated phones index going forward via the profile hook.
+- Invite flow: OS share-sheet with a join link (no fake SMS pipeline). A real SMS invite is v2.

--- a/ops/prod-hotfixes/contact-sync/prod_apply_cs.py
+++ b/ops/prod-hotfixes/contact-sync/prod_apply_cs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Contacts Feature 2 — prod mirror (SSM). Runs ON the dev host (has AWS creds).
+
+Strategy:
+  - contacts.py           : byte-identical mirror (prod == Phase-1 baseline; md5 verified).
+  - contact_match.py      : new file, byte-identical upload.
+  - ops/backfill_...py     : new file, byte-identical upload.
+  - settings/tables/registration/profile/rate_limit : TARGETED idempotent Python
+    patches applied IN PLACE on prod (those files carry prod-only divergence, so we
+    never byte-clobber them). Each patch is a no-op if already applied.
+Keeps .bak of every touched file. Verifies AST + expected markers after.
+"""
+import base64, hashlib, sys, time
+import boto3
+
+REGION = "us-east-2"; IID = "i-08f937fc705ebea75"
+DEV = "/home/sean/dev/testlogon"
+
+# Dev md5s for the two byte-mirrored source files (drift guard).
+CONTACTS_MD5 = "f50b07792542db463cc8f84d7e676f0c"
+
+ssm = boto3.client("ssm", region_name=REGION)
+
+def run(cmd, timeout="180"):
+    r = ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+        Parameters={"commands": [cmd], "executionTimeout": [timeout]})
+    cid = r["Command"]["CommandId"]
+    while True:
+        time.sleep(2)
+        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
+            break
+    return inv
+
+def must(inv, label):
+    if inv["Status"] != "Success":
+        print(f"FAIL {label}: {inv['Status']}")
+        print(inv.get("StandardErrorContent", "")[:1200])
+        sys.exit(1)
+    print(f"OK {label}: {inv.get('StandardOutputContent','').strip()[:600]}")
+
+def stream_file(local_path, remote_tmp, remote_dest, expect_md5=None):
+    data = open(local_path, "rb").read()
+    md5 = hashlib.md5(data).hexdigest()
+    if expect_md5 and md5 != expect_md5:
+        print(f"DEV MD5 DRIFT {local_path}: {md5} != {expect_md5}"); sys.exit(1)
+    b64 = base64.b64encode(data).decode()
+    run(f"rm -f {remote_tmp}")
+    CH = 6000
+    for i in range(0, len(b64), CH):
+        inv = run(f"printf '%s' '{b64[i:i+CH]}' >> {remote_tmp}")
+        if inv["Status"] != "Success":
+            print("chunk fail", i, inv.get("StandardErrorContent","")[:300]); sys.exit(1)
+    inv = run(
+        f"cd {DEV.replace('/home/sean/dev/testlogon','/home/ubuntu/testlogon')} && "
+        f"[ -f {remote_dest} ] && cp {remote_dest} {remote_dest}.bak_contactsync_$(date +%s) || true; "
+        f"base64 -d {remote_tmp} > {remote_dest} && "
+        f"echo MD5=$(md5sum {remote_dest} | cut -d' ' -f1) && "
+        f"python3 -c 'import ast; ast.parse(open(\"{remote_dest}\").read()); print(\"AST_OK\")'"
+    )
+    must(inv, f"stream {remote_dest}")
+    if md5 not in inv.get("StandardOutputContent", ""):
+        print(f"MD5 MISMATCH on {remote_dest} (dev={md5})"); sys.exit(1)
+
+# ── 1) Byte-mirror contacts.py + upload the two new files ────────────────────
+stream_file(f"{DEV}/app/routers/contacts.py", "/tmp/cs_contacts.b64",
+            "app/routers/contacts.py", expect_md5=CONTACTS_MD5)
+stream_file(f"{DEV}/app/services/contact_match.py", "/tmp/cs_cm.b64",
+            "app/services/contact_match.py")
+stream_file(f"{DEV}/ops/backfill_contact_match.py", "/tmp/cs_bf.b64",
+            "ops/backfill_contact_match.py")
+
+# ── 2) Upload the idempotent prod-patcher and run it ─────────────────────────
+patcher = open(f"{DEV}/../prod_patch_shared.py", "rb").read() \
+    if False else open("/home/sean/close_work/prod_patch_shared.py", "rb").read()
+b64 = base64.b64encode(patcher).decode()
+run("rm -f /tmp/cs_patch.b64")
+for i in range(0, len(b64), 6000):
+    run(f"printf '%s' '{b64[i:i+6000]}' >> /tmp/cs_patch.b64")
+inv = run("cd /home/ubuntu/testlogon && base64 -d /tmp/cs_patch.b64 > /tmp/prod_patch_shared.py && "
+          "python3 -c 'import ast; ast.parse(open(\"/tmp/prod_patch_shared.py\").read()); print(\"PATCHER_AST_OK\")'")
+must(inv, "upload patcher")
+
+inv = run("cd /home/ubuntu/testlogon && python3 /tmp/prod_patch_shared.py")
+must(inv, "apply shared patches")
+
+# ── 3) Post-apply verification: AST + markers on every shared file ───────────
+inv = run(
+    "cd /home/ubuntu/testlogon && "
+    "for f in app/core/settings.py app/core/tables.py app/services/registration.py "
+    "app/services/profile.py app/services/rate_limit.py app/routers/contacts.py "
+    "app/services/contact_match.py; do "
+    "python3 -c \"import ast; ast.parse(open('$f').read())\" && echo \"AST_OK $f\" || echo \"AST_FAIL $f\"; done; "
+    "echo salt=$(grep -c contact_match_salt app/core/settings.py); "
+    "echo tbl=$(grep -c contact_match_index app/core/tables.py); "
+    "echo reg=$(grep -c index_user_email app/services/registration.py); "
+    "echo prof=$(grep -c index_user_phone app/services/profile.py); "
+    "echo rl=$(grep -c rate_limit_contact_match app/services/rate_limit.py); "
+    "echo route=$(grep -c match_contacts app/routers/contacts.py)"
+)
+must(inv, "post-apply verify")
+print("\nAPPLY COMPLETE")

--- a/ops/prod-hotfixes/contact-sync/prod_backfill.py
+++ b/ops/prod-hotfixes/contact-sync/prod_backfill.py
@@ -1,0 +1,21 @@
+import time
+import boto3
+REGION="us-east-2"; IID="i-08f937fc705ebea75"
+ssm=boto3.client("ssm", region_name=REGION)
+def run(cmd, timeout="300"):
+    r=ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+        Parameters={"commands":["bash -lc " + repr(cmd)],"executionTimeout":[timeout]})
+    cid=r["Command"]["CommandId"]
+    while True:
+        time.sleep(3)
+        inv=ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success","Failed","Cancelled","TimedOut"): break
+    return inv
+env=("cd /home/ubuntu/testlogon && set -a; for f in .env .env.local .env.prod .env.mock; do [ -f $f ] && . ./$f; done; set +a; ")
+PY=".venv/bin/python"
+inv=run(env + f"PYTHONPATH=. {PY} ops/backfill_contact_match.py --dry-run 2>&1 | tail -3")
+print("DRYRUN", inv["Status"]); print(inv.get("StandardOutputContent","").strip()); print("E:",inv.get("StandardErrorContent","")[:300])
+inv=run(env + f"PYTHONPATH=. {PY} ops/backfill_contact_match.py 2>&1 | tail -3")
+print("APPLY", inv["Status"]); print(inv.get("StandardOutputContent","").strip()); print("E:",inv.get("StandardErrorContent","")[:300])
+inv=run(env + f"{PY} -c 'from app.core.tables import T; print(\"INDEX_ITEMS\", T.contact_match_index.scan(Select=\"COUNT\")[\"Count\"])' 2>&1 | tail -2")
+print("INDEX", inv["Status"]); print(inv.get("StandardOutputContent","").strip())

--- a/ops/prod-hotfixes/contact-sync/prod_create_table.py
+++ b/ops/prod-hotfixes/contact-sync/prod_create_table.py
@@ -1,0 +1,21 @@
+# Create ContactMatchIndex in the instance's DDB-Local (localhost:8001) + backfill + verify.
+import os, time, json, hashlib, urllib.request, urllib.error
+import boto3
+from botocore.config import Config
+
+ep = os.environ.get("DDB_ENDPOINT_URL", "http://localhost:8001")
+c = boto3.client("dynamodb", region_name=os.environ.get("AWS_REGION", "us-east-1"),
+                 endpoint_url=ep, aws_access_key_id="test", aws_secret_access_key="test",
+                 config=Config(retries={"max_attempts": 5}))
+name = os.environ.get("DDB_CONTACT_MATCH_INDEX_TABLE", "ContactMatchIndex")
+existing = c.list_tables()["TableNames"]
+if name in existing:
+    print("TABLE_EXISTS", name)
+else:
+    c.create_table(TableName=name,
+        AttributeDefinitions=[{"AttributeName": "id_hash", "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": "id_hash", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST")
+    c.get_waiter("table_exists").wait(TableName=name)
+    print("TABLE_CREATED", name)
+print("HAS_CONTACTS", "Contacts" in existing, "HAS_USERS", os.environ.get("DDB_USERS","ddb_users") in existing)

--- a/ops/prod-hotfixes/contact-sync/prod_final_health.py
+++ b/ops/prod-hotfixes/contact-sync/prod_final_health.py
@@ -1,0 +1,15 @@
+import time, boto3
+ssm=boto3.client("ssm", region_name="us-east-2"); IID="i-08f937fc705ebea75"
+def run(cmd, t="120"):
+    r=ssm.send_command(InstanceIds=[IID],DocumentName="AWS-RunShellScript",Parameters={"commands":[cmd],"executionTimeout":[t]})
+    cid=r["Command"]["CommandId"]
+    while True:
+        time.sleep(3); inv=ssm.get_command_invocation(CommandId=cid,InstanceId=IID)
+        if inv["Status"] in ("Success","Failed","Cancelled","TimedOut"): break
+    return inv
+cmd=("echo OPENAPI=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/openapi.json); "
+     "echo WORKERS=$(ps aux | grep -c '[u]vicorn'); "
+     "echo ROUTE=$(curl -s http://127.0.0.1:8000/openapi.json | python3 -c 'import sys,json; print(1 if \"/ui/contacts/match\" in json.load(sys.stdin)[\"paths\"] else 0)'); "
+     "echo SUGG=$(curl -s http://127.0.0.1:8000/openapi.json | python3 -c 'import sys,json; print(1 if \"/ui/contacts/suggestions\" in json.load(sys.stdin)[\"paths\"] else 0)')")
+inv=run(cmd)
+print(inv["Status"]); print(inv.get("StandardOutputContent","").strip())

--- a/ops/prod-hotfixes/contact-sync/prod_inspect_cs.py
+++ b/ops/prod-hotfixes/contact-sync/prod_inspect_cs.py
@@ -1,0 +1,25 @@
+import boto3, time
+REGION="us-east-2"; IID="i-08f937fc705ebea75"
+ssm=boto3.client("ssm", region_name=REGION)
+def run(cmd, timeout="120"):
+    r=ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+        Parameters={"commands":[cmd],"executionTimeout":[timeout]})
+    cid=r["Command"]["CommandId"]
+    while True:
+        time.sleep(2)
+        inv=ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success","Failed","Cancelled","TimedOut"): break
+    return inv
+inv=run(
+  "cd /home/ubuntu/testlogon && "
+  "for f in app/routers/contacts.py app/services/contact_match.py app/core/settings.py "
+  "app/services/profile.py app/services/registration.py app/services/rate_limit.py "
+  "app/core/tables.py scripts/local-ddb-init.py ops/backfill_contact_match.py; do "
+  "if [ -f $f ]; then echo \"$(md5sum $f)\"; else echo \"MISSING $f\"; fi; done; "
+  "echo '--- workers ---'; ps aux | grep -c '[u]vicorn'; "
+  "echo '--- openapi ---'; curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/openapi.json; echo; "
+  "echo '--- has match route ---'; grep -c 'contacts/match\|match_contacts' app/routers/contacts.py 2>/dev/null || echo 0"
+)
+print("STATUS", inv["Status"])
+print(inv.get("StandardOutputContent",""))
+print("ERR", inv.get("StandardErrorContent","")[:500])

--- a/ops/prod-hotfixes/contact-sync/prod_live_match.py
+++ b/ops/prod-hotfixes/contact-sync/prod_live_match.py
@@ -1,0 +1,56 @@
+import time, json
+import boto3
+REGION="us-east-2"; IID="i-08f937fc705ebea75"
+ssm=boto3.client("ssm", region_name=REGION)
+def run(cmd, timeout="200"):
+    r=ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+        Parameters={"commands":["bash -lc " + repr(cmd)],"executionTimeout":[timeout]})
+    cid=r["Command"]["CommandId"]
+    while True:
+        time.sleep(3)
+        inv=ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success","Failed","Cancelled","TimedOut"): break
+    return inv
+env=("cd /home/ubuntu/testlogon && set -a; for f in .env .env.local .env.prod .env.mock; do [ -f $f ] && . ./$f; done; set +a; ")
+PY=".venv/bin/python"
+# Index count + a REAL live match: pick an existing user, compute their email hash the
+# same way the client would, POST /ui/contacts/match over live HTTP with a minted cookie.
+script = env + PY + " - <<'PYEOF2'\n" + '''
+import hashlib, json, time, urllib.request, urllib.error
+from app.core.settings import S
+from app.core.tables import T
+from app.core.normalize import normalize_email
+# index count
+cnt = T.contact_match_index.scan(Select="COUNT")["Count"]
+print("INDEX_ITEMS", cnt)
+# pick a sample existing user
+u = T.users.scan(Limit=5).get("Items", [])
+sub = None
+for it in u:
+    s = it.get("user_sub") or it.get("email")
+    if s and "@" in s:
+        sub = s; break
+print("SAMPLE_USER", sub)
+SALT = S.contact_match_salt
+def he(e): return hashlib.sha256(f"{SALT}:{normalize_email(e)}".encode()).hexdigest()
+# confirm that user's email hash is indexed
+item = T.contact_match_index.get_item(Key={"id_hash": he(sub)}).get("Item")
+print("SAMPLE_INDEXED", bool(item), item.get("user_id") if item else None)
+# mint a UI cookie for a DIFFERENT viewer and match the sample user's email hash
+import jwt
+viewer = "contactsync_probe_"+str(int(time.time()))+"@example.com"
+tok = jwt.encode({"sub": viewer, "role":"user", "exp": int(time.time())+600}, S.ui_access_token_secret, algorithm="HS256")
+body = json.dumps({"email_hashes":[he(sub)], "phone_hashes":[]}).encode()
+req = urllib.request.Request("http://127.0.0.1:8000/ui/contacts/match", data=body,
+    headers={"content-type":"application/json","Cookie":f"ui_access_token={tok}"}, method="POST")
+try:
+    r = urllib.request.urlopen(req); st=r.status; out=json.loads(r.read())
+except urllib.error.HTTPError as e:
+    st=e.code; out=json.loads(e.read() or b"{}")
+print("LIVE_MATCH_HTTP", st)
+print("LIVE_MATCH_RESULT", json.dumps(out))
+PYEOF2'''
+inv=run(script)
+print("STATUS", inv["Status"])
+print(inv.get("StandardOutputContent",""))
+print("ERR", inv.get("StandardErrorContent","")[:600])

--- a/ops/prod-hotfixes/contact-sync/prod_patch_shared.py
+++ b/ops/prod-hotfixes/contact-sync/prod_patch_shared.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Contacts Feature 2 — idempotent in-place patcher for prod's SHARED files.
+
+Applies ONLY the Feature-2 additions to settings.py / tables.py / registration.py /
+profile.py / rate_limit.py. Each patch is a no-op if its marker is already present,
+so this is safe to re-run. Keeps a .bak of each file it actually modifies.
+Runs ON the prod host (cwd = /home/ubuntu/testlogon).
+"""
+import ast, time
+
+def backup(p):
+    import shutil
+    shutil.copyfile(p, f"{p}.bak_contactsync_{int(time.time())}")
+
+def patch(p, marker, anchor, replacement):
+    s = open(p).read()
+    if marker in s:
+        print(f"SKIP {p} (already applied)")
+        return
+    if anchor not in s:
+        raise SystemExit(f"ANCHOR MISSING in {p}")
+    backup(p)
+    s = s.replace(anchor, replacement, 1)
+    ast.parse(s)
+    open(p, "w").write(s)
+    print(f"PATCHED {p}")
+
+# ── settings.py ──────────────────────────────────────────────────────────────
+patch(
+    "app/core/settings.py",
+    "contact_match_salt",
+    '    contacts_table_name: str = os.environ.get("DDB_CONTACTS_TABLE", "Contacts")',
+    '    contacts_table_name: str = os.environ.get("DDB_CONTACTS_TABLE", "Contacts")\n'
+    "\n"
+    "    # Contacts Feature 2 — privacy-safe device contact sync (hash -> user_id match index).\n"
+    "    # APP_CONTACT_MATCH_SALT is a FIXED, NON-SECRET app pepper (see\n"
+    "    # app/services/contact_match.py). It is shared byte-for-byte with the Android client\n"
+    "    # (BuildConfig.CONTACT_MATCH_SALT); if you change it you MUST rebuild the app AND\n"
+    "    # re-run the backfill, or existing hashes stop matching.\n"
+    '    contact_match_salt: str = os.environ.get("APP_CONTACT_MATCH_SALT", "tl_contact_match_v1")\n'
+    '    contact_match_index_table_name: str = os.environ.get("DDB_CONTACT_MATCH_INDEX_TABLE", "ContactMatchIndex")\n'
+    "    # Rate limit for POST /ui/contacts/match (per-user token bucket).\n"
+    '    contact_match_max_per_window: int = int(os.environ.get("CONTACT_MATCH_MAX_PER_WINDOW", "30"))\n'
+    '    contact_match_window_seconds: int = int(os.environ.get("CONTACT_MATCH_WINDOW_SECONDS", "3600"))\n'
+    "    # Max hashes accepted per field per request (email_hashes / phone_hashes).\n"
+    '    contact_match_max_hashes: int = int(os.environ.get("CONTACT_MATCH_MAX_HASHES", "2000"))',
+)
+
+# ── tables.py: dataclass field ───────────────────────────────────────────────
+patch(
+    "app/core/tables.py",
+    "contact_match_index: Any",
+    "    contacts: Any\n",
+    "    contacts: Any\n    contact_match_index: Any  # Contacts Feature 2 — hash->user_id device-sync index\n",
+)
+# tables.py: instantiation (separate marker guard so both apply)
+_s = open("app/core/tables.py").read()
+if "contact_match_index=_safe_table" not in _s:
+    ianchor = "    contacts=_safe_table(S.contacts_table_name),\n"
+    if ianchor not in _s:
+        raise SystemExit("tables inst anchor missing")
+    backup("app/core/tables.py")
+    _s = _s.replace(ianchor, ianchor + "    contact_match_index=_safe_table(S.contact_match_index_table_name),\n", 1)
+    ast.parse(_s)
+    open("app/core/tables.py", "w").write(_s)
+    print("PATCHED app/core/tables.py (instantiation)")
+else:
+    print("SKIP app/core/tables.py instantiation (already applied)")
+
+# ── registration.py ──────────────────────────────────────────────────────────
+patch(
+    "app/services/registration.py",
+    "index_user_email",
+    '''    set_account_state(
+        user_sub,
+        status,
+        reason="initial_registration",
+        requested_by=user_sub,
+        ttl_epoch=pending_ttl if verification_required else None,
+    )
+    return {"user_sub": user_sub}''',
+    '''    set_account_state(
+        user_sub,
+        status,
+        reason="initial_registration",
+        requested_by=user_sub,
+        ttl_epoch=pending_ttl if verification_required else None,
+    )
+
+    # Contacts Feature 2 — index this user's email hash so devices can privacy-safely
+    # match their address book to this account. user_sub IS the normalized email.
+    # Best-effort: an index failure must never fail registration.
+    try:
+        from app.services.contact_match import index_user_email
+        index_user_email(user_sub)
+    except Exception:
+        pass
+
+    return {"user_sub": user_sub}''',
+)
+
+# ── profile.py: three coordinated edits (flag init, diff-loop set, reindex) ──
+_p = open("app/services/profile.py").read()
+if "index_user_phone" not in _p:
+    backup("app/services/profile.py")
+    a1 = "    address_changed = False\n    discovery_changed = False\n"
+    if a1 not in _p:
+        raise SystemExit("profile flag-init anchor missing")
+    _p = _p.replace(a1, a1 + "    phone_changed = False\n", 1)
+    a2 = "            if field in DISCOVERY_FIELDS:\n                discovery_changed = True\n"
+    if a2 not in _p:
+        raise SystemExit("profile diff-loop anchor missing")
+    _p = _p.replace(a2, a2 + '            if field == "displayed_telephone_number":\n                phone_changed = True\n', 1)
+    a3 = ("    # PTY-010: re-sync party EMAIL/PHONE contact mechs when those fields change\n"
+          "    # (best-effort, doubly flag-gated, never rolls back the profile write).\n"
+          "    _sync_party_mechs_after_profile_update(user_sub, current, updated)\n")
+    if a3 not in _p:
+        raise SystemExit("profile party-sync anchor missing")
+    add3 = ('''    # Contacts Feature 2: (re)index this user's phone hash when the displayed phone
+    # changes, so devices can privacy-safely match by phone. Best-effort — never
+    # rolls back the (already committed) profile write.
+    if phone_changed:
+        try:
+            from app.services.contact_match import index_user_phone
+            index_user_phone(user_sub, updated.get("displayed_telephone_number"))
+        except Exception:
+            pass
+
+''' + a3)
+    _p = _p.replace(a3, add3, 1)
+    ast.parse(_p)
+    open("app/services/profile.py", "w").write(_p)
+    print("PATCHED app/services/profile.py")
+else:
+    print("SKIP app/services/profile.py (already applied)")
+
+# ── rate_limit.py ────────────────────────────────────────────────────────────
+patch(
+    "app/services/rate_limit.py",
+    "rate_limit_contact_match",
+    "def rate_limit_feed_query(user_sub: str, mode: str) -> None:",
+    '''def rate_limit_contact_match(user_sub: str) -> None:
+    """Contacts Feature 2 — cap POST /ui/contacts/match per user (token bucket)."""
+    cap = max(1, int(getattr(S, "contact_match_max_per_window", 30) or 30))
+    window = max(1, int(getattr(S, "contact_match_window_seconds", 3600) or 3600))
+    sid = "rl#contact_match"
+    if not _bucket_limit(user_sub, sid, cap, window):
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "contact_match_rate_limited",
+                "message": "Too many contact-match requests; try again later",
+                "limit": cap,
+                "window_seconds": window,
+            },
+            headers={"Retry-After": str(window)},
+        )
+
+
+def rate_limit_feed_query(user_sub: str, mode: str) -> None:''',
+)
+
+print("SHARED PATCHES DONE")

--- a/ops/prod-hotfixes/contact-sync/prod_restart_verify_cs.py
+++ b/ops/prod-hotfixes/contact-sync/prod_restart_verify_cs.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Contacts Feature 2 — restart prod backend + run backfill + verify. SSM.
+
+Restart uses the ABSOLUTE /home/ubuntu/restart_backend.sh (it self-detaches via
+setsid/nohup/disown). We do NOT pkill inside the SSM shell (self-kill footgun).
+Then runs the backfill on prod, and verifies openapi 200 + single worker +
+/ui/contacts/match present + index populated.
+"""
+import time
+import boto3
+
+REGION = "us-east-2"; IID = "i-08f937fc705ebea75"
+ssm = boto3.client("ssm", region_name=REGION)
+
+def run(cmd, timeout="300"):
+    r = ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+        Parameters={"commands": [cmd], "executionTimeout": [timeout]})
+    cid = r["Command"]["CommandId"]
+    while True:
+        time.sleep(3)
+        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
+            break
+    return inv
+
+# 1) Restart via the absolute self-detaching script.
+inv = run("sudo /home/ubuntu/restart_backend.sh || /home/ubuntu/restart_backend.sh; echo RESTART_INVOKED")
+print("RESTART", inv["Status"], inv.get("StandardOutputContent","").strip()[:300])
+
+# 2) Poll for openapi 200 + single worker + route present.
+time.sleep(8)
+inv = run(
+    "for i in $(seq 1 20); do "
+    "code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/openapi.json); "
+    "if [ \"$code\" = \"200\" ]; then break; fi; sleep 2; done; "
+    "echo OPENAPI=$code; "
+    "echo WORKERS=$(ps aux | grep -c '[u]vicorn'); "
+    "echo ROUTE=$(curl -s http://127.0.0.1:8000/openapi.json | python3 -c 'import sys,json; d=json.load(sys.stdin); print(1 if \"/ui/contacts/match\" in d[\"paths\"] else 0)')"
+)
+print("VERIFY", inv["Status"])
+print(inv.get("StandardOutputContent","").strip())
+
+# 3) Run the backfill on prod (idempotent).
+inv = run("cd /home/ubuntu/testlogon && (set -a; [ -f .env ] && . ./.env; set +a; PYTHONPATH=. python3 ops/backfill_contact_match.py)")
+print("BACKFILL", inv["Status"])
+print(inv.get("StandardOutputContent","").strip()[:400])
+print("ERR", inv.get("StandardErrorContent","")[:500])
+
+# 4) Index population sanity.
+inv = run("cd /home/ubuntu/testlogon && (set -a; [ -f .env ] && . ./.env; set +a; python3 -c 'from app.core.tables import T; print(\"INDEX_ITEMS\", T.contact_match_index.scan(Select=\"COUNT\")[\"Count\"])')")
+print("INDEX", inv["Status"], inv.get("StandardOutputContent","").strip()[:200])

--- a/ops/prod-hotfixes/contact-sync/prod_run_create_backfill.py
+++ b/ops/prod-hotfixes/contact-sync/prod_run_create_backfill.py
@@ -1,0 +1,21 @@
+import base64, time, boto3
+ssm=boto3.client("ssm", region_name="us-east-2"); IID="i-08f937fc705ebea75"
+def run(cmd, t="180"):
+    r=ssm.send_command(InstanceIds=[IID],DocumentName="AWS-RunShellScript",Parameters={"commands":[cmd],"executionTimeout":[t]})
+    cid=r["Command"]["CommandId"]
+    while True:
+        time.sleep(3); inv=ssm.get_command_invocation(CommandId=cid,InstanceId=IID)
+        if inv["Status"] in ("Success","Failed","Cancelled","TimedOut"): break
+    return inv
+b64=base64.b64encode(open("/home/sean/close_work/prod_fix_local.py","rb").read()).decode()
+run("rm -f /tmp/cs_fix.b64")
+for i in range(0,len(b64),6000): run("printf '%%s' '%s' >> /tmp/cs_fix.b64" % b64[i:i+6000])
+run("base64 -d /tmp/cs_fix.b64 > /tmp/cs_fix.py")
+# CRITICAL: source .env.local (the store the running app uses), not .env.
+env="cd /home/ubuntu/testlogon && set -a; . ./.env.local; set +a; PYTHONPATH=. .venv/bin/python /tmp/cs_fix.py"
+inv=run("bash -c "+repr(env))
+print("CREATE", inv["Status"]); print(inv.get("StandardOutputContent","")); print("ERR", inv.get("StandardErrorContent","")[:400])
+# Now backfill against the SAME store
+env2="cd /home/ubuntu/testlogon && set -a; . ./.env.local; set +a; PYTHONPATH=. .venv/bin/python ops/backfill_contact_match.py 2>&1 | tail -3"
+inv=run("bash -c "+repr(env2))
+print("BACKFILL", inv["Status"]); print(inv.get("StandardOutputContent","").strip())

--- a/ops/prod-hotfixes/contact-sync/prod_run_verify.py
+++ b/ops/prod-hotfixes/contact-sync/prod_run_verify.py
@@ -1,0 +1,16 @@
+import base64, time, boto3
+ssm=boto3.client("ssm", region_name="us-east-2"); IID="i-08f937fc705ebea75"
+def run(cmd, t="180"):
+    r=ssm.send_command(InstanceIds=[IID],DocumentName="AWS-RunShellScript",Parameters={"commands":[cmd],"executionTimeout":[t]})
+    cid=r["Command"]["CommandId"]
+    while True:
+        time.sleep(3); inv=ssm.get_command_invocation(CommandId=cid,InstanceId=IID)
+        if inv["Status"] in ("Success","Failed","Cancelled","TimedOut"): break
+    return inv
+b64=base64.b64encode(open("/home/sean/close_work/prod_verify_local.py","rb").read()).decode()
+run("rm -f /tmp/cs_ver.b64")
+for i in range(0,len(b64),6000): run("printf '%%s' '%s' >> /tmp/cs_ver.b64" % b64[i:i+6000])
+run("base64 -d /tmp/cs_ver.b64 > /tmp/cs_ver.py")
+env="cd /home/ubuntu/testlogon && set -a; . ./.env.local; set +a; PYTHONPATH=. .venv/bin/python /tmp/cs_ver.py"
+inv=run("bash -c "+repr(env))
+print(inv["Status"]); print(inv.get("StandardOutputContent","")); print("ERR", inv.get("StandardErrorContent","")[:500])

--- a/ops/prod-hotfixes/contact-sync/prod_verify_local.py
+++ b/ops/prod-hotfixes/contact-sync/prod_verify_local.py
@@ -1,0 +1,39 @@
+import os, time, json, hashlib, urllib.request, urllib.error
+import boto3
+from botocore.config import Config
+ep = os.environ["DDB_ENDPOINT_URL"]
+c = boto3.client("dynamodb", region_name=os.environ.get("AWS_REGION","us-east-1"),
+                 endpoint_url=ep, aws_access_key_id="test", aws_secret_access_key="test",
+                 config=Config(retries={"max_attempts":5}))
+idx = os.environ.get("DDB_CONTACT_MATCH_INDEX_TABLE","ContactMatchIndex")
+cnt = c.scan(TableName=idx, Select="COUNT")["Count"]
+print("INDEX_ITEMS", cnt)
+# sample items: prove only hashes stored (no '@'/'+')
+s = c.scan(TableName=idx, Limit=3)["Items"]
+for it in s:
+    row = {k: list(v.values())[0] for k, v in it.items()}
+    print("ITEM", row)
+
+# Live match over prod HTTP: pick a real user, hash their email like the client, POST.
+from app.core.settings import S
+from app.core.tables import T
+from app.core.normalize import normalize_email
+import jwt
+sub=None
+for it in T.users.scan(Limit=15).get("Items",[]):
+    ss=it.get("user_sub") or it.get("email")
+    if ss and "@" in ss: sub=ss; break
+SALT=S.contact_match_salt
+def he(e): return hashlib.sha256(("%s:%s"%(SALT,normalize_email(e))).encode()).hexdigest()
+print("SAMPLE_USER", sub, "hash_indexed", bool(T.contact_match_index.get_item(Key={"id_hash":he(sub)}).get("Item")))
+viewer="cs_probe_%d@example.com"%int(time.time())
+tok=jwt.encode({"sub":viewer,"role":"user","exp":int(time.time())+600}, S.ui_access_token_secret, algorithm="HS256")
+body=json.dumps({"email_hashes":[he(sub)],"phone_hashes":[]}).encode()
+req=urllib.request.Request("http://127.0.0.1:8000/ui/contacts/match",data=body,
+    headers={"content-type":"application/json","Cookie":"ui_access_token=%s"%tok},method="POST")
+try:
+    r=urllib.request.urlopen(req); st=r.status; out=json.loads(r.read())
+except urllib.error.HTTPError as e:
+    st=e.code; out=json.loads(e.read() or b"{}")
+print("LIVE_MATCH_HTTP", st)
+print("LIVE_MATCH_RESULT", json.dumps(out))

--- a/ops/prod-hotfixes/contacts-hub/README.md
+++ b/ops/prod-hotfixes/contacts-hub/README.md
@@ -1,0 +1,35 @@
+# Contacts hub (Feature 1) — prod hotfix
+
+Backend change: added `GET /ui/contacts/suggestions` ("people you may know") to
+`app/routers/contacts.py`. Read-only, own-scoped (`require_ui_session`). Composes
+candidates from the social follow graph (followers / following / friend-of-friend
+mutuals) + recent DM peers, excluding already-saved contacts, self, and
+blocked/blocking users. Returns public profile cards
+(`user_id, display_name, profile_photo_url, hint, mutual_count, source`).
+
+No `api_key_route_scope_registry` entry is required: the contacts router is mounted
+WITHOUT the `maybe_enforce_api_key_route_policy` dependency (session-only), so the
+boot-time drift check never flags it and boot never RuntimeErrors.
+
+## Prod mirror (SSM, instance i-08f937fc705ebea75, us-east-2)
+
+Runbook (byte-identical file swap, keep .bak, self-detaching restart):
+
+1. `prod_inspect_contacts.py`  — snapshot current prod md5 / route / workers.
+2. `prod_apply_contacts.py`    — b64-stream the dev `contacts.py` to prod, keep
+   `contacts.py.bak_contactshub_latest`, decode + verify md5 == dev
+   (`148410fecd6c8e8a3677fe131ea3bc1e`) + `ast.parse` OK.
+3. `prod_restart_contacts.py`  — invoke the absolute `/home/ubuntu/restart_backend.sh`
+   (it self-detaches via `setsid nohup ... & disown`; do NOT pkill inside the SSM
+   shell or it self-kills).
+4. `prod_verify_contacts.py`   — poll openapi 200, assert single worker + the new
+   `/ui/contacts/suggestions` route present.
+
+Applied result: openapi 200, WORKERS=1, ROUTE_SUGG=1, prod md5 == dev md5.
+
+## Live dev verification
+
+`verify_contacts.sh` — mints HS256 UI cookies for 3 users, builds a follow graph,
+and exercises the full round-trip against the dev uvicorn (:8000) over real HTTP:
+contacts list/add/favorite/delete, suggestions (mutual/follows-you/you-follow hints,
+saved-exclusion, self-exclusion), follow/unfollow/status. All 2xx.

--- a/ops/prod-hotfixes/contacts-hub/prod_apply_contacts.py
+++ b/ops/prod-hotfixes/contacts-hub/prod_apply_contacts.py
@@ -1,0 +1,61 @@
+import boto3, time, base64, hashlib, subprocess, sys
+
+REGION = "us-east-2"; IID = "i-08f937fc705ebea75"
+DEV_PATH = "/home/sean/dev/testlogon/app/routers/contacts.py"
+DEV_MD5 = "148410fecd6c8e8a3677fe131ea3bc1e"
+
+# Read the exact dev file bytes locally (this script runs ON the dev host).
+data = open(DEV_PATH, "rb").read()
+local_md5 = hashlib.md5(data).hexdigest()
+assert local_md5 == DEV_MD5, f"dev md5 drift: {local_md5} != {DEV_MD5}"
+b64 = base64.b64encode(data).decode()
+print("LOCAL_MD5", local_md5, "bytes", len(data), "b64len", len(b64))
+
+ssm = boto3.client("ssm", region_name=REGION)
+
+# Chunk the base64 to stay well under SSM's per-command limits; append on prod.
+CHUNK = 6000
+chunks = [b64[i:i + CHUNK] for i in range(0, len(b64), CHUNK)]
+
+def run(cmd, timeout="120"):
+    r = ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+                         Parameters={"commands": [cmd], "executionTimeout": [timeout]})
+    cid = r["Command"]["CommandId"]
+    while True:
+        time.sleep(2)
+        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
+            break
+    return inv
+
+# 1) backup + start a fresh staging b64 file.
+inv = run(
+    "cd /home/ubuntu/testlogon && "
+    "cp -n app/routers/contacts.py app/routers/contacts.py.bak_contactshub_$(date +%s) 2>/dev/null; "
+    "cp app/routers/contacts.py app/routers/contacts.py.bak_contactshub_latest && "
+    "rm -f /tmp/contacts_hub.b64 && echo STAGED_RESET_OK"
+)
+print("BACKUP", inv["Status"], inv.get("StandardOutputContent", "").strip())
+if inv["Status"] != "Success":
+    print("ERR", inv.get("StandardErrorContent", "")[:800]); sys.exit(1)
+
+# 2) stream the b64 chunks.
+for i, c in enumerate(chunks):
+    inv = run(f"printf '%s' '{c}' >> /tmp/contacts_hub.b64 && echo CHUNK_{i}_OK")
+    if inv["Status"] != "Success":
+        print("CHUNK FAIL", i, inv.get("StandardErrorContent", "")[:400]); sys.exit(1)
+print(f"STREAMED {len(chunks)} chunks")
+
+# 3) decode into place, verify md5 == dev.
+inv = run(
+    "cd /home/ubuntu/testlogon && "
+    "base64 -d /tmp/contacts_hub.b64 > app/routers/contacts.py && "
+    "echo NEW_MD5=$(md5sum app/routers/contacts.py | cut -d' ' -f1) && "
+    "echo HAS_SUGG=$(grep -c contact_suggestions app/routers/contacts.py) && "
+    "python3 -c 'import ast; ast.parse(open(\"app/routers/contacts.py\").read()); print(\"AST_OK\")'"
+)
+print("DECODE", inv["Status"])
+print(inv.get("StandardOutputContent", "").strip())
+if inv["Status"] != "Success" or DEV_MD5 not in inv.get("StandardOutputContent", ""):
+    print("MD5 MISMATCH / FAIL"); print(inv.get("StandardErrorContent", "")[:800]); sys.exit(1)
+print("APPLY_OK md5 byte-identical to dev")

--- a/ops/prod-hotfixes/contacts-hub/prod_inspect_contacts.py
+++ b/ops/prod-hotfixes/contacts-hub/prod_inspect_contacts.py
@@ -1,0 +1,25 @@
+import boto3, time
+REGION = "us-east-2"; IID = "i-08f937fc705ebea75"
+ssm = boto3.client("ssm", region_name=REGION)
+cmd = (
+    "cd /home/ubuntu/testlogon && "
+    "echo MD5=$(md5sum app/routers/contacts.py | cut -d' ' -f1) && "
+    "echo HAS_SUGG=$(grep -c contact_suggestions app/routers/contacts.py) && "
+    "echo OPENAPI=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/openapi.json) && "
+    "echo ROUTE=$(curl -s http://127.0.0.1:8000/openapi.json | grep -c 'contacts/suggestions') && "
+    "echo WORKERS=$(pgrep -fc 'uvicorn app.main') && "
+    "ls -la /home/ubuntu/restart_backend.sh 2>&1"
+)
+r = ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+                     Parameters={"commands": [cmd], "executionTimeout": ["60"]})
+cid = r["Command"]["CommandId"]
+while True:
+    time.sleep(3)
+    inv = ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+    if inv["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
+        break
+print("STATUS", inv["Status"])
+print(inv.get("StandardOutputContent", ""))
+e = inv.get("StandardErrorContent", "")
+if e.strip():
+    print("--STDERR--", e[:800])

--- a/ops/prod-hotfixes/contacts-hub/prod_restart_contacts.py
+++ b/ops/prod-hotfixes/contacts-hub/prod_restart_contacts.py
@@ -1,0 +1,41 @@
+import boto3, time
+REGION = "us-east-2"; IID = "i-08f937fc705ebea75"
+ssm = boto3.client("ssm", region_name=REGION)
+
+def run(cmd, timeout="120"):
+    r = ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+                         Parameters={"commands": [cmd], "executionTimeout": [timeout]})
+    cid = r["Command"]["CommandId"]
+    while True:
+        time.sleep(3)
+        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
+            break
+    return inv
+
+# Show the restart script so we know it self-detaches (task warns: do NOT pkill inside SSM).
+inv = run("cat /home/ubuntu/restart_backend.sh")
+print("=== restart_backend.sh ===")
+print(inv.get("StandardOutputContent", ""))
+
+# Invoke the absolute self-detaching restarter as ubuntu; it handles the swap safely.
+inv = run(
+    "sudo -u ubuntu bash /home/ubuntu/restart_backend.sh >/tmp/contactshub_restart.log 2>&1; "
+    "echo INVOKED",
+    timeout="90",
+)
+print("RESTART_INVOKE", inv["Status"], inv.get("StandardOutputContent", "").strip())
+
+# Give it a beat to rebind, then verify.
+time.sleep(10)
+inv = run(
+    "echo OPENAPI=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/openapi.json) && "
+    "echo ROUTE=$(curl -s http://127.0.0.1:8000/openapi.json | grep -c 'contacts/suggestions') && "
+    "echo WORKERS=$(pgrep -fc 'uvicorn app.main') && "
+    "ps -eo pid,user,cmd | grep 'uvicorn app.main' | grep -v grep | head"
+)
+print("=== VERIFY ===")
+print(inv.get("StandardOutputContent", ""))
+e = inv.get("StandardErrorContent", "")
+if e.strip():
+    print("--STDERR--", e[:600])

--- a/ops/prod-hotfixes/contacts-hub/prod_verify_contacts.py
+++ b/ops/prod-hotfixes/contacts-hub/prod_verify_contacts.py
@@ -1,0 +1,31 @@
+import boto3, time
+REGION = "us-east-2"; IID = "i-08f937fc705ebea75"
+ssm = boto3.client("ssm", region_name=REGION)
+
+def run(cmd, timeout="90"):
+    r = ssm.send_command(InstanceIds=[IID], DocumentName="AWS-RunShellScript",
+                         Parameters={"commands": [cmd], "executionTimeout": [timeout]})
+    cid = r["Command"]["CommandId"]
+    while True:
+        time.sleep(3)
+        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=IID)
+        if inv["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
+            break
+    return inv
+
+inv = run(
+    "for i in $(seq 1 40); do "
+    "c=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/openapi.json); "
+    "if [ \"$c\" = 200 ]; then echo READY_AFTER=${i}x3s; break; fi; sleep 3; done; "
+    "echo OPENAPI=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/openapi.json) && "
+    "echo ROUTE_SUGG=$(curl -s http://127.0.0.1:8000/openapi.json | grep -c 'contacts/suggestions') && "
+    "echo WORKERS=$(pgrep -fc 'uvicorn app.main') && "
+    "echo BAK=$(ls -1 /home/ubuntu/testlogon/app/routers/contacts.py.bak_contactshub_latest 2>&1) && "
+    "echo NEW_MD5=$(md5sum /home/ubuntu/testlogon/app/routers/contacts.py | cut -d' ' -f1)",
+    timeout="180",
+)
+print("STATUS", inv["Status"])
+print(inv.get("StandardOutputContent", ""))
+e = inv.get("StandardErrorContent", "")
+if e.strip():
+    print("--STDERR--", e[:600])

--- a/ops/prod-hotfixes/contacts-hub/verify_contacts.sh
+++ b/ops/prod-hotfixes/contacts-hub/verify_contacts.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Live-HTTP verification of contacts hub + suggestions against uvicorn :8000.
+set -uo pipefail
+cd /home/sean/dev/testlogon
+BASE=http://127.0.0.1:8000
+SECRET=devsecret_1781764988_xyz
+
+mint() { .venv/bin/python - "$1" << 'PY'
+import jwt, time, sys
+sub=sys.argv[1]
+print(jwt.encode({'sub':sub,'role':'user','exp':int(time.time())+3600},'devsecret_1781764988_xyz',algorithm='HS256'))
+PY
+}
+
+A=$(mint verify-A)
+B=$(mint verify-B)
+C=$(mint verify-C)
+
+echo "===== 1) create profiles for A/B/C (so display_name enrichment + follow user_not_found guard work) ====="
+for who in A:verify-A:Alice_A B:verify-B:Bob_B C:verify-C:Carol_C; do
+  tok_var="${who%%:*}"; sub="${who#*:}"; sub="${sub%%:*}"; name="${who##*:}"
+  case "$tok_var" in A) T=$A;; B) T=$B;; C) T=$C;; esac
+  curl -s -b "ui_access_token=$T" -H 'content-type: application/json' \
+    -X PATCH "$BASE/ui/profile" -d "{\"display_name\":\"$name\"}" -o /dev/null -w "profile $name PATCH -> %{http_code}\n"
+done
+
+echo
+echo "===== 2) build the social graph: A follows B; C follows A; B follows C (so A gets mutuals/followers) ====="
+curl -s -b "ui_access_token=$A" -H 'content-type: application/json' -X POST "$BASE/ui/social/follow" -d '{"target_user_id":"verify-B"}' -w "\n A->B follow HTTP:%{http_code}\n"
+curl -s -b "ui_access_token=$C" -H 'content-type: application/json' -X POST "$BASE/ui/social/follow" -d '{"target_user_id":"verify-A"}' -w "\n C->A follow HTTP:%{http_code}\n"
+curl -s -b "ui_access_token=$B" -H 'content-type: application/json' -X POST "$BASE/ui/social/follow" -d '{"target_user_id":"verify-C"}' -w "\n B->C follow HTTP:%{http_code}\n"
+
+echo
+echo "===== 3) follow-status A->B ====="
+curl -s -b "ui_access_token=$A" "$BASE/ui/social/status/verify-B" -w "\n HTTP:%{http_code}\n" 2>/dev/null || \
+curl -s -b "ui_access_token=$A" "$BASE/ui/social/status/verify-B" -w "\n HTTP:%{http_code}\n"
+
+echo
+echo "===== 4) A's suggestions BEFORE saving anyone (should include B=You follow, C=Follows you, and mutual via B->C) ====="
+curl -s -b "ui_access_token=$A" "$BASE/ui/contacts/suggestions" -w "\n HTTP:%{http_code}\n"
+
+echo
+echo "===== 5) A saves B as a contact ====="
+curl -s -b "ui_access_token=$A" -H 'content-type: application/json' -X POST "$BASE/ui/contacts" -d '{"user_id":"verify-B"}' -w "\n add-contact HTTP:%{http_code}\n"
+
+echo
+echo "===== 6) A lists contacts (should show Bob_B) ====="
+curl -s -b "ui_access_token=$A" "$BASE/ui/contacts" -w "\n HTTP:%{http_code}\n"
+
+echo
+echo "===== 7) A favorites B ====="
+curl -s -b "ui_access_token=$A" -H 'content-type: application/json' -X PATCH "$BASE/ui/contacts/verify-B" -d '{"is_favorite":true}' -w "\n favorite HTTP:%{http_code}\n"
+
+echo
+echo "===== 8) A's suggestions AFTER saving B (B must be EXCLUDED now; self never appears) ====="
+curl -s -b "ui_access_token=$A" "$BASE/ui/contacts/suggestions" -w "\n HTTP:%{http_code}\n"
+
+echo
+echo "===== 9) profile-by-id for B ====="
+curl -s -b "ui_access_token=$A" "$BASE/ui/profiles/verify-B" -w "\n HTTP:%{http_code}\n" | head -c 400
+
+echo
+echo "===== 10) A unfollows B, then deletes contact B ====="
+curl -s -b "ui_access_token=$A" -H 'content-type: application/json' -X POST "$BASE/ui/social/unfollow" -d '{"target_user_id":"verify-B"}' -w "\n unfollow HTTP:%{http_code}\n"
+curl -s -b "ui_access_token=$A" -X DELETE "$BASE/ui/contacts/verify-B" -w " delete-contact HTTP:%{http_code}\n"
+
+echo
+echo "===== 11) final contacts list (empty) ====="
+curl -s -b "ui_access_token=$A" "$BASE/ui/contacts" -w "\n HTTP:%{http_code}\n"

--- a/scripts/local-ddb-init.py
+++ b/scripts/local-ddb-init.py
@@ -1990,6 +1990,8 @@ def _table_defs() -> List[TableDef]:
         ),
         TableDef(os.getenv("DDB_CONVERSATION_ROUTING_EVENTS", "ConversationRoutingEvents"), "conversation_id", "event_id"),
         TableDef(os.getenv("DDB_CONTACTS_TABLE", "Contacts"), "owner_id", "contact_id"),
+        # Contacts Feature 2 — privacy-safe device-sync hash->user_id lookup index.
+        TableDef(os.getenv("DDB_CONTACT_MATCH_INDEX_TABLE", "ContactMatchIndex"), "id_hash"),
         # Sales pipeline — Opportunities (OPP-001)
         TableDef(
             _resolve_table_name(S.sales_opportunities_table_name, "sales_opportunities"),


### PR DESCRIPTION
Adds the Contacts + Picture-in-Picture feature program (Android + backend):

- **Contacts hub** (34877dbe): saved address book (favorites-first) + a people-you-may-know suggestions endpoint (follows/mutuals/recent DM peers, blocked-excluded); full contact card (Message / Call / Follow / Tip / View profile / Save-remove); "View contact" edge from the conversation header; FollowApi wired on Android. Backend live-verified, prod-mirrored.
- **Device contact sync** (eecc6b31): privacy-safe email+phone hash-match (`POST /ui/contacts/match`, hashes only — raw contacts never stored), a ContactMatchIndex + idempotent backfill, READ_CONTACTS runtime flow + share-sheet invite. Client==server hash-vector test.
- **Broadcast-viewer PiP + polish** (7780dfbc): the live broadcast floats on leave (reuses the ExoPlayer PiP path); real aspect-ratio + setAutoEnterEnabled (API 31+).
- **Video-call PiP** (582bb765): active video calls float FaceTime-style via a new WebRTC/LiveKit render branch alongside the media3 path; auto-enter on leave; Telecom/foreground keeps the call alive; media3 PiP unregressed.

Verification: assembleDebug green; call suite 194/194, player 54/54, contacts + hash-vector unit tests green; backends live-verified over real HTTP + prod-mirrored. On-device 2-party call PiP float is device-dependent and deferred (code+unit-verified). Go-live: group-call/contacts need no new flags; real SMS invite is v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>