### PR TITLE
feat: crypto custody (backend proxy + web + android native)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
@@ -1,0 +1,61 @@
+package com.testlogon.android.data.custody
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface for the session-authed custody surface. Paths are relative (no leading slash)
+ * so they resolve against the shared Retrofit base URL; the session cookie + CSRF header are attached
+ * by the core-network interceptor chain. All methods are suspend and return the typed DTO; a non-2xx
+ * surfaces as retrofit2.HttpException (403 on officer-only routes for a non-admin caller; 425 timelock
+ * / 409 under-approved on release).
+ */
+interface CustodyApi {
+
+    @GET("ui/custody/assets")
+    suspend fun assets(): List<CustodyAssetDto>
+
+    @GET("ui/custody/deposit-address")
+    suspend fun depositAddress(
+        @Query("asset") asset: String,
+        @Query("chain") chain: String,
+    ): CustodyDepositAddressDto
+
+    @GET("ui/custody/deposits")
+    suspend fun deposits(): List<CustodyDepositDto>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/custody/withdrawals")
+    suspend fun createWithdrawal(@Body body: CustodyWithdrawalRequestDto): CustodyWithdrawalResultDto
+
+    @GET("ui/custody/withdrawals")
+    suspend fun withdrawals(): List<CustodyWithdrawalDto>
+
+    @GET("ui/custody/withdrawals/{id}")
+    suspend fun withdrawal(@Path("id") id: String): CustodyWithdrawalDto
+
+    // Officer / admin (403 for a non-admin caller).
+
+    @GET("ui/custody/approvals")
+    suspend fun approvals(): List<CustodyWithdrawalDto>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/custody/withdrawals/{id}/approve")
+    suspend fun approve(
+        @Path("id") id: String,
+        @Body body: CustodyApproveRequestDto,
+    ): CustodyApproveResultDto
+
+    @POST("ui/custody/withdrawals/{id}/release")
+    suspend fun release(@Path("id") id: String): CustodyReleaseResultDto
+
+    @GET("ui/custody/audit")
+    suspend fun audit(): CustodyAuditDto
+
+    @GET("ui/custody/audit/verify")
+    suspend fun auditVerify(): CustodyAuditVerifyDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
@@ -1,0 +1,128 @@
+package com.testlogon.android.data.custody
+
+/*
+ * Domain models for the custody feature: null-safe, UI-ready projections of the wire DTOs. The
+ * repository maps DTO -> domain (defaulting blanks, parsing money strings to Double for validation /
+ * Max, and normalizing status codes to a sealed enum) so composables never touch raw wire shapes.
+ */
+
+/** A custodial asset row (one asset on one chain) with its available balance. */
+data class CustodyAsset(
+    val asset: String,
+    val chain: String,
+    val name: String,
+    val symbol: String,
+    val decimals: Int,
+    val network: String,
+    val balanceText: String,
+    val balance: Double,
+    val addressAvailable: Boolean,
+) {
+    /** Stable list key. */
+    val key: String get() = "$asset::$chain"
+}
+
+data class CustodyDepositAddress(
+    val asset: String,
+    val chain: String,
+    val network: String,
+    val address: String,
+    val memo: String?,
+)
+
+/** A pending/observed on-chain deposit. */
+data class CustodyDeposit(
+    val id: String,
+    val asset: String,
+    val chain: String,
+    val amountText: String,
+    val status: String,
+    val confirmations: Int,
+)
+
+/** Normalized withdrawal lifecycle status. */
+enum class WithdrawalStatus(val wire: String, val label: String) {
+    SCREENING("screening", "Screening"),
+    SIGNED("signed", "Signed"),
+    PENDING_APPROVAL("pending_approval", "Pending approval"),
+    BLOCKED("blocked", "Blocked"),
+    REJECTED("rejected", "Rejected"),
+    BROADCAST("broadcast", "Broadcast"),
+    SETTLED("settled", "Settled"),
+    UNKNOWN("", "Unknown");
+
+    /** Terminal statuses no longer advance, so the Activity poller can stop watching them. */
+    val isTerminal: Boolean
+        get() = this == BLOCKED || this == REJECTED || this == SETTLED
+
+    companion object {
+        fun from(wire: String?): WithdrawalStatus =
+            entries.firstOrNull { it.wire == wire?.trim()?.lowercase() } ?: UNKNOWN
+    }
+}
+
+/** The immediate result of submitting a withdrawal. */
+data class CustodyWithdrawalResult(
+    val id: String,
+    val status: WithdrawalStatus,
+    val asset: String,
+    val chain: String,
+    val amountText: String,
+    val destination: String,
+    val signature: String?,
+    val digest: String?,
+    val approvalsRequired: Int?,
+    val approvals: Int?,
+    /** Best-effort human reason on a blocked/rejected outcome (detail, else error). */
+    val reason: String?,
+    val category: String?,
+)
+
+/** A withdrawal record (list + detail projections share this shape). */
+data class CustodyWithdrawal(
+    val id: String,
+    val asset: String,
+    val chain: String,
+    val network: String,
+    val recipient: String,
+    val amountText: String,
+    val status: WithdrawalStatus,
+    val approvals: List<String>,
+    val approvalsCount: Int,
+    val approvalsRequired: Int,
+    val signature: String?,
+    val digest: String?,
+    val reason: String?,
+    val category: String?,
+    val timelockUntilMs: Long?,
+    val createdMs: Long?,
+)
+
+data class CustodyApproveResult(
+    val withdrawalId: String,
+    val status: WithdrawalStatus,
+    val approvals: List<String>,
+    val approvalsRequired: Int,
+)
+
+data class CustodyReleaseResult(
+    val withdrawalId: String,
+    val status: WithdrawalStatus,
+    val signature: String?,
+    val digest: String?,
+)
+
+data class CustodyAuditEntry(
+    val seq: Long,
+    val action: String,
+    val detail: String,
+    val tsMs: Long,
+    val prev: String,
+    val hash: String,
+)
+
+data class CustodyAudit(
+    val entries: List<CustodyAuditEntry>,
+    val verifiedOk: Boolean? = null,
+    val verifiedCount: Int? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
@@ -1,0 +1,153 @@
+package com.testlogon.android.data.custody
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.network.json.LenientInt
+import com.testlogon.android.core.network.json.LenientLong
+
+/*
+ * Wire DTOs for the session-authed custody surface (GET/POST the /ui/custody endpoints).
+ *
+ * Every serialized DTO carries @JsonClass(generateAdapter = true) so the :app unit-test Moshi
+ * (codegen-only, no reflection) can parse it. Money-ish fields (balance / amount) arrive as either a
+ * JSON number OR a numeric string depending on the backend encoder, so they are typed as String and
+ * parsed defensively at the domain boundary; whole-number wire fields (decimals / confirmations /
+ * approval counts / timestamps) use the existing @LenientInt / @LenientLong qualifiers, which tolerate
+ * a number, a numeric string, or an empty string.
+ */
+
+@JsonClass(generateAdapter = true)
+data class CustodyAssetDto(
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "chain") val chain: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "symbol") val symbol: String? = null,
+    @LenientInt @Json(name = "decimals") val decimals: Int? = null,
+    @Json(name = "network") val network: String? = null,
+    @Json(name = "balance") val balance: String? = null,
+    @Json(name = "address_available") val addressAvailable: Boolean? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CustodyDepositAddressDto(
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "chain") val chain: String? = null,
+    @Json(name = "network") val network: String? = null,
+    @Json(name = "address") val address: String? = null,
+    @Json(name = "memo") val memo: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CustodyDepositDto(
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "chain") val chain: String? = null,
+    @Json(name = "amount") val amount: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @LenientInt @Json(name = "confirmations") val confirmations: Int? = null,
+)
+
+/** Body for POST /ui/custody/withdrawals. */
+@JsonClass(generateAdapter = true)
+data class CustodyWithdrawalRequestDto(
+    @Json(name = "asset") val asset: String,
+    @Json(name = "chain") val chain: String,
+    @Json(name = "amount") val amount: String,
+    @Json(name = "destination") val destination: String,
+    @Json(name = "memo") val memo: String? = null,
+)
+
+/**
+ * The immediate POST /ui/custody/withdrawals result. status in signed | pending_approval | blocked |
+ * rejected. The detail / error / category / source fields carry the human-readable reason on a
+ * blocked/rejected outcome.
+ */
+@JsonClass(generateAdapter = true)
+data class CustodyWithdrawalResultDto(
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "chain") val chain: String? = null,
+    @Json(name = "amount") val amount: String? = null,
+    @Json(name = "destination") val destination: String? = null,
+    @Json(name = "signature") val signature: String? = null,
+    @Json(name = "digest") val digest: String? = null,
+    @LenientInt @Json(name = "approvals_required") val approvalsRequired: Int? = null,
+    @LenientInt @Json(name = "approvals") val approvals: Int? = null,
+    @Json(name = "error") val error: String? = null,
+    @Json(name = "category") val category: String? = null,
+    @Json(name = "source") val source: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+)
+
+/**
+ * A single withdrawal record from GET /ui/custody/withdrawals[/{id}] (also the officer approvals feed).
+ * The list projection is a subset; the detail projection adds chain_ref / network / recipient /
+ * approvals[] / timelock / created_ms. All fields optional so either projection parses.
+ */
+@JsonClass(generateAdapter = true)
+data class CustodyWithdrawalDto(
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "chain") val chain: String? = null,
+    @Json(name = "chain_ref") val chainRef: String? = null,
+    @Json(name = "network") val network: String? = null,
+    @Json(name = "recipient") val recipient: String? = null,
+    @Json(name = "destination") val destination: String? = null,
+    @Json(name = "amount") val amount: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "approvals") val approvals: List<String>? = null,
+    @LenientInt @Json(name = "approvals_count") val approvalsCount: Int? = null,
+    @LenientInt @Json(name = "approvals_required") val approvalsRequired: Int? = null,
+    @Json(name = "signature") val signature: String? = null,
+    @Json(name = "digest") val digest: String? = null,
+    @Json(name = "error") val error: String? = null,
+    @Json(name = "category") val category: String? = null,
+    @Json(name = "source") val source: String? = null,
+    @LenientLong @Json(name = "timelock_until_ms") val timelockUntilMs: Long? = null,
+    @LenientLong @Json(name = "created_ms") val createdMs: Long? = null,
+)
+
+/** Result of POST /ui/custody/withdrawals/{id}/approve. */
+@JsonClass(generateAdapter = true)
+data class CustodyApproveRequestDto(
+    @Json(name = "approver") val approver: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CustodyApproveResultDto(
+    @Json(name = "withdrawal_id") val withdrawalId: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "approvals") val approvals: List<String>? = null,
+    @LenientInt @Json(name = "approvals_required") val approvalsRequired: Int? = null,
+)
+
+/** Result of POST /ui/custody/withdrawals/{id}/release. */
+@JsonClass(generateAdapter = true)
+data class CustodyReleaseResultDto(
+    @Json(name = "withdrawal_id") val withdrawalId: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "signature") val signature: String? = null,
+    @Json(name = "digest") val digest: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CustodyAuditEntryDto(
+    @LenientLong @Json(name = "seq") val seq: Long? = null,
+    @Json(name = "action") val action: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @LenientLong @Json(name = "ts_ms") val tsMs: Long? = null,
+    @Json(name = "prev") val prev: String? = null,
+    @Json(name = "hash") val hash: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CustodyAuditDto(
+    @Json(name = "entries") val entries: List<CustodyAuditEntryDto>? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CustodyAuditVerifyDto(
+    @Json(name = "ok") val ok: Boolean? = null,
+    @LenientInt @Json(name = "entries") val entries: Int? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
@@ -1,0 +1,217 @@
+package com.testlogon.android.data.custody
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer for the custody surface. Maps wire DTOs to null-safe domain models and folds transport
+ * failures into [ApiResult] (HttpException -> Failure carrying the HTTP status, so the ViewModel can
+ * branch on 403 = not-an-officer, 425 = timelock, 409 = under-approved; IOException -> NetworkError).
+ * CancellationException is always re-thrown. Reads are safe to retry; the withdrawal POST is not
+ * auto-retried.
+ */
+@Singleton
+class CustodyRepository @Inject constructor(
+    private val api: CustodyApi,
+    private val errorParser: ApiErrorParser,
+) {
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    suspend fun loadAssets(): ApiResult<List<CustodyAsset>> = call {
+        api.assets().map { it.toDomain() }
+    }
+
+    suspend fun depositAddress(asset: String, chain: String): ApiResult<CustodyDepositAddress> = call {
+        api.depositAddress(asset, chain).toDomain(asset, chain)
+    }
+
+    suspend fun loadDeposits(): ApiResult<List<CustodyDeposit>> = call {
+        api.deposits().map { it.toDomain() }
+    }
+
+    suspend fun submitWithdrawal(
+        asset: String,
+        chain: String,
+        amount: String,
+        destination: String,
+        memo: String?,
+    ): ApiResult<CustodyWithdrawalResult> = call {
+        api.createWithdrawal(
+            CustodyWithdrawalRequestDto(
+                asset = asset,
+                chain = chain,
+                amount = amount,
+                destination = destination,
+                memo = memo?.takeIf { it.isNotBlank() },
+            ),
+        ).toDomain()
+    }
+
+    suspend fun loadWithdrawals(): ApiResult<List<CustodyWithdrawal>> = call {
+        api.withdrawals().map { it.toDomain() }
+    }
+
+    suspend fun loadWithdrawal(id: String): ApiResult<CustodyWithdrawal> = call {
+        api.withdrawal(id).toDomain()
+    }
+
+    suspend fun loadApprovals(): ApiResult<List<CustodyWithdrawal>> = call {
+        api.approvals().map { it.toDomain() }
+    }
+
+    suspend fun approve(id: String, approver: String?): ApiResult<CustodyApproveResult> = call {
+        api.approve(id, CustodyApproveRequestDto(approver = approver?.takeIf { it.isNotBlank() })).toDomain()
+    }
+
+    suspend fun release(id: String): ApiResult<CustodyReleaseResult> = call {
+        api.release(id).toDomain()
+    }
+
+    suspend fun loadAudit(): ApiResult<CustodyAudit> = call {
+        val a = api.audit()
+        val entries = a.entries.orEmpty().map { it.toDomain() }
+        CustodyAudit(entries = entries)
+    }
+
+    suspend fun verifyAudit(): ApiResult<CustodyAuditVerifyDto> = call {
+        api.auditVerify()
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = withContext(io) {
+        try {
+            ApiResult.Success(block())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Failure(errorParser.from(e))
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+}
+
+// ---- DTO -> domain mappers ----
+
+private fun String?.orDash(): String = this?.takeIf { it.isNotBlank() } ?: "—"
+
+private fun parseAmount(s: String?): Double = s?.trim()?.toDoubleOrNull() ?: 0.0
+
+private fun CustodyAssetDto.toDomain(): CustodyAsset {
+    val a = asset?.trim().orEmpty()
+    return CustodyAsset(
+        asset = a,
+        chain = chain?.trim().orEmpty(),
+        name = name?.takeIf { it.isNotBlank() } ?: (symbol ?: a),
+        symbol = symbol?.takeIf { it.isNotBlank() } ?: a,
+        decimals = decimals ?: 18,
+        network = network?.takeIf { it.isNotBlank() } ?: (chain ?: ""),
+        balanceText = balance?.trim()?.takeIf { it.isNotBlank() } ?: "0",
+        balance = parseAmount(balance),
+        addressAvailable = addressAvailable ?: false,
+    )
+}
+
+private fun CustodyDepositAddressDto.toDomain(reqAsset: String, reqChain: String): CustodyDepositAddress =
+    CustodyDepositAddress(
+        asset = asset?.takeIf { it.isNotBlank() } ?: reqAsset,
+        chain = chain?.takeIf { it.isNotBlank() } ?: reqChain,
+        network = network?.takeIf { it.isNotBlank() } ?: (chain ?: reqChain),
+        address = address?.trim().orEmpty(),
+        memo = memo?.takeIf { it.isNotBlank() },
+    )
+
+private fun CustodyDepositDto.toDomain(): CustodyDeposit =
+    CustodyDeposit(
+        id = id?.takeIf { it.isNotBlank() } ?: "",
+        asset = asset.orDash(),
+        chain = chain.orDash(),
+        amountText = amount?.trim()?.takeIf { it.isNotBlank() } ?: "0",
+        status = status?.takeIf { it.isNotBlank() } ?: "pending",
+        confirmations = confirmations ?: 0,
+    )
+
+private fun CustodyWithdrawalResultDto.toDomain(): CustodyWithdrawalResult =
+    CustodyWithdrawalResult(
+        id = id?.takeIf { it.isNotBlank() } ?: "",
+        status = WithdrawalStatus.from(status),
+        asset = asset.orDash(),
+        chain = chain.orDash(),
+        amountText = amount?.trim()?.takeIf { it.isNotBlank() } ?: "0",
+        destination = destination.orDash(),
+        signature = signature?.takeIf { it.isNotBlank() },
+        digest = digest?.takeIf { it.isNotBlank() },
+        approvalsRequired = approvalsRequired,
+        approvals = approvals,
+        reason = detail?.takeIf { it.isNotBlank() } ?: error?.takeIf { it.isNotBlank() },
+        category = category?.takeIf { it.isNotBlank() },
+    )
+
+private fun CustodyWithdrawalDto.toDomain(): CustodyWithdrawal =
+    CustodyWithdrawal(
+        id = id?.takeIf { it.isNotBlank() } ?: "",
+        asset = asset.orDash(),
+        chain = (chain ?: chainRef).orDash(),
+        network = network?.takeIf { it.isNotBlank() } ?: (chainRef ?: chain ?: ""),
+        recipient = (recipient ?: destination).orDash(),
+        amountText = amount?.trim()?.takeIf { it.isNotBlank() } ?: "0",
+        status = WithdrawalStatus.from(status),
+        approvals = approvals.orEmpty(),
+        approvalsCount = approvalsCount ?: approvals?.size ?: 0,
+        approvalsRequired = approvalsRequired ?: 0,
+        signature = signature?.takeIf { it.isNotBlank() },
+        digest = digest?.takeIf { it.isNotBlank() },
+        reason = error?.takeIf { it.isNotBlank() },
+        category = category?.takeIf { it.isNotBlank() },
+        timelockUntilMs = timelockUntilMs,
+        createdMs = createdMs,
+    )
+
+private fun CustodyApproveResultDto.toDomain(): CustodyApproveResult =
+    CustodyApproveResult(
+        withdrawalId = withdrawalId?.takeIf { it.isNotBlank() } ?: "",
+        status = WithdrawalStatus.from(status),
+        approvals = approvals.orEmpty(),
+        approvalsRequired = approvalsRequired ?: 0,
+    )
+
+private fun CustodyReleaseResultDto.toDomain(): CustodyReleaseResult =
+    CustodyReleaseResult(
+        withdrawalId = withdrawalId?.takeIf { it.isNotBlank() } ?: "",
+        status = WithdrawalStatus.from(status),
+        signature = signature?.takeIf { it.isNotBlank() },
+        digest = digest?.takeIf { it.isNotBlank() },
+    )
+
+private fun CustodyAuditEntryDto.toDomain(): CustodyAuditEntry =
+    CustodyAuditEntry(
+        seq = seq ?: 0L,
+        action = action?.takeIf { it.isNotBlank() } ?: "—",
+        detail = detail?.takeIf { it.isNotBlank() } ?: "",
+        tsMs = tsMs ?: 0L,
+        prev = prev.orEmpty(),
+        hash = hash.orEmpty(),
+    )
+
+/** Provides the custody Retrofit API (mirrors the auth data module's provider style). */
+@Module
+@InstallIn(SingletonComponent::class)
+object CustodyDataModule {
+
+    @Provides
+    @Singleton
+    fun provideCustodyApi(retrofit: Retrofit): CustodyApi = retrofit.create(CustodyApi::class.java)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
@@ -1,0 +1,736 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.custody
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Verified
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.custody.CustodyAsset
+import com.testlogon.android.data.custody.CustodyAuditEntry
+import com.testlogon.android.data.custody.CustodyDeposit
+import com.testlogon.android.data.custody.CustodyWithdrawal
+import com.testlogon.android.data.custody.CustodyWithdrawalResult
+import com.testlogon.android.data.custody.WithdrawalStatus
+import kotlinx.coroutines.delay
+
+/** Route-level Custody entry (reached from the More -> Wallet hub). */
+@Composable
+fun CustodyRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CustodyViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CustodyScreen(
+        state = state,
+        onBack = onBack,
+        viewModel = viewModel,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CustodyScreen(
+    state: CustodyUiState,
+    onBack: () -> Unit,
+    viewModel: CustodyViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val tabs = remember(state.approvals.isOfficer) {
+        buildList {
+            add(CustodyTab.BALANCES)
+            add(CustodyTab.DEPOSIT)
+            add(CustodyTab.WITHDRAW)
+            add(CustodyTab.ACTIVITY)
+            if (state.approvals.isOfficer) add(CustodyTab.APPROVALS)
+        }
+    }
+    val selectedIndex = tabs.indexOf(state.tab).let { if (it < 0) 0 else it }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Custody") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            ScrollableTabRow(selectedTabIndex = selectedIndex, edgePadding = 8.dp) {
+                tabs.forEach { tab ->
+                    Tab(
+                        selected = tab == state.tab,
+                        onClick = { viewModel.onTabSelected(tab) },
+                        text = { Text(tab.title()) },
+                    )
+                }
+            }
+            when (state.tab) {
+                CustodyTab.BALANCES -> BalancesTab(state, viewModel)
+                CustodyTab.DEPOSIT -> DepositTab(state, viewModel)
+                CustodyTab.WITHDRAW -> WithdrawTab(state, viewModel)
+                CustodyTab.ACTIVITY -> ActivityTab(state, viewModel)
+                CustodyTab.APPROVALS -> ApprovalsTab(state, viewModel)
+            }
+        }
+    }
+}
+
+private fun CustodyTab.title(): String = when (this) {
+    CustodyTab.BALANCES -> "Balances"
+    CustodyTab.DEPOSIT -> "Deposit"
+    CustodyTab.WITHDRAW -> "Withdraw"
+    CustodyTab.ACTIVITY -> "Activity"
+    CustodyTab.APPROVALS -> "Approvals"
+}
+
+// ---------------- Balances ----------------
+
+@Composable
+private fun BalancesTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    val a = state.assets
+    when {
+        a.loading && a.data == null -> LoadingBox()
+        a.error != null && a.data == null -> ErrorBox(a.error) { viewModel.loadAssets() }
+        a.data.isNullOrEmpty() -> EmptyBox("No custody assets yet.")
+        else -> LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            items(a.data, key = { it.key }) { asset ->
+                AssetCard(
+                    asset = asset,
+                    onDeposit = {
+                        viewModel.onTabSelected(CustodyTab.DEPOSIT)
+                        viewModel.onDepositAssetSelected(asset.key)
+                    },
+                    onWithdraw = {
+                        viewModel.onTabSelected(CustodyTab.WITHDRAW)
+                        viewModel.onWithdrawAssetSelected(asset.key)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssetCard(asset: CustodyAsset, onDeposit: () -> Unit, onWithdraw: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(asset.symbol, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        "${asset.name} · ${asset.network}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(asset.balanceText, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(asset.symbol, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onDeposit, enabled = asset.addressAvailable, modifier = Modifier.weight(1f)) {
+                    Text("Deposit")
+                }
+                Button(onClick = onWithdraw, enabled = asset.balance > 0.0, modifier = Modifier.weight(1f)) {
+                    Text("Withdraw")
+                }
+            }
+        }
+    }
+}
+
+// ---------------- Deposit ----------------
+
+@Composable
+private fun DepositTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    val assets = state.assets.data.orEmpty().filter { it.addressAvailable }
+    val clipboard = LocalClipboardManager.current
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("Select asset", style = MaterialTheme.typography.labelLarge)
+        AssetChipRow(
+            assets = assets,
+            selectedKey = state.deposit.selectedKey,
+            onSelect = { viewModel.onDepositAssetSelected(it) },
+        )
+        val addr = state.deposit.address
+        when {
+            state.deposit.selectedKey == null -> HintText("Choose an asset to see its deposit address.")
+            addr.loading -> LoadingBox()
+            addr.error != null -> ErrorBox(addr.error) {
+                state.deposit.selectedKey?.let { viewModel.onDepositAssetSelected(it) }
+            }
+            addr.data != null -> {
+                val data = addr.data
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        if (data.address.isNotBlank()) {
+                            QrCodeImage(content = data.address)
+                            Spacer(Modifier.height(12.dp))
+                        }
+                        Text(
+                            data.address,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        OutlinedButton(onClick = {
+                            clipboard.setText(AnnotatedString(data.address))
+                        }) {
+                            Icon(Icons.Filled.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text("Copy address")
+                        }
+                        if (!data.memo.isNullOrBlank()) {
+                            Spacer(Modifier.height(12.dp))
+                            LabeledValue("Memo / tag (required)", data.memo, copyable = true, clipboardText = data.memo)
+                        }
+                    }
+                }
+                WarningCard("Send only ${data.asset} on ${data.network}. Sending any other asset or using the wrong network may cause permanent loss.")
+            }
+        }
+
+        HorizontalDivider()
+        Text("Recent deposits", style = MaterialTheme.typography.titleSmall)
+        val dep = state.deposit.deposits
+        when {
+            dep.loading && dep.data == null -> LoadingBox()
+            dep.data.isNullOrEmpty() -> HintText("No deposits observed yet.")
+            else -> dep.data.forEach { DepositRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun DepositRow(d: CustodyDeposit) {
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("${d.amountText} ${d.asset}", fontWeight = FontWeight.Medium)
+                Text("${d.chain} · ${d.confirmations} confirmations", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            StatusPill(d.status)
+        }
+    }
+}
+
+// ---------------- Withdraw ----------------
+
+@Composable
+private fun WithdrawTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    val funded = state.fundedAssets
+    val w = state.withdraw
+    var showConfirm by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        if (funded.isEmpty()) {
+            HintText("You have no funded assets to withdraw.")
+            return@Column
+        }
+        Text("Asset", style = MaterialTheme.typography.labelLarge)
+        AssetChipRow(assets = funded, selectedKey = w.selectedKey, onSelect = { viewModel.onWithdrawAssetSelected(it) })
+        val asset = state.assetFor(w.selectedKey)
+        if (asset != null) {
+            Text(
+                "Available: ${asset.balanceText} ${asset.symbol} on ${asset.network}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        OutlinedTextField(
+            value = w.amount,
+            onValueChange = viewModel::onAmountChanged,
+            label = { Text("Amount") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            trailingIcon = {
+                TextButton(onClick = { viewModel.onMax() }, enabled = asset != null) { Text("Max") }
+            },
+        )
+        OutlinedTextField(
+            value = w.destination,
+            onValueChange = viewModel::onDestinationChanged,
+            label = { Text("Destination address") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = w.memo,
+            onValueChange = viewModel::onMemoChanged,
+            label = { Text("Memo / tag (optional)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (w.submitError != null) {
+            Text(w.submitError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+        Button(
+            onClick = {
+                val err = viewModel.validateWithdraw()
+                if (err == null) showConfirm = true else viewModel.onAmountChanged(w.amount)
+            },
+            enabled = !w.submitting && asset != null,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (w.submitting) {
+                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                Spacer(Modifier.width(8.dp))
+            }
+            Text("Review withdrawal")
+        }
+
+        if (w.result != null) {
+            WithdrawResultCard(w.result) { viewModel.clearWithdrawResult() }
+        }
+    }
+
+    if (showConfirm) {
+        val asset = state.assetFor(w.selectedKey)
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text("Confirm withdrawal") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    ConfirmRow("Asset", asset?.symbol ?: "—")
+                    ConfirmRow("Network", asset?.network ?: "—")
+                    ConfirmRow("Amount", "${w.amount} ${asset?.symbol ?: ""}")
+                    ConfirmRow("Destination", w.destination)
+                    if (w.memo.isNotBlank()) ConfirmRow("Memo", w.memo)
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "Double-check the address and network. On-chain transfers cannot be reversed.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    showConfirm = false
+                    viewModel.submitWithdraw()
+                }) { Text("Confirm & submit") }
+            },
+            dismissButton = { TextButton(onClick = { showConfirm = false }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun ConfirmRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text("$label:", modifier = Modifier.width(96.dp), color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+        Text(value, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+private fun WithdrawResultCard(r: CustodyWithdrawalResult, onDismiss: () -> Unit) {
+    val (container, content) = when (r.status) {
+        WithdrawalStatus.SIGNED -> MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+        WithdrawalStatus.PENDING_APPROVAL -> MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+        WithdrawalStatus.BLOCKED, WithdrawalStatus.REJECTED -> MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+        else -> MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = container, contentColor = content)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            when (r.status) {
+                WithdrawalStatus.SIGNED -> {
+                    Text("Signed ✓", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    r.digest?.let { Text("Digest: ${it.short()}", fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodySmall) }
+                    r.signature?.let { Text("Sig: ${it.short()}", fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodySmall) }
+                }
+                WithdrawalStatus.PENDING_APPROVAL -> {
+                    Text("Pending approval", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text("${r.approvals ?: 0} of ${r.approvalsRequired ?: 0} approvals collected.")
+                }
+                WithdrawalStatus.BLOCKED -> {
+                    Text("Blocked", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(r.reason ?: "This withdrawal was blocked by policy.")
+                }
+                WithdrawalStatus.REJECTED -> {
+                    Text("Rejected", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(r.reason ?: "This withdrawal was rejected.")
+                }
+                else -> {
+                    Text(r.status.label, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                }
+            }
+            Text("${r.amountText} ${r.asset} -> ${r.destination.short()}", style = MaterialTheme.typography.bodySmall)
+            TextButton(onClick = onDismiss) { Text("Done") }
+        }
+    }
+}
+
+// ---------------- Activity ----------------
+
+@Composable
+private fun ActivityTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    // Drive polling from the screen: re-fetch every 5s while any row is non-terminal, stop otherwise.
+    // Bounded loop tied to composition (leaves when the tab/screen leaves).
+    LaunchedEffect(Unit) {
+        while (true) {
+            val keepGoing = viewModel.pollActivityOnce()
+            if (!keepGoing) break
+            delay(5_000)
+        }
+    }
+    val act = state.activity
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text("Withdrawals", style = MaterialTheme.typography.titleSmall, modifier = Modifier.weight(1f))
+            IconButton(onClick = { viewModel.loadActivity() }) {
+                Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+            }
+        }
+        when {
+            act.loading && act.data == null -> LoadingBox()
+            act.error != null && act.data == null -> ErrorBox(act.error) { viewModel.loadActivity() }
+            act.data.isNullOrEmpty() -> EmptyBox("No withdrawals yet.")
+            else -> LazyColumn(
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(act.data, key = { it.id }) { wd -> WithdrawalCard(wd) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WithdrawalCard(wd: CustodyWithdrawal) {
+    var expanded by remember { mutableStateOf(false) }
+    Card(modifier = Modifier.fillMaxWidth().clickable { expanded = !expanded }) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("${wd.amountText} ${wd.asset}", fontWeight = FontWeight.SemiBold)
+                    Text("-> ${wd.recipient.short()}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                StatusPill(wd.status.label)
+            }
+            if (wd.status == WithdrawalStatus.PENDING_APPROVAL && wd.approvalsRequired > 0) {
+                Spacer(Modifier.height(8.dp))
+                Text("${wd.approvalsCount} of ${wd.approvalsRequired} approvals", style = MaterialTheme.typography.bodySmall)
+                LinearProgressIndicator(
+                    progress = { (wd.approvalsCount.toFloat() / wd.approvalsRequired).coerceIn(0f, 1f) },
+                    modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                )
+            }
+            if (expanded) {
+                Spacer(Modifier.height(8.dp))
+                HorizontalDivider()
+                Spacer(Modifier.height(8.dp))
+                DetailRow("Network", wd.network)
+                DetailRow("Recipient", wd.recipient)
+                wd.digest?.let { DetailRow("Digest", it.short()) }
+                wd.signature?.let { DetailRow("Signature", it.short()) }
+                wd.reason?.let { DetailRow("Reason", it) }
+                wd.category?.let { DetailRow("Category", it) }
+                TimelockCountdown(wd.timelockUntilMs)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelockCountdown(untilMs: Long?) {
+    if (untilMs == null || untilMs <= 0L) return
+    var now by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(untilMs) {
+        while (true) {
+            now = System.currentTimeMillis()
+            if (now >= untilMs) break
+            delay(1_000)
+        }
+    }
+    val remaining = (untilMs - now).coerceAtLeast(0L)
+    val text = if (remaining <= 0L) "Timelock elapsed" else "Timelock: ${formatDuration(remaining)}"
+    DetailRow("Timelock", text)
+}
+
+// ---------------- Approvals & Audit ----------------
+
+@Composable
+private fun ApprovalsTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    val ap = state.approvals
+    if (!ap.isOfficer) {
+        EmptyBox("Approvals are available to custody officers only.")
+        return
+    }
+    Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("Pending queue", style = MaterialTheme.typography.titleSmall)
+        val q = ap.queue
+        when {
+            q.loading && q.data == null -> LoadingBox()
+            q.error != null && q.data == null -> ErrorBox(q.error) { viewModel.loadApprovals() }
+            q.data.isNullOrEmpty() -> HintText("Nothing awaiting approval.")
+            else -> q.data.forEach { wd ->
+                ApprovalCard(
+                    wd = wd,
+                    actioning = wd.id in ap.actioning,
+                    message = ap.actionMessages[wd.id],
+                    onApprove = { viewModel.approve(wd.id) },
+                    onRelease = { viewModel.release(wd.id) },
+                )
+            }
+        }
+
+        HorizontalDivider()
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Audit trail", style = MaterialTheme.typography.titleSmall, modifier = Modifier.weight(1f))
+            TextButton(onClick = { viewModel.verifyAudit() }) {
+                Icon(Icons.Filled.Verified, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(4.dp))
+                Text("Verify")
+            }
+        }
+        val au = ap.audit
+        au.data?.let { audit ->
+            if (audit.verifiedOk != null) {
+                val ok = audit.verifiedOk
+                AssistChip(
+                    onClick = {},
+                    label = { Text(if (ok) "Chain verified (${audit.verifiedCount ?: audit.entries.size} entries)" else "Verification FAILED") },
+                    leadingIcon = { Icon(if (ok) Icons.Filled.Verified else Icons.Filled.Warning, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                )
+            }
+        }
+        when {
+            au.loading && au.data == null -> LoadingBox()
+            au.error != null && au.data == null -> ErrorBox(au.error) { viewModel.loadAudit() }
+            au.data == null || au.data.entries.isEmpty() -> HintText("No audit entries.")
+            else -> au.data.entries.forEach { AuditRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun ApprovalCard(
+    wd: CustodyWithdrawal,
+    actioning: Boolean,
+    message: String?,
+    onApprove: () -> Unit,
+    onRelease: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("${wd.amountText} ${wd.asset}", fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                StatusPill(wd.status.label)
+            }
+            Text("-> ${wd.recipient.short()}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("${wd.approvalsCount} of ${wd.approvalsRequired} approvals", style = MaterialTheme.typography.bodySmall)
+            wd.reason?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error) }
+            if (message != null) {
+                Text(message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onApprove, enabled = !actioning, modifier = Modifier.weight(1f)) { Text("Approve") }
+                Button(onClick = onRelease, enabled = !actioning, modifier = Modifier.weight(1f)) { Text("Release") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AuditRow(e: CustodyAuditEntry) {
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("#${e.seq} ${e.action}", fontWeight = FontWeight.Medium, modifier = Modifier.weight(1f))
+                Text(e.hash.short(), fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (e.detail.isNotBlank()) {
+                Text(e.detail, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+// ---------------- shared bits ----------------
+
+@Composable
+private fun AssetChipRow(assets: List<CustodyAsset>, selectedKey: String?, onSelect: (String) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        assets.forEach { asset ->
+            FilterChip(
+                selected = asset.key == selectedKey,
+                onClick = { onSelect(asset.key) },
+                label = { Text(asset.symbol) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LabeledValue(label: String, value: String, copyable: Boolean = false, clipboardText: String = value) {
+    val clipboard = LocalClipboardManager.current
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(value, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+            if (copyable) {
+                IconButton(onClick = { clipboard.setText(AnnotatedString(clipboardText)) }) {
+                    Icon(Icons.Filled.ContentCopy, contentDescription = "Copy", modifier = Modifier.size(18.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Text("$label:", modifier = Modifier.width(96.dp), color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+        Text(value, style = MaterialTheme.typography.bodySmall, fontFamily = if (label in setOf("Digest", "Signature")) FontFamily.Monospace else FontFamily.Default)
+    }
+}
+
+@Composable
+private fun StatusPill(status: String) {
+    val color = when (status.lowercase()) {
+        "signed", "settled" -> MaterialTheme.colorScheme.secondaryContainer
+        "pending approval", "screening", "broadcast" -> MaterialTheme.colorScheme.tertiaryContainer
+        "blocked", "rejected" -> MaterialTheme.colorScheme.errorContainer
+        else -> MaterialTheme.colorScheme.surfaceVariant
+    }
+    Box(
+        modifier = Modifier
+            .background(color, RoundedCornerShape(50))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(status, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun WarningCard(text: String) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer, contentColor = MaterialTheme.colorScheme.onErrorContainer), modifier = Modifier.fillMaxWidth()) {
+        Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Filled.Warning, contentDescription = null, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(text, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun LoadingBox() {
+    Box(modifier = Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorBox(message: String, onRetry: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth().padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(message, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium)
+        Button(onClick = onRetry) { Text("Retry") }
+    }
+}
+
+@Composable
+private fun EmptyBox(message: String) {
+    Box(modifier = Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+        Text(message, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun HintText(text: String) {
+    Text(text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+}
+
+// short hash/address display helper.
+private fun String.short(): String = if (length <= 16) this else "${take(8)}…${takeLast(6)}"
+
+private fun formatDuration(ms: Long): String {
+    val totalSec = ms / 1000
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    val s = totalSec % 60
+    return if (h > 0) "%dh %02dm %02ds".format(h, m, s) else "%dm %02ds".format(m, s)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
@@ -1,0 +1,327 @@
+package com.testlogon.android.feature.custody
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.custody.CustodyAsset
+import com.testlogon.android.data.custody.CustodyAudit
+import com.testlogon.android.data.custody.CustodyDeposit
+import com.testlogon.android.data.custody.CustodyDepositAddress
+import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.custody.CustodyWithdrawal
+import com.testlogon.android.data.custody.CustodyWithdrawalResult
+import com.testlogon.android.data.custody.WithdrawalStatus
+import com.testlogon.android.data.feed.CurrentUserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** The five in-screen custody tabs. Approvals is only present for an officer/admin caller. */
+enum class CustodyTab { BALANCES, DEPOSIT, WITHDRAW, ACTIVITY, APPROVALS }
+
+/** A generic async slice: loading / error(message) / data. */
+data class Async<out T>(
+    val loading: Boolean = false,
+    val error: String? = null,
+    val data: T? = null,
+)
+
+/** Deposit-tab state: the selected asset + resolved address + recent deposits. */
+data class DepositUiState(
+    val selectedKey: String? = null,
+    val address: Async<CustodyDepositAddress> = Async(),
+    val deposits: Async<List<CustodyDeposit>> = Async(),
+)
+
+/** Withdraw form + submit result. */
+data class WithdrawUiState(
+    val selectedKey: String? = null,
+    val amount: String = "",
+    val destination: String = "",
+    val memo: String = "",
+    val submitting: Boolean = false,
+    val result: CustodyWithdrawalResult? = null,
+    val submitError: String? = null,
+)
+
+/** Officer approvals queue + audit trail. */
+data class ApprovalsUiState(
+    val isOfficer: Boolean = false,
+    val checkedOfficer: Boolean = false,
+    val queue: Async<List<CustodyWithdrawal>> = Async(),
+    val audit: Async<CustodyAudit> = Async(),
+    /** Per-withdrawal action feedback keyed by id (approve/release outcome). */
+    val actionMessages: Map<String, String> = emptyMap(),
+    val actioning: Set<String> = emptySet(),
+)
+
+data class CustodyUiState(
+    val tab: CustodyTab = CustodyTab.BALANCES,
+    val assets: Async<List<CustodyAsset>> = Async(loading = true),
+    val deposit: DepositUiState = DepositUiState(),
+    val withdraw: WithdrawUiState = WithdrawUiState(),
+    val activity: Async<List<CustodyWithdrawal>> = Async(),
+    val approvals: ApprovalsUiState = ApprovalsUiState(),
+) {
+    val fundedAssets: List<CustodyAsset> get() = assets.data.orEmpty().filter { it.balance > 0.0 }
+    fun assetFor(key: String?): CustodyAsset? = assets.data.orEmpty().firstOrNull { it.key == key }
+}
+
+@HiltViewModel
+class CustodyViewModel @Inject constructor(
+    private val repo: CustodyRepository,
+    private val currentUser: CurrentUserRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CustodyUiState())
+    val uiState: StateFlow<CustodyUiState> = _uiState.asStateFlow()
+
+    init {
+        loadAssets()
+        checkOfficer()
+    }
+
+    // ---- tab + selection ----
+
+    fun onTabSelected(tab: CustodyTab) {
+        _uiState.update { it.copy(tab = tab) }
+        when (tab) {
+            CustodyTab.ACTIVITY -> if (_uiState.value.activity.data == null) loadActivity()
+            CustodyTab.APPROVALS -> {
+                loadApprovals()
+                loadAudit()
+            }
+            else -> Unit
+        }
+    }
+
+    fun loadAssets() {
+        _uiState.update { it.copy(assets = it.assets.copy(loading = true, error = null)) }
+        viewModelScope.launch {
+            _uiState.update { st ->
+                st.copy(assets = repo.loadAssets().toAsync())
+            }
+        }
+    }
+
+    // ---- deposit ----
+
+    fun onDepositAssetSelected(key: String) {
+        _uiState.update { it.copy(deposit = it.deposit.copy(selectedKey = key, address = Async(loading = true))) }
+        val asset = _uiState.value.assetFor(key) ?: return
+        viewModelScope.launch {
+            val res = repo.depositAddress(asset.asset, asset.chain)
+            _uiState.update { it.copy(deposit = it.deposit.copy(address = res.toAsync())) }
+        }
+        loadDeposits()
+    }
+
+    fun loadDeposits() {
+        _uiState.update { it.copy(deposit = it.deposit.copy(deposits = it.deposit.deposits.copy(loading = true))) }
+        viewModelScope.launch {
+            _uiState.update { it.copy(deposit = it.deposit.copy(deposits = repo.loadDeposits().toAsync())) }
+        }
+    }
+
+    // ---- withdraw ----
+
+    fun onWithdrawAssetSelected(key: String) {
+        _uiState.update { it.copy(withdraw = it.withdraw.copy(selectedKey = key, submitError = null, result = null)) }
+    }
+
+    fun onAmountChanged(v: String) {
+        _uiState.update { it.copy(withdraw = it.withdraw.copy(amount = v, submitError = null)) }
+    }
+
+    fun onDestinationChanged(v: String) {
+        _uiState.update { it.copy(withdraw = it.withdraw.copy(destination = v, submitError = null)) }
+    }
+
+    fun onMemoChanged(v: String) {
+        _uiState.update { it.copy(withdraw = it.withdraw.copy(memo = v)) }
+    }
+
+    fun onMax() {
+        val w = _uiState.value.withdraw
+        val asset = _uiState.value.assetFor(w.selectedKey) ?: return
+        _uiState.update { it.copy(withdraw = it.withdraw.copy(amount = asset.balanceText.trim(), submitError = null)) }
+    }
+
+    /** Validates the current form; returns an error string, or null if OK to submit. */
+    fun validateWithdraw(): String? {
+        val w = _uiState.value.withdraw
+        val asset = _uiState.value.assetFor(w.selectedKey) ?: return "Select an asset."
+        val amt = w.amount.trim().toDoubleOrNull()
+        if (amt == null || amt <= 0.0) return "Enter an amount greater than 0."
+        if (amt > asset.balance) return "Amount exceeds your ${asset.symbol} balance."
+        if (w.destination.trim().isEmpty()) return "Enter a destination address."
+        return null
+    }
+
+    fun submitWithdraw() {
+        val err = validateWithdraw()
+        if (err != null) {
+            _uiState.update { it.copy(withdraw = it.withdraw.copy(submitError = err)) }
+            return
+        }
+        val w = _uiState.value.withdraw
+        val asset = _uiState.value.assetFor(w.selectedKey) ?: return
+        _uiState.update { it.copy(withdraw = it.withdraw.copy(submitting = true, submitError = null, result = null)) }
+        viewModelScope.launch {
+            when (val r = repo.submitWithdrawal(asset.asset, asset.chain, w.amount.trim(), w.destination.trim(), w.memo)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(withdraw = it.withdraw.copy(submitting = false, result = r.data))
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(withdraw = it.withdraw.copy(submitting = false, submitError = r.error.message))
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(withdraw = it.withdraw.copy(submitting = false, submitError = "Network error. Check your connection and try again."))
+                }
+            }
+            // Refresh balances + activity so the new withdrawal shows and the balance reflects the debit.
+            loadAssets()
+            loadActivity()
+        }
+    }
+
+    /** Clears the withdraw result/form after the user acknowledges the outcome. */
+    fun clearWithdrawResult() {
+        _uiState.update {
+            it.copy(withdraw = it.withdraw.copy(result = null, amount = "", destination = "", memo = "", submitError = null))
+        }
+    }
+
+    // ---- activity ----
+
+    fun loadActivity() {
+        _uiState.update { it.copy(activity = it.activity.copy(loading = it.activity.data == null, error = null)) }
+        viewModelScope.launch {
+            _uiState.update { it.copy(activity = repo.loadWithdrawals().toAsync()) }
+        }
+    }
+
+    /**
+     * One polling pass: silently re-fetch withdrawals so non-terminal rows advance. Driven from the
+     * screen via a LaunchedEffect loop (NOT an unbounded loop in init), so it stops when the screen
+     * leaves composition. No-ops (returns false) once every row is terminal, letting the screen stop.
+     */
+    suspend fun pollActivityOnce(): Boolean {
+        val current = _uiState.value.activity.data.orEmpty()
+        val hasNonTerminal = current.isEmpty() || current.any { !it.status.isTerminal }
+        val res = repo.loadWithdrawals()
+        if (res is ApiResult.Success) {
+            _uiState.update { it.copy(activity = it.activity.copy(loading = false, error = null, data = res.data)) }
+        }
+        val after = (_uiState.value.activity.data).orEmpty()
+        return hasNonTerminal && (after.isEmpty() || after.any { !it.status.isTerminal })
+    }
+
+    // ---- officer approvals + audit ----
+
+    private fun checkOfficer() {
+        viewModelScope.launch {
+            val res = currentUser.isAdmin()
+            val officer = (res as? ApiResult.Success)?.data ?: false
+            _uiState.update { it.copy(approvals = it.approvals.copy(isOfficer = officer, checkedOfficer = true)) }
+        }
+    }
+
+    fun loadApprovals() {
+        _uiState.update { it.copy(approvals = it.approvals.copy(queue = it.approvals.queue.copy(loading = true, error = null))) }
+        viewModelScope.launch {
+            val res = repo.loadApprovals()
+            // A 403 here means the caller is not actually an officer; reflect that + do not show an error.
+            if (res is ApiResult.Failure && res.error.status == 403) {
+                _uiState.update {
+                    it.copy(approvals = it.approvals.copy(isOfficer = false, checkedOfficer = true, queue = Async(data = emptyList())))
+                }
+                return@launch
+            }
+            _uiState.update { it.copy(approvals = it.approvals.copy(queue = res.toAsync())) }
+        }
+    }
+
+    fun loadAudit() {
+        _uiState.update { it.copy(approvals = it.approvals.copy(audit = it.approvals.audit.copy(loading = true, error = null))) }
+        viewModelScope.launch {
+            _uiState.update { it.copy(approvals = it.approvals.copy(audit = repo.loadAudit().toAsync())) }
+        }
+    }
+
+    fun verifyAudit() {
+        viewModelScope.launch {
+            when (val r = repo.verifyAudit()) {
+                is ApiResult.Success -> _uiState.update { st ->
+                    val existing = st.approvals.audit.data
+                    val merged = existing?.copy(verifiedOk = r.data.ok, verifiedCount = r.data.entries)
+                    st.copy(approvals = st.approvals.copy(audit = st.approvals.audit.copy(data = merged)))
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    fun approve(id: String) {
+        setActioning(id, true)
+        viewModelScope.launch {
+            val msg = when (val r = repo.approve(id, approver = null)) {
+                is ApiResult.Success -> "Approved (${r.data.approvals.size} of ${r.data.approvalsRequired})"
+                is ApiResult.Failure -> r.error.message
+                is ApiResult.NetworkError -> "Network error."
+            }
+            postAction(id, msg)
+            loadApprovals()
+        }
+    }
+
+    fun release(id: String) {
+        setActioning(id, true)
+        viewModelScope.launch {
+            val msg = when (val r = repo.release(id)) {
+                is ApiResult.Success -> "Released — signed ✓"
+                is ApiResult.Failure -> when (r.error.status) {
+                    425 -> "Timelock not yet elapsed."
+                    409 -> "Not enough approvals yet."
+                    else -> r.error.message
+                }
+                is ApiResult.NetworkError -> "Network error."
+            }
+            postAction(id, msg)
+            loadApprovals()
+        }
+    }
+
+    private fun setActioning(id: String, on: Boolean) {
+        _uiState.update {
+            val s = it.approvals.actioning.toMutableSet()
+            if (on) s.add(id) else s.remove(id)
+            it.copy(approvals = it.approvals.copy(actioning = s))
+        }
+    }
+
+    private fun postAction(id: String, message: String) {
+        _uiState.update {
+            val s = it.approvals.actioning.toMutableSet().apply { remove(id) }
+            it.copy(approvals = it.approvals.copy(actioning = s, actionMessages = it.approvals.actionMessages + (id to message)))
+        }
+    }
+}
+
+// ---- ApiResult -> Async projection ----
+
+private fun <T> ApiResult<T>.toAsync(): Async<T> = when (this) {
+    is ApiResult.Success -> Async(loading = false, error = null, data = data)
+    is ApiResult.Failure -> Async(loading = false, error = error.messageFor())
+    is ApiResult.NetworkError -> Async(loading = false, error = "Network error. Check your connection and try again.")
+}
+
+private fun ApiError.messageFor(): String = when (status) {
+    403 -> "You do not have access to this."
+    else -> message
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/QrCode.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/QrCode.kt
@@ -1,0 +1,391 @@
+package com.testlogon.android.feature.custody
+
+/*
+ * A tiny, self-contained QR Code generator (byte mode) — vendored so the Deposit screen can render a
+ * scannable address WITHOUT adding a gradle dependency (e.g. zxing). This is a compact, from-scratch
+ * implementation of the QR Code model-2 encoding for the low-to-medium version range that a crypto
+ * address / URI needs; it produces a square boolean matrix that a Compose Canvas paints as modules.
+ *
+ * Adapted from the public-domain "QR Code generator" reference algorithm (Nayuki), trimmed to the
+ * byte-mode / single-segment path this feature uses. No external I/O, no reflection, no dependency.
+ */
+object QrCode {
+
+    /** Error-correction level. MEDIUM is a good default for on-screen scanning of a wallet address. */
+    enum class Ecc(val formatBits: Int) {
+        LOW(1), MEDIUM(0), QUARTILE(3), HIGH(2)
+    }
+
+    /**
+     * Encodes [text] (UTF-8, byte mode) into a square QR matrix. Returns the module grid where true =
+     * dark. Returns null if the text is too long for the largest supported version (should not happen
+     * for an address). Never throws on ordinary input.
+     */
+    fun encode(text: String, ecc: Ecc = Ecc.MEDIUM): Array<BooleanArray>? {
+        val data = text.toByteArray(Charsets.UTF_8)
+        // Byte-mode segment: 4-bit mode indicator + char-count + payload bytes.
+        for (version in 1..40) {
+            val dataCapacityBits = numDataCodewords(version, ecc) * 8
+            val ccBits = if (version <= 9) 8 else 16
+            val usedBits = 4 + ccBits + data.size * 8
+            if (usedBits <= dataCapacityBits) {
+                return build(version, ecc, data, ccBits)
+            }
+        }
+        return null
+    }
+
+    private fun build(version: Int, ecc: Ecc, data: ByteArray, ccBits: Int): Array<BooleanArray> {
+        val bb = BitBuffer()
+        bb.appendBits(0x4, 4) // byte mode
+        bb.appendBits(data.size, ccBits)
+        for (b in data) bb.appendBits(b.toInt() and 0xFF, 8)
+
+        val dataCapacityBits = numDataCodewords(version, ecc) * 8
+        // Terminator + bit/byte padding.
+        bb.appendBits(0, minOf(4, dataCapacityBits - bb.size))
+        bb.appendBits(0, (8 - bb.size % 8) % 8)
+        var pad = 0xEC
+        while (bb.size < dataCapacityBits) {
+            bb.appendBits(pad, 8)
+            pad = pad xor 0xFD // toggles 0xEC <-> 0x11
+        }
+
+        val allCodewords = addEccAndInterleave(bb.toBytes(), version, ecc)
+        val qr = QrMatrix(version, ecc)
+        qr.drawFunctionPatterns()
+        qr.drawCodewords(allCodewords)
+        qr.applyBestMask()
+        return qr.modules
+    }
+
+    // ---- capacity tables (data codewords per version+ecc), model 2 ----
+
+    private val ECC_CODEWORDS_PER_BLOCK = arrayOf(
+        // version 1..40 (index 0 unused)
+        intArrayOf(-1, 7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30), // LOW
+        intArrayOf(-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28), // MEDIUM
+        intArrayOf(-1, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30), // QUARTILE
+        intArrayOf(-1, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30), // HIGH
+    )
+    private val NUM_ERROR_CORRECTION_BLOCKS = arrayOf(
+        intArrayOf(-1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 4, 6, 6, 6, 6, 7, 8, 8, 9, 9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25), // LOW
+        intArrayOf(-1, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5, 5, 8, 9, 9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49), // MEDIUM
+        intArrayOf(-1, 1, 1, 2, 2, 4, 4, 6, 6, 8, 8, 8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68), // QUARTILE
+        intArrayOf(-1, 1, 1, 2, 4, 4, 4, 5, 6, 8, 8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 81), // HIGH
+    )
+
+    private fun eccIndex(ecc: Ecc) = when (ecc) {
+        Ecc.LOW -> 0; Ecc.MEDIUM -> 1; Ecc.QUARTILE -> 2; Ecc.HIGH -> 3
+    }
+
+    private fun numRawDataModules(ver: Int): Int {
+        var result = (16 * ver + 128) * ver + 64
+        if (ver >= 2) {
+            val numAlign = ver / 7 + 2
+            result -= (25 * numAlign - 10) * numAlign - 55
+            if (ver >= 7) result -= 36
+        }
+        return result
+    }
+
+    private fun numDataCodewords(ver: Int, ecc: Ecc): Int {
+        val e = eccIndex(ecc)
+        val numBlocks = NUM_ERROR_CORRECTION_BLOCKS[e][ver]
+        val eccPerBlock = ECC_CODEWORDS_PER_BLOCK[e][ver]
+        return numRawDataModules(ver) / 8 - eccPerBlock * numBlocks
+    }
+
+    // ---- Reed-Solomon ECC + interleave ----
+
+    private fun addEccAndInterleave(data: ByteArray, ver: Int, ecc: Ecc): ByteArray {
+        val e = eccIndex(ecc)
+        val numBlocks = NUM_ERROR_CORRECTION_BLOCKS[e][ver]
+        val blockEccLen = ECC_CODEWORDS_PER_BLOCK[e][ver]
+        val rawCodewords = numRawDataModules(ver) / 8
+        val numShortBlocks = numBlocks - rawCodewords % numBlocks
+        val shortBlockLen = rawCodewords / numBlocks
+
+        val blocks = ArrayList<ByteArray>()
+        val rsDiv = reedSolomonComputeDivisor(blockEccLen)
+        var k = 0
+        for (i in 0 until numBlocks) {
+            val datLen = shortBlockLen - blockEccLen + (if (i < numShortBlocks) 0 else 1)
+            val dat = data.copyOfRange(k, k + datLen)
+            k += datLen
+            val block = ByteArray(shortBlockLen + 1)
+            System.arraycopy(dat, 0, block, 0, dat.size)
+            val eccBytes = reedSolomonComputeRemainder(dat, rsDiv)
+            System.arraycopy(eccBytes, 0, block, block.size - blockEccLen, eccBytes.size)
+            blocks.add(block)
+        }
+
+        val result = ByteArray(rawCodewords)
+        var idx = 0
+        for (i in 0 until blocks[0].size) {
+            for (j in blocks.indices) {
+                if (i != shortBlockLen - blockEccLen || j >= numShortBlocks) {
+                    result[idx] = blocks[j][i]
+                    idx++
+                }
+            }
+        }
+        return result
+    }
+
+    private fun reedSolomonComputeDivisor(degree: Int): ByteArray {
+        val result = ByteArray(degree)
+        result[degree - 1] = 1
+        var root = 1
+        for (i in 0 until degree) {
+            for (j in 0 until degree) {
+                result[j] = reedSolomonMultiply(result[j].toInt() and 0xFF, root).toByte()
+                if (j + 1 < degree) {
+                    result[j] = (result[j].toInt() xor (result[j + 1].toInt() and 0xFF)).toByte()
+                }
+            }
+            root = reedSolomonMultiply(root, 0x02)
+        }
+        return result
+    }
+
+    private fun reedSolomonComputeRemainder(data: ByteArray, divisor: ByteArray): ByteArray {
+        val result = ByteArray(divisor.size)
+        for (b in data) {
+            val factor = (b.toInt() xor result[0].toInt()) and 0xFF
+            System.arraycopy(result, 1, result, 0, result.size - 1)
+            result[result.size - 1] = 0
+            for (i in result.indices) {
+                result[i] = (result[i].toInt() xor reedSolomonMultiply(divisor[i].toInt() and 0xFF, factor)).toByte()
+            }
+        }
+        return result
+    }
+
+    private fun reedSolomonMultiply(x: Int, y: Int): Int {
+        var z = 0
+        for (i in 7 downTo 0) {
+            z = (z shl 1) xor ((z ushr 7) * 0x11D)
+            z = z xor ((y ushr i) and 1) * x
+        }
+        return z and 0xFF
+    }
+
+    // ---- matrix builder + masking ----
+
+    private class QrMatrix(val version: Int, val ecc: Ecc) {
+        val size = version * 4 + 17
+        val modules = Array(size) { BooleanArray(size) }
+        private val isFunction = Array(size) { BooleanArray(size) }
+
+        fun drawFunctionPatterns() {
+            for (i in 0 until size) {
+                setFunctionModule(6, i, i % 2 == 0)
+                setFunctionModule(i, 6, i % 2 == 0)
+            }
+            drawFinderPattern(3, 3)
+            drawFinderPattern(size - 4, 3)
+            drawFinderPattern(3, size - 4)
+
+            val alignPos = alignmentPatternPositions()
+            val n = alignPos.size
+            for (i in 0 until n) {
+                for (j in 0 until n) {
+                    if (!((i == 0 && j == 0) || (i == 0 && j == n - 1) || (i == n - 1 && j == 0))) {
+                        drawAlignmentPattern(alignPos[i], alignPos[j])
+                    }
+                }
+            }
+            drawFormatBits(0)
+            drawVersion()
+        }
+
+        private fun setFunctionModule(x: Int, y: Int, isDark: Boolean) {
+            modules[y][x] = isDark
+            isFunction[y][x] = true
+        }
+
+        private fun drawFinderPattern(x: Int, y: Int) {
+            for (dy in -4..4) {
+                for (dx in -4..4) {
+                    val dist = maxOf(Math.abs(dx), Math.abs(dy))
+                    val xx = x + dx
+                    val yy = y + dy
+                    if (xx in 0 until size && yy in 0 until size) {
+                        setFunctionModule(xx, yy, dist != 2 && dist != 4)
+                    }
+                }
+            }
+        }
+
+        private fun drawAlignmentPattern(x: Int, y: Int) {
+            for (dy in -2..2) {
+                for (dx in -2..2) {
+                    setFunctionModule(x + dx, y + dy, maxOf(Math.abs(dx), Math.abs(dy)) != 1)
+                }
+            }
+        }
+
+        private fun alignmentPatternPositions(): IntArray {
+            if (version == 1) return IntArray(0)
+            val numAlign = version / 7 + 2
+            val step = if (version == 32) 26 else (version * 4 + numAlign * 2 + 1) / (numAlign * 2 - 2) * 2
+            val result = IntArray(numAlign)
+            var pos = size - 7
+            for (i in numAlign - 1 downTo 1) {
+                result[i] = pos
+                pos -= step
+            }
+            result[0] = 6
+            return result
+        }
+
+        private var currentFormatMask = 0
+
+        fun drawFormatBits(mask: Int) {
+            currentFormatMask = mask
+            val data = ecc.formatBits shl 3 or mask
+            var rem = data
+            for (i in 0 until 10) rem = (rem shl 1) xor ((rem ushr 9) * 0x537)
+            val bits = (data shl 10 or rem) xor 0x5412
+            for (i in 0..5) setFunctionModule(8, i, getBit(bits, i))
+            setFunctionModule(8, 7, getBit(bits, 6))
+            setFunctionModule(8, 8, getBit(bits, 7))
+            setFunctionModule(7, 8, getBit(bits, 8))
+            for (i in 9 until 15) setFunctionModule(14 - i, 8, getBit(bits, i))
+            for (i in 0 until 8) setFunctionModule(size - 1 - i, 8, getBit(bits, i))
+            for (i in 8 until 15) setFunctionModule(8, size - 15 + i, getBit(bits, i))
+            setFunctionModule(8, size - 8, true)
+        }
+
+        private fun drawVersion() {
+            if (version < 7) return
+            var rem = version
+            for (i in 0 until 12) rem = (rem shl 1) xor ((rem ushr 11) * 0x1F25)
+            val bits = version shl 12 or rem
+            for (i in 0 until 18) {
+                val bit = getBit(bits, i)
+                val a = size - 11 + i % 3
+                val b = i / 3
+                setFunctionModule(a, b, bit)
+                setFunctionModule(b, a, bit)
+            }
+        }
+
+        fun drawCodewords(dataArg: ByteArray) {
+            var i = 0
+            var col = size - 1
+            while (col >= 1) {
+                if (col == 6) col = 5
+                for (vert in 0 until size) {
+                    for (j in 0 until 2) {
+                        val x = col - j
+                        val upward = ((col + 1) and 2) == 0
+                        val y = if (upward) size - 1 - vert else vert
+                        if (!isFunction[y][x] && i < dataArg.size * 8) {
+                            modules[y][x] = getBit(dataArg[i ushr 3].toInt(), 7 - (i and 7))
+                            i++
+                        }
+                    }
+                }
+                col -= 2
+            }
+        }
+
+        fun applyBestMask() {
+            var minPenalty = Int.MAX_VALUE
+            var bestMask = 0
+            for (mask in 0 until 8) {
+                applyMask(mask)
+                drawFormatBits(mask)
+                val penalty = penaltyScore()
+                if (penalty < minPenalty) {
+                    minPenalty = penalty
+                    bestMask = mask
+                }
+                applyMask(mask) // undo (XOR is its own inverse)
+            }
+            applyMask(bestMask)
+            drawFormatBits(bestMask)
+        }
+
+        private fun applyMask(mask: Int) {
+            for (y in 0 until size) {
+                for (x in 0 until size) {
+                    if (isFunction[y][x]) continue
+                    val invert = when (mask) {
+                        0 -> (x + y) % 2 == 0
+                        1 -> y % 2 == 0
+                        2 -> x % 3 == 0
+                        3 -> (x + y) % 3 == 0
+                        4 -> (x / 3 + y / 2) % 2 == 0
+                        5 -> x * y % 2 + x * y % 3 == 0
+                        6 -> (x * y % 2 + x * y % 3) % 2 == 0
+                        else -> ((x + y) % 2 + x * y % 3) % 2 == 0
+                    }
+                    if (invert) modules[y][x] = !modules[y][x]
+                }
+            }
+        }
+
+        private fun penaltyScore(): Int {
+            var result = 0
+            // adjacent-same in rows/cols
+            for (y in 0 until size) {
+                var runColor = false
+                var runX = 0
+                for (x in 0 until size) {
+                    if (modules[y][x] == runColor) {
+                        runX++
+                        if (runX == 5) result += 3 else if (runX > 5) result++
+                    } else {
+                        runColor = modules[y][x]; runX = 1
+                    }
+                }
+            }
+            for (x in 0 until size) {
+                var runColor = false
+                var runY = 0
+                for (y in 0 until size) {
+                    if (modules[y][x] == runColor) {
+                        runY++
+                        if (runY == 5) result += 3 else if (runY > 5) result++
+                    } else {
+                        runColor = modules[y][x]; runY = 1
+                    }
+                }
+            }
+            // 2x2 blocks
+            for (y in 0 until size - 1) {
+                for (x in 0 until size - 1) {
+                    val c = modules[y][x]
+                    if (c == modules[y][x + 1] && c == modules[y + 1][x] && c == modules[y + 1][x + 1]) result += 3
+                }
+            }
+            // dark ratio
+            var dark = 0
+            for (row in modules) for (v in row) if (v) dark++
+            val total = size * size
+            val k = (Math.abs(dark * 20 - total * 10) + total - 1) / total - 1
+            result += k * 10
+            return result
+        }
+
+        private fun getBit(x: Int, i: Int): Boolean = ((x ushr i) and 1) != 0
+    }
+
+    private fun getBit(x: Int, i: Int): Boolean = ((x ushr i) and 1) != 0
+
+    private class BitBuffer {
+        private val data = ArrayList<Boolean>()
+        val size: Int get() = data.size
+        fun appendBits(value: Int, len: Int) {
+            for (i in len - 1 downTo 0) data.add(((value ushr i) and 1) != 0)
+        }
+        fun toBytes(): ByteArray {
+            val out = ByteArray((data.size + 7) / 8)
+            for (i in data.indices) if (data[i]) out[i ushr 3] = (out[i ushr 3].toInt() or (0x80 ushr (i and 7))).toByte()
+            return out
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/QrCodeImage.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/QrCodeImage.kt
@@ -1,0 +1,60 @@
+package com.testlogon.android.feature.custody
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Renders [content] as a scannable QR code on a Compose Canvas using the vendored [QrCode] generator
+ * (no gradle dependency). Draws a white quiet-zone background + dark modules. If the content cannot be
+ * encoded (should not happen for an address), shows a small fallback note instead of crashing.
+ */
+@Composable
+fun QrCodeImage(
+    content: String,
+    modifier: Modifier = Modifier,
+    dimension: Dp = 200.dp,
+    dark: Color = Color(0xFF000000),
+    light: Color = Color(0xFFFFFFFF),
+) {
+    val matrix = remember(content) { QrCode.encode(content) }
+    Box(
+        modifier = modifier.size(dimension),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (matrix == null) {
+            Text("QR unavailable", style = MaterialTheme.typography.bodySmall)
+        } else {
+            Canvas(modifier = Modifier.size(dimension)) {
+                val modules = matrix.size
+                val quiet = 4 // standard 4-module quiet zone
+                val total = modules + quiet * 2
+                val cell = size.minDimension / total
+                // background (incl. quiet zone)
+                drawRect(color = light, topLeft = Offset(0f, 0f), size = Size(size.width, size.height))
+                for (y in 0 until modules) {
+                    for (x in 0 until modules) {
+                        if (matrix[y][x]) {
+                            drawRect(
+                                color = dark,
+                                topLeft = Offset((x + quiet) * cell, (y + quiet) * cell),
+                                size = Size(cell, cell),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -946,6 +946,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "custody",
+            labelRes = R.string.more_entry_custody,
+            icon = Icons.Outlined.AccountBalance,
+            route = MoreRoutes.CUSTODY,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "catalog",
             labelRes = R.string.more_entry_catalog,
             icon = Icons.Outlined.Storefront,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -211,6 +211,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         videoUploadDestination(navController)
         // AND-332: read-only file-manager browse (path nav + breadcrumbs + search + sort + paged listing).
         filesDestination(navController)
+        // Custody: native crypto custody surface wired to /ui/custody/* (officer approvals self-gate on the admin signal).
+        custodyDestination(navController)
         // AND-336: backend-mediated Google Drive import picker (authenticated-only).
         driveImportDestination(navController)
         // AND-335: owner share sheet (create/list/revoke share links) + the public share screen

--- a/android/app/src/main/java/com/testlogon/android/navigation/CustodyNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CustodyNavigation.kt
@@ -1,0 +1,24 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.custody.CustodyRoute
+
+/** The native Custody surface (balances / deposit / withdraw / activity / officer approvals), reached from the More -> Wallet hub. */
+data object CustodyDest {
+    const val ROUTE = "custody"
+}
+
+/**
+ * Registers the Custody screen in the authenticated graph. Up / Back pops the back stack. The screen
+ * is wired to the session-authed the /ui/custody endpoints backend (the shared Retrofit client attaches the cookie);
+ * the officer Approvals/Audit tab self-gates on the caller's admin signal.
+ */
+fun NavGraphBuilder.custodyDestination(navController: NavHostController) {
+    composable(CustodyDest.ROUTE) {
+        CustodyRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -97,6 +97,10 @@ object MoreRoutes {
     // AND-332: the server file manager (path-based browse + upload/download/share/Drive-import).
     const val FILES = FilesDest.ROUTE
 
+
+    // Custody: native crypto custody surface (balances / deposit / withdraw / activity / officer approvals), wired to /ui/custody/*.
+    const val CUSTODY = CustodyDest.ROUTE
+
     // AND-219: the purchase history list + search.
     val PURCHASE_HISTORY: String get() = PurchaseHistoryDest.ROUTE
 
@@ -548,6 +552,7 @@ object MoreRoutes {
             SELLER_ORDERS,
             SELLER_SALES,
             FILES,
+            CUSTODY,
             PURCHASE_HISTORY,
             PAYMENT_METHODS,
             WALLET_TRANSACTIONS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1423,6 +1423,7 @@
     <!-- AND-199 / AND-200: Stories tray + viewer -->
     <string name="more_entry_gallery">Gallery</string>
     <string name="more_entry_files">Files</string>
+    <string name="more_entry_custody">Custody</string>
     <string name="story_ring_unseen">Story from %1$s, unseen</string>
     <string name="story_ring_seen">Story from %1$s, seen</string>
     <string name="story_close">Close stories</string>

--- a/android/app/src/test/java/com/testlogon/android/data/auth/SessionsRepositoryContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/auth/SessionsRepositoryContractTest.kt
@@ -3,6 +3,7 @@ package com.testlogon.android.data.auth
 import com.squareup.moshi.Moshi
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.json.LenientNumberAdapters
 import com.testlogon.android.core.testing.net.FixtureName
 import com.testlogon.android.core.testing.net.Fixtures
 import com.testlogon.android.core.testing.net.MockBackendRule
@@ -20,7 +21,7 @@ class SessionsRepositoryContractTest {
     @get:Rule
     val backend = MockBackendRule()
 
-    private val moshi: Moshi = Moshi.Builder().build()
+    private val moshi: Moshi = Moshi.Builder().add(LenientNumberAdapters).build()
 
     private fun repo(): SessionsRepositoryImpl {
         val api = backend.retrofit(moshi).create(AuthApi::class.java)

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -3798,5 +3798,25 @@ class Settings:
     web_to_lead_max_per_ip_per_hour: int = int(os.environ.get("WEB_TO_LEAD_MAX_PER_IP_PER_HOUR", "10"))
     marketing_unsubscribe_token_ttl_days: int = int(os.environ.get("MARKETING_UNSUBSCRIBE_TOKEN_TTL_DAYS", "30"))
 
+    # ------------------------------------------------------------------
+    # CUSTODY (crypto-custody proxy -> external MPC custody gateway).
+    # Unconfigured (no URL/key) => the proxy falls back to an in-memory mock.
+    # Secrets/officer keys are server-to-server ONLY and never reach clients.
+    # ------------------------------------------------------------------
+    custody_gateway_url: str = os.environ.get("CUSTODY_GATEWAY_URL", "").rstrip("/")
+    custody_api_key: str = os.environ.get("CUSTODY_API_KEY", "")
+    custody_api_secret: str = os.environ.get("CUSTODY_API_SECRET", "")
+    custody_tenant: str = os.environ.get("CUSTODY_TENANT", "testlogon")
+    custody_wallet_name: str = os.environ.get("CUSTODY_WALLET_NAME", "main")
+    custody_verify_tls: bool = os.environ.get("CUSTODY_VERIFY_TLS", "0") not in ("0", "false", "False")
+    custody_timeout_seconds: float = float(os.environ.get("CUSTODY_TIMEOUT_SECONDS", "15"))
+    # JSON map: {"approver": {"key": "...", "secret": "..."}, ...}
+    custody_officer_keys: str = os.environ.get("CUSTODY_OFFICER_KEYS", "")
+    # Withdrawal amount (in asset units) at/above which multi-approval is required (mock + client-side hint).
+    custody_approval_threshold: float = float(os.environ.get("CUSTODY_APPROVAL_THRESHOLD", "1000"))
+    custody_approvals_required: int = int(os.environ.get("CUSTODY_APPROVALS_REQUIRED", "2"))
+    # Timelock (seconds) enforced by the gateway/mock before a pending withdrawal may be released.
+    custody_timelock_seconds: int = int(os.environ.get("CUSTODY_TIMELOCK_SECONDS", "0"))
+
 
 S = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -188,6 +188,7 @@ from app.services.engagement_rate import start_engagement_benchmark_task
 from app.routers.per_content_revenue import per_content_revenue_router
 from app.routers.creator_dashboard import router as creator_dashboard_router
 from app.routers.creator_payouts import router as creator_payouts_router
+from app.routers.custody import router as custody_router  # CUSTODY (crypto-custody proxy)
 from app.routers.admin_payouts import router as admin_payouts_router
 from app.routers.admin_tip_reversal import router as admin_tip_reversal_router  # TIPX-A2
 from app.routers.billing_config import billing_config_router
@@ -953,6 +954,7 @@ def create_app() -> FastAPI:
     app.include_router(per_content_revenue_router)
     app.include_router(creator_dashboard_router)
     app.include_router(creator_payouts_router)
+    app.include_router(custody_router)  # CUSTODY (crypto-custody proxy -> MPC gateway; mock in DEV_MODE)
     from app.routers.live_commerce import router as live_commerce_router  # LIVECOM
     app.include_router(live_commerce_router)
     app.include_router(admin_payouts_router)

--- a/app/routers/custody.py
+++ b/app/routers/custody.py
@@ -1,0 +1,404 @@
+"""Crypto-custody proxy router (CUSTODY).
+
+Session-authed ``/ui/custody/*`` endpoints that sit between the frontends and
+the external MPC custody gateway. Clients never see the gateway, its HMAC
+secret, officer keys, or a raw intent/digest — the withdrawal intent wire is
+built SERVER-side from validated fields.
+
+Officer/audit endpoints are role-gated (admin/root).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.policy import require_admin_or_root
+from app.core.settings import S
+from app.services.sessions import require_ui_session
+from app.services.custody_gateway import (
+    ASSET_REGISTRY,
+    get_custody_gateway,
+    is_mock,
+    registry_entry,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/ui/custody", tags=["custody"])
+
+
+# ---------------------------------------------------------------------------
+# user -> wallet / vault mapping helpers.
+#   - one tenant wallet (name from config, default "main"): "<tenant>-<name>"
+#   - per-user deposit addresses via the gateway address endpoint (user=<uid>)
+#   - per-user vault/sub-account id for balances: "<tenant>-u-<uid>"
+# ---------------------------------------------------------------------------
+def _tenant() -> str:
+    return S.custody_tenant
+
+
+def _wallet_id() -> str:
+    return f"{S.custody_tenant}-{S.custody_wallet_name}"
+
+
+def _user_vault_id(user_sub: str) -> str:
+    return f"{S.custody_tenant}-u-{user_sub}"
+
+
+def _gw():
+    return get_custody_gateway()
+
+
+def _ensure_user_state(gw, user_sub: str) -> None:
+    """Make sure the tenant wallet + per-user vault exist (+ seed demo balances on mock)."""
+    try:
+        gw.create_wallet(S.custody_wallet_name)
+    except Exception:
+        pass
+    if is_mock(gw):
+        gw.seed_user_vault(_user_vault_id(user_sub), user_sub)
+
+
+# ---------------------------------------------------------------------------
+# destination validation (basic, per chain family).
+# ---------------------------------------------------------------------------
+_EVM_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+_SOL_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
+_XRP_RE = re.compile(r"^r[1-9A-HJ-NP-Za-km-z]{24,34}$")
+_TRON_RE = re.compile(r"^T[1-9A-HJ-NP-Za-km-z]{33}$")
+_BTC_RE = re.compile(r"^(bc1[0-9a-z]{20,60}|[13][a-km-zA-HJ-NP-Z1-9]{25,39})$")
+
+
+def _valid_destination(family: str, dest: str) -> bool:
+    if family == "evm":
+        return bool(_EVM_RE.match(dest))
+    if family == "solana":
+        return bool(_SOL_RE.match(dest))
+    if family == "xrp":
+        return bool(_XRP_RE.match(dest))
+    if family == "tron":
+        return bool(_TRON_RE.match(dest))
+    if family == "btc":
+        return bool(_BTC_RE.match(dest))
+    return len(dest) >= 8
+
+
+# ===========================================================================
+# request models
+# ===========================================================================
+class WithdrawalIn(BaseModel):
+    asset: str = Field(..., min_length=1)
+    chain: str = Field(..., min_length=1)
+    amount: float = Field(..., gt=0)
+    destination: str = Field(..., min_length=4)
+    memo: Optional[str] = None
+
+
+class ApproveIn(BaseModel):
+    approver: Optional[str] = None
+
+
+# ===========================================================================
+# user endpoints
+# ===========================================================================
+@router.get("/assets")
+def list_assets(session=Depends(require_ui_session)) -> List[Dict[str, Any]]:
+    """Supported-asset registry merged with the user's vault balances."""
+    user_sub = session["user_sub"]
+    gw = _gw()
+    _ensure_user_state(gw, user_sub)
+    balances: Dict[str, float] = {}
+    if is_mock(gw):
+        v = gw.get_vault(_user_vault_id(user_sub))
+        balances = dict(v.get("balances", {})) if v else {}
+    else:
+        try:
+            v = gw.get_vault(_user_vault_id(user_sub))
+            balances = dict((v or {}).get("balances", {}))
+        except Exception:
+            balances = {}
+    out: List[Dict[str, Any]] = []
+    for r in ASSET_REGISTRY:
+        out.append({
+            "asset": r["asset"],
+            "chain": r["chain"],
+            "name": r["name"],
+            "symbol": r["symbol"],
+            "decimals": r["decimals"],
+            "network": r["network"],
+            "balance": float(balances.get(r["asset"], 0.0)),
+            "address_available": True,
+        })
+    return out
+
+
+@router.get("/deposit-address")
+def deposit_address(
+    asset: str = Query(...),
+    chain: str = Query(...),
+    session=Depends(require_ui_session),
+) -> Dict[str, Any]:
+    user_sub = session["user_sub"]
+    entry = registry_entry(asset, chain)
+    if not entry:
+        raise HTTPException(400, "unsupported asset/chain")
+    gw = _gw()
+    _ensure_user_state(gw, user_sub)
+    try:
+        res = gw.get_address(_wallet_id(), user_sub, entry["chain_ref"])
+    except Exception:
+        raise HTTPException(502, "custody gateway unavailable")
+    address = res.get("address") if isinstance(res, dict) else None
+    if not address:
+        raise HTTPException(502, "no address returned")
+    out = {
+        "asset": entry["asset"],
+        "chain": entry["chain"],
+        "network": entry["network"],
+        "address": address,
+    }
+    # XRP-family assets often require a destination tag/memo; expose slot for clients.
+    if entry["family"] in ("xrp",):
+        out["memo"] = None
+    return out
+
+
+@router.get("/deposits")
+def list_deposits(session=Depends(require_ui_session)) -> List[Dict[str, Any]]:
+    """Recent credited deposits for the user (derived from vault balances / audit)."""
+    user_sub = session["user_sub"]
+    gw = _gw()
+    _ensure_user_state(gw, user_sub)
+    deposits: List[Dict[str, Any]] = []
+    if is_mock(gw):
+        v = gw.get_vault(_user_vault_id(user_sub))
+        balances = dict(v.get("balances", {})) if v else {}
+        # Present seeded balances as prior "credited" deposits for demo rendering.
+        idx = 0
+        for asset, amount in balances.items():
+            if amount <= 0:
+                continue
+            entry = next((r for r in ASSET_REGISTRY if r["asset"] == asset), None)
+            deposits.append({
+                "id": f"dep-{user_sub[:8]}-{idx}",
+                "asset": asset,
+                "chain": entry["chain"] if entry else None,
+                "amount": float(amount),
+                "status": "credited",
+                "confirmations": 32,
+            })
+            idx += 1
+    return deposits
+
+
+@router.post("/withdrawals")
+def create_withdrawal(body: WithdrawalIn, session=Depends(require_ui_session)) -> Dict[str, Any]:
+    user_sub = session["user_sub"]
+    entry = registry_entry(body.asset, body.chain)
+    if not entry:
+        raise HTTPException(400, "unsupported asset/chain")
+    if body.amount <= 0:
+        raise HTTPException(400, "amount must be positive")
+    if not _valid_destination(entry["family"], body.destination.strip()):
+        raise HTTPException(400, "invalid destination address for chain")
+
+    gw = _gw()
+    _ensure_user_state(gw, user_sub)
+
+    # Sufficient-balance check against the user's vault.
+    vault_id = _user_vault_id(user_sub)
+    if is_mock(gw):
+        bal = gw.balance(vault_id, entry["asset"])
+        if body.amount > bal:
+            raise HTTPException(400, "insufficient balance")
+
+    # Build the intent wire SERVER-side (never trust a client-supplied intent/digest).
+    ts_ms = uuid_ts()
+    nonce = f"wd-{uuid.uuid4().hex[:12]}"
+    intent = "|".join([
+        entry["asset"],
+        entry["chain_ref"],
+        entry["network"],
+        body.destination.strip(),
+        _fmt_amount(body.amount),
+        str(ts_ms),
+        nonce,
+    ])
+    idem_key = f"{user_sub}:{nonce}"
+
+    try:
+        status_code, payload = gw.create_withdrawal(_wallet_id(), intent, idem_key)
+    except Exception:
+        raise HTTPException(502, "custody gateway unavailable")
+
+    # On mock, debit the vault when signed immediately (below threshold).
+    if is_mock(gw) and status_code == 200 and payload.get("status") == "signed":
+        gw.debit_vault(vault_id, entry["asset"], body.amount)
+
+    out = {
+        "id": payload.get("withdrawal_id"),
+        "status": payload.get("status"),
+        "asset": entry["asset"],
+        "chain": entry["chain"],
+        "amount": body.amount,
+        "destination": body.destination.strip(),
+    }
+    for k in ("approvals_required", "approvals", "signature", "digest", "error", "category", "source", "detail"):
+        if k in payload:
+            out[k] = payload[k]
+    return out
+
+
+@router.get("/withdrawals")
+def list_withdrawals(session=Depends(require_ui_session)) -> List[Dict[str, Any]]:
+    user_sub = session["user_sub"]
+    gw = _gw()
+    if not is_mock(gw):
+        # Real gateway: no per-user list endpoint in the contract; return empty
+        # (frontends track ids they created). Deferred: server-side index.
+        return []
+    all_w = gw.list_withdrawals()
+    mine = [w for w in all_w if _owns(gw, w.get("withdrawal_id"), user_sub)]
+    return [_shape_withdrawal(w) for w in mine]
+
+
+@router.get("/withdrawals/{withdrawal_id}")
+def get_withdrawal(withdrawal_id: str, session=Depends(require_ui_session)) -> Dict[str, Any]:
+    user_sub = session["user_sub"]
+    gw = _gw()
+    if is_mock(gw) and not _owns(gw, withdrawal_id, user_sub):
+        raise HTTPException(404, "not found")
+    try:
+        w = gw.get_withdrawal(withdrawal_id)
+    except Exception:
+        raise HTTPException(502, "custody gateway unavailable")
+    if not w:
+        raise HTTPException(404, "not found")
+    return _shape_withdrawal(w)
+
+
+# ===========================================================================
+# officer / admin endpoints (role-gated)
+# ===========================================================================
+@router.get("/approvals")
+def approvals_queue(user: AuthenticatedUser = Depends(require_admin_or_root)) -> List[Dict[str, Any]]:
+    gw = _gw()
+    if not is_mock(gw):
+        return []
+    pending = [w for w in gw.list_withdrawals() if w.get("status") == "pending_approval"]
+    return [_shape_withdrawal(w) for w in pending]
+
+
+@router.post("/withdrawals/{withdrawal_id}/approve")
+def approve_withdrawal(
+    withdrawal_id: str,
+    body: ApproveIn = ApproveIn(),
+    user: AuthenticatedUser = Depends(require_admin_or_root),
+) -> Dict[str, Any]:
+    gw = _gw()
+    approver = (body.approver or "").strip() or f"officer:{user.sub}"
+    try:
+        code, payload = gw.approve_withdrawal(withdrawal_id, approver)
+    except Exception:
+        raise HTTPException(502, "custody gateway unavailable")
+    if code >= 400:
+        raise HTTPException(code if code in (404, 409) else 400, payload.get("detail", "approve failed"))
+    return payload
+
+
+@router.post("/withdrawals/{withdrawal_id}/release")
+def release_withdrawal(
+    withdrawal_id: str,
+    user: AuthenticatedUser = Depends(require_admin_or_root),
+) -> Dict[str, Any]:
+    gw = _gw()
+    try:
+        code, payload = gw.release_withdrawal(withdrawal_id)
+    except Exception:
+        raise HTTPException(502, "custody gateway unavailable")
+    if code == 425:
+        raise HTTPException(425, "timelock not elapsed")
+    if code >= 400:
+        raise HTTPException(code if code in (404, 409) else 400, payload.get("detail", "release failed"))
+    # Debit the owner's vault on mock release (settlement of a large withdrawal).
+    if is_mock(gw) and payload.get("status") == "signed":
+        w = gw.get_withdrawal(withdrawal_id)
+        owner = _owner_of(gw, withdrawal_id)
+        if owner and w.get("asset"):
+            gw.debit_vault(_user_vault_id(owner), w["asset"], float(w.get("amount", 0)))
+    return payload
+
+
+@router.get("/audit")
+def audit(user: AuthenticatedUser = Depends(require_admin_or_root)) -> Dict[str, Any]:
+    try:
+        return _gw().audit()
+    except Exception:
+        raise HTTPException(502, "custody gateway unavailable")
+
+
+@router.get("/audit/verify")
+def audit_verify(user: AuthenticatedUser = Depends(require_admin_or_root)) -> Dict[str, Any]:
+    try:
+        return _gw().audit_verify()
+    except Exception:
+        raise HTTPException(502, "custody gateway unavailable")
+
+
+# ===========================================================================
+# helpers
+# ===========================================================================
+def uuid_ts() -> int:
+    import time
+    return int(time.time() * 1000)
+
+
+def _fmt_amount(amount: float) -> str:
+    # Compact, deterministic amount string for the intent wire.
+    if amount == int(amount):
+        return str(int(amount))
+    return repr(float(amount))
+
+
+def _shape_withdrawal(w: Dict[str, Any]) -> Dict[str, Any]:
+    approvals = w.get("approvals", []) or []
+    return {
+        "id": w.get("withdrawal_id"),
+        "asset": w.get("asset"),
+        "chain_ref": w.get("chain_ref"),
+        "network": w.get("network"),
+        "recipient": w.get("recipient"),
+        "amount": w.get("amount"),
+        "status": w.get("status"),
+        "approvals": approvals,
+        "approvals_count": len(approvals),
+        "approvals_required": w.get("approvals_required"),
+        "signature": w.get("signature"),
+        "digest": w.get("digest"),
+        "error": w.get("error"),
+        "category": w.get("category"),
+        "source": w.get("source"),
+        "timelock_until_ms": w.get("timelock_until_ms"),
+        "created_ms": w.get("created_ms"),
+    }
+
+
+def _owns(gw, withdrawal_id: Optional[str], user_sub: str) -> bool:
+    return _owner_of(gw, withdrawal_id) == user_sub
+
+
+def _owner_of(gw, withdrawal_id: Optional[str]) -> Optional[str]:
+    """Derive the owning user from the mock idempotency map (key is '<uid>:<nonce>')."""
+    if not withdrawal_id or not is_mock(gw):
+        return None
+    for idem_key, wid in gw._idem.items():  # noqa: SLF001 (mock-internal, same package)
+        if wid == withdrawal_id:
+            return idem_key.split(":", 1)[0]
+    return None

--- a/app/services/custody_gateway.py
+++ b/app/services/custody_gateway.py
@@ -1,0 +1,643 @@
+"""Crypto-custody gateway client + in-memory mock (CUSTODY).
+
+This module is the ONLY thing that talks to the external MPC custody gateway.
+It signs every ``/v1/*`` call (except health) with an HMAC over
+``ts + METHOD + request_target(+query) + body`` using the server-side API secret.
+
+The secret and officer keys are server-to-server credentials and MUST NOT be
+exposed to clients or logged.
+
+When the gateway is not configured (no URL/key — the DEV_MODE demo default),
+``get_custody_gateway()`` returns a ``_MockCustodyGateway`` with deterministic,
+demo-realistic in-memory state so the frontends can render + exercise the full
+flow (submit -> screening -> pending_approval -> approve xN -> release -> settled).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.core.settings import S
+
+logger = logging.getLogger(__name__)
+
+
+class CustodyGatewayError(Exception):
+    """Raised for gateway-level failures. ``status`` mirrors the HTTP status
+    when the gateway answered; ``payload`` is the parsed JSON body (best-effort)."""
+
+    def __init__(self, message: str, status: int = 502, payload: Optional[Dict[str, Any]] = None):
+        super().__init__(message)
+        self.status = status
+        self.payload = payload or {}
+
+
+# ---------------------------------------------------------------------------
+# Supported asset / chain registry. The router builds intent wires from this;
+# the mock uses it to shape addresses. Kept intentionally small + explicit.
+# `chain_ref` is the value placed in the intent wire's <chain_or_ref> slot.
+# ---------------------------------------------------------------------------
+ASSET_REGISTRY: List[Dict[str, Any]] = [
+    {"asset": "ETH", "chain": "ethereum", "chain_ref": "0x1", "network": "Mainnet", "name": "Ether", "symbol": "ETH", "decimals": 18, "family": "evm"},
+    {"asset": "USDC", "chain": "ethereum", "chain_ref": "0x1", "network": "Mainnet", "name": "USD Coin", "symbol": "USDC", "decimals": 6, "family": "evm"},
+    {"asset": "USDT", "chain": "ethereum", "chain_ref": "0x1", "network": "Mainnet", "name": "Tether USD", "symbol": "USDT", "decimals": 6, "family": "evm"},
+    {"asset": "BNB", "chain": "bsc", "chain_ref": "0x38", "network": "Mainnet", "name": "BNB", "symbol": "BNB", "decimals": 18, "family": "evm"},
+    {"asset": "POL", "chain": "polygon", "chain_ref": "0x89", "network": "Mainnet", "name": "Polygon", "symbol": "POL", "decimals": 18, "family": "evm"},
+    {"asset": "SOL", "chain": "solana", "chain_ref": "solana-mainnet", "network": "Mainnet", "name": "Solana", "symbol": "SOL", "decimals": 9, "family": "solana"},
+    {"asset": "XRP", "chain": "xrpl", "chain_ref": "xrpl-mainnet", "network": "Mainnet", "name": "XRP", "symbol": "XRP", "decimals": 6, "family": "xrp"},
+    {"asset": "TRX", "chain": "tron", "chain_ref": "tron-mainnet", "network": "Mainnet", "name": "TRON", "symbol": "TRX", "decimals": 6, "family": "tron"},
+    {"asset": "USDT-TRC20", "chain": "tron", "chain_ref": "tron-mainnet", "network": "Mainnet", "name": "Tether USD (TRC-20)", "symbol": "USDT", "decimals": 6, "family": "tron"},
+    {"asset": "BTC", "chain": "bitcoin", "chain_ref": "bitcoin-mainnet", "network": "Mainnet", "name": "Bitcoin", "symbol": "BTC", "decimals": 8, "family": "btc"},
+    {"asset": "HYPE", "chain": "hyperliquid", "chain_ref": "0x66eee", "network": "Mainnet", "name": "Hyperliquid", "symbol": "HYPE", "decimals": 18, "family": "evm"},
+]
+
+_REGISTRY_BY_KEY: Dict[Tuple[str, str], Dict[str, Any]] = {
+    (r["asset"].upper(), r["chain"].lower()): r for r in ASSET_REGISTRY
+}
+
+
+def registry_entry(asset: str, chain: str) -> Optional[Dict[str, Any]]:
+    return _REGISTRY_BY_KEY.get((str(asset).upper(), str(chain).lower()))
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+# ===========================================================================
+# Real client
+# ===========================================================================
+class CustodyGatewayClient:
+    """HMAC-signing HTTP client for the external MPC custody gateway."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        api_secret: str,
+        tenant: str,
+        verify_tls: bool = False,
+        timeout_seconds: float = 15.0,
+        officer_keys: Optional[Dict[str, Dict[str, str]]] = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._tenant = tenant
+        self._verify_tls = verify_tls
+        self._timeout = timeout_seconds
+        self._officer_keys = officer_keys or {}
+
+    # -- signing -----------------------------------------------------------
+    def _sign(self, secret: str, ts: str, method: str, request_target: str, body: str) -> str:
+        msg = f"{ts}{method}{request_target}{body}".encode("utf-8")
+        return hmac.new(secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+
+    def _headers(
+        self,
+        method: str,
+        request_target: str,
+        body: str,
+        *,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> Dict[str, str]:
+        key = api_key or self._api_key
+        secret = api_secret or self._api_secret
+        ts = str(_now_ms())
+        headers = {
+            "X-Api-Key": key,
+            "X-Api-Timestamp": ts,
+            "X-Api-Signature": self._sign(secret, ts, method, request_target, body),
+        }
+        if body:
+            headers["Content-Type"] = "application/json"
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: str = "",
+        json_body: Optional[Dict[str, Any]] = None,
+        signed: bool = True,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> Tuple[int, Dict[str, Any]]:
+        import httpx  # lazy: keep import cost off the hot path / dev without httpx
+
+        body = "" if json_body is None else json.dumps(json_body, separators=(",", ":"), sort_keys=True)
+        request_target = path if not query else f"{path}?{query}"
+        url = f"{self._base_url}{request_target}"
+        headers: Dict[str, str] = {}
+        if signed:
+            headers = self._headers(
+                method,
+                request_target,
+                body,
+                api_key=api_key,
+                api_secret=api_secret,
+                idempotency_key=idempotency_key,
+            )
+        try:
+            with httpx.Client(verify=self._verify_tls, timeout=self._timeout) as client:
+                resp = client.request(
+                    method,
+                    url,
+                    headers=headers,
+                    content=body.encode("utf-8") if body else None,
+                )
+        except Exception as exc:  # network / TLS failure — never leak creds
+            logger.warning("custody gateway request failed: %s %s: %s", method, path, type(exc).__name__)
+            raise CustodyGatewayError(f"gateway unreachable: {type(exc).__name__}", status=502)
+        try:
+            payload = resp.json() if resp.content else {}
+        except Exception:
+            payload = {"raw": resp.text[:500]}
+        return resp.status_code, payload
+
+    # -- health ------------------------------------------------------------
+    def health(self) -> Dict[str, Any]:
+        _, payload = self._request("GET", "/v1/health", signed=False)
+        return payload
+
+    # -- wallets -----------------------------------------------------------
+    def create_wallet(self, name: str) -> Dict[str, Any]:
+        _, payload = self._request("POST", "/v1/wallets", json_body={"name": name})
+        return payload
+
+    def get_address(self, wallet_id: str, user: str, chain: str) -> Dict[str, Any]:
+        query = f"user={user}&chain={chain}"
+        _, payload = self._request("GET", f"/v1/wallets/{wallet_id}/address", query=query)
+        return payload
+
+    # -- withdrawals -------------------------------------------------------
+    def create_withdrawal(self, wallet: str, intent: str, idempotency_key: str) -> Tuple[int, Dict[str, Any]]:
+        return self._request(
+            "POST",
+            "/v1/withdrawals",
+            json_body={"wallet": wallet, "intent": intent},
+            idempotency_key=idempotency_key,
+        )
+
+    def approve_withdrawal(self, withdrawal_id: str, approver: str) -> Tuple[int, Dict[str, Any]]:
+        officer = self._officer_keys.get(approver) or {}
+        return self._request(
+            "POST",
+            f"/v1/withdrawals/{withdrawal_id}/approvals",
+            json_body={"approver": approver},
+            api_key=officer.get("key") or self._api_key,
+            api_secret=officer.get("secret") or self._api_secret,
+        )
+
+    def release_withdrawal(self, withdrawal_id: str) -> Tuple[int, Dict[str, Any]]:
+        return self._request("POST", f"/v1/withdrawals/{withdrawal_id}/release", json_body={})
+
+    def get_withdrawal(self, withdrawal_id: str) -> Dict[str, Any]:
+        _, payload = self._request("GET", f"/v1/withdrawals/{withdrawal_id}")
+        return payload
+
+    # -- vaults ------------------------------------------------------------
+    def create_vault(self, name: str) -> Dict[str, Any]:
+        _, payload = self._request("POST", "/v1/vaults", json_body={"name": name})
+        return payload
+
+    def list_vaults(self) -> Dict[str, Any]:
+        _, payload = self._request("GET", "/v1/vaults")
+        return payload
+
+    def get_vault(self, vault_id: str) -> Dict[str, Any]:
+        _, payload = self._request("GET", f"/v1/vaults/{vault_id}")
+        return payload
+
+    def credit_vault(self, vault_id: str, asset: str, amount: float) -> Dict[str, Any]:
+        _, payload = self._request(
+            "POST", f"/v1/vaults/{vault_id}/credit", json_body={"asset": asset, "amount": amount}
+        )
+        return payload
+
+    # -- audit -------------------------------------------------------------
+    def audit(self) -> Dict[str, Any]:
+        _, payload = self._request("GET", "/v1/audit")
+        return payload
+
+    def audit_verify(self) -> Dict[str, Any]:
+        _, payload = self._request("GET", "/v1/audit/verify")
+        return payload
+
+    @staticmethod
+    def is_configured() -> bool:
+        return bool(S.custody_gateway_url and S.custody_api_key and S.custody_api_secret)
+
+
+# ===========================================================================
+# Mock
+# ===========================================================================
+def _derive_hex(*parts: str, length: int = 40) -> str:
+    h = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    while len(h) < length:
+        h += hashlib.sha256(h.encode("utf-8")).hexdigest()
+    return h[:length]
+
+
+def _mock_address(user: str, family: str, asset: str, chain: str) -> str:
+    """Deterministic, chain-appropriate-looking address per (user, asset, chain)."""
+    seed = f"{user}|{asset}|{chain}"
+    if family == "evm":
+        return "0x" + _derive_hex("evm", seed, length=40)
+    if family == "solana":
+        # base58-ish; use only base58 alphabet chars derived from the hash
+        raw = _derive_hex("sol", seed, length=64)
+        alpha = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+        return "".join(alpha[int(raw[i:i + 2], 16) % len(alpha)] for i in range(0, 44 * 2, 2))
+    if family == "xrp":
+        raw = _derive_hex("xrp", seed, length=50)
+        alpha = "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"
+        return "r" + "".join(alpha[int(raw[i:i + 2], 16) % len(alpha)] for i in range(0, 32 * 2, 2))
+    if family == "tron":
+        raw = _derive_hex("tron", seed, length=50)
+        alpha = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+        return "T" + "".join(alpha[int(raw[i:i + 2], 16) % len(alpha)] for i in range(0, 33 * 2, 2))
+    if family == "btc":
+        raw = _derive_hex("btc", seed, length=50)
+        alpha = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"  # bech32
+        return "bc1q" + "".join(alpha[int(raw[i:i + 2], 16) % len(alpha)] for i in range(0, 38 * 2, 2))
+    return "0x" + _derive_hex("gen", seed, length=40)
+
+
+# Recipients flagged as sanctioned by the mock screening step (demo).
+_MOCK_SANCTIONED = {"0x0000000000000000000000000000000000000bad", "sanctioned"}
+
+
+class _MockCustodyGateway:
+    """In-memory deterministic custody gateway for DEV_MODE / no gateway configured.
+
+    State is process-wide (module singleton) so a demo flow persists across
+    requests within one server process. Thread-safe via a coarse lock.
+    """
+
+    def __init__(self, tenant: str = "testlogon") -> None:
+        self._tenant = tenant
+        self._lock = threading.RLock()
+        self._wallets: Dict[str, Dict[str, Any]] = {}
+        self._vaults: Dict[str, Dict[str, Any]] = {}
+        self._withdrawals: Dict[str, Dict[str, Any]] = {}
+        self._idem: Dict[str, str] = {}  # idempotency-key -> withdrawal_id
+        self._audit: List[Dict[str, Any]] = []
+        self._audit_prev = "0" * 64
+        self._threshold = float(getattr(S, "custody_approval_threshold", 1000))
+        self._approvals_required = int(getattr(S, "custody_approvals_required", 2))
+        self._seeded_users: set[str] = set()
+
+    # -- audit hash chain --------------------------------------------------
+    def _append_audit(self, action: str, detail: Dict[str, Any]) -> None:
+        entry_body = {"seq": len(self._audit) + 1, "action": action, "detail": detail, "ts_ms": _now_ms()}
+        chained = hashlib.sha256((self._audit_prev + json.dumps(entry_body, sort_keys=True)).encode()).hexdigest()
+        entry = {**entry_body, "prev": self._audit_prev, "hash": chained}
+        self._audit.append(entry)
+        self._audit_prev = chained
+
+    # -- health ------------------------------------------------------------
+    def health(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "status": "ok",
+                "daemon": "mock",
+                "sign_calls": sum(1 for w in self._withdrawals.values() if w.get("signature")),
+                "audit_entries": len(self._audit),
+                "compliance": {"screening": "mock", "sanctions_list": "demo"},
+            }
+
+    @staticmethod
+    def is_configured() -> bool:
+        return False
+
+    # -- wallets -----------------------------------------------------------
+    def create_wallet(self, name: str) -> Dict[str, Any]:
+        with self._lock:
+            wallet_id = f"{self._tenant}-{name}"
+            if wallet_id not in self._wallets:
+                self._wallets[wallet_id] = {
+                    "wallet_id": wallet_id,
+                    "pubkey": "0x" + _derive_hex("pubkey", wallet_id, length=64),
+                }
+                self._append_audit("wallet.create", {"wallet_id": wallet_id})
+            return dict(self._wallets[wallet_id])
+
+    def get_address(self, wallet_id: str, user: str, chain: str) -> Dict[str, Any]:
+        # `chain` here is the chain_ref passed by the router; map back to a family.
+        family = "evm"
+        for r in ASSET_REGISTRY:
+            if r["chain_ref"] == chain or r["chain"] == chain:
+                family = r["family"]
+                break
+        addr = _mock_address(user, family, chain, chain)
+        return {"address": addr}
+
+    # -- vaults ------------------------------------------------------------
+    def _ensure_vault(self, vault_id: str, name: str) -> Dict[str, Any]:
+        if vault_id not in self._vaults:
+            self._vaults[vault_id] = {
+                "vault_id": vault_id,
+                "name": name,
+                "tier": "standard",
+                "per_tx_cap": 50000.0,
+                "daily_cap": 250000.0,
+                "balances": {},
+            }
+        return self._vaults[vault_id]
+
+    def seed_user_vault(self, vault_id: str, user: str) -> None:
+        """Seed a few non-zero demo balances the first time we see a user."""
+        with self._lock:
+            if user in self._seeded_users:
+                return
+            v = self._ensure_vault(vault_id, f"{user} custody")
+            # Deterministic-ish demo balances.
+            v["balances"].setdefault("ETH", 2.5)
+            v["balances"].setdefault("USDC", 5230.0)
+            v["balances"].setdefault("USDT", 1200.0)
+            v["balances"].setdefault("BTC", 0.15)
+            v["balances"].setdefault("SOL", 42.0)
+            self._seeded_users.add(user)
+            self._append_audit("vault.seed", {"vault_id": vault_id})
+
+    def create_vault(self, name: str) -> Dict[str, Any]:
+        with self._lock:
+            vault_id = f"{self._tenant}-v-{_derive_hex('vault', name, length=12)}"
+            v = self._ensure_vault(vault_id, name)
+            self._append_audit("vault.create", {"vault_id": vault_id})
+            return dict(v)
+
+    def list_vaults(self) -> Dict[str, Any]:
+        with self._lock:
+            return {"vaults": [dict(v) for v in self._vaults.values()]}
+
+    def get_vault(self, vault_id: str) -> Dict[str, Any]:
+        with self._lock:
+            v = self._vaults.get(vault_id)
+            return dict(v) if v else {}
+
+    def credit_vault(self, vault_id: str, asset: str, amount: float) -> Dict[str, Any]:
+        with self._lock:
+            v = self._ensure_vault(vault_id, vault_id)
+            v["balances"][asset] = float(v["balances"].get(asset, 0.0)) + float(amount)
+            self._append_audit("vault.credit", {"vault_id": vault_id, "asset": asset, "amount": amount})
+            return dict(v)
+
+    def balance(self, vault_id: str, asset: str) -> float:
+        with self._lock:
+            v = self._vaults.get(vault_id)
+            if not v:
+                return 0.0
+            return float(v["balances"].get(asset, 0.0))
+
+    def debit_vault(self, vault_id: str, asset: str, amount: float) -> None:
+        with self._lock:
+            v = self._ensure_vault(vault_id, vault_id)
+            v["balances"][asset] = max(0.0, float(v["balances"].get(asset, 0.0)) - float(amount))
+
+    # -- withdrawals -------------------------------------------------------
+    @staticmethod
+    def _parse_intent(intent: str) -> Dict[str, Any]:
+        parts = intent.split("|")
+        keys = ["asset", "chain_ref", "network", "recipient", "amount", "ts_ms", "nonce"]
+        out = dict(zip(keys, parts))
+        try:
+            out["amount"] = float(out.get("amount", "0"))
+        except ValueError:
+            out["amount"] = 0.0
+        return out
+
+    def create_withdrawal(self, wallet: str, intent: str, idempotency_key: str) -> Tuple[int, Dict[str, Any]]:
+        with self._lock:
+            if idempotency_key and idempotency_key in self._idem:
+                wid = self._idem[idempotency_key]
+                return self._status_tuple(wid)
+            parsed = self._parse_intent(intent)
+            wid = f"wd-{uuid.uuid4().hex[:16]}"
+            recipient = str(parsed.get("recipient", ""))
+            amount = float(parsed.get("amount", 0.0))
+            asset = str(parsed.get("asset", ""))
+            now = _now_ms()
+            base = {
+                "withdrawal_id": wid,
+                "wallet_id": wallet,
+                "asset": asset,
+                "chain_ref": parsed.get("chain_ref"),
+                "network": parsed.get("network"),
+                "recipient": recipient,
+                "amount": amount,
+                "created_ms": now,
+                "intent": intent,
+                "approvals": [],
+                "approvals_required": self._approvals_required,
+            }
+            # Screening / sanctions gate.
+            if recipient.lower() in _MOCK_SANCTIONED:
+                base["status"] = "blocked"
+                base["error"] = "sanctioned_recipient"
+                base["category"] = "ofac"
+                base["source"] = "demo_list"
+                self._withdrawals[wid] = base
+                if idempotency_key:
+                    self._idem[idempotency_key] = wid
+                self._append_audit("withdrawal.blocked", {"withdrawal_id": wid, "recipient": recipient})
+                return 403, {
+                    "status": "blocked",
+                    "error": "sanctioned_recipient",
+                    "category": "ofac",
+                    "source": "demo_list",
+                    "withdrawal_id": wid,
+                }
+            if amount >= self._threshold:
+                base["status"] = "pending_approval"
+                base["timelock_until_ms"] = now + int(getattr(S, "custody_timelock_seconds", 0)) * 1000
+                self._withdrawals[wid] = base
+                if idempotency_key:
+                    self._idem[idempotency_key] = wid
+                self._append_audit("withdrawal.pending", {"withdrawal_id": wid, "amount": amount})
+                return 202, {
+                    "withdrawal_id": wid,
+                    "status": "pending_approval",
+                    "approvals_required": self._approvals_required,
+                    "approvals": [],
+                }
+            # Below threshold -> screened + signed immediately.
+            base["status"] = "signed"
+            base["signature"] = "0x" + _derive_hex("sig", wid, intent, length=130)
+            base["digest"] = "0x" + _derive_hex("digest", intent, length=64)
+            base["signed_ms"] = now
+            self._withdrawals[wid] = base
+            if idempotency_key:
+                self._idem[idempotency_key] = wid
+            self._append_audit("withdrawal.signed", {"withdrawal_id": wid, "amount": amount})
+            # Auto-progress signed -> broadcast -> settled deterministically for demo.
+            return 200, {
+                "withdrawal_id": wid,
+                "wallet_id": wallet,
+                "status": "signed",
+                "signature": base["signature"],
+                "digest": base["digest"],
+            }
+
+    def approve_withdrawal(self, withdrawal_id: str, approver: str) -> Tuple[int, Dict[str, Any]]:
+        with self._lock:
+            w = self._withdrawals.get(withdrawal_id)
+            if not w:
+                return 404, {"detail": "not_found"}
+            if w["status"] not in ("pending_approval",):
+                return 409, {"status": w["status"], "detail": "not_pending_approval"}
+            if approver not in w["approvals"]:
+                w["approvals"].append(approver)
+                self._append_audit("withdrawal.approval", {"withdrawal_id": withdrawal_id, "approver": approver})
+            if len(w["approvals"]) >= w["approvals_required"]:
+                w["status"] = "approved"
+                self._append_audit("withdrawal.approved", {"withdrawal_id": withdrawal_id})
+            return 200, {
+                "withdrawal_id": withdrawal_id,
+                "status": w["status"],
+                "approvals": list(w["approvals"]),
+                "approvals_required": w["approvals_required"],
+            }
+
+    def release_withdrawal(self, withdrawal_id: str) -> Tuple[int, Dict[str, Any]]:
+        with self._lock:
+            w = self._withdrawals.get(withdrawal_id)
+            if not w:
+                return 404, {"detail": "not_found"}
+            now = _now_ms()
+            if now < int(w.get("timelock_until_ms", 0)):
+                return 425, {"status": "timelock", "detail": "timelock_not_elapsed",
+                             "timelock_until_ms": w.get("timelock_until_ms")}
+            if len(w.get("approvals", [])) < w.get("approvals_required", self._approvals_required):
+                return 409, {"status": w["status"], "detail": "insufficient_approvals"}
+            w["signature"] = "0x" + _derive_hex("sig", withdrawal_id, w.get("intent", ""), length=130)
+            w["digest"] = "0x" + _derive_hex("digest", w.get("intent", ""), length=64)
+            w["status"] = "signed"
+            w["signed_ms"] = now
+            self._append_audit("withdrawal.released", {"withdrawal_id": withdrawal_id})
+            return 200, {
+                "withdrawal_id": withdrawal_id,
+                "status": "signed",
+                "signature": w["signature"],
+                "digest": w["digest"],
+            }
+
+    def _effective_status(self, w: Dict[str, Any]) -> str:
+        """Progress signed -> broadcast -> settled over wall-clock for demo realism."""
+        status = w.get("status")
+        if status == "signed":
+            elapsed = _now_ms() - int(w.get("signed_ms", _now_ms()))
+            if elapsed >= 4000:
+                return "settled"
+            if elapsed >= 1000:
+                return "broadcast"
+        return status
+
+    def _status_tuple(self, withdrawal_id: str) -> Tuple[int, Dict[str, Any]]:
+        w = self._withdrawals.get(withdrawal_id)
+        if not w:
+            return 404, {"detail": "not_found"}
+        return 200, self.get_withdrawal(withdrawal_id)
+
+    def get_withdrawal(self, withdrawal_id: str) -> Dict[str, Any]:
+        with self._lock:
+            w = self._withdrawals.get(withdrawal_id)
+            if not w:
+                return {}
+            eff = self._effective_status(w)
+            out = {
+                "withdrawal_id": w["withdrawal_id"],
+                "wallet_id": w["wallet_id"],
+                "asset": w.get("asset"),
+                "chain_ref": w.get("chain_ref"),
+                "network": w.get("network"),
+                "recipient": w.get("recipient"),
+                "amount": w.get("amount"),
+                "status": eff,
+                "approvals": list(w.get("approvals", [])),
+                "approvals_required": w.get("approvals_required"),
+                "created_ms": w.get("created_ms"),
+            }
+            for k in ("signature", "digest", "error", "category", "source", "timelock_until_ms"):
+                if k in w:
+                    out[k] = w[k]
+            return out
+
+    def list_withdrawals(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [self.get_withdrawal(wid) for wid in self._withdrawals]
+
+    # -- audit -------------------------------------------------------------
+    def audit(self) -> Dict[str, Any]:
+        with self._lock:
+            return {"entries": list(self._audit[-100:])}
+
+    def audit_verify(self) -> Dict[str, Any]:
+        with self._lock:
+            prev = "0" * 64
+            for e in self._audit:
+                body = {"seq": e["seq"], "action": e["action"], "detail": e["detail"], "ts_ms": e["ts_ms"]}
+                chained = hashlib.sha256((prev + json.dumps(body, sort_keys=True)).encode()).hexdigest()
+                if chained != e["hash"] or e["prev"] != prev:
+                    return {"ok": False, "entries": len(self._audit)}
+                prev = chained
+            return {"ok": True, "entries": len(self._audit)}
+
+
+# ---------------------------------------------------------------------------
+# Module-level singletons.
+# ---------------------------------------------------------------------------
+_MOCK_SINGLETON: Optional[_MockCustodyGateway] = None
+_REAL_SINGLETON: Optional[CustodyGatewayClient] = None
+
+
+def _load_officer_keys() -> Dict[str, Dict[str, str]]:
+    raw = getattr(S, "custody_officer_keys", "") or ""
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return {str(k): dict(v) for k, v in data.items() if isinstance(v, dict)}
+    except Exception:
+        logger.warning("CUSTODY_OFFICER_KEYS is not valid JSON; ignoring")
+    return {}
+
+
+def get_custody_gateway():
+    """Return the real client when configured, else the shared in-memory mock."""
+    global _MOCK_SINGLETON, _REAL_SINGLETON
+    if CustodyGatewayClient.is_configured():
+        if _REAL_SINGLETON is None:
+            _REAL_SINGLETON = CustodyGatewayClient(
+                base_url=S.custody_gateway_url,
+                api_key=S.custody_api_key,
+                api_secret=S.custody_api_secret,
+                tenant=S.custody_tenant,
+                verify_tls=bool(S.custody_verify_tls),
+                timeout_seconds=float(S.custody_timeout_seconds),
+                officer_keys=_load_officer_keys(),
+            )
+        return _REAL_SINGLETON
+    if _MOCK_SINGLETON is None:
+        _MOCK_SINGLETON = _MockCustodyGateway(tenant=S.custody_tenant)
+    return _MOCK_SINGLETON
+
+
+def is_mock(gateway: Any) -> bool:
+    return isinstance(gateway, _MockCustodyGateway)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ const ProjectsPage = lazy(() => import("@/pages/projects/ProjectsPage"));
 const ProjectDetailPage = lazy(() => import("@/pages/projects/ProjectDetailPage"));
 const BillingPage = lazy(() => import("@/pages/billing/BillingPage"));
 const CalendarPage = lazy(() => import("@/pages/calendar/CalendarPage"));
+const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
 const CatalogPage = lazy(() => import("@/pages/shop/CatalogPage"));
 const ProductDetail = lazy(() => import("@/pages/shop/ProductDetail"));
 const CartPage = lazy(() => import("@/pages/shop/CartPage"));
@@ -714,6 +715,7 @@ export default function App() {
           <Route path="ads/affiliate-discounts" element={<AdAffiliateDiscountPage />} />
           <Route path="ads/content-controls" element={<ContentAdControlsPage />} />
           <Route path="calendar" element={<CalendarPage />} />
+          <Route path="custody" element={<CustodyPage />} />
           <Route path="content-calendar" element={<ContentCalendarPage />} />
           <Route path="agents/memory/:workerId" element={<AgentMemoryPage />} />
           <Route path="agents/feedback" element={<AgentFeedbackPage />} />

--- a/frontend/src/api/endpoints/custody.ts
+++ b/frontend/src/api/endpoints/custody.ts
@@ -1,0 +1,155 @@
+import { api } from "@/api/client";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface CustodyAsset {
+  asset: string;
+  chain: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  network: string;
+  balance: string | number;
+  address_available: boolean;
+}
+
+export interface DepositAddress {
+  asset: string;
+  chain: string;
+  network: string;
+  address: string;
+  memo?: string | null;
+}
+
+export interface CustodyDeposit {
+  id: string;
+  asset: string;
+  chain: string;
+  amount: string | number;
+  status: string;
+  confirmations: number;
+}
+
+export type WithdrawalStatus =
+  | "screening"
+  | "signed"
+  | "pending_approval"
+  | "blocked"
+  | "rejected"
+  | "broadcast"
+  | "settled";
+
+/** Shape returned by POST /ui/custody/withdrawals (create). */
+export interface WithdrawalCreateResult {
+  id: string;
+  status: WithdrawalStatus;
+  asset: string;
+  chain: string;
+  amount: string | number;
+  destination: string;
+  signature?: string | null;
+  digest?: string | null;
+  approvals_required?: number;
+  approvals?: number | string[];
+  error?: string | null;
+  category?: string | null;
+  source?: string | null;
+  detail?: string | null;
+}
+
+/** Shape returned by list/detail endpoints. */
+export interface Withdrawal {
+  id: string;
+  asset: string;
+  chain_ref?: string;
+  chain?: string;
+  network?: string;
+  recipient?: string;
+  destination?: string;
+  amount: string | number;
+  status: WithdrawalStatus;
+  approvals?: string[];
+  approvals_count?: number;
+  approvals_required?: number;
+  signature?: string | null;
+  digest?: string | null;
+  error?: string | null;
+  category?: string | null;
+  source?: string | null;
+  timelock_until_ms?: number | null;
+  created_ms?: number;
+}
+
+export interface AuditEntry {
+  seq: number;
+  action: string;
+  detail: string;
+  ts_ms: number;
+  prev: string;
+  hash: string;
+}
+
+export interface AuditResp {
+  entries: AuditEntry[];
+}
+
+export interface AuditVerifyResp {
+  ok: boolean;
+  entries: number;
+}
+
+export interface ApproveResp {
+  withdrawal_id: string;
+  status: WithdrawalStatus;
+  approvals: number | string[];
+  approvals_required: number;
+}
+
+export interface ReleaseResp {
+  withdrawal_id: string;
+  status: "signed";
+  signature: string;
+  digest: string;
+}
+
+// ─── Endpoints ──────────────────────────────────────────────────
+
+export const listCustodyAssets = () =>
+  api.get<CustodyAsset[]>("/ui/custody/assets");
+
+export const getDepositAddress = (asset: string, chain: string) =>
+  api.get<DepositAddress>("/ui/custody/deposit-address", { asset, chain });
+
+export const listCustodyDeposits = () =>
+  api.get<CustodyDeposit[]>("/ui/custody/deposits");
+
+export const createWithdrawal = (body: {
+  asset: string;
+  chain: string;
+  amount: string;
+  destination: string;
+  memo?: string;
+}) => api.post<WithdrawalCreateResult>("/ui/custody/withdrawals", body);
+
+export const listWithdrawals = () =>
+  api.get<Withdrawal[]>("/ui/custody/withdrawals");
+
+export const getWithdrawal = (id: string) =>
+  api.get<Withdrawal>(`/ui/custody/withdrawals/${id}`);
+
+// ─── Officer / admin ────────────────────────────────────────────
+
+export const listApprovals = () =>
+  api.get<Withdrawal[]>("/ui/custody/approvals");
+
+export const approveWithdrawal = (id: string, approver?: string) =>
+  api.post<ApproveResp>(`/ui/custody/withdrawals/${id}/approve`, approver ? { approver } : {});
+
+export const releaseWithdrawal = (id: string) =>
+  api.post<ReleaseResp>(`/ui/custody/withdrawals/${id}/release`, {});
+
+export const getCustodyAudit = () =>
+  api.get<AuditResp>("/ui/custody/audit");
+
+export const verifyCustodyAudit = () =>
+  api.get<AuditVerifyResp>("/ui/custody/audit/verify");

--- a/frontend/src/components/custody/QRCode.tsx
+++ b/frontend/src/components/custody/QRCode.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { generateQR } from "./qr";
+
+interface QRCodeProps {
+  value: string;
+  /** Rendered pixel size of the whole code (square). */
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Dependency-free QR renderer. Draws the module matrix from ./qr as a single
+ * inline SVG path (crisp at any size, no canvas, no npm dep). Returns null if
+ * the value can't be encoded (caller still shows the address text).
+ */
+export function QRCode({ value, size = 200, className }: QRCodeProps) {
+  const matrix = useMemo(() => {
+    try {
+      return generateQR(value, "M");
+    } catch {
+      return null;
+    }
+  }, [value]);
+
+  if (!matrix || matrix.length === 0) {
+    return null;
+  }
+
+  const n = matrix.length;
+  const quiet = 4; // quiet-zone modules
+  const dim = n + quiet * 2;
+
+  // Build one path string of all dark modules.
+  let d = "";
+  for (let r = 0; r < n; r++) {
+    const row = matrix[r];
+    if (!row) continue;
+    for (let c = 0; c < n; c++) {
+      if (row[c]) {
+        d += `M${c + quiet} ${r + quiet}h1v1h-1z`;
+      }
+    }
+  }
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${dim} ${dim}`}
+      className={className}
+      shapeRendering="crispEdges"
+      role="img"
+      aria-label="Deposit address QR code"
+    >
+      <rect width={dim} height={dim} fill="#ffffff" />
+      <path d={d} fill="#000000" />
+    </svg>
+  );
+}
+
+export default QRCode;

--- a/frontend/src/components/custody/qr.ts
+++ b/frontend/src/components/custody/qr.ts
@@ -1,0 +1,326 @@
+// Minimal, dependency-free QR Code generator (byte mode, EC level L/M/Q/H).
+// Vendored so the Custody deposit screen can render a scannable QR without
+// adding an npm dependency. Compact TS implementation of the QR standard
+// (Reed–Solomon + mask + format info). Supports versions 1–10, which covers
+// crypto addresses comfortably. Returns a boolean module matrix (true = dark).
+//
+// Written to be clean under noUncheckedIndexedAccess: hot lookup tables are
+// Uint8Array-indexed (which yield `number`, not `number | undefined`), and
+// small config tuples are read via helpers that assert presence.
+
+type ECLevel = "L" | "M" | "Q" | "H";
+
+// GF(256) tables for Reed–Solomon.
+const EXP = new Uint8Array(512);
+const LOG = new Uint8Array(256);
+(function initGF() {
+  let x = 1;
+  for (let i = 0; i < 255; i++) {
+    EXP[i] = x;
+    LOG[x] = i;
+    x <<= 1;
+    if (x & 0x100) x ^= 0x11d;
+  }
+  for (let i = 255; i < 512; i++) EXP[i] = EXP[i - 255]!;
+})();
+
+function gfMul(a: number, b: number): number {
+  if (a === 0 || b === 0) return 0;
+  return EXP[LOG[a]! + LOG[b]!]!;
+}
+
+function rsGenPoly(degree: number): Uint8Array {
+  let poly = new Uint8Array([1]);
+  for (let i = 0; i < degree; i++) {
+    const next = new Uint8Array(poly.length + 1);
+    for (let j = 0; j < poly.length; j++) {
+      next[j] = next[j]! ^ poly[j]!;
+      next[j + 1] = next[j + 1]! ^ gfMul(poly[j]!, EXP[i]!);
+    }
+    poly = next;
+  }
+  return poly;
+}
+
+function rsEncode(data: number[], ecCount: number): number[] {
+  const gen = rsGenPoly(ecCount);
+  const res = new Uint8Array(ecCount);
+  for (const d of data) {
+    const factor = d ^ res[0]!;
+    for (let i = 0; i < res.length - 1; i++) res[i] = res[i + 1]!;
+    res[res.length - 1] = 0;
+    for (let i = 0; i < gen.length - 1; i++) {
+      res[i] = res[i]! ^ gfMul(gen[i + 1]!, factor);
+    }
+  }
+  return Array.from(res);
+}
+
+// EC + capacity tables for versions 1..10 (byte mode).
+// [ecCodewordsPerBlock, numBlocksGroup1, dataCodewordsGroup1, numBlocksGroup2, dataCodewordsGroup2]
+type EcRow = readonly [number, number, number, number, number];
+const EC_TABLE: Record<ECLevel, readonly EcRow[]> = {
+  L: [
+    [7, 1, 19, 0, 0], [10, 1, 34, 0, 0], [15, 1, 55, 0, 0], [20, 1, 80, 0, 0],
+    [26, 1, 108, 0, 0], [18, 2, 68, 0, 0], [20, 2, 78, 0, 0], [24, 2, 97, 0, 0],
+    [30, 2, 116, 0, 0], [18, 2, 68, 2, 69],
+  ],
+  M: [
+    [10, 1, 16, 0, 0], [16, 1, 28, 0, 0], [26, 1, 44, 0, 0], [18, 2, 32, 0, 0],
+    [24, 2, 43, 0, 0], [16, 4, 27, 0, 0], [18, 4, 31, 0, 0], [22, 2, 38, 2, 39],
+    [22, 3, 36, 2, 37], [26, 4, 43, 1, 44],
+  ],
+  Q: [
+    [13, 1, 13, 0, 0], [22, 1, 22, 0, 0], [18, 2, 17, 0, 0], [26, 2, 24, 0, 0],
+    [18, 2, 15, 2, 16], [24, 4, 19, 0, 0], [18, 2, 14, 4, 15], [22, 4, 18, 2, 19],
+    [20, 4, 16, 4, 17], [24, 6, 19, 2, 20],
+  ],
+  H: [
+    [17, 1, 9, 0, 0], [28, 1, 16, 0, 0], [22, 2, 13, 0, 0], [16, 4, 9, 0, 0],
+    [22, 2, 11, 2, 12], [28, 4, 15, 0, 0], [26, 4, 13, 1, 14], [26, 4, 14, 2, 15],
+    [24, 4, 12, 4, 13], [28, 6, 15, 2, 16],
+  ],
+};
+
+function ecRow(version: number, ec: ECLevel): EcRow {
+  const row = EC_TABLE[ec][version - 1];
+  if (!row) throw new Error("QR: unsupported version");
+  return row;
+}
+
+// Alignment pattern centers per version (index = version-1).
+const ALIGN: readonly (readonly number[])[] = [
+  [], [6, 18], [6, 22], [6, 26], [6, 30], [6, 34],
+  [6, 22, 38], [6, 24, 42], [6, 26, 46], [6, 28, 50],
+];
+
+function dataCodewords(version: number, ec: ECLevel): number {
+  const [, g1, d1, g2, d2] = ecRow(version, ec);
+  return g1 * d1 + g2 * d2;
+}
+
+function chooseVersion(byteLen: number, ec: ECLevel): number {
+  for (let v = 1; v <= 10; v++) {
+    const ccBits = v <= 9 ? 8 : 16;
+    const bits = 4 + ccBits + byteLen * 8;
+    const cap = dataCodewords(v, ec) * 8;
+    if (bits <= cap) return v;
+  }
+  throw new Error("QR: data too long for supported versions (1-10)");
+}
+
+function buildBitstream(bytes: number[], version: number, ec: ECLevel): number[] {
+  const bits: number[] = [];
+  const push = (val: number, len: number) => {
+    for (let i = len - 1; i >= 0; i--) bits.push((val >> i) & 1);
+  };
+  push(0b0100, 4); // byte mode
+  push(bytes.length, version <= 9 ? 8 : 16);
+  for (const b of bytes) push(b, 8);
+
+  const capBits = dataCodewords(version, ec) * 8;
+  for (let i = 0; i < 4 && bits.length < capBits; i++) bits.push(0);
+  while (bits.length % 8 !== 0) bits.push(0);
+  const pads = [0xec, 0x11];
+  let pi = 0;
+  while (bits.length < capBits) {
+    push(pads[pi % 2]!, 8);
+    pi++;
+  }
+  const cw: number[] = [];
+  for (let i = 0; i < bits.length; i += 8) {
+    let v = 0;
+    for (let j = 0; j < 8; j++) v = (v << 1) | bits[i + j]!;
+    cw.push(v);
+  }
+  return cw;
+}
+
+function interleave(dataCw: number[], version: number, ec: ECLevel): number[] {
+  const [ecCw, g1, d1, g2, d2] = ecRow(version, ec);
+  const blocks: { data: number[]; ecc: number[] }[] = [];
+  let idx = 0;
+  for (let i = 0; i < g1; i++) {
+    const data = dataCw.slice(idx, idx + d1);
+    idx += d1;
+    blocks.push({ data, ecc: rsEncode(data, ecCw) });
+  }
+  for (let i = 0; i < g2; i++) {
+    const data = dataCw.slice(idx, idx + d2);
+    idx += d2;
+    blocks.push({ data, ecc: rsEncode(data, ecCw) });
+  }
+  const result: number[] = [];
+  const maxData = Math.max(d1, d2);
+  for (let i = 0; i < maxData; i++) {
+    for (const b of blocks) if (i < b.data.length) result.push(b.data[i]!);
+  }
+  for (let i = 0; i < ecCw; i++) {
+    for (const b of blocks) result.push(b.ecc[i]!);
+  }
+  return result;
+}
+
+function sizeForVersion(v: number): number {
+  return 17 + v * 4;
+}
+
+// Row-major boolean grid stored as Uint8Array (0/1) for strict-safe indexing.
+class BitGrid {
+  size: number;
+  cells: Uint8Array;
+  constructor(size: number) {
+    this.size = size;
+    this.cells = new Uint8Array(size * size);
+  }
+  get(r: number, c: number): number {
+    return this.cells[r * this.size + c]!;
+  }
+  set(r: number, c: number, v: boolean | number) {
+    this.cells[r * this.size + c] = v ? 1 : 0;
+  }
+}
+
+function placeFunctionPatterns(grid: BitGrid, reserved: BitGrid, size: number, version: number) {
+  const setFinder = (r: number, c: number) => {
+    for (let dr = -1; dr <= 7; dr++) {
+      for (let dc = -1; dc <= 7; dc++) {
+        const rr = r + dr;
+        const cc = c + dc;
+        if (rr < 0 || rr >= size || cc < 0 || cc >= size) continue;
+        reserved.set(rr, cc, true);
+        const inRing =
+          dr >= 0 && dr <= 6 && dc >= 0 && dc <= 6 &&
+          (dr === 0 || dr === 6 || dc === 0 || dc === 6 || (dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4));
+        grid.set(rr, cc, inRing);
+      }
+    }
+  };
+  setFinder(0, 0);
+  setFinder(0, size - 7);
+  setFinder(size - 7, 0);
+
+  for (let i = 8; i < size - 8; i++) {
+    if (!reserved.get(6, i)) { grid.set(6, i, i % 2 === 0); reserved.set(6, i, true); }
+    if (!reserved.get(i, 6)) { grid.set(i, 6, i % 2 === 0); reserved.set(i, 6, true); }
+  }
+
+  const centers = ALIGN[version - 1] ?? [];
+  for (const r of centers) {
+    for (const c of centers) {
+      if ((r <= 8 && c <= 8) || (r <= 8 && c >= size - 9) || (r >= size - 9 && c <= 8)) continue;
+      for (let dr = -2; dr <= 2; dr++) {
+        for (let dc = -2; dc <= 2; dc++) {
+          const rr = r + dr;
+          const cc = c + dc;
+          reserved.set(rr, cc, true);
+          grid.set(rr, cc, Math.max(Math.abs(dr), Math.abs(dc)) !== 1);
+        }
+      }
+    }
+  }
+
+  grid.set(size - 8, 8, true);
+  reserved.set(size - 8, 8, true);
+
+  for (let i = 0; i < 9; i++) {
+    reserved.set(8, i, true);
+    reserved.set(i, 8, true);
+  }
+  for (let i = 0; i < 8; i++) {
+    reserved.set(8, size - 1 - i, true);
+    reserved.set(size - 1 - i, 8, true);
+  }
+}
+
+function placeData(grid: BitGrid, reserved: BitGrid, size: number, cw: number[]) {
+  const bits: number[] = [];
+  for (const b of cw) for (let i = 7; i >= 0; i--) bits.push((b >> i) & 1);
+  let bi = 0;
+  let upward = true;
+  for (let col = size - 1; col > 0; col -= 2) {
+    if (col === 6) col = 5;
+    for (let i = 0; i < size; i++) {
+      const row = upward ? size - 1 - i : i;
+      for (let c = 0; c < 2; c++) {
+        const cc = col - c;
+        if (reserved.get(row, cc)) continue;
+        grid.set(row, cc, bi < bits.length ? bits[bi] === 1 : false);
+        bi++;
+      }
+    }
+    upward = !upward;
+  }
+}
+
+function maskFn(mask: number, r: number, c: number): boolean {
+  switch (mask) {
+    case 0: return (r + c) % 2 === 0;
+    case 1: return r % 2 === 0;
+    case 2: return c % 3 === 0;
+    case 3: return (r + c) % 3 === 0;
+    case 4: return (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0;
+    case 5: return ((r * c) % 2) + ((r * c) % 3) === 0;
+    case 6: return (((r * c) % 2) + ((r * c) % 3)) % 2 === 0;
+    default: return (((r + c) % 2) + ((r * c) % 3)) % 2 === 0;
+  }
+}
+
+const EC_BITS: Record<ECLevel, number> = { L: 0b01, M: 0b00, Q: 0b11, H: 0b10 };
+
+function formatBits(ec: ECLevel, mask: number): number {
+  const data = (EC_BITS[ec] << 3) | mask;
+  let rem = data;
+  for (let i = 0; i < 10; i++) {
+    rem = (rem << 1) ^ (((rem >> 9) & 1) ? 0x537 : 0);
+  }
+  return ((data << 10) | rem) ^ 0x5412;
+}
+
+function applyFormat(grid: BitGrid, size: number, ec: ECLevel, mask: number) {
+  const fmt = formatBits(ec, mask);
+  const bit = (i: number) => ((fmt >> i) & 1) === 1;
+  for (let i = 0; i <= 5; i++) grid.set(8, i, bit(i));
+  grid.set(8, 7, bit(6));
+  grid.set(8, 8, bit(7));
+  grid.set(7, 8, bit(8));
+  for (let i = 9; i <= 14; i++) grid.set(14 - i, 8, bit(i));
+  for (let i = 0; i <= 7; i++) grid.set(size - 1 - i, 8, bit(i));
+  for (let i = 8; i <= 14; i++) grid.set(8, size - 15 + i, bit(i));
+}
+
+/**
+ * Generate a QR module matrix (true = dark) for the given text.
+ * Byte mode, fixed mask 0 (deterministic, valid).
+ */
+export function generateQR(text: string, ec: ECLevel = "M"): boolean[][] {
+  const bytes = Array.from(new TextEncoder().encode(text));
+  const version = chooseVersion(bytes.length, ec);
+  const size = sizeForVersion(version);
+
+  const dataCw = buildBitstream(bytes, version, ec);
+  const finalCw = interleave(dataCw, version, ec);
+
+  const grid = new BitGrid(size);
+  const reserved = new BitGrid(size);
+  placeFunctionPatterns(grid, reserved, size, version);
+  placeData(grid, reserved, size, finalCw);
+
+  const mask = 0;
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      if (!reserved.get(r, c) && maskFn(mask, r, c)) {
+        grid.set(r, c, grid.get(r, c) ? 0 : 1);
+      }
+    }
+  }
+  applyFormat(grid, size, ec, mask);
+
+  const out: boolean[][] = [];
+  for (let r = 0; r < size; r++) {
+    const row: boolean[] = [];
+    for (let c = 0; c < size; c++) row.push(grid.get(r, c) === 1);
+    out.push(row);
+  }
+  return out;
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -169,6 +169,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Analytics", i18nKey: "nav.analytics", path: "/analytics", icon: <BarChart3 className="h-5 w-5" /> },
       { label: "Content Revenue", i18nKey: "nav.contentRevenue", path: "/analytics/content-revenue", icon: <BarChart3 className="h-5 w-5" /> },
       { label: "Payouts", i18nKey: "nav.payouts", path: "/payouts", icon: <Wallet className="h-5 w-5" /> },
+      { label: "Custody", i18nKey: "nav.custody", path: "/custody", icon: <Coins className="h-5 w-5" /> },
       { label: "Referrals", i18nKey: "nav.referrals", path: "/referrals", icon: <Share2 className="h-5 w-5" /> },
       { label: "Promo Codes", i18nKey: "nav.promoCodes", path: "/promo", icon: <Tag className="h-5 w-5" /> },
       { label: "Affiliates", i18nKey: "nav.affiliates", path: "/affiliates", icon: <Link2 className="h-5 w-5" /> },

--- a/frontend/src/pages/custody/CustodyPage.tsx
+++ b/frontend/src/pages/custody/CustodyPage.tsx
@@ -1,0 +1,1036 @@
+// Crypto Custody — one responsive React page (desktop + mobile web) for the
+// testlogon `/ui/custody/*` backend: balances, deposit (address + QR),
+// withdraw (with confirm step + status), activity (live-polled), and an
+// officer/admin-only Approvals + hash-chained Audit tab.
+import { useEffect, useMemo, useState } from "react";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  Wallet,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  ListChecks,
+  ShieldCheck,
+  Copy,
+  Check,
+  RefreshCw,
+  Loader2,
+  AlertTriangle,
+  CircleCheck,
+  Clock,
+  Ban,
+  XCircle,
+  ScrollText,
+} from "lucide-react";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+import { useAuthStore } from "@/stores/authStore";
+import { cn } from "@/lib/utils";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Progress } from "@/components/ui/progress";
+
+import QRCode from "@/components/custody/QRCode";
+import {
+  listCustodyAssets,
+  getDepositAddress,
+  listCustodyDeposits,
+  createWithdrawal,
+  listWithdrawals,
+  getWithdrawal,
+  listApprovals,
+  approveWithdrawal,
+  releaseWithdrawal,
+  getCustodyAudit,
+  verifyCustodyAudit,
+  type CustodyAsset,
+  type Withdrawal,
+  type WithdrawalCreateResult,
+  type WithdrawalStatus,
+} from "@/api/endpoints/custody";
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function useIsMobile(bp = 767): boolean {
+  const [m, setM] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(`(max-width: ${bp}px)`).matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${bp}px)`);
+    const h = () => setM(mq.matches);
+    mq.addEventListener("change", h);
+    return () => mq.removeEventListener("change", h);
+  }, [bp]);
+  return m;
+}
+
+function num(v: string | number | undefined | null): number {
+  if (v == null) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function fmtAmount(v: string | number | undefined | null): string {
+  const n = num(v);
+  if (n === 0) return "0";
+  return n.toLocaleString(undefined, { maximumFractionDigits: 8 });
+}
+
+const TERMINAL: WithdrawalStatus[] = ["blocked", "rejected", "settled"];
+function isTerminal(s: WithdrawalStatus): boolean {
+  return TERMINAL.includes(s);
+}
+
+function statusBadge(status: WithdrawalStatus | string) {
+  const map: Record<string, { variant: "default" | "secondary" | "destructive" | "success" | "warning" | "outline"; label: string; icon: JSX.Element }> = {
+    screening: { variant: "secondary", label: "Screening", icon: <Loader2 className="h-3 w-3 animate-spin" /> },
+    pending_approval: { variant: "warning", label: "Pending approval", icon: <Clock className="h-3 w-3" /> },
+    signed: { variant: "success", label: "Signed", icon: <CircleCheck className="h-3 w-3" /> },
+    broadcast: { variant: "default", label: "Broadcast", icon: <ArrowUpFromLine className="h-3 w-3" /> },
+    settled: { variant: "success", label: "Settled", icon: <Check className="h-3 w-3" /> },
+    blocked: { variant: "destructive", label: "Blocked", icon: <Ban className="h-3 w-3" /> },
+    rejected: { variant: "destructive", label: "Rejected", icon: <XCircle className="h-3 w-3" /> },
+  };
+  const cfg = map[status] ?? { variant: "outline" as const, label: String(status), icon: <Clock className="h-3 w-3" /> };
+  return (
+    <Badge variant={cfg.variant} className="gap-1 whitespace-nowrap">
+      {cfg.icon}
+      {cfg.label}
+    </Badge>
+  );
+}
+
+function short(s?: string | null, head = 10, tail = 8): string {
+  if (!s) return "";
+  if (s.length <= head + tail + 1) return s;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
+}
+
+function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          toast.success("Copied to clipboard");
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          toast.error("Could not copy");
+        }
+      }}
+      className="gap-1.5"
+    >
+      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      {copied ? "Copied" : label}
+    </Button>
+  );
+}
+
+function approvalsCount(w: Withdrawal): number {
+  if (typeof w.approvals_count === "number") return w.approvals_count;
+  if (Array.isArray(w.approvals)) return w.approvals.length;
+  return 0;
+}
+
+// ─── Balances / Overview ────────────────────────────────────────
+
+function OverviewTab({
+  onDeposit,
+  onWithdraw,
+}: {
+  onDeposit: (a: CustodyAsset) => void;
+  onWithdraw: (a: CustodyAsset) => void;
+}) {
+  const { data: assets, isLoading, isError, refetch, isFetching } = useQuery({
+    queryKey: ["custody", "assets"],
+    queryFn: listCustodyAssets,
+    staleTime: 15_000,
+  });
+
+  const nonZero = (assets ?? []).filter((a) => num(a.balance) > 0);
+  const totalAssets = (assets ?? []).length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Balances</h2>
+          <p className="text-sm text-muted-foreground">
+            {nonZero.length} funded / {totalAssets} supported assets
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching} className="gap-1.5">
+          <RefreshCw className={cn("h-4 w-4", isFetching && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-28 w-full rounded-xl" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
+            <AlertTriangle className="h-8 w-8 text-destructive" />
+            <p className="text-sm text-muted-foreground">Could not load balances.</p>
+            <Button size="sm" onClick={() => refetch()}>Retry</Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && totalAssets === 0 && (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            No custody assets are available for your account yet.
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && totalAssets > 0 && (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {(assets ?? []).map((a) => {
+            const bal = num(a.balance);
+            return (
+              <Card key={`${a.asset}-${a.chain}`} className={cn(bal > 0 && "ring-1 ring-primary/20")}>
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+                        {a.symbol.slice(0, 4)}
+                      </div>
+                      <div>
+                        <CardTitle className="text-sm">{a.name}</CardTitle>
+                        <p className="text-xs text-muted-foreground">{a.network}</p>
+                      </div>
+                    </div>
+                    <Badge variant="outline" className="text-[10px]">{a.symbol}</Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div>
+                    <span className="text-xl font-semibold tabular-nums">{fmtAmount(a.balance)}</span>{" "}
+                    <span className="text-sm text-muted-foreground">{a.symbol}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="secondary" className="flex-1 gap-1" onClick={() => onDeposit(a)} disabled={!a.address_available}>
+                      <ArrowDownToLine className="h-3.5 w-3.5" /> Deposit
+                    </Button>
+                    <Button size="sm" variant="secondary" className="flex-1 gap-1" onClick={() => onWithdraw(a)} disabled={bal <= 0}>
+                      <ArrowUpFromLine className="h-3.5 w-3.5" /> Withdraw
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Deposit ────────────────────────────────────────────────────
+
+function DepositTab({ preselect }: { preselect?: CustodyAsset | null }) {
+  const { data: assets } = useQuery({
+    queryKey: ["custody", "assets"],
+    queryFn: listCustodyAssets,
+    staleTime: 15_000,
+  });
+  const withAddr = (assets ?? []).filter((a) => a.address_available);
+  const [selected, setSelected] = useState<string>("");
+
+  useEffect(() => {
+    if (preselect) {
+      setSelected(`${preselect.asset}::${preselect.chain}`);
+    } else if (!selected && withAddr.length > 0) {
+      const first = withAddr[0]!;
+      setSelected(`${first.asset}::${first.chain}`);
+    }
+  }, [preselect, withAddr, selected]);
+
+  const [asset = "", chain = ""] = selected.split("::");
+  const chosen = (assets ?? []).find((a) => a.asset === asset && a.chain === chain);
+
+  const addrQuery = useQuery({
+    queryKey: ["custody", "deposit-address", asset, chain],
+    queryFn: () => getDepositAddress(asset, chain),
+    enabled: Boolean(asset && chain),
+    retry: false,
+  });
+
+  const depositsQuery = useQuery({
+    queryKey: ["custody", "deposits"],
+    queryFn: listCustodyDeposits,
+    staleTime: 10_000,
+  });
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ArrowDownToLine className="h-5 w-5 text-primary" /> Receive crypto
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Asset / network</Label>
+            <Select value={selected} onValueChange={setSelected}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choose an asset" />
+              </SelectTrigger>
+              <SelectContent>
+                {withAddr.map((a) => (
+                  <SelectItem key={`${a.asset}::${a.chain}`} value={`${a.asset}::${a.chain}`}>
+                    {a.name} ({a.symbol}) — {a.network}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {addrQuery.isLoading && <Skeleton className="h-48 w-full rounded-xl" />}
+
+          {addrQuery.isError && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+              {(addrQuery.error as ApiError)?.detail ?? "Deposit address unavailable for this asset."}
+            </div>
+          )}
+
+          {addrQuery.data && (
+            <div className="space-y-4">
+              <div className="flex justify-center rounded-xl border bg-white p-4">
+                <QRCode value={addrQuery.data.address} size={192} />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">Deposit address</Label>
+                <div className="break-all rounded-lg border bg-muted/40 p-3 font-mono text-sm">
+                  {addrQuery.data.address}
+                </div>
+                <div className="flex flex-wrap gap-2 pt-1">
+                  <CopyButton text={addrQuery.data.address} label="Copy address" />
+                </div>
+              </div>
+
+              {addrQuery.data.memo && (
+                <div className="space-y-1.5">
+                  <Label className="text-xs text-muted-foreground">Memo / tag (required)</Label>
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 break-all rounded-lg border bg-muted/40 p-2 font-mono text-sm">
+                      {addrQuery.data.memo}
+                    </div>
+                    <CopyButton text={addrQuery.data.memo} label="Copy memo" />
+                  </div>
+                </div>
+              )}
+
+              <div className="flex items-start gap-2 rounded-lg border border-warning/40 bg-warning/10 p-3 text-xs">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+                <span>
+                  Send only <strong>{chosen?.symbol ?? asset}</strong> on the{" "}
+                  <strong>{addrQuery.data.network}</strong> network to this address. Sending any other
+                  asset or using another network may result in permanent loss.
+                </span>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent deposits</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {depositsQuery.isLoading && <Skeleton className="h-24 w-full" />}
+          {!depositsQuery.isLoading && (depositsQuery.data ?? []).length === 0 && (
+            <p className="py-8 text-center text-sm text-muted-foreground">No deposits yet.</p>
+          )}
+          {(depositsQuery.data ?? []).length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Asset</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Conf.</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(depositsQuery.data ?? []).map((d) => (
+                  <TableRow key={d.id}>
+                    <TableCell className="font-medium">{d.asset}</TableCell>
+                    <TableCell className="text-right tabular-nums">{fmtAmount(d.amount)}</TableCell>
+                    <TableCell>
+                      <Badge variant={d.status === "confirmed" || d.status === "credited" ? "success" : "secondary"}>
+                        {d.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{d.confirmations}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Withdraw ───────────────────────────────────────────────────
+
+function WithdrawResultView({ result }: { result: WithdrawalCreateResult }) {
+  const status = result.status;
+  if (status === "signed") {
+    return (
+      <div className="space-y-2 rounded-lg border border-success/40 bg-success/10 p-4">
+        <div className="flex items-center gap-2 font-medium text-success">
+          <CircleCheck className="h-5 w-5" /> Withdrawal signed
+        </div>
+        {result.signature && (
+          <p className="break-all font-mono text-xs text-muted-foreground">sig: {short(result.signature, 14, 12)}</p>
+        )}
+        {result.digest && (
+          <p className="break-all font-mono text-xs text-muted-foreground">digest: {short(result.digest, 14, 12)}</p>
+        )}
+      </div>
+    );
+  }
+  if (status === "pending_approval") {
+    const req = result.approvals_required ?? 2;
+    const have = Array.isArray(result.approvals) ? result.approvals.length : num(result.approvals);
+    return (
+      <div className="space-y-2 rounded-lg border border-warning/40 bg-warning/10 p-4">
+        <div className="flex items-center gap-2 font-medium text-warning">
+          <Clock className="h-5 w-5" /> Awaiting officer approval
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {have} of {req} approvals collected. A custody officer must approve before this transfer is signed.
+        </p>
+        <Progress value={req > 0 ? (have / req) * 100 : 0} className="h-2" />
+      </div>
+    );
+  }
+  if (status === "blocked") {
+    return (
+      <div className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/10 p-4">
+        <div className="flex items-center gap-2 font-medium text-destructive">
+          <Ban className="h-5 w-5" /> Blocked by screening
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {result.detail || result.error || `This destination was flagged${result.category ? ` (${result.category})` : ""}. The transfer was blocked and not signed.`}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/10 p-4">
+      <div className="flex items-center gap-2 font-medium text-destructive">
+        <XCircle className="h-5 w-5" /> Rejected
+      </div>
+      <p className="text-sm text-muted-foreground">{result.detail || result.error || "The withdrawal was rejected."}</p>
+    </div>
+  );
+}
+
+function WithdrawTab({ preselect }: { preselect?: CustodyAsset | null }) {
+  const qc = useQueryClient();
+  const { data: assets } = useQuery({
+    queryKey: ["custody", "assets"],
+    queryFn: listCustodyAssets,
+    staleTime: 15_000,
+  });
+  const funded = (assets ?? []).filter((a) => num(a.balance) > 0);
+
+  const [selected, setSelected] = useState<string>("");
+  const [amount, setAmount] = useState("");
+  const [destination, setDestination] = useState("");
+  const [memo, setMemo] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [result, setResult] = useState<WithdrawalCreateResult | null>(null);
+
+  useEffect(() => {
+    if (preselect) setSelected(`${preselect.asset}::${preselect.chain}`);
+    else if (!selected && funded.length > 0) { const first = funded[0]!; setSelected(`${first.asset}::${first.chain}`); }
+  }, [preselect, funded, selected]);
+
+  const [asset = "", chain = ""] = selected.split("::");
+  const chosen = (assets ?? []).find((a) => a.asset === asset && a.chain === chain);
+  const balance = num(chosen?.balance);
+
+  const amt = num(amount);
+  const amountError =
+    amount.trim() === ""
+      ? ""
+      : amt <= 0
+        ? "Amount must be greater than 0."
+        : amt > balance
+          ? "Amount exceeds your available balance."
+          : "";
+  const destError = destination.trim() === "" ? "" : destination.trim().length < 8 ? "Destination address looks too short." : "";
+  const canSubmit = Boolean(asset) && amt > 0 && amt <= balance && destination.trim().length >= 8;
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createWithdrawal({
+        asset,
+        chain,
+        amount: String(amt),
+        destination: destination.trim(),
+        memo: memo.trim() || undefined,
+      }),
+    onSuccess: (res) => {
+      setResult(res);
+      setConfirmOpen(false);
+      qc.invalidateQueries({ queryKey: ["custody", "withdrawals"] });
+      qc.invalidateQueries({ queryKey: ["custody", "assets"] });
+      if (res.status === "signed") toast.success("Withdrawal signed");
+      else if (res.status === "pending_approval") toast.message("Withdrawal awaiting approval");
+      else if (res.status === "blocked") toast.error("Withdrawal blocked by screening");
+      else toast.error("Withdrawal rejected");
+    },
+    onError: (err) => {
+      setConfirmOpen(false);
+      toast.error(err instanceof ApiError ? err.detail : "Withdrawal failed");
+    },
+  });
+
+  return (
+    <div className="mx-auto max-w-xl space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ArrowUpFromLine className="h-5 w-5 text-primary" /> Send crypto
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Asset</Label>
+            <Select value={selected} onValueChange={(v) => { setSelected(v); setResult(null); }}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choose a funded asset" />
+              </SelectTrigger>
+              <SelectContent>
+                {funded.length === 0 && <SelectItem value="__none" disabled>No funded assets</SelectItem>}
+                {funded.map((a) => (
+                  <SelectItem key={`${a.asset}::${a.chain}`} value={`${a.asset}::${a.chain}`}>
+                    {a.name} ({a.symbol}) — {fmtAmount(a.balance)} available
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <Label>Amount</Label>
+              {chosen && (
+                <button
+                  type="button"
+                  className="text-xs text-primary hover:underline"
+                  onClick={() => setAmount(String(balance))}
+                >
+                  Max: {fmtAmount(balance)} {chosen.symbol}
+                </button>
+              )}
+            </div>
+            <Input
+              inputMode="decimal"
+              placeholder="0.00"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))}
+            />
+            {amountError && <p className="text-xs text-destructive">{amountError}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Destination address</Label>
+            <Input
+              placeholder={`${chosen?.symbol ?? ""} address`}
+              value={destination}
+              onChange={(e) => setDestination(e.target.value)}
+              className="font-mono text-sm"
+            />
+            {destError && <p className="text-xs text-destructive">{destError}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Memo / tag (optional)</Label>
+            <Input placeholder="Only if the network requires it" value={memo} onChange={(e) => setMemo(e.target.value)} />
+          </div>
+
+          <Button className="w-full gap-1.5" disabled={!canSubmit} onClick={() => { setResult(null); setConfirmOpen(true); }}>
+            <ArrowUpFromLine className="h-4 w-4" /> Review withdrawal
+          </Button>
+        </CardContent>
+      </Card>
+
+      {result && <WithdrawResultView result={result} />}
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm withdrawal</DialogTitle>
+            <DialogDescription>Review the details carefully — crypto transfers can't be reversed.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-sm">
+            <div className="flex justify-between"><span className="text-muted-foreground">Asset</span><span className="font-medium">{chosen?.name} ({chosen?.symbol})</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Network</span><span className="font-medium">{chosen?.network}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Amount</span><span className="font-medium tabular-nums">{fmtAmount(amt)} {chosen?.symbol}</span></div>
+            <Separator />
+            <div className="space-y-1">
+              <span className="text-muted-foreground">Destination</span>
+              <div className="break-all font-mono text-xs">{destination.trim()}</div>
+            </div>
+            {memo.trim() && (
+              <div className="flex justify-between"><span className="text-muted-foreground">Memo</span><span className="font-mono text-xs">{memo.trim()}</span></div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={mutation.isPending}>Cancel</Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending} className="gap-1.5">
+              {mutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Confirm & send
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// ─── Activity / History ─────────────────────────────────────────
+
+function WithdrawalDetailDrawer({ id, open, onClose }: { id: string | null; open: boolean; onClose: () => void }) {
+  const [now, setNow] = useState(Date.now());
+  const detail = useQuery({
+    queryKey: ["custody", "withdrawal", id],
+    queryFn: () => getWithdrawal(id as string),
+    enabled: Boolean(id) && open,
+    refetchInterval: (q) => {
+      const w = q.state.data as Withdrawal | undefined;
+      return w && !isTerminal(w.status) ? 4000 : false;
+    },
+  });
+  const w = detail.data;
+
+  useEffect(() => {
+    if (!open) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [open]);
+
+  const timelockRemaining = w?.timelock_until_ms ? Math.max(0, w.timelock_until_ms - now) : 0;
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>Withdrawal detail</SheetTitle>
+          <SheetDescription>{id}</SheetDescription>
+        </SheetHeader>
+        {detail.isLoading && <Skeleton className="mt-4 h-40 w-full" />}
+        {w && (
+          <div className="mt-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Status</span>
+              {statusBadge(w.status)}
+            </div>
+            <Separator />
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between"><span className="text-muted-foreground">Asset</span><span className="font-medium">{w.asset}</span></div>
+              <div className="flex justify-between"><span className="text-muted-foreground">Network</span><span className="font-medium">{w.network ?? w.chain_ref ?? w.chain}</span></div>
+              <div className="flex justify-between"><span className="text-muted-foreground">Amount</span><span className="font-medium tabular-nums">{fmtAmount(w.amount)}</span></div>
+              <div className="space-y-0.5">
+                <span className="text-muted-foreground">Recipient</span>
+                <div className="break-all font-mono text-xs">{w.recipient ?? w.destination}</div>
+              </div>
+            </div>
+
+            {(w.approvals_required ?? 0) > 0 && (
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Approvals</span>
+                  <span className="font-medium">{approvalsCount(w)} / {w.approvals_required}</span>
+                </div>
+                <Progress value={(approvalsCount(w) / (w.approvals_required || 1)) * 100} className="h-2" />
+                {Array.isArray(w.approvals) && w.approvals.length > 0 && (
+                  <p className="text-xs text-muted-foreground">by {w.approvals.map((a) => short(a, 6, 4)).join(", ")}</p>
+                )}
+              </div>
+            )}
+
+            {timelockRemaining > 0 && (
+              <div className="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-warning">
+                <Clock className="h-4 w-4" />
+                Timelocked — releasable in {Math.ceil(timelockRemaining / 1000)}s
+              </div>
+            )}
+
+            {w.signature && (
+              <div className="space-y-0.5 rounded-lg border bg-muted/30 p-3">
+                <span className="text-xs text-muted-foreground">Signature</span>
+                <div className="break-all font-mono text-xs">{w.signature}</div>
+              </div>
+            )}
+            {w.digest && (
+              <div className="space-y-0.5 rounded-lg border bg-muted/30 p-3">
+                <span className="text-xs text-muted-foreground">Digest</span>
+                <div className="break-all font-mono text-xs">{w.digest}</div>
+              </div>
+            )}
+            {(w.error || w.category) && (
+              <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                {w.category ? `[${w.category}] ` : ""}{w.error}
+              </div>
+            )}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ActivityTab() {
+  const qc = useQueryClient();
+  const { data, isLoading, refetch, isFetching } = useQuery({
+    queryKey: ["custody", "withdrawals"],
+    queryFn: listWithdrawals,
+    refetchInterval: (q) => {
+      const rows = (q.state.data as Withdrawal[] | undefined) ?? [];
+      return rows.some((r) => !isTerminal(r.status)) ? 5000 : false;
+    },
+  });
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  // Keep the list fresh when a detail drawer advances a status.
+  useEffect(() => {
+    if (!openId) qc.invalidateQueries({ queryKey: ["custody", "withdrawals"] });
+  }, [openId, qc]);
+
+  const rows = data ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Withdrawal activity</h2>
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching} className="gap-1.5">
+          <RefreshCw className={cn("h-4 w-4", isFetching && "animate-spin")} /> Refresh
+        </Button>
+      </div>
+      <Card>
+        <CardContent className="p-0">
+          {isLoading && <div className="p-4"><Skeleton className="h-32 w-full" /></div>}
+          {!isLoading && rows.length === 0 && (
+            <p className="py-12 text-center text-sm text-muted-foreground">No withdrawals yet.</p>
+          )}
+          {rows.length > 0 && (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Asset</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                    <TableHead className="hidden md:table-cell">Recipient</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="w-16" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((w) => (
+                    <TableRow key={w.id} className="cursor-pointer" onClick={() => setOpenId(w.id)}>
+                      <TableCell className="font-medium">{w.asset}</TableCell>
+                      <TableCell className="text-right tabular-nums">{fmtAmount(w.amount)}</TableCell>
+                      <TableCell className="hidden font-mono text-xs md:table-cell">{short(w.recipient ?? w.destination)}</TableCell>
+                      <TableCell>{statusBadge(w.status)}</TableCell>
+                      <TableCell className="text-right"><Button variant="ghost" size="sm">View</Button></TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <WithdrawalDetailDrawer id={openId} open={Boolean(openId)} onClose={() => setOpenId(null)} />
+    </div>
+  );
+}
+
+// ─── Approvals + Audit (officer/admin) ──────────────────────────
+
+function ApprovalsTab() {
+  const qc = useQueryClient();
+  const approvals = useQuery({
+    queryKey: ["custody", "approvals"],
+    queryFn: listApprovals,
+    refetchInterval: 8000,
+  });
+
+  const approveM = useMutation({
+    mutationFn: (id: string) => approveWithdrawal(id),
+    onSuccess: (res) => {
+      toast.success(`Approved — ${typeof res.approvals === "number" ? res.approvals : (res.approvals?.length ?? 0)}/${res.approvals_required}`);
+      qc.invalidateQueries({ queryKey: ["custody", "approvals"] });
+      qc.invalidateQueries({ queryKey: ["custody", "withdrawals"] });
+    },
+    onError: (err) => toast.error(err instanceof ApiError ? err.detail : "Approve failed"),
+  });
+
+  const releaseM = useMutation({
+    mutationFn: (id: string) => releaseWithdrawal(id),
+    onSuccess: () => {
+      toast.success("Released & signed");
+      qc.invalidateQueries({ queryKey: ["custody", "approvals"] });
+      qc.invalidateQueries({ queryKey: ["custody", "withdrawals"] });
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 425) toast.error("Timelocked — cannot release yet");
+      else if (err instanceof ApiError && err.status === 409) toast.error("Not enough approvals to release");
+      else toast.error(err instanceof ApiError ? err.detail : "Release failed");
+    },
+  });
+
+  const audit = useQuery({
+    queryKey: ["custody", "audit"],
+    queryFn: getCustodyAudit,
+    staleTime: 10_000,
+  });
+
+  const verifyM = useMutation({
+    mutationFn: verifyCustodyAudit,
+    onSuccess: (res) => {
+      if (res.ok) toast.success(`Audit chain verified — ${res.entries} entries intact`);
+      else toast.error("Audit chain verification FAILED");
+    },
+    onError: (err) => toast.error(err instanceof ApiError ? err.detail : "Verify failed"),
+  });
+
+  const rows = approvals.data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Approval queue</h2>
+        <Card>
+          <CardContent className="p-0">
+            {approvals.isLoading && <div className="p-4"><Skeleton className="h-24 w-full" /></div>}
+            {!approvals.isLoading && rows.length === 0 && (
+              <p className="py-10 text-center text-sm text-muted-foreground">Nothing awaiting approval.</p>
+            )}
+            {rows.length > 0 && (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Asset</TableHead>
+                      <TableHead className="text-right">Amount</TableHead>
+                      <TableHead className="hidden md:table-cell">Recipient</TableHead>
+                      <TableHead>Approvals</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.map((w) => {
+                      const busy = (approveM.isPending && approveM.variables === w.id) || (releaseM.isPending && releaseM.variables === w.id);
+                      return (
+                        <TableRow key={w.id}>
+                          <TableCell className="font-medium">{w.asset}</TableCell>
+                          <TableCell className="text-right tabular-nums">{fmtAmount(w.amount)}</TableCell>
+                          <TableCell className="hidden font-mono text-xs md:table-cell">{short(w.recipient ?? w.destination)}</TableCell>
+                          <TableCell className="tabular-nums">{approvalsCount(w)}/{w.approvals_required ?? "?"}</TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex justify-end gap-2">
+                              <Button size="sm" variant="outline" disabled={busy} onClick={() => approveM.mutate(w.id)}>Approve</Button>
+                              <Button size="sm" disabled={busy} onClick={() => releaseM.mutate(w.id)}>Release</Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="flex items-center gap-2 text-lg font-semibold"><ScrollText className="h-5 w-5" /> Audit trail</h2>
+          <Button size="sm" variant="outline" onClick={() => verifyM.mutate()} disabled={verifyM.isPending} className="gap-1.5">
+            {verifyM.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+            Verify chain
+          </Button>
+        </div>
+        <Card>
+          <CardContent className="p-0">
+            {audit.isLoading && <div className="p-4"><Skeleton className="h-24 w-full" /></div>}
+            {!audit.isLoading && (audit.data?.entries ?? []).length === 0 && (
+              <p className="py-10 text-center text-sm text-muted-foreground">No audit entries.</p>
+            )}
+            {(audit.data?.entries ?? []).length > 0 && (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-12">#</TableHead>
+                      <TableHead>Action</TableHead>
+                      <TableHead className="hidden md:table-cell">Detail</TableHead>
+                      <TableHead className="hidden sm:table-cell">Time</TableHead>
+                      <TableHead>Hash</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(audit.data?.entries ?? []).map((e) => (
+                      <TableRow key={e.seq}>
+                        <TableCell className="tabular-nums text-muted-foreground">{e.seq}</TableCell>
+                        <TableCell className="font-medium">{e.action}</TableCell>
+                        <TableCell className="hidden max-w-xs truncate text-xs text-muted-foreground md:table-cell">{e.detail}</TableCell>
+                        <TableCell className="hidden whitespace-nowrap text-xs text-muted-foreground sm:table-cell">{new Date(e.ts_ms).toLocaleString()}</TableCell>
+                        <TableCell className="font-mono text-xs">{short(e.hash, 8, 6)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ───────────────────────────────────────────────────────
+
+type TabKey = "overview" | "deposit" | "withdraw" | "activity" | "approvals";
+
+export default function CustodyPage() {
+  const isMobile = useIsMobile(767);
+  const role = useAuthStore((s) => s.role);
+  const isAdmin = useAuthStore((s) => s.isAdmin);
+  const isOfficer = isAdmin || role === "admin" || role === "root";
+
+  const [tab, setTab] = useState<TabKey>("overview");
+  const [depositAsset, setDepositAsset] = useState<CustodyAsset | null>(null);
+  const [withdrawAsset, setWithdrawAsset] = useState<CustodyAsset | null>(null);
+
+  const tabs: { key: TabKey; label: string; short: string; icon: JSX.Element }[] = useMemo(() => {
+    const base: { key: TabKey; label: string; short: string; icon: JSX.Element }[] = [
+      { key: "overview" as const, label: "Balances", short: "Balances", icon: <Wallet className="h-4 w-4" /> },
+      { key: "deposit" as const, label: "Deposit", short: "Deposit", icon: <ArrowDownToLine className="h-4 w-4" /> },
+      { key: "withdraw" as const, label: "Withdraw", short: "Withdraw", icon: <ArrowUpFromLine className="h-4 w-4" /> },
+      { key: "activity" as const, label: "Activity", short: "Activity", icon: <ListChecks className="h-4 w-4" /> },
+    ];
+    if (isOfficer) {
+      base.push({ key: "approvals" as const, label: "Approvals & Audit", short: "Approvals", icon: <ShieldCheck className="h-4 w-4" /> });
+    }
+    return base;
+  }, [isOfficer]);
+
+  return (
+    <div className="mx-auto w-full max-w-6xl p-4 md:p-6">
+      <div className="mb-4 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          <Wallet className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold tracking-tight md:text-2xl">Custody</h1>
+          <p className="text-sm text-muted-foreground">Hold, receive and send crypto from your custodial wallet.</p>
+        </div>
+      </div>
+
+      <Tabs value={tab} onValueChange={(v) => setTab(v as TabKey)}>
+        <TabsList className={cn("mb-4 w-full", isMobile ? "grid grid-cols-4 gap-1" : "inline-flex", isMobile && isOfficer && "grid-cols-5")}>
+          {tabs.map((t) => (
+            <TabsTrigger key={t.key} value={t.key} className="gap-1.5">
+              {t.icon}
+              <span className={cn(isMobile && "sr-only")}>{t.label}</span>
+              {isMobile && <span className="text-[10px]">{t.short}</span>}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="overview">
+          <OverviewTab
+            onDeposit={(a) => { setDepositAsset(a); setTab("deposit"); }}
+            onWithdraw={(a) => { setWithdrawAsset(a); setTab("withdraw"); }}
+          />
+        </TabsContent>
+        <TabsContent value="deposit">
+          <DepositTab preselect={depositAsset} />
+        </TabsContent>
+        <TabsContent value="withdraw">
+          <WithdrawTab preselect={withdrawAsset} />
+        </TabsContent>
+        <TabsContent value="activity">
+          <ActivityTab />
+        </TabsContent>
+        {isOfficer && (
+          <TabsContent value="approvals">
+            <ApprovalsTab />
+          </TabsContent>
+        )}
+      </Tabs>
+    </div>
+  );
+}

--- a/tests/test_custody.py
+++ b/tests/test_custody.py
@@ -1,0 +1,175 @@
+"""CUSTODY — crypto-custody proxy tests (mock path over TestClient)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, get_authenticated_user
+from app.auth.roles import Role
+from app.main import create_app
+from app.services.sessions import require_ui_session
+import app.services.custody_gateway as cg
+
+
+@pytest.fixture(autouse=True)
+def _fresh_mock():
+    # Reset the process-wide mock singleton so each test starts clean.
+    cg._MOCK_SINGLETON = None
+    cg._REAL_SINGLETON = None
+    yield
+    cg._MOCK_SINGLETON = None
+    cg._REAL_SINGLETON = None
+
+
+def _client(user_sub: str = "user-1", role: Role = Role.USER) -> TestClient:
+    app = create_app()
+
+    async def _auth_override():
+        return AuthenticatedUser(sub=user_sub, role=role)
+
+    async def _session_override():
+        return {"user_sub": user_sub, "session_id": "sess_1", "role": role.value}
+
+    app.dependency_overrides[get_authenticated_user] = _auth_override
+    app.dependency_overrides[require_ui_session] = _session_override
+    return TestClient(app)
+
+
+def test_assets_returns_balances():
+    c = _client("user-assets")
+    r = c.get("/ui/custody/assets")
+    assert r.status_code == 200
+    assets = r.json()
+    by_asset = {a["asset"]: a for a in assets}
+    # Seeded demo balances are non-zero.
+    assert by_asset["ETH"]["balance"] > 0
+    assert by_asset["USDC"]["balance"] > 0
+    assert by_asset["BTC"]["balance"] > 0
+    assert by_asset["ETH"]["address_available"] is True
+
+
+def test_deposit_address_returns_address():
+    c = _client("user-addr")
+    r = c.get("/ui/custody/deposit-address", params={"asset": "ETH", "chain": "ethereum"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["asset"] == "ETH"
+    assert body["network"] == "Mainnet"
+    assert body["address"].startswith("0x") and len(body["address"]) == 42
+    # Deterministic per user.
+    r2 = c.get("/ui/custody/deposit-address", params={"asset": "ETH", "chain": "ethereum"})
+    assert r2.json()["address"] == body["address"]
+
+
+def test_withdrawal_below_threshold_is_signed():
+    c = _client("user-small")
+    r = c.post("/ui/custody/withdrawals", json={
+        "asset": "USDC", "chain": "ethereum", "amount": 10.0,
+        "destination": "0x" + "a" * 40,
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "signed"
+    assert body["signature"].startswith("0x")
+    assert body["digest"].startswith("0x")
+
+
+def test_withdrawal_invalid_destination_rejected():
+    c = _client("user-bad")
+    r = c.post("/ui/custody/withdrawals", json={
+        "asset": "ETH", "chain": "ethereum", "amount": 0.1,
+        "destination": "not-an-address",
+    })
+    assert r.status_code == 400
+
+
+def test_withdrawal_insufficient_balance_rejected():
+    c = _client("user-poor")
+    r = c.post("/ui/custody/withdrawals", json={
+        "asset": "ETH", "chain": "ethereum", "amount": 9999.0,
+        "destination": "0x" + "b" * 40,
+    })
+    assert r.status_code == 400
+
+
+def test_full_pending_approval_flow():
+    # Give the user a big balance, then withdraw >= threshold (default 1000).
+    gw = cg.get_custody_gateway()
+    vault_id = f"{cg.S.custody_tenant}-u-user-big"
+    gw.seed_user_vault(vault_id, "user-big")
+    gw.credit_vault(vault_id, "USDC", 50000.0)
+
+    user = _client("user-big")
+    r = user.post("/ui/custody/withdrawals", json={
+        "asset": "USDC", "chain": "ethereum", "amount": 25000.0,
+        "destination": "0x" + "c" * 40,
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "pending_approval"
+    assert body["approvals_required"] == 2
+    wid = body["id"]
+
+    # User can read their own withdrawal.
+    assert user.get(f"/ui/custody/withdrawals/{wid}").json()["status"] == "pending_approval"
+    # It appears in the user's list.
+    assert any(w["id"] == wid for w in user.get("/ui/custody/withdrawals").json())
+
+    # A plain user cannot see the approvals queue.
+    assert user.get("/ui/custody/approvals").status_code in (401, 403)
+
+    # Officer (admin) sees it in the queue and approves M times.
+    officer = _client("officer-1", role=Role.ADMIN)
+    queue = officer.get("/ui/custody/approvals").json()
+    assert any(w["id"] == wid for w in queue)
+
+    a1 = officer.post(f"/ui/custody/withdrawals/{wid}/approve", json={"approver": "officer-a"})
+    assert a1.status_code == 200
+    assert a1.json()["status"] == "pending_approval"  # still needs 2nd
+
+    a2 = officer.post(f"/ui/custody/withdrawals/{wid}/approve", json={"approver": "officer-b"})
+    assert a2.status_code == 200
+    assert a2.json()["status"] == "approved"
+
+    # Release triggers the MPC sign.
+    rel = officer.post(f"/ui/custody/withdrawals/{wid}/release")
+    assert rel.status_code == 200, rel.text
+    assert rel.json()["status"] == "signed"
+    assert rel.json()["signature"].startswith("0x")
+
+    # After settle window, status advances to settled.
+    time.sleep(4.1)
+    assert user.get(f"/ui/custody/withdrawals/{wid}").json()["status"] == "settled"
+
+
+def test_audit_lists_entries_and_verifies():
+    c = _client("user-audit")
+    # generate activity
+    c.get("/ui/custody/assets")
+    c.post("/ui/custody/withdrawals", json={
+        "asset": "USDC", "chain": "ethereum", "amount": 5.0,
+        "destination": "0x" + "d" * 40,
+    })
+    officer = _client("officer-2", role=Role.ADMIN)
+    audit = officer.get("/ui/custody/audit").json()
+    assert len(audit["entries"]) > 0
+    verify = officer.get("/ui/custody/audit/verify").json()
+    assert verify["ok"] is True
+    assert verify["entries"] == len(audit["entries"])
+
+    # A plain user cannot read the audit log.
+    assert c.get("/ui/custody/audit").status_code in (401, 403)
+
+
+def test_sanctioned_recipient_blocked():
+    c = _client("user-sanc")
+    r = c.post("/ui/custody/withdrawals", json={
+        "asset": "ETH", "chain": "ethereum", "amount": 0.1,
+        "destination": "0x0000000000000000000000000000000000000bad",
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "blocked"
+    assert r.json()["error"] == "sanctioned_recipient"


### PR DESCRIPTION
## Crypto custody — full stack (desktop web · mobile web · Android native)

Adds a crypto-custody feature across all three surfaces, backed by a new session-authed testlogon proxy in front of the external **MPC custody gateway** (`custody-mpc-cpp`). The gateway is HMAC server-to-server, so the frontends never hold the tenant secret — they call `/ui/custody/*`, which signs on the user's behalf.

### Commits (custody-only; cherry-picked onto `main`)
- `feat(custody): testlogon session-authed proxy to the MPC custody gateway`
- `feat(custody web): responsive Custody UI (balances/deposit/withdraw/history/approvals+audit)`
- `feat(custody android): native Custody feature`

### What's included
- **Backend** — `app/routers/custody.py` + `app/services/custody_gateway.py`: 10 session-authed `/ui/custody/*` routes (assets+balances, deposit-address, deposits, withdrawals+status/history, officer-gated approvals/release/audit). `CustodyGatewayClient` HMAC-signs (`ts+METHOD+target+body`) with idempotency; **intent wire built server-side** (client-supplied intent/digest never accepted); officer/audit routes `require_admin_or_root`. Config-driven (`CUSTODY_GATEWAY_URL/API_KEY/SECRET/TENANT` + officer keys) with a realistic in-memory **mock fallback** so it works with no gateway deployed.
- **Web** — responsive `/custody` (Sidebar → Commerce): balances, deposit (HD address + vendored dependency-free QR), withdraw (validate → confirm dialog → signed/pending_approval/blocked/rejected), activity/history (live status + timelock polling), officer/admin-gated Approvals & Audit. No npm dep added.
- **Android** — `feature/custody/` (More → Wallet → Custody): same five surfaces; Retrofit/Moshi (`@JsonClass` DTOs), pure-Kotlin QR on Canvas. No gradle dep added.

### Verification
- Backend: `import app.main` OK · `tests/test_custody.py` **8/8** · api-key scope-drift tests **15/15**.
- Web: `npm run build` (tsc + vite) **green**.
- Android: **compiles green from a full clean-from-source build** (`:app:compileDebugKotlin` after purging all module `build/`).
- Data path proven over real HTTP end-to-end (balances → deposit address → withdraw < threshold → signed; ≥ threshold → pending_approval → approve×2 → release → signed → settled; audit hash-chain verify `ok`). Web + Android screens render the mock data (verified against a locally-run backend).

### Follow-ups before real-gateway go-live
Per-user withdrawal index (the gateway has no list-by-user endpoint; mock lists fully), per-asset intent-wire validation against the live gateway, and destination checksum/bech32 validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
