### PR TITLE
fix: wire custody/exchange frontend to the real merged backend (retire stubs)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
@@ -7,13 +7,14 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 /**
- * Retrofit interface for the PRODUCTION custody surface (the me/custody endpoints). The exchange edge proxies
- * these to the MPC gateway. Paths are relative (no leading slash) so they resolve against the shared
- * Retrofit base URL; the session cookie + CSRF header are attached by the core-network interceptor
- * chain. All methods are suspend and return the typed DTO; a non-2xx surfaces as
+ * Retrofit interface for the PRODUCTION custody surface (the me/custody endpoints). The exchange edge
+ * proxies these to the MPC gateway. Paths are relative (no leading slash) so they resolve against the
+ * shared Retrofit base URL; the session cookie + CSRF header are attached by the core-network
+ * interceptor chain. All methods are suspend and return the typed DTO; a non-2xx surfaces as
  * retrofit2.HttpException.
  *
- * Only three endpoints exist on this backend — there is NO history / deposits list / approvals / audit.
+ * The custody<->trading bridge is now FOUR real routes (fund/settle x spot/margin). The old single
+ * POST me/custody/transfer no longer exists.
  */
 interface CustodyApi {
 
@@ -26,8 +27,8 @@ interface CustodyApi {
     suspend fun depositAddress(@Query("chain") chain: Int): DepositAddressDto
 
     /**
-     * Recent scanned incoming transfers into the vault (newest first). NOT deployed on every backend:
-     * a 404 is handled by the repository as a graceful "unavailable" empty state.
+     * Recent scanned incoming transfers into the vault. NOT deployed on every backend: a 404 is handled
+     * by the repository as a graceful "unavailable" empty state.
      */
     @GET("me/custody/deposits")
     suspend fun getDeposits(): CustodyDepositsDto
@@ -36,28 +37,45 @@ interface CustodyApi {
     @Headers("Content-Type: application/json")
     @POST("me/custody/withdraw")
     suspend fun withdraw(@Body body: WithdrawRequestDto): WithdrawResultDto
-    // ==== Sub-accounts + transfers (custody-exchange-gaps) ====
+
+    // ==== Sub-accounts + transfers ====
 
     /**
-     * List the caller's sub-account vaults (base/default vault id + named sub-accounts). NOT deployed
-     * on every backend -> a 404 is handled by the repository as a graceful "unavailable" empty state.
+     * List the caller's sub-account vaults ({label, vault}). NOT deployed on every backend -> a 404 is
+     * handled by the repository as a graceful "unavailable" empty state.
      */
     @GET("me/custody/subaccounts")
     suspend fun getSubAccounts(): SubAccountsDto
 
-    /** Create a named sub-account vault under the caller's base vault. */
+    /** Create a named sub-account vault under the caller's base vault (201 {created, label, vault}). */
     @Headers("Content-Type: application/json")
     @POST("me/custody/subaccounts")
     suspend fun createSubAccount(@Body body: CreateSubAccountDto): CreateSubAccountResultDto
 
-    /** Move an asset between two of the caller's OWN sub-account vaults (documented stub / no-op). */
+    /** Move an asset between two of the caller's OWN sub-account vaults (REAL; echoes new balances). */
     @Headers("Content-Type: application/json")
     @POST("me/custody/subaccounts/transfer")
     suspend fun subAccountTransfer(@Body body: SubAccountTransferDto): SubAccountTransferResultDto
 
-    /** Custody<->trading bridge: move value between the custody vault and the exchange spot ledger. */
-    @Headers("Content-Type: application/json")
-    @POST("me/custody/transfer")
-    suspend fun bridgeTransfer(@Body body: CustodyBridgeTransferDto): CustodyBridgeTransferResultDto
-}
+    // ==== Custody <-> trading bridge (four real routes) ====
 
+    /** Move custody vault value INTO the exchange spot ledger. */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/fund-spot")
+    suspend fun fundSpot(@Body body: BridgeRequestDto): FundResultDto
+
+    /** Move spot-ledger value BACK into the custody vault (422 when insufficient spot available). */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/settle-spot")
+    suspend fun settleSpot(@Body body: BridgeRequestDto): SettleResultDto
+
+    /** Move custody vault value INTO the margin ledger (422 with reason on rejection). */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/fund-margin")
+    suspend fun fundMargin(@Body body: BridgeRequestDto): FundResultDto
+
+    /** Move margin-ledger value BACK into the custody vault (422 with reason on rejection). */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/settle-margin")
+    suspend fun settleMargin(@Body body: BridgeRequestDto): SettleResultDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
@@ -2,9 +2,10 @@ package com.testlogon.android.data.custody
 
 /*
  * Domain models + the static asset registry for the custody feature: null-safe, UI-ready projections
- * of the PRODUCTION /me/custody wire DTOs. The repository maps DTO -> domain (coercing balance
- * number-or-string to a Double, resolving each symbol against the registry, normalizing the withdraw
- * status to a sealed enum) so composables never touch raw wire shapes.
+ * of the PRODUCTION /me/custody wire DTOs (now repointed to the REAL merged backend). The repository
+ * maps DTO -> domain (coercing balance number-or-string to a Double, resolving each symbol against the
+ * registry, normalizing the withdraw status to a sealed enum) so composables never touch raw wire
+ * shapes. Nothing here is "simulated" any more - the bridge and vault<->vault transfer are real.
  */
 
 // ---------------- Asset registry ----------------
@@ -43,6 +44,9 @@ object CustodyAssets {
         CustodyAsset("POL", "Polygon", 137, "Polygon", "Polygon Mainnet", NATIVE, 18),
     )
 
+    /** The asset symbols accepted by the custody<->trading bridge (fund/settle spot/margin). */
+    val BRIDGE_TOKENS: List<String> = ALL.map { it.symbol }
+
     /**
      * Human chain name for a chain id (from the registry, else a generic "Chain <id>"). Used to label
      * scanned deposits whose `chain` arrives as a numeric id string.
@@ -60,7 +64,7 @@ object CustodyAssets {
 
     /**
      * Produces a displayable balance row for EVERY registry asset (0 when absent from [balances]),
-     * followed by any balance key not in the registry — flagged [CustodyBalance.known] = false with
+     * followed by any balance key not in the registry - flagged [CustodyBalance.known] = false with
      * safe fallbacks (chain 1 / native).
      */
     fun mergeBalances(balances: Map<String, Double>): List<CustodyBalance> {
@@ -132,40 +136,29 @@ data class CustodyDepositAddress(
 
 // ---------------- Incoming deposits (scanned) ----------------
 
-/** Whether a scanned incoming transfer was credited or ignored as a duplicate. */
-enum class DepositStatus(val wire: String, val label: String) {
-    CREDITED("credited", "Credited"),
-    DUPLICATE("duplicate", "Duplicate"),
-    UNKNOWN("", "Pending");
-
-    companion object {
-        fun from(wire: String?): DepositStatus =
-            entries.firstOrNull { it.wire == wire?.trim()?.lowercase() } ?: UNKNOWN
-    }
-}
-
-/** One scanned incoming on-chain transfer, resolved to a display-ready row. */
+/**
+ * One scanned incoming on-chain transfer, resolved to a display-ready row. The REAL backend exposes
+ * {vault, asset, amount, chain, txhash, log_index, dedup_key} - there is no status or timestamp.
+ */
 data class CustodyDeposit(
     val chainId: Int?,
     val chainName: String,
     val asset: String,
     val amount: String,
     val txHash: String,
-    val status: DepositStatus,
-    /** Unix epoch in MILLISECONDS (seconds-vs-ms detected at mapping time), or null if absent. */
-    val timestampMs: Long?,
-    val seq: Long?,
+    val logIndex: String?,
+    val dedupKey: String?,
 ) {
     /** Short 0x… head+tail form of the tx hash for a compact row. */
     val txShort: String
         get() = txHash.let { if (it.length <= 14) it else "${it.take(8)}…${it.takeLast(4)}" }
 }
 
-/** The whole deposits response: the vault id + the (newest-first) rows, plus an "unavailable" flag. */
+/** The whole deposits response: the vault id + the rows, plus an "unavailable" flag. */
 data class CustodyDeposits(
     val vault: String,
     val rows: List<CustodyDeposit>,
-    /** True when the backend does not expose deposit scanning (endpoint 404) — a soft, non-error state. */
+    /** True when the backend does not expose deposit scanning (endpoint 404) - a soft, non-error state. */
     val unavailable: Boolean = false,
 ) {
     val isEmpty: Boolean get() = rows.isEmpty()
@@ -208,78 +201,81 @@ data class CustodyWithdrawResult(
 // ---------------- Sub-accounts ----------------
 
 /**
- * A custody sub-account vault: the base ("default") vault or a named sub-account. [balances] are the
- * merged, display-ready rows (same registry treatment as the main balance view).
+ * A custody sub-account vault. The REAL backend returns only {label, vault} - no tier / balances.
  */
 data class CustodySubAccount(
-    val id: String,
     val label: String,
-    val tier: String,
-    val isDefault: Boolean,
-    val rows: List<CustodyBalance>,
+    val vault: String,
 ) {
-    val displayLabel: String get() = if (isDefault) "Base vault" else label.ifBlank { "Sub-account" }
-    val idShort: String get() = if (id.length <= 14) id else "${id.take(8)}…${id.takeLast(4)}"
-    fun funded(): List<CustodyBalance> = rows.filter { it.amount > 0.0 }
+    val displayLabel: String get() = label.ifBlank { "Sub-account" }
+    val vaultShort: String get() = if (vault.length <= 14) vault else "${vault.take(8)}…${vault.takeLast(4)}"
 }
 
 /**
- * The sub-accounts response: the default (base) vault + the named sub-accounts, plus an "unavailable"
- * flag for when the backend does not expose the route (404 -> soft empty state).
+ * The sub-accounts response: the named sub-accounts, plus an "unavailable" flag for when the backend
+ * does not expose the route (404 -> soft empty state).
  */
 data class CustodySubAccounts(
-    val defaultVault: String,
     val subAccounts: List<CustodySubAccount>,
     val unavailable: Boolean = false,
 ) {
-    /** Base vault + named sub-accounts, so a picker can offer every OWN vault as a transfer endpoint. */
-    val all: List<CustodySubAccount>
-        get() = listOf(
-            CustodySubAccount(id = defaultVault, label = "", tier = "—", isDefault = true, rows = emptyList()),
-        ) + subAccounts
-
     val isEmpty: Boolean get() = subAccounts.isEmpty()
 
     companion object {
         fun unavailable(): CustodySubAccounts =
-            CustodySubAccounts(defaultVault = "", subAccounts = emptyList(), unavailable = true)
+            CustodySubAccounts(subAccounts = emptyList(), unavailable = true)
     }
 }
 
-// ---------------- Transfers ----------------
+// ---------------- Custody <-> trading bridge ----------------
 
-/** Which side of the custody<->trading bridge a transfer moves value toward. */
-enum class BridgeDirection(val wire: String, val label: String) {
-    TO_TRADING("to_trading", "Custody → Trading"),
-    TO_CUSTODY("to_custody", "Trading → Custody");
+/**
+ * The four custody<->trading bridge actions. [fund] moves custody value INTO an exchange ledger;
+ * [settle] moves it BACK to custody. [venue] is which exchange ledger (spot or margin).
+ */
+enum class BridgeVenue(val label: String) { SPOT("Spot"), MARGIN("Margin") }
 
-    fun toggle(): BridgeDirection = if (this == TO_TRADING) TO_CUSTODY else TO_TRADING
+enum class BridgeAction(val venue: BridgeVenue, val fund: Boolean, val label: String) {
+    FUND_SPOT(BridgeVenue.SPOT, true, "Fund spot"),
+    SETTLE_SPOT(BridgeVenue.SPOT, false, "Settle spot"),
+    FUND_MARGIN(BridgeVenue.MARGIN, true, "Fund margin"),
+    SETTLE_MARGIN(BridgeVenue.MARGIN, false, "Settle margin");
+
+    val isSettle: Boolean get() = !fund
 }
 
 /**
- * Result of the custody<->trading bridge. [simulated] (stub) is expected true today; [tradingCredited]
- * is only meaningful on the to_trading path. [note] is the honest "not settled" explanation.
+ * Result of a bridge fund/settle. [ok] reflects funded/settled=true; on a 200 the ledger + custody
+ * balances are echoed. On a 422 [ok] is false and [reason] carries the rejection (e.g.
+ * "insufficient_spot_available"). All amounts are decimal strings as returned by the backend.
  */
 data class CustodyBridgeResult(
     val ok: Boolean,
-    val simulated: Boolean,
-    val direction: BridgeDirection?,
-    val asset: Int?,
-    val amount: Long?,
-    val tradingCredited: Boolean,
-    val note: String?,
+    val action: BridgeAction,
+    val token: String?,
+    val amount: String?,
+    /** The engine-side amount actually moved (me_amount), when returned. */
+    val meAmount: String?,
+    /** The resulting spot/margin ledger balance (whichever this action touched), when returned. */
+    val ledger: String?,
+    /** The resulting custody balance (settle path), when returned. */
+    val custody: String?,
+    val reason: String?,
 )
 
+// ---------------- Sub-account transfer ----------------
+
 /**
- * Result of a between-sub-accounts transfer. This route is a documented no-op, so [simulated] is
- * expected true and no balance moves; [note] carries the honest explanation.
+ * Result of a between-sub-accounts transfer (REAL - balance moves). On success the resulting from/to
+ * balances are echoed; on failure [reason] carries the gateway message.
  */
 data class SubAccountTransferResult(
     val ok: Boolean,
-    val simulated: Boolean,
     val from: String?,
     val to: String?,
     val asset: String?,
     val amount: String?,
-    val note: String?,
+    val fromBalance: String?,
+    val toBalance: String?,
+    val reason: String?,
 )

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
@@ -2,20 +2,15 @@ package com.testlogon.android.data.custody
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import com.testlogon.android.core.network.json.LenientLong
 
 /*
- * Wire DTOs for the PRODUCTION custody surface (the three /me/custody endpoints).
+ * Wire DTOs for the PRODUCTION custody surface (the /me/custody endpoints), repointed to the REAL
+ * (now-merged) backend shapes. NONE of these responses carry a stub flag any more - the bridge and
+ * vault<->vault transfer are real; the shapes below are the settled contracts.
  *
  * Every serialized DTO carries @JsonClass(generateAdapter = true) so the :app unit-test Moshi
- * (codegen-only, no reflection) can parse it.
- *
- * BALANCES number-or-string: the per-asset balance values may arrive as a JSON number OR a numeric
- * string depending on the gateway/edge encoder. Rather than register a custom qualifier (which would
- * live outside this feature), the map value is typed as Any? — Moshi's built-in adapter decodes a JSON
- * number to a Double and a JSON string to a String — and the repository coerces each value to a Double
- * / display string at the domain boundary (see toDomain), matching how the app already treats money as
- * String -> Double.
+ * (codegen-only, no reflection) can parse it. Numerics are tolerated as JSON number OR string:
+ * balances stay Map<String, Any?> (coerced at the domain edge) and integer/bps fields are Int?.
  */
 
 /** GET me/custody/balance -> vault id + tier + asset-symbol -> amount (number or numeric string). */
@@ -26,30 +21,28 @@ data class BalanceDto(
     @Json(name = "balances") val balances: Map<String, Any?>? = null,
 )
 
-/** GET me/custody/deposit-address?chain=<id> -> a per-chain deposit address + provenance metadata. */
 /**
- * GET me/custody/deposits (NEW; not on every backend -> 404 handled as graceful-empty by the repo).
- * A scanned incoming on-chain transfer credited (or de-duplicated) into the vault. amount/txhash/asset
- * are strings; seq/ts are int64 but the edge may stringify them, so both use @LenientLong. ts is a unix
- * time whose unit (seconds vs ms) is detected at the domain edge. Newest first.
+ * GET me/custody/deposits -> one scanned incoming on-chain transfer credited (or de-duplicated) into
+ * the vault. REAL shape: {vault, asset, amount, chain, txhash, log_index, dedup_key}. No status / seq /
+ * ts fields exist any more. amount/txhash/asset/chain are strings.
  */
 @JsonClass(generateAdapter = true)
 data class CustodyDepositDto(
+    @Json(name = "vault") val vault: String? = null,
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "amount") val amount: String? = null,
     @Json(name = "chain") val chain: String? = null,
     @Json(name = "txhash") val txhash: String? = null,
     @Json(name = "log_index") val logIndex: String? = null,
-    @Json(name = "asset") val asset: String? = null,
-    @Json(name = "amount") val amount: String? = null,
-    @Json(name = "status") val status: String? = null,
-    @LenientLong @Json(name = "seq") val seq: Long? = null,
-    @LenientLong @Json(name = "ts") val ts: Long? = null,
+    @Json(name = "dedup_key") val dedupKey: String? = null,
 )
 
-/** GET me/custody/deposits envelope: the vault id + the (newest-first) list of scanned deposits. */
+/** GET me/custody/deposits envelope: the vault id + the deposits list + a count. */
 @JsonClass(generateAdapter = true)
 data class CustodyDepositsDto(
     @Json(name = "vault") val vault: String? = null,
     @Json(name = "deposits") val deposits: List<CustodyDepositDto>? = null,
+    @Json(name = "count") val count: Int? = null,
 )
 
 @JsonClass(generateAdapter = true)
@@ -95,96 +88,110 @@ data class WithdrawResultDto(
     @Json(name = "category") val category: String? = null,
 )
 
-// ==== Sub-accounts + transfers (custody-exchange-gaps) ====
+// ==== Sub-accounts + transfers (REAL backend) ====
 
 /**
- * One sub-account vault under the caller's base vault (GET me/custody/subaccounts). [balances] is a
- * number-or-string map like [BalanceDto.balances]; coerced at the domain edge. The base (default)
- * vault is NOT listed here — it is returned separately as [SubAccountsDto.defaultVault].
+ * One sub-account vault under the caller's base vault (GET me/custody/subaccounts). REAL shape is just
+ * {label, vault} - no balances / tier / default_vault.
  */
 @JsonClass(generateAdapter = true)
 data class SubAccountDto(
-    @Json(name = "id") val id: String? = null,
     @Json(name = "label") val label: String? = null,
-    @Json(name = "tier") val tier: String? = null,
-    @Json(name = "balances") val balances: Map<String, Any?>? = null,
+    @Json(name = "vault") val vault: String? = null,
 )
 
-/** GET me/custody/subaccounts envelope: the default (base) vault id + the named sub-accounts. */
+/** GET me/custody/subaccounts envelope: just the list of {label, vault}. */
 @JsonClass(generateAdapter = true)
 data class SubAccountsDto(
-    @Json(name = "default_vault") val defaultVault: String? = null,
     @Json(name = "subaccounts") val subaccounts: List<SubAccountDto>? = null,
 )
 
-/** Body for POST me/custody/subaccounts — the sub-account label (sanitized server-side). */
+/** Body for POST me/custody/subaccounts - the sub-account label (sanitized server-side). */
 @JsonClass(generateAdapter = true)
 data class CreateSubAccountDto(
     @Json(name = "label") val label: String,
 )
 
-/**
- * POST me/custody/subaccounts response: the gateway's created-vault object with {label, vault} added.
- * Loose shape — only the added fields are consumed; the rest are ignored by Moshi.
- */
+/** POST me/custody/subaccounts response (201): {created, label, vault}. */
 @JsonClass(generateAdapter = true)
 data class CreateSubAccountResultDto(
+    @Json(name = "created") val created: Boolean? = null,
     @Json(name = "label") val label: String? = null,
     @Json(name = "vault") val vault: String? = null,
-    @Json(name = "name") val name: String? = null,
-    @Json(name = "id") val id: String? = null,
     @Json(name = "detail") val detail: String? = null,
     @Json(name = "error") val error: String? = null,
 )
 
-/** Body for POST me/custody/subaccounts/transfer — move an asset between two OWN sub-account vaults. */
+/**
+ * Body for POST me/custody/subaccounts/transfer - move an asset between two OWN sub-account vaults.
+ * asset defaults to "native" server-side when omitted.
+ */
 @JsonClass(generateAdapter = true)
 data class SubAccountTransferDto(
     @Json(name = "from_label") val fromLabel: String? = null,
     @Json(name = "to_label") val toLabel: String? = null,
-    @Json(name = "asset") val asset: String,
+    @Json(name = "asset") val asset: String? = null,
     @Json(name = "amount") val amount: String,
 )
 
 /**
- * POST me/custody/subaccounts/transfer response. This route is a documented pure no-op (the gateway
- * has no vault<->vault move), so [stub] is always true and it moves no balance.
+ * POST me/custody/subaccounts/transfer response (REAL - no stub). Balance moves for real; the response
+ * echoes the resulting from/to balances.
  */
 @JsonClass(generateAdapter = true)
 data class SubAccountTransferResultDto(
-    @Json(name = "status") val status: String? = null,
-    @Json(name = "stub") val stub: Boolean? = null,
-    @Json(name = "from") val from: String? = null,
-    @Json(name = "to") val to: String? = null,
+    @Json(name = "transferred") val transferred: Boolean? = null,
     @Json(name = "asset") val asset: String? = null,
     @Json(name = "amount") val amount: String? = null,
-    @Json(name = "note") val note: String? = null,
+    @Json(name = "from") val from: String? = null,
+    @Json(name = "to") val to: String? = null,
+    @Json(name = "from_balance") val fromBalance: String? = null,
+    @Json(name = "to_balance") val toBalance: String? = null,
     @Json(name = "detail") val detail: String? = null,
     @Json(name = "error") val error: String? = null,
 )
 
-/** Body for POST me/custody/transfer — the custody<->trading bridge. [asset] is the engine asset id. */
+// ==== Custody <-> trading bridge (FOUR REAL routes) ====
+
+/** Body for the four bridge routes: {token: asset-symbol, amount: decimal string}. */
 @JsonClass(generateAdapter = true)
-data class CustodyBridgeTransferDto(
-    @Json(name = "direction") val direction: String,
-    @Json(name = "asset") val asset: Int,
-    @Json(name = "amount") val amount: Long,
+data class BridgeRequestDto(
+    @Json(name = "token") val token: String,
+    @Json(name = "amount") val amount: String,
 )
 
 /**
- * POST me/custody/transfer response (custody<->trading bridge). [stub] is true (the bridge is not
- * atomic); on to_trading [tradingCredited] reflects whether the in-process engine credited the spot
- * ledger. No real custody balance moves either way.
+ * POST me/custody/fund-spot / fund-margin (200). {funded:true, token, asset_id, amount, me_amount,
+ * spot|margin}. On 422 {funded:false, reason}. All fields nullable so both shapes parse.
  */
 @JsonClass(generateAdapter = true)
-data class CustodyBridgeTransferResultDto(
-    @Json(name = "status") val status: String? = null,
-    @Json(name = "stub") val stub: Boolean? = null,
-    @Json(name = "direction") val direction: String? = null,
-    @Json(name = "asset") val asset: Int? = null,
-    @Json(name = "amount") val amount: Long? = null,
-    @Json(name = "trading_credited") val tradingCredited: Boolean? = null,
-    @Json(name = "note") val note: String? = null,
+data class FundResultDto(
+    @Json(name = "funded") val funded: Boolean? = null,
+    @Json(name = "token") val token: String? = null,
+    @Json(name = "asset_id") val assetId: String? = null,
+    @Json(name = "amount") val amount: String? = null,
+    @Json(name = "me_amount") val meAmount: String? = null,
+    @Json(name = "spot") val spot: String? = null,
+    @Json(name = "margin") val margin: String? = null,
+    @Json(name = "reason") val reason: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)
+
+/**
+ * POST me/custody/settle-spot / settle-margin (200). {settled:true, token, amount, me_amount,
+ * spot|margin, custody}. On 422 {settled:false, reason:"insufficient_spot_available"}.
+ */
+@JsonClass(generateAdapter = true)
+data class SettleResultDto(
+    @Json(name = "settled") val settled: Boolean? = null,
+    @Json(name = "token") val token: String? = null,
+    @Json(name = "amount") val amount: String? = null,
+    @Json(name = "me_amount") val meAmount: String? = null,
+    @Json(name = "spot") val spot: String? = null,
+    @Json(name = "margin") val margin: String? = null,
+    @Json(name = "custody") val custody: String? = null,
+    @Json(name = "reason") val reason: String? = null,
     @Json(name = "detail") val detail: String? = null,
     @Json(name = "error") val error: String? = null,
 )

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
@@ -21,7 +21,8 @@ import javax.inject.Singleton
  * Data layer for the PRODUCTION custody surface. Maps wire DTOs to null-safe domain models and folds
  * transport failures into [ApiResult] (HttpException -> Failure carrying the HTTP status; IOException
  * -> NetworkError). CancellationException is always re-thrown. Reads are safe to retry; the withdraw
- * POST is not auto-retried.
+ * POST is not auto-retried. The custody<->trading bridge is four real routes (fund/settle x
+ * spot/margin); a 422 rejection surfaces as a Failure whose parsed reason the ViewModel renders.
  */
 @Singleton
 class CustodyRepository @Inject constructor(
@@ -94,15 +95,12 @@ class CustodyRepository @Inject constructor(
     suspend fun createSubAccount(label: String): ApiResult<CustodySubAccount> = call {
         val res = api.createSubAccount(CreateSubAccountDto(label = label.trim()))
         CustodySubAccount(
-            id = (res.vault ?: res.name ?: res.id).orEmpty().trim(),
             label = (res.label ?: label).trim(),
-            tier = "\u2014",
-            isDefault = false,
-            rows = emptyList(),
+            vault = res.vault.orEmpty().trim(),
         )
     }
 
-    /** Move an asset between two OWN sub-account vaults (documented no-op; result carries stub=true). */
+    /** Move an asset between two OWN sub-account vaults (REAL - balance moves; echoes new balances). */
     suspend fun subAccountTransfer(
         fromLabel: String?,
         toLabel: String?,
@@ -113,21 +111,25 @@ class CustodyRepository @Inject constructor(
             SubAccountTransferDto(
                 fromLabel = fromLabel?.trim()?.takeIf { it.isNotBlank() },
                 toLabel = toLabel?.trim()?.takeIf { it.isNotBlank() },
-                asset = asset.trim(),
+                asset = asset.trim().takeIf { it.isNotBlank() },
                 amount = amount.trim(),
             ),
         ).toDomain()
     }
 
-    /** Custody<->trading bridge transfer (hybrid; result carries stub=true + trading_credited). */
-    suspend fun bridgeTransfer(
-        direction: BridgeDirection,
-        asset: Int,
-        amount: Long,
-    ): ApiResult<CustodyBridgeResult> = call {
-        api.bridgeTransfer(
-            CustodyBridgeTransferDto(direction = direction.wire, asset = asset, amount = amount),
-        ).toDomain()
+    /**
+     * Custody<->trading bridge (four real routes). [action] selects fund/settle x spot/margin; the body
+     * is {token (asset symbol), amount (decimal string)}. A 200 maps to funded/settled; a 422 rejection
+     * surfaces as a Failure whose parsed body carries the reason.
+     */
+    suspend fun bridge(action: BridgeAction, token: String, amount: String): ApiResult<CustodyBridgeResult> = call {
+        val body = BridgeRequestDto(token = token.trim().uppercase(), amount = amount.trim())
+        when (action) {
+            BridgeAction.FUND_SPOT -> api.fundSpot(body).toDomain(action)
+            BridgeAction.SETTLE_SPOT -> api.settleSpot(body).toDomain(action)
+            BridgeAction.FUND_MARGIN -> api.fundMargin(body).toDomain(action)
+            BridgeAction.SETTLE_MARGIN -> api.settleMargin(body).toDomain(action)
+        }
     }
 
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = withContext(io) {
@@ -192,14 +194,10 @@ private fun CustodyDepositDto.toDomain(): CustodyDeposit {
         asset = asset?.trim().orEmpty().ifBlank { "?" },
         amount = amount?.trim().orEmpty(),
         txHash = txhash?.trim().orEmpty(),
-        status = DepositStatus.from(status),
-        timestampMs = ts?.let { normalizeToMs(it) },
-        seq = seq,
+        logIndex = logIndex?.trim()?.takeIf { it.isNotBlank() },
+        dedupKey = dedupKey?.trim()?.takeIf { it.isNotBlank() },
     )
 }
-
-/** ts may arrive in seconds or milliseconds; anything below ~1e12 is treated as seconds. */
-private fun normalizeToMs(ts: Long): Long = if (ts in 1L until 100_000_000_000L) ts * 1000L else ts
 
 private fun WithdrawResultDto.toDomain(): CustodyWithdrawResult =
     CustodyWithdrawResult(
@@ -215,45 +213,50 @@ private fun WithdrawResultDto.toDomain(): CustodyWithdrawResult =
     )
 
 private fun SubAccountsDto.toDomain(): CustodySubAccounts {
-    val default = defaultVault?.trim().orEmpty()
     val rows = subaccounts.orEmpty().map { it.toDomain() }
-    return CustodySubAccounts(defaultVault = default, subAccounts = rows, unavailable = false)
+    return CustodySubAccounts(subAccounts = rows, unavailable = false)
 }
 
-private fun SubAccountDto.toDomain(): CustodySubAccount {
-    val coerced: Map<String, Double> = balances.orEmpty()
-        .entries
-        .filter { it.key.isNotBlank() }
-        .associate { it.key.trim() to coerceAmount(it.value) }
-    return CustodySubAccount(
-        id = id?.trim().orEmpty(),
+private fun SubAccountDto.toDomain(): CustodySubAccount =
+    CustodySubAccount(
         label = label?.trim().orEmpty(),
-        tier = tier?.trim()?.takeIf { it.isNotBlank() } ?: "\u2014",
-        isDefault = false,
-        rows = CustodyAssets.mergeBalances(coerced).filter { it.amount > 0.0 },
+        vault = vault?.trim().orEmpty(),
     )
-}
 
 private fun SubAccountTransferResultDto.toDomain(): SubAccountTransferResult =
     SubAccountTransferResult(
-        ok = (status?.trim()?.lowercase() ?: "ok") == "ok",
-        simulated = stub == true,
+        ok = transferred == true,
         from = from?.trim()?.takeIf { it.isNotBlank() },
         to = to?.trim()?.takeIf { it.isNotBlank() },
         asset = asset?.trim()?.takeIf { it.isNotBlank() },
         amount = amount?.trim()?.takeIf { it.isNotBlank() },
-        note = listOfNotNull(note, detail, error).firstOrNull { it.isNotBlank() },
+        fromBalance = fromBalance?.trim()?.takeIf { it.isNotBlank() },
+        toBalance = toBalance?.trim()?.takeIf { it.isNotBlank() },
+        reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
     )
 
-private fun CustodyBridgeTransferResultDto.toDomain(): CustodyBridgeResult =
+private fun FundResultDto.toDomain(action: BridgeAction): CustodyBridgeResult =
     CustodyBridgeResult(
-        ok = (status?.trim()?.lowercase() ?: "ok") == "ok",
-        simulated = stub == true,
-        direction = direction?.let { d -> BridgeDirection.entries.firstOrNull { it.wire == d.trim().lowercase() } },
-        asset = asset,
-        amount = amount,
-        tradingCredited = tradingCredited == true,
-        note = listOfNotNull(note, detail, error).firstOrNull { it.isNotBlank() },
+        ok = funded == true,
+        action = action,
+        token = token?.trim()?.takeIf { it.isNotBlank() },
+        amount = amount?.trim()?.takeIf { it.isNotBlank() },
+        meAmount = meAmount?.trim()?.takeIf { it.isNotBlank() },
+        ledger = (if (action.venue == BridgeVenue.SPOT) spot else margin)?.trim()?.takeIf { it.isNotBlank() },
+        custody = null,
+        reason = listOfNotNull(reason, detail, error).firstOrNull { it.isNotBlank() },
+    )
+
+private fun SettleResultDto.toDomain(action: BridgeAction): CustodyBridgeResult =
+    CustodyBridgeResult(
+        ok = settled == true,
+        action = action,
+        token = token?.trim()?.takeIf { it.isNotBlank() },
+        amount = amount?.trim()?.takeIf { it.isNotBlank() },
+        meAmount = meAmount?.trim()?.takeIf { it.isNotBlank() },
+        ledger = (if (action.venue == BridgeVenue.SPOT) spot else margin)?.trim()?.takeIf { it.isNotBlank() },
+        custody = custody?.trim()?.takeIf { it.isNotBlank() },
+        reason = listOfNotNull(reason, detail, error).firstOrNull { it.isNotBlank() },
     )
 
 /** Provides the custody Retrofit API (mirrors the auth data module's provider style). */

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -85,9 +85,12 @@ interface TradingApi {
     suspend fun spotDeposit(@Body body: SpotDepositDto): SpotDepositAckDto
     // ==== Fees (custody-exchange-gaps) ====
 
-    /** The caller's maker/taker/liquidation fee schedule (venue defaults today; source=stub). */
+    /**
+     * The maker/taker/liquidation fee schedule for a symbol. source is "engine" (a configured
+     * per-symbol/venue rate) or "venue_default"; configured tells whether this symbol has an override.
+     */
     @GET("me/fees/schedule")
-    suspend fun getFeeSchedule(): FeeScheduleDto
+    suspend fun getFeeSchedule(@Query("symbolid") symbolId: Int): FeeScheduleDto
 
     /** Recent fills enriched with a computed fee (empty feed today + the client-side fee formula). */
     @GET("me/fills/fees")

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -321,28 +321,22 @@ data class PmStateDto(
 
 // ==== Fees (custody-exchange-gaps) ====
 
-/** One row of the fee schedule. bps fields may be stringified by the edge, so all use @LenientInt. */
+/**
+ * GET me/fees/schedule?symbolid=<n> (REAL). {status, type, symbolid, maker_fee_bps, taker_fee_bps,
+ * liquidation_fee_bps, source, configured}. source is "engine" (a configured rate) or "venue_default";
+ * configured tells whether this symbol has an explicit override. bps fields may be stringified by the
+ * edge, so all use @LenientInt.
+ */
 @JsonClass(generateAdapter = true)
-data class FeeScheduleRowDto(
+data class FeeScheduleDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "type") val type: String? = null,
     @com.testlogon.android.core.network.json.LenientInt @Json(name = "symbolid") val symbolId: Int? = null,
     @com.testlogon.android.core.network.json.LenientInt @Json(name = "maker_fee_bps") val makerFeeBps: Int? = null,
     @com.testlogon.android.core.network.json.LenientInt @Json(name = "taker_fee_bps") val takerFeeBps: Int? = null,
     @com.testlogon.android.core.network.json.LenientInt @Json(name = "liquidation_fee_bps") val liquidationFeeBps: Int? = null,
-)
-
-/**
- * GET me/fees/schedule. The stub returns a single venue-default row plus the top-level bps mirrors and
- * source/stub markers. Both the [schedule] rows and the flat mirrors are tolerated (either may be
- * present); the repo prefers the first schedule row and falls back to the mirrors.
- */
-@JsonClass(generateAdapter = true)
-data class FeeScheduleDto(
-    @Json(name = "schedule") val schedule: List<FeeScheduleRowDto>? = null,
-    @com.testlogon.android.core.network.json.LenientInt @Json(name = "maker_fee_bps") val makerFeeBps: Int? = null,
-    @com.testlogon.android.core.network.json.LenientInt @Json(name = "taker_fee_bps") val takerFeeBps: Int? = null,
-    @com.testlogon.android.core.network.json.LenientInt @Json(name = "liquidation_fee_bps") val liquidationFeeBps: Int? = null,
     @Json(name = "source") val source: String? = null,
-    @Json(name = "stub") val stub: Boolean? = null,
+    @Json(name = "configured") val configured: Boolean? = null,
 )
 
 /** One enriched fill from GET me/fills/fees, with a server-computed [fee]. */

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -299,8 +299,15 @@ data class FeeSchedule(
     val makerFeeBps: Int,
     val takerFeeBps: Int,
     val liquidationFeeBps: Int,
-    val isStub: Boolean,
+    /** "engine" (a configured rate) or "venue_default". */
+    val source: String,
+    /** Whether this symbol has an explicit fee override (vs. inheriting the venue default). */
+    val configured: Boolean,
 ) {
+    /** True when these are the venue defaults (not a configured per-caller/engine rate). */
+    val isVenueDefault: Boolean get() = source.equals("venue_default", ignoreCase = true) || !configured
+    /** Human label for the source ("engine" / "venue default"). */
+    val sourceLabel: String get() = if (isVenueDefault) "venue default" else "engine"
     /** bps -> a percent string, e.g. 20 -> "0.20%". */
     fun makerPct(): String = bpsToPct(makerFeeBps)
     fun takerPct(): String = bpsToPct(takerFeeBps)
@@ -310,7 +317,7 @@ data class FeeSchedule(
     fun takerFeeFor(price: Long, qty: Long): Long = feeFor(price * qty, takerFeeBps)
 
     companion object {
-        fun default(): FeeSchedule = FeeSchedule(DEFAULT_MAKER_BPS, DEFAULT_TAKER_BPS, DEFAULT_LIQ_BPS, isStub = true)
+        fun default(): FeeSchedule = FeeSchedule(DEFAULT_MAKER_BPS, DEFAULT_TAKER_BPS, DEFAULT_LIQ_BPS, source = "venue_default", configured = false)
     }
 }
 
@@ -321,15 +328,13 @@ fun feeFor(notional: Long, bps: Int): Long =
 private fun bpsToPct(bps: Int): String = String.format(java.util.Locale.US, "%.2f%%", bps / 100.0)
 
 fun FeeScheduleDto.toDomain(): FeeSchedule {
-    val row = schedule.orEmpty().firstOrNull()
-    val maker = row?.makerFeeBps ?: makerFeeBps ?: DEFAULT_MAKER_BPS
-    val taker = row?.takerFeeBps ?: takerFeeBps ?: DEFAULT_TAKER_BPS
-    val liq = row?.liquidationFeeBps ?: liquidationFeeBps ?: DEFAULT_LIQ_BPS
+    val src = source?.trim()?.takeIf { it.isNotBlank() }?.lowercase() ?: "venue_default"
     return FeeSchedule(
-        makerFeeBps = maker,
-        takerFeeBps = taker,
-        liquidationFeeBps = liq,
-        isStub = stub == true || (source?.trim()?.lowercase() == "stub"),
+        makerFeeBps = makerFeeBps ?: DEFAULT_MAKER_BPS,
+        takerFeeBps = takerFeeBps ?: DEFAULT_TAKER_BPS,
+        liquidationFeeBps = liquidationFeeBps ?: DEFAULT_LIQ_BPS,
+        source = src,
+        configured = configured ?: (src == "engine"),
     )
 }
 

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -59,7 +59,7 @@ interface TradingRepository {
     suspend fun placeAlgo(algoType: String, symbolId: Int, side: OrderSide, qty: Long, stopPrice: Long?, limitPrice: Long?): ApiResult<AlgoAck>
     suspend fun placeOto(symbolId: Int, parentSide: OrderSide, parentPrice: Long, parentQty: Long, childSide: OrderSide, childPrice: Long, childQty: Long): ApiResult<OtoAck>
     /** Fees (custody-exchange-gaps): the caller's fee schedule + the enriched fills-fees feed. */
-    suspend fun feeSchedule(): ApiResult<FeeSchedule>
+    suspend fun feeSchedule(symbolId: Int): ApiResult<FeeSchedule>
     suspend fun fillsFees(): ApiResult<FillsFees>
 }
 
@@ -169,8 +169,8 @@ class TradingRepositoryImpl @Inject constructor(
     override suspend fun placeOto(symbolId: Int, parentSide: OrderSide, parentPrice: Long, parentQty: Long, childSide: OrderSide, childPrice: Long, childQty: Long): ApiResult<OtoAck> =
         withContext(io) { apiCall { api.placeOto(OtoOrderDto(symbolId, parentSide.wire, parentPrice, parentQty, childSide.wire, childPrice, childQty)).toDomain() } }
 
-    override suspend fun feeSchedule(): ApiResult<FeeSchedule> =
-        withContext(io) { apiCall { api.getFeeSchedule().toDomain() } }
+    override suspend fun feeSchedule(symbolId: Int): ApiResult<FeeSchedule> =
+        withContext(io) { apiCall { api.getFeeSchedule(symbolId).toDomain() } }
 
     override suspend fun fillsFees(): ApiResult<FillsFees> =
         withContext(io) { apiCall { api.getFillsFees().toDomain() } }

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
@@ -61,16 +61,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.custody.BridgeAction
 import com.testlogon.android.data.custody.CustodyAssets
 import com.testlogon.android.data.custody.CustodyBalance
-import com.testlogon.android.data.custody.BridgeDirection
 import com.testlogon.android.data.custody.CustodyBridgeResult
 import com.testlogon.android.data.custody.CustodySubAccount
-import com.testlogon.android.data.custody.CustodySubAccounts
-import com.testlogon.android.data.custody.SubAccountTransferResult
 import com.testlogon.android.data.custody.CustodyDeposit
 import com.testlogon.android.data.custody.CustodyDeposits
-import com.testlogon.android.data.custody.DepositStatus
+import com.testlogon.android.data.custody.SubAccountTransferResult
 import com.testlogon.android.data.custody.CustodyWithdrawResult
 import com.testlogon.android.data.custody.WithdrawStatus
 
@@ -578,16 +576,13 @@ private fun DepositRow(d: CustodyDeposit) {
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = if (d.amount.isNotBlank()) "+${d.amount} ${d.asset}" else d.asset,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontFamily = FontFamily.Monospace,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                DepositStatusChip(d.status)
-            }
-            Text("${d.chainName} · ${relativeTime(d.timestampMs)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(
+                text = if (d.amount.isNotBlank()) "+${d.amount} ${d.asset}" else d.asset,
+                style = MaterialTheme.typography.titleSmall,
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(d.chainName, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             if (d.txHash.isNotBlank()) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(d.txShort, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace)
@@ -597,34 +592,6 @@ private fun DepositRow(d: CustodyDeposit) {
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun DepositStatusChip(status: DepositStatus) {
-    val (bg, fg) = when (status) {
-        DepositStatus.CREDITED -> MaterialTheme.colorScheme.primaryContainer to MaterialTheme.colorScheme.onPrimaryContainer
-        DepositStatus.DUPLICATE -> MaterialTheme.colorScheme.surface to MaterialTheme.colorScheme.onSurfaceVariant
-        DepositStatus.UNKNOWN -> MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
-    }
-    Box(
-        modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(bg).padding(horizontal = 8.dp, vertical = 3.dp),
-    ) {
-        Text(status.label, style = MaterialTheme.typography.labelSmall, color = fg)
-    }
-}
-
-/** Coarse relative time ("just now" / "5m ago" / "3h ago" / "2d ago") from an epoch-ms timestamp. */
-private fun relativeTime(timestampMs: Long?): String {
-    if (timestampMs == null || timestampMs <= 0L) return "—"
-    val deltaMs = System.currentTimeMillis() - timestampMs
-    if (deltaMs < 0L) return "just now"
-    val mins = deltaMs / 60000L
-    return when {
-        mins < 1L -> "just now"
-        mins < 60L -> "${mins}m ago"
-        mins < 1440L -> "${mins / 60L}h ago"
-        else -> "${mins / 1440L}d ago"
     }
 }
 
@@ -727,7 +694,6 @@ private fun SubAccountsTab(state: CustodyUiState, viewModel: CustodyViewModel) {
             )
             else -> {
                 val data = list.data
-                Text("Base vault: ${data.defaultVault.short().ifBlank { "—" }}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
                 if (data.subAccounts.isEmpty()) {
                     EmptyBox("No sub-accounts yet.")
                 } else {
@@ -741,24 +707,9 @@ private fun SubAccountsTab(state: CustodyUiState, viewModel: CustodyViewModel) {
 @Composable
 private fun SubAccountCard(sub: CustodySubAccount) {
     Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(sub.displayLabel, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
-                Text("Tier: ${sub.tier}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-            Text(sub.idShort, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
-            val funded = sub.funded()
-            if (funded.isEmpty()) {
-                Text("No balances", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(top = 6.dp))
-            } else {
-                Spacer(Modifier.height(6.dp))
-                funded.forEach { row ->
-                    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 1.dp)) {
-                        Text(row.symbol, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
-                        Text(row.amountText, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
-                    }
-                }
-            }
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(sub.displayLabel, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(sub.vaultShort, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
         }
     }
 }
@@ -774,28 +725,38 @@ private fun TransferTab(state: CustodyUiState, viewModel: CustodyViewModel) {
     ) {
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                Text("Custody ↔ Trading bridge", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    BridgeDirection.entries.forEach { d ->
+                Text("Custody ↔ Trading", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "Fund moves value from custody into the exchange; settle moves it back to custody.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text("Action", style = MaterialTheme.typography.labelMedium)
+                Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    BridgeAction.entries.forEach { a ->
                         FilterChip(
-                            selected = d == t.direction,
-                            onClick = { if (d != t.direction) viewModel.onBridgeDirectionToggle() },
-                            label = { Text(d.label) },
-                            modifier = Modifier.testTag("bridge_dir_${d.name}"),
+                            selected = a == t.bridgeAction,
+                            onClick = { viewModel.onBridgeActionSelected(a) },
+                            label = { Text(a.label) },
+                            modifier = Modifier.testTag("bridge_action_${a.name}"),
+                        )
+                    }
+                }
+                Text("Token", style = MaterialTheme.typography.labelMedium)
+                Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    CustodyAssets.BRIDGE_TOKENS.forEach { sym ->
+                        FilterChip(
+                            selected = sym == t.bridgeToken,
+                            onClick = { viewModel.onBridgeTokenSelected(sym) },
+                            label = { Text(sym) },
+                            modifier = Modifier.testTag("bridge_token_$sym"),
                         )
                     }
                 }
                 OutlinedTextField(
-                    value = t.bridgeAssetText,
-                    onValueChange = viewModel::onBridgeAssetChanged,
-                    label = { Text("Engine asset id") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth().testTag("bridge_asset"),
-                )
-                OutlinedTextField(
                     value = t.bridgeAmountText,
                     onValueChange = viewModel::onBridgeAmountChanged,
-                    label = { Text("Amount (integer)") },
+                    label = { Text("Amount") },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth().testTag("bridge_amount"),
                 )
@@ -811,7 +772,7 @@ private fun TransferTab(state: CustodyUiState, viewModel: CustodyViewModel) {
                         CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
                         Spacer(Modifier.width(8.dp))
                     }
-                    Text("Transfer")
+                    Text(t.bridgeAction.label)
                 }
                 t.bridgeResult?.let { r -> BridgeResultCard(r) { viewModel.clearBridgeResult() } }
             }
@@ -876,20 +837,29 @@ private fun VaultChips(labels: List<String>, selected: String, onSelect: (String
 
 @Composable
 private fun BridgeResultCard(r: CustodyBridgeResult, onDismiss: () -> Unit) {
-    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant), modifier = Modifier.fillMaxWidth().testTag("bridge_result")) {
+    val (container, content) = if (r.ok) {
+        MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+    } else {
+        MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+    }
+    Card(colors = CardDefaults.cardColors(containerColor = container, contentColor = content), modifier = Modifier.fillMaxWidth().testTag("bridge_result")) {
         Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(if (r.ok) "Submitted" else "Rejected", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
-                if (r.simulated) SimulatedChip()
-            }
-            r.direction?.let { DetailRow("Direction", it.label) }
-            r.asset?.let { DetailRow("Asset id", it.toString()) }
-            r.amount?.let { DetailRow("Amount", it.toString()) }
-            if (r.direction == BridgeDirection.TO_TRADING) {
-                DetailRow("Trading credited", if (r.tradingCredited) "yes" else "no")
-            }
-            r.note?.let {
-                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            val verb = if (r.action.isSettle) "Settled" else "Funded"
+            Text(
+                if (r.ok) "$verb ✓" else "Rejected",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            DetailRow("Action", r.action.label)
+            r.token?.let { DetailRow("Token", it) }
+            r.amount?.let { DetailRow("Amount", it) }
+            r.meAmount?.let { DetailRow("Engine amt", it) }
+            r.ledger?.let { DetailRow(r.action.venue.label, it) }
+            r.custody?.let { DetailRow("Custody", it) }
+            if (!r.ok) {
+                r.reason?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall)
+                }
             }
             TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) { Text("Dismiss") }
         }
@@ -898,39 +868,31 @@ private fun BridgeResultCard(r: CustodyBridgeResult, onDismiss: () -> Unit) {
 
 @Composable
 private fun SubTransferResultCard(r: SubAccountTransferResult, onDismiss: () -> Unit) {
-    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant), modifier = Modifier.fillMaxWidth().testTag("sub_result")) {
+    val (container, content) = if (r.ok) {
+        MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+    } else {
+        MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+    }
+    Card(colors = CardDefaults.cardColors(containerColor = container, contentColor = content), modifier = Modifier.fillMaxWidth().testTag("sub_result")) {
         Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(if (r.ok) "Submitted" else "Rejected", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
-                if (r.simulated) SimulatedChip()
-            }
+            Text(
+                if (r.ok) "Transferred ✓" else "Rejected",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
             r.from?.let { DetailRow("From", it.short()) }
             r.to?.let { DetailRow("To", it.short()) }
             r.asset?.let { DetailRow("Asset", it) }
             r.amount?.let { DetailRow("Amount", it) }
-            r.note?.let {
-                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            r.fromBalance?.let { DetailRow("From bal", it) }
+            r.toBalance?.let { DetailRow("To bal", it) }
+            if (!r.ok) {
+                r.reason?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall)
+                }
             }
             TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) { Text("Dismiss") }
         }
-    }
-}
-
-/** Honest "not settled" marker shown whenever a transfer response carries stub:true. */
-@Composable
-private fun SimulatedChip() {
-    Box(
-        modifier = Modifier
-            .background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(50))
-            .padding(horizontal = 10.dp, vertical = 3.dp)
-            .testTag("simulated_chip"),
-    ) {
-        Text(
-            "Simulated · not settled",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onTertiaryContainer,
-            fontWeight = FontWeight.Medium,
-        )
     }
 }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
@@ -8,7 +8,7 @@ import com.testlogon.android.data.custody.CustodyAsset
 import com.testlogon.android.data.custody.CustodyAssets
 import com.testlogon.android.data.custody.CustodyBalance
 import com.testlogon.android.data.custody.CustodyBalances
-import com.testlogon.android.data.custody.BridgeDirection
+import com.testlogon.android.data.custody.BridgeAction
 import com.testlogon.android.data.custody.CustodyBridgeResult
 import com.testlogon.android.data.custody.CustodySubAccount
 import com.testlogon.android.data.custody.CustodySubAccounts
@@ -26,7 +26,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * The five in-screen custody tabs. Activity + Approvals have no backing endpoint on this backend and
+ * The seven in-screen custody tabs. Activity + Approvals have no backing endpoint on this backend and
  * render a static "not available" state; they are always shown (no role gating).
  */
 enum class CustodyTab { BALANCES, SUBACCOUNTS, TRANSFER, DEPOSIT, WITHDRAW, ACTIVITY, APPROVALS }
@@ -66,14 +66,14 @@ data class SubAccountsUiState(
 )
 
 /**
- * Transfer tab. Two independent forms: the custody<->trading bridge (direction + engine-asset-id +
- * amount) and the between-sub-accounts move (from/to labels + asset symbol + amount). Each holds its
- * own in-flight flag, error, and last (honest, possibly-simulated) result.
+ * Transfer tab. Two independent forms: the custody<->trading bridge (action = fund/settle x
+ * spot/margin + a token symbol + a decimal amount) and the between-sub-accounts move (from/to labels +
+ * asset symbol + amount). Each holds its own in-flight flag, error, and last (real) result.
  */
 data class TransferUiState(
     // Bridge (custody <-> trading)
-    val direction: BridgeDirection = BridgeDirection.TO_TRADING,
-    val bridgeAssetText: String = "",
+    val bridgeAction: BridgeAction = BridgeAction.FUND_SPOT,
+    val bridgeToken: String = CustodyAssets.BRIDGE_TOKENS.firstOrNull() ?: "ETH",
     val bridgeAmountText: String = "",
     val bridgeSubmitting: Boolean = false,
     val bridgeError: String? = null,
@@ -87,9 +87,10 @@ data class TransferUiState(
     val subError: String? = null,
     val subResult: SubAccountTransferResult? = null,
 ) {
-    val bridgeAssetInt: Int? get() = bridgeAssetText.trim().toIntOrNull()
-    val bridgeAmountLong: Long? get() = bridgeAmountText.trim().toLongOrNull()
-    val canBridge: Boolean get() = !bridgeSubmitting && (bridgeAssetInt ?: -1) >= 0 && (bridgeAmountLong ?: 0L) > 0L
+    val bridgeAmountDouble: Double? get() = bridgeAmountText.trim().toDoubleOrNull()
+    val canBridge: Boolean get() = !bridgeSubmitting &&
+        bridgeToken.trim().isNotEmpty() &&
+        (bridgeAmountDouble ?: 0.0) > 0.0
     val subAmountDouble: Double? get() = subAmountText.trim().toDoubleOrNull()
     val canSubTransfer: Boolean get() = !subSubmitting &&
         subAsset.trim().isNotEmpty() &&
@@ -280,27 +281,27 @@ class CustodyViewModel @Inject constructor(
 
     // ---- transfer: custody <-> trading bridge ----
 
-    fun onBridgeDirectionToggle() =
-        _uiState.update { it.copy(transfer = it.transfer.copy(direction = it.transfer.direction.toggle(), bridgeError = null, bridgeResult = null)) }
+    fun onBridgeActionSelected(action: BridgeAction) =
+        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeAction = action, bridgeError = null, bridgeResult = null)) }
 
-    fun onBridgeAssetChanged(v: String) =
-        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeAssetText = v.filter { c -> c.isDigit() }.take(6), bridgeError = null)) }
+    fun onBridgeTokenSelected(token: String) =
+        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeToken = token.trim().uppercase(), bridgeError = null)) }
 
     fun onBridgeAmountChanged(v: String) =
-        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeAmountText = v.filter { c -> c.isDigit() }.take(15), bridgeError = null)) }
+        _uiState.update { it.copy(transfer = it.transfer.copy(bridgeAmountText = sanitizeDecimal(v), bridgeError = null)) }
 
     fun submitBridgeTransfer() {
         val t = _uiState.value.transfer
         if (!t.canBridge) {
-            _uiState.update { it.copy(transfer = it.transfer.copy(bridgeError = "Enter an asset id and an amount greater than 0.")) }
+            _uiState.update { it.copy(transfer = it.transfer.copy(bridgeError = "Choose a token and an amount greater than 0.")) }
             return
         }
-        val asset = t.bridgeAssetInt!!
-        val amount = t.bridgeAmountLong!!
-        val direction = t.direction
+        val action = t.bridgeAction
+        val token = t.bridgeToken
+        val amount = t.bridgeAmountText.trim()
         _uiState.update { it.copy(transfer = it.transfer.copy(bridgeSubmitting = true, bridgeError = null, bridgeResult = null)) }
         viewModelScope.launch {
-            when (val r = repo.bridgeTransfer(direction, asset, amount)) {
+            when (val r = repo.bridge(action, token, amount)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(transfer = it.transfer.copy(bridgeSubmitting = false, bridgeResult = r.data)) }
                     loadBalance()
@@ -319,7 +320,7 @@ class CustodyViewModel @Inject constructor(
     fun onFromLabelChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(fromLabel = v, subError = null)) }
     fun onToLabelChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(toLabel = v, subError = null)) }
     fun onSubAssetChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(subAsset = v.trim().uppercase().take(12), subError = null)) }
-    fun onSubAmountChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(subAmountText = v, subError = null)) }
+    fun onSubAmountChanged(v: String) = _uiState.update { it.copy(transfer = it.transfer.copy(subAmountText = sanitizeDecimal(v), subError = null)) }
 
     fun submitSubAccountTransfer() {
         val t = _uiState.value.transfer
@@ -338,7 +339,10 @@ class CustodyViewModel @Inject constructor(
         _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = true, subError = null, subResult = null)) }
         viewModelScope.launch {
             when (val r = repo.subAccountTransfer(from.ifBlank { null }, to.ifBlank { null }, asset, amount)) {
-                is ApiResult.Success -> _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = false, subResult = r.data)) }
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = false, subResult = r.data)) }
+                    loadSubAccounts()
+                }
                 is ApiResult.Failure -> _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = false, subError = r.error.messageFor())) }
                 is ApiResult.NetworkError -> _uiState.update { it.copy(transfer = it.transfer.copy(subSubmitting = false, subError = "Network error. Check your connection and try again.")) }
             }
@@ -354,6 +358,16 @@ class CustodyViewModel @Inject constructor(
             it.copy(withdraw = it.withdraw.copy(result = null, amount = "", destination = "", tokenOverride = "", submitError = null))
         }
     }
+}
+
+/** Keep digits + a single decimal point, capped to a sane length. */
+private fun sanitizeDecimal(v: String): String {
+    val filtered = v.filter { it.isDigit() || it == '.' }
+    val firstDot = filtered.indexOf('.')
+    val cleaned = if (firstDot < 0) filtered else {
+        filtered.substring(0, firstDot + 1) + filtered.substring(firstDot + 1).replace(".", "")
+    }
+    return cleaned.take(24)
 }
 
 // ---- ApiResult -> Async projection ----

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -349,8 +349,8 @@ private fun FillsSection(state: TradingUiState) {
 }
 
 /**
- * Fee schedule card (GET /me/fees/schedule). When the schedule is the venue-default stub (source=stub)
- * a small "estimated" marker is shown so the rate is not mistaken for a negotiated per-caller quote.
+ * Fee schedule card (GET /me/fees/schedule?symbolid=<n>). A small source marker shows whether these are
+ * the engine-configured rates or the venue defaults, so the rate is read correctly.
  */
 @Composable
 private fun FeeScheduleCard(fee: com.testlogon.android.data.exchange.FeeSchedule) {
@@ -364,15 +364,13 @@ private fun FeeScheduleCard(fee: com.testlogon.android.data.exchange.FeeSchedule
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text("Fee schedule", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 13.sp, modifier = Modifier.weight(1f))
-            if (fee.isStub) {
-                Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(50))
-                        .background(MarketColors.Surface)
-                        .padding(horizontal = 8.dp, vertical = 2.dp),
-                ) {
-                    Text("venue default · est.", color = MarketColors.TextFaint, fontFamily = FontFamily.Monospace, fontSize = 10.sp)
-                }
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50))
+                    .background(MarketColors.Surface)
+                    .padding(horizontal = 8.dp, vertical = 2.dp),
+            ) {
+                Text(fee.sourceLabel, color = MarketColors.TextFaint, fontFamily = FontFamily.Monospace, fontSize = 10.sp)
             }
         }
         Spacer(Modifier.height(8.dp))

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -58,7 +58,7 @@ class TradingViewModel @Inject constructor(
      */
     fun loadFees() {
         viewModelScope.launch {
-            when (val r = repository.feeSchedule()) {
+            when (val r = repository.feeSchedule(symbolId)) {
                 is ApiResult.Success -> _uiState.update { it.copy(feeSchedule = r.data) }
                 else -> Unit
             }

--- a/android/app/src/test/java/com/testlogon/android/data/custody/CustodySubAccountsContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/custody/CustodySubAccountsContractTest.kt
@@ -1,0 +1,183 @@
+package com.testlogon.android.data.custody
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import com.testlogon.android.testutil.testMoshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Contract tests for the REAL custody sub-accounts + bridge data layer against MockWebServer
+ * (production Retrofit/Moshi). Sub-accounts are now {label, vault}; the vault<->vault transfer is real
+ * (transferred + echoed balances); the custody<->trading bridge is four routes (fund/settle x
+ * spot/margin) with {token, amount} bodies. Also covers the graceful 404 -> unavailable degrade and
+ * the 422 rejection path.
+ */
+class CustodySubAccountsContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi = testMoshi()
+
+    private fun repo(): CustodyRepository {
+        val api = backend.retrofit(moshi).create(CustodyApi::class.java)
+        return CustodyRepository(api = api, errorParser = ApiErrorParser(moshi))
+    }
+
+    @Test
+    fun getSubAccounts_mapsLabelAndVault() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"subaccounts":[
+                    {"label":"savings","vault":"vault-base-abc-savings"},
+                    {"label":"trading","vault":"vault-base-abc-trading"}
+                ]}""",
+            ),
+        )
+        val r = repo().getSubAccounts()
+        assertTrue(r is ApiResult.Success)
+        val data = (r as ApiResult.Success).data
+        assertFalse(data.unavailable)
+        assertEquals(2, data.subAccounts.size)
+        val savings = data.subAccounts.first { it.label == "savings" }
+        assertEquals("vault-base-abc-savings", savings.vault)
+
+        val req = backend.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/me/custody/subaccounts", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun getSubAccounts_404_degradesToUnavailable() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val r = repo().getSubAccounts()
+        assertTrue(r is ApiResult.Success)
+        assertTrue((r as ApiResult.Success).data.unavailable)
+    }
+
+    @Test
+    fun getSubAccounts_transportFailure_isNetworkError() = runTest {
+        backend.enqueue(Fixtures.disconnect())
+        val r = repo().getSubAccounts()
+        assertTrue(r is ApiResult.NetworkError)
+    }
+
+    @Test
+    fun createSubAccount_returnsCreatedVaultWithLabel() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"created":true,"label":"savings","vault":"vault-base-abc-savings"}"""))
+        val r = repo().createSubAccount("savings")
+        assertTrue(r is ApiResult.Success)
+        val sub = (r as ApiResult.Success).data
+        assertEquals("vault-base-abc-savings", sub.vault)
+        assertEquals("savings", sub.label)
+
+        val req = backend.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/me/custody/subaccounts", req.requestUrl?.encodedPath)
+        assertTrue(req.body.readUtf8().contains("\"label\":\"savings\""))
+    }
+
+    @Test
+    fun createSubAccount_400_mapsToFailure() = runTest {
+        backend.enqueue(Fixtures.error("\"empty label\"", 400))
+        val r = repo().createSubAccount("!!!")
+        assertTrue(r is ApiResult.Failure)
+        assertEquals(400, (r as ApiResult.Failure).error.status)
+    }
+
+    @Test
+    fun subAccountTransfer_real_echoesBalances() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"transferred":true,"asset":"ETH","amount":"1","from":"vault-base-abc","to":"vault-base-abc-savings","from_balance":"4","to_balance":"1"}""",
+            ),
+        )
+        val r = repo().subAccountTransfer(fromLabel = null, toLabel = "savings", asset = "ETH", amount = "1")
+        assertTrue(r is ApiResult.Success)
+        val res = (r as ApiResult.Success).data
+        assertTrue(res.ok)
+        assertEquals("ETH", res.asset)
+        assertEquals("4", res.fromBalance)
+        assertEquals("1", res.toBalance)
+
+        val req = backend.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/me/custody/subaccounts/transfer", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun fundSpot_reportsFundedAndLedger() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"funded":true,"token":"ETH","asset_id":"3","amount":"1","me_amount":"1","spot":"5"}""",
+            ),
+        )
+        val r = repo().bridge(BridgeAction.FUND_SPOT, token = "ETH", amount = "1")
+        assertTrue(r is ApiResult.Success)
+        val res = (r as ApiResult.Success).data
+        assertTrue(res.ok)
+        assertEquals(BridgeAction.FUND_SPOT, res.action)
+        assertEquals("ETH", res.token)
+        assertEquals("5", res.ledger)
+
+        val req = backend.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/me/custody/fund-spot", req.requestUrl?.encodedPath)
+        val body = req.body.readUtf8()
+        assertTrue(body.contains("\"token\":\"ETH\""))
+        assertTrue(body.contains("\"amount\":\"1\""))
+    }
+
+    @Test
+    fun settleSpot_insufficient_surfacesReason() = runTest {
+        backend.enqueue(
+            Fixtures.error("""{"settled":false,"reason":"insufficient_spot_available"}""", 422),
+        )
+        val r = repo().bridge(BridgeAction.SETTLE_SPOT, token = "ETH", amount = "100")
+        assertTrue(r is ApiResult.Failure)
+        assertEquals(422, (r as ApiResult.Failure).error.status)
+
+        val req = backend.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/me/custody/settle-spot", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun fundMargin_hitsMarginRoute() = runTest {
+        backend.enqueue(
+            Fixtures.okBody("""{"funded":true,"token":"USDC","asset_id":"5","amount":"10","me_amount":"10","margin":"10"}"""),
+        )
+        val r = repo().bridge(BridgeAction.FUND_MARGIN, token = "USDC", amount = "10")
+        assertTrue(r is ApiResult.Success)
+        val res = (r as ApiResult.Success).data
+        assertTrue(res.ok)
+        assertEquals("10", res.ledger)
+
+        val req = backend.takeRequest()
+        assertEquals("/me/custody/fund-margin", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun settleMargin_reportsCustodyBalance() = runTest {
+        backend.enqueue(
+            Fixtures.okBody("""{"settled":true,"token":"USDC","amount":"10","me_amount":"10","margin":"0","custody":"20"}"""),
+        )
+        val r = repo().bridge(BridgeAction.SETTLE_MARGIN, token = "USDC", amount = "10")
+        assertTrue(r is ApiResult.Success)
+        val res = (r as ApiResult.Success).data
+        assertTrue(res.ok)
+        assertEquals("20", res.custody)
+        assertEquals("0", res.ledger)
+
+        val req = backend.takeRequest()
+        assertEquals("/me/custody/settle-margin", req.requestUrl?.encodedPath)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/TradingFeesContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/TradingFeesContractTest.kt
@@ -1,0 +1,140 @@
+package com.testlogon.android.data.exchange
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import com.testlogon.android.testutil.testMoshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Contract tests for the REAL fee schedule + enriched fills-fees data layer. The fee schedule is now
+ * GET me/fees/schedule?symbolid=<n> returning {maker/taker/liq bps, source ("engine"|"venue_default"),
+ * configured}; the fills-fees feed stays a client-side estimate (its stub flag is genuine).
+ */
+class TradingFeesContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi = testMoshi()
+
+    private fun repo(): TradingRepository {
+        val api = backend.retrofit(moshi).create(TradingApi::class.java)
+        return TradingRepositoryImpl(api = api, errorParser = ApiErrorParser(moshi))
+    }
+
+    @Test
+    fun feeSchedule_engineSource_isConfigured() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"status":"ok","type":"fee_schedule","symbolid":3,"maker_fee_bps":10,"taker_fee_bps":20,"liquidation_fee_bps":100,"source":"engine","configured":true}""",
+            ),
+        )
+        val r = repo().feeSchedule(3)
+        assertTrue(r is ApiResult.Success)
+        val fee = (r as ApiResult.Success).data
+        assertEquals(10, fee.makerFeeBps)
+        assertEquals(20, fee.takerFeeBps)
+        assertEquals(100, fee.liquidationFeeBps)
+        assertFalse(fee.isVenueDefault)
+        assertEquals("engine", fee.sourceLabel)
+        assertEquals("0.20%", fee.takerPct())
+        // round(price*qty*taker_bps/10000) = round(100*5*20/10000) = round(1.0) = 1
+        assertEquals(1L, fee.takerFeeFor(100L, 5L))
+
+        val req = backend.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/me/fees/schedule", req.requestUrl?.encodedPath)
+        assertEquals("3", req.requestUrl?.queryParameter("symbolid"))
+    }
+
+    @Test
+    fun feeSchedule_venueDefault_flaggedAndLabeled() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"status":"ok","type":"fee_schedule","symbolid":7,"maker_fee_bps":10,"taker_fee_bps":20,"liquidation_fee_bps":100,"source":"venue_default","configured":false}""",
+            ),
+        )
+        val r = repo().feeSchedule(7)
+        assertTrue(r is ApiResult.Success)
+        val fee = (r as ApiResult.Success).data
+        assertTrue(fee.isVenueDefault)
+        assertEquals("venue default", fee.sourceLabel)
+    }
+
+    @Test
+    fun feeSchedule_toleratesStringifiedBps() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"symbolid":3,"maker_fee_bps":"10","taker_fee_bps":"20","liquidation_fee_bps":"100","source":"engine","configured":true}"""))
+        val r = repo().feeSchedule(3)
+        assertTrue(r is ApiResult.Success)
+        val fee = (r as ApiResult.Success).data
+        assertEquals(20, fee.takerFeeBps)
+    }
+
+    @Test
+    fun feeSchedule_missingFields_fallsBackToVenueDefaults() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"symbolid":3}"""))
+        val r = repo().feeSchedule(3)
+        assertTrue(r is ApiResult.Success)
+        val fee = (r as ApiResult.Success).data
+        assertEquals(10, fee.makerFeeBps)
+        assertEquals(20, fee.takerFeeBps)
+        assertEquals(100, fee.liquidationFeeBps)
+        assertTrue(fee.isVenueDefault)
+    }
+
+    @Test
+    fun feeSchedule_404_mapsToFailure() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val r = repo().feeSchedule(3)
+        assertTrue(r is ApiResult.Failure)
+        assertEquals(404, (r as ApiResult.Failure).error.status)
+    }
+
+    @Test
+    fun fillsFees_emptyFeed_carriesFormulaAndStub() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"fills":[],"taker_fee_bps":20,"fee_formula":"round(price*qty*taker_fee_bps/10000)","source":"stub","stub":true,"note":"engine exposes no per-fill fee"}""",
+            ),
+        )
+        val r = repo().fillsFees()
+        assertTrue(r is ApiResult.Success)
+        val ff = (r as ApiResult.Success).data
+        assertTrue(ff.fills.isEmpty())
+        assertEquals(20, ff.takerFeeBps)
+        assertTrue(ff.isStub)
+        assertEquals("round(price*qty*taker_fee_bps/10000)", ff.feeFormula)
+
+        val req = backend.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/me/fills/fees", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun fillsFees_populatedFeed_mapsFee() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"fills":[{"price":100,"qty":5,"fee":1,"ts_ns":1700000000000000000,"side":"buy"}],"taker_fee_bps":20,"source":"real"}"""))
+        val r = repo().fillsFees()
+        assertTrue(r is ApiResult.Success)
+        val ff = (r as ApiResult.Success).data
+        assertEquals(1, ff.fills.size)
+        assertEquals(1L, ff.fills.first().fee)
+        assertEquals(OrderSide.BUY, ff.fills.first().side)
+        assertFalse(ff.isStub)
+    }
+
+    @Test
+    fun feeFor_formulaMatchesBackend() {
+        // round(250*4*20/10000) = round(2.0) = 2
+        assertEquals(2L, feeFor(250L * 4L, 20))
+        // round(333*3*20/10000) = round(1.998) = 2
+        assertEquals(2L, feeFor(333L * 3L, 20))
+    }
+}

--- a/frontend/src/api/endpoints/custody.ts
+++ b/frontend/src/api/endpoints/custody.ts
@@ -35,29 +35,29 @@ export interface DepositAddress {
 }
 
 export interface CustodyDeposit {
+  /** Vault the deposit credited into. */
+  vault?: string;
   /** Source chain id (as a string). Map to a name via CUSTODY_ASSETS. */
   chain: string;
   /** On-chain transaction hash of the incoming transfer. */
   txhash: string;
-  /** Log index within the tx (as a string). */
-  log_index: string;
+  /** Log index within the tx (as a string or number). */
+  log_index: string | number;
   /** Credited asset symbol (e.g. "ETH", "USDC"). */
   asset: string;
   /** Amount as a string. */
   amount: string;
-  /** "credited" once applied to the vault; "duplicate" if already seen. */
-  status: "credited" | "duplicate" | string;
-  /** Monotonic scanner sequence number. */
-  seq: number;
-  /** Unix timestamp — seconds if small, ms if large (detect on render). */
-  ts: number;
+  /** Idempotency key for the credited transfer. */
+  dedup_key?: string;
 }
 
 export interface CustodyDepositsResult {
   /** Vault id these deposits credited into. */
   vault: string;
-  /** Incoming transfers, newest first. */
+  /** Incoming transfers. */
   deposits: CustodyDeposit[];
+  /** Count of deposits. */
+  count?: number;
 }
 
 export type WithdrawalStatus =
@@ -237,108 +237,152 @@ export function mergeBalances(
 
 
 // ─── Sub-accounts, custody<->trading bridge, and fee endpoints ───────────
-// NEW gap-closing endpoints (from the exchange-edge custody phase). Every one
-// of these MAY 404 on backends where the edge isn't deployed yet — all callers
-// must degrade gracefully (retry:false + an "unavailable" empty state) and the
-// stub/simulated responses below carry a `stub:true` flag the UI surfaces
-// honestly so a user never mistakes a simulated move for a settled one.
-
-export interface SubaccountBalancesMap {
-  [asset: string]: number | string;
-}
+// Gap-closing endpoints from the exchange-edge custody phase. Every one MAY
+// 404 on backends where the edge isn't deployed yet — all callers must degrade
+// gracefully (retry:false + an "unavailable" empty state). These routes are
+// REAL (atomic, reversal-on-failure) — there is NO stub/simulated flag.
 
 export interface Subaccount {
-  id: string;
+  /** Sub-account label (base vault has no label). */
   label: string;
-  tier?: string;
-  balances?: SubaccountBalancesMap;
-  /** Full vault name (present on create). */
-  vault?: string;
+  /** Full vault name. */
+  vault: string;
 }
 
 export interface SubaccountsResult {
-  /** The caller's base (default) vault name. */
-  default_vault: string;
   subaccounts: Subaccount[];
 }
 
 /**
- * List the caller's sub-account vaults (default base vault + named ones).
+ * List the caller's sub-account vaults (label + vault only — no balances/tier).
  * 404s until the edge deploys — callers should render a graceful
  * "not available on this backend yet" state (retry:false).
  */
 export const getSubaccounts = () =>
   api.get<SubaccountsResult>("/me/custody/subaccounts");
 
+export interface CreateSubaccountResult {
+  created: true;
+  label: string;
+  vault: string;
+}
+
 /** Create a named sub-account vault under the caller's base vault. */
 export const createSubaccount = (label: string) =>
-  api.post<Subaccount>("/me/custody/subaccounts", { label });
+  api.post<CreateSubaccountResult>("/me/custody/subaccounts", { label });
 
-/** Response to a simulated transfer — carries stub:true when not settled. */
-export interface TransferResult {
-  status: string;
-  stub?: boolean;
-  note?: string;
-  from?: string;
-  to?: string;
-  asset?: string | number;
-  amount?: string | number;
-  direction?: "to_trading" | "to_custody" | string;
-  trading_credited?: boolean;
-  [k: string]: unknown;
+/** Real atomic vault->vault transfer result. No stub flag. */
+export interface SubaccountTransferResult {
+  transferred: true;
+  asset: string;
+  amount: string | number;
+  from: string;
+  to: string;
+  from_balance: string | number;
+  to_balance: string | number;
 }
 
 export interface SubaccountTransferRequest {
   from_label?: string;
   to_label?: string;
-  asset: string | number;
+  /** Defaults to "native" when omitted. */
+  asset?: string;
   amount: number | string;
 }
 
 /**
  * Move an asset between two of the caller's OWN sub-account vaults (or the
- * base vault). Deliberately a documented no-op on the backend (stub:true).
+ * base vault when a label is omitted). REAL atomic move — no stub.
  */
 export const transferBetweenSubaccounts = (req: SubaccountTransferRequest) =>
-  api.post<TransferResult>("/me/custody/subaccounts/transfer", req);
+  api.post<SubaccountTransferResult>("/me/custody/subaccounts/transfer", req);
 
-export interface CustodyTradingTransferRequest {
-  direction: "to_trading" | "to_custody";
-  /** Engine asset id for the credit path. */
-  asset: number;
-  /** Positive integer amount. */
-  amount: number;
+// ─── Custody <-> trading bridge (FOUR real routes) ───────────────────────
+// Move value between the custody vault and the exchange spot/margin ledgers.
+// REAL (atomic, reversal-on-failure). Body is keyed by asset SYMBOL.
+
+export interface BridgeRequest {
+  /** Asset symbol from CUSTODY_ASSETS ("ETH","USDC","USDT","BNB","POL"). */
+  token: string;
+  /** Amount as a decimal string. */
+  amount: string;
 }
 
-/**
- * Custody<->trading bridge: move value between the custody vault and the
- * exchange spot ledger. Best-effort / simulated (stub:true) — see the
- * returned `note`.
- */
-export const custodyTradingTransfer = (req: CustodyTradingTransferRequest) =>
-  api.post<TransferResult>("/me/custody/transfer", req);
+/** custody -> spot: 200. */
+export interface FundSpotResult {
+  funded: true;
+  token: string;
+  asset_id: number | string;
+  amount: string | number;
+  me_amount: string | number;
+  spot: unknown;
+}
+
+/** spot -> custody: 200 | 422 {settled:false, reason, spot}. */
+export interface SettleSpotResult {
+  settled: boolean;
+  token?: string;
+  amount?: string | number;
+  me_amount?: string | number;
+  spot?: unknown;
+  custody?: unknown;
+  reason?: string;
+}
+
+/** custody -> margin: 200 | 422 {funded:false, reason, margin}. */
+export interface FundMarginResult {
+  funded: boolean;
+  token?: string;
+  asset_id?: number | string;
+  amount?: string | number;
+  me_amount?: string | number;
+  margin?: unknown;
+  reason?: string;
+}
+
+/** margin -> custody: 200 | 422. */
+export interface SettleMarginResult {
+  settled: boolean;
+  token?: string;
+  amount?: string | number;
+  me_amount?: string | number;
+  margin?: unknown;
+  custody?: unknown;
+  reason?: string;
+}
+
+/** custody -> spot */
+export const fundSpot = (req: BridgeRequest) =>
+  api.post<FundSpotResult>("/me/custody/fund-spot", req);
+
+/** spot -> custody */
+export const settleSpot = (req: BridgeRequest) =>
+  api.post<SettleSpotResult>("/me/custody/settle-spot", req);
+
+/** custody -> margin */
+export const fundMargin = (req: BridgeRequest) =>
+  api.post<FundMarginResult>("/me/custody/fund-margin", req);
+
+/** margin -> custody */
+export const settleMargin = (req: BridgeRequest) =>
+  api.post<SettleMarginResult>("/me/custody/settle-margin", req);
 
 // ─── Fees ────────────────────────────────────────────────────────────────
 
-export interface FeeScheduleRow {
-  symbolid?: number;
-  maker_fee_bps: number;
-  taker_fee_bps: number;
-  liquidation_fee_bps: number;
-}
-
 export interface FeeScheduleResult {
-  schedule: FeeScheduleRow[];
+  status: "ok" | string;
+  type?: string;
+  symbolid: number;
   maker_fee_bps: number;
   taker_fee_bps: number;
   liquidation_fee_bps: number;
-  source?: string;
-  stub?: boolean;
+  source: "engine" | "venue_default" | string;
+  configured: boolean;
 }
 
-/** The caller's maker/taker/liquidation fee schedule (venue defaults when stub). */
-export const getFeeSchedule = () =>
-  api.get<FeeScheduleResult>("/me/fees/schedule");
+/** The maker/taker/liquidation fee schedule for a symbol. */
+export const getFeeSchedule = (symbolid: number) =>
+  api.get<FeeScheduleResult>("/me/fees/schedule", { symbolid: String(symbolid) });
 
 export interface EnrichedFill {
   price?: number;

--- a/frontend/src/pages/custody/CustodyExtras.tsx
+++ b/frontend/src/pages/custody/CustodyExtras.tsx
@@ -1,9 +1,8 @@
 // Custody gap-closing surfaces: Sub-accounts + Transfers.
-// Both wire to NEW exchange-edge routes that 404 until the edge deploys, so
-// every query/mutation degrades gracefully to an "unavailable" state
-// (retry:false) and every simulated (stub:true) response is surfaced honestly
-// with a "simulated / not settled" badge so a user never mistakes a no-op for
-// a real settled transfer.
+// These wire to exchange-edge routes that 404 until the edge deploys, so every
+// query/mutation degrades gracefully to an "unavailable" state (retry:false).
+// The custody<->trading bridge (fund/settle x spot/margin) and the vault<->vault
+// transfer are now REAL (atomic, reversal-on-failure) — no "simulated" framing.
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -39,10 +38,13 @@ import {
   getSubaccounts,
   createSubaccount,
   transferBetweenSubaccounts,
-  custodyTradingTransfer,
+  fundSpot,
+  settleSpot,
+  fundMargin,
+  settleMargin,
   CUSTODY_ASSETS,
   type Subaccount,
-  type TransferResult,
+  type SubaccountTransferResult,
 } from "@/api/endpoints/custody";
 
 // ─── small shared bits ──────────────────────────────────────────
@@ -94,88 +96,6 @@ function UnavailableCard({ line }: { line: string }) {
   );
 }
 
-/** Honest "this move is simulated, not settled" badge for stub responses. */
-function SimulatedBadge() {
-  return (
-    <Badge
-      variant="outline"
-      className="gap-1 border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
-    >
-      <AlertTriangle className="h-3 w-3" /> Simulated · not settled
-    </Badge>
-  );
-}
-
-function TransferResultView({ result }: { result: TransferResult }) {
-  const stub = result.stub === true;
-  return (
-    <div
-      className={cn(
-        "space-y-2 rounded-lg border p-4",
-        stub
-          ? "border-amber-500/40 bg-amber-500/5"
-          : "border-success/40 bg-success/10",
-      )}
-    >
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="flex items-center gap-2 font-medium">
-          <CircleCheck className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-          Transfer accepted
-        </span>
-        {stub && <SimulatedBadge />}
-      </div>
-      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground">
-        {result.from != null && (
-          <div className="col-span-2 flex justify-between">
-            <dt>From</dt>
-            <dd className="font-mono text-foreground">{String(result.from)}</dd>
-          </div>
-        )}
-        {result.to != null && (
-          <div className="col-span-2 flex justify-between">
-            <dt>To</dt>
-            <dd className="font-mono text-foreground">{String(result.to)}</dd>
-          </div>
-        )}
-        {result.direction != null && (
-          <div className="flex justify-between">
-            <dt>Direction</dt>
-            <dd className="text-foreground">{String(result.direction)}</dd>
-          </div>
-        )}
-        {result.asset != null && (
-          <div className="flex justify-between">
-            <dt>Asset</dt>
-            <dd className="text-foreground">{String(result.asset)}</dd>
-          </div>
-        )}
-        {result.amount != null && (
-          <div className="flex justify-between">
-            <dt>Amount</dt>
-            <dd className="tabular-nums text-foreground">
-              {fmtAmount(result.amount as number | string)}
-            </dd>
-          </div>
-        )}
-        {result.trading_credited != null && (
-          <div className="flex justify-between">
-            <dt>Trading credited</dt>
-            <dd className="text-foreground">
-              {result.trading_credited ? "yes" : "no"}
-            </dd>
-          </div>
-        )}
-      </dl>
-      {result.note && (
-        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
-          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          {result.note}
-        </p>
-      )}
-    </div>
-  );
-}
-
 // ─── shared subaccounts query ───────────────────────────────────
 
 function useSubaccountsQuery() {
@@ -196,7 +116,10 @@ export function SubaccountsTab() {
   const [label, setLabel] = useState("");
   const [selected, setSelected] = useState<string | null>(null);
 
-  const subs: Subaccount[] = q.data?.subaccounts ?? [];
+  const all: Subaccount[] = q.data?.subaccounts ?? [];
+  // The base vault is the entry with an empty label; named ones have a label.
+  const baseVault = all.find((s) => !s.label || s.label.trim() === "");
+  const named = all.filter((s) => s.label && s.label.trim() !== "");
 
   const sanitized = label.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 48);
   const labelError =
@@ -243,15 +166,13 @@ export function SubaccountsTab() {
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
-          {q.data?.default_vault && (
+          {baseVault && (
             <button
               type="button"
               onClick={() => setSelected(null)}
               className={cn(
                 "flex w-full rounded-lg border p-3 text-left transition",
-                isMobile
-                  ? "flex-col gap-1"
-                  : "items-center justify-between",
+                isMobile ? "flex-col gap-1" : "items-center justify-between",
                 selected === null ? "ring-1 ring-primary/40" : "hover:bg-muted/40",
               )}
             >
@@ -261,7 +182,7 @@ export function SubaccountsTab() {
                 <Badge variant="outline" className="text-[10px]">default</Badge>
               </span>
               <span className="break-all font-mono text-xs text-muted-foreground">
-                {q.data.default_vault}
+                {baseVault.vault}
               </span>
             </button>
           )}
@@ -281,7 +202,7 @@ export function SubaccountsTab() {
             </div>
           )}
 
-          {!q.isLoading && !q.isError && subs.length === 0 && (
+          {!q.isLoading && !q.isError && named.length === 0 && (
             <p className="py-4 text-center text-sm text-muted-foreground">
               No named sub-accounts yet — create one below to organise balances.
             </p>
@@ -289,59 +210,34 @@ export function SubaccountsTab() {
 
           {!q.isLoading &&
             !q.isError &&
-            subs.map((s) => {
-              const bal = s.balances ?? {};
-              const funded = Object.entries(bal).filter(([, v]) => num(v) > 0);
-              return (
-                <button
-                  key={s.id ?? s.label}
-                  type="button"
-                  onClick={() => setSelected(s.label)}
+            named.map((s) => (
+              <button
+                key={s.label}
+                type="button"
+                onClick={() => setSelected(s.label)}
+                className={cn(
+                  "flex w-full flex-col gap-1 rounded-lg border p-3 text-left transition",
+                  selected === s.label ? "ring-1 ring-primary/40" : "hover:bg-muted/40",
+                )}
+              >
+                <div
                   className={cn(
-                    "flex w-full flex-col gap-1 rounded-lg border p-3 text-left transition",
-                    selected === s.label
-                      ? "ring-1 ring-primary/40"
-                      : "hover:bg-muted/40",
+                    "flex gap-2",
+                    isMobile ? "flex-col" : "items-center justify-between",
                   )}
                 >
-                  <div
-                    className={cn(
-                      "flex gap-2",
-                      isMobile
-                        ? "flex-col"
-                        : "items-center justify-between",
-                    )}
-                  >
-                    <span className="flex items-center gap-2">
-                      <Layers className="h-4 w-4 text-muted-foreground" />
-                      <span className="text-sm font-medium">{s.label}</span>
-                      {s.tier && (
-                        <Badge variant="outline" className="text-[10px]">{s.tier}</Badge>
-                      )}
+                  <span className="flex items-center gap-2">
+                    <Layers className="h-4 w-4 text-muted-foreground" />
+                    <span className="text-sm font-medium">{s.label}</span>
+                  </span>
+                  {s.vault && (
+                    <span className="break-all font-mono text-xs text-muted-foreground">
+                      {s.vault}
                     </span>
-                    {s.vault && (
-                      <span className="break-all font-mono text-xs text-muted-foreground">
-                        {s.vault}
-                      </span>
-                    )}
-                  </div>
-                  {funded.length > 0 ? (
-                    <div className="flex flex-wrap gap-1.5 pt-0.5">
-                      {funded.map(([asset, v]) => (
-                        <span
-                          key={asset}
-                          className="rounded bg-muted px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground"
-                        >
-                          {fmtAmount(v)} {asset}
-                        </span>
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="text-[11px] text-muted-foreground">No balances</span>
                   )}
-                </button>
-              );
-            })}
+                </div>
+              </button>
+            ))}
         </CardContent>
       </Card>
 
@@ -431,46 +327,84 @@ export function TransferTab() {
   );
 }
 
-// ─── (a) custody <-> trading bridge ─────────────────────────────
+// ─── (a) custody <-> trading bridge (fund/settle x spot/margin) ──
+
+type BridgeAction = "fund-spot" | "settle-spot" | "fund-margin" | "settle-margin";
+
+interface BridgeResultView {
+  ok: boolean;
+  amount?: string | number;
+  me_amount?: string | number;
+  spot?: unknown;
+  margin?: unknown;
+  reason?: string;
+}
+
+const BRIDGE_ACTIONS: { value: BridgeAction; label: string; verb: string }[] = [
+  { value: "fund-spot", label: "Custody → Spot", verb: "Fund spot" },
+  { value: "settle-spot", label: "Spot → Custody", verb: "Settle spot" },
+  { value: "fund-margin", label: "Custody → Margin", verb: "Fund margin" },
+  { value: "settle-margin", label: "Margin → Custody", verb: "Settle margin" },
+];
+
+function reasonText(reason?: string): string {
+  if (!reason) return "Transfer failed";
+  if (reason === "insufficient_spot_available") return "Insufficient spot available";
+  return reason.replace(/_/g, " ");
+}
 
 function BridgeTransfer() {
-  const [direction, setDirection] = useState<"to_trading" | "to_custody">("to_trading");
+  const [action, setAction] = useState<BridgeAction>("fund-spot");
   const [assetSymbol, setAssetSymbol] = useState<string>(CUSTODY_ASSETS[0]!.symbol);
   const [amount, setAmount] = useState("");
-  const [result, setResult] = useState<TransferResult | null>(null);
-
-  const asset = CUSTODY_ASSETS.find((a) => a.symbol === assetSymbol);
-  // The bridge credit path is keyed by an engine asset id (int). We map the
-  // registry chainId as the engine asset id proxy (asset id 0 = no-op).
-  const engineAssetId = asset ? asset.chainId : 0;
+  const [result, setResult] = useState<BridgeResultView | null>(null);
 
   const amt = num(amount);
   const amtError =
-    amount.trim() === ""
-      ? ""
-      : amt <= 0
-        ? "Amount must be greater than 0."
-        : !Number.isInteger(amt)
-          ? "Bridge amount must be a whole number."
-          : "";
-  const canSubmit = amt > 0 && Number.isInteger(amt);
+    amount.trim() === "" ? "" : amt <= 0 ? "Amount must be greater than 0." : "";
+  const canSubmit = amt > 0;
 
   const mutation = useMutation({
-    mutationFn: () =>
-      custodyTradingTransfer({ direction, asset: engineAssetId, amount: amt }),
+    mutationFn: async (): Promise<BridgeResultView> => {
+      const req = { token: assetSymbol, amount: amount.trim() };
+      switch (action) {
+        case "fund-spot": {
+          const r = await fundSpot(req);
+          return { ok: r.funded === true, amount: r.amount, me_amount: r.me_amount, spot: r.spot };
+        }
+        case "settle-spot": {
+          const r = await settleSpot(req);
+          return { ok: r.settled === true, amount: r.amount, me_amount: r.me_amount, spot: r.spot, reason: r.reason };
+        }
+        case "fund-margin": {
+          const r = await fundMargin(req);
+          return { ok: r.funded === true, amount: r.amount, me_amount: r.me_amount, margin: r.margin, reason: r.reason };
+        }
+        case "settle-margin": {
+          const r = await settleMargin(req);
+          return { ok: r.settled === true, amount: r.amount, me_amount: r.me_amount, margin: r.margin, reason: r.reason };
+        }
+      }
+    },
     onSuccess: (res) => {
       setResult(res);
-      if (res.stub) toast.message("Transfer accepted (simulated)");
-      else toast.success("Transfer accepted");
+      if (res.ok) toast.success("Transfer settled");
+      else toast.error(reasonText(res.reason));
     },
     onError: (err) => {
-      if (isUnavailable(err)) {
+      if (err instanceof ApiError && err.status === 422) {
+        const reason = (err.body as { reason?: string } | undefined)?.reason;
+        setResult({ ok: false, reason });
+        toast.error(reasonText(reason));
+      } else if (isUnavailable(err)) {
         toast.error("Custody ↔ trading bridge isn't available on this backend yet");
       } else {
         toast.error(err instanceof ApiError ? err.detail : "Transfer failed");
       }
     },
   });
+
+  const current = BRIDGE_ACTIONS.find((a) => a.value === action)!;
 
   return (
     <div className="space-y-4">
@@ -481,37 +415,26 @@ function BridgeTransfer() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-1 rounded-lg border bg-muted/30 p-1">
-            <button
-              type="button"
-              onClick={() => {
-                setDirection("to_trading");
+          <div className="space-y-1.5">
+            <Label>Action</Label>
+            <Select
+              value={action}
+              onValueChange={(v) => {
+                setAction(v as BridgeAction);
                 setResult(null);
               }}
-              className={cn(
-                "rounded-md px-3 py-1.5 text-sm font-medium transition",
-                direction === "to_trading"
-                  ? "bg-background shadow-sm"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
             >
-              To trading
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setDirection("to_custody");
-                setResult(null);
-              }}
-              className={cn(
-                "rounded-md px-3 py-1.5 text-sm font-medium transition",
-                direction === "to_custody"
-                  ? "bg-background shadow-sm"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              To custody
-            </button>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {BRIDGE_ACTIONS.map((a) => (
+                  <SelectItem key={a.value} value={a.value}>
+                    {a.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="space-y-1.5">
@@ -533,21 +456,12 @@ function BridgeTransfer() {
           <div className="space-y-1.5">
             <Label>Amount</Label>
             <Input
-              inputMode="numeric"
-              placeholder="0"
+              inputMode="decimal"
+              placeholder="0.00"
               value={amount}
-              onChange={(e) => setAmount(e.target.value.replace(/[^0-9]/g, ""))}
+              onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))}
             />
             {amtError && <p className="text-xs text-destructive">{amtError}</p>}
-          </div>
-
-          <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
-            <Info className="mt-0.5 h-4 w-4 shrink-0" />
-            <span>
-              The custody vault and the exchange spot ledger are separate systems.
-              This bridge is a best-effort, non-atomic operation and is reported as
-              simulated until the atomic bridge is wired end-to-end.
-            </span>
           </div>
 
           <Button
@@ -563,34 +477,88 @@ function BridgeTransfer() {
             ) : (
               <ArrowLeftRight className="h-4 w-4" />
             )}
-            {direction === "to_trading" ? "Move to trading" : "Move to custody"}
+            {current.verb}
           </Button>
         </CardContent>
       </Card>
 
-      {result && <TransferResultView result={result} />}
+      {result && <BridgeResultCard result={result} symbol={assetSymbol} />}
     </div>
   );
 }
 
-// ─── (b) between sub-accounts ───────────────────────────────────
+function BridgeResultCard({ result, symbol }: { result: BridgeResultView; symbol: string }) {
+  if (!result.ok) {
+    return (
+      <div className="space-y-1 rounded-lg border border-destructive/40 bg-destructive/5 p-4">
+        <span className="flex items-center gap-2 font-medium">
+          <AlertTriangle className="h-5 w-5 text-destructive" />
+          {reasonText(result.reason)}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2 rounded-lg border border-success/40 bg-success/10 p-4">
+      <span className="flex items-center gap-2 font-medium">
+        <CircleCheck className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+        Transfer settled
+      </span>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {result.amount != null && (
+          <div className="flex justify-between">
+            <dt>Amount</dt>
+            <dd className="tabular-nums text-foreground">
+              {fmtAmount(result.amount)} {symbol}
+            </dd>
+          </div>
+        )}
+        {result.me_amount != null && (
+          <div className="flex justify-between">
+            <dt>Engine amount</dt>
+            <dd className="tabular-nums text-foreground">{fmtAmount(result.me_amount)}</dd>
+          </div>
+        )}
+        {result.spot != null && (
+          <div className="col-span-2 flex justify-between">
+            <dt>Spot</dt>
+            <dd className="break-all text-foreground">{String(result.spot)}</dd>
+          </div>
+        )}
+        {result.margin != null && (
+          <div className="col-span-2 flex justify-between">
+            <dt>Margin</dt>
+            <dd className="break-all text-foreground">{String(result.margin)}</dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  );
+}
+
+// ─── (b) between sub-accounts (REAL atomic move) ────────────────
 
 const BASE = "__base__";
 
 function InternalTransfer() {
   const isMobile = useIsMobile();
   const q = useSubaccountsQuery();
-  const subs: Subaccount[] = q.data?.subaccounts ?? [];
+  const named: Subaccount[] = (q.data?.subaccounts ?? []).filter(
+    (s) => s.label && s.label.trim() !== "",
+  );
 
   const [fromLabel, setFromLabel] = useState<string>(BASE);
   const [toLabel, setToLabel] = useState<string>(BASE);
   const [assetSymbol, setAssetSymbol] = useState<string>(CUSTODY_ASSETS[0]!.symbol);
   const [amount, setAmount] = useState("");
-  const [result, setResult] = useState<TransferResult | null>(null);
+  const [result, setResult] = useState<SubaccountTransferResult | null>(null);
 
   const options = useMemo(
-    () => [{ value: BASE, label: "Base vault (default)" }, ...subs.map((s) => ({ value: s.label, label: s.label }))],
-    [subs],
+    () => [
+      { value: BASE, label: "Base vault (default)" },
+      ...named.map((s) => ({ value: s.label, label: s.label })),
+    ],
+    [named],
   );
 
   const amt = num(amount);
@@ -602,15 +570,14 @@ function InternalTransfer() {
   const mutation = useMutation({
     mutationFn: () =>
       transferBetweenSubaccounts({
-        from_label: fromLabel === BASE ? "" : fromLabel,
-        to_label: toLabel === BASE ? "" : toLabel,
+        from_label: fromLabel === BASE ? undefined : fromLabel,
+        to_label: toLabel === BASE ? undefined : toLabel,
         asset: assetSymbol,
-        amount: amt,
+        amount: amount.trim(),
       }),
     onSuccess: (res) => {
       setResult(res);
-      if (res.stub) toast.message("Transfer accepted (simulated)");
-      else toast.success("Transfer accepted");
+      toast.success("Transfer settled");
     },
     onError: (err) => {
       if (isUnavailable(err)) {
@@ -697,15 +664,6 @@ function InternalTransfer() {
             {amtError && <p className="text-xs text-destructive">{amtError}</p>}
           </div>
 
-          <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
-            <Info className="mt-0.5 h-4 w-4 shrink-0" />
-            <span>
-              The custody gateway has no vault↔vault move route, so this transfer
-              is validated but performs no balance change — it is reported as
-              simulated so it can never mint or destroy funds.
-            </span>
-          </div>
-
           <Button
             className="w-full gap-1.5"
             disabled={!canSubmit || mutation.isPending}
@@ -724,7 +682,40 @@ function InternalTransfer() {
         </CardContent>
       </Card>
 
-      {result && <TransferResultView result={result} />}
+      {result && (
+        <div className="space-y-2 rounded-lg border border-success/40 bg-success/10 p-4">
+          <span className="flex items-center gap-2 font-medium">
+            <CircleCheck className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            Transfer settled
+          </span>
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <div className="flex justify-between">
+              <dt>Asset</dt>
+              <dd className="text-foreground">{String(result.asset)}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt>Amount</dt>
+              <dd className="tabular-nums text-foreground">{fmtAmount(result.amount)}</dd>
+            </div>
+            <div className="col-span-2 flex justify-between">
+              <dt>From</dt>
+              <dd className="font-mono text-foreground">{String(result.from)}</dd>
+            </div>
+            <div className="flex justify-between pl-4">
+              <dt>New balance</dt>
+              <dd className="tabular-nums text-foreground">{fmtAmount(result.from_balance)}</dd>
+            </div>
+            <div className="col-span-2 flex justify-between">
+              <dt>To</dt>
+              <dd className="font-mono text-foreground">{String(result.to)}</dd>
+            </div>
+            <div className="flex justify-between pl-4">
+              <dt>New balance</dt>
+              <dd className="tabular-nums text-foreground">{fmtAmount(result.to_balance)}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/custody/CustodyPage.tsx
+++ b/frontend/src/pages/custody/CustodyPage.tsx
@@ -115,33 +115,6 @@ function chainName(chain: string | number | undefined): string {
   return String(chain);
 }
 
-/** ts may be seconds (small) or ms (large) — normalise to ms. */
-function tsToMs(ts: number): number {
-  if (!Number.isFinite(ts) || ts <= 0) return 0;
-  // ~1e12 ms == year 2001; anything below that is almost certainly seconds.
-  return ts > 1e12 ? ts : ts * 1000;
-}
-
-function relTime(ts: number): string {
-  const ms = tsToMs(ts);
-  if (!ms) return "";
-  const diff = Date.now() - ms;
-  const abs = Math.abs(diff);
-  const mins = Math.round(abs / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.round(hrs / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Date(ms).toLocaleDateString();
-}
-
-function absTime(ts: number): string {
-  const ms = tsToMs(ts);
-  return ms ? new Date(ms).toLocaleString() : "";
-}
-
 function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -307,28 +280,6 @@ function OverviewTab({
 
 // ─── Incoming transfers (deposit-scanner feed) ──────────────────
 
-function DepositStatusBadge({ status }: { status: string }) {
-  if (status === "credited") {
-    return (
-      <Badge className="gap-1 border-transparent bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
-        <CircleCheck className="h-3 w-3" /> Credited
-      </Badge>
-    );
-  }
-  if (status === "duplicate") {
-    return (
-      <Badge variant="outline" className="gap-1 text-muted-foreground">
-        <Info className="h-3 w-3" /> Duplicate
-      </Badge>
-    );
-  }
-  return (
-    <Badge variant="outline" className="text-muted-foreground">
-      {status}
-    </Badge>
-  );
-}
-
 function TxHashCell({ txhash }: { txhash: string }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -397,18 +348,14 @@ function IncomingTransfers() {
             <div className="space-y-2">
               {deposits.map((d) => (
                 <div
-                  key={`${d.txhash}-${d.log_index}-${d.seq}`}
+                  key={`${d.txhash}-${d.log_index}`}
                   className="rounded-lg border p-3 text-sm"
                 >
                   <div className="flex items-center justify-between">
                     <span className="font-semibold tabular-nums">
                       {fmtAmount(d.amount)} {d.asset}
                     </span>
-                    <DepositStatusBadge status={d.status} />
-                  </div>
-                  <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
-                    <span>{chainName(d.chain)}</span>
-                    <span title={absTime(d.ts)}>{relTime(d.ts)}</span>
+                    <span className="text-xs text-muted-foreground">{chainName(d.chain)}</span>
                   </div>
                   <div className="mt-1">
                     <TxHashCell txhash={d.txhash} />
@@ -424,15 +371,13 @@ function IncomingTransfers() {
                     <th className="py-2 pr-3 font-medium">Chain</th>
                     <th className="py-2 pr-3 font-medium">Asset</th>
                     <th className="py-2 pr-3 text-right font-medium">Amount</th>
-                    <th className="py-2 pr-3 font-medium">Tx</th>
-                    <th className="py-2 pr-3 font-medium">Status</th>
-                    <th className="py-2 text-right font-medium">Time</th>
+                    <th className="py-2 font-medium">Tx</th>
                   </tr>
                 </thead>
                 <tbody>
                   {deposits.map((d) => (
                     <tr
-                      key={`${d.txhash}-${d.log_index}-${d.seq}`}
+                      key={`${d.txhash}-${d.log_index}`}
                       className="border-b last:border-0"
                     >
                       <td className="py-2 pr-3">{chainName(d.chain)}</td>
@@ -440,14 +385,8 @@ function IncomingTransfers() {
                       <td className="py-2 pr-3 text-right tabular-nums">
                         {fmtAmount(d.amount)}
                       </td>
-                      <td className="py-2 pr-3">
+                      <td className="py-2">
                         <TxHashCell txhash={d.txhash} />
-                      </td>
-                      <td className="py-2 pr-3">
-                        <DepositStatusBadge status={d.status} />
-                      </td>
-                      <td className="py-2 text-right text-muted-foreground" title={absTime(d.ts)}>
-                        {relTime(d.ts)}
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -139,9 +139,9 @@ const MARGIN_CONFIG_FIELDS: {
 ];
 
 // Compact maker/taker/liquidation fee schedule card. Sourced from the
-// /me/fees/schedule route; 404s until the exchange edge deploys, in which
-// case the card hides itself entirely (retry:false, graceful). When the
-// backend flags the row as a stub it is labelled clearly as venue defaults.
+// /me/fees/schedule route (per-symbol); 404s until the exchange edge deploys,
+// in which case the card hides itself entirely (retry:false, graceful). When
+// the backend has no engine-configured row it echoes venue-default rates.
 function useIsMobile(bp = 767): boolean {
   const [m, setM] = useState(
     () =>
@@ -157,11 +157,12 @@ function useIsMobile(bp = 767): boolean {
   return m;
 }
 
-function FeeSchedulePanel() {
+function FeeSchedulePanel({ symbolId }: { symbolId: number }) {
   const isMobile = useIsMobile();
   const q = useQuery({
-    queryKey: ["fees", "schedule"],
-    queryFn: getFeeSchedule,
+    queryKey: ["fees", "schedule", symbolId],
+    queryFn: () => getFeeSchedule(symbolId),
+    enabled: symbolId > 0,
     retry: false,
     staleTime: 60_000,
   });
@@ -169,11 +170,11 @@ function FeeSchedulePanel() {
   // Hide entirely when the route isn't available on this backend yet.
   if (q.isError || (!q.isLoading && !q.data)) return null;
 
-  const row = q.data?.schedule?.[0];
-  const maker = row?.maker_fee_bps ?? q.data?.maker_fee_bps;
-  const taker = row?.taker_fee_bps ?? q.data?.taker_fee_bps;
-  const liq = row?.liquidation_fee_bps ?? q.data?.liquidation_fee_bps;
-  const isStub = q.data?.stub === true || q.data?.source === "stub";
+  const maker = q.data?.maker_fee_bps;
+  const taker = q.data?.taker_fee_bps;
+  const liq = q.data?.liquidation_fee_bps;
+  const venueDefault = q.data?.source === "venue_default" || q.data?.configured === false;
+  const sourceLabel = venueDefault ? "venue default" : "engine";
 
   return (
     <Card className="mt-3">
@@ -182,14 +183,17 @@ function FeeSchedulePanel() {
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Fee schedule
           </span>
-          {isStub && (
-            <Badge
-              variant="outline"
-              className="gap-1 border-amber-500/40 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
-            >
-              venue defaults
-            </Badge>
-          )}
+          <Badge
+            variant="outline"
+            className={cn(
+              "gap-1 text-[10px]",
+              venueDefault
+                ? "border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                : "border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+            )}
+          >
+            {sourceLabel}
+          </Badge>
         </div>
         {q.isLoading ? (
           <p className="py-2 text-center text-xs text-muted-foreground">Loading…</p>
@@ -209,10 +213,10 @@ function FeeSchedulePanel() {
             </div>
           </div>
         )}
-        {isStub && (
+        {venueDefault && (
           <p className="text-[10px] text-muted-foreground">
-            Shown fees are venue defaults; per-symbol rates apply when the engine
-            exposes a per-caller fee query.
+            Shown fees are venue defaults; engine-configured per-symbol rates
+            apply once this symbol has a fee schedule set.
           </p>
         )}
       </CardContent>
@@ -1254,7 +1258,7 @@ export function TradeTicket({
         {msg && <p className={cn("text-xs font-mono", msg.error ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400")}>{msg.text}</p>}
       </CardContent>
     </Card>
-    <FeeSchedulePanel />
+    <FeeSchedulePanel symbolId={symbolId} />
     <MarginConfigPanel symbolId={symbolId} />
     </div>
   );


### PR DESCRIPTION
Follows #208/#209. The gap frontend was built against **stub** shapes; the **real backend is now merged** (testlogon-cpp: custody sub-accounts + atomic vault↔vault transfer, real deposit history, engine-backed fee schedule, and the fund/settle spot+margin bridge; custody-mpc-cpp `c62dfa8`). This repoints web + Android to the real contracts and removes the now-false "Simulated · not settled" badges.

## Changes
- **Bridge** — dead `POST /me/custody/transfer {direction,asset}` replaced by the four real routes `fund-spot`/`settle-spot`/`fund-margin`/`settle-margin` `{token,amount}` (atomic, reversal-on-failure). UI = fund/settle × spot/margin; 422 (`insufficient_spot_available`) handled.
- **Sub-accounts** — real `{label,vault}` list, `{created,label,vault}` create, and the real atomic transfer `{transferred,from,to,from_balance,to_balance}`. Simulated badge removed.
- **Deposits** — real item `{vault,asset,amount,chain,txhash,log_index,dedup_key}` (dropped the stub's status/seq/ts).
- **Fees** — `GET /me/fees/schedule?symbolid=<n>` real engine shape (`source`/`configured`; engine vs venue_default).
- The **fills-fee estimate** stays the one honestly-labeled deferred stub (per-fill fee needs matching-engine hot-path work).

## Verification
- Web: `npm run build` + `tsc --noEmit` = 0.
- Android: `assembleDebug` + `testDebugUnitTest` green, incl. new `data/custody` + `data/exchange` DTO/mapper contract tests.
- The real edge routes are **not yet deployed to prod**, so the UI still degrades gracefully on 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
