### PR TITLE
feat: custody/exchange gap scaffolding (sub-accounts, simulated transfers, fee reporting) + mobile-web polish

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
@@ -36,4 +36,28 @@ interface CustodyApi {
     @Headers("Content-Type: application/json")
     @POST("me/custody/withdraw")
     suspend fun withdraw(@Body body: WithdrawRequestDto): WithdrawResultDto
+    // ==== Sub-accounts + transfers (custody-exchange-gaps) ====
+
+    /**
+     * List the caller's sub-account vaults (base/default vault id + named sub-accounts). NOT deployed
+     * on every backend -> a 404 is handled by the repository as a graceful "unavailable" empty state.
+     */
+    @GET("me/custody/subaccounts")
+    suspend fun getSubAccounts(): SubAccountsDto
+
+    /** Create a named sub-account vault under the caller's base vault. */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/subaccounts")
+    suspend fun createSubAccount(@Body body: CreateSubAccountDto): CreateSubAccountResultDto
+
+    /** Move an asset between two of the caller's OWN sub-account vaults (documented stub / no-op). */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/subaccounts/transfer")
+    suspend fun subAccountTransfer(@Body body: SubAccountTransferDto): SubAccountTransferResultDto
+
+    /** Custody<->trading bridge: move value between the custody vault and the exchange spot ledger. */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/transfer")
+    suspend fun bridgeTransfer(@Body body: CustodyBridgeTransferDto): CustodyBridgeTransferResultDto
 }
+

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
@@ -204,3 +204,82 @@ data class CustodyWithdrawResult(
     val reason: String?,
     val category: String?,
 )
+
+// ---------------- Sub-accounts ----------------
+
+/**
+ * A custody sub-account vault: the base ("default") vault or a named sub-account. [balances] are the
+ * merged, display-ready rows (same registry treatment as the main balance view).
+ */
+data class CustodySubAccount(
+    val id: String,
+    val label: String,
+    val tier: String,
+    val isDefault: Boolean,
+    val rows: List<CustodyBalance>,
+) {
+    val displayLabel: String get() = if (isDefault) "Base vault" else label.ifBlank { "Sub-account" }
+    val idShort: String get() = if (id.length <= 14) id else "${id.take(8)}…${id.takeLast(4)}"
+    fun funded(): List<CustodyBalance> = rows.filter { it.amount > 0.0 }
+}
+
+/**
+ * The sub-accounts response: the default (base) vault + the named sub-accounts, plus an "unavailable"
+ * flag for when the backend does not expose the route (404 -> soft empty state).
+ */
+data class CustodySubAccounts(
+    val defaultVault: String,
+    val subAccounts: List<CustodySubAccount>,
+    val unavailable: Boolean = false,
+) {
+    /** Base vault + named sub-accounts, so a picker can offer every OWN vault as a transfer endpoint. */
+    val all: List<CustodySubAccount>
+        get() = listOf(
+            CustodySubAccount(id = defaultVault, label = "", tier = "—", isDefault = true, rows = emptyList()),
+        ) + subAccounts
+
+    val isEmpty: Boolean get() = subAccounts.isEmpty()
+
+    companion object {
+        fun unavailable(): CustodySubAccounts =
+            CustodySubAccounts(defaultVault = "", subAccounts = emptyList(), unavailable = true)
+    }
+}
+
+// ---------------- Transfers ----------------
+
+/** Which side of the custody<->trading bridge a transfer moves value toward. */
+enum class BridgeDirection(val wire: String, val label: String) {
+    TO_TRADING("to_trading", "Custody → Trading"),
+    TO_CUSTODY("to_custody", "Trading → Custody");
+
+    fun toggle(): BridgeDirection = if (this == TO_TRADING) TO_CUSTODY else TO_TRADING
+}
+
+/**
+ * Result of the custody<->trading bridge. [simulated] (stub) is expected true today; [tradingCredited]
+ * is only meaningful on the to_trading path. [note] is the honest "not settled" explanation.
+ */
+data class CustodyBridgeResult(
+    val ok: Boolean,
+    val simulated: Boolean,
+    val direction: BridgeDirection?,
+    val asset: Int?,
+    val amount: Long?,
+    val tradingCredited: Boolean,
+    val note: String?,
+)
+
+/**
+ * Result of a between-sub-accounts transfer. This route is a documented no-op, so [simulated] is
+ * expected true and no balance moves; [note] carries the honest explanation.
+ */
+data class SubAccountTransferResult(
+    val ok: Boolean,
+    val simulated: Boolean,
+    val from: String?,
+    val to: String?,
+    val asset: String?,
+    val amount: String?,
+    val note: String?,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
@@ -94,3 +94,97 @@ data class WithdrawResultDto(
     @Json(name = "reason") val reason: String? = null,
     @Json(name = "category") val category: String? = null,
 )
+
+// ==== Sub-accounts + transfers (custody-exchange-gaps) ====
+
+/**
+ * One sub-account vault under the caller's base vault (GET me/custody/subaccounts). [balances] is a
+ * number-or-string map like [BalanceDto.balances]; coerced at the domain edge. The base (default)
+ * vault is NOT listed here — it is returned separately as [SubAccountsDto.defaultVault].
+ */
+@JsonClass(generateAdapter = true)
+data class SubAccountDto(
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "label") val label: String? = null,
+    @Json(name = "tier") val tier: String? = null,
+    @Json(name = "balances") val balances: Map<String, Any?>? = null,
+)
+
+/** GET me/custody/subaccounts envelope: the default (base) vault id + the named sub-accounts. */
+@JsonClass(generateAdapter = true)
+data class SubAccountsDto(
+    @Json(name = "default_vault") val defaultVault: String? = null,
+    @Json(name = "subaccounts") val subaccounts: List<SubAccountDto>? = null,
+)
+
+/** Body for POST me/custody/subaccounts — the sub-account label (sanitized server-side). */
+@JsonClass(generateAdapter = true)
+data class CreateSubAccountDto(
+    @Json(name = "label") val label: String,
+)
+
+/**
+ * POST me/custody/subaccounts response: the gateway's created-vault object with {label, vault} added.
+ * Loose shape — only the added fields are consumed; the rest are ignored by Moshi.
+ */
+@JsonClass(generateAdapter = true)
+data class CreateSubAccountResultDto(
+    @Json(name = "label") val label: String? = null,
+    @Json(name = "vault") val vault: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)
+
+/** Body for POST me/custody/subaccounts/transfer — move an asset between two OWN sub-account vaults. */
+@JsonClass(generateAdapter = true)
+data class SubAccountTransferDto(
+    @Json(name = "from_label") val fromLabel: String? = null,
+    @Json(name = "to_label") val toLabel: String? = null,
+    @Json(name = "asset") val asset: String,
+    @Json(name = "amount") val amount: String,
+)
+
+/**
+ * POST me/custody/subaccounts/transfer response. This route is a documented pure no-op (the gateway
+ * has no vault<->vault move), so [stub] is always true and it moves no balance.
+ */
+@JsonClass(generateAdapter = true)
+data class SubAccountTransferResultDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "stub") val stub: Boolean? = null,
+    @Json(name = "from") val from: String? = null,
+    @Json(name = "to") val to: String? = null,
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "amount") val amount: String? = null,
+    @Json(name = "note") val note: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)
+
+/** Body for POST me/custody/transfer — the custody<->trading bridge. [asset] is the engine asset id. */
+@JsonClass(generateAdapter = true)
+data class CustodyBridgeTransferDto(
+    @Json(name = "direction") val direction: String,
+    @Json(name = "asset") val asset: Int,
+    @Json(name = "amount") val amount: Long,
+)
+
+/**
+ * POST me/custody/transfer response (custody<->trading bridge). [stub] is true (the bridge is not
+ * atomic); on to_trading [tradingCredited] reflects whether the in-process engine credited the spot
+ * ledger. No real custody balance moves either way.
+ */
+@JsonClass(generateAdapter = true)
+data class CustodyBridgeTransferResultDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "stub") val stub: Boolean? = null,
+    @Json(name = "direction") val direction: String? = null,
+    @Json(name = "asset") val asset: Int? = null,
+    @Json(name = "amount") val amount: Long? = null,
+    @Json(name = "trading_credited") val tradingCredited: Boolean? = null,
+    @Json(name = "note") val note: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
@@ -73,6 +73,63 @@ class CustodyRepository @Inject constructor(
         ).toDomain()
     }
 
+    /**
+     * List the caller's sub-account vaults. Like [getDeposits], a 404 (route not deployed) folds into a
+     * soft "unavailable" success so the tab can degrade to an explanatory empty state; other HTTP errors
+     * also degrade (there is nothing actionable for the user). Network errors still surface.
+     */
+    suspend fun getSubAccounts(): ApiResult<CustodySubAccounts> = withContext(io) {
+        try {
+            ApiResult.Success(api.getSubAccounts().toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(CustodySubAccounts.unavailable())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    /** Create a named sub-account vault. A gateway rejection (400/409) surfaces as a [ApiResult.Failure]. */
+    suspend fun createSubAccount(label: String): ApiResult<CustodySubAccount> = call {
+        val res = api.createSubAccount(CreateSubAccountDto(label = label.trim()))
+        CustodySubAccount(
+            id = (res.vault ?: res.name ?: res.id).orEmpty().trim(),
+            label = (res.label ?: label).trim(),
+            tier = "\u2014",
+            isDefault = false,
+            rows = emptyList(),
+        )
+    }
+
+    /** Move an asset between two OWN sub-account vaults (documented no-op; result carries stub=true). */
+    suspend fun subAccountTransfer(
+        fromLabel: String?,
+        toLabel: String?,
+        asset: String,
+        amount: String,
+    ): ApiResult<SubAccountTransferResult> = call {
+        api.subAccountTransfer(
+            SubAccountTransferDto(
+                fromLabel = fromLabel?.trim()?.takeIf { it.isNotBlank() },
+                toLabel = toLabel?.trim()?.takeIf { it.isNotBlank() },
+                asset = asset.trim(),
+                amount = amount.trim(),
+            ),
+        ).toDomain()
+    }
+
+    /** Custody<->trading bridge transfer (hybrid; result carries stub=true + trading_credited). */
+    suspend fun bridgeTransfer(
+        direction: BridgeDirection,
+        asset: Int,
+        amount: Long,
+    ): ApiResult<CustodyBridgeResult> = call {
+        api.bridgeTransfer(
+            CustodyBridgeTransferDto(direction = direction.wire, asset = asset, amount = amount),
+        ).toDomain()
+    }
+
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = withContext(io) {
         try {
             ApiResult.Success(block())
@@ -155,6 +212,48 @@ private fun WithdrawResultDto.toDomain(): CustodyWithdrawResult =
         reason = listOfNotNull(detail, reason, error)
             .firstOrNull { it.isNotBlank() },
         category = category?.takeIf { it.isNotBlank() },
+    )
+
+private fun SubAccountsDto.toDomain(): CustodySubAccounts {
+    val default = defaultVault?.trim().orEmpty()
+    val rows = subaccounts.orEmpty().map { it.toDomain() }
+    return CustodySubAccounts(defaultVault = default, subAccounts = rows, unavailable = false)
+}
+
+private fun SubAccountDto.toDomain(): CustodySubAccount {
+    val coerced: Map<String, Double> = balances.orEmpty()
+        .entries
+        .filter { it.key.isNotBlank() }
+        .associate { it.key.trim() to coerceAmount(it.value) }
+    return CustodySubAccount(
+        id = id?.trim().orEmpty(),
+        label = label?.trim().orEmpty(),
+        tier = tier?.trim()?.takeIf { it.isNotBlank() } ?: "\u2014",
+        isDefault = false,
+        rows = CustodyAssets.mergeBalances(coerced).filter { it.amount > 0.0 },
+    )
+}
+
+private fun SubAccountTransferResultDto.toDomain(): SubAccountTransferResult =
+    SubAccountTransferResult(
+        ok = (status?.trim()?.lowercase() ?: "ok") == "ok",
+        simulated = stub == true,
+        from = from?.trim()?.takeIf { it.isNotBlank() },
+        to = to?.trim()?.takeIf { it.isNotBlank() },
+        asset = asset?.trim()?.takeIf { it.isNotBlank() },
+        amount = amount?.trim()?.takeIf { it.isNotBlank() },
+        note = listOfNotNull(note, detail, error).firstOrNull { it.isNotBlank() },
+    )
+
+private fun CustodyBridgeTransferResultDto.toDomain(): CustodyBridgeResult =
+    CustodyBridgeResult(
+        ok = (status?.trim()?.lowercase() ?: "ok") == "ok",
+        simulated = stub == true,
+        direction = direction?.let { d -> BridgeDirection.entries.firstOrNull { it.wire == d.trim().lowercase() } },
+        asset = asset,
+        amount = amount,
+        tradingCredited = tradingCredited == true,
+        note = listOfNotNull(note, detail, error).firstOrNull { it.isNotBlank() },
     )
 
 /** Provides the custody Retrofit API (mirrors the auth data module's provider style). */

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -83,4 +83,14 @@ interface TradingApi {
     /** Credit a spot asset balance. */
     @POST("me/spot_deposit")
     suspend fun spotDeposit(@Body body: SpotDepositDto): SpotDepositAckDto
+    // ==== Fees (custody-exchange-gaps) ====
+
+    /** The caller's maker/taker/liquidation fee schedule (venue defaults today; source=stub). */
+    @GET("me/fees/schedule")
+    suspend fun getFeeSchedule(): FeeScheduleDto
+
+    /** Recent fills enriched with a computed fee (empty feed today + the client-side fee formula). */
+    @GET("me/fills/fees")
+    suspend fun getFillsFees(): FillsFeesDto
 }
+

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -318,3 +318,53 @@ data class PmStateDto(
     val error: String? = null,
     val detail: String? = null,
 )
+
+// ==== Fees (custody-exchange-gaps) ====
+
+/** One row of the fee schedule. bps fields may be stringified by the edge, so all use @LenientInt. */
+@JsonClass(generateAdapter = true)
+data class FeeScheduleRowDto(
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "symbolid") val symbolId: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "maker_fee_bps") val makerFeeBps: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "taker_fee_bps") val takerFeeBps: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "liquidation_fee_bps") val liquidationFeeBps: Int? = null,
+)
+
+/**
+ * GET me/fees/schedule. The stub returns a single venue-default row plus the top-level bps mirrors and
+ * source/stub markers. Both the [schedule] rows and the flat mirrors are tolerated (either may be
+ * present); the repo prefers the first schedule row and falls back to the mirrors.
+ */
+@JsonClass(generateAdapter = true)
+data class FeeScheduleDto(
+    @Json(name = "schedule") val schedule: List<FeeScheduleRowDto>? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "maker_fee_bps") val makerFeeBps: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "taker_fee_bps") val takerFeeBps: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "liquidation_fee_bps") val liquidationFeeBps: Int? = null,
+    @Json(name = "source") val source: String? = null,
+    @Json(name = "stub") val stub: Boolean? = null,
+)
+
+/** One enriched fill from GET me/fills/fees, with a server-computed [fee]. */
+@JsonClass(generateAdapter = true)
+data class FillFeeDto(
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "price") val price: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "qty") val qty: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "fee") val fee: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "ts_ns") val tsNs: Long? = null,
+    @Json(name = "side") val side: String? = null,
+)
+
+/**
+ * GET me/fills/fees. Today the enriched [fills] feed is empty (the engine exposes no per-fill fee), so
+ * the UI computes fees client-side using [takerFeeBps] + [feeFormula]. source/stub mark it honest.
+ */
+@JsonClass(generateAdapter = true)
+data class FillsFeesDto(
+    @Json(name = "fills") val fills: List<FillFeeDto>? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "taker_fee_bps") val takerFeeBps: Int? = null,
+    @Json(name = "fee_formula") val feeFormula: String? = null,
+    @Json(name = "source") val source: String? = null,
+    @Json(name = "stub") val stub: Boolean? = null,
+    @Json(name = "note") val note: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -282,3 +282,90 @@ fun PmStateDto.toDomain(): PmState = PmState(
     faceValue = faceValue ?: 0L,
     resolverId = resolverId.orEmpty(),
 )
+
+// ==== Fees (custody-exchange-gaps) ====
+
+/** Venue default bps used when the backend/stub omits an explicit fee. */
+private const val DEFAULT_MAKER_BPS = 10
+private const val DEFAULT_TAKER_BPS = 20
+private const val DEFAULT_LIQ_BPS = 100
+
+/**
+ * The caller's fee schedule: maker/taker/liquidation in basis points. [isStub] is true when the value
+ * is the venue default (source == "stub") rather than a real per-caller/per-symbol quote — the UI
+ * labels it so the number isn't mistaken for a negotiated rate.
+ */
+data class FeeSchedule(
+    val makerFeeBps: Int,
+    val takerFeeBps: Int,
+    val liquidationFeeBps: Int,
+    val isStub: Boolean,
+) {
+    /** bps -> a percent string, e.g. 20 -> "0.20%". */
+    fun makerPct(): String = bpsToPct(makerFeeBps)
+    fun takerPct(): String = bpsToPct(takerFeeBps)
+    fun liquidationPct(): String = bpsToPct(liquidationFeeBps)
+
+    /** Fee for a notional (price*qty) at the taker rate, using the stub'"'"'s round(notional*bps/10000). */
+    fun takerFeeFor(price: Long, qty: Long): Long = feeFor(price * qty, takerFeeBps)
+
+    companion object {
+        fun default(): FeeSchedule = FeeSchedule(DEFAULT_MAKER_BPS, DEFAULT_TAKER_BPS, DEFAULT_LIQ_BPS, isStub = true)
+    }
+}
+
+/** round(notional * bps / 10000), matching the backend fee_formula. */
+fun feeFor(notional: Long, bps: Int): Long =
+    Math.round(notional.toDouble() * bps.toDouble() / 10000.0)
+
+private fun bpsToPct(bps: Int): String = String.format(java.util.Locale.US, "%.2f%%", bps / 100.0)
+
+fun FeeScheduleDto.toDomain(): FeeSchedule {
+    val row = schedule.orEmpty().firstOrNull()
+    val maker = row?.makerFeeBps ?: makerFeeBps ?: DEFAULT_MAKER_BPS
+    val taker = row?.takerFeeBps ?: takerFeeBps ?: DEFAULT_TAKER_BPS
+    val liq = row?.liquidationFeeBps ?: liquidationFeeBps ?: DEFAULT_LIQ_BPS
+    return FeeSchedule(
+        makerFeeBps = maker,
+        takerFeeBps = taker,
+        liquidationFeeBps = liq,
+        isStub = stub == true || (source?.trim()?.lowercase() == "stub"),
+    )
+}
+
+/** One fill enriched with a fee. When the server feed is empty the UI computes [fee] client-side. */
+data class FillFee(
+    val price: Long,
+    val qty: Long,
+    val fee: Long,
+    val tsNs: Long,
+    val side: OrderSide?,
+)
+
+/**
+ * The enriched fills-fees feed. [fills] is empty today (engine exposes no per-fill fee); [takerFeeBps]
+ * + [feeFormula] let the UI compute fees for its own session fills. [isStub] marks that honesty.
+ */
+data class FillsFees(
+    val fills: List<FillFee>,
+    val takerFeeBps: Int,
+    val feeFormula: String?,
+    val isStub: Boolean,
+    val note: String?,
+)
+
+fun FillFeeDto.toDomain(): FillFee = FillFee(
+    price = price ?: 0L,
+    qty = qty ?: 0L,
+    fee = fee ?: 0L,
+    tsNs = tsNs ?: 0L,
+    side = when (side?.lowercase()) { "buy" -> OrderSide.BUY; "sell" -> OrderSide.SELL; else -> null },
+)
+
+fun FillsFeesDto.toDomain(): FillsFees = FillsFees(
+    fills = fills.orEmpty().map { it.toDomain() },
+    takerFeeBps = takerFeeBps ?: DEFAULT_TAKER_BPS,
+    feeFormula = feeFormula?.takeIf { it.isNotBlank() },
+    isStub = stub == true || (source?.trim()?.lowercase() == "stub"),
+    note = note?.takeIf { it.isNotBlank() },
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -58,6 +58,9 @@ interface TradingRepository {
     suspend fun placeQuote(symbolId: Int, bidPrice: Long, askPrice: Long, bidQty: Long, askQty: Long): ApiResult<QuoteAck>
     suspend fun placeAlgo(algoType: String, symbolId: Int, side: OrderSide, qty: Long, stopPrice: Long?, limitPrice: Long?): ApiResult<AlgoAck>
     suspend fun placeOto(symbolId: Int, parentSide: OrderSide, parentPrice: Long, parentQty: Long, childSide: OrderSide, childPrice: Long, childQty: Long): ApiResult<OtoAck>
+    /** Fees (custody-exchange-gaps): the caller's fee schedule + the enriched fills-fees feed. */
+    suspend fun feeSchedule(): ApiResult<FeeSchedule>
+    suspend fun fillsFees(): ApiResult<FillsFees>
 }
 
 @Singleton
@@ -165,6 +168,12 @@ class TradingRepositoryImpl @Inject constructor(
 
     override suspend fun placeOto(symbolId: Int, parentSide: OrderSide, parentPrice: Long, parentQty: Long, childSide: OrderSide, childPrice: Long, childQty: Long): ApiResult<OtoAck> =
         withContext(io) { apiCall { api.placeOto(OtoOrderDto(symbolId, parentSide.wire, parentPrice, parentQty, childSide.wire, childPrice, childQty)).toDomain() } }
+
+    override suspend fun feeSchedule(): ApiResult<FeeSchedule> =
+        withContext(io) { apiCall { api.getFeeSchedule().toDomain() } }
+
+    override suspend fun fillsFees(): ApiResult<FillsFees> =
+        withContext(io) { apiCall { api.getFillsFees().toDomain() } }
 
     private suspend fun <T> apiCall(block: suspend () -> T): ApiResult<T> = try {
         ApiResult.Success(block())

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -62,6 +63,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.data.custody.CustodyAssets
 import com.testlogon.android.data.custody.CustodyBalance
+import com.testlogon.android.data.custody.BridgeDirection
+import com.testlogon.android.data.custody.CustodyBridgeResult
+import com.testlogon.android.data.custody.CustodySubAccount
+import com.testlogon.android.data.custody.CustodySubAccounts
+import com.testlogon.android.data.custody.SubAccountTransferResult
 import com.testlogon.android.data.custody.CustodyDeposit
 import com.testlogon.android.data.custody.CustodyDeposits
 import com.testlogon.android.data.custody.DepositStatus
@@ -94,6 +100,8 @@ fun CustodyScreen(
     val tabs = remember {
         listOf(
             CustodyTab.BALANCES,
+            CustodyTab.SUBACCOUNTS,
+            CustodyTab.TRANSFER,
             CustodyTab.DEPOSIT,
             CustodyTab.WITHDRAW,
             CustodyTab.ACTIVITY,
@@ -127,6 +135,8 @@ fun CustodyScreen(
             }
             when (state.tab) {
                 CustodyTab.BALANCES -> BalancesTab(state, viewModel)
+                CustodyTab.SUBACCOUNTS -> SubAccountsTab(state, viewModel)
+                CustodyTab.TRANSFER -> TransferTab(state, viewModel)
                 CustodyTab.DEPOSIT -> DepositTab(state, viewModel)
                 CustodyTab.WITHDRAW -> WithdrawTab(state, viewModel)
                 CustodyTab.ACTIVITY -> UnavailableTab(
@@ -144,6 +154,8 @@ fun CustodyScreen(
 
 private fun CustodyTab.title(): String = when (this) {
     CustodyTab.BALANCES -> "Balances"
+    CustodyTab.SUBACCOUNTS -> "Sub-accounts"
+    CustodyTab.TRANSFER -> "Transfer"
     CustodyTab.DEPOSIT -> "Deposit"
     CustodyTab.WITHDRAW -> "Withdraw"
     CustodyTab.ACTIVITY -> "Activity"
@@ -664,3 +676,271 @@ private fun HintText(text: String) {
 
 // short hash/address display helper.
 private fun String.short(): String = if (length <= 16) this else "${take(8)}…${takeLast(6)}"
+
+// ---------------- Sub-accounts ----------------
+
+@Composable
+private fun SubAccountsTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    val sa = state.subAccounts
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text("Create sub-account", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "A named vault under your base vault. Letters, digits, _ and - only.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                OutlinedTextField(
+                    value = sa.newLabel,
+                    onValueChange = viewModel::onNewSubAccountLabelChanged,
+                    label = { Text("Label") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("subaccount_label"),
+                )
+                if (sa.createError != null) {
+                    Text(sa.createError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+                Button(
+                    onClick = { viewModel.createSubAccount() },
+                    enabled = !sa.creating && sa.newLabel.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth().testTag("subaccount_create"),
+                ) {
+                    if (sa.creating) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                        Spacer(Modifier.width(8.dp))
+                    }
+                    Text("Create sub-account")
+                }
+            }
+        }
+
+        val list = sa.list
+        when {
+            list.loading && list.data == null -> LoadingBox()
+            list.error != null && list.data == null -> ErrorBox(list.error) { viewModel.loadSubAccounts() }
+            list.data == null || list.data.unavailable -> UnavailableCard(
+                "Sub-accounts are not available on this backend yet. Creating one will start working once the gateway route is deployed.",
+            )
+            else -> {
+                val data = list.data
+                Text("Base vault: ${data.defaultVault.short().ifBlank { "—" }}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
+                if (data.subAccounts.isEmpty()) {
+                    EmptyBox("No sub-accounts yet.")
+                } else {
+                    data.subAccounts.forEach { sub -> SubAccountCard(sub) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubAccountCard(sub: CustodySubAccount) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(sub.displayLabel, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                Text("Tier: ${sub.tier}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Text(sub.idShort, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
+            val funded = sub.funded()
+            if (funded.isEmpty()) {
+                Text("No balances", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(top = 6.dp))
+            } else {
+                Spacer(Modifier.height(6.dp))
+                funded.forEach { row ->
+                    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 1.dp)) {
+                        Text(row.symbol, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+                        Text(row.amountText, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------- Transfer ----------------
+
+@Composable
+private fun TransferTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    val t = state.transfer
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text("Custody ↔ Trading bridge", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    BridgeDirection.entries.forEach { d ->
+                        FilterChip(
+                            selected = d == t.direction,
+                            onClick = { if (d != t.direction) viewModel.onBridgeDirectionToggle() },
+                            label = { Text(d.label) },
+                            modifier = Modifier.testTag("bridge_dir_${d.name}"),
+                        )
+                    }
+                }
+                OutlinedTextField(
+                    value = t.bridgeAssetText,
+                    onValueChange = viewModel::onBridgeAssetChanged,
+                    label = { Text("Engine asset id") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("bridge_asset"),
+                )
+                OutlinedTextField(
+                    value = t.bridgeAmountText,
+                    onValueChange = viewModel::onBridgeAmountChanged,
+                    label = { Text("Amount (integer)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("bridge_amount"),
+                )
+                if (t.bridgeError != null) {
+                    Text(t.bridgeError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+                Button(
+                    onClick = { viewModel.submitBridgeTransfer() },
+                    enabled = t.canBridge,
+                    modifier = Modifier.fillMaxWidth().testTag("bridge_submit"),
+                ) {
+                    if (t.bridgeSubmitting) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                        Spacer(Modifier.width(8.dp))
+                    }
+                    Text("Transfer")
+                }
+                t.bridgeResult?.let { r -> BridgeResultCard(r) { viewModel.clearBridgeResult() } }
+            }
+        }
+
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text("Between sub-accounts", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                val labels = viewModel.subAccountLabels()
+                Text("From", style = MaterialTheme.typography.labelMedium)
+                VaultChips(labels = labels, selected = t.fromLabel, onSelect = viewModel::onFromLabelChanged, tagPrefix = "from")
+                Text("To", style = MaterialTheme.typography.labelMedium)
+                VaultChips(labels = labels, selected = t.toLabel, onSelect = viewModel::onToLabelChanged, tagPrefix = "to")
+                OutlinedTextField(
+                    value = t.subAsset,
+                    onValueChange = viewModel::onSubAssetChanged,
+                    label = { Text("Asset (e.g. ETH)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("sub_asset"),
+                )
+                OutlinedTextField(
+                    value = t.subAmountText,
+                    onValueChange = viewModel::onSubAmountChanged,
+                    label = { Text("Amount") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("sub_amount"),
+                )
+                if (t.subError != null) {
+                    Text(t.subError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+                Button(
+                    onClick = { viewModel.submitSubAccountTransfer() },
+                    enabled = t.canSubTransfer,
+                    modifier = Modifier.fillMaxWidth().testTag("sub_submit"),
+                ) {
+                    if (t.subSubmitting) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                        Spacer(Modifier.width(8.dp))
+                    }
+                    Text("Move")
+                }
+                t.subResult?.let { r -> SubTransferResultCard(r) { viewModel.clearSubTransferResult() } }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VaultChips(labels: List<String>, selected: String, onSelect: (String) -> Unit, tagPrefix: String) {
+    Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        labels.forEach { lbl ->
+            val display = if (lbl.isBlank()) "Base vault" else lbl
+            FilterChip(
+                selected = lbl == selected,
+                onClick = { onSelect(lbl) },
+                label = { Text(display) },
+                modifier = Modifier.testTag("vault_${tagPrefix}_${if (lbl.isBlank()) "base" else lbl}"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BridgeResultCard(r: CustodyBridgeResult, onDismiss: () -> Unit) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant), modifier = Modifier.fillMaxWidth().testTag("bridge_result")) {
+        Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(if (r.ok) "Submitted" else "Rejected", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                if (r.simulated) SimulatedChip()
+            }
+            r.direction?.let { DetailRow("Direction", it.label) }
+            r.asset?.let { DetailRow("Asset id", it.toString()) }
+            r.amount?.let { DetailRow("Amount", it.toString()) }
+            if (r.direction == BridgeDirection.TO_TRADING) {
+                DetailRow("Trading credited", if (r.tradingCredited) "yes" else "no")
+            }
+            r.note?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) { Text("Dismiss") }
+        }
+    }
+}
+
+@Composable
+private fun SubTransferResultCard(r: SubAccountTransferResult, onDismiss: () -> Unit) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant), modifier = Modifier.fillMaxWidth().testTag("sub_result")) {
+        Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(if (r.ok) "Submitted" else "Rejected", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                if (r.simulated) SimulatedChip()
+            }
+            r.from?.let { DetailRow("From", it.short()) }
+            r.to?.let { DetailRow("To", it.short()) }
+            r.asset?.let { DetailRow("Asset", it) }
+            r.amount?.let { DetailRow("Amount", it) }
+            r.note?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) { Text("Dismiss") }
+        }
+    }
+}
+
+/** Honest "not settled" marker shown whenever a transfer response carries stub:true. */
+@Composable
+private fun SimulatedChip() {
+    Box(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(50))
+            .padding(horizontal = 10.dp, vertical = 3.dp)
+            .testTag("simulated_chip"),
+    ) {
+        Text(
+            "Simulated · not settled",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun UnavailableCard(text: String) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant), modifier = Modifier.fillMaxWidth()) {
+        Row(modifier = Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Filled.Info, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.width(10.dp))
+            Text(text, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
@@ -8,6 +8,11 @@ import com.testlogon.android.data.custody.CustodyAsset
 import com.testlogon.android.data.custody.CustodyAssets
 import com.testlogon.android.data.custody.CustodyBalance
 import com.testlogon.android.data.custody.CustodyBalances
+import com.testlogon.android.data.custody.BridgeDirection
+import com.testlogon.android.data.custody.CustodyBridgeResult
+import com.testlogon.android.data.custody.CustodySubAccount
+import com.testlogon.android.data.custody.CustodySubAccounts
+import com.testlogon.android.data.custody.SubAccountTransferResult
 import com.testlogon.android.data.custody.CustodyDepositAddress
 import com.testlogon.android.data.custody.CustodyDeposits
 import com.testlogon.android.data.custody.CustodyRepository
@@ -24,7 +29,7 @@ import javax.inject.Inject
  * The five in-screen custody tabs. Activity + Approvals have no backing endpoint on this backend and
  * render a static "not available" state; they are always shown (no role gating).
  */
-enum class CustodyTab { BALANCES, DEPOSIT, WITHDRAW, ACTIVITY, APPROVALS }
+enum class CustodyTab { BALANCES, SUBACCOUNTS, TRANSFER, DEPOSIT, WITHDRAW, ACTIVITY, APPROVALS }
 
 /** A generic async slice: loading / error(message) / data. */
 data class Async<out T>(
@@ -52,11 +57,53 @@ data class WithdrawUiState(
     val submitError: String? = null,
 )
 
+/** Sub-accounts tab: the vault list + the create-form field / in-flight flag. */
+data class SubAccountsUiState(
+    val list: Async<CustodySubAccounts> = Async(loading = true),
+    val newLabel: String = "",
+    val creating: Boolean = false,
+    val createError: String? = null,
+)
+
+/**
+ * Transfer tab. Two independent forms: the custody<->trading bridge (direction + engine-asset-id +
+ * amount) and the between-sub-accounts move (from/to labels + asset symbol + amount). Each holds its
+ * own in-flight flag, error, and last (honest, possibly-simulated) result.
+ */
+data class TransferUiState(
+    // Bridge (custody <-> trading)
+    val direction: BridgeDirection = BridgeDirection.TO_TRADING,
+    val bridgeAssetText: String = "",
+    val bridgeAmountText: String = "",
+    val bridgeSubmitting: Boolean = false,
+    val bridgeError: String? = null,
+    val bridgeResult: CustodyBridgeResult? = null,
+    // Between sub-accounts
+    val fromLabel: String = "",
+    val toLabel: String = "",
+    val subAsset: String = "",
+    val subAmountText: String = "",
+    val subSubmitting: Boolean = false,
+    val subError: String? = null,
+    val subResult: SubAccountTransferResult? = null,
+) {
+    val bridgeAssetInt: Int? get() = bridgeAssetText.trim().toIntOrNull()
+    val bridgeAmountLong: Long? get() = bridgeAmountText.trim().toLongOrNull()
+    val canBridge: Boolean get() = !bridgeSubmitting && (bridgeAssetInt ?: -1) >= 0 && (bridgeAmountLong ?: 0L) > 0L
+    val subAmountDouble: Double? get() = subAmountText.trim().toDoubleOrNull()
+    val canSubTransfer: Boolean get() = !subSubmitting &&
+        subAsset.trim().isNotEmpty() &&
+        (subAmountDouble ?: 0.0) > 0.0 &&
+        fromLabel.trim() != toLabel.trim()
+}
+
 data class CustodyUiState(
     val tab: CustodyTab = CustodyTab.BALANCES,
     val balances: Async<CustodyBalances> = Async(loading = true),
     val deposit: DepositUiState = DepositUiState(),
     val withdraw: WithdrawUiState = WithdrawUiState(),
+    val subAccounts: SubAccountsUiState = SubAccountsUiState(),
+    val transfer: TransferUiState = TransferUiState(),
 ) {
     val rows: List<CustodyBalance> get() = balances.data?.rows.orEmpty()
     val fundedRows: List<CustodyBalance> get() = balances.data?.funded().orEmpty()
@@ -74,6 +121,7 @@ class CustodyViewModel @Inject constructor(
     init {
         loadBalance()
         loadDeposits()
+        loadSubAccounts()
     }
 
     // ---- tab + selection ----
@@ -185,6 +233,120 @@ class CustodyViewModel @Inject constructor(
             }
         }
     }
+
+    // ---- sub-accounts ----
+
+    fun loadSubAccounts() {
+        _uiState.update { it.copy(subAccounts = it.subAccounts.copy(list = it.subAccounts.list.copy(loading = true, error = null))) }
+        viewModelScope.launch {
+            _uiState.update { st -> st.copy(subAccounts = st.subAccounts.copy(list = repo.getSubAccounts().toAsync())) }
+        }
+    }
+
+    fun onNewSubAccountLabelChanged(v: String) {
+        // Mirror the server sanitizer client-side: [A-Za-z0-9_-], capped 48.
+        val sanitized = v.filter { it.isLetterOrDigit() || it == '_' || it == '-' }.take(48)
+        _uiState.update { it.copy(subAccounts = it.subAccounts.copy(newLabel = sanitized, createError = null)) }
+    }
+
+    fun createSubAccount() {
+        val label = _uiState.value.subAccounts.newLabel.trim()
+        if (label.isEmpty()) {
+            _uiState.update { it.copy(subAccounts = it.subAccounts.copy(createError = "Enter a label.")) }
+            return
+        }
+        _uiState.update { it.copy(subAccounts = it.subAccounts.copy(creating = true, createError = null)) }
+        viewModelScope.launch {
+            when (val r = repo.createSubAccount(label)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(subAccounts = it.subAccounts.copy(creating = false, newLabel = "")) }
+                    loadSubAccounts()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(subAccounts = it.subAccounts.copy(creating = false, createError = r.error.messageFor()))
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(subAccounts = it.subAccounts.copy(creating = false, createError = "Network error. Check your connection and try again."))
+                }
+            }
+        }
+    }
+
+    /** Sub-account labels available as transfer endpoints (base vault + named), for the picker chips. */
+    fun subAccountLabels(): List<String> {
+        val subs = _uiState.value.subAccounts.list.data?.subAccounts.orEmpty().map { it.label }.filter { it.isNotBlank() }
+        return listOf("") + subs   // "" == base vault
+    }
+
+    // ---- transfer: custody <-> trading bridge ----
+
+    fun onBridgeDirectionToggle() =
+        _uiState.update { it.copy(transfer = it.transfer.copy(direction = it.transfer.direction.toggle(), bridgeError = null, bridgeResult = null)) }
+
+    fun onBridgeAssetChanged(v: String) =
+        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeAssetText = v.filter { c -> c.isDigit() }.take(6), bridgeError = null)) }
+
+    fun onBridgeAmountChanged(v: String) =
+        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeAmountText = v.filter { c -> c.isDigit() }.take(15), bridgeError = null)) }
+
+    fun submitBridgeTransfer() {
+        val t = _uiState.value.transfer
+        if (!t.canBridge) {
+            _uiState.update { it.copy(transfer = it.transfer.copy(bridgeError = "Enter an asset id and an amount greater than 0.")) }
+            return
+        }
+        val asset = t.bridgeAssetInt!!
+        val amount = t.bridgeAmountLong!!
+        val direction = t.direction
+        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeSubmitting = true, bridgeError = null, bridgeResult = null)) }
+        viewModelScope.launch {
+            when (val r = repo.bridgeTransfer(direction, asset, amount)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(transfer = it.transfer.copy(bridgeSubmitting = false, bridgeResult = r.data)) }
+                    loadBalance()
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(transfer = it.transfer.copy(bridgeSubmitting = false, bridgeError = r.error.messageFor())) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(transfer = it.transfer.copy(bridgeSubmitting = false, bridgeError = "Network error. Check your connection and try again.")) }
+            }
+        }
+    }
+
+    fun clearBridgeResult() =
+        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeResult = null, bridgeAmountText = "")) }
+
+    // ---- transfer: between sub-accounts ----
+
+    fun onFromLabelChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(fromLabel = v, subError = null)) }
+    fun onToLabelChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(toLabel = v, subError = null)) }
+    fun onSubAssetChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(subAsset = v.trim().uppercase().take(12), subError = null)) }
+    fun onSubAmountChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(subAmountText = v, subError = null)) }
+
+    fun submitSubAccountTransfer() {
+        val t = _uiState.value.transfer
+        if (t.fromLabel.trim() == t.toLabel.trim()) {
+            _uiState.update { it.copy(transfer = it.transfer.copy(subError = "Choose two different vaults.")) }
+            return
+        }
+        if (!t.canSubTransfer) {
+            _uiState.update { it.copy(transfer = it.transfer.copy(subError = "Enter an asset and an amount greater than 0.")) }
+            return
+        }
+        val from = t.fromLabel.trim()
+        val to = t.toLabel.trim()
+        val asset = t.subAsset.trim()
+        val amount = t.subAmountText.trim()
+        _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = true, subError = null, subResult = null)) }
+        viewModelScope.launch {
+            when (val r = repo.subAccountTransfer(from.ifBlank { null }, to.ifBlank { null }, asset, amount)) {
+                is ApiResult.Success -> _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = false, subResult = r.data)) }
+                is ApiResult.Failure -> _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = false, subError = r.error.messageFor())) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = false, subError = "Network error. Check your connection and try again.")) }
+            }
+        }
+    }
+
+    fun clearSubTransferResult() =
+        _uiState.update { it.copy(transfer = it.transfer.copy(subResult = null, subAmountText = "")) }
 
     /** Clears the withdraw result/form after the user acknowledges the outcome. */
     fun clearWithdrawResult() {

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -322,6 +322,10 @@ private fun OrdersSection(state: TradingUiState, viewModel: TradingViewModel) {
 
 @Composable
 private fun FillsSection(state: TradingUiState) {
+    state.feeSchedule?.let {
+        FeeScheduleCard(it)
+        Spacer(Modifier.height(10.dp))
+    }
     if (state.sessionFills.isEmpty()) {
         EmptyHint("No fills this session")
         return
@@ -329,9 +333,62 @@ private fun FillsSection(state: TradingUiState) {
     Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
         Text("Price", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1.2f))
         Text("Qty", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
+        Text("Fee", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
         Text("Time", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
     }
-    state.sessionFills.take(60).forEach { f -> FillRow(f) }
+    state.sessionFills.take(60).forEach { f -> FillRow(f, state.feeForFill(f.price, f.qty)) }
+    state.fillsFees?.takeIf { it.isStub }?.let {
+        Spacer(Modifier.height(6.dp))
+        Text(
+            "Fee = ${it.feeFormula ?: "round(price*qty*taker_bps/10000)"} · computed client-side (est.)",
+            color = MarketColors.TextFaint,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 10.sp,
+        )
+    }
+}
+
+/**
+ * Fee schedule card (GET /me/fees/schedule). When the schedule is the venue-default stub (source=stub)
+ * a small "estimated" marker is shown so the rate is not mistaken for a negotiated per-caller quote.
+ */
+@Composable
+private fun FeeScheduleCard(fee: com.testlogon.android.data.exchange.FeeSchedule) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MarketColors.SurfaceAlt)
+            .padding(12.dp)
+            .testTag("fee_schedule_card"),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Fee schedule", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 13.sp, modifier = Modifier.weight(1f))
+            if (fee.isStub) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(50))
+                        .background(MarketColors.Surface)
+                        .padding(horizontal = 8.dp, vertical = 2.dp),
+                ) {
+                    Text("venue default · est.", color = MarketColors.TextFaint, fontFamily = FontFamily.Monospace, fontSize = 10.sp)
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        FeeRow("Maker", fee.makerPct(), fee.makerFeeBps)
+        FeeRow("Taker", fee.takerPct(), fee.takerFeeBps)
+        FeeRow("Liquidation", fee.liquidationPct(), fee.liquidationFeeBps)
+    }
+}
+
+@Composable
+private fun FeeRow(label: String, pct: String, bps: Int) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 1.dp)) {
+        Text(label, color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.weight(1f))
+        Text(pct, color = MarketColors.TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.weight(1f))
+        Text("$bps bps", color = MarketColors.TextFaint, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.weight(1f))
+    }
 }
 
 @Composable
@@ -453,7 +510,7 @@ private fun StepBtn(sym: String, tag: String, onClick: () -> Unit) {
 private val fillTimeFmt = java.text.SimpleDateFormat("HH:mm:ss", Locale.US)
 
 @Composable
-private fun FillRow(fill: com.testlogon.android.data.exchange.Fill) {
+private fun FillRow(fill: com.testlogon.android.data.exchange.Fill, fee: Long) {
     val color = when (fill.side) {
         OrderSide.BUY -> MarketColors.Up
         OrderSide.SELL -> MarketColors.Down
@@ -462,6 +519,7 @@ private fun FillRow(fill: com.testlogon.android.data.exchange.Fill) {
     Row(modifier = Modifier.fillMaxWidth().padding(vertical = 1.dp)) {
         Text(fmt(fill.price.toDouble()), color = color, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.weight(1.2f))
         Text(fill.qty.toString(), color = MarketColors.TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.weight(1f))
+        Text(fmt(fee.toDouble()), color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.weight(1f))
         Text(
             text = if (fill.tsNs > 0) fillTimeFmt.format(java.util.Date(fill.tsNs / 1_000_000L)) else "--",
             color = MarketColors.TextFaint,

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -1,6 +1,9 @@
 package com.testlogon.android.feature.markets.trade
 
 import com.testlogon.android.data.exchange.Fill
+import com.testlogon.android.data.exchange.FeeSchedule
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.feeFor
 import com.testlogon.android.data.exchange.MarginAccount
 import com.testlogon.android.data.exchange.OrderSide
 import com.testlogon.android.data.exchange.SpotBalance
@@ -97,7 +100,13 @@ data class TradingUiState(
     val pm: com.testlogon.android.data.exchange.PmState? = null,   // set when this symbol is a binary prediction market
     val isAdmin: Boolean = false,   // resolved from CurrentUserRepository; gates the margin-config panel
     val marginConfig: MarginConfigForm = MarginConfigForm(),
+    val feeSchedule: FeeSchedule? = null,
+    val fillsFees: FillsFees? = null,
 ) {
+    /** The taker bps used to compute a per-fill fee client-side (enriched feed, else schedule, else 20). */
+    val effectiveTakerBps: Int get() = fillsFees?.takerFeeBps ?: feeSchedule?.takerFeeBps ?: 20
+    /** round(price*qty*takerBps/10000) for a session fill, matching the backend fee_formula. */
+    fun feeForFill(price: Long, qty: Long): Long = feeFor(price * qty, effectiveTakerBps)
     val isAmending: Boolean get() = amendingClordid != null
     val depositLong: Long? get() = depositText.toLongOrNull()
     val canDeposit: Boolean get() = !depositing && (depositLong ?: 0L) > 0L

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.data.exchange.OrderSide
 import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.data.exchange.FeeSchedule
+import com.testlogon.android.data.exchange.FillsFees
 import com.testlogon.android.data.feed.CurrentUserRepository
 import com.testlogon.android.navigation.SymbolDetailDest
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -46,7 +48,27 @@ class TradingViewModel @Inject constructor(
         refreshAccount()
         pollAccount()
         refreshPm()
+        loadFees()
         if (TradingFeatures.SPOT_ENABLED) refreshSpot()
+    }
+
+    /**
+     * Load the caller's fee schedule + the enriched fills-fees feed (custody-exchange-gaps). Both 404
+     * until deployed; a failure just leaves the fee card hidden (no error surfaced on the ticket).
+     */
+    fun loadFees() {
+        viewModelScope.launch {
+            when (val r = repository.feeSchedule()) {
+                is ApiResult.Success -> _uiState.update { it.copy(feeSchedule = r.data) }
+                else -> Unit
+            }
+        }
+        viewModelScope.launch {
+            when (val r = repository.fillsFees()) {
+                is ApiResult.Success -> _uiState.update { it.copy(fillsFees = r.data) }
+                else -> Unit
+            }
+        }
     }
 
     /** Detect + track a binary prediction market on this symbol (404 -> not a PM -> stays null). */

--- a/frontend/src/api/endpoints/custody.ts
+++ b/frontend/src/api/endpoints/custody.ts
@@ -234,3 +234,143 @@ export function mergeBalances(
   }
   return rows;
 }
+
+
+// ─── Sub-accounts, custody<->trading bridge, and fee endpoints ───────────
+// NEW gap-closing endpoints (from the exchange-edge custody phase). Every one
+// of these MAY 404 on backends where the edge isn't deployed yet — all callers
+// must degrade gracefully (retry:false + an "unavailable" empty state) and the
+// stub/simulated responses below carry a `stub:true` flag the UI surfaces
+// honestly so a user never mistakes a simulated move for a settled one.
+
+export interface SubaccountBalancesMap {
+  [asset: string]: number | string;
+}
+
+export interface Subaccount {
+  id: string;
+  label: string;
+  tier?: string;
+  balances?: SubaccountBalancesMap;
+  /** Full vault name (present on create). */
+  vault?: string;
+}
+
+export interface SubaccountsResult {
+  /** The caller's base (default) vault name. */
+  default_vault: string;
+  subaccounts: Subaccount[];
+}
+
+/**
+ * List the caller's sub-account vaults (default base vault + named ones).
+ * 404s until the edge deploys — callers should render a graceful
+ * "not available on this backend yet" state (retry:false).
+ */
+export const getSubaccounts = () =>
+  api.get<SubaccountsResult>("/me/custody/subaccounts");
+
+/** Create a named sub-account vault under the caller's base vault. */
+export const createSubaccount = (label: string) =>
+  api.post<Subaccount>("/me/custody/subaccounts", { label });
+
+/** Response to a simulated transfer — carries stub:true when not settled. */
+export interface TransferResult {
+  status: string;
+  stub?: boolean;
+  note?: string;
+  from?: string;
+  to?: string;
+  asset?: string | number;
+  amount?: string | number;
+  direction?: "to_trading" | "to_custody" | string;
+  trading_credited?: boolean;
+  [k: string]: unknown;
+}
+
+export interface SubaccountTransferRequest {
+  from_label?: string;
+  to_label?: string;
+  asset: string | number;
+  amount: number | string;
+}
+
+/**
+ * Move an asset between two of the caller's OWN sub-account vaults (or the
+ * base vault). Deliberately a documented no-op on the backend (stub:true).
+ */
+export const transferBetweenSubaccounts = (req: SubaccountTransferRequest) =>
+  api.post<TransferResult>("/me/custody/subaccounts/transfer", req);
+
+export interface CustodyTradingTransferRequest {
+  direction: "to_trading" | "to_custody";
+  /** Engine asset id for the credit path. */
+  asset: number;
+  /** Positive integer amount. */
+  amount: number;
+}
+
+/**
+ * Custody<->trading bridge: move value between the custody vault and the
+ * exchange spot ledger. Best-effort / simulated (stub:true) — see the
+ * returned `note`.
+ */
+export const custodyTradingTransfer = (req: CustodyTradingTransferRequest) =>
+  api.post<TransferResult>("/me/custody/transfer", req);
+
+// ─── Fees ────────────────────────────────────────────────────────────────
+
+export interface FeeScheduleRow {
+  symbolid?: number;
+  maker_fee_bps: number;
+  taker_fee_bps: number;
+  liquidation_fee_bps: number;
+}
+
+export interface FeeScheduleResult {
+  schedule: FeeScheduleRow[];
+  maker_fee_bps: number;
+  taker_fee_bps: number;
+  liquidation_fee_bps: number;
+  source?: string;
+  stub?: boolean;
+}
+
+/** The caller's maker/taker/liquidation fee schedule (venue defaults when stub). */
+export const getFeeSchedule = () =>
+  api.get<FeeScheduleResult>("/me/fees/schedule");
+
+export interface EnrichedFill {
+  price?: number;
+  qty?: number;
+  fee?: number;
+  [k: string]: unknown;
+}
+
+export interface FillsFeesResult {
+  fills: EnrichedFill[];
+  taker_fee_bps: number;
+  fee_formula?: string;
+  source?: string;
+  stub?: boolean;
+  note?: string;
+}
+
+/**
+ * Recent fills enriched with a computed fee (thin wrapper). Returns an empty
+ * feed + the fee formula / taker rate that WOULD apply until the engine
+ * exposes a per-caller fills feed. 404s until the edge deploys.
+ */
+export const getFillsFees = () => api.get<FillsFeesResult>("/me/fills/fees");
+
+/** round(price*qty*taker_fee_bps/10000) — the documented fee formula. */
+export function computeFee(
+  price: number | undefined | null,
+  qty: number | undefined | null,
+  takerFeeBps: number,
+): number {
+  const p = typeof price === "number" ? price : 0;
+  const q = typeof qty === "number" ? qty : 0;
+  if (!(p > 0) || !(q > 0) || !(takerFeeBps > 0)) return 0;
+  return Math.round((p * q * takerFeeBps) / 10000);
+}

--- a/frontend/src/components/blotter/grid/columns.tsx
+++ b/frontend/src/components/blotter/grid/columns.tsx
@@ -598,4 +598,15 @@ export const orderColumns: ColumnDef<Order>[] = [
       );
     },
   },
+  {
+    id: 'fee', header: 'Fee', accessorKey: 'fee', size: 84,
+    filterFn: numFilter, meta: { filterKind: 'num' },
+    cell: info => {
+      const v = info.getValue<number | undefined>();
+      return v == null || !Number.isFinite(v)
+        ? <span className="dim">—</span>
+        : <span className="num">{fmtQty(v)}</span>;
+    },
+    aggregatedCell: ({ getValue }) => <span className="num dim">{String(getValue() ?? '')}</span>,
+  },
 ];

--- a/frontend/src/components/blotter/grid/fillsColumns.tsx
+++ b/frontend/src/components/blotter/grid/fillsColumns.tsx
@@ -26,6 +26,7 @@ export const fillsColumns: ColumnDef<Order>[] = [
   { ...pick('side') },
   { ...pick('cumQty'),   header: 'FillQty'  },
   { ...pick('avgPx'),    header: 'FillPx'   },
+  { ...pick('fee') },
   { ...pick('edgeToExec') },       // small: one signed number, quick scan
   { ...pick('px'),       header: 'OrderPx'  },
   { ...pick('leaves'),   header: 'Remaining' },

--- a/frontend/src/components/blotter/types.ts
+++ b/frontend/src/components/blotter/types.ts
@@ -66,6 +66,10 @@ export interface Order {
   linkExecid?:   string;  // hedge lineage: quoter execid this hedge traces to (hex string)
   impliedPx?:    number;  // implied hedge price from linked quoter fill
   slipBp?:       number;  // + = FAVOURABLE (we did better than implied), − = adverse
+  // Computed taker fee for the fill = round(avgPx*cumQty*takerFeeBps/10000),
+  // sourced from the /me/fills/fees taker rate. Undefined until enriched;
+  // the Fee column hides entirely when no fee rate is available.
+  fee?:          number;
   // display-only derived: milliseconds since last update, refreshed each tick.
   // Not stored in mock data — computed at render time.
 }

--- a/frontend/src/pages/blotter/TradingWorkspacePage.tsx
+++ b/frontend/src/pages/blotter/TradingWorkspacePage.tsx
@@ -2,6 +2,8 @@
 // hosting the testlogon blotter: Orders, Fills, and Positions panels. Drag tabs
 // to split or float; the "+ Panel" menu reopens closed panels; layout persists.
 import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getFillsFees, computeFee } from "@/api/endpoints/custody";
 import {
   DockviewReact,
   type DockviewReadyEvent,
@@ -61,7 +63,7 @@ const posColumns: ColumnDef<any>[] = [
 // Compact column sets for narrow (mobile) screens — fewer columns so rows are
 // readable without horizontal scrolling.
 const MOBILE_ORDER_IDS = new Set(["sym", "side", "px", "qty", "cumQty", "status"]);
-const MOBILE_FILL_IDS = new Set(["sym", "side", "px", "qty", "avgPx", "status"]);
+const MOBILE_FILL_IDS = new Set(["sym", "side", "px", "qty", "avgPx", "fee", "status"]);
 const mobileOrderColumns = orderColumns.filter((c) => MOBILE_ORDER_IDS.has((c as any).id));
 const mobileFillsColumns = fillsColumns.filter((c) => MOBILE_FILL_IDS.has((c as any).id));
 
@@ -77,12 +79,12 @@ function useIsMobile(bp = 767): boolean {
 }
 
 const LAYOUT_KEY = "testlogon.trading.dock.v1";
-interface Ctx { orders: Order[]; touched: Set<string>; onCancel: (c: string) => void; isMobile: boolean; }
+interface Ctx { orders: Order[]; touched: Set<string>; onCancel: (c: string) => void; isMobile: boolean; takerFeeBps: number | null; }
 const WsCtx = createContext<Ctx | null>(null);
 const useWs = (): Ctx => { const c = useContext(WsCtx); if (!c) throw new Error("WsCtx missing"); return c; };
 
 function OrdersPanel() { const c = useWs(); return <div className="tl-panel-body"><Blotter data={c.orders} columns={c.isMobile ? mobileOrderColumns : orderColumns} touched={c.touched} storageKeyPrefix="tl-ws-orders" onCancel={c.onCancel} /></div>; }
-function FillsPanel() { const c = useWs(); const fills = useMemo(() => c.orders.filter((o) => o.cumQty > 0), [c.orders]); return <div className="tl-panel-body"><Blotter data={fills} columns={c.isMobile ? mobileFillsColumns : fillsColumns} touched={c.touched} storageKeyPrefix="tl-ws-fills" /></div>; }
+function FillsPanel() { const c = useWs(); const fills = useMemo(() => c.orders.filter((o) => o.cumQty > 0).map((o) => (c.takerFeeBps == null ? o : { ...o, fee: computeFee(o.avgPx, o.cumQty, c.takerFeeBps) })), [c.orders, c.takerFeeBps]); return <div className="tl-panel-body"><Blotter data={fills} columns={c.isMobile ? mobileFillsColumns : fillsColumns} touched={c.touched} storageKeyPrefix="tl-ws-fills" /></div>; }
 function PositionsPanel() {
   const c = useWs();
   const pos = useMemo(() => {
@@ -115,6 +117,10 @@ export default function TradingWorkspacePage() {
   const cancel = (clord: string) => setOrders((prev) => prev.map((o) => (o.clord === clord ? { ...o, status: "cancelled" as OrderStatus, leaves: 0 } : o)));
   const isMobile = useIsMobile();
   const [activeTab, setActiveTab] = useState<PanelId>("orders");
+  // Enriched fills-fee feed. 404s until the edge deploys -> null taker rate,
+  // and the Fills grid then hides its Fee column gracefully (no error).
+  const feesQuery = useQuery({ queryKey: ["fills", "fees"], queryFn: getFillsFees, retry: false, staleTime: 60_000 });
+  const takerFeeBps = feesQuery.data?.taker_fee_bps ?? null;
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -144,8 +150,8 @@ export default function TradingWorkspacePage() {
     return () => { clearInterval(id); if (clearTimer.current) clearTimeout(clearTimer.current); };
   }, []);
 
-  const ctxRef = useRef<Ctx>({ orders, touched, onCancel: cancel, isMobile });
-  ctxRef.current = { orders, touched, onCancel: cancel, isMobile };
+  const ctxRef = useRef<Ctx>({ orders, touched, onCancel: cancel, isMobile, takerFeeBps });
+  ctxRef.current = { orders, touched, onCancel: cancel, isMobile, takerFeeBps };
   const stableCtx = useMemo(() => new Proxy({} as Ctx, { get(_, k: string) { return (ctxRef.current as any)[k]; } }), []);
 
   const [dockApi, setDockApi] = useState<DockviewApi | null>(null);

--- a/frontend/src/pages/custody/CustodyExtras.tsx
+++ b/frontend/src/pages/custody/CustodyExtras.tsx
@@ -4,7 +4,7 @@
 // (retry:false) and every simulated (stub:true) response is surfaced honestly
 // with a "simulated / not settled" badge so a user never mistakes a no-op for
 // a real settled transfer.
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Layers,
@@ -46,6 +46,21 @@ import {
 } from "@/api/endpoints/custody";
 
 // ─── small shared bits ──────────────────────────────────────────
+
+function useIsMobile(bp = 767): boolean {
+  const [m, setM] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${bp}px)`).matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${bp}px)`);
+    const h = () => setM(mq.matches);
+    mq.addEventListener("change", h);
+    return () => mq.removeEventListener("change", h);
+  }, [bp]);
+  return m;
+}
 
 function num(v: string | number | undefined | null): number {
   if (v == null) return 0;
@@ -175,6 +190,7 @@ function useSubaccountsQuery() {
 // ─── Sub-accounts tab ───────────────────────────────────────────
 
 export function SubaccountsTab() {
+  const isMobile = useIsMobile();
   const qc = useQueryClient();
   const q = useSubaccountsQuery();
   const [label, setLabel] = useState("");
@@ -232,7 +248,10 @@ export function SubaccountsTab() {
               type="button"
               onClick={() => setSelected(null)}
               className={cn(
-                "flex w-full items-center justify-between rounded-lg border p-3 text-left transition",
+                "flex w-full rounded-lg border p-3 text-left transition",
+                isMobile
+                  ? "flex-col gap-1"
+                  : "items-center justify-between",
                 selected === null ? "ring-1 ring-primary/40" : "hover:bg-muted/40",
               )}
             >
@@ -241,7 +260,7 @@ export function SubaccountsTab() {
                 <span className="text-sm font-medium">Base vault</span>
                 <Badge variant="outline" className="text-[10px]">default</Badge>
               </span>
-              <span className="font-mono text-xs text-muted-foreground">
+              <span className="break-all font-mono text-xs text-muted-foreground">
                 {q.data.default_vault}
               </span>
             </button>
@@ -285,7 +304,14 @@ export function SubaccountsTab() {
                       : "hover:bg-muted/40",
                   )}
                 >
-                  <div className="flex items-center justify-between gap-2">
+                  <div
+                    className={cn(
+                      "flex gap-2",
+                      isMobile
+                        ? "flex-col"
+                        : "items-center justify-between",
+                    )}
+                  >
                     <span className="flex items-center gap-2">
                       <Layers className="h-4 w-4 text-muted-foreground" />
                       <span className="text-sm font-medium">{s.label}</span>
@@ -294,7 +320,7 @@ export function SubaccountsTab() {
                       )}
                     </span>
                     {s.vault && (
-                      <span className="font-mono text-xs text-muted-foreground">
+                      <span className="break-all font-mono text-xs text-muted-foreground">
                         {s.vault}
                       </span>
                     )}
@@ -552,6 +578,7 @@ function BridgeTransfer() {
 const BASE = "__base__";
 
 function InternalTransfer() {
+  const isMobile = useIsMobile();
   const q = useSubaccountsQuery();
   const subs: Subaccount[] = q.data?.subaccounts ?? [];
 
@@ -609,7 +636,7 @@ function InternalTransfer() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-3">
+          <div className={cn("grid gap-3", isMobile ? "grid-cols-1" : "grid-cols-2")}>
             <div className="space-y-1.5">
               <Label>From</Label>
               <Select value={fromLabel} onValueChange={(v) => { setFromLabel(v); setResult(null); }}>

--- a/frontend/src/pages/custody/CustodyExtras.tsx
+++ b/frontend/src/pages/custody/CustodyExtras.tsx
@@ -1,0 +1,703 @@
+// Custody gap-closing surfaces: Sub-accounts + Transfers.
+// Both wire to NEW exchange-edge routes that 404 until the edge deploys, so
+// every query/mutation degrades gracefully to an "unavailable" state
+// (retry:false) and every simulated (stub:true) response is surfaced honestly
+// with a "simulated / not settled" badge so a user never mistakes a no-op for
+// a real settled transfer.
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Layers,
+  Plus,
+  ArrowLeftRight,
+  Loader2,
+  Info,
+  AlertTriangle,
+  CircleCheck,
+  RefreshCw,
+  Wallet,
+} from "lucide-react";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+import { cn } from "@/lib/utils";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import {
+  getSubaccounts,
+  createSubaccount,
+  transferBetweenSubaccounts,
+  custodyTradingTransfer,
+  CUSTODY_ASSETS,
+  type Subaccount,
+  type TransferResult,
+} from "@/api/endpoints/custody";
+
+// ─── small shared bits ──────────────────────────────────────────
+
+function num(v: string | number | undefined | null): number {
+  if (v == null) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function fmtAmount(v: string | number | undefined | null): string {
+  const n = num(v);
+  if (n === 0) return "0";
+  return n.toLocaleString(undefined, { maximumFractionDigits: 8 });
+}
+
+function isUnavailable(err: unknown): boolean {
+  return err instanceof ApiError && (err.status === 404 || err.status === 501);
+}
+
+function UnavailableCard({ line }: { line: string }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-3 py-14 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Info className="h-6 w-6" />
+        </div>
+        <p className="mx-auto max-w-md text-sm text-muted-foreground">{line}</p>
+        <Badge variant="outline" className="gap-1.5">
+          <Info className="h-3 w-3" /> Not available on this backend yet
+        </Badge>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Honest "this move is simulated, not settled" badge for stub responses. */
+function SimulatedBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1 border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+    >
+      <AlertTriangle className="h-3 w-3" /> Simulated · not settled
+    </Badge>
+  );
+}
+
+function TransferResultView({ result }: { result: TransferResult }) {
+  const stub = result.stub === true;
+  return (
+    <div
+      className={cn(
+        "space-y-2 rounded-lg border p-4",
+        stub
+          ? "border-amber-500/40 bg-amber-500/5"
+          : "border-success/40 bg-success/10",
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="flex items-center gap-2 font-medium">
+          <CircleCheck className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+          Transfer accepted
+        </span>
+        {stub && <SimulatedBadge />}
+      </div>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {result.from != null && (
+          <div className="col-span-2 flex justify-between">
+            <dt>From</dt>
+            <dd className="font-mono text-foreground">{String(result.from)}</dd>
+          </div>
+        )}
+        {result.to != null && (
+          <div className="col-span-2 flex justify-between">
+            <dt>To</dt>
+            <dd className="font-mono text-foreground">{String(result.to)}</dd>
+          </div>
+        )}
+        {result.direction != null && (
+          <div className="flex justify-between">
+            <dt>Direction</dt>
+            <dd className="text-foreground">{String(result.direction)}</dd>
+          </div>
+        )}
+        {result.asset != null && (
+          <div className="flex justify-between">
+            <dt>Asset</dt>
+            <dd className="text-foreground">{String(result.asset)}</dd>
+          </div>
+        )}
+        {result.amount != null && (
+          <div className="flex justify-between">
+            <dt>Amount</dt>
+            <dd className="tabular-nums text-foreground">
+              {fmtAmount(result.amount as number | string)}
+            </dd>
+          </div>
+        )}
+        {result.trading_credited != null && (
+          <div className="flex justify-between">
+            <dt>Trading credited</dt>
+            <dd className="text-foreground">
+              {result.trading_credited ? "yes" : "no"}
+            </dd>
+          </div>
+        )}
+      </dl>
+      {result.note && (
+        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          {result.note}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── shared subaccounts query ───────────────────────────────────
+
+function useSubaccountsQuery() {
+  return useQuery({
+    queryKey: ["custody", "subaccounts"],
+    queryFn: getSubaccounts,
+    retry: false,
+    staleTime: 15_000,
+  });
+}
+
+// ─── Sub-accounts tab ───────────────────────────────────────────
+
+export function SubaccountsTab() {
+  const qc = useQueryClient();
+  const q = useSubaccountsQuery();
+  const [label, setLabel] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const subs: Subaccount[] = q.data?.subaccounts ?? [];
+
+  const sanitized = label.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 48);
+  const labelError =
+    label.trim() !== "" && sanitized === ""
+      ? "Label must contain letters, numbers, - or _."
+      : "";
+
+  const create = useMutation({
+    mutationFn: () => createSubaccount(sanitized),
+    onSuccess: (sa) => {
+      toast.success(`Sub-account "${sa.label ?? sanitized}" created`);
+      setLabel("");
+      qc.invalidateQueries({ queryKey: ["custody", "subaccounts"] });
+    },
+    onError: (err) => {
+      toast.error(err instanceof ApiError ? err.detail : "Could not create sub-account");
+    },
+  });
+
+  if (!q.isLoading && q.isError && isUnavailable(q.error)) {
+    return (
+      <UnavailableCard line="Sub-account vaults aren't served by this backend yet. Once the exchange edge is deployed, you'll be able to create and manage named vaults under your custody account here." />
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Layers className="h-5 w-5 text-primary" /> Sub-accounts
+            </CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => q.refetch()}
+              disabled={q.isFetching}
+            >
+              <RefreshCw className={cn("h-4 w-4", q.isFetching && "animate-spin")} />
+              Refresh
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {q.data?.default_vault && (
+            <button
+              type="button"
+              onClick={() => setSelected(null)}
+              className={cn(
+                "flex w-full items-center justify-between rounded-lg border p-3 text-left transition",
+                selected === null ? "ring-1 ring-primary/40" : "hover:bg-muted/40",
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <Wallet className="h-4 w-4 text-primary" />
+                <span className="text-sm font-medium">Base vault</span>
+                <Badge variant="outline" className="text-[10px]">default</Badge>
+              </span>
+              <span className="font-mono text-xs text-muted-foreground">
+                {q.data.default_vault}
+              </span>
+            </button>
+          )}
+
+          {q.isLoading && (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-14 w-full rounded-lg" />
+              ))}
+            </div>
+          )}
+
+          {!q.isLoading && q.isError && (
+            <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>Could not load sub-accounts. Please try again.</span>
+            </div>
+          )}
+
+          {!q.isLoading && !q.isError && subs.length === 0 && (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No named sub-accounts yet — create one below to organise balances.
+            </p>
+          )}
+
+          {!q.isLoading &&
+            !q.isError &&
+            subs.map((s) => {
+              const bal = s.balances ?? {};
+              const funded = Object.entries(bal).filter(([, v]) => num(v) > 0);
+              return (
+                <button
+                  key={s.id ?? s.label}
+                  type="button"
+                  onClick={() => setSelected(s.label)}
+                  className={cn(
+                    "flex w-full flex-col gap-1 rounded-lg border p-3 text-left transition",
+                    selected === s.label
+                      ? "ring-1 ring-primary/40"
+                      : "hover:bg-muted/40",
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <Layers className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-sm font-medium">{s.label}</span>
+                      {s.tier && (
+                        <Badge variant="outline" className="text-[10px]">{s.tier}</Badge>
+                      )}
+                    </span>
+                    {s.vault && (
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {s.vault}
+                      </span>
+                    )}
+                  </div>
+                  {funded.length > 0 ? (
+                    <div className="flex flex-wrap gap-1.5 pt-0.5">
+                      {funded.map(([asset, v]) => (
+                        <span
+                          key={asset}
+                          className="rounded bg-muted px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground"
+                        >
+                          {fmtAmount(v)} {asset}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-[11px] text-muted-foreground">No balances</span>
+                  )}
+                </button>
+              );
+            })}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Plus className="h-5 w-5 text-primary" /> Create sub-account
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="sub-label">Label</Label>
+            <Input
+              id="sub-label"
+              placeholder="e.g. trading, savings, desk-2"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              maxLength={64}
+            />
+            {labelError ? (
+              <p className="text-xs text-destructive">{labelError}</p>
+            ) : (
+              sanitized !== label &&
+              sanitized !== "" && (
+                <p className="text-xs text-muted-foreground">
+                  Will be created as <span className="font-mono">{sanitized}</span>
+                </p>
+              )
+            )}
+          </div>
+          <Button
+            className="w-full gap-1.5"
+            disabled={sanitized === "" || create.isPending}
+            onClick={() => create.mutate()}
+          >
+            {create.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Create sub-account
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Transfer tab ───────────────────────────────────────────────
+
+type TransferMode = "bridge" | "internal";
+
+export function TransferTab() {
+  const [mode, setMode] = useState<TransferMode>("bridge");
+
+  return (
+    <div className="mx-auto max-w-xl space-y-4">
+      <div className="grid grid-cols-2 gap-1 rounded-lg border bg-muted/30 p-1">
+        <button
+          type="button"
+          onClick={() => setMode("bridge")}
+          className={cn(
+            "rounded-md px-3 py-1.5 text-sm font-medium transition",
+            mode === "bridge"
+              ? "bg-background shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          Custody ↔ Trading
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("internal")}
+          className={cn(
+            "rounded-md px-3 py-1.5 text-sm font-medium transition",
+            mode === "internal"
+              ? "bg-background shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          Between sub-accounts
+        </button>
+      </div>
+
+      {mode === "bridge" ? <BridgeTransfer /> : <InternalTransfer />}
+    </div>
+  );
+}
+
+// ─── (a) custody <-> trading bridge ─────────────────────────────
+
+function BridgeTransfer() {
+  const [direction, setDirection] = useState<"to_trading" | "to_custody">("to_trading");
+  const [assetSymbol, setAssetSymbol] = useState<string>(CUSTODY_ASSETS[0]!.symbol);
+  const [amount, setAmount] = useState("");
+  const [result, setResult] = useState<TransferResult | null>(null);
+
+  const asset = CUSTODY_ASSETS.find((a) => a.symbol === assetSymbol);
+  // The bridge credit path is keyed by an engine asset id (int). We map the
+  // registry chainId as the engine asset id proxy (asset id 0 = no-op).
+  const engineAssetId = asset ? asset.chainId : 0;
+
+  const amt = num(amount);
+  const amtError =
+    amount.trim() === ""
+      ? ""
+      : amt <= 0
+        ? "Amount must be greater than 0."
+        : !Number.isInteger(amt)
+          ? "Bridge amount must be a whole number."
+          : "";
+  const canSubmit = amt > 0 && Number.isInteger(amt);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      custodyTradingTransfer({ direction, asset: engineAssetId, amount: amt }),
+    onSuccess: (res) => {
+      setResult(res);
+      if (res.stub) toast.message("Transfer accepted (simulated)");
+      else toast.success("Transfer accepted");
+    },
+    onError: (err) => {
+      if (isUnavailable(err)) {
+        toast.error("Custody ↔ trading bridge isn't available on this backend yet");
+      } else {
+        toast.error(err instanceof ApiError ? err.detail : "Transfer failed");
+      }
+    },
+  });
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ArrowLeftRight className="h-5 w-5 text-primary" /> Custody ↔ Trading
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-1 rounded-lg border bg-muted/30 p-1">
+            <button
+              type="button"
+              onClick={() => {
+                setDirection("to_trading");
+                setResult(null);
+              }}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-sm font-medium transition",
+                direction === "to_trading"
+                  ? "bg-background shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              To trading
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setDirection("to_custody");
+                setResult(null);
+              }}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-sm font-medium transition",
+                direction === "to_custody"
+                  ? "bg-background shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              To custody
+            </button>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Asset</Label>
+            <Select value={assetSymbol} onValueChange={setAssetSymbol}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choose an asset" />
+              </SelectTrigger>
+              <SelectContent>
+                {CUSTODY_ASSETS.map((a) => (
+                  <SelectItem key={a.symbol} value={a.symbol}>
+                    {a.name} ({a.symbol})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Amount</Label>
+            <Input
+              inputMode="numeric"
+              placeholder="0"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value.replace(/[^0-9]/g, ""))}
+            />
+            {amtError && <p className="text-xs text-destructive">{amtError}</p>}
+          </div>
+
+          <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              The custody vault and the exchange spot ledger are separate systems.
+              This bridge is a best-effort, non-atomic operation and is reported as
+              simulated until the atomic bridge is wired end-to-end.
+            </span>
+          </div>
+
+          <Button
+            className="w-full gap-1.5"
+            disabled={!canSubmit || mutation.isPending}
+            onClick={() => {
+              setResult(null);
+              mutation.mutate();
+            }}
+          >
+            {mutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ArrowLeftRight className="h-4 w-4" />
+            )}
+            {direction === "to_trading" ? "Move to trading" : "Move to custody"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {result && <TransferResultView result={result} />}
+    </div>
+  );
+}
+
+// ─── (b) between sub-accounts ───────────────────────────────────
+
+const BASE = "__base__";
+
+function InternalTransfer() {
+  const q = useSubaccountsQuery();
+  const subs: Subaccount[] = q.data?.subaccounts ?? [];
+
+  const [fromLabel, setFromLabel] = useState<string>(BASE);
+  const [toLabel, setToLabel] = useState<string>(BASE);
+  const [assetSymbol, setAssetSymbol] = useState<string>(CUSTODY_ASSETS[0]!.symbol);
+  const [amount, setAmount] = useState("");
+  const [result, setResult] = useState<TransferResult | null>(null);
+
+  const options = useMemo(
+    () => [{ value: BASE, label: "Base vault (default)" }, ...subs.map((s) => ({ value: s.label, label: s.label }))],
+    [subs],
+  );
+
+  const amt = num(amount);
+  const sameError = fromLabel === toLabel ? "From and To must differ." : "";
+  const amtError =
+    amount.trim() === "" ? "" : amt <= 0 ? "Amount must be greater than 0." : "";
+  const canSubmit = amt > 0 && fromLabel !== toLabel;
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      transferBetweenSubaccounts({
+        from_label: fromLabel === BASE ? "" : fromLabel,
+        to_label: toLabel === BASE ? "" : toLabel,
+        asset: assetSymbol,
+        amount: amt,
+      }),
+    onSuccess: (res) => {
+      setResult(res);
+      if (res.stub) toast.message("Transfer accepted (simulated)");
+      else toast.success("Transfer accepted");
+    },
+    onError: (err) => {
+      if (isUnavailable(err)) {
+        toast.error("Sub-account transfers aren't available on this backend yet");
+      } else {
+        toast.error(err instanceof ApiError ? err.detail : "Transfer failed");
+      }
+    },
+  });
+
+  if (!q.isLoading && q.isError && isUnavailable(q.error)) {
+    return (
+      <UnavailableCard line="Sub-account transfers aren't served by this backend yet. Once the exchange edge is deployed, you'll be able to move assets between your own vaults here." />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ArrowLeftRight className="h-5 w-5 text-primary" /> Between sub-accounts
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label>From</Label>
+              <Select value={fromLabel} onValueChange={(v) => { setFromLabel(v); setResult(null); }}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {options.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>To</Label>
+              <Select value={toLabel} onValueChange={(v) => { setToLabel(v); setResult(null); }}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {options.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          {sameError && <p className="text-xs text-destructive">{sameError}</p>}
+
+          <div className="space-y-1.5">
+            <Label>Asset</Label>
+            <Select value={assetSymbol} onValueChange={setAssetSymbol}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choose an asset" />
+              </SelectTrigger>
+              <SelectContent>
+                {CUSTODY_ASSETS.map((a) => (
+                  <SelectItem key={a.symbol} value={a.symbol}>
+                    {a.name} ({a.symbol})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Amount</Label>
+            <Input
+              inputMode="decimal"
+              placeholder="0.00"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))}
+            />
+            {amtError && <p className="text-xs text-destructive">{amtError}</p>}
+          </div>
+
+          <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              The custody gateway has no vault↔vault move route, so this transfer
+              is validated but performs no balance change — it is reported as
+              simulated so it can never mint or destroy funds.
+            </span>
+          </div>
+
+          <Button
+            className="w-full gap-1.5"
+            disabled={!canSubmit || mutation.isPending}
+            onClick={() => {
+              setResult(null);
+              mutation.mutate();
+            }}
+          >
+            {mutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ArrowLeftRight className="h-4 w-4" />
+            )}
+            Transfer
+          </Button>
+        </CardContent>
+      </Card>
+
+      {result && <TransferResultView result={result} />}
+    </div>
+  );
+}

--- a/frontend/src/pages/custody/CustodyPage.tsx
+++ b/frontend/src/pages/custody/CustodyPage.tsx
@@ -12,6 +12,8 @@ import {
   ArrowUpFromLine,
   ListChecks,
   ShieldCheck,
+  Layers,
+  ArrowLeftRight,
   Copy,
   Check,
   RefreshCw,
@@ -64,6 +66,7 @@ import {
   type DisplayAsset,
   type WithdrawResult,
 } from "@/api/endpoints/custody";
+import { SubaccountsTab, TransferTab } from "./CustodyExtras";
 
 // ─── helpers ────────────────────────────────────────────────────
 
@@ -945,7 +948,14 @@ function NotAvailable({
 
 // ─── Page ───────────────────────────────────────────────────────
 
-type TabKey = "overview" | "deposit" | "withdraw" | "activity" | "approvals";
+type TabKey =
+  | "overview"
+  | "deposit"
+  | "withdraw"
+  | "subaccounts"
+  | "transfer"
+  | "activity"
+  | "approvals";
 
 export default function CustodyPage() {
   const isMobile = useIsMobile(767);
@@ -974,6 +984,18 @@ export default function CustodyPage() {
           label: "Withdraw",
           short: "Withdraw",
           icon: <ArrowUpFromLine className="h-4 w-4" />,
+        },
+        {
+          key: "subaccounts" as const,
+          label: "Sub-accounts",
+          short: "Subaccts",
+          icon: <Layers className="h-4 w-4" />,
+        },
+        {
+          key: "transfer" as const,
+          label: "Transfer",
+          short: "Transfer",
+          icon: <ArrowLeftRight className="h-4 w-4" />,
         },
         {
           key: "activity" as const,
@@ -1009,7 +1031,7 @@ export default function CustodyPage() {
         <TabsList
           className={cn(
             "mb-4 w-full",
-            isMobile ? "grid grid-cols-5 gap-1" : "inline-flex",
+            isMobile ? "grid grid-cols-7 gap-1" : "inline-flex",
           )}
         >
           {tabs.map((t) => (
@@ -1038,6 +1060,12 @@ export default function CustodyPage() {
         </TabsContent>
         <TabsContent value="withdraw">
           <WithdrawTab preselect={withdrawAsset} />
+        </TabsContent>
+        <TabsContent value="subaccounts">
+          <SubaccountsTab />
+        </TabsContent>
+        <TabsContent value="transfer">
+          <TransferTab />
         </TabsContent>
         <TabsContent value="activity">
           <NotAvailable

--- a/frontend/src/pages/custody/CustodyPage.tsx
+++ b/frontend/src/pages/custody/CustodyPage.tsx
@@ -1031,14 +1031,23 @@ export default function CustodyPage() {
         <TabsList
           className={cn(
             "mb-4 w-full",
-            isMobile ? "grid grid-cols-7 gap-1" : "inline-flex",
+            isMobile
+              ? "flex justify-start gap-1 overflow-x-auto"
+              : "inline-flex",
           )}
         >
           {tabs.map((t) => (
-            <TabsTrigger key={t.key} value={t.key} className="gap-1.5">
+            <TabsTrigger
+              key={t.key}
+              value={t.key}
+              className={cn(
+                "gap-1.5",
+                isMobile && "flex-none shrink-0 px-2.5",
+              )}
+            >
               {t.icon}
               <span className={cn(isMobile && "sr-only")}>{t.label}</span>
-              {isMobile && <span className="text-[10px]">{t.short}</span>}
+              {isMobile && <span className="text-[11px]">{t.short}</span>}
             </TabsTrigger>
           ))}
         </TabsList>

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -142,7 +142,23 @@ const MARGIN_CONFIG_FIELDS: {
 // /me/fees/schedule route; 404s until the exchange edge deploys, in which
 // case the card hides itself entirely (retry:false, graceful). When the
 // backend flags the row as a stub it is labelled clearly as venue defaults.
+function useIsMobile(bp = 767): boolean {
+  const [m, setM] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${bp}px)`).matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${bp}px)`);
+    const h = () => setM(mq.matches);
+    mq.addEventListener("change", h);
+    return () => mq.removeEventListener("change", h);
+  }, [bp]);
+  return m;
+}
+
 function FeeSchedulePanel() {
+  const isMobile = useIsMobile();
   const q = useQuery({
     queryKey: ["fees", "schedule"],
     queryFn: getFeeSchedule,
@@ -178,7 +194,7 @@ function FeeSchedulePanel() {
         {q.isLoading ? (
           <p className="py-2 text-center text-xs text-muted-foreground">Loading…</p>
         ) : (
-          <div className="grid grid-cols-3 gap-2 text-center">
+          <div className={cn("grid gap-2 text-center", isMobile ? "grid-cols-1" : "grid-cols-3")}>
             <div className="rounded-md border bg-muted/30 p-2">
               <div className="text-[10px] uppercase text-muted-foreground">Maker</div>
               <div className="text-sm font-semibold tabular-nums">{maker ?? "—"} bps</div>
@@ -205,6 +221,7 @@ function FeeSchedulePanel() {
 }
 
 function MarginConfigPanel({ symbolId }: { symbolId: number }) {
+  const isMobile = useIsMobile();
   const isAdmin = useAuthStore((st) => st.isAdmin);
   const configM = useMarginConfig();
   const [open, setOpen] = useState(false);
@@ -274,7 +291,7 @@ function MarginConfigPanel({ symbolId }: { symbolId: number }) {
         {open && (
           <div className="mt-3 space-y-2">
             <Field label="Symbol id" value={symId} onChange={setSymId} />
-            <div className="grid grid-cols-2 gap-2">
+            <div className={cn("grid gap-2", isMobile ? "grid-cols-1" : "grid-cols-2")}>
               {MARGIN_CONFIG_FIELDS.map((f) => (
                 <Field
                   key={f.key}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getFeeSchedule } from "@/api/endpoints/custody";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import {
   useMarginAccount,
   usePmState,
@@ -134,6 +137,72 @@ const MARGIN_CONFIG_FIELDS: {
   { key: "taker_fee_bps", label: "Taker fee (bps)", def: "5" },
   { key: "max_position_qty", label: "Max position qty", def: "1000000" },
 ];
+
+// Compact maker/taker/liquidation fee schedule card. Sourced from the
+// /me/fees/schedule route; 404s until the exchange edge deploys, in which
+// case the card hides itself entirely (retry:false, graceful). When the
+// backend flags the row as a stub it is labelled clearly as venue defaults.
+function FeeSchedulePanel() {
+  const q = useQuery({
+    queryKey: ["fees", "schedule"],
+    queryFn: getFeeSchedule,
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  // Hide entirely when the route isn't available on this backend yet.
+  if (q.isError || (!q.isLoading && !q.data)) return null;
+
+  const row = q.data?.schedule?.[0];
+  const maker = row?.maker_fee_bps ?? q.data?.maker_fee_bps;
+  const taker = row?.taker_fee_bps ?? q.data?.taker_fee_bps;
+  const liq = row?.liquidation_fee_bps ?? q.data?.liquidation_fee_bps;
+  const isStub = q.data?.stub === true || q.data?.source === "stub";
+
+  return (
+    <Card className="mt-3">
+      <CardContent className="space-y-2 p-3">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Fee schedule
+          </span>
+          {isStub && (
+            <Badge
+              variant="outline"
+              className="gap-1 border-amber-500/40 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
+            >
+              venue defaults
+            </Badge>
+          )}
+        </div>
+        {q.isLoading ? (
+          <p className="py-2 text-center text-xs text-muted-foreground">Loading…</p>
+        ) : (
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div className="rounded-md border bg-muted/30 p-2">
+              <div className="text-[10px] uppercase text-muted-foreground">Maker</div>
+              <div className="text-sm font-semibold tabular-nums">{maker ?? "—"} bps</div>
+            </div>
+            <div className="rounded-md border bg-muted/30 p-2">
+              <div className="text-[10px] uppercase text-muted-foreground">Taker</div>
+              <div className="text-sm font-semibold tabular-nums">{taker ?? "—"} bps</div>
+            </div>
+            <div className="rounded-md border bg-muted/30 p-2">
+              <div className="text-[10px] uppercase text-muted-foreground">Liq.</div>
+              <div className="text-sm font-semibold tabular-nums">{liq ?? "—"} bps</div>
+            </div>
+          </div>
+        )}
+        {isStub && (
+          <p className="text-[10px] text-muted-foreground">
+            Shown fees are venue defaults; per-symbol rates apply when the engine
+            exposes a per-caller fee query.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
 
 function MarginConfigPanel({ symbolId }: { symbolId: number }) {
   const isAdmin = useAuthStore((st) => st.isAdmin);
@@ -1168,6 +1237,7 @@ export function TradeTicket({
         {msg && <p className={cn("text-xs font-mono", msg.error ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400")}>{msg.text}</p>}
       </CardContent>
     </Card>
+    <FeeSchedulePanel />
     <MarginConfigPanel symbolId={symbolId} />
     </div>
   );


### PR DESCRIPTION
Follows #208. Brings the custody/exchange **gap scaffolding** + **mobile-web polish** to `main`.

## ⚠️ Read first: this is scaffolding, not live functionality
Per the audit (see `custody_missing_features.md`), several capabilities have **no real backend yet**. This PR adds the UI + honestly-stubbed edge routes so the surfaces exist and degrade truthfully. It does NOT make them functionally real.

- **Sub-accounts** — real (edge proxies the gateway `/v1/vaults`).
- **Transfers** (custody↔trading bridge, vault↔vault) — **simulated**; the UI shows a "Simulated · not settled" badge on every `stub:true` response. No atomic settlement exists.
- **Fees** (schedule + fills fee) — **stub**; client-computed from a default schedule until the engine exposes per-fill fees.
- The edge routes are **code-only, not deployed**; the whole custody surface is account-gated and **404s on the demo account** — nothing here is live-tested.

## Included
- Web + Android UI for sub-accounts, transfers, fee reporting (build + tsc green; Android assembleDebug + unit green).
- Mobile-web responsiveness polish (custody tab bar scrolls on phones; transfer/sub-account + margin/fee panels collapse to one column ≤767px).

The real backend work (atomic vault↔vault + custody↔exchange settlement, engine fills/fee/liquidation/funding feeds) is tracked in `custody_missing_features.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
