### PR TITLE
feat: exchange features — admin engine config, prediction markets, staking & auctions (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -132,5 +132,28 @@ interface TradingApi {
     /** ADMIN: bind a symbol to its base/quote asset ids (defines a spot pair). */
     @POST("me/spot_config")
     suspend fun spotConfig(@Body body: SpotConfigDto): EngineConfigAckDto
+
+    // ==== Admin prediction-markets (exchange-admin-config); admin-gated; ack {status,...}. ====
+    // Not deployed to prod -> the repository degrades on 404 (like the engine-config routes).
+
+    /** ADMIN: configure a binary PM on a symbol (face_value>1, optional designated resolver). */
+    @POST("me/pm_config")
+    suspend fun pmConfig(@Body body: PmConfigDto): PmConfigAckDto
+
+    /** ADMIN: configure a categorical (grouped) PM: a group of mutually-exclusive outcome symbols. */
+    @POST("me/pm_group_config")
+    suspend fun pmGroupConfig(@Body body: PmGroupConfigDto): PmConfigAckDto
+
+    /** ADMIN (designated resolver): resolve a binary PM to yes/no. 403 if the caller is not the resolver. */
+    @POST("me/pm_resolve")
+    suspend fun pmResolve(@Body body: PmResolveDto): PmConfigAckDto
+
+    /** ADMIN (designated resolver): resolve a categorical PM to its winning outcome symbol. */
+    @POST("me/pm_group_resolve")
+    suspend fun pmGroupResolve(@Body body: PmGroupResolveDto): PmConfigAckDto
+
+    /** ADMIN: the resolution audit log (symbol/group, outcome, resolver, ts, source). 404 -> empty. */
+    @GET("me/pm_resolutions")
+    suspend fun getPmResolutions(): List<PmResolutionDto>
 }
 

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -155,5 +155,25 @@ interface TradingApi {
     /** ADMIN: the resolution audit log (symbol/group, outcome, resolver, ts, source). 404 -> empty. */
     @GET("me/pm_resolutions")
     suspend fun getPmResolutions(): List<PmResolutionDto>
+
+    // ==== Trader staking + auctions (peer mechanisms). Ack JSON carries the created id + status.
+    // Not deployed to prod yet -> the repository degrades on 404 (like the engine-config routes).
+    // There is NO list/GET for open stake requests or auctions -> action forms surface the returned id. ====
+
+    /** Create a stake request (offer your position as collateral for others to stake against). */
+    @POST("me/stake_request")
+    suspend fun stakeRequest(@Body body: StakeRequestDto): StakeAuctionAckDto
+
+    /** Offer collateral to stake against an open stake request (by request id). */
+    @POST("me/stake_offer")
+    suspend fun stakeOffer(@Body body: StakeOfferDto): StakeAuctionAckDto
+
+    /** Create an auction to sell a position quantity (optional reserve price + duration). */
+    @POST("me/auction_request")
+    suspend fun auctionRequest(@Body body: AuctionRequestDto): StakeAuctionAckDto
+
+    /** Place a bid on an open auction (by auction id). */
+    @POST("me/auction_bid")
+    suspend fun auctionBid(@Body body: AuctionBidDto): StakeAuctionAckDto
 }
 

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -106,5 +106,31 @@ interface TradingApi {
     /** This account's recent perpetual funding payments (signed: negative=paid, positive=received). 404 when undeployed. */
     @GET("me/funding/payments")
     suspend fun getFundingPayments(): FundingPaymentsDto
+
+    // ==== Admin engine-config (exchange-admin-config); all admin-only, ack {status,...}; 404 -> degrade. ====
+
+    /** ADMIN: set per-symbol matching algorithm (0 = price-time; 1+ = pro-rata/specialist). */
+    @POST("me/matching_algo")
+    suspend fun matchingAlgo(@Body body: MatchingAlgoDto): EngineConfigAckDto
+
+    /** ADMIN: define a two-leg spread instrument. */
+    @POST("me/spread_config")
+    suspend fun spreadConfig(@Body body: SpreadConfigDto): EngineConfigAckDto
+
+    /** ADMIN: per-symbol trading-parameter / risk-limit overrides. */
+    @POST("me/trading_params")
+    suspend fun tradingParams(@Body body: TradingParamsDto): EngineConfigAckDto
+
+    /** ADMIN: aggregate notional cap over a rolling window. */
+    @POST("me/risk_config")
+    suspend fun riskConfig(@Body body: RiskConfigDto): EngineConfigAckDto
+
+    /** ADMIN: publish a spot index (mark) price for a symbol. */
+    @POST("me/spot_index")
+    suspend fun spotIndex(@Body body: SpotIndexDto): EngineConfigAckDto
+
+    /** ADMIN: bind a symbol to its base/quote asset ids (defines a spot pair). */
+    @POST("me/spot_config")
+    suspend fun spotConfig(@Body body: SpotConfigDto): EngineConfigAckDto
 }
 

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -557,3 +557,72 @@ data class PmResolutionDto(
     @com.testlogon.android.core.network.json.LenientLong @Json(name = "ts") val ts: Long? = null,
     @Json(name = "source") val source: String? = null,
 )
+
+// ==== Trader staking + auctions (peer mechanisms) ====
+// Two peer trader mechanisms. All four POST routes ack with a JSON body carrying a status + the
+// created id (request_id / auction_id). Numeric ids may be stringified by the edge -> lenient. Not
+// deployed to prod yet -> the repository degrades on 404 (like the engine-config routes). There is NO
+// list/GET for open stake requests or auctions, so the forms surface the returned id.
+
+/**
+ * POST me/stake_request: create a stake request. [minCollateral] is the minimum collateral an offeror
+ * must post; [maxStakePct] caps the stake percentage; [lockupSeconds] / [durationSeconds] bound the
+ * lockup and request lifetime. [symbolId] is optional (defaults to the ticket symbol on the wire).
+ */
+@JsonClass(generateAdapter = true)
+data class StakeRequestDto(
+    @Json(name = "symbolid") val symbolId: Int? = null,
+    @Json(name = "min_collateral") val minCollateral: Long,
+    @Json(name = "max_stake_pct") val maxStakePct: Long,
+    @Json(name = "lockup_seconds") val lockupSeconds: Int,
+    @Json(name = "duration_seconds") val durationSeconds: Int,
+)
+
+/** POST me/stake_offer: offer collateral to stake against an open stake request (by [requestId]). */
+@JsonClass(generateAdapter = true)
+data class StakeOfferDto(
+    @Json(name = "request_id") val requestId: Long,
+    @Json(name = "collateral_amount") val collateralAmount: Long,
+    @Json(name = "stake_pct") val stakePct: Long,
+)
+
+/**
+ * POST me/auction_request: auction off a position [qty]. [reservePrice] is an optional floor; the
+ * [durationSeconds] bounds the auction lifetime. [symbolId] is optional (defaults to the ticket symbol).
+ */
+@JsonClass(generateAdapter = true)
+data class AuctionRequestDto(
+    @Json(name = "symbolid") val symbolId: Int? = null,
+    @Json(name = "qty") val qty: Int,
+    @Json(name = "reserve_price") val reservePrice: Long? = null,
+    @Json(name = "duration_seconds") val durationSeconds: Int? = null,
+)
+
+/** POST me/auction_bid: bid [price] for [qty] on an open auction (by [auctionId]). */
+@JsonClass(generateAdapter = true)
+data class AuctionBidDto(
+    @Json(name = "auction_id") val auctionId: Long,
+    @Json(name = "price") val price: Long,
+    @Json(name = "qty") val qty: Int,
+)
+
+/**
+ * Shared ack for the four staking/auction routes. status = "ack"/"ok"/... ; the created id comes back
+ * as [requestId] (stake_request) or [auctionId] (auction_request); offer/bid acks may echo the parent
+ * id + an [offerId]/[bidId]. All numeric fields lenient (the edge may stringify) + all optional so an
+ * unexpected/partial shape still parses. detail/error/note/reason carry any engine message.
+ */
+@JsonClass(generateAdapter = true)
+data class StakeAuctionAckDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "type") val type: String? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "request_id") val requestId: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "auction_id") val auctionId: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "offer_id") val offerId: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "bid_id") val bidId: Long? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "result") val result: Int? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+    @Json(name = "note") val note: String? = null,
+    @Json(name = "reason") val reason: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -487,3 +487,73 @@ data class EngineConfigAckDto(
     val error: String? = null,
     val note: String? = null,
 )
+
+
+// ==== Admin prediction-markets (exchange-admin-config) — POST me/pm_config, pm_group_config,
+// pm_resolve, pm_group_resolve; GET me/pm_resolutions. All admin-only; not deployed to prod yet ->
+// the repository degrades on 404 (see the engine-config routes). ====
+
+/** POST me/pm_config: configure a binary PM on [symbolId]. [faceValue] must be > 1. */
+@JsonClass(generateAdapter = true)
+data class PmConfigDto(
+    @Json(name = "symbolid") val symbolId: Int,
+    @Json(name = "face_value") val faceValue: Long,
+    @Json(name = "resolver") val resolver: String? = null,
+)
+
+/** POST me/pm_group_config: configure a categorical PM — a group of mutually-exclusive outcome symbols. */
+@JsonClass(generateAdapter = true)
+data class PmGroupConfigDto(
+    @Json(name = "group_id") val groupId: Int,
+    @Json(name = "outcomes") val outcomes: List<Int>,
+    @Json(name = "face_value") val faceValue: Long,
+    @Json(name = "resolver") val resolver: String? = null,
+)
+
+/** POST me/pm_resolve: resolve a binary PM. [outcome] = "yes" | "no". 403 if not the designated resolver. */
+@JsonClass(generateAdapter = true)
+data class PmResolveDto(
+    @Json(name = "symbolid") val symbolId: Int,
+    @Json(name = "outcome") val outcome: String,
+    @Json(name = "source") val source: String? = null,
+)
+
+/** POST me/pm_group_resolve: resolve a categorical PM by its winning outcome symbol id. */
+@JsonClass(generateAdapter = true)
+data class PmGroupResolveDto(
+    @Json(name = "group_id") val groupId: Int,
+    @Json(name = "winning_symbolid") val winningSymbolId: Int,
+    @Json(name = "source") val source: String? = null,
+)
+
+/**
+ * Shared PM admin ack ({status, ...}). status = "ack" | "rejected"; result == 0 (when present) means
+ * applied. detail/error/note carry the engine message (e.g. the resolver 403 detail). Tolerant.
+ */
+@JsonClass(generateAdapter = true)
+data class PmConfigAckDto(
+    val status: String? = null,
+    val type: String? = null,
+    @Json(name = "symbolid") val symbolId: Int? = null,
+    @Json(name = "group_id") val groupId: Int? = null,
+    val result: Int? = null,
+    val detail: String? = null,
+    val error: String? = null,
+    val note: String? = null,
+)
+
+/**
+ * One row from GET me/pm_resolutions. A binary resolution carries [symbolId] + [outcome] ("yes"/"no");
+ * a categorical one carries [groupId] + the winning [symbolId]. [ts] is a (ns/ms) timestamp; numeric
+ * fields are lenient since the edge may stringify them.
+ */
+@JsonClass(generateAdapter = true)
+data class PmResolutionDto(
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "symbolid") val symbolId: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "group_id") val groupId: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "winning_symbolid") val winningSymbolId: Int? = null,
+    @Json(name = "outcome") val outcome: String? = null,
+    @Json(name = "resolver_id") val resolverId: String? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "ts") val ts: Long? = null,
+    @Json(name = "source") val source: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -415,3 +415,75 @@ data class FundingPaymentsDto(
     @com.testlogon.android.core.network.json.LenientInt @Json(name = "count") val count: Int? = null,
     @Json(name = "funding") val funding: List<FundingPaymentDto>? = null,
 )
+
+// ==== Admin engine-config (exchange-admin-config) — POST me/{matching_algo,spread_config,...} ====
+// All six are admin-only and return the shared engine ack [EngineConfigAckDto] ({status, ...}).
+// Not deployed to prod yet -> the repository degrades on 404 (see marginConfig-style handling).
+
+/** POST me/matching_algo: set the per-symbol matching algorithm (0 = price-time; 1+ = pro-rata/specialist). */
+@JsonClass(generateAdapter = true)
+data class MatchingAlgoDto(
+    @Json(name = "symbolid") val symbolId: Int,
+    @Json(name = "algo") val algo: Int,
+    @Json(name = "specialist_mpid") val specialistMpid: String? = null,
+    @Json(name = "specialist_pct") val specialistPct: Int? = null,
+)
+
+/** POST me/spread_config: define a two-leg spread instrument (leg1/leg2 symbol ids + signed ratios). */
+@JsonClass(generateAdapter = true)
+data class SpreadConfigDto(
+    @Json(name = "spread_symbolid") val spreadSymbolId: Int,
+    @Json(name = "leg1") val leg1: Int,
+    @Json(name = "leg2") val leg2: Int,
+    @Json(name = "leg1_ratio") val leg1Ratio: Int? = null,
+    @Json(name = "leg2_ratio") val leg2Ratio: Int? = null,
+)
+
+/** POST me/trading_params: per-symbol risk-limit / trading-parameter overrides (all optional but symbolid). */
+@JsonClass(generateAdapter = true)
+data class TradingParamsDto(
+    @Json(name = "symbolid") val symbolId: Int,
+    @Json(name = "max_qty") val maxQty: Int? = null,
+    @Json(name = "max_notional") val maxNotional: Long? = null,
+    @Json(name = "price_band_pct") val priceBandPct: Long? = null,
+    @Json(name = "circuit_breaker_pct") val circuitBreakerPct: Long? = null,
+    @Json(name = "min_block_size") val minBlockSize: Int? = null,
+)
+
+/** POST me/risk_config: an aggregate notional cap over a rolling window (optionally scoped to an mpid). */
+@JsonClass(generateAdapter = true)
+data class RiskConfigDto(
+    @Json(name = "max_notional") val maxNotional: Long,
+    @Json(name = "window_seconds") val windowSeconds: Int,
+    @Json(name = "mpid") val mpid: String? = null,
+)
+
+/** POST me/spot_index: publish a spot index (mark) price for a symbol. */
+@JsonClass(generateAdapter = true)
+data class SpotIndexDto(
+    @Json(name = "symbolid") val symbolId: Int,
+    @Json(name = "spot_index_price") val spotIndexPrice: Long,
+)
+
+/** POST me/spot_config: bind a symbol to its base/quote asset ids (defines a spot pair). */
+@JsonClass(generateAdapter = true)
+data class SpotConfigDto(
+    @Json(name = "symbolid") val symbolId: Int,
+    @Json(name = "base_asset") val baseAsset: Int,
+    @Json(name = "quote_asset") val quoteAsset: Int,
+)
+
+/**
+ * Shared engine-config ack for the six admin routes. status = "ack" | "rejected"; result == 0 (when
+ * present) means applied. detail/error/note carry any engine message. Tolerant: all fields optional.
+ */
+@JsonClass(generateAdapter = true)
+data class EngineConfigAckDto(
+    val status: String? = null,
+    val type: String? = null,
+    @Json(name = "symbolid") val symbolId: Int? = null,
+    val result: Int? = null,
+    val detail: String? = null,
+    val error: String? = null,
+    val note: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -467,3 +467,63 @@ fun EngineConfigAckDto.toDomain(): EngineConfigAck = EngineConfigAck(
     result = result,
     message = detail ?: error ?: note,
 )
+
+
+// ==== Admin prediction-markets (exchange-admin-config) — domain + mappers ====
+
+/**
+ * Result of an admin PM config/resolve apply (pm_config / pm_group_config / pm_resolve /
+ * pm_group_resolve). [applied] is true when status == "ack" and, if a [result] is present, it is 0.
+ * [message] surfaces any detail/error/note (e.g. the resolver 403 message on pm_resolve).
+ */
+data class PmConfigAck(
+    val applied: Boolean,
+    val symbolId: Int?,
+    val groupId: Int?,
+    val result: Int?,
+    val message: String?,
+)
+
+fun PmConfigAckDto.toDomain(): PmConfigAck = PmConfigAck(
+    applied = status == "ack" && (result ?: 0) == 0,
+    symbolId = symbolId,
+    groupId = groupId,
+    result = result,
+    message = detail ?: error ?: note,
+)
+
+/**
+ * One PM resolution audit row. [isGroup] is true for a categorical resolution (carries [groupId] +
+ * [winningSymbolId]); otherwise it is a binary resolution (carries [symbolId] + [outcomeYes]).
+ */
+data class PmResolution(
+    val symbolId: Int?,
+    val groupId: Int?,
+    val winningSymbolId: Int?,
+    val outcome: String?,
+    val resolverId: String,
+    val ts: Long,
+    val source: String,
+) {
+    val isGroup: Boolean get() = groupId != null
+    /** For a binary row: true = YES won, false = NO, null when the outcome string is absent/unknown. */
+    val outcomeYes: Boolean? get() = when (outcome?.lowercase()) {
+        "yes" -> true
+        "no" -> false
+        else -> null
+    }
+    /** A compact human label for the resolved market ("#<sym>" or "group <id>"). */
+    val marketLabel: String get() = if (isGroup) "group $groupId" else "#" + (symbolId ?: 0)
+    /** A compact human label for the outcome (YES/NO for binary; the winning symbol for categorical). */
+    val outcomeLabel: String get() = if (isGroup) "#" + (winningSymbolId ?: 0) else (outcome?.uppercase() ?: "--")
+}
+
+fun PmResolutionDto.toDomain(): PmResolution = PmResolution(
+    symbolId = symbolId,
+    groupId = groupId,
+    winningSymbolId = winningSymbolId,
+    outcome = outcome,
+    resolverId = resolverId.orEmpty(),
+    ts = ts ?: 0L,
+    source = source.orEmpty(),
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -527,3 +527,54 @@ fun PmResolutionDto.toDomain(): PmResolution = PmResolution(
     ts = ts ?: 0L,
     source = source.orEmpty(),
 )
+
+// ==== Trader staking + auctions (peer mechanisms) — domain + mapper ====
+
+/** Which peer mechanism produced an ack (drives the id label the UI surfaces). */
+enum class StakeAuctionKind { STAKE_REQUEST, STAKE_OFFER, AUCTION_REQUEST, AUCTION_BID }
+
+/**
+ * Result of a staking/auction action. [accepted] is true when the engine acked (status ack/ok and,
+ * if a numeric result is present, it is 0). [createdId] is the most relevant id the engine returned
+ * for [kind] (request_id / auction_id / offer_id / bid_id), surfaced prominently by the UI. [message]
+ * carries any engine detail/error/note.
+ */
+data class StakeAuctionAck(
+    val accepted: Boolean,
+    val kind: StakeAuctionKind,
+    val createdId: Long?,
+    val message: String?,
+) {
+    /** Human label for [createdId], e.g. "Request #42" / "Auction #7" (null when no id came back). */
+    val idLabel: String? get() = createdId?.let {
+        when (kind) {
+            StakeAuctionKind.STAKE_REQUEST -> "Request #$it"
+            StakeAuctionKind.STAKE_OFFER -> "Offer #$it"
+            StakeAuctionKind.AUCTION_REQUEST -> "Auction #$it"
+            StakeAuctionKind.AUCTION_BID -> "Bid #$it"
+        }
+    }
+}
+
+private fun ackAccepted(status: String?, result: Int?): Boolean {
+    val ok = when (status?.lowercase()) {
+        "ack", "ok", "accepted", "created" -> true
+        else -> false
+    }
+    return ok && (result ?: 0) == 0
+}
+
+fun StakeAuctionAckDto.toDomain(kind: StakeAuctionKind): StakeAuctionAck {
+    val createdId = when (kind) {
+        StakeAuctionKind.STAKE_REQUEST -> requestId
+        StakeAuctionKind.STAKE_OFFER -> offerId ?: requestId
+        StakeAuctionKind.AUCTION_REQUEST -> auctionId
+        StakeAuctionKind.AUCTION_BID -> bidId ?: auctionId
+    }
+    return StakeAuctionAck(
+        accepted = ackAccepted(status, result),
+        kind = kind,
+        createdId = createdId,
+        message = detail ?: error ?: note ?: reason,
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -448,3 +448,22 @@ fun FundingPaymentsDto.toDomain(): FundingPayments = FundingPayments(
     payments = funding.orEmpty().map { it.toDomain() },
     count = count ?: funding.orEmpty().size,
 )
+
+/**
+ * Result of an admin engine-config apply (matching_algo / spread_config / trading_params / risk_config
+ * / spot_index / spot_config). [applied] is true when status == "ack" and, if the engine returns a
+ * [result], it is 0. [message] surfaces any detail/error/note the engine sent back.
+ */
+data class EngineConfigAck(
+    val applied: Boolean,
+    val symbolId: Int?,
+    val result: Int?,
+    val message: String?,
+)
+
+fun EngineConfigAckDto.toDomain(): EngineConfigAck = EngineConfigAck(
+    applied = status == "ack" && (result ?: 0) == 0,
+    symbolId = symbolId,
+    result = result,
+    message = detail ?: error ?: note,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -65,6 +65,14 @@ interface TradingRepository {
     suspend fun liquidations(): ApiResult<Liquidations>
     /** Recent perpetual funding payments (404 -> empty feed). */
     suspend fun fundingPayments(): ApiResult<FundingPayments>
+
+    // ---- ADMIN engine-config (exchange-admin-config); 404 (undeployed) -> un-applied ack. ----
+    suspend fun matchingAlgo(symbolId: Int, algo: Int, specialistMpid: String?, specialistPct: Int?): ApiResult<EngineConfigAck>
+    suspend fun spreadConfig(spreadSymbolId: Int, leg1: Int, leg2: Int, leg1Ratio: Int?, leg2Ratio: Int?): ApiResult<EngineConfigAck>
+    suspend fun tradingParams(symbolId: Int, maxQty: Int?, maxNotional: Long?, priceBandPct: Long?, circuitBreakerPct: Long?, minBlockSize: Int?): ApiResult<EngineConfigAck>
+    suspend fun riskConfig(maxNotional: Long, windowSeconds: Int, mpid: String?): ApiResult<EngineConfigAck>
+    suspend fun spotIndex(symbolId: Int, spotIndexPrice: Long): ApiResult<EngineConfigAck>
+    suspend fun spotConfig(symbolId: Int, baseAsset: Int, quoteAsset: Int): ApiResult<EngineConfigAck>
 }
 
 @Singleton
@@ -184,6 +192,28 @@ class TradingRepositoryImpl @Inject constructor(
 
     override suspend fun fundingPayments(): ApiResult<FundingPayments> =
         withContext(io) { emptyOn404(FundingPayments(emptyList(), 0)) { api.getFundingPayments().toDomain() } }
+
+    // ---- ADMIN engine-config. Not deployed to prod -> a 404 folds to an un-applied ack. ----
+
+    private val notDeployedAck = EngineConfigAck(applied = false, symbolId = null, result = null, message = "Engine config endpoint not deployed")
+
+    override suspend fun matchingAlgo(symbolId: Int, algo: Int, specialistMpid: String?, specialistPct: Int?): ApiResult<EngineConfigAck> =
+        withContext(io) { emptyOn404(notDeployedAck) { api.matchingAlgo(MatchingAlgoDto(symbolId, algo, specialistMpid, specialistPct)).toDomain() } }
+
+    override suspend fun spreadConfig(spreadSymbolId: Int, leg1: Int, leg2: Int, leg1Ratio: Int?, leg2Ratio: Int?): ApiResult<EngineConfigAck> =
+        withContext(io) { emptyOn404(notDeployedAck) { api.spreadConfig(SpreadConfigDto(spreadSymbolId, leg1, leg2, leg1Ratio, leg2Ratio)).toDomain() } }
+
+    override suspend fun tradingParams(symbolId: Int, maxQty: Int?, maxNotional: Long?, priceBandPct: Long?, circuitBreakerPct: Long?, minBlockSize: Int?): ApiResult<EngineConfigAck> =
+        withContext(io) { emptyOn404(notDeployedAck) { api.tradingParams(TradingParamsDto(symbolId, maxQty, maxNotional, priceBandPct, circuitBreakerPct, minBlockSize)).toDomain() } }
+
+    override suspend fun riskConfig(maxNotional: Long, windowSeconds: Int, mpid: String?): ApiResult<EngineConfigAck> =
+        withContext(io) { emptyOn404(notDeployedAck) { api.riskConfig(RiskConfigDto(maxNotional, windowSeconds, mpid)).toDomain() } }
+
+    override suspend fun spotIndex(symbolId: Int, spotIndexPrice: Long): ApiResult<EngineConfigAck> =
+        withContext(io) { emptyOn404(notDeployedAck) { api.spotIndex(SpotIndexDto(symbolId, spotIndexPrice)).toDomain() } }
+
+    override suspend fun spotConfig(symbolId: Int, baseAsset: Int, quoteAsset: Int): ApiResult<EngineConfigAck> =
+        withContext(io) { emptyOn404(notDeployedAck) { api.spotConfig(SpotConfigDto(symbolId, baseAsset, quoteAsset)).toDomain() } }
 
     /**
      * Like [apiCall] but a 404 (endpoint not deployed yet) folds to a Success carrying [emptyValue],

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -73,6 +73,13 @@ interface TradingRepository {
     suspend fun riskConfig(maxNotional: Long, windowSeconds: Int, mpid: String?): ApiResult<EngineConfigAck>
     suspend fun spotIndex(symbolId: Int, spotIndexPrice: Long): ApiResult<EngineConfigAck>
     suspend fun spotConfig(symbolId: Int, baseAsset: Int, quoteAsset: Int): ApiResult<EngineConfigAck>
+
+    // ---- ADMIN prediction-markets (exchange-admin-config); 404 (undeployed) -> un-applied ack / empty log. ----
+    suspend fun pmConfig(symbolId: Int, faceValue: Long, resolver: String?): ApiResult<PmConfigAck>
+    suspend fun pmGroupConfig(groupId: Int, outcomes: List<Int>, faceValue: Long, resolver: String?): ApiResult<PmConfigAck>
+    suspend fun pmResolve(symbolId: Int, outcome: String, source: String?): ApiResult<PmConfigAck>
+    suspend fun pmGroupResolve(groupId: Int, winningSymbolId: Int, source: String?): ApiResult<PmConfigAck>
+    suspend fun pmResolutions(): ApiResult<List<PmResolution>>
 }
 
 @Singleton
@@ -214,6 +221,25 @@ class TradingRepositoryImpl @Inject constructor(
 
     override suspend fun spotConfig(symbolId: Int, baseAsset: Int, quoteAsset: Int): ApiResult<EngineConfigAck> =
         withContext(io) { emptyOn404(notDeployedAck) { api.spotConfig(SpotConfigDto(symbolId, baseAsset, quoteAsset)).toDomain() } }
+
+    // ---- ADMIN prediction-markets. Not deployed to prod -> a 404 folds to an un-applied ack / empty log. ----
+
+    private val notDeployedPmAck = PmConfigAck(applied = false, symbolId = null, groupId = null, result = null, message = "PM admin endpoint not deployed")
+
+    override suspend fun pmConfig(symbolId: Int, faceValue: Long, resolver: String?): ApiResult<PmConfigAck> =
+        withContext(io) { emptyOn404(notDeployedPmAck) { api.pmConfig(PmConfigDto(symbolId, faceValue, resolver)).toDomain() } }
+
+    override suspend fun pmGroupConfig(groupId: Int, outcomes: List<Int>, faceValue: Long, resolver: String?): ApiResult<PmConfigAck> =
+        withContext(io) { emptyOn404(notDeployedPmAck) { api.pmGroupConfig(PmGroupConfigDto(groupId, outcomes, faceValue, resolver)).toDomain() } }
+
+    override suspend fun pmResolve(symbolId: Int, outcome: String, source: String?): ApiResult<PmConfigAck> =
+        withContext(io) { emptyOn404(notDeployedPmAck) { api.pmResolve(PmResolveDto(symbolId, outcome, source)).toDomain() } }
+
+    override suspend fun pmGroupResolve(groupId: Int, winningSymbolId: Int, source: String?): ApiResult<PmConfigAck> =
+        withContext(io) { emptyOn404(notDeployedPmAck) { api.pmGroupResolve(PmGroupResolveDto(groupId, winningSymbolId, source)).toDomain() } }
+
+    override suspend fun pmResolutions(): ApiResult<List<PmResolution>> =
+        withContext(io) { emptyOn404(emptyList<PmResolution>()) { api.getPmResolutions().map { it.toDomain() } } }
 
     /**
      * Like [apiCall] but a 404 (endpoint not deployed yet) folds to a Success carrying [emptyValue],

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -80,6 +80,12 @@ interface TradingRepository {
     suspend fun pmResolve(symbolId: Int, outcome: String, source: String?): ApiResult<PmConfigAck>
     suspend fun pmGroupResolve(groupId: Int, winningSymbolId: Int, source: String?): ApiResult<PmConfigAck>
     suspend fun pmResolutions(): ApiResult<List<PmResolution>>
+
+    // ---- Trader staking + auctions (peer mechanisms); 404 (undeployed) -> un-applied ack. ----
+    suspend fun stakeRequest(symbolId: Int?, minCollateral: Long, maxStakePct: Long, lockupSeconds: Int, durationSeconds: Int): ApiResult<StakeAuctionAck>
+    suspend fun stakeOffer(requestId: Long, collateralAmount: Long, stakePct: Long): ApiResult<StakeAuctionAck>
+    suspend fun auctionRequest(symbolId: Int?, qty: Int, reservePrice: Long?, durationSeconds: Int?): ApiResult<StakeAuctionAck>
+    suspend fun auctionBid(auctionId: Long, price: Long, qty: Int): ApiResult<StakeAuctionAck>
 }
 
 @Singleton
@@ -240,6 +246,39 @@ class TradingRepositoryImpl @Inject constructor(
 
     override suspend fun pmResolutions(): ApiResult<List<PmResolution>> =
         withContext(io) { emptyOn404(emptyList<PmResolution>()) { api.getPmResolutions().map { it.toDomain() } } }
+
+    // ---- Trader staking + auctions. Not deployed to prod -> a 404 folds to an un-applied ack. ----
+
+    private fun notDeployedStakeAck(kind: StakeAuctionKind) =
+        StakeAuctionAck(accepted = false, kind = kind, createdId = null, message = "Staking/auctions endpoint not deployed")
+
+    override suspend fun stakeRequest(symbolId: Int?, minCollateral: Long, maxStakePct: Long, lockupSeconds: Int, durationSeconds: Int): ApiResult<StakeAuctionAck> =
+        withContext(io) {
+            emptyOn404(notDeployedStakeAck(StakeAuctionKind.STAKE_REQUEST)) {
+                api.stakeRequest(StakeRequestDto(symbolId, minCollateral, maxStakePct, lockupSeconds, durationSeconds)).toDomain(StakeAuctionKind.STAKE_REQUEST)
+            }
+        }
+
+    override suspend fun stakeOffer(requestId: Long, collateralAmount: Long, stakePct: Long): ApiResult<StakeAuctionAck> =
+        withContext(io) {
+            emptyOn404(notDeployedStakeAck(StakeAuctionKind.STAKE_OFFER)) {
+                api.stakeOffer(StakeOfferDto(requestId, collateralAmount, stakePct)).toDomain(StakeAuctionKind.STAKE_OFFER)
+            }
+        }
+
+    override suspend fun auctionRequest(symbolId: Int?, qty: Int, reservePrice: Long?, durationSeconds: Int?): ApiResult<StakeAuctionAck> =
+        withContext(io) {
+            emptyOn404(notDeployedStakeAck(StakeAuctionKind.AUCTION_REQUEST)) {
+                api.auctionRequest(AuctionRequestDto(symbolId, qty, reservePrice, durationSeconds)).toDomain(StakeAuctionKind.AUCTION_REQUEST)
+            }
+        }
+
+    override suspend fun auctionBid(auctionId: Long, price: Long, qty: Int): ApiResult<StakeAuctionAck> =
+        withContext(io) {
+            emptyOn404(notDeployedStakeAck(StakeAuctionKind.AUCTION_BID)) {
+                api.auctionBid(AuctionBidDto(auctionId, price, qty)).toDomain(StakeAuctionKind.AUCTION_BID)
+            }
+        }
 
     /**
      * Like [apiCall] but a 404 (endpoint not deployed yet) folds to a Success carrying [emptyValue],

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -121,6 +121,8 @@ fun TradeTicket(
             MarginConfigPanel(state.marginConfig, viewModel)
             Spacer(Modifier.height(16.dp))
             EngineConfigSection(state, viewModel)
+            Spacer(Modifier.height(16.dp))
+            PmAdminSection(state, viewModel)
         }
     }
 }
@@ -1476,6 +1478,231 @@ private fun TextInputField(label: String, value: String, onValue: (String) -> Un
                 cursorBrush = SolidColor(MarketColors.Accent),
                 modifier = Modifier.fillMaxWidth().testTag("field_$label"),
             )
+        }
+    }
+}
+
+
+/**
+ * Admin prediction-markets section (exchange-admin-config). Compact create/resolve forms for binary +
+ * categorical PMs plus a resolution-history list. isAdmin-gated by the caller. Endpoints 404 until
+ * deployed -> the repository degrades to an un-applied ack surfaced inline; a 403 on resolve (caller is
+ * not the designated resolver) is surfaced as the engine's error message.
+ */
+@Composable
+private fun PmAdminSection(state: TradingUiState, viewModel: TradingViewModel) {
+    Column(modifier = Modifier.fillMaxWidth().testTag("pm_admin_section")) {
+        Text("Prediction markets (admin)", color = MarketColors.Accent, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            "Configure and resolve prediction markets. Resolving requires the designated resolver (else 403).",
+            color = MarketColors.TextSecondary,
+            fontSize = 11.sp,
+        )
+        Spacer(Modifier.height(10.dp))
+        PmCreateBinaryPanel(state.pmCreateBinary, viewModel)
+        Spacer(Modifier.height(12.dp))
+        PmCreateCategoricalPanel(state.pmCreateCategorical, viewModel)
+        Spacer(Modifier.height(12.dp))
+        PmResolveBinaryPanel(state.pmResolveBinary, viewModel)
+        Spacer(Modifier.height(12.dp))
+        PmResolveCategoricalPanel(state.pmResolveCategorical, viewModel)
+        Spacer(Modifier.height(12.dp))
+        PmResolutionHistory(state.pmResolutions, viewModel)
+    }
+}
+
+/** Apply button + inline error/ack feedback for the PM admin forms (mirrors [EngineApply]). */
+@Composable
+private fun PmApply(
+    label: String,
+    canSubmit: Boolean,
+    submitting: Boolean,
+    error: String?,
+    result: com.testlogon.android.data.exchange.PmConfigAck?,
+    testTag: String,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Spacer(Modifier.height(12.dp))
+    Text(
+        text = if (submitting) "Applying" else label,
+        color = if (canSubmit) Color.Black else MarketColors.TextFaint,
+        fontWeight = FontWeight.Bold,
+        fontSize = 13.sp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (canSubmit) MarketColors.Accent else MarketColors.SurfaceAlt)
+            .then(if (canSubmit) Modifier.clickable { onSubmit() } else Modifier)
+            .testTag(testTag)
+            .padding(vertical = 12.dp),
+        textAlign = TextAlign.Center,
+    )
+    error?.let {
+        Spacer(Modifier.height(8.dp))
+        Text(it, color = MarketColors.Down, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+    }
+    result?.let { r ->
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = if (r.applied) "Applied (result ${r.result ?: 0})" else (r.message ?: "Rejected (result ${r.result ?: "?"})"),
+            color = if (r.applied) MarketColors.Up else MarketColors.Down,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Dismiss",
+            color = MarketColors.TextSecondary,
+            fontSize = 11.sp,
+            modifier = Modifier.clickable { onDismiss() }.padding(vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun PmCreateBinaryPanel(form: PmCreateBinaryForm, viewModel: TradingViewModel) {
+    EngineCard("Create binary market", "YES pays the face value on YES; face value must be > 1.") {
+        NumberField("Symbol id", form.symbolText, viewModel::setPmBinSymbol)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Face value (payout)", form.faceText, viewModel::setPmBinFace)
+        Spacer(Modifier.height(8.dp))
+        TextInputField("Resolver id (optional)", form.resolverText, viewModel::setPmBinResolver)
+        PmApply(
+            label = "Create binary market",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_pm_create_binary",
+            onSubmit = viewModel::submitPmCreateBinary,
+            onDismiss = viewModel::clearPmBinResult,
+        )
+    }
+}
+
+@Composable
+private fun PmCreateCategoricalPanel(form: PmCreateCategoricalForm, viewModel: TradingViewModel) {
+    EngineCard("Create categorical market", "A group of >= 2 mutually-exclusive outcome symbols.") {
+        NumberField("Group id", form.groupText, viewModel::setPmCatGroup)
+        Spacer(Modifier.height(8.dp))
+        TextInputField("Outcome symbol ids (comma-separated)", form.outcomesText, viewModel::setPmCatOutcomes)
+        Spacer(Modifier.height(4.dp))
+        Text("${form.outcomes.size} outcome(s): ${form.outcomes.joinToString(", ")}", color = MarketColors.TextFaint, fontSize = 10.sp)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Face value (payout)", form.faceText, viewModel::setPmCatFace)
+        Spacer(Modifier.height(8.dp))
+        TextInputField("Resolver id (optional)", form.resolverText, viewModel::setPmCatResolver)
+        PmApply(
+            label = "Create categorical market",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_pm_create_categorical",
+            onSubmit = viewModel::submitPmCreateCategorical,
+            onDismiss = viewModel::clearPmCatResult,
+        )
+    }
+}
+
+@Composable
+private fun PmResolveBinaryPanel(form: PmResolveBinaryForm, viewModel: TradingViewModel) {
+    EngineCard("Resolve binary market", "Settle a binary PM. Requires the designated resolver.") {
+        NumberField("Symbol id", form.symbolText, viewModel::setPmResolveSymbol)
+        Spacer(Modifier.height(8.dp))
+        Text("Outcome", color = MarketColors.TextSecondary, fontSize = 11.sp)
+        Spacer(Modifier.height(4.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            AlgoChip("YES", form.yes) { viewModel.setPmResolveYes(true) }
+            AlgoChip("NO", !form.yes) { viewModel.setPmResolveYes(false) }
+        }
+        Spacer(Modifier.height(8.dp))
+        TextInputField("Source (optional)", form.sourceText, viewModel::setPmResolveSource)
+        PmApply(
+            label = "Resolve ${form.outcome.uppercase()}",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_pm_resolve_binary",
+            onSubmit = viewModel::submitPmResolveBinary,
+            onDismiss = viewModel::clearPmResolveResult,
+        )
+    }
+}
+
+@Composable
+private fun PmResolveCategoricalPanel(form: PmResolveCategoricalForm, viewModel: TradingViewModel) {
+    EngineCard("Resolve categorical market", "Settle a group to its winning outcome symbol.") {
+        NumberField("Group id", form.groupText, viewModel::setPmGroupResolveGroup)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Winning symbol id", form.winningText, viewModel::setPmGroupResolveWinning)
+        Spacer(Modifier.height(8.dp))
+        TextInputField("Source (optional)", form.sourceText, viewModel::setPmGroupResolveSource)
+        PmApply(
+            label = "Resolve group",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_pm_resolve_categorical",
+            onSubmit = viewModel::submitPmResolveCategorical,
+            onDismiss = viewModel::clearPmGroupResolveResult,
+        )
+    }
+}
+
+@Composable
+private fun PmResolutionHistory(resolutions: List<com.testlogon.android.data.exchange.PmResolution>, viewModel: TradingViewModel) {
+    EngineCard("Resolution history", "The most recent PM resolutions (audit log).") {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Text("${resolutions.size} resolution(s)", color = MarketColors.TextSecondary, fontSize = 11.sp)
+            Text(
+                "Refresh",
+                color = MarketColors.Accent,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.clickable { viewModel.loadPmResolutions() }.testTag("pm_resolutions_refresh").padding(vertical = 2.dp),
+            )
+        }
+        if (resolutions.isEmpty()) {
+            Spacer(Modifier.height(8.dp))
+            Text("No resolutions yet.", color = MarketColors.TextFaint, fontSize = 11.sp)
+        } else {
+            resolutions.take(20).forEach { r ->
+                Spacer(Modifier.height(8.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "${r.marketLabel} -> ${r.outcomeLabel}",
+                            color = MarketColors.TextPrimary,
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 12.sp,
+                        )
+                        val meta = listOfNotNull(
+                            r.resolverId.takeIf { it.isNotBlank() }?.let { "by $it" },
+                            r.source.takeIf { it.isNotBlank() }?.let { "src $it" },
+                        ).joinToString(" · ")
+                        if (meta.isNotBlank()) {
+                            Text(meta, color = MarketColors.TextFaint, fontSize = 10.sp)
+                        }
+                    }
+                    Text(
+                        if (r.isGroup) "GROUP" else (r.outcome?.uppercase() ?: "--"),
+                        color = when {
+                            r.isGroup -> MarketColors.Accent
+                            r.outcomeYes == true -> MarketColors.Up
+                            r.outcomeYes == false -> MarketColors.Down
+                            else -> MarketColors.TextSecondary
+                        },
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 11.sp,
+                    )
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.EngineConfigAck
 import com.testlogon.android.feature.markets.ui.MarketColors
 import java.util.Locale
 
@@ -118,6 +119,8 @@ fun TradeTicket(
         if (state.isAdmin) {
             Spacer(Modifier.height(16.dp))
             MarginConfigPanel(state.marginConfig, viewModel)
+            Spacer(Modifier.height(16.dp))
+            EngineConfigSection(state, viewModel)
         }
     }
 }
@@ -1187,4 +1190,292 @@ private fun MarginConfigPanel(form: MarginConfigForm, viewModel: TradingViewMode
 private fun fmt(v: Double): String {
     val whole = v == v.toLong().toDouble()
     return if (whole) String.format(Locale.US, "%,d", v.toLong()) else String.format(Locale.US, "%,.2f", v)
+}
+
+// ======================= Admin engine-config (exchange-admin-config) =======================
+
+/**
+ * Admin-only "Engine config" section: six compact forms mirroring [MarginConfigPanel], one per engine
+ * config route. Each is a bordered card with labeled integer inputs, defaults, a validated Apply button,
+ * and inline ack/error feedback. Shown only when [TradingUiState.isAdmin]. Endpoints 404 until deployed
+ * -> the repository degrades to an un-applied ack surfaced here.
+ */
+@Composable
+private fun EngineConfigSection(state: TradingUiState, viewModel: TradingViewModel) {
+    Column(modifier = Modifier.fillMaxWidth().testTag("engine_config_section")) {
+        Text("Engine config (admin)", color = MarketColors.Accent, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            "Matching-engine parameters. Not deployed to every venue; an undeployed route reports \"not deployed\".",
+            color = MarketColors.TextSecondary,
+            fontSize = 11.sp,
+        )
+        Spacer(Modifier.height(10.dp))
+        MatchingAlgoPanel(state.matchingAlgo, viewModel)
+        Spacer(Modifier.height(12.dp))
+        SpreadConfigPanel(state.spreadConfig, viewModel)
+        Spacer(Modifier.height(12.dp))
+        TradingParamsPanel(state.tradingParams, viewModel)
+        Spacer(Modifier.height(12.dp))
+        RiskConfigPanel(state.riskConfig, viewModel)
+        Spacer(Modifier.height(12.dp))
+        SpotIndexPanel(state.spotIndex, viewModel)
+        Spacer(Modifier.height(12.dp))
+        SpotConfigPanel(state.spotConfig, viewModel)
+    }
+}
+
+/** Bordered card wrapper shared by every engine-config form (matches MarginConfigPanel styling). */
+@Composable
+private fun EngineCard(title: String, subtitle: String, content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(MarketColors.Surface)
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(10.dp))
+            .padding(12.dp),
+    ) {
+        Text(title, color = MarketColors.Accent, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+        Spacer(Modifier.height(2.dp))
+        Text(subtitle, color = MarketColors.TextSecondary, fontSize = 11.sp)
+        Spacer(Modifier.height(10.dp))
+        content()
+    }
+}
+
+/** Apply button + inline error/ack feedback, shared by every engine-config form. */
+@Composable
+private fun EngineApply(
+    label: String,
+    canSubmit: Boolean,
+    submitting: Boolean,
+    error: String?,
+    result: EngineConfigAck?,
+    testTag: String,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Spacer(Modifier.height(12.dp))
+    Text(
+        text = if (submitting) "Applying…" else label,
+        color = if (canSubmit) Color.Black else MarketColors.TextFaint,
+        fontWeight = FontWeight.Bold,
+        fontSize = 13.sp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (canSubmit) MarketColors.Accent else MarketColors.SurfaceAlt)
+            .then(if (canSubmit) Modifier.clickable { onSubmit() } else Modifier)
+            .testTag(testTag)
+            .padding(vertical = 12.dp),
+        textAlign = TextAlign.Center,
+    )
+    error?.let {
+        Spacer(Modifier.height(8.dp))
+        Text(it, color = MarketColors.Down, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+    }
+    result?.let { r ->
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = if (r.applied) "Applied (result ${r.result ?: 0})" else (r.message ?: "Rejected (result ${r.result ?: "?"})"),
+            color = if (r.applied) MarketColors.Up else MarketColors.Down,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Dismiss",
+            color = MarketColors.TextSecondary,
+            fontSize = 11.sp,
+            modifier = Modifier.clickable { onDismiss() }.padding(vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun MatchingAlgoPanel(form: MatchingAlgoForm, viewModel: TradingViewModel) {
+    EngineCard("Matching algorithm", "Order-allocation model for a symbol.") {
+        NumberField("Symbol id", form.symbolText, viewModel::setAlgoSymbol)
+        Spacer(Modifier.height(8.dp))
+        Text("Algorithm", color = MarketColors.TextSecondary, fontSize = 11.sp)
+        Spacer(Modifier.height(4.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            AlgoChip("Price-time", form.algo == 0) { viewModel.setAlgo(0) }
+            AlgoChip("Pro-rata", form.algo == 1) { viewModel.setAlgo(1) }
+            AlgoChip("Specialist", form.algo == 2) { viewModel.setAlgo(2) }
+        }
+        if (form.algo >= 2) {
+            Spacer(Modifier.height(8.dp))
+            TextInputField("Specialist MPID", form.specialistMpidText, viewModel::setAlgoSpecialistMpid)
+            Spacer(Modifier.height(8.dp))
+            NumberField("Specialist %", form.specialistPctText, viewModel::setAlgoSpecialistPct)
+        }
+        EngineApply(
+            label = "Apply matching algo",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_matching_algo",
+            onSubmit = viewModel::submitMatchingAlgo,
+            onDismiss = viewModel::clearAlgoResult,
+        )
+    }
+}
+
+@Composable
+private fun AlgoChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    Text(
+        text = label,
+        color = if (selected) Color.Black else MarketColors.TextSecondary,
+        fontSize = 12.sp,
+        fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(if (selected) MarketColors.Accent else MarketColors.SurfaceAlt)
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(6.dp))
+            .clickable(onClick = onClick)
+            .testTag("algo_$label")
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+    )
+}
+
+@Composable
+private fun SpreadConfigPanel(form: SpreadConfigForm, viewModel: TradingViewModel) {
+    EngineCard("Spread instrument", "Two-leg spread (signed ratios; e.g. 1 / -1).") {
+        NumberField("Spread symbol id", form.spreadSymbolText, viewModel::setSpreadSymbol)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Leg 1 symbol id", form.leg1Text, viewModel::setSpreadLeg1)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Leg 2 symbol id", form.leg2Text, viewModel::setSpreadLeg2)
+        Spacer(Modifier.height(8.dp))
+        TextInputField("Leg 1 ratio", form.leg1RatioText, viewModel::setSpreadLeg1Ratio)
+        Spacer(Modifier.height(8.dp))
+        TextInputField("Leg 2 ratio", form.leg2RatioText, viewModel::setSpreadLeg2Ratio)
+        EngineApply(
+            label = "Apply spread config",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_spread_config",
+            onSubmit = viewModel::submitSpreadConfig,
+            onDismiss = viewModel::clearSpreadResult,
+        )
+    }
+}
+
+@Composable
+private fun TradingParamsPanel(form: TradingParamsForm, viewModel: TradingViewModel) {
+    EngineCard("Trading params", "Per-symbol risk limits (leave blank to skip a param).") {
+        NumberField("Symbol id", form.symbolText, viewModel::setTpSymbol)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Max qty", form.maxQtyText, viewModel::setTpMaxQty)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Max notional", form.maxNotionalText, viewModel::setTpMaxNotional)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Price band %", form.priceBandPctText, viewModel::setTpPriceBand)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Circuit breaker %", form.circuitBreakerPctText, viewModel::setTpCircuitBreaker)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Min block size", form.minBlockSizeText, viewModel::setTpMinBlock)
+        EngineApply(
+            label = "Apply trading params",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_trading_params",
+            onSubmit = viewModel::submitTradingParams,
+            onDismiss = viewModel::clearTpResult,
+        )
+    }
+}
+
+@Composable
+private fun RiskConfigPanel(form: RiskConfigForm, viewModel: TradingViewModel) {
+    EngineCard("Risk config", "Aggregate notional cap over a rolling window.") {
+        NumberField("Max notional", form.maxNotionalText, viewModel::setRiskMaxNotional)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Window seconds", form.windowSecondsText, viewModel::setRiskWindow)
+        Spacer(Modifier.height(8.dp))
+        TextInputField("MPID (optional)", form.mpidText, viewModel::setRiskMpid)
+        EngineApply(
+            label = "Apply risk config",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_risk_config",
+            onSubmit = viewModel::submitRiskConfig,
+            onDismiss = viewModel::clearRiskResult,
+        )
+    }
+}
+
+@Composable
+private fun SpotIndexPanel(form: SpotIndexForm, viewModel: TradingViewModel) {
+    EngineCard("Spot index", "Publish a spot index (mark) price.") {
+        NumberField("Symbol id", form.symbolText, viewModel::setSpotIndexSymbol)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Spot index price", form.spotIndexPriceText, viewModel::setSpotIndexPrice)
+        EngineApply(
+            label = "Apply spot index",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_spot_index",
+            onSubmit = viewModel::submitSpotIndex,
+            onDismiss = viewModel::clearSpotIndexResult,
+        )
+    }
+}
+
+@Composable
+private fun SpotConfigPanel(form: SpotConfigForm, viewModel: TradingViewModel) {
+    EngineCard("Spot config", "Bind a symbol to its base/quote asset ids.") {
+        NumberField("Symbol id", form.symbolText, viewModel::setSpotCfgSymbol)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Base asset id", form.baseAssetText, viewModel::setSpotCfgBase)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Quote asset id", form.quoteAssetText, viewModel::setSpotCfgQuote)
+        EngineApply(
+            label = "Apply spot config",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "apply_spot_config",
+            onSubmit = viewModel::submitSpotConfig,
+            onDismiss = viewModel::clearSpotCfgResult,
+        )
+    }
+}
+
+/** Like [NumberField] but accepts free text (for signed ratios / alphanumeric MPIDs). */
+@Composable
+private fun TextInputField(label: String, value: String, onValue: (String) -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(label, color = MarketColors.TextSecondary, fontSize = 11.sp)
+        Spacer(Modifier.height(3.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(MarketColors.Surface)
+                .border(1.dp, MarketColors.Border, RoundedCornerShape(8.dp))
+                .padding(horizontal = 12.dp, vertical = 12.dp),
+        ) {
+            BasicTextField(
+                value = value,
+                onValueChange = onValue,
+                singleLine = true,
+                textStyle = TextStyle(color = MarketColors.TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 16.sp),
+                cursorBrush = SolidColor(MarketColors.Accent),
+                modifier = Modifier.fillMaxWidth().testTag("field_$label"),
+            )
+        }
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -319,6 +319,9 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, viewModel: Tra
         Spacer(Modifier.height(10.dp))
         SpotPanel(state, viewModel)
     }
+
+    Spacer(Modifier.height(20.dp))
+    StakingAuctionsSection(state, viewModel)
 }
 
 @Composable
@@ -1704,5 +1707,203 @@ private fun PmResolutionHistory(resolutions: List<com.testlogon.android.data.exc
                 }
             }
         }
+    }
+}
+
+/**
+ * Trader-facing Staking & Auctions section (peer mechanisms). NOT admin-gated. Four compact forms:
+ * create a stake request, offer on an open request (by id), auction a position qty, and bid on an
+ * auction (by id). Each surfaces the engine's returned request_id / auction_id prominently. There is
+ * no list/GET for open items yet, so an honest "browsing open items isn't available yet" note is shown;
+ * the routes 404 until deployed -> the repository degrades to an un-applied ack surfaced inline.
+ */
+@Composable
+private fun StakingAuctionsSection(state: TradingUiState, viewModel: TradingViewModel) {
+    Column(modifier = Modifier.fillMaxWidth().testTag("staking_auctions_section")) {
+        Text("Staking & auctions", color = MarketColors.Accent, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            "Peer mechanisms: stake against another trader's request, or auction a position. Browsing open " +
+                "requests/auctions isn't available yet — act on an id you already have, or create one and share " +
+                "the id it returns.",
+            color = MarketColors.TextSecondary,
+            fontSize = 11.sp,
+        )
+        Spacer(Modifier.height(10.dp))
+        StakeRequestPanel(state.stakeRequest, viewModel)
+        Spacer(Modifier.height(12.dp))
+        StakeOfferPanel(state.stakeOffer, viewModel)
+        Spacer(Modifier.height(12.dp))
+        AuctionRequestPanel(state.auctionRequest, viewModel)
+        Spacer(Modifier.height(12.dp))
+        AuctionBidPanel(state.auctionBid, viewModel)
+    }
+}
+
+/**
+ * Apply button + inline feedback for a staking/auction form. On accept it surfaces the created id
+ * ([StakeAuctionAck.idLabel]) prominently so the trader can copy/share it (there's no list view yet).
+ */
+@Composable
+private fun StakeApply(
+    label: String,
+    canSubmit: Boolean,
+    submitting: Boolean,
+    error: String?,
+    result: com.testlogon.android.data.exchange.StakeAuctionAck?,
+    testTag: String,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Spacer(Modifier.height(12.dp))
+    Text(
+        text = if (submitting) "Submitting…" else label,
+        color = if (canSubmit) Color.Black else MarketColors.TextFaint,
+        fontWeight = FontWeight.Bold,
+        fontSize = 13.sp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (canSubmit) MarketColors.Accent else MarketColors.SurfaceAlt)
+            .then(if (canSubmit) Modifier.clickable { onSubmit() } else Modifier)
+            .testTag(testTag)
+            .padding(vertical = 12.dp),
+        textAlign = TextAlign.Center,
+    )
+    error?.let {
+        Spacer(Modifier.height(8.dp))
+        Text(it, color = MarketColors.Down, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+    }
+    result?.let { r ->
+        Spacer(Modifier.height(8.dp))
+        if (r.accepted) {
+            r.idLabel?.let { idLabel ->
+                Text(
+                    text = idLabel,
+                    color = Color.Black,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 15.sp,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MarketColors.Up)
+                        .testTag(testTag + "_id")
+                        .padding(vertical = 10.dp),
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+            Text(
+                text = if (r.idLabel != null) "Accepted — save this id (no open-items list yet)." else "Accepted.",
+                color = MarketColors.Up,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+            )
+        } else {
+            Text(
+                text = r.message ?: "Rejected",
+                color = MarketColors.Down,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Dismiss",
+            color = MarketColors.TextSecondary,
+            fontSize = 11.sp,
+            modifier = Modifier.clickable { onDismiss() }.padding(vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun StakeRequestPanel(form: StakeRequestForm, viewModel: TradingViewModel) {
+    EngineCard("Create stake request", "Invite others to stake against your position.") {
+        NumberField("Symbol id (optional)", form.symbolText, viewModel::setStakeReqSymbol)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Min collateral", form.minCollateralText, viewModel::setStakeReqMinCollateral)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Max stake %", form.maxStakePctText, viewModel::setStakeReqMaxPct)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Lockup seconds", form.lockupSecondsText, viewModel::setStakeReqLockup)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Duration seconds", form.durationSecondsText, viewModel::setStakeReqDuration)
+        StakeApply(
+            label = "Create stake request",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "create_stake_request",
+            onSubmit = viewModel::submitStakeRequest,
+            onDismiss = viewModel::clearStakeReqResult,
+        )
+    }
+}
+
+@Composable
+private fun StakeOfferPanel(form: StakeOfferForm, viewModel: TradingViewModel) {
+    EngineCard("Offer on stake request", "Stake against an open request by its id.") {
+        NumberField("Request id", form.requestIdText, viewModel::setStakeOfferRequestId)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Collateral amount", form.collateralText, viewModel::setStakeOfferCollateral)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Stake %", form.stakePctText, viewModel::setStakeOfferPct)
+        StakeApply(
+            label = "Submit offer",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "submit_stake_offer",
+            onSubmit = viewModel::submitStakeOffer,
+            onDismiss = viewModel::clearStakeOfferResult,
+        )
+    }
+}
+
+@Composable
+private fun AuctionRequestPanel(form: AuctionRequestForm, viewModel: TradingViewModel) {
+    EngineCard("Create auction", "Auction a position quantity (optional reserve + duration).") {
+        NumberField("Symbol id (optional)", form.symbolText, viewModel::setAuctionReqSymbol)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Quantity", form.qtyText, viewModel::setAuctionReqQty)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Reserve price (optional)", form.reservePriceText, viewModel::setAuctionReqReserve)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Duration seconds (optional)", form.durationSecondsText, viewModel::setAuctionReqDuration)
+        StakeApply(
+            label = "Create auction",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "create_auction_request",
+            onSubmit = viewModel::submitAuctionRequest,
+            onDismiss = viewModel::clearAuctionReqResult,
+        )
+    }
+}
+
+@Composable
+private fun AuctionBidPanel(form: AuctionBidForm, viewModel: TradingViewModel) {
+    EngineCard("Bid on auction", "Bid on an open auction by its id.") {
+        NumberField("Auction id", form.auctionIdText, viewModel::setAuctionBidId)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Price", form.priceText, viewModel::setAuctionBidPrice)
+        Spacer(Modifier.height(8.dp))
+        NumberField("Quantity", form.qtyText, viewModel::setAuctionBidQty)
+        StakeApply(
+            label = "Submit bid",
+            canSubmit = form.canSubmit,
+            submitting = form.submitting,
+            error = form.error,
+            result = form.result,
+            testTag = "submit_auction_bid",
+            onSubmit = viewModel::submitAuctionBid,
+            onDismiss = viewModel::clearAuctionBidResult,
+        )
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -113,6 +113,12 @@ data class TradingUiState(
     val riskConfig: RiskConfigForm = RiskConfigForm(),
     val spotIndex: SpotIndexForm = SpotIndexForm(),
     val spotConfig: SpotConfigForm = SpotConfigForm(),
+    // Admin prediction-markets forms (exchange-admin-config); shown only when isAdmin.
+    val pmCreateBinary: PmCreateBinaryForm = PmCreateBinaryForm(),
+    val pmCreateCategorical: PmCreateCategoricalForm = PmCreateCategoricalForm(),
+    val pmResolveBinary: PmResolveBinaryForm = PmResolveBinaryForm(),
+    val pmResolveCategorical: PmResolveCategoricalForm = PmResolveCategoricalForm(),
+    val pmResolutions: List<com.testlogon.android.data.exchange.PmResolution> = emptyList(),
     val feeSchedule: FeeSchedule? = null,
     val fillsFees: FillsFees? = null,
     val liquidations: Liquidations? = null,
@@ -342,4 +348,106 @@ fun SpotConfigForm.finish(r: ApiResult<EngineConfigAck>): SpotConfigForm = when 
     is ApiResult.Success -> copy(submitting = false, result = r.data)
     is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
     is ApiResult.NetworkError -> copy(submitting = false, error = NET_ERR)
+}
+
+// ==== Admin prediction-markets (exchange-admin-config) — form state ====
+
+/** Import alias: the PM admin ack + resolution domain types live in data.exchange. */
+
+/**
+ * Admin form: configure a BINARY PM on a symbol. [faceText] is the payout on YES (must parse and be
+ * > 1); [resolverText] is an optional designated resolver id (blank -> null on the wire).
+ */
+data class PmCreateBinaryForm(
+    val symbolText: String = "",
+    val faceText: String = "",
+    val resolverText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.PmConfigAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val faceLong: Long? get() = faceText.toLongOrNull()
+    val resolver: String? get() = resolverText.trim().ifEmpty { null }
+    val canSubmit: Boolean get() = !submitting && symbolInt != null && (faceLong ?: 0L) > 1L
+}
+
+/**
+ * Admin form: configure a CATEGORICAL (grouped) PM. [outcomesText] is a comma/space-separated list of
+ * outcome symbol ids (>= 2 distinct); [faceText] the shared payout (> 1).
+ */
+data class PmCreateCategoricalForm(
+    val groupText: String = "",
+    val outcomesText: String = "",
+    val faceText: String = "",
+    val resolverText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.PmConfigAck? = null,
+    val error: String? = null,
+) {
+    val groupInt: Int? get() = groupText.toIntOrNull()
+    val faceLong: Long? get() = faceText.toLongOrNull()
+    val resolver: String? get() = resolverText.trim().ifEmpty { null }
+    /** Parse the outcome ids from a comma/space/newline-separated list, de-duplicated, order-preserving. */
+    val outcomes: List<Int> get() = outcomesText
+        .split(',', ' ', '\n', '\t')
+        .mapNotNull { it.trim().toIntOrNull() }
+        .distinct()
+    val canSubmit: Boolean get() = !submitting && (groupInt ?: 0) > 0 && (faceLong ?: 0L) > 1L && outcomes.size >= 2
+}
+
+/** Admin form: resolve a BINARY PM to yes/no. [yes] holds the selected outcome. */
+data class PmResolveBinaryForm(
+    val symbolText: String = "",
+    val yes: Boolean = true,
+    val sourceText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.PmConfigAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val source: String? get() = sourceText.trim().ifEmpty { null }
+    val outcome: String get() = if (yes) "yes" else "no"
+    val canSubmit: Boolean get() = !submitting && symbolInt != null
+}
+
+/** Admin form: resolve a CATEGORICAL PM by its winning outcome symbol id. */
+data class PmResolveCategoricalForm(
+    val groupText: String = "",
+    val winningText: String = "",
+    val sourceText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.PmConfigAck? = null,
+    val error: String? = null,
+) {
+    val groupInt: Int? get() = groupText.toIntOrNull()
+    val winningInt: Int? get() = winningText.toIntOrNull()
+    val source: String? get() = sourceText.trim().ifEmpty { null }
+    val canSubmit: Boolean get() = !submitting && (groupInt ?: 0) > 0 && winningInt != null
+}
+
+private const val PM_NET_ERR = "Network error. Check your connection and try again."
+
+fun PmCreateBinaryForm.finish(r: ApiResult<com.testlogon.android.data.exchange.PmConfigAck>): PmCreateBinaryForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = PM_NET_ERR)
+}
+
+fun PmCreateCategoricalForm.finish(r: ApiResult<com.testlogon.android.data.exchange.PmConfigAck>): PmCreateCategoricalForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = PM_NET_ERR)
+}
+
+fun PmResolveBinaryForm.finish(r: ApiResult<com.testlogon.android.data.exchange.PmConfigAck>): PmResolveBinaryForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = PM_NET_ERR)
+}
+
+fun PmResolveCategoricalForm.finish(r: ApiResult<com.testlogon.android.data.exchange.PmConfigAck>): PmResolveCategoricalForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = PM_NET_ERR)
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -10,6 +10,8 @@ import com.testlogon.android.data.exchange.MarginAccount
 import com.testlogon.android.data.exchange.OrderSide
 import com.testlogon.android.data.exchange.SpotBalance
 import com.testlogon.android.data.exchange.MarginConfigAck
+import com.testlogon.android.data.exchange.EngineConfigAck
+import com.testlogon.android.core.model.ApiResult
 
 /** Order entry type. LIMIT is the plain resting limit; the rest map to advanced engine endpoints. */
 enum class OrderType(val label: String) {
@@ -104,6 +106,13 @@ data class TradingUiState(
     val pm: com.testlogon.android.data.exchange.PmState? = null,   // set when this symbol is a binary prediction market
     val isAdmin: Boolean = false,   // resolved from CurrentUserRepository; gates the margin-config panel
     val marginConfig: MarginConfigForm = MarginConfigForm(),
+    // Admin engine-config forms (exchange-admin-config); shown only when isAdmin.
+    val matchingAlgo: MatchingAlgoForm = MatchingAlgoForm(),
+    val spreadConfig: SpreadConfigForm = SpreadConfigForm(),
+    val tradingParams: TradingParamsForm = TradingParamsForm(),
+    val riskConfig: RiskConfigForm = RiskConfigForm(),
+    val spotIndex: SpotIndexForm = SpotIndexForm(),
+    val spotConfig: SpotConfigForm = SpotConfigForm(),
     val feeSchedule: FeeSchedule? = null,
     val fillsFees: FillsFees? = null,
     val liquidations: Liquidations? = null,
@@ -197,4 +206,140 @@ data class MarginConfigForm(
         liquidationFeeLong != null && hourlyBorrowLong != null &&
         makerFeeLong != null && takerFeeLong != null &&
         maxPositionLong != null
+}
+
+/**
+ * Admin engine-config forms (exchange-admin-config). Each mirrors [MarginConfigForm]: plain-integer
+ * text fields with parse accessors + a [canSubmit] gate + submitting/result/error. Optional engine
+ * params are left blank (null on the wire); required ones must parse.
+ */
+data class MatchingAlgoForm(
+    val symbolText: String = "",
+    val algo: Int = 0,                     // 0 = price-time, 1 = pro-rata, 2 = specialist
+    val specialistMpidText: String = "",
+    val specialistPctText: String = "",
+    val submitting: Boolean = false,
+    val result: EngineConfigAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val specialistPctInt: Int? get() = specialistPctText.toIntOrNull()
+    val specialistMpid: String? get() = specialistMpidText.trim().ifEmpty { null }
+    val canSubmit: Boolean get() = !submitting && symbolInt != null
+}
+
+data class SpreadConfigForm(
+    val spreadSymbolText: String = "",
+    val leg1Text: String = "",
+    val leg2Text: String = "",
+    val leg1RatioText: String = "1",
+    val leg2RatioText: String = "-1",
+    val submitting: Boolean = false,
+    val result: EngineConfigAck? = null,
+    val error: String? = null,
+) {
+    val spreadSymbolInt: Int? get() = spreadSymbolText.toIntOrNull()
+    val leg1Int: Int? get() = leg1Text.toIntOrNull()
+    val leg2Int: Int? get() = leg2Text.toIntOrNull()
+    val leg1RatioInt: Int? get() = leg1RatioText.toIntOrNull()
+    val leg2RatioInt: Int? get() = leg2RatioText.toIntOrNull()
+    val canSubmit: Boolean get() = !submitting && spreadSymbolInt != null && leg1Int != null && leg2Int != null
+}
+
+data class TradingParamsForm(
+    val symbolText: String = "",
+    val maxQtyText: String = "",
+    val maxNotionalText: String = "",
+    val priceBandPctText: String = "",
+    val circuitBreakerPctText: String = "",
+    val minBlockSizeText: String = "",
+    val submitting: Boolean = false,
+    val result: EngineConfigAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val maxQtyInt: Int? get() = maxQtyText.toIntOrNull()
+    val maxNotionalLong: Long? get() = maxNotionalText.toLongOrNull()
+    val priceBandPctLong: Long? get() = priceBandPctText.toLongOrNull()
+    val circuitBreakerPctLong: Long? get() = circuitBreakerPctText.toLongOrNull()
+    val minBlockSizeInt: Int? get() = minBlockSizeText.toIntOrNull()
+    val canSubmit: Boolean get() = !submitting && symbolInt != null
+}
+
+data class RiskConfigForm(
+    val maxNotionalText: String = "",
+    val windowSecondsText: String = "",
+    val mpidText: String = "",
+    val submitting: Boolean = false,
+    val result: EngineConfigAck? = null,
+    val error: String? = null,
+) {
+    val maxNotionalLong: Long? get() = maxNotionalText.toLongOrNull()
+    val windowSecondsInt: Int? get() = windowSecondsText.toIntOrNull()
+    val mpid: String? get() = mpidText.trim().ifEmpty { null }
+    val canSubmit: Boolean get() = !submitting && maxNotionalLong != null && windowSecondsInt != null && windowSecondsInt!! > 0
+}
+
+data class SpotIndexForm(
+    val symbolText: String = "",
+    val spotIndexPriceText: String = "",
+    val submitting: Boolean = false,
+    val result: EngineConfigAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val spotIndexPriceLong: Long? get() = spotIndexPriceText.toLongOrNull()
+    val canSubmit: Boolean get() = !submitting && symbolInt != null && spotIndexPriceLong != null
+}
+
+data class SpotConfigForm(
+    val symbolText: String = "",
+    val baseAssetText: String = "",
+    val quoteAssetText: String = "",
+    val submitting: Boolean = false,
+    val result: EngineConfigAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val baseAssetInt: Int? get() = baseAssetText.toIntOrNull()
+    val quoteAssetInt: Int? get() = quoteAssetText.toIntOrNull()
+    val canSubmit: Boolean get() = !submitting && symbolInt != null && baseAssetInt != null && quoteAssetInt != null
+}
+
+private const val NET_ERR = "Network error. Check your connection and try again."
+
+fun MatchingAlgoForm.finish(r: ApiResult<EngineConfigAck>): MatchingAlgoForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = NET_ERR)
+}
+
+fun SpreadConfigForm.finish(r: ApiResult<EngineConfigAck>): SpreadConfigForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = NET_ERR)
+}
+
+fun TradingParamsForm.finish(r: ApiResult<EngineConfigAck>): TradingParamsForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = NET_ERR)
+}
+
+fun RiskConfigForm.finish(r: ApiResult<EngineConfigAck>): RiskConfigForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = NET_ERR)
+}
+
+fun SpotIndexForm.finish(r: ApiResult<EngineConfigAck>): SpotIndexForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = NET_ERR)
+}
+
+fun SpotConfigForm.finish(r: ApiResult<EngineConfigAck>): SpotConfigForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = NET_ERR)
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -125,6 +125,11 @@ data class TradingUiState(
     val fundingPayments: FundingPayments? = null,
     /** symbolId -> ticker, for labelling the account-wide liquidation/funding/fills feeds. */
     val symbolNames: Map<Int, String> = emptyMap(),
+    // Trader staking + auctions forms (peer mechanisms); trader-facing (NOT admin-gated).
+    val stakeRequest: StakeRequestForm = StakeRequestForm(),
+    val stakeOffer: StakeOfferForm = StakeOfferForm(),
+    val auctionRequest: AuctionRequestForm = AuctionRequestForm(),
+    val auctionBid: AuctionBidForm = AuctionBidForm(),
 ) {
     /** Ticker for [symbolId] from the resolved catalogue, else "#<id>". */
     fun symbolLabel(symbolId: Int): String = symbolNames[symbolId] ?: ("#" + symbolId)
@@ -450,4 +455,111 @@ fun PmResolveCategoricalForm.finish(r: ApiResult<com.testlogon.android.data.exch
     is ApiResult.Success -> copy(submitting = false, result = r.data)
     is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
     is ApiResult.NetworkError -> copy(submitting = false, error = PM_NET_ERR)
+}
+
+// ==== Trader staking + auctions (peer mechanisms) — form state ====
+
+/** Import alias: the staking/auction ack domain type lives in data.exchange. */
+
+/**
+ * Trader form: create a stake request. [symbolText] defaults to the ticket symbol but is editable.
+ * [minCollateralText]/[maxStakePctText] are raw integers; [lockupSecondsText]/[durationSecondsText]
+ * are seconds. [result] holds the last ack (which surfaces the returned request_id).
+ */
+data class StakeRequestForm(
+    val symbolText: String = "",
+    val minCollateralText: String = "",
+    val maxStakePctText: String = "",
+    val lockupSecondsText: String = "",
+    val durationSecondsText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.StakeAuctionAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val minCollateralLong: Long? get() = minCollateralText.toLongOrNull()
+    val maxStakePctLong: Long? get() = maxStakePctText.toLongOrNull()
+    val lockupSecondsInt: Int? get() = lockupSecondsText.toIntOrNull()
+    val durationSecondsInt: Int? get() = durationSecondsText.toIntOrNull()
+    val canSubmit: Boolean get() = !submitting &&
+        (minCollateralLong ?: 0L) > 0L && (maxStakePctLong ?: 0L) > 0L &&
+        (lockupSecondsInt ?: 0) > 0 && (durationSecondsInt ?: 0) > 0
+}
+
+/** Trader form: offer collateral to stake against an open stake request (by id). */
+data class StakeOfferForm(
+    val requestIdText: String = "",
+    val collateralText: String = "",
+    val stakePctText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.StakeAuctionAck? = null,
+    val error: String? = null,
+) {
+    val requestIdLong: Long? get() = requestIdText.toLongOrNull()
+    val collateralLong: Long? get() = collateralText.toLongOrNull()
+    val stakePctLong: Long? get() = stakePctText.toLongOrNull()
+    val canSubmit: Boolean get() = !submitting &&
+        (requestIdLong ?: 0L) > 0L && (collateralLong ?: 0L) > 0L && (stakePctLong ?: 0L) > 0L
+}
+
+/**
+ * Trader form: auction off a position quantity. [symbolText] defaults to the ticket symbol.
+ * [reservePriceText]/[durationSecondsText] are optional (blank -> null on the wire).
+ */
+data class AuctionRequestForm(
+    val symbolText: String = "",
+    val qtyText: String = "",
+    val reservePriceText: String = "",
+    val durationSecondsText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.StakeAuctionAck? = null,
+    val error: String? = null,
+) {
+    val symbolInt: Int? get() = symbolText.toIntOrNull()
+    val qtyInt: Int? get() = qtyText.toIntOrNull()
+    val reservePriceLong: Long? get() = reservePriceText.toLongOrNull()
+    val durationSecondsInt: Int? get() = durationSecondsText.toIntOrNull()
+    val canSubmit: Boolean get() = !submitting && (qtyInt ?: 0) > 0
+}
+
+/** Trader form: bid on an open auction (by id). */
+data class AuctionBidForm(
+    val auctionIdText: String = "",
+    val priceText: String = "",
+    val qtyText: String = "",
+    val submitting: Boolean = false,
+    val result: com.testlogon.android.data.exchange.StakeAuctionAck? = null,
+    val error: String? = null,
+) {
+    val auctionIdLong: Long? get() = auctionIdText.toLongOrNull()
+    val priceLong: Long? get() = priceText.toLongOrNull()
+    val qtyInt: Int? get() = qtyText.toIntOrNull()
+    val canSubmit: Boolean get() = !submitting &&
+        (auctionIdLong ?: 0L) > 0L && (priceLong ?: 0L) > 0L && (qtyInt ?: 0) > 0
+}
+
+private const val STAKE_NET_ERR = "Network error. Check your connection and try again."
+
+fun StakeRequestForm.finish(r: ApiResult<com.testlogon.android.data.exchange.StakeAuctionAck>): StakeRequestForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data, error = null)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = STAKE_NET_ERR)
+}
+
+fun StakeOfferForm.finish(r: ApiResult<com.testlogon.android.data.exchange.StakeAuctionAck>): StakeOfferForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data, error = null)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = STAKE_NET_ERR)
+}
+
+fun AuctionRequestForm.finish(r: ApiResult<com.testlogon.android.data.exchange.StakeAuctionAck>): AuctionRequestForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data, error = null)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = STAKE_NET_ERR)
+}
+
+fun AuctionBidForm.finish(r: ApiResult<com.testlogon.android.data.exchange.StakeAuctionAck>): AuctionBidForm = when (r) {
+    is ApiResult.Success -> copy(submitting = false, result = r.data, error = null)
+    is ApiResult.Failure -> copy(submitting = false, error = r.error.message)
+    is ApiResult.NetworkError -> copy(submitting = false, error = STAKE_NET_ERR)
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -56,6 +56,8 @@ class TradingViewModel @Inject constructor(
                 spotConfig = it.spotConfig.copy(symbolText = sym),
                 pmCreateBinary = it.pmCreateBinary.copy(symbolText = sym),
                 pmResolveBinary = it.pmResolveBinary.copy(symbolText = sym),
+                stakeRequest = it.stakeRequest.copy(symbolText = sym),
+                auctionRequest = it.auctionRequest.copy(symbolText = sym),
             )
         }
         resolveAdmin()
@@ -898,5 +900,70 @@ class TradingViewModel @Inject constructor(
 
     /** Sanitize an optional free-text resolution source (alnum + a few separators). */
     private fun source(t: String): String = t.filter { it.isLetterOrDigit() || it == '-' || it == '_' || it == ' ' || it == '.' }.take(40)
+
+    // ---- Trader staking + auctions (peer mechanisms). Trader-facing; 404 -> un-applied ack. ----
+
+    // stake_request
+    fun setStakeReqSymbol(t: String) = _uiState.update { it.copy(stakeRequest = it.stakeRequest.copy(symbolText = digits(t, 9), error = null)) }
+    fun setStakeReqMinCollateral(t: String) = _uiState.update { it.copy(stakeRequest = it.stakeRequest.copy(minCollateralText = digits(t, 15), error = null)) }
+    fun setStakeReqMaxPct(t: String) = _uiState.update { it.copy(stakeRequest = it.stakeRequest.copy(maxStakePctText = digits(t, 6), error = null)) }
+    fun setStakeReqLockup(t: String) = _uiState.update { it.copy(stakeRequest = it.stakeRequest.copy(lockupSecondsText = digits(t, 9), error = null)) }
+    fun setStakeReqDuration(t: String) = _uiState.update { it.copy(stakeRequest = it.stakeRequest.copy(durationSecondsText = digits(t, 9), error = null)) }
+    fun clearStakeReqResult() = _uiState.update { it.copy(stakeRequest = it.stakeRequest.copy(result = null, error = null)) }
+    fun submitStakeRequest() {
+        val f = _uiState.value.stakeRequest
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(stakeRequest = it.stakeRequest.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.stakeRequest(f.symbolInt, f.minCollateralLong!!, f.maxStakePctLong!!, f.lockupSecondsInt!!, f.durationSecondsInt!!)
+            _uiState.update { it.copy(stakeRequest = it.stakeRequest.finish(r)) }
+        }
+    }
+
+    // stake_offer
+    fun setStakeOfferRequestId(t: String) = _uiState.update { it.copy(stakeOffer = it.stakeOffer.copy(requestIdText = digits(t, 18), error = null)) }
+    fun setStakeOfferCollateral(t: String) = _uiState.update { it.copy(stakeOffer = it.stakeOffer.copy(collateralText = digits(t, 15), error = null)) }
+    fun setStakeOfferPct(t: String) = _uiState.update { it.copy(stakeOffer = it.stakeOffer.copy(stakePctText = digits(t, 6), error = null)) }
+    fun clearStakeOfferResult() = _uiState.update { it.copy(stakeOffer = it.stakeOffer.copy(result = null, error = null)) }
+    fun submitStakeOffer() {
+        val f = _uiState.value.stakeOffer
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(stakeOffer = it.stakeOffer.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.stakeOffer(f.requestIdLong!!, f.collateralLong!!, f.stakePctLong!!)
+            _uiState.update { it.copy(stakeOffer = it.stakeOffer.finish(r)) }
+        }
+    }
+
+    // auction_request
+    fun setAuctionReqSymbol(t: String) = _uiState.update { it.copy(auctionRequest = it.auctionRequest.copy(symbolText = digits(t, 9), error = null)) }
+    fun setAuctionReqQty(t: String) = _uiState.update { it.copy(auctionRequest = it.auctionRequest.copy(qtyText = digits(t, 9), error = null)) }
+    fun setAuctionReqReserve(t: String) = _uiState.update { it.copy(auctionRequest = it.auctionRequest.copy(reservePriceText = digits(t, 15), error = null)) }
+    fun setAuctionReqDuration(t: String) = _uiState.update { it.copy(auctionRequest = it.auctionRequest.copy(durationSecondsText = digits(t, 9), error = null)) }
+    fun clearAuctionReqResult() = _uiState.update { it.copy(auctionRequest = it.auctionRequest.copy(result = null, error = null)) }
+    fun submitAuctionRequest() {
+        val f = _uiState.value.auctionRequest
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(auctionRequest = it.auctionRequest.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.auctionRequest(f.symbolInt, f.qtyInt!!, f.reservePriceLong, f.durationSecondsInt)
+            _uiState.update { it.copy(auctionRequest = it.auctionRequest.finish(r)) }
+        }
+    }
+
+    // auction_bid
+    fun setAuctionBidId(t: String) = _uiState.update { it.copy(auctionBid = it.auctionBid.copy(auctionIdText = digits(t, 18), error = null)) }
+    fun setAuctionBidPrice(t: String) = _uiState.update { it.copy(auctionBid = it.auctionBid.copy(priceText = digits(t, 15), error = null)) }
+    fun setAuctionBidQty(t: String) = _uiState.update { it.copy(auctionBid = it.auctionBid.copy(qtyText = digits(t, 9), error = null)) }
+    fun clearAuctionBidResult() = _uiState.update { it.copy(auctionBid = it.auctionBid.copy(result = null, error = null)) }
+    fun submitAuctionBid() {
+        val f = _uiState.value.auctionBid
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(auctionBid = it.auctionBid.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.auctionBid(f.auctionIdLong!!, f.priceLong!!, f.qtyInt!!)
+            _uiState.update { it.copy(auctionBid = it.auctionBid.finish(r)) }
+        }
+    }
 
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -45,7 +45,17 @@ class TradingViewModel @Inject constructor(
     private var seq = 0
 
     init {
-        _uiState.update { it.copy(marginConfig = it.marginConfig.copy(symbolText = symbolId.toString())) }
+        val sym = symbolId.toString()
+        _uiState.update {
+            it.copy(
+                marginConfig = it.marginConfig.copy(symbolText = sym),
+                matchingAlgo = it.matchingAlgo.copy(symbolText = sym),
+                spreadConfig = it.spreadConfig.copy(spreadSymbolText = sym),
+                tradingParams = it.tradingParams.copy(symbolText = sym),
+                spotIndex = it.spotIndex.copy(symbolText = sym),
+                spotConfig = it.spotConfig.copy(symbolText = sym),
+            )
+        }
         resolveAdmin()
         refreshAccount()
         pollAccount()
@@ -156,6 +166,112 @@ class TradingViewModel @Inject constructor(
                 is ApiResult.Failure -> _uiState.update { it.copy(marginConfig = it.marginConfig.copy(submitting = false, error = r.error.message)) }
                 is ApiResult.NetworkError -> _uiState.update { it.copy(marginConfig = it.marginConfig.copy(submitting = false, error = "Network error. Check your connection and try again.")) }
             }
+        }
+    }
+
+    // ---- Admin engine-config forms (exchange-admin-config) ----
+
+    private fun mpid(t: String) = t.filter { it.isLetterOrDigit() }.take(12)
+
+    // Allow an optional leading '-' plus digits (for signed spread ratios).
+    private fun signed(t: String): String {
+        val neg = t.startsWith("-")
+        val d = t.filter { it.isDigit() }.take(6)
+        return if (neg) "-" + d else d
+    }
+
+    // matching_algo
+    fun setAlgoSymbol(t: String) = _uiState.update { it.copy(matchingAlgo = it.matchingAlgo.copy(symbolText = digits(t, 9), error = null)) }
+    fun setAlgo(v: Int) = _uiState.update { it.copy(matchingAlgo = it.matchingAlgo.copy(algo = v, error = null)) }
+    fun setAlgoSpecialistMpid(t: String) = _uiState.update { it.copy(matchingAlgo = it.matchingAlgo.copy(specialistMpidText = mpid(t), error = null)) }
+    fun setAlgoSpecialistPct(t: String) = _uiState.update { it.copy(matchingAlgo = it.matchingAlgo.copy(specialistPctText = digits(t, 3), error = null)) }
+    fun clearAlgoResult() = _uiState.update { it.copy(matchingAlgo = it.matchingAlgo.copy(result = null, error = null)) }
+    fun submitMatchingAlgo() {
+        val f = _uiState.value.matchingAlgo
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(matchingAlgo = it.matchingAlgo.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.matchingAlgo(f.symbolInt!!, f.algo, if (f.algo >= 2) f.specialistMpid else null, if (f.algo >= 2) f.specialistPctInt else null)
+            _uiState.update { it.copy(matchingAlgo = it.matchingAlgo.finish(r)) }
+        }
+    }
+
+    // spread_config
+    fun setSpreadSymbol(t: String) = _uiState.update { it.copy(spreadConfig = it.spreadConfig.copy(spreadSymbolText = digits(t, 9), error = null)) }
+    fun setSpreadLeg1(t: String) = _uiState.update { it.copy(spreadConfig = it.spreadConfig.copy(leg1Text = digits(t, 9), error = null)) }
+    fun setSpreadLeg2(t: String) = _uiState.update { it.copy(spreadConfig = it.spreadConfig.copy(leg2Text = digits(t, 9), error = null)) }
+    fun setSpreadLeg1Ratio(t: String) = _uiState.update { it.copy(spreadConfig = it.spreadConfig.copy(leg1RatioText = signed(t), error = null)) }
+    fun setSpreadLeg2Ratio(t: String) = _uiState.update { it.copy(spreadConfig = it.spreadConfig.copy(leg2RatioText = signed(t), error = null)) }
+    fun clearSpreadResult() = _uiState.update { it.copy(spreadConfig = it.spreadConfig.copy(result = null, error = null)) }
+    fun submitSpreadConfig() {
+        val f = _uiState.value.spreadConfig
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(spreadConfig = it.spreadConfig.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.spreadConfig(f.spreadSymbolInt!!, f.leg1Int!!, f.leg2Int!!, f.leg1RatioInt, f.leg2RatioInt)
+            _uiState.update { it.copy(spreadConfig = it.spreadConfig.finish(r)) }
+        }
+    }
+
+    // trading_params
+    fun setTpSymbol(t: String) = _uiState.update { it.copy(tradingParams = it.tradingParams.copy(symbolText = digits(t, 9), error = null)) }
+    fun setTpMaxQty(t: String) = _uiState.update { it.copy(tradingParams = it.tradingParams.copy(maxQtyText = digits(t, 9), error = null)) }
+    fun setTpMaxNotional(t: String) = _uiState.update { it.copy(tradingParams = it.tradingParams.copy(maxNotionalText = digits(t, 15), error = null)) }
+    fun setTpPriceBand(t: String) = _uiState.update { it.copy(tradingParams = it.tradingParams.copy(priceBandPctText = digits(t, 9), error = null)) }
+    fun setTpCircuitBreaker(t: String) = _uiState.update { it.copy(tradingParams = it.tradingParams.copy(circuitBreakerPctText = digits(t, 9), error = null)) }
+    fun setTpMinBlock(t: String) = _uiState.update { it.copy(tradingParams = it.tradingParams.copy(minBlockSizeText = digits(t, 9), error = null)) }
+    fun clearTpResult() = _uiState.update { it.copy(tradingParams = it.tradingParams.copy(result = null, error = null)) }
+    fun submitTradingParams() {
+        val f = _uiState.value.tradingParams
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(tradingParams = it.tradingParams.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.tradingParams(f.symbolInt!!, f.maxQtyInt, f.maxNotionalLong, f.priceBandPctLong, f.circuitBreakerPctLong, f.minBlockSizeInt)
+            _uiState.update { it.copy(tradingParams = it.tradingParams.finish(r)) }
+        }
+    }
+
+    // risk_config
+    fun setRiskMaxNotional(t: String) = _uiState.update { it.copy(riskConfig = it.riskConfig.copy(maxNotionalText = digits(t, 15), error = null)) }
+    fun setRiskWindow(t: String) = _uiState.update { it.copy(riskConfig = it.riskConfig.copy(windowSecondsText = digits(t, 9), error = null)) }
+    fun setRiskMpid(t: String) = _uiState.update { it.copy(riskConfig = it.riskConfig.copy(mpidText = mpid(t), error = null)) }
+    fun clearRiskResult() = _uiState.update { it.copy(riskConfig = it.riskConfig.copy(result = null, error = null)) }
+    fun submitRiskConfig() {
+        val f = _uiState.value.riskConfig
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(riskConfig = it.riskConfig.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.riskConfig(f.maxNotionalLong!!, f.windowSecondsInt!!, f.mpid)
+            _uiState.update { it.copy(riskConfig = it.riskConfig.finish(r)) }
+        }
+    }
+
+    // spot_index
+    fun setSpotIndexSymbol(t: String) = _uiState.update { it.copy(spotIndex = it.spotIndex.copy(symbolText = digits(t, 9), error = null)) }
+    fun setSpotIndexPrice(t: String) = _uiState.update { it.copy(spotIndex = it.spotIndex.copy(spotIndexPriceText = digits(t, 15), error = null)) }
+    fun clearSpotIndexResult() = _uiState.update { it.copy(spotIndex = it.spotIndex.copy(result = null, error = null)) }
+    fun submitSpotIndex() {
+        val f = _uiState.value.spotIndex
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(spotIndex = it.spotIndex.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.spotIndex(f.symbolInt!!, f.spotIndexPriceLong!!)
+            _uiState.update { it.copy(spotIndex = it.spotIndex.finish(r)) }
+        }
+    }
+
+    // spot_config
+    fun setSpotCfgSymbol(t: String) = _uiState.update { it.copy(spotConfig = it.spotConfig.copy(symbolText = digits(t, 9), error = null)) }
+    fun setSpotCfgBase(t: String) = _uiState.update { it.copy(spotConfig = it.spotConfig.copy(baseAssetText = digits(t, 9), error = null)) }
+    fun setSpotCfgQuote(t: String) = _uiState.update { it.copy(spotConfig = it.spotConfig.copy(quoteAssetText = digits(t, 9), error = null)) }
+    fun clearSpotCfgResult() = _uiState.update { it.copy(spotConfig = it.spotConfig.copy(result = null, error = null)) }
+    fun submitSpotConfig() {
+        val f = _uiState.value.spotConfig
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(spotConfig = it.spotConfig.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.spotConfig(f.symbolInt!!, f.baseAssetInt!!, f.quoteAssetInt!!)
+            _uiState.update { it.copy(spotConfig = it.spotConfig.finish(r)) }
         }
     }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -54,6 +54,8 @@ class TradingViewModel @Inject constructor(
                 tradingParams = it.tradingParams.copy(symbolText = sym),
                 spotIndex = it.spotIndex.copy(symbolText = sym),
                 spotConfig = it.spotConfig.copy(symbolText = sym),
+                pmCreateBinary = it.pmCreateBinary.copy(symbolText = sym),
+                pmResolveBinary = it.pmResolveBinary.copy(symbolText = sym),
             )
         }
         resolveAdmin()
@@ -121,7 +123,7 @@ class TradingViewModel @Inject constructor(
     private fun resolveAdmin() {
         viewModelScope.launch {
             when (val r = currentUserRepository.isAdmin()) {
-                is ApiResult.Success -> _uiState.update { it.copy(isAdmin = r.data) }
+                is ApiResult.Success -> { _uiState.update { it.copy(isAdmin = r.data) }; if (r.data) loadPmResolutions() }
                 else -> Unit
             }
         }
@@ -817,4 +819,84 @@ class TradingViewModel @Inject constructor(
             }
         }
     }
+
+    // ---- Admin prediction-markets forms (exchange-admin-config) ----
+
+    // create binary
+    fun setPmBinSymbol(t: String) = _uiState.update { it.copy(pmCreateBinary = it.pmCreateBinary.copy(symbolText = digits(t, 9), error = null)) }
+    fun setPmBinFace(t: String) = _uiState.update { it.copy(pmCreateBinary = it.pmCreateBinary.copy(faceText = digits(t, 12), error = null)) }
+    fun setPmBinResolver(t: String) = _uiState.update { it.copy(pmCreateBinary = it.pmCreateBinary.copy(resolverText = mpid(t), error = null)) }
+    fun clearPmBinResult() = _uiState.update { it.copy(pmCreateBinary = it.pmCreateBinary.copy(result = null, error = null)) }
+    fun submitPmCreateBinary() {
+        val f = _uiState.value.pmCreateBinary
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(pmCreateBinary = it.pmCreateBinary.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.pmConfig(f.symbolInt!!, f.faceLong!!, f.resolver)
+            _uiState.update { it.copy(pmCreateBinary = it.pmCreateBinary.finish(r)) }
+            if (r is ApiResult.Success && r.data.applied) refreshPm()
+        }
+    }
+
+    // create categorical (grouped)
+    fun setPmCatGroup(t: String) = _uiState.update { it.copy(pmCreateCategorical = it.pmCreateCategorical.copy(groupText = digits(t, 9), error = null)) }
+    fun setPmCatOutcomes(t: String) = _uiState.update { it.copy(pmCreateCategorical = it.pmCreateCategorical.copy(outcomesText = t.filter { c -> c.isDigit() || c == ',' || c == ' ' }.take(120), error = null)) }
+    fun setPmCatFace(t: String) = _uiState.update { it.copy(pmCreateCategorical = it.pmCreateCategorical.copy(faceText = digits(t, 12), error = null)) }
+    fun setPmCatResolver(t: String) = _uiState.update { it.copy(pmCreateCategorical = it.pmCreateCategorical.copy(resolverText = mpid(t), error = null)) }
+    fun clearPmCatResult() = _uiState.update { it.copy(pmCreateCategorical = it.pmCreateCategorical.copy(result = null, error = null)) }
+    fun submitPmCreateCategorical() {
+        val f = _uiState.value.pmCreateCategorical
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(pmCreateCategorical = it.pmCreateCategorical.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.pmGroupConfig(f.groupInt!!, f.outcomes, f.faceLong!!, f.resolver)
+            _uiState.update { it.copy(pmCreateCategorical = it.pmCreateCategorical.finish(r)) }
+        }
+    }
+
+    // resolve binary
+    fun setPmResolveSymbol(t: String) = _uiState.update { it.copy(pmResolveBinary = it.pmResolveBinary.copy(symbolText = digits(t, 9), error = null)) }
+    fun setPmResolveYes(yes: Boolean) = _uiState.update { it.copy(pmResolveBinary = it.pmResolveBinary.copy(yes = yes, error = null)) }
+    fun setPmResolveSource(t: String) = _uiState.update { it.copy(pmResolveBinary = it.pmResolveBinary.copy(sourceText = source(t), error = null)) }
+    fun clearPmResolveResult() = _uiState.update { it.copy(pmResolveBinary = it.pmResolveBinary.copy(result = null, error = null)) }
+    fun submitPmResolveBinary() {
+        val f = _uiState.value.pmResolveBinary
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(pmResolveBinary = it.pmResolveBinary.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.pmResolve(f.symbolInt!!, f.outcome, f.source)
+            _uiState.update { it.copy(pmResolveBinary = it.pmResolveBinary.finish(r)) }
+            if (r is ApiResult.Success && r.data.applied) { refreshPm(); loadPmResolutions() }
+        }
+    }
+
+    // resolve categorical
+    fun setPmGroupResolveGroup(t: String) = _uiState.update { it.copy(pmResolveCategorical = it.pmResolveCategorical.copy(groupText = digits(t, 9), error = null)) }
+    fun setPmGroupResolveWinning(t: String) = _uiState.update { it.copy(pmResolveCategorical = it.pmResolveCategorical.copy(winningText = digits(t, 9), error = null)) }
+    fun setPmGroupResolveSource(t: String) = _uiState.update { it.copy(pmResolveCategorical = it.pmResolveCategorical.copy(sourceText = source(t), error = null)) }
+    fun clearPmGroupResolveResult() = _uiState.update { it.copy(pmResolveCategorical = it.pmResolveCategorical.copy(result = null, error = null)) }
+    fun submitPmResolveCategorical() {
+        val f = _uiState.value.pmResolveCategorical
+        if (!f.canSubmit) return
+        _uiState.update { it.copy(pmResolveCategorical = it.pmResolveCategorical.copy(submitting = true, error = null, result = null)) }
+        viewModelScope.launch {
+            val r = repository.pmGroupResolve(f.groupInt!!, f.winningInt!!, f.source)
+            _uiState.update { it.copy(pmResolveCategorical = it.pmResolveCategorical.finish(r)) }
+            if (r is ApiResult.Success && r.data.applied) loadPmResolutions()
+        }
+    }
+
+    /** Load the PM resolution audit log (admin). 404 -> empty; failure leaves the list unchanged. */
+    fun loadPmResolutions() {
+        viewModelScope.launch {
+            when (val r = repository.pmResolutions()) {
+                is ApiResult.Success -> _uiState.update { it.copy(pmResolutions = r.data) }
+                else -> Unit
+            }
+        }
+    }
+
+    /** Sanitize an optional free-text resolution source (alnum + a few separators). */
+    private fun source(t: String): String = t.filter { it.isLetterOrDigit() || it == '-' || it == '_' || it == ' ' || it == '.' }.take(40)
+
 }

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/EngineConfigContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/EngineConfigContractTest.kt
@@ -1,0 +1,80 @@
+package com.testlogon.android.data.exchange
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import com.testlogon.android.testutil.testMoshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Contract tests for the admin engine-config data layer (exchange-admin-config). Verifies the shared
+ * [EngineConfigAckDto] -> [EngineConfigAck] mapping (ack/rejected/result) and that an undeployed route
+ * (404) degrades to an un-applied ack instead of failing.
+ */
+class EngineConfigContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi = testMoshi()
+
+    private fun repo(): TradingRepository {
+        val api = backend.retrofit(moshi).create(TradingApi::class.java)
+        return TradingRepositoryImpl(api = api, errorParser = ApiErrorParser(moshi))
+    }
+
+    @Test
+    fun matchingAlgo_ackResultZero_isApplied() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","type":"matching_algo","symbolid":3,"result":0}"""))
+        val r = repo().matchingAlgo(3, 1, null, null)
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertTrue(ack.applied)
+        assertEquals(3, ack.symbolId)
+        assertEquals(0, ack.result)
+    }
+
+    @Test
+    fun spreadConfig_rejected_isNotApplied_withMessage() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"rejected","type":"spread_config","result":7,"error":"bad legs"}"""))
+        val r = repo().spreadConfig(9, 1, 2, 1, -1)
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertFalse(ack.applied)
+        assertEquals(7, ack.result)
+        assertEquals("bad legs", ack.message)
+    }
+
+    @Test
+    fun ackWithNoResultField_defaultsAppliedOnAck() = runTest {
+        // result absent -> treated as 0 (applied) when status is "ack".
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","type":"risk_config"}"""))
+        val r = repo().riskConfig(1_000_000L, 60, null)
+        assertTrue(r is ApiResult.Success)
+        assertTrue((r as ApiResult.Success).data.applied)
+    }
+
+    @Test
+    fun undeployedRoute_404_degradesToUnappliedAck() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val r = repo().spotConfig(3, 100, 200)
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertFalse(ack.applied)
+    }
+
+    @Test
+    fun spotIndex_ack_maps() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","type":"spot_index","symbolid":5,"result":0}"""))
+        val r = repo().spotIndex(5, 4_200_000L)
+        assertTrue(r is ApiResult.Success)
+        assertTrue((r as ApiResult.Success).data.applied)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/PmAdminContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/PmAdminContractTest.kt
@@ -1,0 +1,141 @@
+package com.testlogon.android.data.exchange
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import com.testlogon.android.testutil.testMoshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Contract + mapper tests for the admin prediction-markets data layer (exchange-admin-config):
+ * pm_config / pm_group_config / pm_resolve / pm_group_resolve acks and the pm_resolutions log. Covers
+ * the ack/rejected/result mapping, the resolver 403, the 404 degrade, and the binary/categorical
+ * resolution-row mapping.
+ */
+class PmAdminContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi = testMoshi()
+
+    private fun repo(): TradingRepository {
+        val api = backend.retrofit(moshi).create(TradingApi::class.java)
+        return TradingRepositoryImpl(api = api, errorParser = ApiErrorParser(moshi))
+    }
+
+    @Test
+    fun pmConfig_ackResultZero_isApplied() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","type":"pm_config","symbolid":7,"result":0}"""))
+        val r = repo().pmConfig(7, 100L, "resolver1")
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertTrue(ack.applied)
+        assertEquals(7, ack.symbolId)
+        assertEquals(0, ack.result)
+    }
+
+    @Test
+    fun pmGroupConfig_rejected_isNotApplied_withMessage() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"rejected","type":"pm_group_config","group_id":3,"result":9,"error":"need >= 2 outcomes"}"""))
+        val r = repo().pmGroupConfig(3, listOf(11, 12), 100L, null)
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertFalse(ack.applied)
+        assertEquals(3, ack.groupId)
+        assertEquals("need >= 2 outcomes", ack.message)
+    }
+
+    @Test
+    fun pmResolve_ack_maps() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","type":"pm_resolve","symbolid":7}"""))
+        val r = repo().pmResolve(7, "yes", "reuters")
+        assertTrue(r is ApiResult.Success)
+        // result absent -> treated as 0 (applied) when status is "ack".
+        assertTrue((r as ApiResult.Success).data.applied)
+    }
+
+    @Test
+    fun pmResolve_403_notDesignatedResolver_isFailure() = runTest {
+        backend.enqueue(Fixtures.error("\"not the designated resolver\"", 403))
+        val r = repo().pmResolve(7, "no", null)
+        assertTrue(r is ApiResult.Failure)
+    }
+
+    @Test
+    fun pmGroupResolve_ack_maps() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","type":"pm_group_resolve","group_id":3,"result":0}"""))
+        val r = repo().pmGroupResolve(3, 12, "oracle")
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertTrue(ack.applied)
+        assertEquals(3, ack.groupId)
+    }
+
+    @Test
+    fun undeployedRoute_404_degradesToUnappliedAck() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val r = repo().pmConfig(7, 100L, null)
+        assertTrue(r is ApiResult.Success)
+        assertFalse((r as ApiResult.Success).data.applied)
+    }
+
+    @Test
+    fun pmResolutions_parsesBinaryAndCategoricalRows() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """[
+                    {"symbolid":7,"outcome":"yes","resolver_id":"resolver1","ts":1710000000000,"source":"reuters"},
+                    {"group_id":3,"winning_symbolid":12,"resolver_id":"oracle","ts":"1710000001000","source":"oracle"}
+                ]""",
+            ),
+        )
+        val r = repo().pmResolutions()
+        assertTrue(r is ApiResult.Success)
+        val rows = (r as ApiResult.Success).data
+        assertEquals(2, rows.size)
+
+        val binary = rows[0]
+        assertFalse(binary.isGroup)
+        assertEquals(7, binary.symbolId)
+        assertEquals(true, binary.outcomeYes)
+        assertEquals("#7", binary.marketLabel)
+        assertEquals("YES", binary.outcomeLabel)
+        assertEquals("resolver1", binary.resolverId)
+
+        val group = rows[1]
+        assertTrue(group.isGroup)
+        assertEquals(3, group.groupId)
+        assertEquals(12, group.winningSymbolId)
+        // ts arrived as a JSON string -> lenient long parse.
+        assertEquals(1710000001000L, group.ts)
+        assertEquals("group 3", group.marketLabel)
+        assertEquals("#12", group.outcomeLabel)
+    }
+
+    @Test
+    fun pmResolutions_404_degradesToEmptyList() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val r = repo().pmResolutions()
+        assertTrue(r is ApiResult.Success)
+        assertTrue((r as ApiResult.Success).data.isEmpty())
+    }
+
+    @Test
+    fun pmResolutionDto_binaryNo_mapsOutcomeFalse() {
+        val dto = PmResolutionDto(symbolId = 5, outcome = "no", resolverId = "r", ts = 1L, source = "s")
+        val m = dto.toDomain()
+        assertFalse(m.isGroup)
+        assertEquals(false, m.outcomeYes)
+        assertEquals("NO", m.outcomeLabel)
+        assertNull(dto.groupId)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/StakeAuctionContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/StakeAuctionContractTest.kt
@@ -1,0 +1,114 @@
+package com.testlogon.android.data.exchange
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import com.testlogon.android.testutil.testMoshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Contract tests for the trader staking + auctions data layer (peer mechanisms). Verifies the shared
+ * [StakeAuctionAckDto] -> [StakeAuctionAck] mapping (per-kind created id + accepted/rejected/message +
+ * the id label) and that an undeployed route (404) degrades to an un-applied ack instead of failing.
+ */
+class StakeAuctionContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi = testMoshi()
+
+    private fun repo(): TradingRepository {
+        val api = backend.retrofit(moshi).create(TradingApi::class.java)
+        return TradingRepositoryImpl(api = api, errorParser = ApiErrorParser(moshi))
+    }
+
+    @Test
+    fun stakeRequest_ack_surfacesRequestId() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","type":"stake_request","request_id":42}"""))
+        val r = repo().stakeRequest(3, 1000L, 50L, 3600, 86400)
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertTrue(ack.accepted)
+        assertEquals(StakeAuctionKind.STAKE_REQUEST, ack.kind)
+        assertEquals(42L, ack.createdId)
+        assertEquals("Request #42", ack.idLabel)
+    }
+
+    @Test
+    fun stakeRequest_stringifiedId_isLenient() = runTest {
+        // The edge may stringify numeric ids -> the @LenientLong adapter must still parse it.
+        backend.enqueue(Fixtures.okBody("""{"status":"ok","request_id":"77"}"""))
+        val r = repo().stakeRequest(null, 500L, 10L, 60, 120)
+        val ack = (r as ApiResult.Success).data
+        assertTrue(ack.accepted)
+        assertEquals(77L, ack.createdId)
+    }
+
+    @Test
+    fun auctionRequest_ack_surfacesAuctionId() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"created","type":"auction_request","auction_id":7}"""))
+        val r = repo().auctionRequest(3, 5, 250L, 3600)
+        val ack = (r as ApiResult.Success).data
+        assertTrue(ack.accepted)
+        assertEquals(StakeAuctionKind.AUCTION_REQUEST, ack.kind)
+        assertEquals(7L, ack.createdId)
+        assertEquals("Auction #7", ack.idLabel)
+    }
+
+    @Test
+    fun stakeOffer_ack_prefersOfferId_elseFallsBackToRequestId() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","offer_id":9,"request_id":42}"""))
+        val withOffer = (repo().stakeOffer(42L, 1000L, 25L) as ApiResult.Success).data
+        assertEquals(9L, withOffer.createdId)
+        assertEquals("Offer #9", withOffer.idLabel)
+
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","request_id":42}"""))
+        val withoutOffer = (repo().stakeOffer(42L, 1000L, 25L) as ApiResult.Success).data
+        assertEquals(42L, withoutOffer.createdId)
+    }
+
+    @Test
+    fun auctionBid_ack_prefersBidId_elseFallsBackToAuctionId() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","bid_id":3,"auction_id":7}"""))
+        val withBid = (repo().auctionBid(7L, 300L, 2) as ApiResult.Success).data
+        assertEquals(3L, withBid.createdId)
+        assertEquals("Bid #3", withBid.idLabel)
+    }
+
+    @Test
+    fun rejected_nonZeroResult_isNotAccepted_withMessage() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"status":"rejected","type":"auction_bid","result":5,"error":"below reserve"}"""))
+        val ack = (repo().auctionBid(7L, 1L, 1) as ApiResult.Success).data
+        assertFalse(ack.accepted)
+        assertEquals("below reserve", ack.message)
+        assertNull(ack.idLabel)
+    }
+
+    @Test
+    fun ackWithNonZeroResult_isNotAccepted() = runTest {
+        // status ack but a non-zero result means the engine did not apply it.
+        backend.enqueue(Fixtures.okBody("""{"status":"ack","result":3}"""))
+        val ack = (repo().stakeRequest(1, 1L, 1L, 1, 1) as ApiResult.Success).data
+        assertFalse(ack.accepted)
+    }
+
+    @Test
+    fun undeployedRoute_404_degradesToUnappliedAck() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val r = repo().stakeRequest(3, 1000L, 50L, 3600, 86400)
+        assertTrue(r is ApiResult.Success)
+        val ack = (r as ApiResult.Success).data
+        assertFalse(ack.accepted)
+        assertNull(ack.createdId)
+        assertEquals(StakeAuctionKind.STAKE_REQUEST, ack.kind)
+    }
+}

--- a/frontend/src/api/endpoints/trading.ts
+++ b/frontend/src/api/endpoints/trading.ts
@@ -509,3 +509,93 @@ export const setSpotIndex = (body: SpotIndexRequest) =>
 /** Admin-only: mark a symbol spot-enforced with a base/quote asset pair. */
 export const setSpotConfig = (body: SpotConfigRequest) =>
   api.post<EngineConfigAck>("/me/spot_config", body);
+
+
+// ── Prediction-market admin surfaces (`/me/pm_*`) ────────────────────
+// Admin-only routes that create/configure & resolve prediction markets. A binary
+// PM trades YES shares in (0, face_value); a YES share pays face_value on YES
+// resolution else 0 (implied probability = price / face_value). A categorical
+// market is N linked binaries sharing a group_id where exactly one wins. Each
+// route returns an engine ack `{ status, ... }` ("ack" | "rejected"); pm_resolve
+// / pm_group_resolve return 403 when the caller is not the designated resolver.
+// NOT deployed to every backend — the route MAY 404; callers degrade gracefully.
+
+/** Create/config a binary prediction market. `face_value` must be > 1. */
+export interface PmConfigRequest {
+  symbolid: number;
+  face_value: number;
+  resolver?: string;
+}
+
+/** Create/config a categorical (group of linked binary outcomes). */
+export interface PmGroupConfigRequest {
+  group_id: number;
+  outcomes: number[];
+  face_value: number;
+  resolver?: string;
+}
+
+/** Settle a binary PM: "yes" pays face, "no" pays 0. */
+export interface PmResolveRequest {
+  symbolid: number;
+  outcome: "yes" | "no";
+  source?: string;
+}
+
+/** Resolve a categorical: winning_symbolid pays face, the rest pay 0. */
+export interface PmGroupResolveRequest {
+  group_id: number;
+  winning_symbolid: number;
+  source?: string;
+}
+
+/** Generic PM admin ack. `status` "ack" | "rejected"; 403 surfaces via detail/error. */
+export interface PmAdminAck {
+  status?: "ack" | "rejected" | string;
+  type?: string;
+  symbolid?: number;
+  group_id?: number;
+  outcome?: string;
+  /** 0 = applied; non-zero = rejected (mirrors EngineConfigAck). */
+  result?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+  reasoncode?: number;
+}
+
+/** One entry in the resolution audit log. */
+export interface PmResolution {
+  symbolid?: number;
+  group_id?: number;
+  outcome?: string;
+  winning_symbolid?: number;
+  resolver_id?: string;
+  ts?: number;
+  source?: string;
+}
+
+/** The resolution audit log (array). 404s until the PM surface deploys. */
+export interface PmResolutionsResult {
+  status?: string;
+  type?: string;
+  resolutions?: PmResolution[];
+}
+
+/** Admin-only: create/config a binary prediction market. */
+export const pmConfig = (body: PmConfigRequest) => api.post<PmAdminAck>("/me/pm_config", body);
+
+/** Admin-only: create/config a categorical (N linked binary outcomes). */
+export const pmGroupConfig = (body: PmGroupConfigRequest) =>
+  api.post<PmAdminAck>("/me/pm_group_config", body);
+
+/** Admin-only: settle a binary PM (403 if not the designated resolver). */
+export const pmResolve = (body: PmResolveRequest) => api.post<PmAdminAck>("/me/pm_resolve", body);
+
+/** Admin-only: resolve a categorical PM (403 if not the designated resolver). */
+export const pmGroupResolve = (body: PmGroupResolveRequest) =>
+  api.post<PmAdminAck>("/me/pm_group_resolve", body);
+
+/** The prediction-market resolution audit log. 404s until the PM surface deploys. */
+export const getPmResolutions = () => api.get<PmResolutionsResult>("/me/pm_resolutions");

--- a/frontend/src/api/endpoints/trading.ts
+++ b/frontend/src/api/endpoints/trading.ts
@@ -599,3 +599,112 @@ export const pmGroupResolve = (body: PmGroupResolveRequest) =>
 
 /** The prediction-market resolution audit log. 404s until the PM surface deploys. */
 export const getPmResolutions = () => api.get<PmResolutionsResult>("/me/pm_resolutions");
+
+
+// ── Staking & Auctions trader surfaces (`/me/*`) ─────────────────────
+// Two PEER trader mechanisms on the matching engine (NOT admin): a collateral
+// staking market and distressed-position auctions. Each POST returns an engine
+// ack `{ status, ... }` that surfaces the created id (`request_id` / `auction_id`)
+// when present. There is NO server-side list/GET of open stake requests or open
+// auctions — callers can create + act-by-id but cannot browse open items.
+// Amounts/prices/qty are int64 engine ticks. Routes are NOT deployed to prod →
+// they MAY 404; callers degrade gracefully (surface the failure inline, no crash).
+
+/** Create an outstanding stake request (peer collateral-staking market). */
+export interface StakeRequestRequest {
+  symbolid?: number;
+  min_collateral: number;
+  max_stake_pct: number;
+  lockup_seconds: number;
+  duration_seconds: number;
+}
+
+/** Offer collateral to fill an outstanding stake request by id. */
+export interface StakeOfferRequest {
+  request_id: number;
+  collateral_amount: number;
+  stake_pct: number;
+}
+
+/** Create an auction of a (distressed) position qty. */
+export interface AuctionRequestRequest {
+  symbolid?: number;
+  qty: number;
+  reserve_price?: number;
+  duration_seconds?: number;
+}
+
+/** Bid into an open auction by id. */
+export interface AuctionBidRequest {
+  auction_id: number;
+  price: number;
+  qty: number;
+}
+
+/** Ack for a created stake request — surfaces `request_id` when present. */
+export interface StakeRequestAck {
+  status?: string;
+  type?: string;
+  request_id?: number;
+  symbolid?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+  reasoncode?: number;
+}
+
+/** Ack for an offer on a stake request. */
+export interface StakeOfferAck {
+  status?: string;
+  type?: string;
+  request_id?: number;
+  offer_id?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+  reasoncode?: number;
+}
+
+/** Ack for a created auction — surfaces `auction_id` when present. */
+export interface AuctionRequestAck {
+  status?: string;
+  type?: string;
+  auction_id?: number;
+  symbolid?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+  reasoncode?: number;
+}
+
+/** Ack for a bid into an auction. */
+export interface AuctionBidAck {
+  status?: string;
+  type?: string;
+  auction_id?: number;
+  bid_id?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+  reasoncode?: number;
+}
+
+/** Trader: create an outstanding stake request. 404s until the surface deploys. */
+export const stakeRequest = (body: StakeRequestRequest) =>
+  api.post<StakeRequestAck>("/me/stake_request", body);
+
+/** Trader: offer collateral to fill an outstanding stake request by id. */
+export const stakeOffer = (body: StakeOfferRequest) =>
+  api.post<StakeOfferAck>("/me/stake_offer", body);
+
+/** Trader: create an auction of a position qty. 404s until the surface deploys. */
+export const auctionRequest = (body: AuctionRequestRequest) =>
+  api.post<AuctionRequestAck>("/me/auction_request", body);
+
+/** Trader: bid into an open auction by id. */
+export const auctionBid = (body: AuctionBidRequest) =>
+  api.post<AuctionBidAck>("/me/auction_bid", body);

--- a/frontend/src/api/endpoints/trading.ts
+++ b/frontend/src/api/endpoints/trading.ts
@@ -415,3 +415,97 @@ export const getLiquidations = () => api.get<LiquidationsResult>("/me/liquidatio
 /** The caller's periodic funding payments (newest first). 404s until edge deploys. */
 export const getFundingPayments = () =>
   api.get<FundingPaymentsResult>("/me/funding/payments");
+
+
+// ── Admin engine-config surfaces (`/me/*`) ───────────────────────────
+// Six admin-only POST routes that tune the matching engine per-symbol. Each
+// returns an engine ack `{ status, ... }` where status is "ack" | "rejected"
+// (or carries a `result`/computed field). NOT deployed to every backend — the
+// route MAY 404; callers degrade gracefully (surface the failure inline, no crash).
+
+/** Generic admin engine-config ack. `status` "ack" | "rejected"; extra fields per-route. */
+export interface EngineConfigAck {
+  status?: "ack" | "rejected" | string;
+  type?: string;
+  symbolid?: number;
+  /** 0 = applied; non-zero = rejected (mirrors MarginConfigAck). */
+  result?: number;
+  /** Recomputed funding rate returned by /me/spot_index. */
+  funding_rate_bps?: number;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+  reasoncode?: number;
+}
+
+/** Per-symbol matching algorithm. algo 0 = price-time (default); 1+ = pro-rata / specialist. */
+export interface MatchingAlgoRequest {
+  symbolid: number;
+  algo: number;
+  specialist_mpid?: string;
+  specialist_pct?: number;
+}
+
+/** Two-leg spread definition. leg1_ratio defaults 1, leg2_ratio defaults -1. */
+export interface SpreadConfigRequest {
+  spread_symbolid: number;
+  leg1: number;
+  leg2: number;
+  leg1_ratio?: number;
+  leg2_ratio?: number;
+}
+
+/** Per-symbol trading limits / bands / circuit breaker. */
+export interface TradingParamsRequest {
+  symbolid: number;
+  max_qty?: number;
+  max_notional?: number;
+  price_band_pct?: number;
+  circuit_breaker_pct?: number;
+  min_block_size?: number;
+}
+
+/** Per-MPID notional kill switch over a rolling window. */
+export interface RiskConfigRequest {
+  max_notional: number;
+  window_seconds: number;
+  mpid?: string;
+}
+
+/** Sets the perp funding index; engine recomputes funding_rate_bps (returned in ack). */
+export interface SpotIndexRequest {
+  symbolid: number;
+  spot_index_price: number;
+}
+
+/** Marks a symbol spot-enforced with a base/quote asset pair. */
+export interface SpotConfigRequest {
+  symbolid: number;
+  base_asset: number;
+  quote_asset: number;
+}
+
+/** Admin-only: set the per-symbol matching algorithm. */
+export const setMatchingAlgo = (body: MatchingAlgoRequest) =>
+  api.post<EngineConfigAck>("/me/matching_algo", body);
+
+/** Admin-only: define a two-leg spread symbol. */
+export const setSpreadConfig = (body: SpreadConfigRequest) =>
+  api.post<EngineConfigAck>("/me/spread_config", body);
+
+/** Admin-only: set per-symbol trading limits / price bands / circuit breaker. */
+export const setTradingParams = (body: TradingParamsRequest) =>
+  api.post<EngineConfigAck>("/me/trading_params", body);
+
+/** Admin-only: set a per-MPID notional kill switch over a rolling window. */
+export const setRiskConfig = (body: RiskConfigRequest) =>
+  api.post<EngineConfigAck>("/me/risk_config", body);
+
+/** Admin-only: set the perp funding index; ack echoes the recomputed funding_rate_bps. */
+export const setSpotIndex = (body: SpotIndexRequest) =>
+  api.post<EngineConfigAck>("/me/spot_index", body);
+
+/** Admin-only: mark a symbol spot-enforced with a base/quote asset pair. */
+export const setSpotConfig = (body: SpotConfigRequest) =>
+  api.post<EngineConfigAck>("/me/spot_config", body);

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -10,6 +10,7 @@ export const tradingKeys = {
   fillsFees: ["me", "fills_fees"] as const,
   liquidations: ["me", "liquidations"] as const,
   fundingPayments: ["me", "funding_payments"] as const,
+  pmResolutions: ["me", "pm_resolutions"] as const,
 };
 
 /** Exchange account-feed poll (fills-fees / liquidations / funding). */
@@ -214,4 +215,42 @@ export function useSpotIndex() {
 /** Admin-only: mark a symbol spot-enforced (base/quote asset pair). */
 export function useSpotConfig() {
   return useMutation({ mutationFn: trading.setSpotConfig });
+}
+
+
+// ── Prediction-market admin surfaces (`/me/pm_*`) ────────────────────
+// Admin-only PM create/config + resolve mutations and the resolution audit-log
+// query. No account-invalidate (they tune markets, not the caller balance).
+// Routes MAY 404 (not deployed everywhere); resolve MAY 403 (not the resolver)
+// — the calling UI reports either inline, no retry loop.
+
+/** Admin-only: create/config a binary prediction market. */
+export function usePmConfig() {
+  return useMutation({ mutationFn: trading.pmConfig });
+}
+
+/** Admin-only: create/config a categorical (N linked binary outcomes). */
+export function usePmGroupConfig() {
+  return useMutation({ mutationFn: trading.pmGroupConfig });
+}
+
+/** Admin-only: settle a binary PM (403 if not the designated resolver). */
+export function usePmResolve() {
+  return useMutation({ mutationFn: trading.pmResolve });
+}
+
+/** Admin-only: resolve a categorical PM (403 if not the designated resolver). */
+export function usePmGroupResolve() {
+  return useMutation({ mutationFn: trading.pmGroupResolve });
+}
+
+/** PM resolution audit log. `retry: false` — the route 404s until the PM surface deploys. */
+export function usePmResolutions(enabled = true) {
+  return useQuery({
+    queryKey: tradingKeys.pmResolutions,
+    queryFn: trading.getPmResolutions,
+    enabled,
+    retry: false,
+    refetchInterval: ACCOUNT_REFETCH_MS,
+  });
 }

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -179,3 +179,39 @@ export function useFundingPayments(enabled = true) {
     refetchInterval: FEED_REFETCH_MS,
   });
 }
+
+
+// ── Admin engine-config mutations (`/me/*`) ──────────────────────────
+// Six admin-only engine-config POSTs. No account-invalidate needed (they tune
+// the engine, not the caller balance). Each route MAY 404 on backends without
+// the surface deployed — the calling UI reports that inline, no retry loop.
+
+/** Admin-only: per-symbol matching algorithm (price-time / pro-rata / specialist). */
+export function useMatchingAlgo() {
+  return useMutation({ mutationFn: trading.setMatchingAlgo });
+}
+
+/** Admin-only: define a two-leg spread symbol. */
+export function useSpreadConfig() {
+  return useMutation({ mutationFn: trading.setSpreadConfig });
+}
+
+/** Admin-only: per-symbol trading limits / price bands / circuit breaker. */
+export function useTradingParams() {
+  return useMutation({ mutationFn: trading.setTradingParams });
+}
+
+/** Admin-only: per-MPID notional kill switch. */
+export function useRiskConfig() {
+  return useMutation({ mutationFn: trading.setRiskConfig });
+}
+
+/** Admin-only: set the perp funding index (ack echoes recomputed funding_rate_bps). */
+export function useSpotIndex() {
+  return useMutation({ mutationFn: trading.setSpotIndex });
+}
+
+/** Admin-only: mark a symbol spot-enforced (base/quote asset pair). */
+export function useSpotConfig() {
+  return useMutation({ mutationFn: trading.setSpotConfig });
+}

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -254,3 +254,29 @@ export function usePmResolutions(enabled = true) {
     refetchInterval: ACCOUNT_REFETCH_MS,
   });
 }
+
+
+// ── Staking & Auctions trader mutations (`/me/*`) ────────────────────
+// Two PEER trader mechanisms (NOT admin). No account-invalidate — the created
+// id (request_id / auction_id) is the caller-tracked handle. Each route MAY 404
+// (not deployed to prod); the calling UI reports that inline, no retry loop.
+
+/** Trader: create an outstanding stake request. */
+export function useStakeRequest() {
+  return useMutation({ mutationFn: trading.stakeRequest });
+}
+
+/** Trader: offer collateral to fill an outstanding stake request by id. */
+export function useStakeOffer() {
+  return useMutation({ mutationFn: trading.stakeOffer });
+}
+
+/** Trader: create an auction of a position qty. */
+export function useAuctionRequest() {
+  return useMutation({ mutationFn: trading.auctionRequest });
+}
+
+/** Trader: bid into an open auction by id. */
+export function useAuctionBid() {
+  return useMutation({ mutationFn: trading.auctionBid });
+}

--- a/frontend/src/pages/markets/EngineConfigPanel.tsx
+++ b/frontend/src/pages/markets/EngineConfigPanel.tsx
@@ -1,0 +1,499 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  useMatchingAlgo,
+  useSpreadConfig,
+  useTradingParams,
+  useRiskConfig,
+  useSpotIndex,
+  useSpotConfig,
+} from "@/hooks/useTrading";
+import type { EngineConfigAck } from "@/api/endpoints/trading";
+import { useAuthStore } from "@/stores/authStore";
+
+// ─── Admin: matching-engine config surfaces ────────────────────────
+// A single admin-gated panel grouping the six engine-config POST routes as
+// compact collapsible forms. Mirrors MarginConfigPanel styling (amber accent,
+// collapsible). Returns null for non-admins. Every route MAY 404 (not deployed
+// to all backends) — failures surface inline, never crash the ticket.
+
+type Ack = { text: string; error: boolean } | null;
+
+/** Turn an engine ack into inline "applied vs rejected" feedback. */
+function ackFeedback(a: EngineConfigAck, appliedText: string): { text: string; error: boolean } {
+  const okd = a.status === "ack" && (a.result ?? 0) === 0;
+  if (okd) return { text: appliedText, error: false };
+  const why = a.detail || a.error || a.note;
+  const code = a.result != null ? ` (result ${a.result})` : "";
+  return { text: `Rejected${code}${why ? `: ${why}` : ""}`, error: true };
+}
+
+function errText(e: unknown): string {
+  return (e as Error)?.message ?? "Request failed";
+}
+
+/** A single labeled numeric input (digits only; optional). */
+function NumField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="w-full">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Input
+        value={value}
+        inputMode="numeric"
+        placeholder="0"
+        onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ""))}
+        className="mt-1 tabular-nums"
+      />
+    </div>
+  );
+}
+
+/** A single labeled free-text input (for MPIDs). */
+function TextField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="w-full">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Input
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-1"
+      />
+    </div>
+  );
+}
+
+/** Signed integer field (allows a leading minus, e.g. spread leg ratios). */
+function SignedField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="w-full">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Input
+        value={value}
+        inputMode="numeric"
+        placeholder="0"
+        onChange={(e) => onChange(e.target.value.replace(/[^0-9-]/g, ""))}
+        className="mt-1 tabular-nums"
+      />
+    </div>
+  );
+}
+
+/** Inline ack line (green applied / red rejected), shared across sub-forms. */
+function AckLine({ ack }: { ack: Ack }) {
+  if (!ack) return null;
+  return (
+    <p
+      className={cn(
+        "text-xs font-mono",
+        ack.error ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400",
+      )}
+    >
+      {ack.text}
+    </p>
+  );
+}
+
+/** A collapsible titled sub-section wrapping one config form. */
+function SubForm({ title, children }: { title: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-3 py-2 text-xs font-semibold"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span>{title}</span>
+        <span className="text-muted-foreground">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && <div className="space-y-2 border-t px-3 py-3">{children}</div>}
+    </div>
+  );
+}
+
+// ─── 1. Matching algorithm ─────────────────────────────────────────
+const ALGO_OPTS: { value: number; label: string }[] = [
+  { value: 0, label: "0 — Price-Time (default)" },
+  { value: 1, label: "1 — Pro-rata" },
+  { value: 2, label: "2 — Specialist" },
+];
+
+function MatchingAlgoForm({ symbolId }: { symbolId: number }) {
+  const m = useMatchingAlgo();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [algo, setAlgo] = useState("0");
+  const [mpid, setMpid] = useState("");
+  const [pct, setPct] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  const algoN = parseInt(algo) || 0;
+  const pctN = pct === "" ? undefined : parseInt(pct) || 0;
+  const valid = symN > 0 && (pctN === undefined || (pctN >= 0 && pctN <= 100));
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Symbol id must be > 0 and specialist % in 0–100.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      {
+        symbolid: symN,
+        algo: algoN,
+        specialist_mpid: mpid.trim() || undefined,
+        specialist_pct: pctN,
+      },
+      {
+        onSuccess: (a) => setAck(ackFeedback(a, `Algo ${algoN} set on symbol ${a.symbolid ?? symN}.`)),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <NumField label="Symbol id" value={symId} onChange={setSymId} />
+      <div>
+        <label className="text-xs text-muted-foreground">Algorithm</label>
+        <select
+          value={algo}
+          onChange={(e) => setAlgo(e.target.value)}
+          className="mt-1 h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+        >
+          {ALGO_OPTS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {algoN >= 2 && (
+        <div className="grid grid-cols-2 gap-2">
+          <TextField label="Specialist MPID" value={mpid} onChange={setMpid} placeholder="MPID" />
+          <NumField label="Specialist %" value={pct} onChange={setPct} />
+        </div>
+      )}
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Applying…" : "Apply matching algo"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 2. Spread config ──────────────────────────────────────────────
+function SpreadConfigForm({ symbolId }: { symbolId: number }) {
+  const m = useSpreadConfig();
+  const [spreadSym, setSpreadSym] = useState(String(symbolId || ""));
+  const [leg1, setLeg1] = useState("");
+  const [leg2, setLeg2] = useState("");
+  const [r1, setR1] = useState("1");
+  const [r2, setR2] = useState("-1");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSpreadSym(String(symbolId || "")), [symbolId]);
+
+  const spreadN = parseInt(spreadSym) || 0;
+  const leg1N = parseInt(leg1) || 0;
+  const leg2N = parseInt(leg2) || 0;
+  // Ratios may be negative (short leg); parse signed.
+  const r1N = r1.trim() === "" ? 1 : parseInt(r1, 10);
+  const r2N = r2.trim() === "" ? -1 : parseInt(r2, 10);
+  const valid = spreadN > 0 && leg1N > 0 && leg2N > 0 && Number.isFinite(r1N) && Number.isFinite(r2N);
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Spread symbol + both legs must be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { spread_symbolid: spreadN, leg1: leg1N, leg2: leg2N, leg1_ratio: r1N, leg2_ratio: r2N },
+      {
+        onSuccess: (a) => setAck(ackFeedback(a, `Spread ${a.symbolid ?? spreadN} = ${r1N}×${leg1N} + ${r2N}×${leg2N}.`)),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <NumField label="Spread symbol id" value={spreadSym} onChange={setSpreadSym} />
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Leg 1 symbol id" value={leg1} onChange={setLeg1} />
+        <NumField label="Leg 2 symbol id" value={leg2} onChange={setLeg2} />
+        <SignedField label="Leg 1 ratio" value={r1} onChange={setR1} />
+        <SignedField label="Leg 2 ratio" value={r2} onChange={setR2} />
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Applying…" : "Apply spread config"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 3. Trading params ─────────────────────────────────────────────
+const TP_FIELDS: { key: string; label: string }[] = [
+  { key: "max_qty", label: "Max qty" },
+  { key: "max_notional", label: "Max notional" },
+  { key: "price_band_pct", label: "Price band %" },
+  { key: "circuit_breaker_pct", label: "Circuit breaker %" },
+  { key: "min_block_size", label: "Min block size" },
+];
+
+function TradingParamsForm({ symbolId }: { symbolId: number }) {
+  const m = useTradingParams();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [vals, setVals] = useState<Record<string, string>>({});
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  // All optional; only include the ones the operator filled. Any filled value must be >= 0.
+  const filled = TP_FIELDS.filter((f) => (vals[f.key] ?? "").trim() !== "");
+  const valid = symN > 0 && filled.every((f) => (parseInt(vals[f.key]!) || 0) >= 0) && filled.length > 0;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Symbol id > 0 and set at least one non-negative param.", error: true });
+      return;
+    }
+    setAck(null);
+    const body: Record<string, number> = { symbolid: symN };
+    for (const f of filled) body[f.key] = parseInt(vals[f.key]!) || 0;
+    m.mutate(body as never, {
+      onSuccess: (a) => setAck(ackFeedback(a, `Params applied to symbol ${a.symbolid ?? symN}.`)),
+      onError: (e) => setAck({ text: errText(e), error: true }),
+    });
+  };
+
+  return (
+    <>
+      <NumField label="Symbol id" value={symId} onChange={setSymId} />
+      <div className="grid grid-cols-2 gap-2">
+        {TP_FIELDS.map((f) => (
+          <NumField
+            key={f.key}
+            label={f.label}
+            value={vals[f.key] ?? ""}
+            onChange={(v) => setVals((p) => ({ ...p, [f.key]: v }))}
+          />
+        ))}
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Applying…" : "Apply trading params"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 4. Risk config (per-MPID kill switch) ─────────────────────────
+function RiskConfigForm() {
+  const m = useRiskConfig();
+  const [maxNotional, setMaxNotional] = useState("");
+  const [windowSec, setWindowSec] = useState("");
+  const [mpid, setMpid] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  const maxN = parseInt(maxNotional) || 0;
+  const winN = parseInt(windowSec) || 0;
+  const valid = maxN >= 0 && winN > 0 && maxNotional.trim() !== "";
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Max notional ≥ 0 and window seconds > 0 required.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { max_notional: maxN, window_seconds: winN, mpid: mpid.trim() || undefined },
+      {
+        onSuccess: (a) => setAck(ackFeedback(a, `Kill switch set: ${maxN} / ${winN}s${mpid.trim() ? ` for ${mpid.trim()}` : ""}.`)),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Max notional" value={maxNotional} onChange={setMaxNotional} />
+        <NumField label="Window (seconds)" value={windowSec} onChange={setWindowSec} />
+      </div>
+      <TextField label="MPID (optional — blank = all)" value={mpid} onChange={setMpid} placeholder="MPID" />
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Applying…" : "Apply risk config"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 5. Spot index (perp funding) ──────────────────────────────────
+function SpotIndexForm({ symbolId }: { symbolId: number }) {
+  const m = useSpotIndex();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [idxPrice, setIdxPrice] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  const idxN = parseInt(idxPrice) || 0;
+  const valid = symN > 0 && idxN > 0 && idxPrice.trim() !== "";
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Symbol id and spot index price must be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { symbolid: symN, spot_index_price: idxN },
+      {
+        onSuccess: (a) => {
+          const base = ackFeedback(a, `Index set on symbol ${a.symbolid ?? symN}.`);
+          if (!base.error && a.funding_rate_bps != null) {
+            base.text = `Index set on symbol ${a.symbolid ?? symN} → funding ${a.funding_rate_bps} bps.`;
+          }
+          setAck(base);
+        },
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Symbol id" value={symId} onChange={setSymId} />
+        <NumField label="Spot index price" value={idxPrice} onChange={setIdxPrice} />
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Applying…" : "Set spot index"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 6. Spot config (base/quote asset) ─────────────────────────────
+function SpotConfigForm({ symbolId }: { symbolId: number }) {
+  const m = useSpotConfig();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [base, setBase] = useState("");
+  const [quote, setQuote] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  const baseN = parseInt(base) || 0;
+  const quoteN = parseInt(quote) || 0;
+  const valid = symN > 0 && baseN >= 0 && quoteN >= 0 && base.trim() !== "" && quote.trim() !== "";
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Symbol id > 0 and base/quote asset ids required.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { symbolid: symN, base_asset: baseN, quote_asset: quoteN },
+      {
+        onSuccess: (a) => setAck(ackFeedback(a, `Symbol ${a.symbolid ?? symN} spot-enforced (${baseN}/${quoteN}).`)),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <NumField label="Symbol id" value={symId} onChange={setSymId} />
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Base asset id" value={base} onChange={setBase} />
+        <NumField label="Quote asset id" value={quote} onChange={setQuote} />
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Applying…" : "Apply spot config"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── Panel: groups all six (admin-gated, collapsible) ──────────────
+export function EngineConfigPanel({ symbolId }: { symbolId: number }) {
+  const isAdmin = useAuthStore((st) => st.isAdmin);
+  const [open, setOpen] = useState(false);
+
+  if (!isAdmin) return null;
+
+  return (
+    <Card className="border-amber-500/40">
+      <CardContent className="pt-4">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between text-sm font-semibold text-amber-600 dark:text-amber-400"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span>Engine config (admin)</span>
+          <span>{open ? "▲" : "▼"}</span>
+        </button>
+        {open && (
+          <div className="mt-3 space-y-2">
+            <p className="text-[10px] text-muted-foreground">
+              Matching-engine tuning. Routes may be unavailable on this backend (404) — failures show inline.
+            </p>
+            <SubForm title="Matching algorithm">
+              <MatchingAlgoForm symbolId={symbolId} />
+            </SubForm>
+            <SubForm title="Spread config">
+              <SpreadConfigForm symbolId={symbolId} />
+            </SubForm>
+            <SubForm title="Trading params">
+              <TradingParamsForm symbolId={symbolId} />
+            </SubForm>
+            <SubForm title="Risk config (kill switch)">
+              <RiskConfigForm />
+            </SubForm>
+            <SubForm title="Spot index (perp funding)">
+              <SpotIndexForm symbolId={symbolId} />
+            </SubForm>
+            <SubForm title="Spot config (base/quote)">
+              <SpotConfigForm symbolId={symbolId} />
+            </SubForm>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/markets/PmAdminPanel.tsx
+++ b/frontend/src/pages/markets/PmAdminPanel.tsx
@@ -1,0 +1,416 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  usePmConfig,
+  usePmGroupConfig,
+  usePmResolve,
+  usePmGroupResolve,
+  usePmResolutions,
+} from "@/hooks/useTrading";
+import type { PmAdminAck } from "@/api/endpoints/trading";
+import { useAuthStore } from "@/stores/authStore";
+
+// ─── Admin: prediction-market create/config + resolve surfaces ─────
+// A single admin-gated panel grouping the four PM admin POST routes as compact
+// collapsible forms, plus a resolution audit-log table. Mirrors EngineConfigPanel
+// styling (amber accent, collapsible SubForms, inline ack). Returns null for
+// non-admins. Every route MAY 404 (not deployed to all backends) and resolve
+// routes MAY 403 (caller is not the designated resolver) — both surface inline,
+// never crash the ticket.
+
+type Ack = { text: string; error: boolean } | null;
+
+/** Turn a PM admin ack into inline "applied vs rejected" feedback. */
+function ackFeedback(a: PmAdminAck, appliedText: string): { text: string; error: boolean } {
+  const okd = a.status === "ack" && (a.result ?? 0) === 0;
+  if (okd) return { text: appliedText, error: false };
+  const why = a.detail || a.error || a.note;
+  const code = a.result != null ? ` (result ${a.result})` : "";
+  return { text: `Rejected${code}${why ? `: ${why}` : ""}`, error: true };
+}
+
+/** Error → message; call out the 403 "not the designated resolver" case clearly. */
+function errText(e: unknown): string {
+  const msg = (e as Error)?.message ?? "Request failed";
+  if (/\b403\b/.test(msg) || /forbidden/i.test(msg) || /resolver/i.test(msg)) {
+    return "Rejected: you are not the designated resolver for this market (403).";
+  }
+  return msg;
+}
+
+/** A single labeled numeric input (digits only). */
+function NumField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="w-full">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Input
+        value={value}
+        inputMode="numeric"
+        placeholder="0"
+        onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ""))}
+        className="mt-1 tabular-nums"
+      />
+    </div>
+  );
+}
+
+/** A single labeled free-text input (for resolver ids / source notes). */
+function TextField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="w-full">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Input value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} className="mt-1" />
+    </div>
+  );
+}
+
+/** Inline ack line (green applied / red rejected), shared across sub-forms. */
+function AckLine({ ack }: { ack: Ack }) {
+  if (!ack) return null;
+  return (
+    <p
+      className={cn(
+        "text-xs font-mono",
+        ack.error ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400",
+      )}
+    >
+      {ack.text}
+    </p>
+  );
+}
+
+/** A collapsible titled sub-section wrapping one form. */
+function SubForm({ title, children }: { title: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-3 py-2 text-xs font-semibold"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span>{title}</span>
+        <span className="text-muted-foreground">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && <div className="space-y-2 border-t px-3 py-3">{children}</div>}
+    </div>
+  );
+}
+
+// ─── 1. Create binary market (pm_config) ───────────────────────────
+function PmConfigForm({ symbolId }: { symbolId: number }) {
+  const m = usePmConfig();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [face, setFace] = useState("");
+  const [resolver, setResolver] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  const faceN = parseInt(face) || 0;
+  const valid = symN > 0 && faceN > 1;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Symbol id must be > 0 and face value > 1.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { symbolid: symN, face_value: faceN, resolver: resolver.trim() || undefined },
+      {
+        onSuccess: (a) => setAck(ackFeedback(a, `Binary PM set on symbol ${a.symbolid ?? symN} (face ${faceN}).`)),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Symbol id" value={symId} onChange={setSymId} />
+        <NumField label="Face value (> 1)" value={face} onChange={setFace} />
+      </div>
+      <TextField label="Resolver (optional)" value={resolver} onChange={setResolver} placeholder="user id / MPID" />
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Creating…" : "Create binary market"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 2. Create categorical market (pm_group_config) ────────────────
+function PmGroupConfigForm() {
+  const m = usePmGroupConfig();
+  const [groupId, setGroupId] = useState("");
+  const [outcomes, setOutcomes] = useState("");
+  const [face, setFace] = useState("");
+  const [resolver, setResolver] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  const groupN = parseInt(groupId) || 0;
+  const faceN = parseInt(face) || 0;
+  // Comma/space separated symbol ids.
+  const outArr = outcomes
+    .split(/[\s,]+/)
+    .map((s) => parseInt(s, 10))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  const valid = groupN > 0 && faceN > 1 && outArr.length >= 2;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Group id > 0, face > 1, and ≥ 2 outcome symbol ids required.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { group_id: groupN, outcomes: outArr, face_value: faceN, resolver: resolver.trim() || undefined },
+      {
+        onSuccess: (a) =>
+          setAck(ackFeedback(a, `Categorical group ${a.group_id ?? groupN} set (${outArr.length} outcomes, face ${faceN}).`)),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Group id" value={groupId} onChange={setGroupId} />
+        <NumField label="Face value (> 1)" value={face} onChange={setFace} />
+      </div>
+      <TextField
+        label="Outcome symbol ids (comma/space separated)"
+        value={outcomes}
+        onChange={setOutcomes}
+        placeholder="101, 102, 103"
+      />
+      <TextField label="Resolver (optional)" value={resolver} onChange={setResolver} placeholder="user id / MPID" />
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Creating…" : "Create categorical market"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 3. Resolve binary (pm_resolve) ────────────────────────────────
+function PmResolveForm({ symbolId }: { symbolId: number }) {
+  const m = usePmResolve();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [outcome, setOutcome] = useState<"yes" | "no">("yes");
+  const [source, setSource] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  const valid = symN > 0;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Symbol id must be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { symbolid: symN, outcome, source: source.trim() || undefined },
+      {
+        onSuccess: (a) =>
+          setAck(
+            ackFeedback(
+              a,
+              `Symbol ${a.symbolid ?? symN} resolved ${outcome.toUpperCase()} (${outcome === "yes" ? "YES pays face" : "YES pays 0"}).`,
+            ),
+          ),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <NumField label="Symbol id" value={symId} onChange={setSymId} />
+      <div>
+        <label className="text-xs text-muted-foreground">Outcome</label>
+        <select
+          value={outcome}
+          onChange={(e) => setOutcome(e.target.value as "yes" | "no")}
+          className="mt-1 h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+        >
+          <option value="yes">YES — pays face value</option>
+          <option value="no">NO — pays 0</option>
+        </select>
+      </div>
+      <TextField label="Source (optional)" value={source} onChange={setSource} placeholder="e.g. official result" />
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Resolving…" : "Resolve binary market"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 4. Resolve categorical (pm_group_resolve) ─────────────────────
+function PmGroupResolveForm() {
+  const m = usePmGroupResolve();
+  const [groupId, setGroupId] = useState("");
+  const [winner, setWinner] = useState("");
+  const [source, setSource] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  const groupN = parseInt(groupId) || 0;
+  const winN = parseInt(winner) || 0;
+  const valid = groupN > 0 && winN > 0;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Group id and winning symbol id must be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { group_id: groupN, winning_symbolid: winN, source: source.trim() || undefined },
+      {
+        onSuccess: (a) =>
+          setAck(ackFeedback(a, `Group ${a.group_id ?? groupN} resolved — winner ${winN} pays face, rest 0.`)),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Group id" value={groupId} onChange={setGroupId} />
+        <NumField label="Winning symbol id" value={winner} onChange={setWinner} />
+      </div>
+      <TextField label="Source (optional)" value={source} onChange={setSource} placeholder="e.g. official result" />
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Resolving…" : "Resolve categorical market"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 5. Resolution history (getPmResolutions) ──────────────────────
+function fmtTs(ts?: number): string {
+  if (!ts) return "—";
+  // Engine may send seconds or ms — normalise to ms.
+  const ms = ts > 1e12 ? ts : ts * 1000;
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? String(ts) : d.toLocaleString();
+}
+
+function ResolutionHistory() {
+  const q = usePmResolutions();
+  const rows = q.data?.resolutions ?? [];
+
+  return (
+    <div className="space-y-2">
+      {q.isError && (
+        <p className="text-xs text-muted-foreground">Resolution log unavailable on this backend (404).</p>
+      )}
+      {!q.isError && rows.length === 0 && (
+        <p className="text-xs text-muted-foreground">{q.isLoading ? "Loading…" : "No resolutions yet."}</p>
+      )}
+      {rows.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-muted-foreground">
+                <th className="py-1 pr-2 font-medium">Market</th>
+                <th className="py-1 pr-2 font-medium">Outcome</th>
+                <th className="py-1 pr-2 font-medium">Resolver</th>
+                <th className="py-1 pr-2 font-medium">Time</th>
+                <th className="py-1 font-medium">Source</th>
+              </tr>
+            </thead>
+            <tbody className="tabular-nums">
+              {rows.map((r, i) => (
+                <tr key={i} className="border-t">
+                  <td className="py-1 pr-2">
+                    {r.group_id != null
+                      ? `group ${r.group_id}`
+                      : r.symbolid != null
+                        ? `sym ${r.symbolid}`
+                        : "—"}
+                  </td>
+                  <td className="py-1 pr-2">
+                    {r.winning_symbolid != null ? `win ${r.winning_symbolid}` : (r.outcome ?? "—")}
+                  </td>
+                  <td className="py-1 pr-2 font-mono">{r.resolver_id ?? "—"}</td>
+                  <td className="py-1 pr-2">{fmtTs(r.ts)}</td>
+                  <td className="py-1">{r.source ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Panel: groups the four PM admin forms + history (admin-gated) ─
+export function PmAdminPanel({ symbolId }: { symbolId: number }) {
+  const isAdmin = useAuthStore((st) => st.isAdmin);
+  const [open, setOpen] = useState(false);
+
+  if (!isAdmin) return null;
+
+  return (
+    <Card className="border-amber-500/40">
+      <CardContent className="pt-4">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between text-sm font-semibold text-amber-600 dark:text-amber-400"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span>Prediction markets (admin)</span>
+          <span>{open ? "▲" : "▼"}</span>
+        </button>
+        {open && (
+          <div className="mt-3 space-y-2">
+            <p className="text-[10px] text-muted-foreground">
+              Create/config &amp; resolve prediction markets. Price = implied YES probability &times; face value.
+              Routes may be unavailable (404) or resolve may be forbidden (403 if you are not the resolver) —
+              failures show inline.
+            </p>
+            <SubForm title="Create binary market">
+              <PmConfigForm symbolId={symbolId} />
+            </SubForm>
+            <SubForm title="Create categorical market">
+              <PmGroupConfigForm />
+            </SubForm>
+            <SubForm title="Resolve binary market">
+              <PmResolveForm symbolId={symbolId} />
+            </SubForm>
+            <SubForm title="Resolve categorical market">
+              <PmGroupResolveForm />
+            </SubForm>
+            <SubForm title="Resolution history">
+              <ResolutionHistory />
+            </SubForm>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/markets/StakingAuctionsPanel.tsx
+++ b/frontend/src/pages/markets/StakingAuctionsPanel.tsx
@@ -1,0 +1,396 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  useStakeRequest,
+  useStakeOffer,
+  useAuctionRequest,
+  useAuctionBid,
+} from "@/hooks/useTrading";
+import { formatPrice, formatQty } from "./format";
+
+// ─── Trader: Staking & Auctions surfaces ───────────────────────────
+// Two PEER trader mechanisms on the matching engine (NOT admin-gated): a
+// collateral-staking market and distressed-position auctions. There is NO
+// list/GET of open stake requests or open auctions — you can create + act-by-id
+// but cannot browse open items, so each form surfaces the returned
+// request_id / auction_id prominently (note/share it) and we show an honest
+// "browsing open items isn't available yet" note. Mirrors PmAdminPanel styling
+// (collapsible SubForms, inline ack). Routes MAY 404 (not deployed to prod) —
+// failures surface inline, never crash the ticket.
+
+type Ack = { text: string; error: boolean; id?: { label: string; value: number } } | null;
+
+/** Turn a staking/auction ack into inline "created vs rejected" feedback. */
+function ackFeedback(
+  a: { status?: string; detail?: string; error?: string; note?: string; reason?: string | number; reasoncode?: number },
+  okText: string,
+  id?: { label: string; value?: number },
+): { text: string; error: boolean; id?: { label: string; value: number } } {
+  const okd = a.status === "ack" || a.status === "created" || a.status === "ok";
+  if (okd) {
+    return {
+      text: okText,
+      error: false,
+      id: id && id.value != null ? { label: id.label, value: id.value } : undefined,
+    };
+  }
+  const why = a.detail || a.error || a.note;
+  const code = a.reason ?? a.reasoncode;
+  const codeStr = code != null ? ` (code ${code})` : "";
+  return { text: `Rejected${codeStr}${why ? `: ${why}` : ""}`, error: true };
+}
+
+/** Error → message; call out the 404 "not deployed" case clearly. */
+function errText(e: unknown): string {
+  const msg = (e as Error)?.message ?? "Request failed";
+  if (/\b404\b/.test(msg) || /not found/i.test(msg)) {
+    return "Unavailable on this backend (404) — the staking/auction surface is not deployed yet.";
+  }
+  return msg;
+}
+
+/** A single labeled numeric input (digits only). */
+function NumField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="w-full">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Input
+        value={value}
+        inputMode="numeric"
+        placeholder={placeholder ?? "0"}
+        onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ""))}
+        className="mt-1 tabular-nums"
+      />
+    </div>
+  );
+}
+
+/** Inline ack line (green created / red rejected). When an id is present it is
+ *  shown prominently on its own so the trader can note/share it. */
+function AckLine({ ack }: { ack: Ack }) {
+  if (!ack) return null;
+  return (
+    <div className="space-y-1">
+      <p
+        className={cn(
+          "text-xs font-mono",
+          ack.error ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400",
+        )}
+      >
+        {ack.text}
+      </p>
+      {ack.id && (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 px-3 py-2">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{ack.id.label}</div>
+          <div className="select-all font-mono text-lg font-semibold tabular-nums text-emerald-700 dark:text-emerald-300">
+            {ack.id.value}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A collapsible titled sub-section wrapping one form. */
+function SubForm({ title, children }: { title: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-3 py-2 text-xs font-semibold"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span>{title}</span>
+        <span className="text-muted-foreground">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && <div className="space-y-2 border-t px-3 py-3">{children}</div>}
+    </div>
+  );
+}
+
+// ─── 1. Create stake request (stake_request) ───────────────────────
+function StakeRequestForm({ symbolId, scaler }: { symbolId: number; scaler: number }) {
+  const m = useStakeRequest();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [minCollateral, setMinCollateral] = useState("");
+  const [maxStakePct, setMaxStakePct] = useState("");
+  const [lockup, setLockup] = useState("");
+  const [duration, setDuration] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  const minColN = parseInt(minCollateral) || 0;
+  const maxPctN = parseInt(maxStakePct) || 0;
+  const lockupN = parseInt(lockup) || 0;
+  const durN = parseInt(duration) || 0;
+  const valid = minColN > 0 && maxPctN > 0 && lockupN > 0 && durN > 0;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Min collateral, max stake %, lockup and duration must all be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      {
+        symbolid: symN > 0 ? symN : undefined,
+        min_collateral: minColN,
+        max_stake_pct: maxPctN,
+        lockup_seconds: lockupN,
+        duration_seconds: durN,
+      },
+      {
+        onSuccess: (a) =>
+          setAck(
+            ackFeedback(
+              a,
+              `Stake request created (min collateral ${formatPrice(minColN, scaler)}, up to ${maxPctN}% stake).`,
+              { label: "Request id", value: a.request_id },
+            ),
+          ),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Symbol id (optional)" value={symId} onChange={setSymId} />
+        <NumField label="Min collateral (ticks)" value={minCollateral} onChange={setMinCollateral} />
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <NumField label="Max stake %" value={maxStakePct} onChange={setMaxStakePct} />
+        <NumField label="Lockup (s)" value={lockup} onChange={setLockup} />
+        <NumField label="Duration (s)" value={duration} onChange={setDuration} />
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Creating…" : "Create stake request"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 2. Offer on a stake request (stake_offer) ─────────────────────
+function StakeOfferForm({ scaler }: { scaler: number }) {
+  const m = useStakeOffer();
+  const [requestId, setRequestId] = useState("");
+  const [collateral, setCollateral] = useState("");
+  const [stakePct, setStakePct] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  const reqN = parseInt(requestId) || 0;
+  const colN = parseInt(collateral) || 0;
+  const pctN = parseInt(stakePct) || 0;
+  const valid = reqN > 0 && colN > 0 && pctN > 0;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Request id, collateral amount and stake % must all be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { request_id: reqN, collateral_amount: colN, stake_pct: pctN },
+      {
+        onSuccess: (a) =>
+          setAck(
+            ackFeedback(
+              a,
+              `Offer submitted on request ${a.request_id ?? reqN} (collateral ${formatPrice(colN, scaler)}, ${pctN}% stake).`,
+              a.offer_id != null ? { label: "Offer id", value: a.offer_id } : { label: "Request id", value: a.request_id ?? reqN },
+            ),
+          ),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <NumField label="Stake request id" value={requestId} onChange={setRequestId} />
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Collateral amount (ticks)" value={collateral} onChange={setCollateral} />
+        <NumField label="Stake %" value={stakePct} onChange={setStakePct} />
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Offering…" : "Offer on request"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 3. Create auction (auction_request) ───────────────────────────
+function AuctionRequestForm({ symbolId, scaler }: { symbolId: number; scaler: number }) {
+  const m = useAuctionRequest();
+  const [symId, setSymId] = useState(String(symbolId || ""));
+  const [qty, setQty] = useState("");
+  const [reserve, setReserve] = useState("");
+  const [duration, setDuration] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  useEffect(() => setSymId(String(symbolId || "")), [symbolId]);
+
+  const symN = parseInt(symId) || 0;
+  const qtyN = parseInt(qty) || 0;
+  const reserveN = parseInt(reserve) || 0;
+  const durN = parseInt(duration) || 0;
+  const valid = qtyN > 0;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Auction qty must be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      {
+        symbolid: symN > 0 ? symN : undefined,
+        qty: qtyN,
+        reserve_price: reserveN > 0 ? reserveN : undefined,
+        duration_seconds: durN > 0 ? durN : undefined,
+      },
+      {
+        onSuccess: (a) =>
+          setAck(
+            ackFeedback(
+              a,
+              `Auction created (qty ${formatQty(qtyN, scaler)}${reserveN > 0 ? `, reserve ${formatPrice(reserveN, scaler)}` : ""}).`,
+              { label: "Auction id", value: a.auction_id },
+            ),
+          ),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Symbol id (optional)" value={symId} onChange={setSymId} />
+        <NumField label="Qty" value={qty} onChange={setQty} />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Reserve price (optional)" value={reserve} onChange={setReserve} />
+        <NumField label="Duration (s, optional)" value={duration} onChange={setDuration} />
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Creating…" : "Create auction"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── 4. Bid on an auction (auction_bid) ────────────────────────────
+function AuctionBidForm({ scaler }: { scaler: number }) {
+  const m = useAuctionBid();
+  const [auctionId, setAuctionId] = useState("");
+  const [price, setPrice] = useState("");
+  const [qty, setQty] = useState("");
+  const [ack, setAck] = useState<Ack>(null);
+
+  const aucN = parseInt(auctionId) || 0;
+  const priceN = parseInt(price) || 0;
+  const qtyN = parseInt(qty) || 0;
+  const valid = aucN > 0 && priceN > 0 && qtyN > 0;
+
+  const submit = () => {
+    if (!valid) {
+      setAck({ text: "Auction id, price and qty must all be > 0.", error: true });
+      return;
+    }
+    setAck(null);
+    m.mutate(
+      { auction_id: aucN, price: priceN, qty: qtyN },
+      {
+        onSuccess: (a) =>
+          setAck(
+            ackFeedback(
+              a,
+              `Bid submitted on auction ${a.auction_id ?? aucN} (${formatQty(qtyN, scaler)} @ ${formatPrice(priceN, scaler)}).`,
+              a.bid_id != null ? { label: "Bid id", value: a.bid_id } : { label: "Auction id", value: a.auction_id ?? aucN },
+            ),
+          ),
+        onError: (e) => setAck({ text: errText(e), error: true }),
+      },
+    );
+  };
+
+  return (
+    <>
+      <NumField label="Auction id" value={auctionId} onChange={setAuctionId} />
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Price (ticks)" value={price} onChange={setPrice} />
+        <NumField label="Qty" value={qty} onChange={setQty} />
+      </div>
+      <Button type="button" variant="secondary" className="w-full" disabled={m.isPending || !valid} onClick={submit}>
+        {m.isPending ? "Bidding…" : "Bid on auction"}
+      </Button>
+      <AckLine ack={ack} />
+    </>
+  );
+}
+
+// ─── Panel: groups the four trader forms (NOT admin-gated) ─────────
+export function StakingAuctionsPanel({ symbolId, scaler }: { symbolId: number; scaler: number }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Card className="border-sky-500/40">
+      <CardContent className="pt-4">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between text-sm font-semibold text-sky-600 dark:text-sky-400"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span>Staking &amp; Auctions</span>
+          <span>{open ? "▲" : "▼"}</span>
+        </button>
+        {open && (
+          <div className="mt-3 space-y-2">
+            <p className="text-[10px] text-muted-foreground">
+              Peer trader mechanisms: stake collateral against a request, or auction a position. Amounts / prices
+              are int64 engine ticks. Note the returned request / auction id — you will need it to act.
+              Routes may be unavailable (404) on backends without the surface deployed — failures show inline.
+            </p>
+            <p className="rounded-md border border-sky-500/30 bg-sky-500/5 px-3 py-2 text-[10px] text-muted-foreground">
+              Note: browsing open stake requests / open auctions isn&apos;t available yet — there is no list
+              endpoint. You can create items and act on a specific id, then share the id shown below.
+            </p>
+            <SubForm title="Create stake request">
+              <StakeRequestForm symbolId={symbolId} scaler={scaler} />
+            </SubForm>
+            <SubForm title="Offer on a stake request (by id)">
+              <StakeOfferForm scaler={scaler} />
+            </SubForm>
+            <SubForm title="Create auction (of a position qty)">
+              <AuctionRequestForm symbolId={symbolId} scaler={scaler} />
+            </SubForm>
+            <SubForm title="Bid on an auction (by id)">
+              <AuctionBidForm scaler={scaler} />
+            </SubForm>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -38,6 +38,7 @@ import { formatPrice, formatQty, formatTimeNs } from "./format";
 import { vibrate, notify, ensureNotifyPermission } from "@/lib/tradeFeedback";
 import { tradingFeatures } from "./tradingFeatures";
 import { useAuthStore } from "@/stores/authStore";
+import { EngineConfigPanel } from "./EngineConfigPanel";
 
 type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto" | "oco" | "funding";
 type Section = "trade" | "positions" | "orders" | "fills";
@@ -1321,6 +1322,7 @@ export function TradeTicket({
     </Card>
     <FeeSchedulePanel symbolId={symbolId} />
     <MarginConfigPanel symbolId={symbolId} />
+    <EngineConfigPanel symbolId={symbolId} />
     </div>
   );
 }

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -39,6 +39,7 @@ import { vibrate, notify, ensureNotifyPermission } from "@/lib/tradeFeedback";
 import { tradingFeatures } from "./tradingFeatures";
 import { useAuthStore } from "@/stores/authStore";
 import { EngineConfigPanel } from "./EngineConfigPanel";
+import { PmAdminPanel } from "./PmAdminPanel";
 
 type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto" | "oco" | "funding";
 type Section = "trade" | "positions" | "orders" | "fills";
@@ -1323,6 +1324,7 @@ export function TradeTicket({
     <FeeSchedulePanel symbolId={symbolId} />
     <MarginConfigPanel symbolId={symbolId} />
     <EngineConfigPanel symbolId={symbolId} />
+    <PmAdminPanel symbolId={symbolId} />
     </div>
   );
 }

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -40,6 +40,7 @@ import { tradingFeatures } from "./tradingFeatures";
 import { useAuthStore } from "@/stores/authStore";
 import { EngineConfigPanel } from "./EngineConfigPanel";
 import { PmAdminPanel } from "./PmAdminPanel";
+import { StakingAuctionsPanel } from "./StakingAuctionsPanel";
 
 type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto" | "oco" | "funding";
 type Section = "trade" | "positions" | "orders" | "fills";
@@ -1325,6 +1326,7 @@ export function TradeTicket({
     <MarginConfigPanel symbolId={symbolId} />
     <EngineConfigPanel symbolId={symbolId} />
     <PmAdminPanel symbolId={symbolId} />
+    <StakingAuctionsPanel symbolId={symbolId} scaler={scaler} />
     </div>
   );
 }


### PR DESCRIPTION
Adds four previously-uncovered exchange feature areas to the frontend (web + Android) — the backend routes existed with no UI. Each area was built against the real route contracts, admin surfaces gated on isAdmin, all 404-degrading since not every route is prod-deployed.

## 1. Admin engine config (`b17ebf88`)
Admin-gated panels extending the existing margin_config pattern: `matching_algo` (price-time/pro-rata/specialist), `spread_config`, `trading_params` (max qty/notional/price-band/circuit-breaker/min-block), `risk_config` (per-MPID kill switch), `spot_index` (funding index), `spot_config` (spot-enforced symbol).

## 2. Prediction Markets (`5d1bdcbe`)
Admin lifecycle: create binary (`pm_config`) + categorical (`pm_group_config`), resolve (`pm_resolve` / `pm_group_resolve`, surfacing the 403 "not the designated resolver" case), and a resolution audit log (`pm_resolutions`). The trader PM banner (implied YES % / Trading·Resolved) already existed.

## 3+4. Staking & Auctions (`256210a2`)
Trader action forms: `stake_request` / `stake_offer` (peer collateral-staking) and `auction_request` / `auction_bid` (distressed-position auctions), with the created id surfaced in the ack.
**Known gap (honest):** the engine exposes no list/GET for open stake requests or auctions — you act by id; there's no discovery/browse. Flagged inline in the UI. (Also: the custody gateway's `/v1/staking` yield is distinct and has no edge route, so it's out of reach for now.)

## Verification
- Web: `npm run build` + `tsc --noEmit` = 0 at each phase.
- Android: `assembleDebug` + `testDebugUnitTest` green; +22 new contract tests (engine-config 5, PM 9, stake/auction 8).

## Note
These 3 commits landed directly on android-impl (an errant branch-checkout in a prior cleanup watcher switched the working tree mid-build); the work is intact and this PR brings it to main, same pattern as #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
