### PR TITLE
trading: prediction markets + mobile-web parity + h1.1 login fix

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <!-- AND-107: runtime notification permission (requested at runtime on Android 13+ / API 33). -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <!-- Contacts Feature 2: read the device address book to privacy-safely match contacts
          against platform users. Requested at RUNTIME behind an explicit "Find people you know"

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -6,6 +6,7 @@ import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 /**
  * Retrofit interface for the trader order-entry (`me/ (matching-engine)`) endpoints. Write-only order
@@ -56,6 +57,10 @@ interface TradingApi {
     /** Drain this session's async exec events (algo/oto triggers + fills that landed after placement). */
     @GET("me/algo/events")
     suspend fun algoEvents(): ExecEventsDto
+
+    /** Binary prediction-market state for a symbol (404 when the symbol is not a configured PM). */
+    @GET("me/pm_state")
+    suspend fun getPmState(@Query("symbolid") symbolId: Int): PmStateDto
 
     // ---- Pre-staged (behind TradingFeatures flags); align field names with the backend port. ----
 

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -273,3 +273,18 @@ data class SpotDepositAckDto(
     val detail: String? = null,
     val error: String? = null,
 )
+
+/** Binary prediction-market state (`GET /me/pm_state`). state = "trading" | "resolved". */
+@JsonClass(generateAdapter = true)
+data class PmStateDto(
+    val symbolid: Int? = null,
+    @Json(name = "is_binary") val isBinary: Boolean? = null,
+    val state: String? = null,
+    val outcome: Int? = null,
+    @Json(name = "face_value") val faceValue: Long? = null,
+    @Json(name = "resolve_ts") val resolveTs: Long? = null,
+    @Json(name = "resolver_id") val resolverId: String? = null,
+    val status: String? = null,
+    val error: String? = null,
+    val detail: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -239,3 +239,31 @@ fun SpotDepositAckDto.toDomain(): SpotDepositAck = SpotDepositAck(
     availableBalance = availableBalance ?: 0L,
     message = detail ?: error,
 )
+
+/**
+ * A binary prediction market: the symbol trades in [0, faceValue] where price = implied YES
+ * probability x faceValue. YES = buy/long (pays faceValue on YES), NO = sell/short.
+ */
+data class PmState(
+    val symbolId: Int,
+    val isBinary: Boolean,
+    val resolved: Boolean,
+    val outcomeYes: Boolean?,   // when resolved: true = YES won, false = NO
+    val faceValue: Long,
+    val resolverId: String,
+) {
+    /** Implied YES probability (0..1) at [price], or null when faceValue is unknown. */
+    fun impliedYes(price: Long?): Float? {
+        if (faceValue <= 0 || price == null) return null
+        return (price.toFloat() / faceValue.toFloat()).coerceIn(0f, 1f)
+    }
+}
+
+fun PmStateDto.toDomain(): PmState = PmState(
+    symbolId = symbolid ?: 0,
+    isBinary = isBinary == true,
+    resolved = state == "resolved",
+    outcomeYes = if (state == "resolved") (outcome ?: 0) == 1 else null,
+    faceValue = faceValue ?: 0L,
+    resolverId = resolverId.orEmpty(),
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -36,6 +36,7 @@ interface TradingRepository {
     suspend fun cancelOrder(clordid: String): ApiResult<CancelAck>
     suspend fun marginAccount(): ApiResult<MarginAccount>
     suspend fun execEvents(): ApiResult<ExecEvents>
+    suspend fun pmState(symbolId: Int): ApiResult<PmState>
     // Pre-staged (behind TradingFeatures flags):
     suspend fun placeOco(symbolId: Int, aSide: OrderSide, aPrice: Long, aQty: Long, bSide: OrderSide, bPrice: Long, bQty: Long): ApiResult<OcoAck>
     suspend fun placeFunding(rateBps: Long, qty: Long, isBorrow: Boolean, durationSeconds: Long?, symbolId: Int?): ApiResult<FundingAck>
@@ -91,6 +92,9 @@ class TradingRepositoryImpl @Inject constructor(
 
     override suspend fun execEvents(): ApiResult<ExecEvents> =
         withContext(io) { apiCall { api.algoEvents().toDomain() } }
+
+    override suspend fun pmState(symbolId: Int): ApiResult<PmState> =
+        withContext(io) { apiCall { api.getPmState(symbolId).toDomain() } }
 
     override suspend fun placeOco(symbolId: Int, aSide: OrderSide, aPrice: Long, aQty: Long, bSide: OrderSide, bPrice: Long, bQty: Long): ApiResult<OcoAck> =
         withContext(io) {

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -60,6 +60,10 @@ fun TradeTicket(
     }
 
     Column(modifier = modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp).testTag("trade_ticket")) {
+        state.pm?.let {
+            PmBanner(it, lastPrice)
+            Spacer(Modifier.height(10.dp))
+        }
         state.account?.let {
             AccountStrip(it)
             Spacer(Modifier.height(10.dp))
@@ -114,9 +118,11 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, viewModel: Tra
     Spacer(Modifier.height(10.dp))
 
     if (state.orderType != OrderType.QUOTE && state.orderType != OrderType.FUNDING) {
+        val buyLabel = if (state.pm != null) "YES" else "Buy"
+        val sellLabel = if (state.pm != null) "NO" else "Sell"
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            SideButton("Buy", state.side == OrderSide.BUY, MarketColors.Up, Modifier.weight(1f)) { viewModel.setSide(OrderSide.BUY) }
-            SideButton("Sell", state.side == OrderSide.SELL, MarketColors.Down, Modifier.weight(1f)) { viewModel.setSide(OrderSide.SELL) }
+            SideButton(buyLabel, state.side == OrderSide.BUY, MarketColors.Up, Modifier.weight(1f)) { viewModel.setSide(OrderSide.BUY) }
+            SideButton(sellLabel, state.side == OrderSide.SELL, MarketColors.Down, Modifier.weight(1f)) { viewModel.setSide(OrderSide.SELL) }
         }
         Spacer(Modifier.height(10.dp))
     }
@@ -702,6 +708,53 @@ private fun submitLabel(state: TradingUiState): String {
         OrderType.OTO -> "Place OTO ($side parent)"
         OrderType.OCO -> "Place OCO ($side / ${if (state.side == OrderSide.BUY) "Sell" else "Buy"})"
         OrderType.FUNDING -> if (state.fundingBorrow) "Borrow" else "Lend"
+    }
+}
+
+@Composable
+private fun PmBanner(pm: com.testlogon.android.data.exchange.PmState, lastPrice: Long?) {
+    val resolved = pm.resolved
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (resolved) MarketColors.SurfaceAlt else MarketColors.Surface)
+            .border(1.dp, if (resolved) MarketColors.Border else MarketColors.Accent, RoundedCornerShape(10.dp))
+            .padding(12.dp),
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Text("Prediction market", color = MarketColors.Accent, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+            Text("payout ${fmt(pm.faceValue.toDouble())}", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+        }
+        Spacer(Modifier.height(6.dp))
+        if (resolved) {
+            val yesWon = pm.outcomeYes == true
+            Text(
+                text = "Resolved: ${if (yesWon) "YES" else "NO"} - " + if (yesWon) "YES pays ${fmt(pm.faceValue.toDouble())}" else "YES pays 0",
+                color = if (yesWon) MarketColors.Up else MarketColors.Down,
+                fontWeight = FontWeight.Bold,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 13.sp,
+            )
+        } else {
+            val prob = pm.impliedYes(lastPrice)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("Implied YES", color = MarketColors.TextSecondary, fontSize = 11.sp)
+                Text(prob?.let { "${(it * 100f).toInt()}%" } ?: "--", color = MarketColors.Up, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+            }
+            Spacer(Modifier.height(4.dp))
+            Row(modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)).background(MarketColors.Down.copy(alpha = 0.35f))) {
+                val f = (prob ?: 0f).coerceIn(0.001f, 1f)
+                Box(modifier = Modifier.weight(f).fillMaxHeight().background(MarketColors.Up))
+                Box(modifier = Modifier.weight((1f - f).coerceAtLeast(0.001f)))
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Buy YES to bet it happens, Buy NO to bet against; each YES contract pays ${fmt(pm.faceValue.toDouble())} if it resolves YES.",
+                color = MarketColors.TextFaint,
+                fontSize = 10.sp,
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -40,7 +40,10 @@ import com.testlogon.android.data.exchange.OrderSide
 import com.testlogon.android.feature.markets.ui.MarketColors
 import java.util.Locale
 
-/** Order ticket: side + limit price + qty → place, plus this-session working orders + margin strip. */
+/**
+ * Order ticket. Account context sits on top; the rest is split into Trade / Positions / Orders / Fills
+ * sections so order entry isn't buried under a long scroll.
+ */
 @Composable
 fun TradeTicket(
     lastPrice: Long?,
@@ -56,161 +59,26 @@ fun TradeTicket(
         }
     }
 
-    val sideColor = if (state.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down
     Column(modifier = modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp).testTag("trade_ticket")) {
-        // ---- Order type ----
-        OrderTypeRow(selected = state.orderType, onSelect = viewModel::setOrderType)
-        Spacer(Modifier.height(10.dp))
-
-        // ---- Buy / Sell (hidden for the two-sided quote + funding) ----
-        if (state.orderType != OrderType.QUOTE && state.orderType != OrderType.FUNDING) {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                SideButton("Buy", selected = state.side == OrderSide.BUY, color = MarketColors.Up, modifier = Modifier.weight(1f)) {
-                    viewModel.setSide(OrderSide.BUY)
-                }
-                SideButton("Sell", selected = state.side == OrderSide.SELL, color = MarketColors.Down, modifier = Modifier.weight(1f)) {
-                    viewModel.setSide(OrderSide.SELL)
-                }
-            }
-        }
-
-        Spacer(Modifier.height(10.dp))
-        state.account?.let { AccountStrip(it) }
-
-        Spacer(Modifier.height(8.dp))
-        FundRow(
-            value = state.depositText,
-            canDeposit = state.canDeposit,
-            depositing = state.depositing,
-            onValue = viewModel::setDeposit,
-            onDeposit = viewModel::deposit,
-        )
-
-        if (TradingFeatures.SPOT_ENABLED) {
+        state.account?.let {
+            AccountStrip(it)
             Spacer(Modifier.height(10.dp))
-            SpotPanel(state, viewModel)
         }
 
-        Spacer(Modifier.height(10.dp))
-        // ---- Type-specific inputs ----
-        when (state.orderType) {
-            OrderType.LIMIT -> {
-                NumberField("Price", state.priceText, viewModel::setPrice)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Quantity", state.qtyText, viewModel::setQty)
-                Spacer(Modifier.height(8.dp))
-                TifRow(state.tif, viewModel::setTif)
-                if (state.tif == "GTD") {
-                    Spacer(Modifier.height(8.dp))
-                    NumberField("Expires in (minutes)", state.expiryMinText, viewModel::setExpiryMin)
-                }
-                Spacer(Modifier.height(8.dp))
-                OrderValueRow(state.orderValue)
-                AdvancedSection(state, viewModel)
-            }
-            OrderType.MARKET -> {
-                NumberField("Quantity", state.qtyText, viewModel::setQty)
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Market order — fills immediately at the best available price.",
-                    color = MarketColors.TextSecondary,
-                    fontSize = 11.sp,
-                )
-                AdvancedSection(state, viewModel)
-            }
-            OrderType.STOP -> {
-                NumberField("Stop (trigger) price", state.stopText, viewModel::setStop)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Quantity", state.qtyText, viewModel::setQty)
-            }
-            OrderType.STOP_LIMIT -> {
-                NumberField("Stop (trigger) price", state.stopText, viewModel::setStop)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Limit price", state.priceText, viewModel::setPrice)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Quantity", state.qtyText, viewModel::setQty)
-            }
-            OrderType.TAKE_PROFIT -> {
-                NumberField("Take-profit trigger", state.stopText, viewModel::setStop)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Limit price (optional)", state.priceText, viewModel::setPrice)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Quantity", state.qtyText, viewModel::setQty)
-            }
-            OrderType.QUOTE -> {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(Modifier.weight(1f)) { NumberField("Bid price", state.bidText, viewModel::setBid) }
-                    Box(Modifier.weight(1f)) { NumberField("Ask price", state.askText, viewModel::setAsk) }
-                }
-                Spacer(Modifier.height(8.dp))
-                NumberField("Quantity (each side)", state.qtyText, viewModel::setQty)
-            }
-            OrderType.OTO -> {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(Modifier.weight(1f)) { NumberField("Parent price", state.priceText, viewModel::setPrice) }
-                    Box(Modifier.weight(1f)) { NumberField("Parent qty", state.qtyText, viewModel::setQty) }
-                }
-                Spacer(Modifier.height(8.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(Modifier.weight(1f)) { NumberField("Child price", state.childPriceText, viewModel::setChildPrice) }
-                    Box(Modifier.weight(1f)) { NumberField("Child qty", state.childQtyText, viewModel::setChildQty) }
-                }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Child = ${if (state.side == OrderSide.BUY) "Sell" else "Buy"} · triggers when the parent fills",
-                    color = MarketColors.TextSecondary,
-                    fontSize = 11.sp,
-                )
-            }
-            OrderType.OCO -> {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(Modifier.weight(1f)) { NumberField("Leg A price", state.priceText, viewModel::setPrice) }
-                    Box(Modifier.weight(1f)) { NumberField("Leg A qty", state.qtyText, viewModel::setQty) }
-                }
-                Spacer(Modifier.height(8.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(Modifier.weight(1f)) { NumberField("Leg B price", state.childPriceText, viewModel::setChildPrice) }
-                    Box(Modifier.weight(1f)) { NumberField("Leg B qty", state.childQtyText, viewModel::setChildQty) }
-                }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Leg A = ${if (state.side == OrderSide.BUY) "Buy" else "Sell"}, Leg B = ${if (state.side == OrderSide.BUY) "Sell" else "Buy"} · a fill on one cancels the other",
-                    color = MarketColors.TextSecondary,
-                    fontSize = 11.sp,
-                )
-            }
-            OrderType.FUNDING -> {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    SideButton("Borrow", selected = state.fundingBorrow, color = MarketColors.Up, modifier = Modifier.weight(1f)) { viewModel.setFundingBorrow(true) }
-                    SideButton("Lend", selected = !state.fundingBorrow, color = MarketColors.Down, modifier = Modifier.weight(1f)) { viewModel.setFundingBorrow(false) }
-                }
-                Spacer(Modifier.height(8.dp))
-                NumberField("Rate (bps)", state.fundingRateText, viewModel::setFundingRate)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Quantity", state.fundingQtyText, viewModel::setFundingQty)
-                Spacer(Modifier.height(8.dp))
-                NumberField("Duration (seconds, optional)", state.fundingDurationText, viewModel::setFundingDuration)
-            }
-        }
-
+        SectionTabs(
+            section = state.section,
+            ordersCount = state.workingOrders.size,
+            posCount = if (state.account?.position != null) 1 else 0,
+            fillsCount = state.sessionFills.size,
+            onSelect = viewModel::setSection,
+        )
         Spacer(Modifier.height(12.dp))
-        val submitColor = if (state.orderType == OrderType.QUOTE) MarketColors.Accent else sideColor
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-                .background(if (state.canSubmit) submitColor else MarketColors.SurfaceAlt)
-                .clickable(enabled = state.canSubmit) { viewModel.submit() }
-                .testTag("trade_place")
-                .padding(vertical = 14.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = submitLabel(state),
-                color = if (state.canSubmit) Color.Black else MarketColors.TextFaint,
-                fontWeight = FontWeight.Bold,
-                fontSize = 15.sp,
-            )
+
+        when (state.section) {
+            TicketSection.TRADE -> TradeSection(state, lastPrice, viewModel)
+            TicketSection.POSITIONS -> PositionsSection(state, lastPrice, viewModel)
+            TicketSection.ORDERS -> OrdersSection(state, viewModel)
+            TicketSection.FILLS -> FillsSection(state)
         }
 
         if (state.isAmending) {
@@ -233,53 +101,340 @@ fun TradeTicket(
                 fontSize = 12.sp,
             )
         }
+    }
+}
 
-        Spacer(Modifier.height(12.dp))
-        Text(
-            text = "Cancel all resting orders",
-            color = MarketColors.Down,
-            fontFamily = FontFamily.Monospace,
-            fontSize = 12.sp,
-            modifier = Modifier
-                .clip(RoundedCornerShape(6.dp))
-                .border(1.dp, MarketColors.Border, RoundedCornerShape(6.dp))
-                .clickable { viewModel.cancelAll() }
-                .testTag("cancel_all")
-                .padding(horizontal = 12.dp, vertical = 7.dp),
-        )
+// ======================= Sections =======================
 
-        if (state.workingOrders.isNotEmpty()) {
-            Spacer(Modifier.height(16.dp))
-            Text("Open orders · this session", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+@Composable
+private fun TradeSection(state: TradingUiState, lastPrice: Long?, viewModel: TradingViewModel) {
+    val sideColor = if (state.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down
+
+    OrderTypeRow(selected = state.orderType, onSelect = viewModel::setOrderType)
+    Spacer(Modifier.height(10.dp))
+
+    if (state.orderType != OrderType.QUOTE && state.orderType != OrderType.FUNDING) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            SideButton("Buy", state.side == OrderSide.BUY, MarketColors.Up, Modifier.weight(1f)) { viewModel.setSide(OrderSide.BUY) }
+            SideButton("Sell", state.side == OrderSide.SELL, MarketColors.Down, Modifier.weight(1f)) { viewModel.setSide(OrderSide.SELL) }
+        }
+        Spacer(Modifier.height(10.dp))
+    }
+
+    // Reference price for %-of-buying-power sizing.
+    val refPrice = state.priceLong ?: state.stopLong ?: lastPrice
+
+    when (state.orderType) {
+        OrderType.LIMIT -> {
+            StepperField("Price", state.priceText, viewModel::setPrice) { viewModel.stepPrice(it) }
+            Spacer(Modifier.height(8.dp))
+            StepperField("Quantity", state.qtyText, viewModel::setQty) { viewModel.stepQty(it) }
+            QtyPercentRow { viewModel.setQtyPercent(it, refPrice) }
+            Spacer(Modifier.height(8.dp))
+            TifRow(state.tif, viewModel::setTif)
+            if (state.tif == "GTD") {
+                Spacer(Modifier.height(8.dp))
+                NumberField("Expires in (minutes)", state.expiryMinText, viewModel::setExpiryMin)
+            }
+            Spacer(Modifier.height(8.dp))
+            OrderValueRow(state.orderValue, state.account?.availableBalance)
+            AdvancedSection(state, viewModel)
+        }
+        OrderType.MARKET -> {
+            StepperField("Quantity", state.qtyText, viewModel::setQty) { viewModel.stepQty(it) }
+            QtyPercentRow { viewModel.setQtyPercent(it, refPrice) }
             Spacer(Modifier.height(4.dp))
-            state.workingOrders.forEach { wo ->
-                WorkingOrderRow(
-                    label = "${if (wo.side == OrderSide.BUY) "Buy" else "Sell"}  ${fmt(wo.qty.toDouble())} @ ${fmt(wo.price.toDouble())}",
-                    sideColor = if (wo.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down,
-                    onAmend = { viewModel.startAmend(wo) },
-                    onCancel = { viewModel.cancel(wo.clordid) },
+            Text("Market order — fills immediately at the best available price.", color = MarketColors.TextSecondary, fontSize = 11.sp)
+            AdvancedSection(state, viewModel)
+        }
+        OrderType.STOP -> {
+            StepperField("Stop (trigger) price", state.stopText, viewModel::setStop) { viewModel.stepStop(it) }
+            Spacer(Modifier.height(8.dp))
+            StepperField("Quantity", state.qtyText, viewModel::setQty) { viewModel.stepQty(it) }
+            QtyPercentRow { viewModel.setQtyPercent(it, refPrice) }
+        }
+        OrderType.STOP_LIMIT -> {
+            StepperField("Stop (trigger) price", state.stopText, viewModel::setStop) { viewModel.stepStop(it) }
+            Spacer(Modifier.height(8.dp))
+            StepperField("Limit price", state.priceText, viewModel::setPrice) { viewModel.stepPrice(it) }
+            Spacer(Modifier.height(8.dp))
+            StepperField("Quantity", state.qtyText, viewModel::setQty) { viewModel.stepQty(it) }
+            QtyPercentRow { viewModel.setQtyPercent(it, refPrice) }
+        }
+        OrderType.TAKE_PROFIT -> {
+            StepperField("Take-profit trigger", state.stopText, viewModel::setStop) { viewModel.stepStop(it) }
+            Spacer(Modifier.height(8.dp))
+            NumberField("Limit price (optional)", state.priceText, viewModel::setPrice)
+            Spacer(Modifier.height(8.dp))
+            StepperField("Quantity", state.qtyText, viewModel::setQty) { viewModel.stepQty(it) }
+            QtyPercentRow { viewModel.setQtyPercent(it, refPrice) }
+        }
+        OrderType.QUOTE -> {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { NumberField("Bid price", state.bidText, viewModel::setBid) }
+                Box(Modifier.weight(1f)) { NumberField("Ask price", state.askText, viewModel::setAsk) }
+            }
+            Spacer(Modifier.height(8.dp))
+            NumberField("Quantity (each side)", state.qtyText, viewModel::setQty)
+        }
+        OrderType.OTO -> {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { NumberField("Parent price", state.priceText, viewModel::setPrice) }
+                Box(Modifier.weight(1f)) { NumberField("Parent qty", state.qtyText, viewModel::setQty) }
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { NumberField("Child price", state.childPriceText, viewModel::setChildPrice) }
+                Box(Modifier.weight(1f)) { NumberField("Child qty", state.childQtyText, viewModel::setChildQty) }
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Child = ${if (state.side == OrderSide.BUY) "Sell" else "Buy"} · triggers when the parent fills",
+                color = MarketColors.TextSecondary,
+                fontSize = 11.sp,
+            )
+        }
+        OrderType.OCO -> {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { NumberField("Leg A price", state.priceText, viewModel::setPrice) }
+                Box(Modifier.weight(1f)) { NumberField("Leg A qty", state.qtyText, viewModel::setQty) }
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { NumberField("Leg B price", state.childPriceText, viewModel::setChildPrice) }
+                Box(Modifier.weight(1f)) { NumberField("Leg B qty", state.childQtyText, viewModel::setChildQty) }
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Leg A = ${if (state.side == OrderSide.BUY) "Buy" else "Sell"}, Leg B = ${if (state.side == OrderSide.BUY) "Sell" else "Buy"} · a fill on one cancels the other",
+                color = MarketColors.TextSecondary,
+                fontSize = 11.sp,
+            )
+        }
+        OrderType.FUNDING -> {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                SideButton("Borrow", state.fundingBorrow, MarketColors.Up, Modifier.weight(1f)) { viewModel.setFundingBorrow(true) }
+                SideButton("Lend", !state.fundingBorrow, MarketColors.Down, Modifier.weight(1f)) { viewModel.setFundingBorrow(false) }
+            }
+            Spacer(Modifier.height(8.dp))
+            NumberField("Rate (bps)", state.fundingRateText, viewModel::setFundingRate)
+            Spacer(Modifier.height(8.dp))
+            NumberField("Quantity", state.fundingQtyText, viewModel::setFundingQty)
+            Spacer(Modifier.height(8.dp))
+            NumberField("Duration (seconds, optional)", state.fundingDurationText, viewModel::setFundingDuration)
+        }
+    }
+
+    Spacer(Modifier.height(12.dp))
+    val armedMarket = state.armed == "market"
+    val submitColor = when {
+        armedMarket -> MarketColors.Accent
+        state.orderType == OrderType.QUOTE -> MarketColors.Accent
+        else -> sideColor
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (state.canSubmit) submitColor else MarketColors.SurfaceAlt)
+            .clickable(enabled = state.canSubmit) { viewModel.submit() }
+            .testTag("trade_place")
+            .padding(vertical = 14.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = if (armedMarket) "Confirm ${if (state.side == OrderSide.BUY) "Buy" else "Sell"} ${state.qtyText} @ market".trim() else submitLabel(state),
+            color = if (state.canSubmit) Color.Black else MarketColors.TextFaint,
+            fontWeight = FontWeight.Bold,
+            fontSize = 15.sp,
+        )
+    }
+    state.entryHint?.let {
+        Spacer(Modifier.height(6.dp))
+        Text(it, color = MarketColors.TextFaint, fontSize = 11.sp)
+    }
+
+    Spacer(Modifier.height(16.dp))
+    FundRow(
+        value = state.depositText,
+        canDeposit = state.canDeposit,
+        depositing = state.depositing,
+        onValue = viewModel::setDeposit,
+        onDeposit = viewModel::deposit,
+    )
+    if (TradingFeatures.SPOT_ENABLED) {
+        Spacer(Modifier.height(10.dp))
+        SpotPanel(state, viewModel)
+    }
+}
+
+@Composable
+private fun PositionsSection(state: TradingUiState, lastPrice: Long?, viewModel: TradingViewModel) {
+    val pos = state.account?.position
+    if (pos == null) {
+        EmptyHint("No open position")
+    } else {
+        PositionCard(pos = pos, armed = state.armed == "close", onClose = { lastPrice?.let { viewModel.closePositionRequested(it) } })
+    }
+}
+
+@Composable
+private fun OrdersSection(state: TradingUiState, viewModel: TradingViewModel) {
+    if (state.workingOrders.isEmpty()) {
+        EmptyHint("No resting orders this session")
+    } else {
+        state.workingOrders.forEach { wo ->
+            WorkingOrderRow(
+                label = "${if (wo.side == OrderSide.BUY) "Buy" else "Sell"}  ${fmt(wo.qty.toDouble())} @ ${fmt(wo.price.toDouble())}",
+                sideColor = if (wo.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down,
+                onAmend = { viewModel.startAmend(wo); viewModel.setSection(TicketSection.TRADE) },
+                onCancel = { viewModel.cancel(wo.clordid) },
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+    }
+    // Cancel-all also clears server-side quote/OTO legs (no local clordid), so keep it always available.
+    Text(
+        text = "Cancel all resting orders",
+        color = MarketColors.Down,
+        fontFamily = FontFamily.Monospace,
+        fontSize = 12.sp,
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(6.dp))
+            .clickable { viewModel.cancelAll() }
+            .testTag("cancel_all")
+            .padding(horizontal = 12.dp, vertical = 7.dp),
+    )
+}
+
+@Composable
+private fun FillsSection(state: TradingUiState) {
+    if (state.sessionFills.isEmpty()) {
+        EmptyHint("No fills this session")
+        return
+    }
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Text("Price", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1.2f))
+        Text("Qty", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
+        Text("Time", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
+    }
+    state.sessionFills.take(60).forEach { f -> FillRow(f) }
+}
+
+@Composable
+private fun EmptyHint(text: String) {
+    Text(text, color = MarketColors.TextFaint, fontSize = 12.sp, modifier = Modifier.padding(vertical = 8.dp))
+}
+
+// ======================= Building blocks =======================
+
+@Composable
+private fun SectionTabs(section: TicketSection, ordersCount: Int, posCount: Int, fillsCount: Int, onSelect: (TicketSection) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)).background(MarketColors.SurfaceAlt).padding(3.dp),
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        TicketSection.values().forEach { s ->
+            val count = when (s) {
+                TicketSection.ORDERS -> ordersCount
+                TicketSection.POSITIONS -> posCount
+                TicketSection.FILLS -> fillsCount
+                else -> 0
+            }
+            val label = if (count > 0 && s != TicketSection.TRADE) "${s.label} $count" else s.label
+            val on = s == section
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(if (on) MarketColors.Surface else Color.Transparent)
+                    .clickable { onSelect(s) }
+                    .testTag("section_${s.name}")
+                    .padding(vertical = 8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    label,
+                    color = if (on) MarketColors.TextPrimary else MarketColors.TextSecondary,
+                    fontWeight = if (on) FontWeight.Bold else FontWeight.Normal,
+                    fontSize = 12.sp,
+                    maxLines = 1,
                 )
             }
         }
+    }
+}
 
-        state.account?.position?.let { pos ->
-            Spacer(Modifier.height(16.dp))
-            Text("Position", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 13.sp)
-            Spacer(Modifier.height(4.dp))
-            PositionCard(pos = pos, onClose = { lastPrice?.let { viewModel.closePosition(it) } })
-        }
-
-        if (state.sessionFills.isNotEmpty()) {
-            Spacer(Modifier.height(16.dp))
-            Text("Fills · this session", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 13.sp)
-            Spacer(Modifier.height(4.dp))
-            Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
-                Text("Price", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1.2f))
-                Text("Qty", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
-                Text("Time", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
+@Composable
+private fun QtyPercentRow(onPct: (Int) -> Unit) {
+    Spacer(Modifier.height(6.dp))
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        listOf(25, 50, 75, 100).forEach { pct ->
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(MarketColors.Surface)
+                    .border(1.dp, MarketColors.Border, RoundedCornerShape(6.dp))
+                    .clickable { onPct(pct) }
+                    .testTag("qty_pct_$pct")
+                    .padding(vertical = 6.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(if (pct == 100) "Max" else "$pct%", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
             }
-            state.sessionFills.take(40).forEach { f -> FillRow(f) }
         }
+    }
+}
+
+@Composable
+private fun StepperField(label: String, value: String, onValue: (String) -> Unit, onStep: (Long) -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(label, color = MarketColors.TextSecondary, fontSize = 11.sp)
+        Spacer(Modifier.height(3.dp))
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            StepBtn("−", "step_dn_$label") { onStep(-1L) }
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MarketColors.Surface)
+                    .border(1.dp, MarketColors.Border, RoundedCornerShape(8.dp))
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+            ) {
+                if (value.isEmpty()) {
+                    Text("0", color = MarketColors.TextFaint, fontFamily = FontFamily.Monospace, fontSize = 16.sp)
+                }
+                BasicTextField(
+                    value = value,
+                    onValueChange = onValue,
+                    singleLine = true,
+                    textStyle = TextStyle(color = MarketColors.TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 16.sp),
+                    cursorBrush = SolidColor(MarketColors.Accent),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth().testTag("field_$label"),
+                )
+            }
+            StepBtn("+", "step_up_$label") { onStep(1L) }
+        }
+    }
+}
+
+@Composable
+private fun StepBtn(sym: String, tag: String, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .width(44.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MarketColors.Surface)
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .testTag(tag)
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(sym, color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 18.sp)
     }
 }
 
@@ -314,7 +469,7 @@ private fun WalletRow(label: String, value: Long) {
 }
 
 @Composable
-private fun PositionCard(pos: com.testlogon.android.data.exchange.PositionSnapshot, onClose: () -> Unit) {
+private fun PositionCard(pos: com.testlogon.android.data.exchange.PositionSnapshot, armed: Boolean, onClose: () -> Unit) {
     val long = pos.qty > 0
     val sideColor = if (long) MarketColors.Up else MarketColors.Down
     val pnlColor = if (pos.unrealizedPnl >= 0) MarketColors.Up else MarketColors.Down
@@ -335,14 +490,14 @@ private fun PositionCard(pos: com.testlogon.android.data.exchange.PositionSnapsh
                 fontSize = 14.sp,
             )
             Text(
-                text = "Close",
+                text = if (armed) "Confirm close" else "Close",
                 color = Color.Black,
                 fontWeight = FontWeight.Bold,
                 fontFamily = FontFamily.Monospace,
                 fontSize = 12.sp,
                 modifier = Modifier
                     .clip(RoundedCornerShape(6.dp))
-                    .background(sideColor)
+                    .background(if (armed) MarketColors.Accent else sideColor)
                     .clickable(onClick = onClose)
                     .testTag("close_position")
                     .padding(horizontal = 12.dp, vertical = 6.dp),
@@ -474,12 +629,16 @@ private fun AdvancedSection(state: TradingUiState, viewModel: TradingViewModel) 
     )
     if (state.advancedOpen) {
         Spacer(Modifier.height(6.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
             if (state.orderType == OrderType.LIMIT) {
                 TogglePill("Post-only", state.postOnly, viewModel::togglePostOnly, "flag_post_only")
             }
             TogglePill("Hidden", state.hidden, viewModel::toggleHidden, "flag_hidden")
             TogglePill("AON", state.aon, viewModel::toggleAon, "flag_aon")
+            TogglePill("1-tap", state.oneTap, viewModel::toggleOneTap, "flag_one_tap")
         }
         Spacer(Modifier.height(8.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -515,12 +674,13 @@ private fun OrderTypeRow(selected: OrderType, onSelect: (OrderType) -> Unit) {
 }
 
 @Composable
-private fun OrderValueRow(value: Long?) {
+private fun OrderValueRow(value: Long?, available: Long?) {
+    val exceeds = value != null && available != null && value > available
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         Text("Order value", color = MarketColors.TextSecondary, fontSize = 12.sp)
         Text(
-            text = value?.let { fmt(it.toDouble()) } ?: "--",
-            color = MarketColors.TextPrimary,
+            text = (value?.let { fmt(it.toDouble()) } ?: "--") + (available?.let { " · avail ${fmt(it.toDouble())}" } ?: ""),
+            color = if (exceeds) MarketColors.Down else MarketColors.TextPrimary,
             fontFamily = FontFamily.Monospace,
             fontWeight = FontWeight.SemiBold,
             fontSize = 12.sp,

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingNotifier.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingNotifier.kt
@@ -1,0 +1,120 @@
+package com.testlogon.android.feature.markets.trade
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.testlogon.android.R
+import com.testlogon.android.core.ui.theme.BrandPrimary
+import com.testlogon.android.notifications.NotificationChannelInitializer
+import com.testlogon.android.notifications.NotificationPermissionState
+import com.testlogon.android.notifications.TlChannels
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Distinct haptic patterns for trading feedback. */
+enum class TradeHaptic { TICK, SUCCESS, WARN, ERROR }
+
+/**
+ * Trading feedback: haptics (via [Vibrator]) + system notifications for notable events (fills, algo/OTO
+ * triggers, liquidation distress). Notifications route to the existing [TlChannels.ALERTS] channel and
+ * are permission-gated + failure-safe (never throw). Haptics degrade to a no-op when the device has no
+ * vibrator. Notable events buzz AND notify so a fill is felt even when you're on another tab.
+ */
+@Singleton
+class TradingNotifier @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val permission: NotificationPermissionState,
+    private val initializer: NotificationChannelInitializer,
+) {
+    private val vibrator: Vibrator? = runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager)?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION") context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        }
+    }.getOrNull()
+
+    // ---- haptics ----
+    fun tick() = haptic(TradeHaptic.TICK)
+    fun success() = haptic(TradeHaptic.SUCCESS)
+    fun warn() = haptic(TradeHaptic.WARN)
+    fun error() = haptic(TradeHaptic.ERROR)
+
+    @Suppress("DEPRECATION")
+    fun haptic(kind: TradeHaptic) {
+        val v = vibrator ?: return
+        if (!v.hasVibrator()) return
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val effect = when (kind) {
+                    TradeHaptic.TICK -> VibrationEffect.createOneShot(12, VibrationEffect.DEFAULT_AMPLITUDE)
+                    TradeHaptic.WARN -> VibrationEffect.createOneShot(35, VibrationEffect.DEFAULT_AMPLITUDE)
+                    TradeHaptic.SUCCESS -> VibrationEffect.createWaveform(longArrayOf(0, 25, 60, 25), -1)
+                    TradeHaptic.ERROR -> VibrationEffect.createWaveform(longArrayOf(0, 45, 55, 45, 55, 45), -1)
+                }
+                v.vibrate(effect)
+            } else {
+                val ms = when (kind) {
+                    TradeHaptic.TICK -> 12L
+                    TradeHaptic.WARN -> 35L
+                    TradeHaptic.SUCCESS -> 60L
+                    TradeHaptic.ERROR -> 120L
+                }
+                v.vibrate(ms)
+            }
+        }
+    }
+
+    // ---- notifications ----
+    fun notifyFill(title: String, body: String) {
+        success()
+        post(title, body)
+    }
+
+    fun notifyTrigger(title: String, body: String) {
+        success()
+        post(title, body)
+    }
+
+    fun notifyDistress(title: String, body: String) {
+        warn()
+        post(title, body)
+    }
+
+    @SuppressLint("MissingPermission") // gated by NotificationPermissionState.isGranted()
+    private fun post(title: String, body: String) {
+        if (!permission.isGranted()) return
+        runCatching {
+            initializer.ensureChannels()
+            val notifId = ("trade:" + title + body).hashCode()
+            val launch = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            val pending = launch?.let {
+                PendingIntent.getActivity(
+                    context,
+                    notifId,
+                    it,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                )
+            }
+            val builder = NotificationCompat.Builder(context, TlChannels.ALERTS)
+                .setSmallIcon(R.drawable.ic_stat_notification)
+                .setColor(BrandPrimary.toArgb())
+                .setContentTitle(title)
+                .setContentText(body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setGroup(TlChannels.ALERTS)
+                .setAutoCancel(true)
+            if (pending != null) builder.setContentIntent(pending)
+            NotificationManagerCompat.from(context).notify(notifId, builder.build())
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -93,6 +93,7 @@ data class TradingUiState(
     val section: TicketSection = TicketSection.TRADE,
     val armed: String? = null,        // "market" | "close" -> a confirm is pending (skipped when oneTap)
     val oneTap: Boolean = false,      // when true, market/close fire without a confirm step
+    val pm: com.testlogon.android.data.exchange.PmState? = null,   // set when this symbol is a binary prediction market
 ) {
     val isAmending: Boolean get() = amendingClordid != null
     val depositLong: Long? get() = depositText.toLongOrNull()

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -35,6 +35,14 @@ fun OrderType.isAvailable(): Boolean = when (this) {
     else -> true
 }
 
+/** The order-tab is split into these sections so entry isn't buried under positions/orders/fills. */
+enum class TicketSection(val label: String) {
+    TRADE("Trade"),
+    POSITIONS("Positions"),
+    ORDERS("Orders"),
+    FILLS("Fills"),
+}
+
 /** A working order this session placed (the engine has no server-side list, so we track our own). */
 data class WorkingOrder(
     val clordid: String,
@@ -82,6 +90,9 @@ data class TradingUiState(
     val spotBalance: SpotBalance? = null,
     val spotAssetText: String = "",
     val spotAmountText: String = "",
+    val section: TicketSection = TicketSection.TRADE,
+    val armed: String? = null,        // "market" | "close" -> a confirm is pending (skipped when oneTap)
+    val oneTap: Boolean = false,      // when true, market/close fire without a confirm step
 ) {
     val isAmending: Boolean get() = amendingClordid != null
     val depositLong: Long? get() = depositText.toLongOrNull()
@@ -107,6 +118,17 @@ data class TradingUiState(
     val fundingDurationLong: Long? get() = fundingDurationText.toLongOrNull()
     val spotAssetInt: Int? get() = spotAssetText.toIntOrNull()
     val spotAmountLong: Long? get() = spotAmountText.toLongOrNull()
+
+    /** A short prompt for what's missing, shown when submit is disabled (crisper than a dead button). */
+    val entryHint: String? get() = if (placing || canSubmit) null else when (orderType) {
+        OrderType.LIMIT -> "Enter price and quantity"
+        OrderType.MARKET -> "Enter a quantity"
+        OrderType.STOP, OrderType.TAKE_PROFIT -> "Enter trigger price and quantity"
+        OrderType.STOP_LIMIT -> "Enter stop, limit and quantity"
+        OrderType.QUOTE -> "Enter bid, ask and quantity"
+        OrderType.OTO, OrderType.OCO -> "Enter both legs' price and quantity"
+        OrderType.FUNDING -> "Enter rate and quantity"
+    }
 
     /** Whether the current order-type has all the fields it needs to submit. */
     val canSubmit: Boolean get() = !placing && when (orderType) {

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -25,8 +25,11 @@ import javax.inject.Inject
 @HiltViewModel
 class TradingViewModel @Inject constructor(
     private val repository: TradingRepository,
+    private val notifier: TradingNotifier,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
+
+    private var wasLiquidating = false
 
     private val symbolId: Int = savedStateHandle.get<Int>(SymbolDetailDest.ARG_SYMBOL_ID) ?: 0
 
@@ -52,7 +55,7 @@ class TradingViewModel @Inject constructor(
         }
     }
 
-    fun setSide(side: OrderSide) = _uiState.update { it.copy(side = side, armed = null) }
+    fun setSide(side: OrderSide) { notifier.tick(); _uiState.update { it.copy(side = side, armed = null) } }
     fun setPrice(text: String) = _uiState.update { it.copy(priceText = text.filter { c -> c.isDigit() }.take(12), armed = null) }
     fun setQty(text: String) = _uiState.update { it.copy(qtyText = text.filter { c -> c.isDigit() }.take(9), armed = null) }
     fun setDeposit(text: String) = _uiState.update { it.copy(depositText = text.filter { c -> c.isDigit() }.take(12)) }
@@ -61,7 +64,7 @@ class TradingViewModel @Inject constructor(
     fun setAsk(text: String) = _uiState.update { it.copy(askText = digits(text, 12)) }
     fun setChildPrice(text: String) = _uiState.update { it.copy(childPriceText = digits(text, 12)) }
     fun setChildQty(text: String) = _uiState.update { it.copy(childQtyText = digits(text, 9)) }
-    fun setOrderType(t: OrderType) = _uiState.update { it.copy(orderType = t, amendingClordid = null, message = null, armed = null) }
+    fun setOrderType(t: OrderType) { notifier.tick(); _uiState.update { it.copy(orderType = t, amendingClordid = null, message = null, armed = null) } }
     fun setSection(s: TicketSection) = _uiState.update { it.copy(section = s, armed = null) }
     fun toggleOneTap() = _uiState.update { it.copy(oneTap = !it.oneTap) }
 
@@ -72,20 +75,24 @@ class TradingViewModel @Inject constructor(
         if (px <= 0 || avail <= 0) return
         val maxQty = avail / px
         val q = (maxQty * pct / 100).coerceAtLeast(if (pct > 0) 1L else 0L)
+        notifier.tick()
         _uiState.update { it.copy(qtyText = q.toString(), armed = null) }
     }
 
     fun stepQty(delta: Long) {
+        notifier.tick()
         val n = ((_uiState.value.qtyText.toLongOrNull() ?: 0L) + delta).coerceAtLeast(0L)
         _uiState.update { it.copy(qtyText = if (n == 0L) "" else n.toString(), armed = null) }
     }
 
     fun stepPrice(delta: Long) {
+        notifier.tick()
         val n = ((_uiState.value.priceText.toLongOrNull() ?: 0L) + delta).coerceAtLeast(0L)
         _uiState.update { it.copy(priceText = if (n == 0L) "" else n.toString(), armed = null) }
     }
 
     fun stepStop(delta: Long) {
+        notifier.tick()
         val n = ((_uiState.value.stopText.toLongOrNull() ?: 0L) + delta).coerceAtLeast(0L)
         _uiState.update { it.copy(stopText = if (n == 0L) "" else n.toString(), armed = null) }
     }
@@ -132,8 +139,8 @@ class TradingViewModel @Inject constructor(
                     }
                     if (ack.accepted) refreshSpot()
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -155,8 +162,8 @@ class TradingViewModel @Inject constructor(
                     _uiState.update { it.copy(placing = false, message = if (ack.accepted) "OCO #${ack.ocoId ?: "?"} placed" else (ack.message ?: "OCO rejected"), messageIsError = !ack.accepted) }
                     if (ack.accepted) refreshAccount()
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -175,8 +182,8 @@ class TradingViewModel @Inject constructor(
                     _uiState.update { it.copy(placing = false, message = if (ack.accepted) "Funding ${if (s.fundingBorrow) "borrow" else "lend"} #${ack.fundingId ?: "?"}" else (ack.message ?: "Funding rejected"), messageIsError = !ack.accepted) }
                     if (ack.accepted) refreshAccount()
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -185,6 +192,7 @@ class TradingViewModel @Inject constructor(
     fun submit() {
         val s = _uiState.value
         if (s.orderType == OrderType.MARKET && !s.oneTap && s.armed != "market") {
+            notifier.warn()
             _uiState.update { it.copy(armed = "market", message = "Tap Confirm to send the market order", messageIsError = false) }
             return
         }
@@ -241,7 +249,14 @@ class TradingViewModel @Inject constructor(
     fun refreshAccount() {
         viewModelScope.launch {
             when (val r = repository.marginAccount()) {
-                is ApiResult.Success -> _uiState.update { it.copy(account = r.data) }
+                is ApiResult.Success -> {
+                    val acct = r.data
+                    if (acct.isLiquidating && !wasLiquidating) {
+                        notifier.notifyDistress("⚠ Liquidation", "Your position is being liquidated")
+                    }
+                    wasLiquidating = acct.isLiquidating
+                    _uiState.update { it.copy(account = acct) }
+                }
                 else -> Unit
             }
         }
@@ -266,6 +281,12 @@ class TradingViewModel @Inject constructor(
                     )
                 }
                 refreshAccount()
+                when {
+                    ev.triggeredCount > 0 -> notifier.notifyTrigger("Algo triggered", "${ev.triggeredCount} algo order(s) triggered")
+                    ev.otoTriggeredCount > 0 -> notifier.notifyTrigger("OTO triggered", "${ev.otoTriggeredCount} child order(s) fired")
+                    ev.fills.isNotEmpty() -> notifier.notifyFill("Fill", "Filled ${ev.fills.sumOf { f -> f.qty }} on a resting order")
+                    else -> {}
+                }
             }
         }
     }
@@ -310,12 +331,14 @@ class TradingViewModel @Inject constructor(
                             )
                         }
                         refreshAccount()
+                        if (filled > 0) notifier.notifyFill("Order filled", "Filled $filled @ ${ack.fills.firstOrNull()?.price ?: price}") else notifier.success()
                     } else {
                         _uiState.update { it.copy(placing = false, message = ack.message ?: "Order rejected", messageIsError = true) }
+                        notifier.error()
                     }
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -384,9 +407,10 @@ class TradingViewModel @Inject constructor(
                         )
                     }
                     refreshAccount()
+                    if (ack.accepted) notifier.notifyFill("Position closed", "${if (side == OrderSide.SELL) "Sold" else "Bought"} $qty to flatten") else notifier.error()
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -427,8 +451,8 @@ class TradingViewModel @Inject constructor(
                     }
                     if (ack.accepted) refreshAccount()
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -456,8 +480,8 @@ class TradingViewModel @Inject constructor(
                     }
                     if (ack.accepted) refreshAccount()
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -486,8 +510,8 @@ class TradingViewModel @Inject constructor(
                     }
                     if (ack.accepted) refreshAccount()
                 }
-                is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
             }
         }
     }
@@ -497,6 +521,7 @@ class TradingViewModel @Inject constructor(
         val s = _uiState.value
         if (s.account?.position == null) return
         if (!s.oneTap && s.armed != "close") {
+            notifier.warn()
             _uiState.update { it.copy(armed = "close", message = "Tap Confirm close to flatten the position", messageIsError = false) }
             return
         }
@@ -529,8 +554,8 @@ class TradingViewModel @Inject constructor(
                         }
                         refreshAccount()
                     } else _uiState.update { it.copy(placing = false, message = r.data.message ?: "Amend rejected", messageIsError = true) }
-                    is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                    is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                    is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                    is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
                 }
             } else {
                 // replace: cancel then place a fresh order at the new price/qty
@@ -554,8 +579,8 @@ class TradingViewModel @Inject constructor(
                             refreshAccount()
                         } else _uiState.update { it.copy(placing = false, message = ack.message ?: "Replace rejected", messageIsError = true) }
                     }
-                    is ApiResult.Failure -> _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }
-                    is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
+                    is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
+                    is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
                 }
             }
         }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -52,16 +52,43 @@ class TradingViewModel @Inject constructor(
         }
     }
 
-    fun setSide(side: OrderSide) = _uiState.update { it.copy(side = side) }
-    fun setPrice(text: String) = _uiState.update { it.copy(priceText = text.filter { c -> c.isDigit() }.take(12)) }
-    fun setQty(text: String) = _uiState.update { it.copy(qtyText = text.filter { c -> c.isDigit() }.take(9)) }
+    fun setSide(side: OrderSide) = _uiState.update { it.copy(side = side, armed = null) }
+    fun setPrice(text: String) = _uiState.update { it.copy(priceText = text.filter { c -> c.isDigit() }.take(12), armed = null) }
+    fun setQty(text: String) = _uiState.update { it.copy(qtyText = text.filter { c -> c.isDigit() }.take(9), armed = null) }
     fun setDeposit(text: String) = _uiState.update { it.copy(depositText = text.filter { c -> c.isDigit() }.take(12)) }
-    fun setStop(text: String) = _uiState.update { it.copy(stopText = digits(text, 12)) }
+    fun setStop(text: String) = _uiState.update { it.copy(stopText = digits(text, 12), armed = null) }
     fun setBid(text: String) = _uiState.update { it.copy(bidText = digits(text, 12)) }
     fun setAsk(text: String) = _uiState.update { it.copy(askText = digits(text, 12)) }
     fun setChildPrice(text: String) = _uiState.update { it.copy(childPriceText = digits(text, 12)) }
     fun setChildQty(text: String) = _uiState.update { it.copy(childQtyText = digits(text, 9)) }
-    fun setOrderType(t: OrderType) = _uiState.update { it.copy(orderType = t, amendingClordid = null, message = null) }
+    fun setOrderType(t: OrderType) = _uiState.update { it.copy(orderType = t, amendingClordid = null, message = null, armed = null) }
+    fun setSection(s: TicketSection) = _uiState.update { it.copy(section = s, armed = null) }
+    fun toggleOneTap() = _uiState.update { it.copy(oneTap = !it.oneTap) }
+
+    /** Quick-size: set qty to a % of (no-leverage) buying power = availableBalance / refPrice. */
+    fun setQtyPercent(pct: Int, refPrice: Long?) {
+        val avail = _uiState.value.account?.availableBalance ?: return
+        val px = refPrice ?: return
+        if (px <= 0 || avail <= 0) return
+        val maxQty = avail / px
+        val q = (maxQty * pct / 100).coerceAtLeast(if (pct > 0) 1L else 0L)
+        _uiState.update { it.copy(qtyText = q.toString(), armed = null) }
+    }
+
+    fun stepQty(delta: Long) {
+        val n = ((_uiState.value.qtyText.toLongOrNull() ?: 0L) + delta).coerceAtLeast(0L)
+        _uiState.update { it.copy(qtyText = if (n == 0L) "" else n.toString(), armed = null) }
+    }
+
+    fun stepPrice(delta: Long) {
+        val n = ((_uiState.value.priceText.toLongOrNull() ?: 0L) + delta).coerceAtLeast(0L)
+        _uiState.update { it.copy(priceText = if (n == 0L) "" else n.toString(), armed = null) }
+    }
+
+    fun stepStop(delta: Long) {
+        val n = ((_uiState.value.stopText.toLongOrNull() ?: 0L) + delta).coerceAtLeast(0L)
+        _uiState.update { it.copy(stopText = if (n == 0L) "" else n.toString(), armed = null) }
+    }
     fun setTif(t: String) = _uiState.update { it.copy(tif = t) }
     fun togglePostOnly() = _uiState.update { it.copy(postOnly = !it.postOnly) }
     fun toggleHidden() = _uiState.update { it.copy(hidden = !it.hidden) }
@@ -156,7 +183,13 @@ class TradingViewModel @Inject constructor(
 
     /** Route the ticket's primary action to the right engine endpoint for the selected order type. */
     fun submit() {
-        when (_uiState.value.orderType) {
+        val s = _uiState.value
+        if (s.orderType == OrderType.MARKET && !s.oneTap && s.armed != "market") {
+            _uiState.update { it.copy(armed = "market", message = "Tap Confirm to send the market order", messageIsError = false) }
+            return
+        }
+        _uiState.update { it.copy(armed = null) }
+        when (s.orderType) {
             OrderType.LIMIT -> place()
             OrderType.MARKET -> place()
             OrderType.STOP -> submitAlgo("stop_market")
@@ -457,6 +490,18 @@ class TradingViewModel @Inject constructor(
                 is ApiResult.NetworkError -> _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }
             }
         }
+    }
+
+    /** Close with a confirm step (unless one-tap is on). The UI calls this; [closePosition] executes. */
+    fun closePositionRequested(lastPrice: Long) {
+        val s = _uiState.value
+        if (s.account?.position == null) return
+        if (!s.oneTap && s.armed != "close") {
+            _uiState.update { it.copy(armed = "close", message = "Tap Confirm close to flatten the position", messageIsError = false) }
+            return
+        }
+        _uiState.update { it.copy(armed = null) }
+        closePosition(lastPrice)
     }
 
     /**

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -41,7 +41,18 @@ class TradingViewModel @Inject constructor(
     init {
         refreshAccount()
         pollAccount()
+        refreshPm()
         if (TradingFeatures.SPOT_ENABLED) refreshSpot()
+    }
+
+    /** Detect + track a binary prediction market on this symbol (404 -> not a PM -> stays null). */
+    fun refreshPm() {
+        viewModelScope.launch {
+            when (val r = repository.pmState(symbolId)) {
+                is ApiResult.Success -> _uiState.update { it.copy(pm = if (r.data.isBinary) r.data else null) }
+                else -> Unit
+            }
+        }
     }
 
     /** Keep the wallet / margin / position fresh while the VM is alive. */
@@ -51,6 +62,7 @@ class TradingViewModel @Inject constructor(
                 delay(5_000L)
                 refreshAccount()
                 drainExecEvents()
+                if (_uiState.value.pm != null) refreshPm()   // catch resolution while it's an active PM
             }
         }
     }

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/di/NetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/di/NetworkModule.kt
@@ -30,6 +30,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -119,6 +120,9 @@ object NetworkModule {
         .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .retryOnConnectionFailure(true)
+        // cpp edge HTTP/2 resets concurrent streams under the messaging poll+SSE load, which
+        // cancelled the login POST stream. Pin the app data plane to HTTP/1.1 (exchange already does).
+        .protocols(listOf(Protocol.HTTP_1_1))
         .cookieJar(cookieJar)
         // Host selection first (so downstream sees the effective URL), then delegate re-routing (so the
         // rewritten messaging path is the one CSRF/retry/logging observe), then CSRF, then retry, and

--- a/frontend/docs/web-trading-parity-backlog.md
+++ b/frontend/docs/web-trading-parity-backlog.md
@@ -1,0 +1,61 @@
+# Web trading + prediction-market parity backlog
+
+Goal: bring the **mobile-web** client to parity with the Android trading + market-data feature
+set. The web app already has **market-data view-only** (`src/pages/markets/*`, `src/hooks/useMarketData*`);
+everything below the market-data line is currently **Android-only**.
+
+## Audit (2026-08-11)
+
+**Stack:** React + TypeScript + Vite + React Query v5 (`@tanstack/react-query`). API client
+`src/api/client.ts` already sends **cookie (`credentials: include`) + `Authorization: Bearer` +
+`X-CSRF-Token`** → authed `/me/*` POSTs work with no extra plumbing. Web builds green (Node 20).
+
+**Present:** `api/endpoints/marketData.ts` (symbols/book/candles/trades), `useMarketData`
+(RQ 2s) + `useMarketDataStream` (SSE live book+candles), `MarketsPage`, `SymbolDetailPage`
+(book + trades + chart + live), `CandleChart` (**basic SVG candles — no indicators/drawing**).
+Routes `/markets`, `/markets/:symbolId`.
+
+**Missing vs Android (the parity gap):** all order entry; advanced order types (quote/algo/OTO,
++OCO/funding/spot staged); account/positions/margin/close; fills + exec-events; working orders +
+amend/cancel-all; click-to-trade; chart indicators + drawing + dual-style book + search/watchlist;
+prediction markets; web-native feedback (Notification API + `navigator.vibrate`); mobile-first layout.
+
+## Contract (same endpoints Android uses; see also the exchange-client memory)
+
+- Order entry `POST /me/orders` `{symbolid, side, price, qty, clordid, market?, tif?(GTC/IOC/FOK/GTD),
+  post_only?, hidden?, aon?, display_qty?, min_qty?, expiry_ns?}`; `PATCH /me/orders/{clordid}`
+  `{new_qty, new_price?, symbolid?}`; `DELETE /me/orders/{clordid}?symbolid=N`.
+- `POST /me/bulk_cancel`; `POST /me/quote {symbolid,bid_price,ask_price,bid_qty,ask_qty}`;
+  `POST /me/algo {algo_type(stop|stop_limit|stop_market|take_profit),symbolid,side,qty,stop_price?,limit_price?}`;
+  `POST /me/oto {symbolid,parent_*,child_*}`.
+- `GET /me/margin_account`; `POST /me/margin_deposit {amount}`; `GET /me/algo/events`.
+- Prediction market: `GET /me/pm_state?symbolid=N` → `{is_binary,state,outcome,face_value,resolve_ts,resolver_id}`.
+  A PM is a symbol; price ∈ [0, face] = implied YES prob × face; YES=buy, NO=sell.
+- Staged (edge/config-blocked today): `POST /me/oco`, `POST /me/funding_order`, `GET /me/spot_balance`, `POST /me/spot_deposit`.
+
+## Waves
+
+- **WEB-A — Trading data layer ✅ (this change).** `api/endpoints/trading.ts` (all calls + types +
+  helpers `isAck`/`ackMessage`/`impliedYes`/`marginUsedFraction`) + `hooks/useTrading.ts` (RQ
+  queries `useMarginAccount`/`usePmState`/`useExecEvents` + mutations place/amend/cancel/bulk-cancel/
+  deposit/quote/algo/oto). Reuses `client.ts`. Type-checks clean; no UI yet.
+- **WEB-B — Order ticket.** Order-type selector (Limit/Market/Stop/Stop-Limit/TP/Quote/OTO; OCO/Funding
+  gated), Buy/Sell, price/qty **steppers + 25/50/75/Max chips**, TIF+GTD, advanced flags
+  (post-only/hidden/AON/iceberg/min-qty), order value + avail, submit with **confirm step** for
+  market/close, entry hints, sectioned **Trade / Positions / Orders / Fills**, **mobile-first**.
+- **WEB-C — Account + positions + fills.** Wallet/margin strip + meter + distress, position card +
+  **market-order close (STP guard)**, session fills + exec-events feed, cancel-all, amend/replace,
+  funding deposit.
+- **WEB-D — Click-to-trade + chart/book enrichment.** Prefill from book/chart; dual-style book;
+  chart indicators (MA/EMA/RSI/MACD/BB/VWAP/volume) + chart types + drawing tools; symbol search + watchlist.
+- **WEB-E — Prediction markets.** `pm_state` banner (implied-YES bar, payout, resolved YES/NO) + YES/NO relabel.
+- **WEB-F — Web-native polish.** Web Notification API + `navigator.vibrate` (haptics/notifications
+  equivalent); OCO/funding/spot behind flags; responsive/touch pass.
+
+## Notes / caveats
+- **Prediction markets are merged to backend `origin/main` but NOT yet on the running prod binary**
+  (`pm_state` 404s live today) → the PM UI stays inert until prod redeploys + an admin configures a
+  market. Same graceful-degrade approach as Android.
+- No server-side working-orders / fills list → the client tracks its own from acks + `/me/algo/events` (like Android).
+- OCO returns `no_response` through the prod edge; `funding_order` rejects `reason 30`; spot needs an
+  asset-id map — all staged/flagged, not wired into the primary flow.

--- a/frontend/src/api/endpoints/trading.ts
+++ b/frontend/src/api/endpoints/trading.ts
@@ -1,0 +1,294 @@
+import { api } from "@/api/client";
+
+/**
+ * Trader order-entry (`/me/*`) endpoints — the web mirror of the Android TradingApi.
+ *
+ * A prediction market is just a symbol traded through the same order book (price in
+ * [0, face_value] = implied YES probability x face). Fields are the engine's raw snake_case
+ * shapes; ack `status` is "ack" | "nak" | "killed" | "rejected". Auth (cookie + bearer + CSRF)
+ * is handled by [api]. There is NO server-side list of working orders or fills history — callers
+ * track their own from these acks + the exec-events drain (parity with Android).
+ */
+
+export type OrderSide = "buy" | "sell";
+export type TimeInForce = "GTC" | "IOC" | "FOK" | "GTD";
+
+export interface Fill {
+  price?: number;
+  qty?: number;
+  ts_ns?: number;
+  side?: string;
+  aggressor?: string;
+}
+
+// ── Requests ─────────────────────────────────────────────────────────
+
+export interface PlaceOrderRequest {
+  symbolid: number;
+  side: OrderSide;
+  price: number;
+  qty: number;
+  clordid: string;
+  market?: boolean;
+  tif?: TimeInForce;
+  post_only?: boolean;
+  hidden?: boolean;
+  aon?: boolean;
+  display_qty?: number;
+  min_qty?: number;
+  expiry_ns?: number;
+}
+
+export interface AmendRequest {
+  new_qty: number;
+  new_price?: number;
+  symbolid?: number;
+}
+
+export interface QuoteRequest {
+  symbolid: number;
+  bid_price: number;
+  ask_price: number;
+  bid_qty: number;
+  ask_qty: number;
+}
+
+export interface AlgoRequest {
+  algo_type: "stop" | "stop_limit" | "stop_market" | "take_profit";
+  symbolid: number;
+  side: OrderSide;
+  qty: number;
+  stop_price?: number;
+  limit_price?: number;
+}
+
+export interface OtoRequest {
+  symbolid: number;
+  parent_side: OrderSide;
+  parent_price: number;
+  parent_qty: number;
+  child_side: OrderSide;
+  child_price: number;
+  child_qty: number;
+}
+
+export interface OcoLeg {
+  side: OrderSide;
+  price: number;
+  qty: number;
+}
+
+export interface FundingRequest {
+  rate_bps: number;
+  qty: number;
+  is_borrow: boolean;
+  duration_seconds?: number;
+  symbolid?: number;
+}
+
+// ── Acks / reads ─────────────────────────────────────────────────────
+
+export interface OrderAck {
+  status?: string;
+  type?: string;
+  clordid?: string;
+  orderid?: number;
+  symbolid?: number;
+  cancelled_qty?: number;
+  fills?: Fill[];
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+}
+
+export interface MarginAccount {
+  available_balance?: number;
+  balance?: number;
+  reserved_margin?: number;
+  num_positions?: number;
+  pos_symbol_idx?: number;
+  pos_qty?: number;
+  pos_entry_price?: number;
+  pos_liquidation_price?: number;
+  pos_unrealized_pnl?: number;
+  distress_level?: number;
+  is_liquidating?: number;
+  margin_mode?: number;
+  mpid?: string;
+  status?: string;
+  type?: string;
+}
+
+export interface DepositAck {
+  status?: string;
+  new_balance?: number;
+  available_balance?: number;
+  asset?: number;
+  detail?: string;
+  error?: string;
+}
+
+export interface BulkCancelAck {
+  status?: string;
+  type?: string;
+  cancelled_count?: number;
+}
+
+export interface QuoteAck {
+  status?: string;
+  type?: string;
+  quote_id?: string;
+  bid_orderid?: number;
+  ask_orderid?: number;
+  fills?: Fill[];
+  reasoncode?: number;
+  note?: string;
+  detail?: string;
+  error?: string;
+}
+
+export interface AlgoAck {
+  status?: string;
+  type?: string;
+  algo_id?: number;
+  clordid?: string;
+  reasoncode?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+}
+
+export interface OtoAck {
+  status?: string;
+  type?: string;
+  oto_id?: number;
+  parent_orderid?: number;
+  parent_clordid?: string;
+  child_clordid?: string;
+  fills?: Fill[];
+  reasoncode?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+}
+
+export interface FundingAck {
+  status?: string;
+  type?: string;
+  funding_id?: number;
+  clordid?: string;
+  reason?: number;
+  reasoncode?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+}
+
+export interface Trigger {
+  algo_id?: number;
+  oto_id?: number;
+  clordid?: string;
+  orderid?: number;
+  symbolid?: number;
+}
+
+export interface ExecEvents {
+  fills?: Fill[];
+  triggered?: Trigger[];
+  oto_triggered?: Trigger[];
+}
+
+/** Binary prediction-market state. `state` = "trading" | "resolved"; `outcome` 1 = YES. */
+export interface PmState {
+  symbolid?: number;
+  is_binary?: boolean;
+  state?: string;
+  outcome?: number;
+  face_value?: number;
+  resolve_ts?: number;
+  resolver_id?: string;
+  status?: string;
+  error?: string;
+  detail?: string;
+}
+
+export interface SpotAsset {
+  asset?: number;
+  symbol?: string;
+  balance?: number;
+  available?: number;
+}
+
+export interface SpotBalance {
+  balances?: SpotAsset[];
+  mpid?: string;
+}
+
+// ── Calls ────────────────────────────────────────────────────────────
+
+export const placeOrder = (body: PlaceOrderRequest) => api.post<OrderAck>("/me/orders", body);
+
+export const amendOrder = (clordid: string, body: AmendRequest) =>
+  api.patch<OrderAck>(`/me/orders/${encodeURIComponent(clordid)}`, body);
+
+export const cancelOrder = (clordid: string, symbolId: number) =>
+  api.del<OrderAck>(`/me/orders/${encodeURIComponent(clordid)}`, { symbolid: String(symbolId) });
+
+export const bulkCancel = () => api.post<BulkCancelAck>("/me/bulk_cancel", {});
+
+export const getMarginAccount = () => api.get<MarginAccount>("/me/margin_account");
+
+export const marginDeposit = (amount: number) => api.post<DepositAck>("/me/margin_deposit", { amount });
+
+export const placeQuote = (body: QuoteRequest) => api.post<QuoteAck>("/me/quote", body);
+
+export const placeAlgo = (body: AlgoRequest) => api.post<AlgoAck>("/me/algo", body);
+
+export const placeOto = (body: OtoRequest) => api.post<OtoAck>("/me/oto", body);
+
+export const getExecEvents = () => api.get<ExecEvents>("/me/algo/events");
+
+export const getPmState = (symbolId: number) =>
+  api.get<PmState>("/me/pm_state", { symbolid: String(symbolId) });
+
+// Staged surfaces (edge/config-blocked today; gated in the UI waves):
+export const placeOco = (symbolid: number, legs: OcoLeg[]) =>
+  api.post<OrderAck>("/me/oco", { symbolid, legs });
+
+export const placeFunding = (body: FundingRequest) => api.post<FundingAck>("/me/funding_order", body);
+
+export const getSpotBalance = () => api.get<SpotBalance>("/me/spot_balance");
+
+export const spotDeposit = (asset: number, amount: number) =>
+  api.post<DepositAck>("/me/spot_deposit", { asset, amount });
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** ack.status === "ack" */
+export const isAck = (a: { status?: string } | null | undefined): boolean => a?.status === "ack";
+
+/** Best human message off any ack (rejection reason / engine note). */
+export const ackMessage = (
+  a: { detail?: string; error?: string; note?: string; reason?: string | number; reasoncode?: number } | null | undefined,
+): string | undefined => {
+  if (!a) return undefined;
+  if (a.detail) return a.detail;
+  if (a.error) return a.error;
+  if (a.note) return a.note;
+  const code = a.reason ?? a.reasoncode;
+  return code != null ? `rejected (code ${code})` : undefined;
+};
+
+/** Implied YES probability (0..1) for a prediction market at `price`. */
+export const impliedYes = (price: number | null | undefined, faceValue: number | undefined): number | null => {
+  if (!faceValue || faceValue <= 0 || price == null) return null;
+  return Math.min(1, Math.max(0, price / faceValue));
+};
+
+/** Fraction of balance locked as margin (0..1). */
+export const marginUsedFraction = (a: MarginAccount | undefined): number => {
+  const bal = a?.balance ?? 0;
+  const res = a?.reserved_margin ?? 0;
+  return bal > 0 ? Math.min(1, Math.max(0, res / bal)) : 0;
+};

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -96,3 +96,36 @@ export function usePlaceOto() {
   const invalidate = useInvalidateAccount();
   return useMutation({ mutationFn: trading.placeOto, onSuccess: invalidate });
 }
+
+export function usePlaceOco() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({
+    mutationFn: (args: { symbolId: number; legs: trading.OcoLeg[] }) =>
+      trading.placeOco(args.symbolId, args.legs),
+    onSuccess: invalidate,
+  });
+}
+
+export function usePlaceFunding() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({ mutationFn: trading.placeFunding, onSuccess: invalidate });
+}
+
+/** Spot wallet balances; polls while mounted. `retry: false` — a backend without spot deployed 404s. */
+export function useSpotBalance(enabled = true) {
+  return useQuery({
+    queryKey: tradingKeys.spotBalance,
+    queryFn: trading.getSpotBalance,
+    enabled,
+    refetchInterval: ACCOUNT_REFETCH_MS,
+    retry: false,
+  });
+}
+
+export function useSpotDeposit() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({
+    mutationFn: (args: { asset: number; amount: number }) => trading.spotDeposit(args.asset, args.amount),
+    onSuccess: invalidate,
+  });
+}

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -1,0 +1,98 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import * as trading from "@/api/endpoints/trading";
+
+/** Query keys for the trader (`/me/*`) surface. */
+export const tradingKeys = {
+  marginAccount: ["me", "margin_account"] as const,
+  execEvents: ["me", "algo_events"] as const,
+  pmState: (symbolId: number) => ["me", "pm_state", symbolId] as const,
+  spotBalance: ["me", "spot_balance"] as const,
+};
+
+const ACCOUNT_REFETCH_MS = 5000;
+
+/** Wallet / margin / net-position snapshot; polls while mounted. */
+export function useMarginAccount(enabled = true) {
+  return useQuery({
+    queryKey: tradingKeys.marginAccount,
+    queryFn: trading.getMarginAccount,
+    enabled,
+    refetchInterval: ACCOUNT_REFETCH_MS,
+  });
+}
+
+/**
+ * Binary prediction-market state for a symbol. `retry: false` because a non-PM symbol (or a
+ * backend without PM deployed) returns 404 — we simply treat that as "not a PM".
+ */
+export function usePmState(symbolId: number, enabled = true) {
+  return useQuery({
+    queryKey: tradingKeys.pmState(symbolId),
+    queryFn: () => trading.getPmState(symbolId),
+    enabled: enabled && Number.isFinite(symbolId) && symbolId > 0,
+    retry: false,
+    refetchInterval: ACCOUNT_REFETCH_MS,
+  });
+}
+
+/** Async exec-event drain (fills + algo/OTO triggers since the last read). */
+export function useExecEvents(enabled = true) {
+  return useQuery({
+    queryKey: tradingKeys.execEvents,
+    queryFn: trading.getExecEvents,
+    enabled,
+    refetchInterval: ACCOUNT_REFETCH_MS,
+  });
+}
+
+function useInvalidateAccount() {
+  const qc = useQueryClient();
+  return () => qc.invalidateQueries({ queryKey: tradingKeys.marginAccount });
+}
+
+// ── Mutations ────────────────────────────────────────────────────────
+
+export function usePlaceOrder() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({ mutationFn: trading.placeOrder, onSuccess: invalidate });
+}
+
+export function useAmendOrder() {
+  return useMutation({
+    mutationFn: (args: { clordid: string; body: trading.AmendRequest }) =>
+      trading.amendOrder(args.clordid, args.body),
+  });
+}
+
+export function useCancelOrder() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({
+    mutationFn: (args: { clordid: string; symbolId: number }) =>
+      trading.cancelOrder(args.clordid, args.symbolId),
+    onSuccess: invalidate,
+  });
+}
+
+export function useBulkCancel() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({ mutationFn: trading.bulkCancel, onSuccess: invalidate });
+}
+
+export function useDeposit() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({ mutationFn: (amount: number) => trading.marginDeposit(amount), onSuccess: invalidate });
+}
+
+export function usePlaceQuote() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({ mutationFn: trading.placeQuote, onSuccess: invalidate });
+}
+
+export function usePlaceAlgo() {
+  return useMutation({ mutationFn: trading.placeAlgo });
+}
+
+export function usePlaceOto() {
+  const invalidate = useInvalidateAccount();
+  return useMutation({ mutationFn: trading.placeOto, onSuccess: invalidate });
+}

--- a/frontend/src/lib/tradeFeedback.ts
+++ b/frontend/src/lib/tradeFeedback.ts
@@ -1,0 +1,51 @@
+/**
+ * Web-native trade feedback — the browser analog of the Android TradingNotifier.
+ *
+ * - `vibrate(kind)` uses the Vibration API (Android Chrome supports it; iOS Safari and desktop
+ *   simply ignore it — always a safe no-op).
+ * - `notify(title, body)` shows a system Notification when the user has granted permission, so a
+ *   fill is felt/seen even when the trading tab isn't focused. `ensureNotifyPermission()` requests
+ *   permission lazily, once, from a user gesture.
+ * All calls are failure-safe (wrapped) and no-op when the API is unavailable.
+ */
+
+export type Haptic = "tick" | "success" | "warn" | "error";
+
+const PATTERNS: Record<Haptic, number | number[]> = {
+  tick: 10,
+  success: [0, 25, 50, 25],
+  warn: 30,
+  error: [0, 40, 50, 40, 50, 40],
+};
+
+export function vibrate(kind: Haptic): void {
+  try {
+    if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
+      navigator.vibrate(PATTERNS[kind]);
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+let asked = false;
+export function ensureNotifyPermission(): void {
+  try {
+    if (typeof Notification === "undefined") return;
+    if (Notification.permission === "default" && !asked) {
+      asked = true;
+      void Notification.requestPermission();
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+export function notify(title: string, body: string): void {
+  try {
+    if (typeof Notification === "undefined" || Notification.permission !== "granted") return;
+    new Notification(title, { body });
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/pages/markets/CandleChart.tsx
+++ b/frontend/src/pages/markets/CandleChart.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { Candle } from "@/api/endpoints/marketData";
+import { cn } from "@/lib/utils";
 
 interface CandleChartProps {
   bars: Candle[];
@@ -11,16 +12,25 @@ interface CandleChartProps {
 
 const UP = "#059669"; // emerald-600
 const DOWN = "#e11d48"; // rose-600
+const BB_COLOR = "#8b5cf6"; // violet-500
+const VWAP_COLOR = "#0ea5e9"; // sky-500
+const RSI_COLOR = "#f59e0b"; // amber-500
+const MACD_COLOR = "#0ea5e9"; // sky-500
+const SIGNAL_COLOR = "#f59e0b"; // amber-500
+const LINE_COLOR = "#e11d48"; // rose-600 (drawing tool)
 const PAD_TOP = 8;
 const PAD_BOTTOM = 8;
 const PAD_LEFT = 8;
 const PAD_RIGHT = 56;
+const SUB_GAP = 8; // gap between price pane and oscillator sub-pane
 
 const MAS = [
   { period: 7, color: "#f59e0b" }, // amber
   { period: 25, color: "#8b5cf6" }, // violet
   { period: 99, color: "#0ea5e9" }, // sky
 ];
+
+type Oscillator = "none" | "rsi" | "macd";
 
 /** Simple moving average over `vals`; the first (period-1) entries are null. */
 function sma(vals: number[], period: number): (number | null)[] {
@@ -34,11 +44,131 @@ function sma(vals: number[], period: number): (number | null)[] {
   return out;
 }
 
-/** Hand-rolled SVG candlestick chart (auto-scaled) with MA overlays + click-to-trade. */
+/** Rolling population standard deviation over `period`; first (period-1) entries null. */
+function rollingStdDev(vals: number[], period: number, means: (number | null)[]): (number | null)[] {
+  const out: (number | null)[] = [];
+  for (let i = 0; i < vals.length; i++) {
+    const mean = means[i];
+    if (i < period - 1 || mean == null) {
+      out.push(null);
+      continue;
+    }
+    let acc = 0;
+    for (let j = i - period + 1; j <= i; j++) {
+      const d = vals[j]! - mean;
+      acc += d * d;
+    }
+    out.push(Math.sqrt(acc / period));
+  }
+  return out;
+}
+
+/** Exponential moving average; first `period-1` entries null, seeded with an SMA. */
+function ema(vals: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = new Array(vals.length).fill(null);
+  if (vals.length < period) return out;
+  const k = 2 / (period + 1);
+  let seed = 0;
+  for (let i = 0; i < period; i++) seed += vals[i]!;
+  let prev = seed / period;
+  out[period - 1] = prev;
+  for (let i = period; i < vals.length; i++) {
+    prev = vals[i]! * k + prev * (1 - k);
+    out[i] = prev;
+  }
+  return out;
+}
+
+/** Wilder's RSI(period), 0..100; entries before the first computable point are null. */
+function rsi(closes: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = new Array(closes.length).fill(null);
+  if (closes.length <= period) return out;
+  let gainSum = 0;
+  let lossSum = 0;
+  for (let i = 1; i <= period; i++) {
+    const ch = closes[i]! - closes[i - 1]!;
+    if (ch >= 0) gainSum += ch;
+    else lossSum -= ch;
+  }
+  let avgGain = gainSum / period;
+  let avgLoss = lossSum / period;
+  out[period] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+  for (let i = period + 1; i < closes.length; i++) {
+    const ch = closes[i]! - closes[i - 1]!;
+    const gain = ch > 0 ? ch : 0;
+    const loss = ch < 0 ? -ch : 0;
+    avgGain = (avgGain * (period - 1) + gain) / period;
+    avgLoss = (avgLoss * (period - 1) + loss) / period;
+    out[i] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+  }
+  return out;
+}
+
+/** VWAP: cumulative(sum(typical*volume)) / cumulative(volume). */
+function vwap(bars: Candle[]): (number | null)[] {
+  const out: (number | null)[] = [];
+  let pv = 0;
+  let vol = 0;
+  for (const b of bars) {
+    const typical = (b.high + b.low + b.close) / 3;
+    const v = b.volume || 0;
+    pv += typical * v;
+    vol += v;
+    out.push(vol > 0 ? pv / vol : null);
+  }
+  return out;
+}
+
+/** Chip button used for the controls row. */
+function Chip({
+  active,
+  onClick,
+  children,
+  color,
+  className,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  color?: string;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded border px-1.5 py-0.5 text-[10px] leading-none transition-colors",
+        active ? "border-transparent bg-foreground/10 font-medium" : "border-border text-muted-foreground hover:bg-foreground/5",
+        className,
+      )}
+      style={active && color ? { color } : undefined}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Hand-rolled SVG candlestick chart (auto-scaled) with MA/BB/VWAP overlays, an
+ *  RSI/MACD sub-pane, a horizontal-line drawing tool, and click-to-trade. */
 export default function CandleChart({ bars, scaler = 1, height = 320, onPriceClick }: CandleChartProps) {
   const width = 720;
+
+  const [showBB, setShowBB] = useState(false);
+  const [showVwap, setShowVwap] = useState(false);
+  const [osc, setOsc] = useState<Oscillator>("none");
+  const [lineTool, setLineTool] = useState(false);
+  const [lines, setLines] = useState<number[]>([]); // horizontal price lines (raw integer prices)
+
+  const oscActive = osc !== "none";
+
   const layout = useMemo(() => {
     if (!bars.length) return null;
+
+    // Split the vertical space between the price pane and (optional) oscillator pane.
+    const oscH = oscActive ? Math.round(height * 0.28) : 0;
+    const priceAreaH = height - oscH - (oscActive ? SUB_GAP : 0);
+
     const highs = bars.map((b) => b.high);
     const lows = bars.map((b) => b.low);
     let max = Math.max(...highs);
@@ -49,7 +179,7 @@ export default function CandleChart({ bars, scaler = 1, height = 320, onPriceCli
     }
     const range = max - min;
     const plotW = width - PAD_LEFT - PAD_RIGHT;
-    const plotH = height - PAD_TOP - PAD_BOTTOM;
+    const plotH = priceAreaH - PAD_TOP - PAD_BOTTOM;
     const slot = plotW / bars.length;
     const bodyW = Math.max(1, Math.min(slot * 0.7, 14));
 
@@ -67,14 +197,39 @@ export default function CandleChart({ bars, scaler = 1, height = 320, onPriceCli
     });
 
     const closes = bars.map((b) => b.close);
-    const maLines = MAS.map((m) => {
-      const s = sma(closes, m.period);
-      const points = s
+
+    const polyFrom = (series: (number | null)[]) =>
+      series
         .map((v, i) => (v == null ? null : `${xOf(i).toFixed(1)},${yOf(v).toFixed(1)}`))
         .filter((p): p is string => p !== null)
         .join(" ");
-      return { period: m.period, color: m.color, points };
-    }).filter((m) => m.points.length > 0);
+
+    const maLines = MAS.map((m) => ({ period: m.period, color: m.color, points: polyFrom(sma(closes, m.period)) })).filter(
+      (m) => m.points.length > 0,
+    );
+
+    // Bollinger Bands: SMA(20) +/- 2 * stdDev(20).
+    let bb: { upper: string; lower: string; areaPath: string } | null = null;
+    if (bars.length >= 20) {
+      const basis = sma(closes, 20);
+      const sd = rollingStdDev(closes, 20, basis);
+      const upperPts: string[] = [];
+      const lowerPts: string[] = [];
+      for (let i = 0; i < bars.length; i++) {
+        const m = basis[i];
+        const s = sd[i];
+        if (m == null || s == null) continue;
+        upperPts.push(`${xOf(i).toFixed(1)},${yOf(m + 2 * s).toFixed(1)}`);
+        lowerPts.push(`${xOf(i).toFixed(1)},${yOf(m - 2 * s).toFixed(1)}`);
+      }
+      if (upperPts.length > 1) {
+        const areaPath = `M ${upperPts.join(" L ")} L ${[...lowerPts].reverse().join(" L ")} Z`;
+        bb = { upper: upperPts.join(" "), lower: lowerPts.join(" "), areaPath };
+      }
+    }
+
+    // VWAP.
+    const vwapPoints = polyFrom(vwap(bars));
 
     const ticks = 4;
     const labels = Array.from({ length: ticks + 1 }, (_, i) => {
@@ -82,8 +237,111 @@ export default function CandleChart({ bars, scaler = 1, height = 320, onPriceCli
       return { y: yOf(v), value: v / (scaler || 1) };
     });
 
-    return { candles, labels, maLines, max, range, plotH };
-  }, [bars, height, scaler]);
+    // Horizontal drawing lines (only those inside the visible price range render on-scale).
+    const drawnLines = lines.map((p, i) => ({ key: i, y: yOf(p), price: p }));
+
+    // ---- Oscillator sub-pane -------------------------------------------------
+    const oscTop = priceAreaH + SUB_GAP;
+    const oscInnerH = oscH - PAD_TOP - PAD_BOTTOM;
+    let oscPane: {
+      kind: "rsi" | "macd";
+      lines: { points: string; color: string; width: number }[];
+      hist: { x: number; y: number; w: number; h: number; color: string }[];
+      guides: { y: number; label: string }[];
+      zeroY: number | null;
+    } | null = null;
+
+    if (oscActive && oscInnerH > 0) {
+      const oscY = (frac: number) => oscTop + PAD_TOP + (1 - frac) * oscInnerH; // frac 0..1 bottom..top
+
+      if (osc === "rsi") {
+        const series = rsi(closes, 14);
+        const pts = series
+          .map((v, i) => (v == null ? null : `${xOf(i).toFixed(1)},${oscY(v / 100).toFixed(1)}`))
+          .filter((p): p is string => p !== null)
+          .join(" ");
+        oscPane = {
+          kind: "rsi",
+          lines: pts ? [{ points: pts, color: RSI_COLOR, width: 1.25 }] : [],
+          hist: [],
+          guides: [
+            { y: oscY(0.7), label: "70" },
+            { y: oscY(0.3), label: "30" },
+          ],
+          zeroY: null,
+        };
+      } else {
+        // MACD(12,26,9).
+        const e12 = ema(closes, 12);
+        const e26 = ema(closes, 26);
+        const macd: (number | null)[] = closes.map((_, i) =>
+          e12[i] != null && e26[i] != null ? (e12[i] as number) - (e26[i] as number) : null,
+        );
+        // Signal = EMA(9) over the defined portion of the MACD line.
+        const firstDef = macd.findIndex((v) => v != null);
+        const signal: (number | null)[] = new Array(closes.length).fill(null);
+        if (firstDef >= 0) {
+          const defVals = macd.slice(firstDef).map((v) => v as number);
+          const sig = ema(defVals, 9);
+          for (let i = 0; i < sig.length; i++) signal[firstDef + i] = sig[i] ?? null;
+        }
+        let lo = Infinity;
+        let hi = -Infinity;
+        for (let i = 0; i < closes.length; i++) {
+          for (const v of [macd[i], signal[i]]) {
+            if (v == null) continue;
+            if (v < lo) lo = v;
+            if (v > hi) hi = v;
+          }
+          if (macd[i] != null && signal[i] != null) {
+            const h = (macd[i] as number) - (signal[i] as number);
+            if (h < lo) lo = h;
+            if (h > hi) hi = h;
+          }
+        }
+        if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+          oscPane = { kind: "macd", lines: [], hist: [], guides: [], zeroY: null };
+        } else {
+          if (lo === hi) {
+            lo -= 1;
+            hi += 1;
+          }
+          const span = hi - lo;
+          const oscVal = (v: number) => oscY((v - lo) / span);
+          const macdPts = macd
+            .map((v, i) => (v == null ? null : `${xOf(i).toFixed(1)},${oscVal(v).toFixed(1)}`))
+            .filter((p): p is string => p !== null)
+            .join(" ");
+          const sigPts = signal
+            .map((v, i) => (v == null ? null : `${xOf(i).toFixed(1)},${oscVal(v).toFixed(1)}`))
+            .filter((p): p is string => p !== null)
+            .join(" ");
+          const zeroY = lo <= 0 && hi >= 0 ? oscVal(0) : null;
+          const hist: { x: number; y: number; w: number; h: number; color: string }[] = [];
+          for (let i = 0; i < closes.length; i++) {
+            if (macd[i] == null || signal[i] == null) continue;
+            const hVal = (macd[i] as number) - (signal[i] as number);
+            const base = zeroY ?? oscVal(0 >= lo && 0 <= hi ? 0 : lo);
+            const yTop = Math.min(base, oscVal(hVal));
+            const h = Math.max(1, Math.abs(oscVal(hVal) - base));
+            hist.push({ x: xOf(i) - bodyW / 2, y: yTop, w: bodyW, h, color: hVal >= 0 ? UP : DOWN });
+          }
+          oscPane = {
+            kind: "macd",
+            lines: [
+              ...(macdPts ? [{ points: macdPts, color: MACD_COLOR, width: 1.25 }] : []),
+              ...(sigPts ? [{ points: sigPts, color: SIGNAL_COLOR, width: 1.25 }] : []),
+            ],
+            hist,
+            guides: [],
+            zeroY,
+          };
+        }
+      }
+    }
+
+    return { candles, labels, maLines, bb, vwapPoints, drawnLines, oscPane, max, range, priceAreaH, plotH };
+  }, [bars, height, scaler, showBB, showVwap, osc, oscActive, lines]);
 
   if (!layout) {
     return (
@@ -94,28 +352,60 @@ export default function CandleChart({ bars, scaler = 1, height = 320, onPriceCli
   }
 
   function handleClick(e: React.MouseEvent<SVGSVGElement>) {
-    if (!onPriceClick || !layout) return;
+    if (!layout) return;
     const rect = e.currentTarget.getBoundingClientRect();
     if (!rect.height) return;
     const yView = ((e.clientY - rect.top) / rect.height) * height;
     const price = layout.max - ((yView - PAD_TOP) / layout.plotH) * layout.range;
-    if (Number.isFinite(price)) onPriceClick(Math.max(0, Math.round(price)));
+    if (!Number.isFinite(price)) return;
+    const rounded = Math.max(0, Math.round(price));
+    if (lineTool) {
+      setLines((prev) => [...prev, rounded]);
+      return;
+    }
+    onPriceClick?.(rounded);
   }
+
+  const interactive = !!onPriceClick || lineTool;
 
   return (
     <div>
-      {layout.maLines.length > 0 && (
-        <div className="mb-1 flex gap-3 text-[10px]">
-          {layout.maLines.map((m) => (
-            <span key={m.period} style={{ color: m.color }}>
-              MA{m.period}
-            </span>
-          ))}
-        </div>
-      )}
+      <div className="mb-1 flex flex-wrap items-center gap-1.5">
+        {layout.maLines.map((m) => (
+          <span key={m.period} className="text-[10px]" style={{ color: m.color }}>
+            MA{m.period}
+          </span>
+        ))}
+        <span className="mx-0.5 text-[10px] text-muted-foreground">|</span>
+        <Chip active={showBB} onClick={() => setShowBB((v) => !v)} color={BB_COLOR}>
+          BB
+        </Chip>
+        <Chip active={showVwap} onClick={() => setShowVwap((v) => !v)} color={VWAP_COLOR}>
+          VWAP
+        </Chip>
+        <span className="mx-0.5 text-[10px] text-muted-foreground">|</span>
+        <Chip active={osc === "none"} onClick={() => setOsc("none")}>
+          None
+        </Chip>
+        <Chip active={osc === "rsi"} onClick={() => setOsc("rsi")} color={RSI_COLOR}>
+          RSI
+        </Chip>
+        <Chip active={osc === "macd"} onClick={() => setOsc("macd")} color={MACD_COLOR}>
+          MACD
+        </Chip>
+        <span className="mx-0.5 text-[10px] text-muted-foreground">|</span>
+        <Chip active={lineTool} onClick={() => setLineTool((v) => !v)} color={LINE_COLOR}>
+          Line
+        </Chip>
+        {lines.length > 0 && (
+          <Chip active={false} onClick={() => setLines([])}>
+            Clear
+          </Chip>
+        )}
+      </div>
       <svg
         viewBox={`0 0 ${width} ${height}`}
-        className={onPriceClick ? "w-full cursor-crosshair" : "w-full"}
+        className={interactive ? "w-full cursor-crosshair" : "w-full"}
         style={{ height }}
         preserveAspectRatio="none"
         role="img"
@@ -130,12 +420,37 @@ export default function CandleChart({ bars, scaler = 1, height = 320, onPriceCli
             </text>
           </g>
         ))}
+
+        {/* Bollinger Bands */}
+        {showBB && layout.bb && (
+          <g>
+            <path d={layout.bb.areaPath} fill={BB_COLOR} fillOpacity={0.06} stroke="none" />
+            <polyline
+              points={layout.bb.upper}
+              fill="none"
+              stroke={BB_COLOR}
+              strokeWidth={1}
+              strokeOpacity={0.75}
+              vectorEffect="non-scaling-stroke"
+            />
+            <polyline
+              points={layout.bb.lower}
+              fill="none"
+              stroke={BB_COLOR}
+              strokeWidth={1}
+              strokeOpacity={0.75}
+              vectorEffect="non-scaling-stroke"
+            />
+          </g>
+        )}
+
         {layout.candles.map((c) => (
           <g key={c.key}>
             <line x1={c.cx} x2={c.cx} y1={c.highY} y2={c.lowY} stroke={c.color} strokeWidth={1} />
             <rect x={c.bodyX} y={c.bodyY} width={c.bodyW} height={c.bodyH} fill={c.color} />
           </g>
         ))}
+
         {layout.maLines.map((m) => (
           <polyline
             key={m.period}
@@ -147,6 +462,92 @@ export default function CandleChart({ bars, scaler = 1, height = 320, onPriceCli
             vectorEffect="non-scaling-stroke"
           />
         ))}
+
+        {/* VWAP */}
+        {showVwap && layout.vwapPoints && (
+          <polyline
+            points={layout.vwapPoints}
+            fill="none"
+            stroke={VWAP_COLOR}
+            strokeWidth={1.5}
+            strokeOpacity={0.9}
+            strokeDasharray="4 3"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+
+        {/* Drawing tool: horizontal price lines */}
+        {layout.drawnLines.map((dl) => (
+          <g key={`dl${dl.key}`}>
+            <line
+              x1={PAD_LEFT}
+              x2={width - PAD_RIGHT}
+              y1={dl.y}
+              y2={dl.y}
+              stroke={LINE_COLOR}
+              strokeWidth={1}
+              strokeDasharray="3 2"
+              vectorEffect="non-scaling-stroke"
+            />
+            <text x={PAD_LEFT + 2} y={dl.y - 2} fontSize={9} fill={LINE_COLOR} fillOpacity={0.9}>
+              {(dl.price / (scaler || 1)).toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </text>
+          </g>
+        ))}
+
+        {/* Oscillator sub-pane */}
+        {layout.oscPane && (
+          <g>
+            <line
+              x1={PAD_LEFT}
+              x2={width - PAD_RIGHT}
+              y1={layout.priceAreaH + SUB_GAP / 2}
+              y2={layout.priceAreaH + SUB_GAP / 2}
+              stroke="currentColor"
+              strokeOpacity={0.15}
+            />
+            {layout.oscPane.guides.map((g, i) => (
+              <g key={`og${i}`}>
+                <line
+                  x1={PAD_LEFT}
+                  x2={width - PAD_RIGHT}
+                  y1={g.y}
+                  y2={g.y}
+                  stroke="currentColor"
+                  strokeOpacity={0.12}
+                  strokeDasharray="2 2"
+                />
+                <text x={width - PAD_RIGHT + 4} y={g.y + 3} fontSize={9} fill="currentColor" fillOpacity={0.5}>
+                  {g.label}
+                </text>
+              </g>
+            ))}
+            {layout.oscPane.zeroY != null && (
+              <line
+                x1={PAD_LEFT}
+                x2={width - PAD_RIGHT}
+                y1={layout.oscPane.zeroY}
+                y2={layout.oscPane.zeroY}
+                stroke="currentColor"
+                strokeOpacity={0.15}
+              />
+            )}
+            {layout.oscPane.hist.map((h, i) => (
+              <rect key={`oh${i}`} x={h.x} y={h.y} width={h.w} height={h.h} fill={h.color} fillOpacity={0.5} />
+            ))}
+            {layout.oscPane.lines.map((ln, i) => (
+              <polyline
+                key={`ol${i}`}
+                points={ln.points}
+                fill="none"
+                stroke={ln.color}
+                strokeWidth={ln.width}
+                strokeOpacity={0.9}
+                vectorEffect="non-scaling-stroke"
+              />
+            ))}
+          </g>
+        )}
       </svg>
     </div>
   );

--- a/frontend/src/pages/markets/CandleChart.tsx
+++ b/frontend/src/pages/markets/CandleChart.tsx
@@ -5,6 +5,8 @@ interface CandleChartProps {
   bars: Candle[];
   scaler?: number;
   height?: number;
+  /** Click anywhere on the chart to prefill the ticket at that price level. */
+  onPriceClick?: (price: number) => void;
 }
 
 const UP = "#059669"; // emerald-600
@@ -14,8 +16,26 @@ const PAD_BOTTOM = 8;
 const PAD_LEFT = 8;
 const PAD_RIGHT = 56;
 
-/** Hand-rolled SVG candlestick chart (auto-scaled, green up / red down). */
-export default function CandleChart({ bars, scaler = 1, height = 320 }: CandleChartProps) {
+const MAS = [
+  { period: 7, color: "#f59e0b" }, // amber
+  { period: 25, color: "#8b5cf6" }, // violet
+  { period: 99, color: "#0ea5e9" }, // sky
+];
+
+/** Simple moving average over `vals`; the first (period-1) entries are null. */
+function sma(vals: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  let sum = 0;
+  for (let i = 0; i < vals.length; i++) {
+    sum += vals[i]!;
+    if (i >= period) sum -= vals[i - period]!;
+    out.push(i >= period - 1 ? sum / period : null);
+  }
+  return out;
+}
+
+/** Hand-rolled SVG candlestick chart (auto-scaled) with MA overlays + click-to-trade. */
+export default function CandleChart({ bars, scaler = 1, height = 320, onPriceClick }: CandleChartProps) {
   const width = 720;
   const layout = useMemo(() => {
     if (!bars.length) return null;
@@ -24,7 +44,6 @@ export default function CandleChart({ bars, scaler = 1, height = 320 }: CandleCh
     let max = Math.max(...highs);
     let min = Math.min(...lows);
     if (max === min) {
-      // Avoid a zero-height range.
       max += 1;
       min -= 1;
     }
@@ -34,85 +53,101 @@ export default function CandleChart({ bars, scaler = 1, height = 320 }: CandleCh
     const slot = plotW / bars.length;
     const bodyW = Math.max(1, Math.min(slot * 0.7, 14));
 
-    const yOf = (v: number) => PAD_TOP + (max - v) / range * plotH;
+    const yOf = (v: number) => PAD_TOP + ((max - v) / range) * plotH;
+    const xOf = (i: number) => PAD_LEFT + slot * i + slot / 2;
 
     const candles = bars.map((b, i) => {
-      const cx = PAD_LEFT + slot * i + slot / 2;
+      const cx = xOf(i);
       const up = b.close >= b.open;
       const openY = yOf(b.open);
       const closeY = yOf(b.close);
       const top = Math.min(openY, closeY);
       const bodyH = Math.max(1, Math.abs(closeY - openY));
-      return {
-        key: i,
-        cx,
-        highY: yOf(b.high),
-        lowY: yOf(b.low),
-        bodyX: cx - bodyW / 2,
-        bodyY: top,
-        bodyW,
-        bodyH,
-        color: up ? UP : DOWN,
-      };
+      return { key: i, cx, highY: yOf(b.high), lowY: yOf(b.low), bodyX: cx - bodyW / 2, bodyY: top, bodyW, bodyH, color: up ? UP : DOWN };
     });
 
-    // A handful of price gridlines/labels on the right axis.
+    const closes = bars.map((b) => b.close);
+    const maLines = MAS.map((m) => {
+      const s = sma(closes, m.period);
+      const points = s
+        .map((v, i) => (v == null ? null : `${xOf(i).toFixed(1)},${yOf(v).toFixed(1)}`))
+        .filter((p): p is string => p !== null)
+        .join(" ");
+      return { period: m.period, color: m.color, points };
+    }).filter((m) => m.points.length > 0);
+
     const ticks = 4;
     const labels = Array.from({ length: ticks + 1 }, (_, i) => {
       const v = max - (range * i) / ticks;
-      return { y: yOf(v), value: (v / (scaler || 1)) };
+      return { y: yOf(v), value: v / (scaler || 1) };
     });
 
-    return { candles, labels };
+    return { candles, labels, maLines, max, range, plotH };
   }, [bars, height, scaler]);
 
   if (!layout) {
     return (
-      <div
-        className="flex items-center justify-center text-sm text-muted-foreground"
-        style={{ height }}
-      >
+      <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
         No candles available.
       </div>
     );
   }
 
+  function handleClick(e: React.MouseEvent<SVGSVGElement>) {
+    if (!onPriceClick || !layout) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (!rect.height) return;
+    const yView = ((e.clientY - rect.top) / rect.height) * height;
+    const price = layout.max - ((yView - PAD_TOP) / layout.plotH) * layout.range;
+    if (Number.isFinite(price)) onPriceClick(Math.max(0, Math.round(price)));
+  }
+
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      className="w-full"
-      style={{ height }}
-      preserveAspectRatio="none"
-      role="img"
-      aria-label="Candlestick chart"
-    >
-      {layout.labels.map((l, i) => (
-        <g key={`g${i}`}>
-          <line
-            x1={PAD_LEFT}
-            x2={width - PAD_RIGHT}
-            y1={l.y}
-            y2={l.y}
-            stroke="currentColor"
-            strokeOpacity={0.1}
+    <div>
+      {layout.maLines.length > 0 && (
+        <div className="mb-1 flex gap-3 text-[10px]">
+          {layout.maLines.map((m) => (
+            <span key={m.period} style={{ color: m.color }}>
+              MA{m.period}
+            </span>
+          ))}
+        </div>
+      )}
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className={onPriceClick ? "w-full cursor-crosshair" : "w-full"}
+        style={{ height }}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Candlestick chart"
+        onClick={handleClick}
+      >
+        {layout.labels.map((l, i) => (
+          <g key={`g${i}`}>
+            <line x1={PAD_LEFT} x2={width - PAD_RIGHT} y1={l.y} y2={l.y} stroke="currentColor" strokeOpacity={0.1} />
+            <text x={width - PAD_RIGHT + 4} y={l.y + 3} fontSize={10} fill="currentColor" fillOpacity={0.6}>
+              {l.value.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </text>
+          </g>
+        ))}
+        {layout.candles.map((c) => (
+          <g key={c.key}>
+            <line x1={c.cx} x2={c.cx} y1={c.highY} y2={c.lowY} stroke={c.color} strokeWidth={1} />
+            <rect x={c.bodyX} y={c.bodyY} width={c.bodyW} height={c.bodyH} fill={c.color} />
+          </g>
+        ))}
+        {layout.maLines.map((m) => (
+          <polyline
+            key={m.period}
+            points={m.points}
+            fill="none"
+            stroke={m.color}
+            strokeWidth={1.25}
+            strokeOpacity={0.9}
+            vectorEffect="non-scaling-stroke"
           />
-          <text
-            x={width - PAD_RIGHT + 4}
-            y={l.y + 3}
-            fontSize={10}
-            fill="currentColor"
-            fillOpacity={0.6}
-          >
-            {l.value.toLocaleString(undefined, { maximumFractionDigits: 2 })}
-          </text>
-        </g>
-      ))}
-      {layout.candles.map((c) => (
-        <g key={c.key}>
-          <line x1={c.cx} x2={c.cx} y1={c.highY} y2={c.lowY} stroke={c.color} strokeWidth={1} />
-          <rect x={c.bodyX} y={c.bodyY} width={c.bodyW} height={c.bodyH} fill={c.color} />
-        </g>
-      ))}
-    </svg>
+        ))}
+      </svg>
+    </div>
   );
 }

--- a/frontend/src/pages/markets/MarketsPage.tsx
+++ b/frontend/src/pages/markets/MarketsPage.tsx
@@ -1,15 +1,11 @@
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { CandlestickChart } from "lucide-react";
+import { CandlestickChart, Star } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Table,
-  TableHeader,
-  TableBody,
-  TableHead,
-  TableRow,
-  TableCell,
-} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 import { useSymbols, useOrderBook, useTrades } from "@/hooks/useMarketData";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
 import { formatPrice } from "./format";
@@ -21,7 +17,9 @@ const FALLBACK_SYMBOLS: MarketSymbol[] = [
   { symbol: "SOLUSDC", symbol_id: 3, instrument_id: 3, price_scaler: 1, lot_size: 1, reference_price: 150, matching_algo: "price_time", is_perpetual: false, funding_interval_s: 0 },
 ];
 
-function MarketRow({ sym }: { sym: MarketSymbol }) {
+const FAV_KEY = "markets_favorites";
+
+function MarketRow({ sym, fav, onToggleFav }: { sym: MarketSymbol; fav: boolean; onToggleFav: (id: number) => void }) {
   const navigate = useNavigate();
   const scaler = sym.price_scaler || 1;
   const book = useOrderBook(sym.symbol_id);
@@ -30,17 +28,24 @@ function MarketRow({ sym }: { sym: MarketSymbol }) {
   const bestBid = book.data?.bid_px ?? book.data?.bids?.[0]?.[0];
   const bestAsk = book.data?.ask_px ?? book.data?.asks?.[0]?.[0];
   const lastTrade = trades.data?.trades?.[0]?.price;
-  const mid =
-    bestBid != null && bestAsk != null ? (bestBid + bestAsk) / 2 : undefined;
+  const mid = bestBid != null && bestAsk != null ? (bestBid + bestAsk) / 2 : undefined;
   const last = lastTrade ?? mid ?? sym.reference_price;
-  const spread =
-    bestBid != null && bestAsk != null ? bestAsk - bestBid : undefined;
+  const spread = bestBid != null && bestAsk != null ? bestAsk - bestBid : undefined;
 
   return (
-    <TableRow
-      className="cursor-pointer"
-      onClick={() => navigate(`/markets/${sym.symbol_id}`)}
-    >
+    <TableRow className="cursor-pointer" onClick={() => navigate(`/markets/${sym.symbol_id}`)}>
+      <TableCell className="w-8 pr-0">
+        <button
+          type="button"
+          aria-label="Toggle watchlist"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleFav(sym.symbol_id);
+          }}
+        >
+          <Star className={cn("h-4 w-4", fav ? "fill-amber-400 text-amber-400" : "text-muted-foreground hover:text-amber-400")} />
+        </button>
+      </TableCell>
       <TableCell className="font-medium">{sym.symbol}</TableCell>
       <TableCell className="text-right tabular-nums">{formatPrice(last, scaler)}</TableCell>
       <TableCell className="text-right tabular-nums text-emerald-600 dark:text-emerald-400">
@@ -58,9 +63,35 @@ function MarketRow({ sym }: { sym: MarketSymbol }) {
 
 export default function MarketsPage() {
   const symbolsQuery = useSymbols();
-
   const apiSymbols = symbolsQuery.data?.symbols ?? [];
-  const symbols = apiSymbols.length > 0 ? apiSymbols : FALLBACK_SYMBOLS;
+  const base = apiSymbols.length > 0 ? apiSymbols : FALLBACK_SYMBOLS;
+
+  const [query, setQuery] = useState("");
+  const [favorites, setFavorites] = useState<number[]>(() => {
+    try {
+      const raw = localStorage.getItem(FAV_KEY);
+      return raw ? (JSON.parse(raw) as number[]) : [];
+    } catch {
+      return [];
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(FAV_KEY, JSON.stringify(favorites));
+    } catch {
+      /* ignore */
+    }
+  }, [favorites]);
+  const toggleFav = (id: number) =>
+    setFavorites((f) => (f.includes(id) ? f.filter((x) => x !== id) : [...f, id]));
+
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q ? base.filter((s) => s.symbol.toLowerCase().includes(q)) : base;
+    return [...filtered].sort(
+      (a, b) => (favorites.includes(a.symbol_id) ? 0 : 1) - (favorites.includes(b.symbol_id) ? 0 : 1)
+    );
+  }, [base, query, favorites]);
 
   return (
     <div className="space-y-6">
@@ -68,18 +99,24 @@ export default function MarketsPage() {
         <CandlestickChart className="h-6 w-6 text-muted-foreground" />
         <div>
           <h1 className="text-2xl font-semibold">Markets</h1>
-          <p className="text-sm text-muted-foreground">
-            Live exchange market data — view-only.
-          </p>
+          <p className="text-sm text-muted-foreground">Live exchange market data — tap a symbol to trade.</p>
         </div>
       </div>
 
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Instruments</CardTitle>
-          <CardDescription>Prices update every 2 seconds.</CardDescription>
+          <CardDescription>Prices update every 2 seconds. Star a market to pin it.</CardDescription>
         </CardHeader>
         <CardContent>
+          <div className="mb-3">
+            <Input
+              placeholder="Search symbol…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="max-w-xs"
+            />
+          </div>
           {symbolsQuery.isLoading ? (
             <div className="space-y-2">
               <Skeleton className="h-10 w-full" />
@@ -90,6 +127,7 @@ export default function MarketsPage() {
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead className="w-8" />
                   <TableHead>Symbol</TableHead>
                   <TableHead className="text-right">Last</TableHead>
                   <TableHead className="text-right">Bid</TableHead>
@@ -98,9 +136,21 @@ export default function MarketsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {symbols.map((sym) => (
-                  <MarketRow key={sym.symbol_id} sym={sym} />
+                {rows.map((sym) => (
+                  <MarketRow
+                    key={sym.symbol_id}
+                    sym={sym}
+                    fav={favorites.includes(sym.symbol_id)}
+                    onToggleFav={toggleFav}
+                  />
                 ))}
+                {rows.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-4 text-center text-sm text-muted-foreground">
+                      No symbols match “{query}”.
+                    </TableCell>
+                  </TableRow>
+                )}
               </TableBody>
             </Table>
           )}

--- a/frontend/src/pages/markets/SymbolDetailPage.tsx
+++ b/frontend/src/pages/markets/SymbolDetailPage.tsx
@@ -9,6 +9,7 @@ import { useSymbols, useOrderBook, useCandles, useTrades } from "@/hooks/useMark
 import { useMarketDataStream } from "@/hooks/useMarketDataStream";
 import type { BookLevel, Candle } from "@/api/endpoints/marketData";
 import CandleChart from "./CandleChart";
+import { TradeTicket } from "./TradeTicket";
 import { formatPrice, formatQty, formatTimeNs } from "./format";
 
 /** Trades still poll (SSE carries no trades), relaxed since the book is live. */
@@ -109,6 +110,7 @@ export default function SymbolDetailPage() {
   }, [candles.data, stream.latestCandle]);
 
   const recentTrades = trades.data?.trades ?? [];
+  const lastPrice = recentTrades[0]?.price ?? bestAsk ?? bestBid;
 
   return (
     <div className="space-y-6">
@@ -130,6 +132,8 @@ export default function SymbolDetailPage() {
           )}
         </div>
       </div>
+
+      <TradeTicket symbolId={id} scaler={scaler} lastPrice={lastPrice} />
 
       <Card>
         <CardHeader>

--- a/frontend/src/pages/markets/SymbolDetailPage.tsx
+++ b/frontend/src/pages/markets/SymbolDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { useSymbols, useOrderBook, useCandles, useTrades } from "@/hooks/useMarketData";
 import { useMarketDataStream } from "@/hooks/useMarketDataStream";
 import type { BookLevel, Candle } from "@/api/endpoints/marketData";
+import type { OrderSide } from "@/api/endpoints/trading";
 import CandleChart from "./CandleChart";
 import { TradeTicket } from "./TradeTicket";
 import { formatPrice, formatQty, formatTimeNs } from "./format";
@@ -20,17 +21,22 @@ function DepthRow({
   side,
   maxQty,
   scaler,
+  onPick,
 }: {
   level: BookLevel;
   side: "bid" | "ask";
   maxQty: number;
   scaler: number;
+  onPick?: (price: number, orderSide: OrderSide) => void;
 }) {
   const [price, qty] = level;
   const pct = maxQty > 0 ? Math.min(100, (qty / maxQty) * 100) : 0;
   const isBid = side === "bid";
   return (
-    <div className="relative flex items-center justify-between px-2 py-0.5 text-sm tabular-nums">
+    <div
+      className="relative flex cursor-pointer items-center justify-between px-2 py-0.5 text-sm tabular-nums hover:bg-muted/40"
+      onClick={() => onPick?.(price, isBid ? "sell" : "buy")}
+    >
       <div
         className={cn(
           "absolute inset-y-0 right-0",
@@ -54,6 +60,10 @@ function DepthRow({
 export default function SymbolDetailPage() {
   const { symbolId } = useParams<{ symbolId: string }>();
   const id = Number(symbolId);
+
+  const [prefill, setPrefill] = useState<{ price?: number; side?: OrderSide; nonce: number }>({ nonce: 0 });
+  const prefillTicket = (price: number, side?: OrderSide) =>
+    setPrefill((p) => ({ price, side, nonce: p.nonce + 1 }));
 
   const symbolsQuery = useSymbols();
   // SSE drives the book; keep an initial React Query fetch for the first paint
@@ -133,7 +143,7 @@ export default function SymbolDetailPage() {
         </div>
       </div>
 
-      <TradeTicket symbolId={id} scaler={scaler} lastPrice={lastPrice} />
+      <TradeTicket symbolId={id} scaler={scaler} lastPrice={lastPrice} prefill={prefill} />
 
       <Card>
         <CardHeader>
@@ -145,7 +155,7 @@ export default function SymbolDetailPage() {
             <Skeleton className="h-[320px] w-full" />
           ) : (
             <div className="text-muted-foreground">
-              <CandleChart bars={bars} scaler={scaler} />
+              <CandleChart bars={bars} scaler={scaler} onPriceClick={(p) => prefillTicket(p)} />
             </div>
           )}
         </CardContent>
@@ -182,7 +192,7 @@ export default function SymbolDetailPage() {
                 </div>
                 <div className="flex flex-col-reverse">
                   {asks.map((l, i) => (
-                    <DepthRow key={"a" + i} level={l} side="ask" maxQty={maxQty} scaler={scaler} />
+                    <DepthRow key={"a" + i} level={l} side="ask" maxQty={maxQty} scaler={scaler} onPick={prefillTicket} />
                   ))}
                 </div>
                 <div className="my-1 flex items-center justify-between border-y px-2 py-1 text-sm font-medium">
@@ -193,7 +203,7 @@ export default function SymbolDetailPage() {
                 </div>
                 <div>
                   {bids.map((l, i) => (
-                    <DepthRow key={"b" + i} level={l} side="bid" maxQty={maxQty} scaler={scaler} />
+                    <DepthRow key={"b" + i} level={l} side="bid" maxQty={maxQty} scaler={scaler} onPick={prefillTicket} />
                   ))}
                 </div>
                 {asks.length === 0 && bids.length === 0 && (

--- a/frontend/src/pages/markets/SymbolDetailPage.tsx
+++ b/frontend/src/pages/markets/SymbolDetailPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useSymbols, useOrderBook, useCandles, useTrades } from "@/hooks/useMarketData";
 import { useMarketDataStream } from "@/hooks/useMarketDataStream";
@@ -57,10 +58,63 @@ function DepthRow({
   );
 }
 
+/** Single row inside the two-column (COLUMNS) book style. Depth bar grows
+ * outward from the center divider: bids to the left, asks to the right. */
+function ColumnRow({
+  level,
+  side,
+  maxQty,
+  scaler,
+  onPick,
+}: {
+  level: BookLevel;
+  side: "bid" | "ask";
+  maxQty: number;
+  scaler: number;
+  onPick?: (price: number, orderSide: OrderSide) => void;
+}) {
+  const [price, qty] = level;
+  const pct = maxQty > 0 ? Math.min(100, (qty / maxQty) * 100) : 0;
+  const isBid = side === "bid";
+  return (
+    <div
+      className={cn(
+        "relative flex cursor-pointer items-center px-2 py-0.5 text-sm tabular-nums hover:bg-muted/40",
+        isBid ? "justify-end text-right" : "justify-start text-left"
+      )}
+      onClick={() => onPick?.(price, isBid ? "sell" : "buy")}
+    >
+      <div
+        className={cn(
+          "absolute inset-y-0",
+          isBid ? "right-0 bg-emerald-500/10" : "left-0 bg-rose-500/10"
+        )}
+        style={{ width: pct + "%" }}
+      />
+      {isBid ? (
+        <>
+          <span className="relative z-10 mr-3 text-muted-foreground">{formatQty(qty, scaler)}</span>
+          <span className="relative z-10 font-medium text-emerald-600 dark:text-emerald-400">
+            {formatPrice(price, scaler)}
+          </span>
+        </>
+      ) : (
+        <>
+          <span className="relative z-10 mr-3 font-medium text-rose-600 dark:text-rose-400">
+            {formatPrice(price, scaler)}
+          </span>
+          <span className="relative z-10 text-muted-foreground">{formatQty(qty, scaler)}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function SymbolDetailPage() {
   const { symbolId } = useParams<{ symbolId: string }>();
   const id = Number(symbolId);
 
+  const [bookStyle, setBookStyle] = useState<"ladder" | "columns">("ladder");
   const [prefill, setPrefill] = useState<{ price?: number; side?: OrderSide; nonce: number }>({ nonce: 0 });
   const prefillTicket = (price: number, side?: OrderSide) =>
     setPrefill((p) => ({ price, side, nonce: p.nonce + 1 }));
@@ -165,26 +219,48 @@ export default function SymbolDetailPage() {
         <Card>
           <CardHeader>
             <div className="flex items-center justify-between">
-              <CardTitle className="text-base">Order Book</CardTitle>
-              {stream.live && (
-                <Badge
-                  variant="outline"
-                  className="gap-1 border-emerald-500/40 text-emerald-600 dark:text-emerald-400"
+              <div className="flex items-center gap-2">
+                <CardTitle className="text-base">Order Book</CardTitle>
+                {stream.live && (
+                  <Badge
+                    variant="outline"
+                    className="gap-1 border-emerald-500/40 text-emerald-600 dark:text-emerald-400"
+                  >
+                    <span className="relative flex h-2 w-2">
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500/70" />
+                      <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+                    </span>
+                    LIVE
+                  </Badge>
+                )}
+              </div>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={bookStyle === "ladder" ? "default" : "outline"}
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setBookStyle("ladder")}
                 >
-                  <span className="relative flex h-2 w-2">
-                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500/70" />
-                    <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
-                  </span>
-                  LIVE
-                </Badge>
-              )}
+                  Ladder
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={bookStyle === "columns" ? "default" : "outline"}
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setBookStyle("columns")}
+                >
+                  Columns
+                </Button>
+              </div>
             </div>
             <CardDescription>Best bid/ask ladder with depth.</CardDescription>
           </CardHeader>
           <CardContent>
             {book.isLoading && !liveBook ? (
               <Skeleton className="h-64 w-full" />
-            ) : (
+            ) : bookStyle === "ladder" ? (
               <div>
                 <div className="flex justify-between px-2 pb-1 text-xs uppercase text-muted-foreground">
                   <span>Price</span>
@@ -205,6 +281,48 @@ export default function SymbolDetailPage() {
                   {bids.map((l, i) => (
                     <DepthRow key={"b" + i} level={l} side="bid" maxQty={maxQty} scaler={scaler} onPick={prefillTicket} />
                   ))}
+                </div>
+                {asks.length === 0 && bids.length === 0 && (
+                  <p className="py-4 text-center text-sm text-muted-foreground">
+                    No book data.
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div>
+                <div className="mb-1 grid grid-cols-2 text-xs uppercase text-muted-foreground">
+                  <div className="flex justify-between px-2 text-emerald-600 dark:text-emerald-400">
+                    <span>Qty</span>
+                    <span>Bid</span>
+                  </div>
+                  <div className="flex justify-between px-2 text-rose-600 dark:text-rose-400">
+                    <span>Ask</span>
+                    <span>Qty</span>
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 divide-x">
+                  <div className="flex flex-col">
+                    {bids.map((l, i) => (
+                      <ColumnRow key={"cb" + i} level={l} side="bid" maxQty={maxQty} scaler={scaler} onPick={prefillTicket} />
+                    ))}
+                    {bids.length === 0 && (
+                      <p className="py-4 text-center text-sm text-muted-foreground">No bids.</p>
+                    )}
+                  </div>
+                  <div className="flex flex-col">
+                    {asks.map((l, i) => (
+                      <ColumnRow key={"ca" + i} level={l} side="ask" maxQty={maxQty} scaler={scaler} onPick={prefillTicket} />
+                    ))}
+                    {asks.length === 0 && (
+                      <p className="py-4 text-center text-sm text-muted-foreground">No asks.</p>
+                    )}
+                  </div>
+                </div>
+                <div className="mt-1 flex items-center justify-center gap-2 border-t px-2 py-1 text-sm font-medium">
+                  <span className="text-muted-foreground">Spread</span>
+                  <span className="tabular-nums">
+                    {spread != null ? formatPrice(spread, scaler) : "-"}
+                  </span>
                 </div>
                 {asks.length === 0 && bids.length === 0 && (
                   <p className="py-4 text-center text-sm text-muted-foreground">

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -1,0 +1,812 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  useMarginAccount,
+  usePmState,
+  useExecEvents,
+  usePlaceOrder,
+  useCancelOrder,
+  useBulkCancel,
+  useDeposit,
+  usePlaceQuote,
+  usePlaceAlgo,
+  usePlaceOto,
+} from "@/hooks/useTrading";
+import { isAck, ackMessage, impliedYes, marginUsedFraction } from "@/api/endpoints/trading";
+import type { OrderSide, Fill, PlaceOrderRequest } from "@/api/endpoints/trading";
+import { formatPrice, formatQty, formatTimeNs } from "./format";
+
+type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto";
+type Section = "trade" | "positions" | "orders" | "fills";
+type SetStr = React.Dispatch<React.SetStateAction<string>>;
+
+const ORDER_TYPES: { id: OrderType; label: string }[] = [
+  { id: "limit", label: "Limit" },
+  { id: "market", label: "Market" },
+  { id: "stop", label: "Stop" },
+  { id: "stop_limit", label: "Stop-Limit" },
+  { id: "take_profit", label: "Take-Profit" },
+  { id: "quote", label: "Quote" },
+  { id: "oto", label: "OTO" },
+];
+const TIFS = ["GTC", "IOC", "FOK", "GTD"] as const;
+
+interface WorkingOrder {
+  clordid: string;
+  side: OrderSide;
+  price: number;
+  qty: number;
+  orderid?: number;
+}
+
+function Pill({
+  active,
+  onClick,
+  children,
+  tag,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  tag?: string;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={tag}
+      onClick={onClick}
+      className={cn(
+        "rounded-md border px-2.5 py-1 text-xs font-semibold whitespace-nowrap transition-colors",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-border bg-background text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  onStep,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  onStep?: (delta: number) => void;
+}) {
+  return (
+    <div className="w-full">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <div className="mt-1 flex items-center gap-1.5">
+        {onStep && (
+          <Button type="button" variant="outline" size="icon" className="h-9 w-9 shrink-0" onClick={() => onStep(-1)}>
+            −
+          </Button>
+        )}
+        <Input
+          value={value}
+          inputMode="numeric"
+          placeholder="0"
+          onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ""))}
+          className="tabular-nums"
+        />
+        {onStep && (
+          <Button type="button" variant="outline" size="icon" className="h-9 w-9 shrink-0" onClick={() => onStep(1)}>
+            +
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TradeTicket({
+  symbolId,
+  scaler,
+  lastPrice,
+}: {
+  symbolId: number;
+  scaler: number;
+  lastPrice?: number;
+}) {
+  const account = useMarginAccount();
+  const pm = usePmState(symbolId);
+  const exec = useExecEvents();
+  const placeM = usePlaceOrder();
+  const cancelM = useCancelOrder();
+  const bulkM = useBulkCancel();
+  const depositM = useDeposit();
+  const quoteM = usePlaceQuote();
+  const algoM = usePlaceAlgo();
+  const otoM = usePlaceOto();
+
+  const acct = account.data;
+  const pmState = pm.data?.is_binary ? pm.data : undefined;
+
+  const [section, setSection] = useState<Section>("trade");
+  const [orderType, setOrderType] = useState<OrderType>("limit");
+  const [side, setSide] = useState<OrderSide>("buy");
+  const [price, setPrice] = useState("");
+  const [qty, setQty] = useState("");
+  const [stop, setStop] = useState("");
+  const [bid, setBid] = useState("");
+  const [ask, setAsk] = useState("");
+  const [childPrice, setChildPrice] = useState("");
+  const [childQty, setChildQty] = useState("");
+  const [tif, setTif] = useState<(typeof TIFS)[number]>("GTC");
+  const [expiryMin, setExpiryMin] = useState("");
+  const [postOnly, setPostOnly] = useState(false);
+  const [hidden, setHidden] = useState(false);
+  const [aon, setAon] = useState(false);
+  const [displayQty, setDisplayQty] = useState("");
+  const [minQty, setMinQty] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [depositAmt, setDepositAmt] = useState("");
+  const [armed, setArmed] = useState<"market" | "close" | null>(null);
+  const [oneTap, setOneTap] = useState(false);
+  const [workingOrders, setWorkingOrders] = useState<WorkingOrder[]>([]);
+  const [fills, setFills] = useState<Fill[]>([]);
+  const [msg, setMsg] = useState<{ text: string; error: boolean } | null>(null);
+
+  const seq = useRef(0);
+  const nextClordid = () => `t${Date.now()}${seq.current++ % 100}`;
+
+  // Prefill the price from the last trade while untouched.
+  useEffect(() => {
+    if (!price && lastPrice && lastPrice > 0) setPrice(String(lastPrice));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastPrice]);
+
+  // Fold async fills + triggers from the exec-events drain into the local state.
+  useEffect(() => {
+    const ev = exec.data;
+    if (!ev) return;
+    if (ev.fills && ev.fills.length) setFills((f) => [...ev.fills!, ...f].slice(0, 100));
+    const triggers = (ev.triggered?.length ?? 0) + (ev.oto_triggered?.length ?? 0);
+    if (triggers > 0) {
+      setMsg({ text: `${triggers} algo/OTO trigger(s)`, error: false });
+      account.refetch();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [exec.data]);
+
+  const priceN = parseInt(price) || 0;
+  const qtyN = parseInt(qty) || 0;
+  const stopN = parseInt(stop) || 0;
+  const bidN = parseInt(bid) || 0;
+  const askN = parseInt(ask) || 0;
+  const childPriceN = parseInt(childPrice) || 0;
+  const childQtyN = parseInt(childQty) || 0;
+  const refPrice = priceN || stopN || lastPrice || 0;
+  const avail = acct?.available_balance ?? 0;
+  const orderValue = priceN > 0 && qtyN > 0 ? priceN * qtyN : undefined;
+  const posQty = acct?.pos_qty ?? 0;
+  const marginPct = Math.round(marginUsedFraction(acct) * 100);
+
+  const resetArmed = () => armed && setArmed(null);
+  const setQtyPct = (pct: number) => {
+    if (!avail || !refPrice) return;
+    const max = Math.floor(avail / refPrice);
+    setQty(String(Math.max(pct > 0 ? 1 : 0, Math.floor((max * pct) / 100))));
+    resetArmed();
+  };
+  const stepField = (setter: SetStr, val: string, delta: number) => {
+    const n = Math.max(0, (parseInt(val) || 0) + delta);
+    setter(n === 0 ? "" : String(n));
+    resetArmed();
+  };
+
+  const canSubmit =
+    !placeM.isPending &&
+    !algoM.isPending &&
+    !quoteM.isPending &&
+    !otoM.isPending &&
+    (() => {
+      switch (orderType) {
+        case "limit":
+          return priceN > 0 && qtyN > 0;
+        case "market":
+          return qtyN > 0;
+        case "stop":
+        case "take_profit":
+          return stopN > 0 && qtyN > 0;
+        case "stop_limit":
+          return stopN > 0 && priceN > 0 && qtyN > 0;
+        case "quote":
+          return bidN > 0 && askN > 0 && qtyN > 0;
+        case "oto":
+          return priceN > 0 && qtyN > 0 && childPriceN > 0 && childQtyN > 0;
+        default:
+          return false;
+      }
+    })();
+
+  type AnyAck = {
+    status?: string;
+    orderid?: number;
+    fills?: Fill[];
+    clordid?: string;
+    cancelled_qty?: number;
+    algo_id?: number;
+    oto_id?: number;
+    bid_orderid?: number;
+    ask_orderid?: number;
+    new_balance?: number;
+    detail?: string;
+    error?: string;
+    note?: string;
+    reason?: string | number;
+    reasoncode?: number;
+  };
+
+  async function handleAck(
+    p: Promise<AnyAck>,
+    opts: { workingSide?: OrderSide; workingPrice?: number; workingQty?: number; okMsg: (a: AnyAck) => string }
+  ) {
+    try {
+      const a = await p;
+      if (isAck(a)) {
+        const fl = a.fills ?? [];
+        if (fl.length) setFills((f) => [...fl, ...f].slice(0, 100));
+        const filled = fl.reduce((s, x) => s + (x.qty ?? 0), 0);
+        const leaves = (opts.workingQty ?? 0) - filled;
+        if (opts.workingSide && leaves > 0 && a.clordid) {
+          setWorkingOrders((w) => [
+            ...w,
+            { clordid: a.clordid!, side: opts.workingSide!, price: opts.workingPrice ?? 0, qty: leaves, orderid: a.orderid },
+          ]);
+        }
+        setMsg({ text: opts.okMsg(a), error: false });
+        account.refetch();
+      } else {
+        setMsg({ text: ackMessage(a) ?? "Rejected", error: true });
+      }
+    } catch (e) {
+      setMsg({ text: (e as Error)?.message ?? "Network error", error: true });
+    }
+  }
+
+  function submit() {
+    if (orderType === "market" && !oneTap && armed !== "market") {
+      setArmed("market");
+      setMsg({ text: "Tap Confirm to send the market order", error: false });
+      return;
+    }
+    setArmed(null);
+    const cl = nextClordid();
+    if (orderType === "limit" || orderType === "market") {
+      const isMarket = orderType === "market";
+      const body: PlaceOrderRequest = {
+        symbolid: symbolId,
+        side,
+        price: isMarket ? 0 : priceN,
+        qty: qtyN,
+        clordid: cl,
+        market: isMarket || undefined,
+        tif: !isMarket && tif !== "GTC" ? tif : undefined,
+        post_only: postOnly || undefined,
+        hidden: hidden || undefined,
+        aon: aon || undefined,
+        display_qty: parseInt(displayQty) || undefined,
+        min_qty: parseInt(minQty) || undefined,
+        expiry_ns:
+          !isMarket && tif === "GTD" && expiryMin
+            ? (Date.now() + parseInt(expiryMin) * 60000) * 1_000_000
+            : undefined,
+      };
+      void handleAck(placeM.mutateAsync(body), {
+        workingSide: side,
+        workingPrice: priceN,
+        workingQty: isMarket ? 0 : qtyN,
+        okMsg: (a) => `Placed #${a.orderid ?? "?"}`,
+      });
+    } else if (orderType === "stop" || orderType === "stop_limit" || orderType === "take_profit") {
+      const algoType = orderType === "stop" ? "stop_market" : orderType === "stop_limit" ? "stop_limit" : "take_profit";
+      void handleAck(
+        algoM.mutateAsync({
+          algo_type: algoType,
+          symbolid: symbolId,
+          side,
+          qty: qtyN,
+          stop_price: stopN,
+          limit_price: algoType === "stop_market" ? undefined : priceN || undefined,
+        }),
+        { okMsg: (a) => `Algo #${(a as { algo_id?: number }).algo_id ?? "?"} armed` }
+      );
+    } else if (orderType === "quote") {
+      void handleAck(
+        quoteM.mutateAsync({ symbolid: symbolId, bid_price: bidN, ask_price: askN, bid_qty: qtyN, ask_qty: qtyN }),
+        {
+          okMsg: (a) =>
+            `Quote bid #${(a as { bid_orderid?: number }).bid_orderid ?? 0} / ask #${
+              (a as { ask_orderid?: number }).ask_orderid ?? 0
+            }`,
+        }
+      );
+    } else if (orderType === "oto") {
+      const childSide: OrderSide = side === "buy" ? "sell" : "buy";
+      void handleAck(
+        otoM.mutateAsync({
+          symbolid: symbolId,
+          parent_side: side,
+          parent_price: priceN,
+          parent_qty: qtyN,
+          child_side: childSide,
+          child_price: childPriceN,
+          child_qty: childQtyN,
+        }),
+        { okMsg: (a) => `OTO #${(a as { oto_id?: number }).oto_id ?? "?"}` }
+      );
+    }
+  }
+
+  function closePosition() {
+    if (!posQty) return;
+    if (!oneTap && armed !== "close") {
+      setArmed("close");
+      setMsg({ text: "Tap Confirm close to flatten the position", error: false });
+      return;
+    }
+    setArmed(null);
+    const closeSide: OrderSide = posQty > 0 ? "sell" : "buy";
+    const q = Math.abs(posQty);
+    const colliding = workingOrders.filter((w) => w.side !== closeSide);
+    colliding.forEach((w) => cancelM.mutate({ clordid: w.clordid, symbolId }));
+    if (colliding.length) setWorkingOrders((w) => w.filter((x) => !colliding.some((c) => c.clordid === x.clordid)));
+    void handleAck(
+      placeM.mutateAsync({ symbolid: symbolId, side: closeSide, price: 0, qty: q, clordid: nextClordid(), market: true }),
+      { okMsg: () => `Closing (${closeSide === "sell" ? "sold" : "bought"} ${q})` }
+    );
+  }
+
+  const cancelOne = (clo: string) =>
+    cancelM.mutate(
+      { clordid: clo, symbolId },
+      {
+        onSuccess: (a) => {
+          if (isAck(a)) {
+            setWorkingOrders((w) => w.filter((x) => x.clordid !== clo));
+            setMsg({ text: `Cancelled ${a.cancelled_qty ?? ""}`, error: false });
+            account.refetch();
+          }
+        },
+      }
+    );
+  const cancelAll = () =>
+    bulkM.mutate(undefined, {
+      onSuccess: (a) => {
+        setWorkingOrders([]);
+        setMsg({ text: `Cancelled all (${a.cancelled_count ?? 0})`, error: false });
+        account.refetch();
+      },
+    });
+  const deposit = () => {
+    const amt = parseInt(depositAmt) || 0;
+    if (amt <= 0) return;
+    depositM.mutate(amt, {
+      onSuccess: (a) => {
+        setDepositAmt("");
+        setMsg({ text: isAck(a) ? `Deposited (balance ${a.new_balance})` : ackMessage(a) ?? "Deposit rejected", error: !isAck(a) });
+        account.refetch();
+      },
+    });
+  };
+
+  const isPm = !!pmState;
+  const buyLabel = isPm ? "YES" : "Buy";
+  const sellLabel = isPm ? "NO" : "Sell";
+  const submitLabel = useMemo(() => {
+    if (armed === "market") return `Confirm ${side === "buy" ? "Buy" : "Sell"} ${qty} @ market`;
+    const s = side === "buy" ? "Buy" : "Sell";
+    switch (orderType) {
+      case "limit":
+        return `${s} ${qty}`.trim();
+      case "market":
+        return `${s} ${qty} (market)`.trim();
+      case "stop":
+        return `${s} Stop`;
+      case "stop_limit":
+        return `${s} Stop-Limit`;
+      case "take_profit":
+        return `${s} Take-Profit`;
+      case "quote":
+        return "Place quote";
+      case "oto":
+        return `Place OTO (${s} parent)`;
+      default:
+        return "Submit";
+    }
+  }, [armed, side, qty, orderType]);
+
+  const sections: { id: Section; label: string; count?: number }[] = [
+    { id: "trade", label: "Trade" },
+    { id: "positions", label: "Positions", count: posQty ? 1 : 0 },
+    { id: "orders", label: "Orders", count: workingOrders.length },
+    { id: "fills", label: "Fills", count: fills.length },
+  ];
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-6">
+        {/* Prediction-market banner */}
+        {isPm && pmState && (
+          <div
+            className={cn(
+              "rounded-lg border p-3",
+              pmState.state === "resolved" ? "border-border bg-muted/40" : "border-primary/50"
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold text-primary">Prediction market</span>
+              <span className="text-xs tabular-nums text-muted-foreground">payout {formatPrice(pmState.face_value, scaler)}</span>
+            </div>
+            {pmState.state === "resolved" ? (
+              <p
+                className={cn(
+                  "mt-1 text-sm font-bold",
+                  pmState.outcome === 1 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"
+                )}
+              >
+                Resolved: {pmState.outcome === 1 ? "YES" : "NO"} —{" "}
+                {pmState.outcome === 1 ? `YES pays ${formatPrice(pmState.face_value, scaler)}` : "YES pays 0"}
+              </p>
+            ) : (
+              <>
+                <div className="mt-1 flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Implied YES</span>
+                  <span className="font-bold tabular-nums text-emerald-600 dark:text-emerald-400">
+                    {(() => {
+                      const p = impliedYes(lastPrice, pmState.face_value);
+                      return p == null ? "—" : `${Math.round(p * 100)}%`;
+                    })()}
+                  </span>
+                </div>
+                <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-rose-500/30">
+                  <div
+                    className="h-full bg-emerald-500"
+                    style={{ width: `${Math.round((impliedYes(lastPrice, pmState.face_value) ?? 0) * 100)}%` }}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Account strip */}
+        {acct && (
+          <div className="rounded-lg border p-3 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Available</span>
+              <span className="tabular-nums">{formatPrice(acct.available_balance, scaler)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Reserved margin</span>
+              <span className="tabular-nums">{formatPrice(acct.reserved_margin, scaler)}</span>
+            </div>
+            <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
+              <span>Margin used</span>
+              <span className="tabular-nums">{marginPct}%</span>
+            </div>
+            <div className="mt-1 h-1 w-full overflow-hidden rounded-full bg-muted">
+              <div className={cn("h-full", acct.is_liquidating ? "bg-rose-500" : "bg-primary")} style={{ width: `${Math.max(1, marginPct)}%` }} />
+            </div>
+            {(acct.is_liquidating || (acct.distress_level ?? 0) > 0) && (
+              <p className="mt-1 text-xs font-bold text-rose-600 dark:text-rose-400">
+                ⚠ {acct.is_liquidating ? "Liquidating" : `Distress ${acct.distress_level}`}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Section tabs */}
+        <div className="flex gap-1 rounded-lg bg-muted p-1">
+          {sections.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => {
+                setSection(s.id);
+                resetArmed();
+              }}
+              className={cn(
+                "flex-1 rounded-md py-1.5 text-xs font-medium transition-colors",
+                section === s.id ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"
+              )}
+            >
+              {s.label}
+              {s.count ? ` ${s.count}` : ""}
+            </button>
+          ))}
+        </div>
+
+        {section === "trade" && (
+          <div className="space-y-3">
+            {/* Order type */}
+            <div className="flex gap-1.5 overflow-x-auto pb-1">
+              {ORDER_TYPES.map((t) => (
+                <Pill
+                  key={t.id}
+                  active={orderType === t.id}
+                  onClick={() => {
+                    setOrderType(t.id);
+                    resetArmed();
+                  }}
+                  tag={`otype_${t.id}`}
+                >
+                  {t.label}
+                </Pill>
+              ))}
+            </div>
+
+            {/* Side (hidden for quote) */}
+            {orderType !== "quote" && (
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant={side === "buy" ? "default" : "outline"}
+                  className={cn("flex-1", side === "buy" && "bg-emerald-600 hover:bg-emerald-600/90")}
+                  onClick={() => {
+                    setSide("buy");
+                    resetArmed();
+                  }}
+                >
+                  {buyLabel}
+                </Button>
+                <Button
+                  type="button"
+                  variant={side === "sell" ? "default" : "outline"}
+                  className={cn("flex-1", side === "sell" && "bg-rose-600 hover:bg-rose-600/90")}
+                  onClick={() => {
+                    setSide("sell");
+                    resetArmed();
+                  }}
+                >
+                  {sellLabel}
+                </Button>
+              </div>
+            )}
+
+            {/* Type-specific fields */}
+            {orderType === "limit" && (
+              <>
+                <Field label="Price" value={price} onChange={setPrice} onStep={(d) => stepField(setPrice, price, d)} />
+                <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} />
+              </>
+            )}
+            {orderType === "market" && <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} />}
+            {orderType === "stop" && (
+              <>
+                <Field label="Stop (trigger) price" value={stop} onChange={setStop} onStep={(d) => stepField(setStop, stop, d)} />
+                <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} />
+              </>
+            )}
+            {orderType === "stop_limit" && (
+              <>
+                <Field label="Stop (trigger) price" value={stop} onChange={setStop} onStep={(d) => stepField(setStop, stop, d)} />
+                <Field label="Limit price" value={price} onChange={setPrice} onStep={(d) => stepField(setPrice, price, d)} />
+                <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} />
+              </>
+            )}
+            {orderType === "take_profit" && (
+              <>
+                <Field label="Take-profit trigger" value={stop} onChange={setStop} onStep={(d) => stepField(setStop, stop, d)} />
+                <Field label="Limit price (optional)" value={price} onChange={setPrice} />
+                <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} />
+              </>
+            )}
+            {orderType === "quote" && (
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Bid price" value={bid} onChange={setBid} />
+                <Field label="Ask price" value={ask} onChange={setAsk} />
+                <div className="col-span-2">
+                  <Field label="Quantity (each side)" value={qty} onChange={setQty} />
+                </div>
+              </div>
+            )}
+            {orderType === "oto" && (
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Parent price" value={price} onChange={setPrice} />
+                <Field label="Parent qty" value={qty} onChange={setQty} />
+                <Field label="Child price" value={childPrice} onChange={setChildPrice} />
+                <Field label="Child qty" value={childQty} onChange={setChildQty} />
+                <p className="col-span-2 text-xs text-muted-foreground">
+                  Child = {side === "buy" ? "Sell" : "Buy"} · triggers when the parent fills
+                </p>
+              </div>
+            )}
+
+            {/* Quick-size */}
+            {(orderType === "limit" ||
+              orderType === "market" ||
+              orderType === "stop" ||
+              orderType === "stop_limit" ||
+              orderType === "take_profit") && (
+              <div className="flex gap-1.5">
+                {[25, 50, 75, 100].map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => setQtyPct(p)}
+                    className="flex-1 rounded-md border py-1 text-xs tabular-nums text-muted-foreground hover:text-foreground"
+                  >
+                    {p === 100 ? "Max" : `${p}%`}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* TIF (limit only) */}
+            {orderType === "limit" && (
+              <div>
+                <label className="text-xs text-muted-foreground">Time in force</label>
+                <div className="mt-1 flex gap-1.5">
+                  {TIFS.map((t) => (
+                    <Pill key={t} active={tif === t} onClick={() => setTif(t)} tag={`tif_${t}`}>
+                      {t}
+                    </Pill>
+                  ))}
+                </div>
+                {tif === "GTD" && <Field label="Expires in (minutes)" value={expiryMin} onChange={setExpiryMin} />}
+              </div>
+            )}
+
+            {/* Order value */}
+            {orderType === "limit" && (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Order value</span>
+                <span className={cn("tabular-nums", orderValue && orderValue > avail ? "text-rose-600 dark:text-rose-400" : "")}>
+                  {orderValue != null ? formatPrice(orderValue, scaler) : "—"} · avail {formatPrice(avail, scaler)}
+                </span>
+              </div>
+            )}
+
+            {/* Advanced */}
+            {(orderType === "limit" || orderType === "market") && (
+              <div>
+                <button type="button" className="text-xs font-semibold text-primary" onClick={() => setAdvancedOpen((v) => !v)}>
+                  Advanced {advancedOpen ? "▲" : "▼"}
+                </button>
+                {advancedOpen && (
+                  <div className="mt-2 space-y-2">
+                    <div className="flex flex-wrap gap-1.5">
+                      {orderType === "limit" && (
+                        <Pill active={postOnly} onClick={() => setPostOnly((v) => !v)} tag="flag_post_only">
+                          Post-only
+                        </Pill>
+                      )}
+                      <Pill active={hidden} onClick={() => setHidden((v) => !v)} tag="flag_hidden">
+                        Hidden
+                      </Pill>
+                      <Pill active={aon} onClick={() => setAon((v) => !v)} tag="flag_aon">
+                        AON
+                      </Pill>
+                      <Pill active={oneTap} onClick={() => setOneTap((v) => !v)} tag="flag_one_tap">
+                        1-tap
+                      </Pill>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <Field label="Display qty (iceberg)" value={displayQty} onChange={setDisplayQty} />
+                      <Field label="Min qty" value={minQty} onChange={setMinQty} />
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Submit */}
+            <Button
+              type="button"
+              disabled={!canSubmit}
+              onClick={submit}
+              data-testid="trade_place"
+              className={cn(
+                "w-full",
+                armed === "market"
+                  ? "bg-primary"
+                  : side === "buy"
+                  ? "bg-emerald-600 hover:bg-emerald-600/90"
+                  : "bg-rose-600 hover:bg-rose-600/90"
+              )}
+            >
+              {submitLabel}
+            </Button>
+
+            {/* Deposit collateral */}
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <Field label="Deposit collateral" value={depositAmt} onChange={setDepositAmt} />
+              </div>
+              <Button type="button" variant="secondary" onClick={deposit} disabled={depositM.isPending}>
+                Deposit
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {section === "positions" &&
+          (posQty ? (
+            <div className="rounded-lg border p-3">
+              <div className="flex items-center justify-between">
+                <span className={cn("font-bold tabular-nums", posQty > 0 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400")}>
+                  {posQty > 0 ? "Long" : "Short"} {formatQty(Math.abs(posQty), scaler)}
+                </span>
+                <Button type="button" size="sm" variant={armed === "close" ? "default" : "destructive"} onClick={closePosition} data-testid="close_position">
+                  {armed === "close" ? "Confirm close" : "Close"}
+                </Button>
+              </div>
+              <div className="mt-2 space-y-0.5 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Entry</span>
+                  <span className="tabular-nums">{formatPrice(acct?.pos_entry_price, scaler)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Liq. price</span>
+                  <span className="tabular-nums">{acct?.pos_liquidation_price ? formatPrice(acct.pos_liquidation_price, scaler) : "—"}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Unrealized PnL</span>
+                  <span className={cn("tabular-nums", (acct?.pos_unrealized_pnl ?? 0) >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400")}>
+                    {(acct?.pos_unrealized_pnl ?? 0) >= 0 ? "+" : ""}
+                    {formatPrice(acct?.pos_unrealized_pnl, scaler)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="py-6 text-center text-sm text-muted-foreground">No open position</p>
+          ))}
+
+        {section === "orders" && (
+          <div className="space-y-2">
+            {workingOrders.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">No resting orders this session</p>
+            ) : (
+              workingOrders.map((w) => (
+                <div key={w.clordid} className="flex items-center justify-between text-sm">
+                  <span className={cn("tabular-nums", w.side === "buy" ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400")}>
+                    {w.side === "buy" ? "Buy" : "Sell"} {formatQty(w.qty, scaler)} @ {formatPrice(w.price, scaler)}
+                  </span>
+                  <Button type="button" size="sm" variant="outline" onClick={() => cancelOne(w.clordid)}>
+                    Cancel
+                  </Button>
+                </div>
+              ))
+            )}
+            <Button type="button" variant="outline" size="sm" onClick={cancelAll} data-testid="cancel_all" className="text-rose-600 dark:text-rose-400">
+              Cancel all resting orders
+            </Button>
+          </div>
+        )}
+
+        {section === "fills" &&
+          (fills.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">No fills this session</p>
+          ) : (
+            <div className="max-h-72 overflow-y-auto">
+              <div className="flex justify-between px-1 pb-1 text-xs uppercase text-muted-foreground">
+                <span>Price</span>
+                <span>Qty</span>
+                <span>Time</span>
+              </div>
+              {fills.slice(0, 60).map((f, i) => (
+                <div key={i} className="flex justify-between px-1 py-0.5 text-sm tabular-nums">
+                  <span>{formatPrice(f.price, scaler)}</span>
+                  <span className="text-muted-foreground">{formatQty(f.qty, scaler)}</span>
+                  <span className="text-muted-foreground">{formatTimeNs(f.ts_ns)}</span>
+                </div>
+              ))}
+            </div>
+          ))}
+
+        {msg && <p className={cn("text-xs font-mono", msg.error ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400")}>{msg.text}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -18,6 +18,7 @@ import {
 import { isAck, ackMessage, impliedYes, marginUsedFraction } from "@/api/endpoints/trading";
 import type { OrderSide, Fill, PlaceOrderRequest } from "@/api/endpoints/trading";
 import { formatPrice, formatQty, formatTimeNs } from "./format";
+import { vibrate, notify, ensureNotifyPermission } from "@/lib/tradeFeedback";
 
 type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto";
 type Section = "trade" | "positions" | "orders" | "fills";
@@ -180,10 +181,16 @@ export function TradeTicket({
   useEffect(() => {
     const ev = exec.data;
     if (!ev) return;
-    if (ev.fills && ev.fills.length) setFills((f) => [...ev.fills!, ...f].slice(0, 100));
+    if (ev.fills && ev.fills.length) {
+      setFills((f) => [...ev.fills!, ...f].slice(0, 100));
+      vibrate("success");
+      notify("Fill", `Filled ${ev.fills.reduce((sum, x) => sum + (x.qty ?? 0), 0)} on a resting order`);
+    }
     const triggers = (ev.triggered?.length ?? 0) + (ev.oto_triggered?.length ?? 0);
     if (triggers > 0) {
       setMsg({ text: `${triggers} algo/OTO trigger(s)`, error: false });
+      notify("Algo/OTO triggered", `${triggers} order(s) fired`);
+      vibrate("success");
       account.refetch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -207,9 +214,11 @@ export function TradeTicket({
     if (!avail || !refPrice) return;
     const max = Math.floor(avail / refPrice);
     setQty(String(Math.max(pct > 0 ? 1 : 0, Math.floor((max * pct) / 100))));
+    vibrate("tick");
     resetArmed();
   };
   const stepField = (setter: SetStr, val: string, delta: number) => {
+    vibrate("tick");
     const n = Math.max(0, (parseInt(val) || 0) + delta);
     setter(n === 0 ? "" : String(n));
     resetArmed();
@@ -276,17 +285,27 @@ export function TradeTicket({
           ]);
         }
         setMsg({ text: opts.okMsg(a), error: false });
+        if (filled > 0) {
+          vibrate("success");
+          notify("Order filled", `Filled ${filled}`);
+        } else {
+          vibrate("tick");
+        }
         account.refetch();
       } else {
+        vibrate("error");
         setMsg({ text: ackMessage(a) ?? "Rejected", error: true });
       }
     } catch (e) {
+      vibrate("error");
       setMsg({ text: (e as Error)?.message ?? "Network error", error: true });
     }
   }
 
   function submit() {
+    ensureNotifyPermission();
     if (orderType === "market" && !oneTap && armed !== "market") {
+      vibrate("warn");
       setArmed("market");
       setMsg({ text: "Tap Confirm to send the market order", error: false });
       return;
@@ -362,6 +381,7 @@ export function TradeTicket({
   function closePosition() {
     if (!posQty) return;
     if (!oneTap && armed !== "close") {
+      vibrate("warn");
       setArmed("close");
       setMsg({ text: "Tap Confirm close to flatten the position", error: false });
       return;
@@ -405,6 +425,7 @@ export function TradeTicket({
     depositM.mutate(amt, {
       onSuccess: (a) => {
         setDepositAmt("");
+        vibrate(isAck(a) ? "success" : "error");
         setMsg({ text: isAck(a) ? `Deposited (balance ${a.new_balance})` : ackMessage(a) ?? "Deposit rejected", error: !isAck(a) });
         account.refetch();
       },
@@ -547,6 +568,7 @@ export function TradeTicket({
                   key={t.id}
                   active={orderType === t.id}
                   onClick={() => {
+                    vibrate("tick");
                     setOrderType(t.id);
                     resetArmed();
                   }}
@@ -565,6 +587,7 @@ export function TradeTicket({
                   variant={side === "buy" ? "default" : "outline"}
                   className={cn("flex-1", side === "buy" && "bg-emerald-600 hover:bg-emerald-600/90")}
                   onClick={() => {
+                    vibrate("tick");
                     setSide("buy");
                     resetArmed();
                   }}
@@ -576,6 +599,7 @@ export function TradeTicket({
                   variant={side === "sell" ? "default" : "outline"}
                   className={cn("flex-1", side === "sell" && "bg-rose-600 hover:bg-rose-600/90")}
                   onClick={() => {
+                    vibrate("tick");
                     setSide("sell");
                     resetArmed();
                   }}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -14,13 +14,18 @@ import {
   usePlaceQuote,
   usePlaceAlgo,
   usePlaceOto,
+  usePlaceOco,
+  usePlaceFunding,
+  useSpotBalance,
+  useSpotDeposit,
 } from "@/hooks/useTrading";
 import { isAck, ackMessage, impliedYes, marginUsedFraction } from "@/api/endpoints/trading";
 import type { OrderSide, Fill, PlaceOrderRequest } from "@/api/endpoints/trading";
 import { formatPrice, formatQty, formatTimeNs } from "./format";
 import { vibrate, notify, ensureNotifyPermission } from "@/lib/tradeFeedback";
+import { tradingFeatures } from "./tradingFeatures";
 
-type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto";
+type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto" | "oco" | "funding";
 type Section = "trade" | "positions" | "orders" | "fills";
 type SetStr = React.Dispatch<React.SetStateAction<string>>;
 
@@ -32,6 +37,9 @@ const ORDER_TYPES: { id: OrderType; label: string }[] = [
   { id: "take_profit", label: "Take-Profit" },
   { id: "quote", label: "Quote" },
   { id: "oto", label: "OTO" },
+  // Staged surfaces — only surface when their feature flag is on.
+  ...(tradingFeatures.OCO_ENABLED ? [{ id: "oco" as OrderType, label: "OCO" }] : []),
+  ...(tradingFeatures.FUNDING_ENABLED ? [{ id: "funding" as OrderType, label: "Funding" }] : []),
 ];
 const TIFS = ["GTC", "IOC", "FOK", "GTD"] as const;
 
@@ -129,6 +137,10 @@ export function TradeTicket({
   const quoteM = usePlaceQuote();
   const algoM = usePlaceAlgo();
   const otoM = usePlaceOto();
+  const ocoM = usePlaceOco();
+  const fundingM = usePlaceFunding();
+  const spot = useSpotBalance(tradingFeatures.SPOT_ENABLED);
+  const spotDepositM = useSpotDeposit();
 
   const acct = account.data;
   const pmState = pm.data?.is_binary ? pm.data : undefined;
@@ -152,6 +164,12 @@ export function TradeTicket({
   const [minQty, setMinQty] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [depositAmt, setDepositAmt] = useState("");
+  const [isBorrow, setIsBorrow] = useState(true);
+  const [rateBps, setRateBps] = useState("");
+  const [fundingQty, setFundingQty] = useState("");
+  const [durationSec, setDurationSec] = useState("");
+  const [spotAsset, setSpotAsset] = useState("");
+  const [spotAmt, setSpotAmt] = useState("");
   const [armed, setArmed] = useState<"market" | "close" | null>(null);
   const [oneTap, setOneTap] = useState(false);
   const [workingOrders, setWorkingOrders] = useState<WorkingOrder[]>([]);
@@ -203,6 +221,9 @@ export function TradeTicket({
   const askN = parseInt(ask) || 0;
   const childPriceN = parseInt(childPrice) || 0;
   const childQtyN = parseInt(childQty) || 0;
+  const rateBpsN = parseInt(rateBps) || 0;
+  const fundingQtyN = parseInt(fundingQty) || 0;
+  const durationSecN = parseInt(durationSec) || 0;
   const refPrice = priceN || stopN || lastPrice || 0;
   const avail = acct?.available_balance ?? 0;
   const orderValue = priceN > 0 && qtyN > 0 ? priceN * qtyN : undefined;
@@ -229,6 +250,8 @@ export function TradeTicket({
     !algoM.isPending &&
     !quoteM.isPending &&
     !otoM.isPending &&
+    !ocoM.isPending &&
+    !fundingM.isPending &&
     (() => {
       switch (orderType) {
         case "limit":
@@ -244,6 +267,10 @@ export function TradeTicket({
           return bidN > 0 && askN > 0 && qtyN > 0;
         case "oto":
           return priceN > 0 && qtyN > 0 && childPriceN > 0 && childQtyN > 0;
+        case "oco":
+          return priceN > 0 && qtyN > 0 && childPriceN > 0 && childQtyN > 0;
+        case "funding":
+          return rateBpsN > 0 && fundingQtyN > 0;
         default:
           return false;
       }
@@ -257,6 +284,7 @@ export function TradeTicket({
     cancelled_qty?: number;
     algo_id?: number;
     oto_id?: number;
+    funding_id?: number;
     bid_orderid?: number;
     ask_orderid?: number;
     new_balance?: number;
@@ -375,6 +403,29 @@ export function TradeTicket({
         }),
         { okMsg: (a) => `OTO #${(a as { oto_id?: number }).oto_id ?? "?"}` }
       );
+    } else if (orderType === "oco") {
+      const legBSide: OrderSide = side === "buy" ? "sell" : "buy";
+      void handleAck(
+        ocoM.mutateAsync({
+          symbolId,
+          legs: [
+            { side, price: priceN, qty: qtyN },
+            { side: legBSide, price: childPriceN, qty: childQtyN },
+          ],
+        }),
+        { okMsg: (a) => `OCO placed #${a.orderid ?? "?"}` }
+      );
+    } else if (orderType === "funding") {
+      void handleAck(
+        fundingM.mutateAsync({
+          rate_bps: rateBpsN,
+          qty: fundingQtyN,
+          is_borrow: isBorrow,
+          duration_seconds: durationSecN > 0 ? durationSecN : undefined,
+          symbolid: symbolId,
+        }),
+        { okMsg: (a) => `Funding #${(a as { funding_id?: number }).funding_id ?? "?"} (${isBorrow ? "borrow" : "lend"})` }
+      );
     }
   }
 
@@ -453,10 +504,14 @@ export function TradeTicket({
         return "Place quote";
       case "oto":
         return `Place OTO (${s} parent)`;
+      case "oco":
+        return `Place OCO (${s} leg A)`;
+      case "funding":
+        return isBorrow ? "Borrow funding" : "Lend funding";
       default:
         return "Submit";
     }
-  }, [armed, side, qty, orderType]);
+  }, [armed, side, qty, orderType, isBorrow]);
 
   const sections: { id: Section; label: string; count?: number }[] = [
     { id: "trade", label: "Trade" },
@@ -579,8 +634,8 @@ export function TradeTicket({
               ))}
             </div>
 
-            {/* Side (hidden for quote) */}
-            {orderType !== "quote" && (
+            {/* Side (hidden for quote / funding) */}
+            {orderType !== "quote" && orderType !== "funding" && (
               <div className="flex gap-2">
                 <Button
                   type="button"
@@ -655,6 +710,52 @@ export function TradeTicket({
                 <p className="col-span-2 text-xs text-muted-foreground">
                   Child = {side === "buy" ? "Sell" : "Buy"} · triggers when the parent fills
                 </p>
+              </div>
+            )}
+            {orderType === "oco" && (
+              <div className="grid grid-cols-2 gap-2">
+                <Field label={`Leg A price (${side === "buy" ? "Buy" : "Sell"})`} value={price} onChange={setPrice} />
+                <Field label="Leg A qty" value={qty} onChange={setQty} />
+                <Field label={`Leg B price (${side === "buy" ? "Sell" : "Buy"})`} value={childPrice} onChange={setChildPrice} />
+                <Field label="Leg B qty" value={childQty} onChange={setChildQty} />
+                <p className="col-span-2 text-xs text-muted-foreground">
+                  Leg B = opposite side; a fill on one cancels the other.
+                </p>
+              </div>
+            )}
+            {orderType === "funding" && (
+              <div className="space-y-2">
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant={isBorrow ? "default" : "outline"}
+                    className={cn("flex-1", isBorrow && "bg-emerald-600 hover:bg-emerald-600/90")}
+                    onClick={() => {
+                      vibrate("tick");
+                      setIsBorrow(true);
+                      resetArmed();
+                    }}
+                  >
+                    Borrow
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={!isBorrow ? "default" : "outline"}
+                    className={cn("flex-1", !isBorrow && "bg-rose-600 hover:bg-rose-600/90")}
+                    onClick={() => {
+                      vibrate("tick");
+                      setIsBorrow(false);
+                      resetArmed();
+                    }}
+                  >
+                    Lend
+                  </Button>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Field label="Rate (bps)" value={rateBps} onChange={setRateBps} onStep={(d) => stepField(setRateBps, rateBps, d)} />
+                  <Field label="Quantity" value={fundingQty} onChange={setFundingQty} onStep={(d) => stepField(setFundingQty, fundingQty, d)} />
+                </div>
+                <Field label="Duration (seconds, optional)" value={durationSec} onChange={setDurationSec} />
               </div>
             )}
 
@@ -763,6 +864,53 @@ export function TradeTicket({
                 Deposit
               </Button>
             </div>
+
+            {/* Spot wallet (staged surface) */}
+            {tradingFeatures.SPOT_ENABLED && (
+              <div className="rounded-lg border p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold">Spot balances</span>
+                  {spot.isLoading && <span className="text-xs text-muted-foreground">loading…</span>}
+                </div>
+                {spot.data?.balances && spot.data.balances.length > 0 ? (
+                  <div className="mt-2 space-y-0.5 text-sm">
+                    {spot.data.balances.map((b, i) => (
+                      <div key={b.asset ?? i} className="flex justify-between">
+                        <span className="text-muted-foreground">{b.symbol ?? `asset ${b.asset ?? "?"}`}</span>
+                        <span className="tabular-nums">{formatQty(b.available ?? b.balance ?? 0, scaler)}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  !spot.isLoading && <p className="mt-2 text-xs text-muted-foreground">No spot balances</p>
+                )}
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  <Field label="Asset id" value={spotAsset} onChange={setSpotAsset} />
+                  <Field label="Amount" value={spotAmt} onChange={setSpotAmt} />
+                </div>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-2 w-full"
+                  disabled={spotDepositM.isPending || (parseInt(spotAsset) || 0) <= 0 || (parseInt(spotAmt) || 0) <= 0}
+                  onClick={() =>
+                    spotDepositM.mutate(
+                      { asset: parseInt(spotAsset) || 0, amount: parseInt(spotAmt) || 0 },
+                      {
+                        onSuccess: (a) => {
+                          vibrate(isAck(a) ? "success" : "error");
+                          setMsg({ text: isAck(a) ? "Spot deposit ok" : ackMessage(a) ?? "Spot deposit rejected", error: !isAck(a) });
+                          setSpotAmt("");
+                          spot.refetch();
+                        },
+                      }
+                    )
+                  }
+                >
+                  Deposit spot
+                </Button>
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -111,10 +111,12 @@ export function TradeTicket({
   symbolId,
   scaler,
   lastPrice,
+  prefill,
 }: {
   symbolId: number;
   scaler: number;
   lastPrice?: number;
+  prefill?: { price?: number; side?: OrderSide; nonce: number };
 }) {
   const account = useMarginAccount();
   const pm = usePmState(symbolId);
@@ -163,6 +165,16 @@ export function TradeTicket({
     if (!price && lastPrice && lastPrice > 0) setPrice(String(lastPrice));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastPrice]);
+
+  // Click-to-trade prefill from the book/chart (nonce re-fires on each pick).
+  useEffect(() => {
+    if (!prefill) return;
+    if (prefill.price != null) setPrice(String(prefill.price));
+    if (prefill.side) setSide(prefill.side);
+    setSection("trade");
+    setArmed(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefill?.nonce]);
 
   // Fold async fills + triggers from the exec-events drain into the local state.
   useEffect(() => {

--- a/frontend/src/pages/markets/tradingFeatures.ts
+++ b/frontend/src/pages/markets/tradingFeatures.ts
@@ -1,0 +1,15 @@
+/**
+ * Staged trading-feature flags for the web ticket. These mirror the Android
+ * `TradingFeatures` staged surfaces and are all OFF by default so the shipped
+ * UI is unchanged.
+ *
+ * Current backend reality (flip when the backend port lands):
+ *  - OCO      -> `/me/oco` returns no_response through the prod edge.
+ *  - FUNDING  -> `/me/funding_order` rejects with reason 30.
+ *  - SPOT     -> `/me/spot_balance` / deposit need an asset-id map first.
+ */
+export const tradingFeatures = {
+  OCO_ENABLED: false,
+  FUNDING_ENABLED: false,
+  SPOT_ENABLED: false,
+} as const;


### PR DESCRIPTION
Brings the exchange trading UX polish, prediction markets, the full mobile-web parity track, and the login stability fix to `main`.

## Android
- Trading UX crispness pass — segmented Trade/Positions/Orders/Fills, quick-size chips, steppers, arm-to-confirm, proactive hints
- Haptic feedback + trade notifications (TradingNotifier)
- **Prediction markets** — binary YES/NO markets (pm_state banner, implied-YES bar, Buy/Sell→YES/NO relabel); a PM is a symbol traded through the normal book
- **Login/stability fix** — pin the shared OkHttp client to HTTP/1.1 (the cpp edge's HTTP/2 server resets concurrent streams under the messaging poll+SSE load, cancelling the login POST). Verified on-device (A15): logged into prod and placed a live PM YES order that filled.

## Web (mobile-web parity)
- WEB-A data layer + parity backlog
- WEB-B order ticket on the symbol page (+ positions/orders/fills + PM banner)
- WEB-D click-to-trade + chart MA overlays + search/watchlist
- WEB-F web-native feedback (Vibration API + Web Notifications)
- WEB-D2 chart oscillators/drawing + dual-style book + OCO/Funding/Spot (flagged off)

Web matches the Android trading + PM feature set. typecheck (tsc -b) + vite build green.

## Verification
Backend contract + prediction markets verified live over HTTPS against prod (order suite, funding, margin, pm_state, YES/NO fills, position tracking). Android PM flow verified on-device end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
