### PR TITLE
feat: staking dashboard, open-item discovery, portfolio overview (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
@@ -78,4 +78,18 @@ interface CustodyApi {
     @Headers("Content-Type: application/json")
     @POST("me/custody/settle-margin")
     suspend fun settleMargin(@Body body: BridgeRequestDto): SettleResultDto
+    // ==== Staking (custody-gated; real gateway-backed). 404/403 -> repository degrades to unavailable. ====
+
+    /** Stakeable providers (chain/protocol staking contracts). */
+    @GET("me/staking/providers")
+    suspend fun stakingProviders(): StakingProvidersDto
+
+    /** The caller's open staking positions (principal/rewards/total per position). */
+    @GET("me/staking/positions")
+    suspend fun stakingPositions(): StakingPositionsDto
+
+    /** Stake an amount with a provider (custody value -> staking contract). */
+    @Headers("Content-Type: application/json")
+    @POST("me/staking/stake")
+    suspend fun stake(@Body body: StakeRequestBodyDto): StakeAckDto
 }

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
@@ -279,3 +279,62 @@ data class SubAccountTransferResult(
     val toBalance: String?,
     val reason: String?,
 )
+
+// ---------------- Staking (custody-gated) ----------------
+
+/** One stakeable provider (chain/protocol staking contract), display-ready. */
+data class StakingProvider(
+    val id: String,
+    val chain: String,
+    val contract: String,
+    val kind: String,
+    val asset: String,
+) {
+    val displayId: String get() = id.ifBlank { "provider" }
+    val contractShort: String
+        get() = if (contract.length <= 14) contract else "${contract.take(8)}…${contract.takeLast(4)}"
+}
+
+/** One open staking position, display-ready. Amounts stay as backend decimal strings. */
+data class StakingPosition(
+    val positionId: String,
+    val vault: String,
+    val provider: String,
+    val chain: String,
+    val asset: String,
+    val principal: String,
+    val rewards: String,
+    val total: String,
+    val status: String,
+) {
+    val statusLabel: String get() = status.ifBlank { "—" }
+}
+
+/**
+ * The staking dashboard read (providers + positions). [unavailable] is true when the backend does not
+ * expose staking (404/403) — a soft, non-error empty state the UI degrades to.
+ */
+data class StakingDashboard(
+    val vault: String,
+    val providers: List<StakingProvider>,
+    val positions: List<StakingPosition>,
+    val unavailable: Boolean = false,
+) {
+    val hasProviders: Boolean get() = providers.isNotEmpty()
+    val hasPositions: Boolean get() = positions.isNotEmpty()
+
+    companion object {
+        fun unavailable(): StakingDashboard =
+            StakingDashboard(vault = "", providers = emptyList(), positions = emptyList(), unavailable = true)
+    }
+}
+
+/** Result of submitting a stake. [ok] reflects staked=true; [reason] carries any gateway message. */
+data class StakeResult(
+    val ok: Boolean,
+    val positionId: String?,
+    val provider: String?,
+    val amount: String?,
+    val status: String?,
+    val reason: String?,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
@@ -195,3 +195,72 @@ data class SettleResultDto(
     @Json(name = "detail") val detail: String? = null,
     @Json(name = "error") val error: String? = null,
 )
+
+// ==== Staking (custody-gated; real gateway-backed) ====
+// The custody edge proxies these to the MPC staking gateway. Providers + positions are reads; stake is
+// a write. Amounts arrive as strings. Not deployed on every backend -> a 404/403 folds to a graceful
+// "unavailable" empty state in the repository. All fields nullable/optional so a partial shape parses.
+
+/** One stakeable provider (a chain/protocol staking contract). */
+@JsonClass(generateAdapter = true)
+data class StakingProviderDto(
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "chain") val chain: String? = null,
+    @Json(name = "contract") val contract: String? = null,
+    @Json(name = "kind") val kind: String? = null,
+    @Json(name = "asset") val asset: String? = null,
+)
+
+/** GET me/staking/providers envelope. */
+@JsonClass(generateAdapter = true)
+data class StakingProvidersDto(
+    @Json(name = "providers") val providers: List<StakingProviderDto>? = null,
+)
+
+/**
+ * One open staking position. amounts (principal/rewards/total) are decimal strings; the gateway echoes
+ * the provider id + vault + status.
+ */
+@JsonClass(generateAdapter = true)
+data class StakingPositionDto(
+    @Json(name = "position_id") val positionId: String? = null,
+    @Json(name = "vault") val vault: String? = null,
+    @Json(name = "provider") val provider: String? = null,
+    @Json(name = "chain") val chain: String? = null,
+    @Json(name = "asset") val asset: String? = null,
+    @Json(name = "principal") val principal: String? = null,
+    @Json(name = "rewards") val rewards: String? = null,
+    @Json(name = "total") val total: String? = null,
+    @Json(name = "status") val status: String? = null,
+)
+
+/** GET me/staking/positions envelope. */
+@JsonClass(generateAdapter = true)
+data class StakingPositionsDto(
+    @Json(name = "positions") val positions: List<StakingPositionDto>? = null,
+    @Json(name = "count") val count: Int? = null,
+    @Json(name = "vault") val vault: String? = null,
+)
+
+/** Body for POST me/staking/stake: {provider, amount (decimal string)}. */
+@JsonClass(generateAdapter = true)
+data class StakeRequestBodyDto(
+    @Json(name = "provider") val provider: String,
+    @Json(name = "amount") val amount: String,
+)
+
+/**
+ * POST me/staking/stake ack. staked=true on success; the gateway may echo the created position_id +
+ * provider + amount + status. On rejection staked=false and detail/error/reason carries the message.
+ */
+@JsonClass(generateAdapter = true)
+data class StakeAckDto(
+    @Json(name = "staked") val staked: Boolean? = null,
+    @Json(name = "position_id") val positionId: String? = null,
+    @Json(name = "provider") val provider: String? = null,
+    @Json(name = "amount") val amount: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+    @Json(name = "reason") val reason: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
@@ -132,6 +132,39 @@ class CustodyRepository @Inject constructor(
         }
     }
 
+    /**
+     * Staking dashboard read: providers + the caller's positions. Like [getDeposits], a 404/403 (route
+     * not deployed or not custody-gated for this account) folds into a soft "unavailable" success so the
+     * Staking tab can degrade to an explanatory empty state instead of an error. Network errors still
+     * surface. Providers + positions are fetched sequentially; if positions 404 but providers succeed the
+     * providers still render (positions default empty).
+     */
+    suspend fun getStaking(): ApiResult<StakingDashboard> = withContext(io) {
+        try {
+            val providers = api.stakingProviders().providers.orEmpty().map { it.toDomain() }
+            val posDto = api.stakingPositions()
+            StakingDashboard(
+                vault = posDto.vault?.trim().orEmpty(),
+                providers = providers,
+                positions = posDto.positions.orEmpty().map { it.toDomain() },
+                unavailable = false,
+            ).let { ApiResult.Success(it) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(StakingDashboard.unavailable())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    /** Submit a stake (custody value -> a provider's staking contract). A gateway rejection surfaces as a Failure. */
+    suspend fun stake(provider: String, amount: String): ApiResult<StakeResult> = call {
+        api.stake(
+            StakeRequestBodyDto(provider = provider.trim(), amount = amount.trim()),
+        ).toDomain()
+    }
+
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = withContext(io) {
         try {
             ApiResult.Success(block())
@@ -258,6 +291,35 @@ private fun SettleResultDto.toDomain(action: BridgeAction): CustodyBridgeResult 
         custody = custody?.trim()?.takeIf { it.isNotBlank() },
         reason = listOfNotNull(reason, detail, error).firstOrNull { it.isNotBlank() },
     )
+
+private fun StakingProviderDto.toDomain(): StakingProvider = StakingProvider(
+    id = id?.trim().orEmpty(),
+    chain = chain?.trim().orEmpty(),
+    contract = contract?.trim().orEmpty(),
+    kind = kind?.trim().orEmpty(),
+    asset = asset?.trim().orEmpty(),
+)
+
+private fun StakingPositionDto.toDomain(): StakingPosition = StakingPosition(
+    positionId = positionId?.trim().orEmpty(),
+    vault = vault?.trim().orEmpty(),
+    provider = provider?.trim().orEmpty(),
+    chain = chain?.trim().orEmpty(),
+    asset = asset?.trim().orEmpty(),
+    principal = principal?.trim().orEmpty().ifBlank { "0" },
+    rewards = rewards?.trim().orEmpty().ifBlank { "0" },
+    total = total?.trim().orEmpty().ifBlank { "0" },
+    status = status?.trim().orEmpty(),
+)
+
+private fun StakeAckDto.toDomain(): StakeResult = StakeResult(
+    ok = staked == true,
+    positionId = positionId?.trim()?.takeIf { it.isNotBlank() },
+    provider = provider?.trim()?.takeIf { it.isNotBlank() },
+    amount = amount?.trim()?.takeIf { it.isNotBlank() },
+    status = status?.trim()?.takeIf { it.isNotBlank() },
+    reason = listOfNotNull(detail, error, reason).firstOrNull { it.isNotBlank() },
+)
 
 /** Provides the custody Retrofit API (mirrors the auth data module's provider style). */
 @Module

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -175,5 +175,13 @@ interface TradingApi {
     /** Place a bid on an open auction (by auction id). */
     @POST("me/auction_bid")
     suspend fun auctionBid(@Body body: AuctionBidDto): StakeAuctionAckDto
-}
+    // ==== Discovery browse (STUB; empty + stub:true + note). 404 -> repository degrades to empty. ====
 
+    /** Browse open stake requests (STUB: empty list + note until the matching backend ships). */
+    @GET("me/stake_requests")
+    suspend fun getStakeRequests(): StakeRequestsBrowseDto
+
+    /** Browse open auctions (STUB: empty list + note until the matching backend ships). */
+    @GET("me/auctions")
+    suspend fun getAuctions(): AuctionsBrowseDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -626,3 +626,50 @@ data class StakeAuctionAckDto(
     @Json(name = "note") val note: String? = null,
     @Json(name = "reason") val reason: String? = null,
 )
+// ==== Discovery browse (STUB) ====
+// GET me/stake_requests / me/auctions return an empty list + stub:true + a human note today; the
+// item shapes below are lenient guesses so that when the backend ships real rows they still parse.
+// All fields optional; numeric ids lenient (the edge may stringify).
+
+/** One open stake request row (browse). Amounts/pcts are strings-or-numbers -> kept as String?. */
+@JsonClass(generateAdapter = true)
+data class StakeRequestBrowseItemDto(
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "request_id") val requestId: Long? = null,
+    @Json(name = "symbolid") val symbolId: Int? = null,
+    @Json(name = "symbol") val symbol: String? = null,
+    @Json(name = "min_collateral") val minCollateral: String? = null,
+    @Json(name = "max_stake_pct") val maxStakePct: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "owner") val owner: String? = null,
+)
+
+/** GET me/stake_requests envelope (STUB: stake_requests empty, stub=true, note set). */
+@JsonClass(generateAdapter = true)
+data class StakeRequestsBrowseDto(
+    @Json(name = "stake_requests") val stakeRequests: List<StakeRequestBrowseItemDto>? = null,
+    @Json(name = "count") val count: Int? = null,
+    @Json(name = "stub") val stub: Boolean? = null,
+    @Json(name = "note") val note: String? = null,
+)
+
+/** One open auction row (browse). */
+@JsonClass(generateAdapter = true)
+data class AuctionBrowseItemDto(
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "auction_id") val auctionId: Long? = null,
+    @Json(name = "symbolid") val symbolId: Int? = null,
+    @Json(name = "symbol") val symbol: String? = null,
+    @Json(name = "qty") val qty: String? = null,
+    @Json(name = "reserve_price") val reservePrice: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "owner") val owner: String? = null,
+)
+
+/** GET me/auctions envelope (STUB: auctions empty, stub=true, note set). */
+@JsonClass(generateAdapter = true)
+data class AuctionsBrowseDto(
+    @Json(name = "auctions") val auctions: List<AuctionBrowseItemDto>? = null,
+    @Json(name = "count") val count: Int? = null,
+    @Json(name = "stub") val stub: Boolean? = null,
+    @Json(name = "note") val note: String? = null,
+)
+

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -578,3 +578,108 @@ fun StakeAuctionAckDto.toDomain(kind: StakeAuctionKind): StakeAuctionAck {
         message = detail ?: error ?: note ?: reason,
     )
 }
+// ==== Discovery browse (STUB) — domain + mappers ====
+
+/** One open stake request (browse row), display-ready. Amounts stay as backend strings. */
+data class StakeRequestBrowseItem(
+    val requestId: Long?,
+    val symbolId: Int?,
+    val symbol: String?,
+    val minCollateral: String?,
+    val maxStakePct: String?,
+    val status: String?,
+    val owner: String?,
+) {
+    val idLabel: String get() = requestId?.let { "Request #$it" } ?: "Request"
+    val symbolLabel: String? get() = symbol?.takeIf { it.isNotBlank() } ?: symbolId?.let { "Symbol $it" }
+}
+
+/** One open auction (browse row), display-ready. */
+data class AuctionBrowseItem(
+    val auctionId: Long?,
+    val symbolId: Int?,
+    val symbol: String?,
+    val qty: String?,
+    val reservePrice: String?,
+    val status: String?,
+    val owner: String?,
+) {
+    val idLabel: String get() = auctionId?.let { "Auction #$it" } ?: "Auction"
+    val symbolLabel: String? get() = symbol?.takeIf { it.isNotBlank() } ?: symbolId?.let { "Symbol $it" }
+}
+
+/**
+ * Browse result for open stake requests / auctions. [stub] is true while the backend returns the stub
+ * (empty + note); [note] is the honest human explanation to render when [items] is empty. [unavailable]
+ * is set when the route 404s (undeployed) so the UI degrades the same way.
+ */
+data class StakeRequestsBrowse(
+    val items: List<StakeRequestBrowseItem>,
+    val count: Int,
+    val stub: Boolean,
+    val note: String?,
+    val unavailable: Boolean = false,
+) {
+    val isEmpty: Boolean get() = items.isEmpty()
+    companion object {
+        fun unavailable(): StakeRequestsBrowse =
+            StakeRequestsBrowse(items = emptyList(), count = 0, stub = false, note = null, unavailable = true)
+    }
+}
+
+data class AuctionsBrowse(
+    val items: List<AuctionBrowseItem>,
+    val count: Int,
+    val stub: Boolean,
+    val note: String?,
+    val unavailable: Boolean = false,
+) {
+    val isEmpty: Boolean get() = items.isEmpty()
+    companion object {
+        fun unavailable(): AuctionsBrowse =
+            AuctionsBrowse(items = emptyList(), count = 0, stub = false, note = null, unavailable = true)
+    }
+}
+
+fun StakeRequestBrowseItemDto.toDomain(): StakeRequestBrowseItem = StakeRequestBrowseItem(
+    requestId = requestId,
+    symbolId = symbolId,
+    symbol = symbol?.trim()?.takeIf { it.isNotBlank() },
+    minCollateral = minCollateral?.trim()?.takeIf { it.isNotBlank() },
+    maxStakePct = maxStakePct?.trim()?.takeIf { it.isNotBlank() },
+    status = status?.trim()?.takeIf { it.isNotBlank() },
+    owner = owner?.trim()?.takeIf { it.isNotBlank() },
+)
+
+fun AuctionBrowseItemDto.toDomain(): AuctionBrowseItem = AuctionBrowseItem(
+    auctionId = auctionId,
+    symbolId = symbolId,
+    symbol = symbol?.trim()?.takeIf { it.isNotBlank() },
+    qty = qty?.trim()?.takeIf { it.isNotBlank() },
+    reservePrice = reservePrice?.trim()?.takeIf { it.isNotBlank() },
+    status = status?.trim()?.takeIf { it.isNotBlank() },
+    owner = owner?.trim()?.takeIf { it.isNotBlank() },
+)
+
+fun StakeRequestsBrowseDto.toDomain(): StakeRequestsBrowse {
+    val rows = stakeRequests.orEmpty().map { it.toDomain() }
+    return StakeRequestsBrowse(
+        items = rows,
+        count = count ?: rows.size,
+        stub = stub == true,
+        note = note?.trim()?.takeIf { it.isNotBlank() },
+        unavailable = false,
+    )
+}
+
+fun AuctionsBrowseDto.toDomain(): AuctionsBrowse {
+    val rows = auctions.orEmpty().map { it.toDomain() }
+    return AuctionsBrowse(
+        items = rows,
+        count = count ?: rows.size,
+        stub = stub == true,
+        note = note?.trim()?.takeIf { it.isNotBlank() },
+        unavailable = false,
+    )
+}
+

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -86,6 +86,10 @@ interface TradingRepository {
     suspend fun stakeOffer(requestId: Long, collateralAmount: Long, stakePct: Long): ApiResult<StakeAuctionAck>
     suspend fun auctionRequest(symbolId: Int?, qty: Int, reservePrice: Long?, durationSeconds: Int?): ApiResult<StakeAuctionAck>
     suspend fun auctionBid(auctionId: Long, price: Long, qty: Int): ApiResult<StakeAuctionAck>
+
+    // ---- Discovery browse (STUB; empty + note). 404 (undeployed) -> unavailable. ----
+    suspend fun stakeRequestsBrowse(): ApiResult<StakeRequestsBrowse>
+    suspend fun auctionsBrowse(): ApiResult<AuctionsBrowse>
 }
 
 @Singleton
@@ -279,6 +283,14 @@ class TradingRepositoryImpl @Inject constructor(
                 api.auctionBid(AuctionBidDto(auctionId, price, qty)).toDomain(StakeAuctionKind.AUCTION_BID)
             }
         }
+
+    // ---- Discovery browse (STUB; 404 -> unavailable). ----
+
+    override suspend fun stakeRequestsBrowse(): ApiResult<StakeRequestsBrowse> =
+        withContext(io) { emptyOn404(StakeRequestsBrowse.unavailable()) { api.getStakeRequests().toDomain() } }
+
+    override suspend fun auctionsBrowse(): ApiResult<AuctionsBrowse> =
+        withContext(io) { emptyOn404(AuctionsBrowse.unavailable()) { api.getAuctions().toDomain() } }
 
     /**
      * Like [apiCall] but a 404 (endpoint not deployed yet) folds to a Success carrying [emptyValue],

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
@@ -66,6 +66,9 @@ import com.testlogon.android.data.custody.CustodyAssets
 import com.testlogon.android.data.custody.CustodyBalance
 import com.testlogon.android.data.custody.CustodyBridgeResult
 import com.testlogon.android.data.custody.CustodySubAccount
+import com.testlogon.android.data.custody.StakingProvider
+import com.testlogon.android.data.custody.StakingPosition
+import com.testlogon.android.data.custody.StakingDashboard
 import com.testlogon.android.data.custody.CustodyDeposit
 import com.testlogon.android.data.custody.CustodyDeposits
 import com.testlogon.android.data.custody.SubAccountTransferResult
@@ -98,6 +101,7 @@ fun CustodyScreen(
     val tabs = remember {
         listOf(
             CustodyTab.BALANCES,
+            CustodyTab.STAKING,
             CustodyTab.SUBACCOUNTS,
             CustodyTab.TRANSFER,
             CustodyTab.DEPOSIT,
@@ -133,6 +137,7 @@ fun CustodyScreen(
             }
             when (state.tab) {
                 CustodyTab.BALANCES -> BalancesTab(state, viewModel)
+                CustodyTab.STAKING -> StakingTab(state, viewModel)
                 CustodyTab.SUBACCOUNTS -> SubAccountsTab(state, viewModel)
                 CustodyTab.TRANSFER -> TransferTab(state, viewModel)
                 CustodyTab.DEPOSIT -> DepositTab(state, viewModel)
@@ -152,6 +157,7 @@ fun CustodyScreen(
 
 private fun CustodyTab.title(): String = when (this) {
     CustodyTab.BALANCES -> "Balances"
+    CustodyTab.STAKING -> "Staking"
     CustodyTab.SUBACCOUNTS -> "Sub-accounts"
     CustodyTab.TRANSFER -> "Transfer"
     CustodyTab.DEPOSIT -> "Deposit"
@@ -254,6 +260,180 @@ private fun BalanceCard(row: CustodyBalance, onDeposit: () -> Unit, onWithdraw: 
                     Text("Withdraw")
                 }
             }
+        }
+    }
+}
+
+// ---------------- Staking ----------------
+
+@Composable
+private fun StakingTab(state: CustodyUiState, viewModel: CustodyViewModel) {
+    val st = state.staking
+    val d = st.dashboard.data
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("Staking", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(
+            "Stake custody balances with a provider to earn rewards. Positions and rewards are read from the staking gateway.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        when {
+            st.dashboard.loading && d == null -> LoadingBox()
+            st.dashboard.error != null && d == null -> ErrorBox(st.dashboard.error) { viewModel.loadStaking() }
+            d == null || d.unavailable ->
+                UnavailableTab(
+                    "Staking",
+                    "Staking isn't available on this backend yet. When the staking gateway is connected, your providers, positions and rewards will appear here.",
+                )
+            else -> {
+                StakingPositionsSection(d)
+                StakingProvidersSection(d)
+                StakeFormCard(st, viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StakingPositionsSection(d: StakingDashboard) {
+    Text("Your positions", style = MaterialTheme.typography.labelLarge)
+    if (d.vault.isNotBlank()) {
+        Text("Vault ${d.vault.short()}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
+    }
+    if (!d.hasPositions) {
+        HintText("No staking positions yet. Stake with a provider below to open one.")
+    } else {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            d.positions.forEach { StakingPositionCard(it) }
+        }
+    }
+}
+
+@Composable
+private fun StakingPositionCard(p: StakingPosition) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    (p.asset.ifBlank { p.provider }).ifBlank { "Position" },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                if (p.statusLabel.isNotBlank()) {
+                    Box(
+                        modifier = Modifier
+                            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(50))
+                            .padding(horizontal = 8.dp, vertical = 2.dp),
+                    ) { Text(p.statusLabel, style = MaterialTheme.typography.labelSmall) }
+                }
+            }
+            if (p.provider.isNotBlank()) DetailRow("Provider", p.provider)
+            DetailRow("Principal", p.principal)
+            DetailRow("Rewards", p.rewards)
+            DetailRow("Total", p.total)
+            if (p.positionId.isNotBlank()) DetailRow("Position", p.positionId.short())
+        }
+    }
+}
+
+@Composable
+private fun StakingProvidersSection(d: StakingDashboard) {
+    HorizontalDivider()
+    Text("Providers", style = MaterialTheme.typography.labelLarge)
+    if (!d.hasProviders) {
+        HintText("No staking providers are configured yet.")
+    } else {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            d.providers.forEach { ProviderRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun ProviderRow(p: StakingProvider) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(p.displayId, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            val sub = listOfNotNull(
+                p.asset.takeIf { it.isNotBlank() },
+                p.kind.takeIf { it.isNotBlank() },
+                p.chain.takeIf { it.isNotBlank() }?.let { "chain $it" },
+            ).joinToString(" - ")
+            if (sub.isNotBlank()) Text(sub, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            if (p.contract.isNotBlank()) Text(p.contractShort, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun StakeFormCard(st: StakingUiState, viewModel: CustodyViewModel) {
+    val providers = st.dashboard.data?.providers.orEmpty()
+    HorizontalDivider()
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text("Stake", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            if (providers.isEmpty()) {
+                HintText("No providers available to stake with yet.")
+            } else {
+                Text("Provider", style = MaterialTheme.typography.labelMedium)
+                Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    providers.forEach { prov ->
+                        FilterChip(
+                            selected = prov.id == st.selectedProvider,
+                            onClick = { viewModel.onStakeProviderSelected(prov.id) },
+                            label = { Text(prov.displayId) },
+                        )
+                    }
+                }
+                OutlinedTextField(
+                    value = st.amountText,
+                    onValueChange = viewModel::onStakeAmountChanged,
+                    label = { Text("Amount") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("stake_amount"),
+                )
+                st.submitError?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
+                st.result?.let { r -> StakeResultCard(r) { viewModel.clearStakeResult() } }
+                Button(
+                    onClick = { viewModel.submitStake() },
+                    enabled = st.canStake,
+                    modifier = Modifier.fillMaxWidth().testTag("submit_stake"),
+                ) {
+                    Text(if (st.submitting) "Staking..." else "Stake")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StakeResultCard(r: com.testlogon.android.data.custody.StakeResult, onDismiss: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (r.ok) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                if (r.ok) "Staked" else "Not staked",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            r.provider?.let { DetailRow("Provider", it) }
+            r.amount?.let { DetailRow("Amount", it) }
+            r.positionId?.let { DetailRow("Position", it.short()) }
+            r.status?.let { DetailRow("Status", it) }
+            r.reason?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+            TextButton(onClick = onDismiss) { Text("Dismiss") }
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyViewModel.kt
@@ -16,6 +16,8 @@ import com.testlogon.android.data.custody.SubAccountTransferResult
 import com.testlogon.android.data.custody.CustodyDepositAddress
 import com.testlogon.android.data.custody.CustodyDeposits
 import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.custody.StakingDashboard
+import com.testlogon.android.data.custody.StakeResult
 import com.testlogon.android.data.custody.CustodyWithdrawResult
 import com.testlogon.android.data.exchange.MarginAccount
 import com.testlogon.android.data.exchange.SpotBalance
@@ -33,7 +35,7 @@ import javax.inject.Inject
  * The seven in-screen custody tabs. Activity + Approvals have no backing endpoint on this backend and
  * render a static "not available" state; they are always shown (no role gating).
  */
-enum class CustodyTab { BALANCES, SUBACCOUNTS, TRANSFER, DEPOSIT, WITHDRAW, ACTIVITY, APPROVALS }
+enum class CustodyTab { BALANCES, STAKING, SUBACCOUNTS, TRANSFER, DEPOSIT, WITHDRAW, ACTIVITY, APPROVALS }
 
 /** A generic async slice: loading / error(message) / data. */
 data class Async<out T>(
@@ -102,12 +104,31 @@ data class TransferUiState(
         fromLabel.trim() != toLabel.trim()
 }
 
+/**
+ * Staking tab: the providers + positions read (soft-unavailable when the backend lacks the endpoint)
+ * plus the stake form (selected provider id + amount + in-flight/result).
+ */
+data class StakingUiState(
+    val dashboard: Async<StakingDashboard> = Async(loading = true),
+    val selectedProvider: String = "",
+    val amountText: String = "",
+    val submitting: Boolean = false,
+    val submitError: String? = null,
+    val result: StakeResult? = null,
+) {
+    val amountDouble: Double? get() = amountText.trim().toDoubleOrNull()
+    val canStake: Boolean get() = !submitting &&
+        selectedProvider.trim().isNotEmpty() &&
+        (amountDouble ?: 0.0) > 0.0
+}
+
 data class CustodyUiState(
     val tab: CustodyTab = CustodyTab.BALANCES,
     val balances: Async<CustodyBalances> = Async(loading = true),
     val deposit: DepositUiState = DepositUiState(),
     val withdraw: WithdrawUiState = WithdrawUiState(),
     val subAccounts: SubAccountsUiState = SubAccountsUiState(),
+    val staking: StakingUiState = StakingUiState(),
     val transfer: TransferUiState = TransferUiState(),
     /** Best-effort exchange-side balances for the bridge settle path (source-balance guidance only). */
     val spot: Async<SpotBalance> = Async(),
@@ -147,6 +168,7 @@ class CustodyViewModel @Inject constructor(
         loadBalance()
         loadDeposits()
         loadSubAccounts()
+        loadStaking()
         loadExchangeBalances()
     }
 
@@ -165,6 +187,46 @@ class CustodyViewModel @Inject constructor(
             when (val r = trading.marginAccount()) {
                 is Success -> _uiState.update { it.copy(margin = Async(data = r.data)) }
                 else -> _uiState.update { it.copy(margin = Async(error = "unavailable")) }
+            }
+        }
+    }
+
+    // ---- staking (custody-gated; 404/403 -> soft unavailable) ----
+
+    fun loadStaking() {
+        _uiState.update { it.copy(staking = it.staking.copy(dashboard = it.staking.dashboard.copy(loading = true, error = null))) }
+        viewModelScope.launch {
+            _uiState.update { st -> st.copy(staking = st.staking.copy(dashboard = repo.getStaking().toAsync())) }
+        }
+    }
+
+    fun onStakeProviderSelected(providerId: String) {
+        _uiState.update { it.copy(staking = it.staking.copy(selectedProvider = providerId, submitError = null)) }
+    }
+
+    fun onStakeAmountChanged(v: String) {
+        _uiState.update { it.copy(staking = it.staking.copy(amountText = sanitizeDecimal(v), submitError = null)) }
+    }
+
+    fun clearStakeResult() {
+        _uiState.update { it.copy(staking = it.staking.copy(result = null, submitError = null)) }
+    }
+
+    fun submitStake() {
+        val f = _uiState.value.staking
+        if (!f.canStake) return
+        _uiState.update { it.copy(staking = it.staking.copy(submitting = true, submitError = null, result = null)) }
+        viewModelScope.launch {
+            when (val r = repo.stake(f.selectedProvider.trim(), f.amountText.trim())) {
+                is Success -> {
+                    _uiState.update { it.copy(staking = it.staking.copy(submitting = false, result = r.data)) }
+                    // Refresh positions so a newly-created stake shows up.
+                    loadStaking()
+                }
+                is ApiResult.Failure ->
+                    _uiState.update { it.copy(staking = it.staking.copy(submitting = false, submitError = r.error.messageFor())) }
+                is ApiResult.NetworkError ->
+                    _uiState.update { it.copy(staking = it.staking.copy(submitting = false, submitError = "Network error. Check your connection and try again.")) }
             }
         }
     }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -1723,13 +1723,17 @@ private fun StakingAuctionsSection(state: TradingUiState, viewModel: TradingView
         Text("Staking & auctions", color = MarketColors.Accent, fontWeight = FontWeight.Bold, fontSize = 14.sp)
         Spacer(Modifier.height(2.dp))
         Text(
-            "Peer mechanisms: stake against another trader's request, or auction a position. Browsing open " +
-                "requests/auctions isn't available yet — act on an id you already have, or create one and share " +
-                "the id it returns.",
+            "Peer mechanisms: stake against another trader's request, or auction a position. Browse open " +
+                "requests/auctions below (read-only preview), or act on an id you already have — create one " +
+                "and share the id it returns.",
             color = MarketColors.TextSecondary,
             fontSize = 11.sp,
         )
         Spacer(Modifier.height(10.dp))
+        BrowseOpenStakeRequests(state.stakeRequestsBrowse)
+        Spacer(Modifier.height(12.dp))
+        BrowseOpenAuctions(state.auctionsBrowse)
+        Spacer(Modifier.height(12.dp))
         StakeRequestPanel(state.stakeRequest, viewModel)
         Spacer(Modifier.height(12.dp))
         StakeOfferPanel(state.stakeOffer, viewModel)
@@ -1737,6 +1741,79 @@ private fun StakingAuctionsSection(state: TradingUiState, viewModel: TradingView
         AuctionRequestPanel(state.auctionRequest, viewModel)
         Spacer(Modifier.height(12.dp))
         AuctionBidPanel(state.auctionBid, viewModel)
+    }
+}
+
+/**
+ * Browse-open (read) subsection for open stake requests. STUB today: the backend returns an empty list
+ * plus a human note, so an honest empty state from [StakeRequestsBrowse.note] is rendered; when real
+ * rows arrive they render as compact cards. Keeps the action forms below unchanged.
+ */
+@Composable
+private fun BrowseOpenStakeRequests(browse: com.testlogon.android.data.exchange.StakeRequestsBrowse?) {
+    EngineCard("Browse open stake requests", "Open requests you can stake against.") {
+        when {
+            browse == null -> Text("Loading...", color = MarketColors.TextSecondary, fontSize = 12.sp)
+            browse.isEmpty -> Text(
+                browse.note ?: if (browse.unavailable) "Browsing open requests isn't available yet." else "No open stake requests right now.",
+                color = MarketColors.TextSecondary,
+                fontSize = 12.sp,
+            )
+            else -> Column(modifier = Modifier.fillMaxWidth()) {
+                browse.items.forEach { item ->
+                    BrowseRow(
+                        title = item.idLabel,
+                        subtitle = listOfNotNull(
+                            item.symbolLabel,
+                            item.minCollateral?.let { "min $it" },
+                            item.maxStakePct?.let { "<= $it%" },
+                            item.status,
+                        ).joinToString("  -  "),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Browse-open (read) subsection for open auctions. STUB today (empty + note); renders rows when present.
+ */
+@Composable
+private fun BrowseOpenAuctions(browse: com.testlogon.android.data.exchange.AuctionsBrowse?) {
+    EngineCard("Browse open auctions", "Open auctions you can bid on.") {
+        when {
+            browse == null -> Text("Loading...", color = MarketColors.TextSecondary, fontSize = 12.sp)
+            browse.isEmpty -> Text(
+                browse.note ?: if (browse.unavailable) "Browsing open auctions isn't available yet." else "No open auctions right now.",
+                color = MarketColors.TextSecondary,
+                fontSize = 12.sp,
+            )
+            else -> Column(modifier = Modifier.fillMaxWidth()) {
+                browse.items.forEach { item ->
+                    BrowseRow(
+                        title = item.idLabel,
+                        subtitle = listOfNotNull(
+                            item.symbolLabel,
+                            item.qty?.let { "qty $it" },
+                            item.reservePrice?.let { "reserve $it" },
+                            item.status,
+                        ).joinToString("  -  "),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** One compact browse row: a bold id label + a monospace subtitle line. */
+@Composable
+private fun BrowseRow(title: String, subtitle: String) {
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Text(title, color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+        if (subtitle.isNotBlank()) {
+            Text(subtitle, color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+        }
     }
 }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -130,6 +130,9 @@ data class TradingUiState(
     val stakeOffer: StakeOfferForm = StakeOfferForm(),
     val auctionRequest: AuctionRequestForm = AuctionRequestForm(),
     val auctionBid: AuctionBidForm = AuctionBidForm(),
+    // Discovery browse (STUB): open stake requests + auctions (read subsections).
+    val stakeRequestsBrowse: com.testlogon.android.data.exchange.StakeRequestsBrowse? = null,
+    val auctionsBrowse: com.testlogon.android.data.exchange.AuctionsBrowse? = null,
 ) {
     /** Ticker for [symbolId] from the resolved catalogue, else "#<id>". */
     fun symbolLabel(symbolId: Int): String = symbolNames[symbolId] ?: ("#" + symbolId)

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -66,6 +66,7 @@ class TradingViewModel @Inject constructor(
         refreshPm()
         loadFees()
         resolveSymbols()
+        loadStakeAuctionBrowse()
         if (TradingFeatures.SPOT_ENABLED) refreshSpot()
     }
 
@@ -900,6 +901,25 @@ class TradingViewModel @Inject constructor(
 
     /** Sanitize an optional free-text resolution source (alnum + a few separators). */
     private fun source(t: String): String = t.filter { it.isLetterOrDigit() || it == '-' || it == '_' || it == ' ' || it == '.' }.take(40)
+
+    /**
+     * Load the STUB discovery browse feeds (open stake requests + auctions). Both return an empty list +
+     * a note today (or 404 -> unavailable); a failure just leaves the browse subsections empty.
+     */
+    fun loadStakeAuctionBrowse() {
+        viewModelScope.launch {
+            when (val r = repository.stakeRequestsBrowse()) {
+                is ApiResult.Success -> _uiState.update { it.copy(stakeRequestsBrowse = r.data) }
+                else -> Unit
+            }
+        }
+        viewModelScope.launch {
+            when (val r = repository.auctionsBrowse()) {
+                is ApiResult.Success -> _uiState.update { it.copy(auctionsBrowse = r.data) }
+                else -> Unit
+            }
+        }
+    }
 
     // ---- Trader staking + auctions (peer mechanisms). Trader-facing; 404 -> un-applied ack. ----
 

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -3,6 +3,7 @@ package com.testlogon.android.feature.more
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.PieChart
 import androidx.compose.material.icons.outlined.Assessment
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.Devices
@@ -959,6 +960,14 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_custody,
             icon = Icons.Outlined.AccountBalance,
             route = MoreRoutes.CUSTODY,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "portfolio",
+            labelRes = R.string.more_entry_portfolio,
+            icon = Icons.Outlined.PieChart,
+            route = MoreRoutes.PORTFOLIO,
             hub = MoreHub.WALLET,
             section = MoreSection.APP,
         ),

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
@@ -1,0 +1,302 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.portfolio
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/** Green/red for uPnL, independent of the app theme (matches the markets convention). */
+private val PnlUp = Color(0xFF16A34A)
+private val PnlDown = Color(0xFFDC2626)
+
+@Composable
+fun PortfolioRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PortfolioViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PortfolioScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PortfolioScreen(
+    state: PortfolioUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Portfolio") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { TotalEquityHeader(state) }
+
+            if (state.anyLoading && state.cards.all { it.loading }) {
+                item { LoadingBlock() }
+            } else if (state.allEmpty) {
+                item { EmptyBlock() }
+            }
+
+            items(count = state.cards.size, key = { state.cards[it].venue.name }) { i ->
+                VenueCardView(state.cards[i])
+            }
+
+            if (state.positions.isNotEmpty()) {
+                item {
+                    Text(
+                        "Open positions",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+                items(count = state.positions.size, key = { "pos_" + state.positions[it].symbol + it }) { i ->
+                    PositionCardView(state.positions[i])
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TotalEquityHeader(state: PortfolioUiState) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Total equity",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = fmt(state.totalEquity),
+                fontSize = 30.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Cross-venue snapshot (readable sources, source-native units).",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VenueCardView(card: VenueCard) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    card.venue.label,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                when {
+                    card.loading -> CircularProgressIndicator(Modifier.height(18.dp), strokeWidth = 2.dp)
+                    !card.unavailable -> Text(
+                        fmt(card.equity),
+                        fontFamily = FontFamily.Monospace,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    else -> {}
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            when {
+                card.loading -> Text(
+                    "Loading…",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                card.unavailable -> Text(
+                    card.unavailableReason ?: "Unavailable.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                card.lines.isEmpty() -> Text(
+                    "No holdings.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                else -> card.lines.forEach { line ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 2.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(line.label, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            line.value,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PositionCardView(pos: PortfolioPosition) {
+    val pnlColor = if (pos.isProfit) PnlUp else PnlDown
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(pos.symbol, fontWeight = FontWeight.SemiBold)
+                Text(
+                    (if (pos.isLong) "LONG " else "SHORT ") + pos.qty.toString(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = FontFamily.Monospace,
+                    color = if (pos.isLong) PnlUp else PnlDown,
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(6.dp))
+            PosStat("Entry", pos.entryPrice.toString())
+            PosStat("Liq. price", if (pos.liquidationPrice > 0) pos.liquidationPrice.toString() else "--")
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 2.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text("Unrealized P&L", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    (if (pos.isProfit) "+" else "") + pos.unrealizedPnl.toString(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.SemiBold,
+                    color = pnlColor,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PosStat(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontFamily = FontFamily.Monospace)
+    }
+}
+
+@Composable
+private fun LoadingBlock() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(Modifier.height(12.dp))
+        Text("Loading your portfolio…", style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun EmptyBlock() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("No holdings yet", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Fund custody, spot, or margin to see them here.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** Compact number format: drop a trailing .0 for whole numbers. */
+private fun fmt(v: Double): String =
+    if (v == v.toLong().toDouble()) v.toLong().toString() else v.toString()

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioUiState.kt
@@ -1,0 +1,210 @@
+package com.testlogon.android.feature.portfolio
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.custody.CustodyBalances
+import com.testlogon.android.data.custody.StakingDashboard
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.SpotBalance
+
+/**
+ * Read-only Portfolio (cross-venue account overview). Aggregates four INDEPENDENT read sources
+ * (custody vault balances, custody staking, exchange spot balance, exchange margin account) into a
+ * single snapshot. Each source degrades on its own: a 404/403/undeployed venue renders its card as
+ * "unavailable" while the others still show. Nothing here moves money - it is a consolidated view.
+ */
+
+/** Which venue a card represents, for labelling + iteration order. */
+enum class PortfolioVenue(val label: String) {
+    CUSTODY("Custody"),
+    SPOT("Spot"),
+    MARGIN("Margin"),
+    STAKING("Staking"),
+}
+
+/**
+ * One venue card. When [loading] is false, a readable venue carries an [equity] contribution (a coarse
+ * cross-venue number) plus [lines] (per-asset / per-field detail); an unreadable venue carries a human
+ * [unavailableReason] and [unavailable] = true.
+ */
+data class VenueCard(
+    val venue: PortfolioVenue,
+    val loading: Boolean = true,
+    /** The venue's contribution to the cross-venue equity total (source-native units, unscaled). */
+    val equity: Double = 0.0,
+    /** True when this venue could NOT be read (404/403/undeployed/error) - render "unavailable". */
+    val unavailable: Boolean = false,
+    /** Human reason shown on an unavailable card. */
+    val unavailableReason: String? = null,
+    /** Per-row detail lines (asset + amount, or field + value). Empty on an unavailable/empty card. */
+    val lines: List<PortfolioLine> = emptyList(),
+) {
+    val isEmpty: Boolean get() = !loading && !unavailable && lines.isEmpty()
+    /** True once this venue's equity should count toward the header total. */
+    val countsTowardTotal: Boolean get() = !loading && !unavailable
+}
+
+/** One labelled detail row inside a venue card. */
+data class PortfolioLine(val label: String, val value: String)
+
+/** One open margin position, projected for display (symbol, qty, entry, liq, uPnL). */
+data class PortfolioPosition(
+    val symbol: String,
+    val qty: Long,
+    val entryPrice: Long,
+    val liquidationPrice: Long,
+    val unrealizedPnl: Long,
+) {
+    val isLong: Boolean get() = qty > 0
+    val isProfit: Boolean get() = unrealizedPnl >= 0
+}
+
+/**
+ * The whole Portfolio screen state. [cards] is always the four venues in a stable order; positions are
+ * lifted out of the margin read for the dedicated open-positions section.
+ */
+data class PortfolioUiState(
+    val loading: Boolean = true,
+    val cards: List<VenueCard> = PortfolioVenue.entries.map { VenueCard(venue = it) },
+    val positions: List<PortfolioPosition> = emptyList(),
+) {
+    /** Sum of the readable venues' equity contributions - a coarse cross-venue snapshot, not a settled total. */
+    val totalEquity: Double get() = cards.filter { it.countsTowardTotal }.sumOf { it.equity }
+    /** True while at least one source is still loading. */
+    val anyLoading: Boolean get() = cards.any { it.loading }
+    /** True when every readable venue is empty AND nothing is loading (whole-screen empty state). */
+    val allEmpty: Boolean get() = !anyLoading &&
+        cards.none { it.countsTowardTotal && it.lines.isNotEmpty() } && positions.isEmpty()
+    fun card(venue: PortfolioVenue): VenueCard? = cards.firstOrNull { it.venue == venue }
+}
+
+/**
+ * Pure aggregator: folds the four already-fetched [ApiResult]s into a [PortfolioUiState]. Kept free of
+ * Android/coroutine deps so it is unit-testable in isolation (the ViewModel just fetches + calls this).
+ * A [ApiResult.Failure] whose status is 404/403 (or a soft-unavailable domain flag) degrades that venue
+ * to an "unavailable" card; any other Failure/NetworkError likewise degrades (there is nothing the user
+ * can act on in a read-only overview), so one broken venue never blanks the screen.
+ */
+object PortfolioAggregator {
+
+    fun aggregate(
+        custody: ApiResult<CustodyBalances>,
+        staking: ApiResult<StakingDashboard>,
+        spot: ApiResult<SpotBalance>,
+        margin: ApiResult<MarginAccount>,
+    ): PortfolioUiState {
+        val custodyCard = custodyCard(custody)
+        val stakingCard = stakingCard(staking)
+        val spotCard = spotCard(spot)
+        val marginCard = marginCard(margin)
+        val positions = (margin as? ApiResult.Success)?.data?.position
+            ?.takeIf { it.qty != 0L }
+            ?.let {
+                listOf(
+                    PortfolioPosition(
+                        symbol = symbolLabel(it.symbolId),
+                        qty = it.qty,
+                        entryPrice = it.entryPrice,
+                        liquidationPrice = it.liquidationPrice,
+                        unrealizedPnl = it.unrealizedPnl,
+                    ),
+                )
+            }.orEmpty()
+        return PortfolioUiState(
+            loading = false,
+            cards = listOf(custodyCard, spotCard, marginCard, stakingCard),
+            positions = positions,
+        )
+    }
+
+    private fun custodyCard(r: ApiResult<CustodyBalances>): VenueCard = when (r) {
+        is ApiResult.Success -> {
+            val funded = r.data.rows.filter { it.amount > 0.0 }
+            VenueCard(
+                venue = PortfolioVenue.CUSTODY,
+                loading = false,
+                equity = funded.sumOf { it.amount },
+                lines = funded.map { PortfolioLine(it.symbol, it.amountText) },
+            )
+        }
+        is ApiResult.Failure -> unavailableCard(PortfolioVenue.CUSTODY, r.error.status)
+        is ApiResult.NetworkError -> networkCard(PortfolioVenue.CUSTODY)
+    }
+
+    private fun stakingCard(r: ApiResult<StakingDashboard>): VenueCard = when (r) {
+        is ApiResult.Success -> {
+            if (r.data.unavailable) {
+                unavailableCard(PortfolioVenue.STAKING, 404)
+            } else {
+                val total = r.data.positions.sumOf { it.total.toDoubleOrNull() ?: 0.0 }
+                VenueCard(
+                    venue = PortfolioVenue.STAKING,
+                    loading = false,
+                    equity = total,
+                    lines = r.data.positions.map {
+                        PortfolioLine(it.asset + " (" + it.statusLabel + ")", it.total)
+                    },
+                )
+            }
+        }
+        is ApiResult.Failure -> unavailableCard(PortfolioVenue.STAKING, r.error.status)
+        is ApiResult.NetworkError -> networkCard(PortfolioVenue.STAKING)
+    }
+
+    private fun spotCard(r: ApiResult<SpotBalance>): VenueCard = when (r) {
+        is ApiResult.Success -> {
+            val funded = r.data.assets.filter { it.balance > 0L }
+            VenueCard(
+                venue = PortfolioVenue.SPOT,
+                loading = false,
+                equity = funded.sumOf { it.balance.toDouble() },
+                lines = funded.map { PortfolioLine(it.symbol.ifBlank { "#" + it.asset }, it.balance.toString()) },
+            )
+        }
+        is ApiResult.Failure -> unavailableCard(PortfolioVenue.SPOT, r.error.status)
+        is ApiResult.NetworkError -> networkCard(PortfolioVenue.SPOT)
+    }
+
+    private fun marginCard(r: ApiResult<MarginAccount>): VenueCard = when (r) {
+        is ApiResult.Success -> {
+            val a = r.data
+            VenueCard(
+                venue = PortfolioVenue.MARGIN,
+                loading = false,
+                equity = a.balance.toDouble(),
+                lines = listOf(
+                    PortfolioLine("Balance", a.balance.toString()),
+                    PortfolioLine("Available", a.availableBalance.toString()),
+                    PortfolioLine("Reserved margin", a.reservedMargin.toString()),
+                ),
+            )
+        }
+        is ApiResult.Failure -> unavailableCard(PortfolioVenue.MARGIN, r.error.status)
+        is ApiResult.NetworkError -> networkCard(PortfolioVenue.MARGIN)
+    }
+
+    private fun unavailableCard(venue: PortfolioVenue, status: Int): VenueCard = VenueCard(
+        venue = venue,
+        loading = false,
+        unavailable = true,
+        unavailableReason = when (status) {
+            403 -> "Not available for this account."
+            404 -> "Not available on this deployment."
+            else -> "Unavailable right now."
+        },
+    )
+
+    private fun networkCard(venue: PortfolioVenue): VenueCard = VenueCard(
+        venue = venue,
+        loading = false,
+        unavailable = true,
+        unavailableReason = "Network error. Pull to retry.",
+    )
+
+    /** Static market-symbol labels (mirror of the markets feature: 1=BTC, 2=ETH, 3=SOL). */
+    private fun symbolLabel(symbolId: Int): String = when (symbolId) {
+        1 -> "BTCUSDC"
+        2 -> "ETHUSDC"
+        3 -> "SOLUSDC"
+        else -> "#" + symbolId
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioViewModel.kt
@@ -1,0 +1,56 @@
+package com.testlogon.android.feature.portfolio
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.exchange.TradingRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Read-only Portfolio ViewModel: fans the four independent venue reads out in parallel (custody
+ * balances + staking via [CustodyRepository]; spot balance + margin account via [TradingRepository]),
+ * then folds them into a single [PortfolioUiState] via the pure [PortfolioAggregator]. No writes.
+ *
+ * The reads are launched concurrently with [async] and awaited together; each already folds its own
+ * transport failure into an [com.testlogon.android.core.model.ApiResult] variant, so the aggregator
+ * degrades any broken/undeployed venue to an "unavailable" card without failing the others.
+ */
+@HiltViewModel
+class PortfolioViewModel @Inject constructor(
+    private val custody: CustodyRepository,
+    private val trading: TradingRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PortfolioUiState())
+    val uiState: StateFlow<PortfolioUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.value = PortfolioUiState(loading = true)
+        viewModelScope.launch {
+            val snapshot = coroutineScope {
+                val custodyDef = async { custody.getBalance() }
+                val stakingDef = async { custody.getStaking() }
+                val spotDef = async { trading.spotBalance() }
+                val marginDef = async { trading.marginAccount() }
+                PortfolioAggregator.aggregate(
+                    custody = custodyDef.await(),
+                    staking = stakingDef.await(),
+                    spot = spotDef.await(),
+                    margin = marginDef.await(),
+                )
+            }
+            _uiState.value = snapshot
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -215,6 +215,7 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         blotterDestination(navController)
         // Custody: native crypto custody surface wired to /me/custody/* (officer approvals self-gate on the admin signal).
         custodyDestination(navController)
+        portfolioDestination(navController)
         // AND-336: backend-mediated Google Drive import picker (authenticated-only).
         driveImportDestination(navController)
         // AND-335: owner share sheet (create/list/revoke share links) + the public share screen

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -103,6 +103,9 @@ object MoreRoutes {
     // Custody: native crypto custody surface (balances / deposit / withdraw / activity / officer approvals), wired to /me/custody/*.
     const val CUSTODY = CustodyDest.ROUTE
 
+    // Portfolio: read-only cross-venue account overview (custody / spot / margin / staking snapshot).
+    const val PORTFOLIO = PortfolioDest.ROUTE
+
     // AND-219: the purchase history list + search.
     val PURCHASE_HISTORY: String get() = PurchaseHistoryDest.ROUTE
 
@@ -556,6 +559,7 @@ object MoreRoutes {
             FILES,
             TRADING_BLOTTER,
             CUSTODY,
+            PORTFOLIO,
             PURCHASE_HISTORY,
             PAYMENT_METHODS,
             WALLET_TRANSACTIONS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/PortfolioNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/PortfolioNavigation.kt
@@ -1,0 +1,24 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.portfolio.PortfolioRoute
+
+/**
+ * The read-only Portfolio (cross-venue account overview) surface, reached from the More -> Wallet hub.
+ * Aggregates custody / spot / margin / staking reads into one snapshot; each source degrades
+ * independently. No order entry, no money movement.
+ */
+data object PortfolioDest {
+    const val ROUTE = "portfolio"
+}
+
+/** Registers the Portfolio screen in the authenticated graph. Up / Back pops the back stack. */
+fun NavGraphBuilder.portfolioDestination(navController: NavHostController) {
+    composable(PortfolioDest.ROUTE) {
+        PortfolioRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1425,6 +1425,7 @@
     <string name="more_entry_files">Files</string>
     <string name="more_entry_trading_blotter">Trading Blotter</string>
     <string name="more_entry_custody">Custody</string>
+    <string name="more_entry_portfolio">Portfolio</string>
     <string name="story_ring_unseen">Story from %1$s, unseen</string>
     <string name="story_ring_seen">Story from %1$s, seen</string>
     <string name="story_close">Close stories</string>

--- a/android/app/src/test/java/com/testlogon/android/data/custody/StakingContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/custody/StakingContractTest.kt
@@ -1,0 +1,126 @@
+package com.testlogon.android.data.custody
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import com.testlogon.android.testutil.testMoshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Contract tests for the custody staking data layer (providers + positions read; stake write) against
+ * MockWebServer with the production Retrofit/Moshi. Covers the DTO -> domain mapping (string amounts
+ * preserved), the graceful 404/403 -> unavailable degrade, and the stake ack (ok + reason).
+ */
+class StakingContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi = testMoshi()
+
+    private fun repo(): CustodyRepository {
+        val api = backend.retrofit(moshi).create(CustodyApi::class.java)
+        return CustodyRepository(api = api, errorParser = ApiErrorParser(moshi))
+    }
+
+    @Test
+    fun getStaking_mapsProvidersAndPositions() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"providers":[
+                    {"id":"lido","chain":"1","contract":"0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84","kind":"liquid","asset":"ETH"}
+                ]}""",
+            ),
+        )
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"vault":"vault-abc","count":1,"positions":[
+                    {"position_id":"pos-1","vault":"vault-abc","provider":"lido","chain":"1","asset":"ETH","principal":"1.5","rewards":"0.03","total":"1.53","status":"active"}
+                ]}""",
+            ),
+        )
+        val r = repo().getStaking()
+        assertTrue(r is ApiResult.Success)
+        val d = (r as ApiResult.Success).data
+        assertFalse(d.unavailable)
+        assertEquals("vault-abc", d.vault)
+        assertEquals(1, d.providers.size)
+        assertEquals("lido", d.providers.first().id)
+        assertEquals("ETH", d.providers.first().asset)
+        assertEquals(1, d.positions.size)
+        val pos = d.positions.first()
+        assertEquals("1.5", pos.principal)
+        assertEquals("0.03", pos.rewards)
+        assertEquals("1.53", pos.total)
+        assertEquals("active", pos.status)
+
+        val req1 = backend.takeRequest()
+        assertEquals("GET", req1.method)
+        assertEquals("/me/staking/providers", req1.requestUrl?.encodedPath)
+        val req2 = backend.takeRequest()
+        assertEquals("/me/staking/positions", req2.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun getStaking_404_degradesToUnavailable() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val r = repo().getStaking()
+        assertTrue(r is ApiResult.Success)
+        val d = (r as ApiResult.Success).data
+        assertTrue(d.unavailable)
+        assertTrue(d.providers.isEmpty())
+        assertTrue(d.positions.isEmpty())
+    }
+
+    @Test
+    fun getStaking_403_degradesToUnavailable() = runTest {
+        backend.enqueue(Fixtures.error("\"forbidden\"", 403))
+        val d = (repo().getStaking() as ApiResult.Success).data
+        assertTrue(d.unavailable)
+    }
+
+    @Test
+    fun getStaking_missingAmounts_defaultToZeroStrings() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"providers":[]}"""))
+        backend.enqueue(Fixtures.okBody("""{"positions":[{"position_id":"p","provider":"x"}]}"""))
+        val d = (repo().getStaking() as ApiResult.Success).data
+        val pos = d.positions.first()
+        assertEquals("0", pos.principal)
+        assertEquals("0", pos.rewards)
+        assertEquals("0", pos.total)
+    }
+
+    @Test
+    fun stake_ok_mapsResult() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"staked":true,"position_id":"pos-9","provider":"lido","amount":"2.0","status":"pending"}"""))
+        val r = repo().stake("lido", "2.0")
+        assertTrue(r is ApiResult.Success)
+        val res = (r as ApiResult.Success).data
+        assertTrue(res.ok)
+        assertEquals("pos-9", res.positionId)
+        assertEquals("lido", res.provider)
+        assertEquals("2.0", res.amount)
+        assertEquals("pending", res.status)
+        assertNull(res.reason)
+
+        val req = backend.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/me/staking/stake", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun stake_rejected_surfacesReason() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"staked":false,"reason":"insufficient_balance"}"""))
+        val res = (repo().stake("lido", "999") as ApiResult.Success).data
+        assertFalse(res.ok)
+        assertEquals("insufficient_balance", res.reason)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/StakeAuctionBrowseContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/StakeAuctionBrowseContractTest.kt
@@ -1,0 +1,115 @@
+package com.testlogon.android.data.exchange
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import com.testlogon.android.testutil.testMoshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Contract tests for the STUB discovery-browse data layer (GET me/stake_requests, me/auctions). The
+ * stub returns an empty list + stub:true + a human note; real rows must also map. A 404 (undeployed)
+ * degrades to an unavailable empty state.
+ */
+class StakeAuctionBrowseContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi = testMoshi()
+
+    private fun repo(): TradingRepository {
+        val api = backend.retrofit(moshi).create(TradingApi::class.java)
+        return TradingRepositoryImpl(api = api, errorParser = ApiErrorParser(moshi))
+    }
+
+    @Test
+    fun stakeRequests_stub_emptyWithNote() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"stake_requests":[],"count":0,"stub":true,"note":"Open stake requests browsing is not available yet."}"""))
+        val r = repo().stakeRequestsBrowse()
+        assertTrue(r is ApiResult.Success)
+        val d = (r as ApiResult.Success).data
+        assertTrue(d.isEmpty)
+        assertTrue(d.stub)
+        assertFalse(d.unavailable)
+        assertEquals(0, d.count)
+        assertEquals("Open stake requests browsing is not available yet.", d.note)
+
+        val req = backend.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/me/stake_requests", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun stakeRequests_realRows_map() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"stake_requests":[
+                    {"request_id":"42","symbolid":3,"symbol":"BTC","min_collateral":"1000","max_stake_pct":"50","status":"open","owner":"alice"}
+                ],"count":1,"stub":false}""",
+            ),
+        )
+        val d = (repo().stakeRequestsBrowse() as ApiResult.Success).data
+        assertFalse(d.isEmpty)
+        assertEquals(1, d.items.size)
+        val item = d.items.first()
+        assertEquals(42L, item.requestId)
+        assertEquals("Request #42", item.idLabel)
+        assertEquals("BTC", item.symbolLabel)
+        assertEquals("1000", item.minCollateral)
+        assertEquals("open", item.status)
+    }
+
+    @Test
+    fun stakeRequests_404_unavailable() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val d = (repo().stakeRequestsBrowse() as ApiResult.Success).data
+        assertTrue(d.unavailable)
+        assertTrue(d.isEmpty)
+    }
+
+    @Test
+    fun auctions_stub_emptyWithNote() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"auctions":[],"count":0,"stub":true,"note":"Open auctions browsing is not available yet."}"""))
+        val d = (repo().auctionsBrowse() as ApiResult.Success).data
+        assertTrue(d.isEmpty)
+        assertTrue(d.stub)
+        assertEquals("Open auctions browsing is not available yet.", d.note)
+
+        val req = backend.takeRequest()
+        assertEquals("/me/auctions", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun auctions_realRows_map() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"auctions":[
+                    {"auction_id":7,"symbol":"ETH","qty":"5","reserve_price":"250","status":"open"}
+                ],"count":1}""",
+            ),
+        )
+        val d = (repo().auctionsBrowse() as ApiResult.Success).data
+        assertEquals(1, d.items.size)
+        val item = d.items.first()
+        assertEquals(7L, item.auctionId)
+        assertEquals("Auction #7", item.idLabel)
+        assertEquals("ETH", item.symbolLabel)
+        assertEquals("5", item.qty)
+        assertEquals("250", item.reservePrice)
+    }
+
+    @Test
+    fun auctions_404_unavailable() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        val d = (repo().auctionsBrowse() as ApiResult.Success).data
+        assertTrue(d.unavailable)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/portfolio/PortfolioAggregatorTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/portfolio/PortfolioAggregatorTest.kt
@@ -1,0 +1,188 @@
+package com.testlogon.android.feature.portfolio
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.custody.CustodyAsset
+import com.testlogon.android.data.custody.CustodyBalance
+import com.testlogon.android.data.custody.CustodyBalances
+import com.testlogon.android.data.custody.StakingDashboard
+import com.testlogon.android.data.custody.StakingPosition
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.PositionSnapshot
+import com.testlogon.android.data.exchange.SpotAsset
+import com.testlogon.android.data.exchange.SpotBalance
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Aggregation logic for the read-only Portfolio: [PortfolioAggregator.aggregate] folds four
+ * independent venue reads into one snapshot. Covers the cross-venue equity sum (readable sources
+ * only), per-venue INDEPENDENT degradation (a 404/403/network venue becomes an "unavailable" card
+ * without dropping the others), staking soft-unavailable, and open-position projection.
+ */
+class PortfolioAggregatorTest {
+
+    private fun asset(sym: String) =
+        CustodyAsset(sym, sym, 1, "Ethereum", "Ethereum Mainnet", "native", 18)
+
+    private fun custody(vararg pairs: Pair<String, Double>): ApiResult<CustodyBalances> =
+        ApiResult.Success(
+            CustodyBalances(
+                vault = "0xvault",
+                tier = "T1",
+                rows = pairs.map { CustodyBalance(asset(it.first), it.second, known = true) },
+            ),
+        )
+
+    private fun spot(vararg pairs: Pair<String, Long>): ApiResult<SpotBalance> =
+        ApiResult.Success(
+            SpotBalance(
+                assets = pairs.mapIndexed { i, p -> SpotAsset(i, p.first, p.second, p.second) },
+                mpid = "MP1",
+            ),
+        )
+
+    private fun margin(balance: Long, position: PositionSnapshot? = null): ApiResult<MarginAccount> =
+        ApiResult.Success(
+            MarginAccount(
+                balance = balance,
+                availableBalance = balance,
+                reservedMargin = 0,
+                numPositions = if (position != null) 1 else 0,
+                position = position,
+                distressLevel = 0,
+                isLiquidating = false,
+                mpid = "MP1",
+            ),
+        )
+
+    private fun stakingWith(vararg totals: String): ApiResult<StakingDashboard> =
+        ApiResult.Success(
+            StakingDashboard(
+                vault = "0xvault",
+                providers = emptyList(),
+                positions = totals.map {
+                    StakingPosition("p", "0xvault", "prov", "eth", "ETH", "0", "0", it, "active")
+                },
+                unavailable = false,
+            ),
+        )
+
+    private val stakingUnavailable: ApiResult<StakingDashboard> =
+        ApiResult.Success(StakingDashboard.unavailable())
+
+    private fun failure(status: Int): ApiResult<Nothing> =
+        ApiResult.Failure(ApiError(status = status, message = "err"))
+
+    private val networkErr: ApiResult<Nothing> =
+        ApiResult.NetworkError(IOException("offline"))
+
+    @Test
+    fun aggregate_sumsReadableVenuesIntoTotalEquity() {
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("ETH" to 2.0, "USDC" to 100.0),
+            staking = stakingWith("5"),
+            spot = spot("BTC" to 10L),
+            margin = margin(balance = 50L),
+        )
+        // 102 (custody) + 10 (spot) + 50 (margin) + 5 (staking)
+        assertEquals(167.0, state.totalEquity, 0.0001)
+        assertFalse(state.anyLoading)
+        assertFalse(state.allEmpty)
+        assertEquals(4, state.cards.size)
+    }
+
+    @Test
+    fun aggregate_custodyFiltersZeroBalances() {
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("ETH" to 0.0, "USDC" to 3.0),
+            staking = stakingUnavailable,
+            spot = spot(),
+            margin = margin(0L),
+        )
+        val card = state.card(PortfolioVenue.CUSTODY)!!
+        assertEquals(1, card.lines.size)
+        assertEquals("USDC", card.lines.first().label)
+    }
+
+    @Test
+    fun aggregate_oneBrokenVenueDoesNotDropTheOthers() {
+        val state = PortfolioAggregator.aggregate(
+            custody = failure(404),
+            staking = stakingUnavailable,
+            spot = spot("BTC" to 7L),
+            margin = failure(403),
+        )
+        assertTrue(state.card(PortfolioVenue.CUSTODY)!!.unavailable)
+        assertTrue(state.card(PortfolioVenue.STAKING)!!.unavailable)
+        assertTrue(state.card(PortfolioVenue.MARGIN)!!.unavailable)
+        val spotCard = state.card(PortfolioVenue.SPOT)!!
+        assertFalse(spotCard.unavailable)
+        assertEquals(7.0, spotCard.equity, 0.0001)
+        // total counts only the one readable venue
+        assertEquals(7.0, state.totalEquity, 0.0001)
+    }
+
+    @Test
+    fun aggregate_networkErrorDegradesThatVenueOnly() {
+        val state = PortfolioAggregator.aggregate(
+            custody = networkErr,
+            staking = stakingWith("2"),
+            spot = spot(),
+            margin = margin(1L),
+        )
+        assertTrue(state.card(PortfolioVenue.CUSTODY)!!.unavailable)
+        assertEquals(3.0, state.totalEquity, 0.0001) // 2 staking + 1 margin
+    }
+
+    @Test
+    fun aggregate_liftsOpenPositionOutOfMargin() {
+        val pos = PositionSnapshot(
+            symbolId = 1,
+            qty = -5,
+            entryPrice = 30000,
+            liquidationPrice = 33000,
+            unrealizedPnl = -120,
+        )
+        val state = PortfolioAggregator.aggregate(
+            custody = custody(),
+            staking = stakingUnavailable,
+            spot = spot(),
+            margin = margin(balance = 500L, position = pos),
+        )
+        assertEquals(1, state.positions.size)
+        val p = state.positions.first()
+        assertEquals("BTCUSDC", p.symbol)
+        assertFalse(p.isLong)
+        assertFalse(p.isProfit)
+        assertEquals(-120L, p.unrealizedPnl)
+    }
+
+    @Test
+    fun aggregate_zeroQtyPositionIsNotShown() {
+        val pos = PositionSnapshot(1, 0, 0, 0, 0)
+        val state = PortfolioAggregator.aggregate(
+            custody = custody(),
+            staking = stakingUnavailable,
+            spot = spot(),
+            margin = margin(balance = 10L, position = pos),
+        )
+        assertTrue(state.positions.isEmpty())
+    }
+
+    @Test
+    fun aggregate_allEmptyWhenNothingFunded() {
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("ETH" to 0.0),
+            staking = stakingUnavailable,
+            spot = spot(),
+            margin = failure(404),
+        )
+        // custody readable but empty, spot readable but empty, margin+staking unavailable, no positions
+        assertTrue(state.allEmpty)
+        assertEquals(0.0, state.totalEquity, 0.0001)
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ const CalendarPage = lazy(() => import("@/pages/calendar/CalendarPage"));
 const TradingBlotterPage = lazy(() => import("@/pages/blotter/TradingBlotterPage"));
 const TradingWorkspacePage = lazy(() => import("@/pages/blotter/TradingWorkspacePage"));
 const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
+const PortfolioPage = lazy(() => import("@/pages/portfolio/PortfolioPage"));
 const CatalogPage = lazy(() => import("@/pages/shop/CatalogPage"));
 const ProductDetail = lazy(() => import("@/pages/shop/ProductDetail"));
 const CartPage = lazy(() => import("@/pages/shop/CartPage"));
@@ -720,6 +721,7 @@ export default function App() {
           <Route path="blotter" element={<TradingWorkspacePage />} />
           <Route path="blotter/single" element={<TradingBlotterPage />} />
           <Route path="custody" element={<CustodyPage />} />
+          <Route path="portfolio" element={<PortfolioPage />} />
           <Route path="content-calendar" element={<ContentCalendarPage />} />
           <Route path="agents/memory/:workerId" element={<AgentMemoryPage />} />
           <Route path="agents/feedback" element={<AgentFeedbackPage />} />

--- a/frontend/src/api/endpoints/custody.ts
+++ b/frontend/src/api/endpoints/custody.ts
@@ -383,3 +383,82 @@ export interface FeeScheduleResult {
 /** The maker/taker/liquidation fee schedule for a symbol. */
 export const getFeeSchedule = (symbolid: number) =>
   api.get<FeeScheduleResult>("/me/fees/schedule", { symbolid: String(symbolid) });
+
+
+// ─── Staking (real gateway-backed yield staking) ───────────────────
+// Three custody-side routes served by the exchange edge (which HMACs to the
+// custody gateway itself). Every one MAY 404/403 on backends where the staking
+// surface isn't deployed / the caller isn't custody-gated — all callers must
+// degrade gracefully (retry:false + a "not available" state). principal/rewards/
+// total are decimal STRING amounts.
+
+/** A staking provider the gateway offers (a yield vault / validator contract). */
+export interface StakingProvider {
+  id: string;
+  chain: string;
+  contract: string;
+  /** e.g. "validator", "vault", "liquid". */
+  kind: string;
+  asset: string;
+}
+
+export interface StakingProvidersResult {
+  providers: StakingProvider[];
+}
+
+/** One of the caller's staking positions. Amounts are decimal strings. */
+export interface StakingPosition {
+  position_id: string;
+  vault: string;
+  provider: string;
+  chain: string;
+  asset: string;
+  /** Staked principal (decimal string). */
+  principal: string;
+  /** Accrued rewards (decimal string). */
+  rewards: string;
+  /** principal + rewards (decimal string). */
+  total: string;
+  status: string;
+}
+
+export interface StakingPositionsResult {
+  positions: StakingPosition[];
+  count: number;
+  vault: string;
+}
+
+export interface StakeRequestBody {
+  provider: string;
+  /** Amount as a decimal string. */
+  amount: string;
+}
+
+/** Gateway stake acknowledgement. Extra fields may be present. */
+export interface StakeAck {
+  status?: string;
+  position_id?: string;
+  provider?: string;
+  asset?: string;
+  amount?: string | number;
+  vault?: string;
+  detail?: string;
+  error?: string;
+  reason?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * The staking providers the gateway offers. 404/403s until the edge deploys /
+ * the caller is custody-gated — render a graceful "not available" state (retry:false).
+ */
+export const getStakingProviders = () =>
+  api.get<StakingProvidersResult>("/me/staking/providers");
+
+/** The caller's staking positions (principal/rewards/total as decimal strings). */
+export const getStakingPositions = () =>
+  api.get<StakingPositionsResult>("/me/staking/positions");
+
+/** Stake `amount` of the given provider's asset. Returns the gateway stake ack. */
+export const stake = (body: StakeRequestBody) =>
+  api.post<StakeAck>("/me/staking/stake", body);

--- a/frontend/src/api/endpoints/trading.ts
+++ b/frontend/src/api/endpoints/trading.ts
@@ -708,3 +708,68 @@ export const auctionRequest = (body: AuctionRequestRequest) =>
 /** Trader: bid into an open auction by id. */
 export const auctionBid = (body: AuctionBidRequest) =>
   api.post<AuctionBidAck>("/me/auction_bid", body);
+
+
+// ── Discovery browse (open stake requests / open auctions) ──────────
+// Read-only "browse open items" feeds for the peer staking/auction market.
+// STUB today — the engine has no listing endpoint yet, so the edge returns an
+// EMPTY array plus `stub:true` + a human `note`. Callers render the list when
+// present and otherwise show an honest empty state using `note`. Routes MAY
+// 404 until the edge deploys — callers degrade gracefully (retry:false).
+
+/** One browsable open stake request (shape mirrors the engine when it lands). */
+export interface OpenStakeRequest {
+  request_id?: number;
+  symbolid?: number;
+  /** int64 engine tick. */
+  min_collateral?: number;
+  max_stake_pct?: number;
+  lockup_seconds?: number;
+  duration_seconds?: number;
+  status?: string;
+  [k: string]: unknown;
+}
+
+export interface StakeRequestsResult {
+  stake_requests: OpenStakeRequest[];
+  count: number;
+  /** True while the engine has no listing endpoint (empty results). */
+  stub: boolean;
+  /** Human note explaining the stub / why the list is empty. */
+  note?: string;
+}
+
+/** One browsable open auction (shape mirrors the engine when it lands). */
+export interface OpenAuction {
+  auction_id?: number;
+  symbolid?: number;
+  /** int64 engine tick. */
+  qty?: number;
+  /** int64 engine tick. */
+  reserve_price?: number;
+  duration_seconds?: number;
+  status?: string;
+  [k: string]: unknown;
+}
+
+export interface AuctionsResult {
+  auctions: OpenAuction[];
+  count: number;
+  /** True while the engine has no listing endpoint (empty results). */
+  stub: boolean;
+  /** Human note explaining the stub / why the list is empty. */
+  note?: string;
+}
+
+/**
+ * Browse open stake requests. STUB (empty + stub:true + note) until the engine
+ * adds a listing. 404s until the edge deploys — callers degrade gracefully.
+ */
+export const getStakeRequests = () =>
+  api.get<StakeRequestsResult>("/me/stake_requests");
+
+/**
+ * Browse open auctions. STUB (empty + stub:true + note) until the engine adds a
+ * listing. 404s until the edge deploys — callers degrade gracefully.
+ */
+export const getOpenAuctions = () => api.get<AuctionsResult>("/me/auctions");

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -103,6 +103,7 @@ import {
   Building,
   Award,
   CandlestickChart,
+  PieChart,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -144,6 +145,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Helpdesk", i18nKey: "nav.helpdesk", path: "/helpdesk", icon: <Headphones className="h-5 w-5" /> },
       { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: <Rss className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
+      { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
       { label: "Activity", i18nKey: "nav.activity", path: "/activity", icon: <Activity className="h-5 w-5" /> },
       { label: "Discover", i18nKey: "nav.discover", path: "/discover", icon: <Compass className="h-5 w-5" /> },
       { label: "Saved", i18nKey: "nav.saved", path: "/saved", icon: <Bookmark className="h-5 w-5" /> },

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -280,3 +280,31 @@ export function useAuctionRequest() {
 export function useAuctionBid() {
   return useMutation({ mutationFn: trading.auctionBid });
 }
+
+
+// ── Discovery browse reads (open stake requests / open auctions) ─────
+// STUB feeds (empty + stub:true + note) for the peer staking/auction market.
+// `retry: false` — the route 404s until the edge deploys; the calling UI shows
+// an honest empty state using the returned `note`. Light poll while mounted.
+
+/** Browse open stake requests. STUB until the engine adds a listing (retry:false). */
+export function useStakeRequests(enabled = true) {
+  return useQuery({
+    queryKey: ["me", "stake_requests"] as const,
+    queryFn: trading.getStakeRequests,
+    enabled,
+    retry: false,
+    refetchInterval: FEED_REFETCH_MS,
+  });
+}
+
+/** Browse open auctions. STUB until the engine adds a listing (retry:false). */
+export function useOpenAuctions(enabled = true) {
+  return useQuery({
+    queryKey: ["me", "auctions"] as const,
+    queryFn: trading.getOpenAuctions,
+    enabled,
+    retry: false,
+    refetchInterval: FEED_REFETCH_MS,
+  });
+}

--- a/frontend/src/pages/custody/CustodyPage.tsx
+++ b/frontend/src/pages/custody/CustodyPage.tsx
@@ -25,6 +25,7 @@ import {
   XCircle,
   Info,
   History,
+  Sprout,
 } from "lucide-react";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
@@ -67,6 +68,7 @@ import {
   type WithdrawResult,
 } from "@/api/endpoints/custody";
 import { SubaccountsTab, TransferTab } from "./CustodyExtras";
+import StakingDashboard from "./StakingDashboard";
 
 // ─── helpers ────────────────────────────────────────────────────
 
@@ -894,6 +896,7 @@ type TabKey =
   | "withdraw"
   | "subaccounts"
   | "transfer"
+  | "staking"
   | "activity"
   | "approvals";
 
@@ -936,6 +939,12 @@ export default function CustodyPage() {
           label: "Transfer",
           short: "Transfer",
           icon: <ArrowLeftRight className="h-4 w-4" />,
+        },
+        {
+          key: "staking" as const,
+          label: "Staking",
+          short: "Staking",
+          icon: <Sprout className="h-4 w-4" />,
         },
         {
           key: "activity" as const,
@@ -1015,6 +1024,9 @@ export default function CustodyPage() {
         </TabsContent>
         <TabsContent value="transfer">
           <TransferTab />
+        </TabsContent>
+        <TabsContent value="staking">
+          <StakingDashboard />
         </TabsContent>
         <TabsContent value="activity">
           <NotAvailable

--- a/frontend/src/pages/custody/StakingDashboard.tsx
+++ b/frontend/src/pages/custody/StakingDashboard.tsx
@@ -1,0 +1,598 @@
+// Custody Staking — real gateway-backed yield staking surface for the
+// `/me/staking/*` routes (served via the exchange edge, which HMACs to the
+// custody gateway itself). Three reads/writes:
+//   GET  /me/staking/providers  → available yield providers
+//   GET  /me/staking/positions  → the caller's positions (principal/rewards/total)
+//   POST /me/staking/stake      → stake an amount with a provider
+// Every route MAY 404/403 (not custody-gated / not deployed) → degrade
+// gracefully to a clear "not available on this backend" state. principal/
+// rewards/total are decimal STRING amounts.
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Sprout,
+  RefreshCw,
+  Loader2,
+  Info,
+  AlertTriangle,
+  CircleCheck,
+  Coins,
+} from "lucide-react";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+import { cn } from "@/lib/utils";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import {
+  getStakingProviders,
+  getStakingPositions,
+  stake,
+  type StakingProvider,
+  type StakingPosition,
+} from "@/api/endpoints/custody";
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function useIsMobile(bp = 767): boolean {
+  const [m, setM] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${bp}px)`).matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${bp}px)`);
+    const h = () => setM(mq.matches);
+    mq.addEventListener("change", h);
+    return () => mq.removeEventListener("change", h);
+  }, [bp]);
+  return m;
+}
+
+function num(v: string | number | undefined | null): number {
+  if (v == null) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function fmtAmount(v: string | number | undefined | null): string {
+  const n = num(v);
+  if (n === 0) return "0";
+  return n.toLocaleString(undefined, { maximumFractionDigits: 8 });
+}
+
+/** True when an error is a 404/403 — the "not available on this backend" case. */
+function isUnavailable(err: unknown): boolean {
+  if (err instanceof ApiError) return err.status === 404 || err.status === 403;
+  const msg = (err as Error)?.message ?? "";
+  return /\b40[34]\b/.test(msg);
+}
+
+function StatusBadge({ status }: { status?: string }) {
+  const s = (status ?? "").toLowerCase();
+  const ok = s === "active" || s === "staked" || s === "bonded";
+  const pending = s === "pending" || s === "activating" || s === "unbonding";
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-[10px] capitalize",
+        ok && "border-emerald-500/40 text-emerald-600 dark:text-emerald-400",
+        pending && "border-amber-500/40 text-amber-600 dark:text-amber-400",
+      )}
+    >
+      {status || "unknown"}
+    </Badge>
+  );
+}
+
+function NotAvailable({ line }: { line: string }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Sprout className="h-6 w-6" />
+        </div>
+        <p className="mx-auto max-w-md text-sm text-muted-foreground">{line}</p>
+        <Badge variant="outline" className="gap-1.5">
+          <Info className="h-3 w-3" /> Not available on this backend
+        </Badge>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Positions ──────────────────────────────────────────────────
+
+function PositionsSection({
+  positions,
+  vault,
+  isLoading,
+  isError,
+  error,
+  refetch,
+  isFetching,
+}: {
+  positions: StakingPosition[];
+  vault?: string;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  refetch: () => void;
+  isFetching: boolean;
+}) {
+  const isMobile = useIsMobile(767);
+
+  const totals = useMemo(() => {
+    let principal = 0;
+    let rewards = 0;
+    let total = 0;
+    for (const p of positions) {
+      principal += num(p.principal);
+      rewards += num(p.rewards);
+      total += num(p.total);
+    }
+    return { principal, rewards, total };
+  }, [positions]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold">Your staking positions</h2>
+          <p className="text-sm text-muted-foreground">
+            {positions.length} position{positions.length === 1 ? "" : "s"}
+            {vault ? (
+              <>
+                {" "}
+                · vault <span className="font-mono">{vault}</span>
+              </>
+            ) : null}
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={refetch}
+          disabled={isFetching}
+          className="gap-1.5"
+        >
+          <RefreshCw className={cn("h-4 w-4", isFetching && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && isError && isUnavailable(error) && (
+        <NotAvailable line="Staking positions aren't available on this backend yet — the custody staking surface isn't deployed or your account isn't custody-gated." />
+      )}
+
+      {!isLoading && isError && !isUnavailable(error) && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
+            <AlertTriangle className="h-8 w-8 text-destructive" />
+            <p className="text-sm text-muted-foreground">
+              Could not load staking positions.
+            </p>
+            <Button size="sm" onClick={refetch}>
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && positions.length === 0 && (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            You have no staking positions yet — stake an asset below to start
+            earning yield.
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && positions.length > 0 && (
+        <>
+          {isMobile ? (
+            <div className="space-y-2">
+              {positions.map((p) => (
+                <Card key={p.position_id}>
+                  <CardContent className="space-y-2 p-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <span className="font-semibold">{p.asset}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {p.provider}
+                        </span>
+                      </div>
+                      <StatusBadge status={p.status} />
+                    </div>
+                    <div className="grid grid-cols-3 gap-2 text-xs">
+                      <div>
+                        <div className="text-muted-foreground">Principal</div>
+                        <div className="font-medium tabular-nums">
+                          {fmtAmount(p.principal)}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-muted-foreground">Rewards</div>
+                        <div className="font-medium tabular-nums text-emerald-600 dark:text-emerald-400">
+                          {fmtAmount(p.rewards)}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-muted-foreground">Total</div>
+                        <div className="font-semibold tabular-nums">
+                          {fmtAmount(p.total)}
+                        </div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <Card>
+              <CardContent className="overflow-x-auto p-0">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs uppercase text-muted-foreground">
+                      <th className="px-4 py-2 font-medium">Provider</th>
+                      <th className="px-4 py-2 font-medium">Asset</th>
+                      <th className="px-4 py-2 font-medium">Chain</th>
+                      <th className="px-4 py-2 text-right font-medium">
+                        Principal
+                      </th>
+                      <th className="px-4 py-2 text-right font-medium">
+                        Rewards
+                      </th>
+                      <th className="px-4 py-2 text-right font-medium">Total</th>
+                      <th className="px-4 py-2 font-medium">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {positions.map((p) => (
+                      <tr
+                        key={p.position_id}
+                        className="border-b last:border-0"
+                      >
+                        <td className="px-4 py-2 font-medium">{p.provider}</td>
+                        <td className="px-4 py-2">{p.asset}</td>
+                        <td className="px-4 py-2 text-muted-foreground">
+                          {p.chain}
+                        </td>
+                        <td className="px-4 py-2 text-right tabular-nums">
+                          {fmtAmount(p.principal)}
+                        </td>
+                        <td className="px-4 py-2 text-right tabular-nums text-emerald-600 dark:text-emerald-400">
+                          {fmtAmount(p.rewards)}
+                        </td>
+                        <td className="px-4 py-2 text-right font-semibold tabular-nums">
+                          {fmtAmount(p.total)}
+                        </td>
+                        <td className="px-4 py-2">
+                          <StatusBadge status={p.status} />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                  <tfoot>
+                    <tr className="border-t bg-muted/30 text-xs">
+                      <td className="px-4 py-2 font-medium" colSpan={3}>
+                        Totals
+                      </td>
+                      <td className="px-4 py-2 text-right font-medium tabular-nums">
+                        {fmtAmount(totals.principal)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-medium tabular-nums text-emerald-600 dark:text-emerald-400">
+                        {fmtAmount(totals.rewards)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-semibold tabular-nums">
+                        {fmtAmount(totals.total)}
+                      </td>
+                      <td className="px-4 py-2" />
+                    </tr>
+                  </tfoot>
+                </table>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Providers + stake form ─────────────────────────────────────
+
+function StakeSection({
+  providers,
+  isLoading,
+  isError,
+  error,
+  refetchPositions,
+}: {
+  providers: StakingProvider[];
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  refetchPositions: () => void;
+}) {
+  const qc = useQueryClient();
+  const [selected, setSelected] = useState<string>("");
+  const [amount, setAmount] = useState("");
+
+  useEffect(() => {
+    if (!selected && providers.length > 0) setSelected(providers[0]!.id);
+  }, [providers, selected]);
+
+  const chosen = providers.find((p) => p.id === selected);
+  const amt = num(amount);
+  const amountError =
+    amount.trim() === "" ? "" : amt <= 0 ? "Amount must be greater than 0." : "";
+  const canSubmit = Boolean(chosen) && amt > 0;
+
+  const mutation = useMutation({
+    mutationFn: () => stake({ provider: chosen!.id, amount: String(amount).trim() }),
+    onSuccess: (res) => {
+      const ok =
+        !res.status ||
+        res.status === "ok" ||
+        res.status === "staked" ||
+        res.status === "ack" ||
+        res.status === "active";
+      if (ok) {
+        toast.success("Stake submitted");
+        setAmount("");
+        qc.invalidateQueries({ queryKey: ["custody", "staking", "positions"] });
+        refetchPositions();
+      } else {
+        toast.error(res.detail || res.error || res.reason || "Stake rejected");
+      }
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiError ? err.detail : "Stake failed"),
+  });
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-5">
+      {/* Providers list */}
+      <Card className="lg:col-span-3">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Coins className="h-5 w-5 text-primary" /> Available providers
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading && (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-14 w-full rounded-lg" />
+              ))}
+            </div>
+          )}
+
+          {!isLoading && isError && isUnavailable(error) && (
+            <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+              <Info className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Staking providers aren't available on this backend yet.
+              </span>
+            </div>
+          )}
+
+          {!isLoading && isError && !isUnavailable(error) && (
+            <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>Could not load providers.</span>
+            </div>
+          )}
+
+          {!isLoading && !isError && providers.length === 0 && (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              No staking providers are offered right now.
+            </p>
+          )}
+
+          {!isLoading && !isError && providers.length > 0 && (
+            <div className="space-y-2">
+              {providers.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setSelected(p.id)}
+                  className={cn(
+                    "flex w-full items-center justify-between rounded-lg border p-3 text-left transition",
+                    selected === p.id
+                      ? "border-primary/50 bg-primary/5 ring-1 ring-primary/20"
+                      : "hover:bg-muted/40",
+                  )}
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{p.id}</span>
+                      <Badge variant="outline" className="text-[10px] capitalize">
+                        {p.kind}
+                      </Badge>
+                    </div>
+                    <p className="truncate font-mono text-[11px] text-muted-foreground">
+                      {p.contract}
+                    </p>
+                  </div>
+                  <div className="ml-2 shrink-0 text-right text-xs">
+                    <div className="font-semibold">{p.asset}</div>
+                    <div className="text-muted-foreground">chain {p.chain}</div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Stake form */}
+      <Card className="lg:col-span-2">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Sprout className="h-5 w-5 text-primary" /> Stake
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Provider</Label>
+            <Select value={selected} onValueChange={setSelected}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choose a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                {providers.length === 0 && (
+                  <SelectItem value="__none" disabled>
+                    No providers available
+                  </SelectItem>
+                )}
+                {providers.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.id} — {p.asset} ({p.kind})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Amount{chosen ? ` (${chosen.asset})` : ""}</Label>
+            <Input
+              inputMode="decimal"
+              placeholder="0.00"
+              value={amount}
+              onChange={(e) =>
+                setAmount(e.target.value.replace(/[^0-9.]/g, ""))
+              }
+            />
+            {amountError && (
+              <p className="text-xs text-destructive">{amountError}</p>
+            )}
+          </div>
+
+          {chosen && (
+            <div className="rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+              <div className="flex justify-between">
+                <span>Asset</span>
+                <span className="font-medium text-foreground">
+                  {chosen.asset}
+                </span>
+              </div>
+              <div className="mt-1 flex justify-between">
+                <span>Chain</span>
+                <span className="font-medium text-foreground">
+                  {chosen.chain}
+                </span>
+              </div>
+              <Separator className="my-2" />
+              <div className="flex justify-between">
+                <span>Contract</span>
+                <span className="break-all font-mono text-foreground/80">
+                  {chosen.contract}
+                </span>
+              </div>
+            </div>
+          )}
+
+          <Button
+            className="w-full gap-1.5"
+            disabled={!canSubmit || mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            {mutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sprout className="h-4 w-4" />
+            )}
+            Stake
+          </Button>
+
+          {mutation.isSuccess && (
+            <div className="flex items-center gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-2 text-xs text-emerald-700 dark:text-emerald-300">
+              <CircleCheck className="h-4 w-4" /> Stake submitted — see your
+              positions above.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Dashboard ──────────────────────────────────────────────────
+
+export default function StakingDashboard() {
+  const positionsQ = useQuery({
+    queryKey: ["custody", "staking", "positions"],
+    queryFn: getStakingPositions,
+    retry: false,
+    staleTime: 15_000,
+  });
+
+  const providersQ = useQuery({
+    queryKey: ["custody", "staking", "providers"],
+    queryFn: getStakingProviders,
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const positions = positionsQ.data?.positions ?? [];
+  const providers = providersQ.data?.providers ?? [];
+
+  // If BOTH reads are unavailable (404/403), the whole surface isn't deployed.
+  const bothUnavailable =
+    positionsQ.isError &&
+    providersQ.isError &&
+    isUnavailable(positionsQ.error) &&
+    isUnavailable(providersQ.error);
+
+  if (bothUnavailable) {
+    return (
+      <NotAvailable line="Custody staking isn't available on this backend yet — the /me/staking surface isn't deployed or your account isn't custody-gated." />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <PositionsSection
+        positions={positions}
+        vault={positionsQ.data?.vault}
+        isLoading={positionsQ.isLoading}
+        isError={positionsQ.isError}
+        error={positionsQ.error}
+        refetch={() => positionsQ.refetch()}
+        isFetching={positionsQ.isFetching}
+      />
+      <StakeSection
+        providers={providers}
+        isLoading={providersQ.isLoading}
+        isError={providersQ.isError}
+        error={providersQ.error}
+        refetchPositions={() => positionsQ.refetch()}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/markets/StakingAuctionsPanel.tsx
+++ b/frontend/src/pages/markets/StakingAuctionsPanel.tsx
@@ -8,6 +8,8 @@ import {
   useStakeOffer,
   useAuctionRequest,
   useAuctionBid,
+  useStakeRequests,
+  useOpenAuctions,
 } from "@/hooks/useTrading";
 import { formatPrice, formatQty } from "./format";
 
@@ -350,6 +352,116 @@ function AuctionBidForm({ scaler }: { scaler: number }) {
   );
 }
 
+// ─── Browse open items (read, STUB-backed) ─────────────────────────
+// Two read-only "browse open" sections for the peer staking/auction market.
+// The listing endpoints are STUB today (empty + stub:true + note) — render the
+// list when present, otherwise show an honest empty state using the returned
+// `note`. Routes MAY 404 (not deployed) — degrade gracefully (retry:false).
+
+/** Honest empty / unavailable state for a browse section. */
+function BrowseEmpty({ note, error }: { note?: string; error?: unknown }) {
+  const msg =
+    error != null
+      ? errText(error)
+      : note ||
+        "Browsing open items isn't available yet — backend listing pending.";
+  return (
+    <p className="rounded-md border border-dashed bg-muted/20 px-3 py-3 text-[11px] text-muted-foreground">
+      {msg}
+    </p>
+  );
+}
+
+/** Browse open stake requests (read). */
+function OpenStakeRequests({ scaler }: { scaler: number }) {
+  const q = useStakeRequests();
+  const items = q.data?.stake_requests ?? [];
+  return (
+    <div className="space-y-2">
+      {q.isLoading ? (
+        <p className="text-[11px] text-muted-foreground">Loading…</p>
+      ) : q.isError || items.length === 0 ? (
+        <BrowseEmpty note={q.data?.note} error={q.isError ? q.error : undefined} />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b text-left text-[10px] uppercase text-muted-foreground">
+                <th className="py-1.5 pr-2 font-medium">Req id</th>
+                <th className="py-1.5 pr-2 font-medium">Symbol</th>
+                <th className="py-1.5 pr-2 text-right font-medium">Min collateral</th>
+                <th className="py-1.5 pr-2 text-right font-medium">Max stake %</th>
+                <th className="py-1.5 pr-2 text-right font-medium">Lockup (s)</th>
+                <th className="py-1.5 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((r, i) => (
+                <tr key={r.request_id ?? i} className="border-b last:border-0">
+                  <td className="py-1.5 pr-2 font-mono tabular-nums">{r.request_id ?? "—"}</td>
+                  <td className="py-1.5 pr-2 tabular-nums">{r.symbolid ?? "—"}</td>
+                  <td className="py-1.5 pr-2 text-right tabular-nums">
+                    {r.min_collateral != null ? formatPrice(r.min_collateral, scaler) : "—"}
+                  </td>
+                  <td className="py-1.5 pr-2 text-right tabular-nums">{r.max_stake_pct ?? "—"}</td>
+                  <td className="py-1.5 pr-2 text-right tabular-nums">{r.lockup_seconds ?? "—"}</td>
+                  <td className="py-1.5">{r.status ?? "open"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Browse open auctions (read). */
+function OpenAuctions({ scaler }: { scaler: number }) {
+  const q = useOpenAuctions();
+  const items = q.data?.auctions ?? [];
+  return (
+    <div className="space-y-2">
+      {q.isLoading ? (
+        <p className="text-[11px] text-muted-foreground">Loading…</p>
+      ) : q.isError || items.length === 0 ? (
+        <BrowseEmpty note={q.data?.note} error={q.isError ? q.error : undefined} />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b text-left text-[10px] uppercase text-muted-foreground">
+                <th className="py-1.5 pr-2 font-medium">Auction id</th>
+                <th className="py-1.5 pr-2 font-medium">Symbol</th>
+                <th className="py-1.5 pr-2 text-right font-medium">Qty</th>
+                <th className="py-1.5 pr-2 text-right font-medium">Reserve</th>
+                <th className="py-1.5 pr-2 text-right font-medium">Duration (s)</th>
+                <th className="py-1.5 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((a, i) => (
+                <tr key={a.auction_id ?? i} className="border-b last:border-0">
+                  <td className="py-1.5 pr-2 font-mono tabular-nums">{a.auction_id ?? "—"}</td>
+                  <td className="py-1.5 pr-2 tabular-nums">{a.symbolid ?? "—"}</td>
+                  <td className="py-1.5 pr-2 text-right tabular-nums">
+                    {a.qty != null ? formatQty(a.qty, scaler) : "—"}
+                  </td>
+                  <td className="py-1.5 pr-2 text-right tabular-nums">
+                    {a.reserve_price != null ? formatPrice(a.reserve_price, scaler) : "—"}
+                  </td>
+                  <td className="py-1.5 pr-2 text-right tabular-nums">{a.duration_seconds ?? "—"}</td>
+                  <td className="py-1.5">{a.status ?? "open"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Panel: groups the four trader forms (NOT admin-gated) ─────────
 export function StakingAuctionsPanel({ symbolId, scaler }: { symbolId: number; scaler: number }) {
   const [open, setOpen] = useState(false);
@@ -373,9 +485,16 @@ export function StakingAuctionsPanel({ symbolId, scaler }: { symbolId: number; s
               Routes may be unavailable (404) on backends without the surface deployed — failures show inline.
             </p>
             <p className="rounded-md border border-sky-500/30 bg-sky-500/5 px-3 py-2 text-[10px] text-muted-foreground">
-              Note: browsing open stake requests / open auctions isn&apos;t available yet — there is no list
-              endpoint. You can create items and act on a specific id, then share the id shown below.
+              Note: browsing open stake requests / open auctions is backed by a stub listing today — items
+              appear here when the engine exposes them. You can always create items and act on a specific id,
+              then share the id shown below.
             </p>
+            <SubForm title="Browse open stake requests">
+              <OpenStakeRequests scaler={scaler} />
+            </SubForm>
+            <SubForm title="Browse open auctions">
+              <OpenAuctions scaler={scaler} />
+            </SubForm>
             <SubForm title="Create stake request">
               <StakeRequestForm symbolId={symbolId} scaler={scaler} />
             </SubForm>

--- a/frontend/src/pages/portfolio/PortfolioPage.tsx
+++ b/frontend/src/pages/portfolio/PortfolioPage.tsx
@@ -1,0 +1,515 @@
+// Portfolio — a READ-ONLY consolidated overview aggregating the caller's
+// holdings across every venue the account touches: custody vault balances,
+// custody staking positions, trading spot balances, and the margin account
+// (balance / available / reserved) with its open position. NO new backend —
+// every card reuses an existing typed endpoint and DEGRADES INDEPENDENTLY:
+// if one source 404s / 403s (edge-undeployed or custody-gated) that card shows
+// an "unavailable" state while the rest still render. All reads, no mutations.
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  PieChart,
+  RefreshCw,
+  Vault,
+  Coins,
+  Sprout,
+  Landmark,
+  TrendingUp,
+  Info,
+  Loader2,
+} from "lucide-react";
+import { ApiError } from "@/api/client";
+import { cn } from "@/lib/utils";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+
+import {
+  getBalance,
+  getStakingPositions,
+  mergeBalances,
+  type StakingPosition,
+} from "@/api/endpoints/custody";
+import {
+  getSpotBalance,
+  getMarginAccount,
+  type MarginAccount,
+} from "@/api/endpoints/trading";
+import { getSymbols, type MarketSymbol } from "@/api/endpoints/marketData";
+import { formatPrice, formatQty } from "@/pages/markets/format";
+
+// --- helpers ----------------------------------------------------
+
+function useIsMobile(bp = 767): boolean {
+  const [m, setM] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${bp}px)`).matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${bp}px)`);
+    const h = () => setM(mq.matches);
+    mq.addEventListener("change", h);
+    return () => mq.removeEventListener("change", h);
+  }, [bp]);
+  return m;
+}
+
+function num(v: string | number | undefined | null): number {
+  if (v == null) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function fmtAmount(v: string | number | undefined | null): string {
+  const n = num(v);
+  if (n === 0) return "0";
+  return n.toLocaleString(undefined, { maximumFractionDigits: 8 });
+}
+
+/** True when an error is a 404/403 — the "not available on this backend" case. */
+function isUnavailable(err: unknown): boolean {
+  if (err instanceof ApiError) return err.status === 404 || err.status === 403;
+  const msg = (err as Error)?.message ?? "";
+  return /\b40[34]\b/.test(msg);
+}
+
+function errLine(err: unknown, gated: string): string {
+  if (isUnavailable(err)) return gated;
+  const msg = (err as Error)?.message;
+  return msg ? `Could not load: ${msg}` : "Could not load this source.";
+}
+
+const signColor = (v: number): string | undefined =>
+  v > 0
+    ? "rgb(16 185 129)" // emerald-500
+    : v < 0
+      ? "rgb(239 68 68)" // red-500
+      : undefined;
+
+// --- small building blocks --------------------------------------
+
+function VenueCard({
+  title,
+  icon,
+  refetch,
+  isFetching,
+  children,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  refetch?: () => void;
+  isFetching?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          {icon}
+          {title}
+        </CardTitle>
+        {refetch && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => refetch()}
+            aria-label={`Refresh ${title}`}
+          >
+            <RefreshCw className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} />
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="flex-1 text-sm">{children}</CardContent>
+    </Card>
+  );
+}
+
+function Unavailable({ line }: { line: string }) {
+  return (
+    <div className="flex flex-col items-start gap-2 py-4">
+      <p className="text-sm text-muted-foreground">{line}</p>
+      <Badge variant="outline" className="gap-1.5">
+        <Info className="h-3 w-3" /> Not available on this backend
+      </Badge>
+    </div>
+  );
+}
+
+function RowsSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="space-y-2 py-1">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center justify-between">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function KV({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="num font-medium tabular-nums" style={valueColor ? { color: valueColor } : undefined}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// --- page -------------------------------------------------------
+
+export default function PortfolioPage() {
+  useIsMobile(767); // responsive grid is CSS-driven; hook kept for parity/future use
+
+  const custodyQ = useQuery({
+    queryKey: ["portfolio", "custody", "balance"],
+    queryFn: getBalance,
+    retry: false,
+  });
+  const stakingQ = useQuery({
+    queryKey: ["portfolio", "staking", "positions"],
+    queryFn: getStakingPositions,
+    retry: false,
+  });
+  const spotQ = useQuery({
+    queryKey: ["portfolio", "spot", "balance"],
+    queryFn: getSpotBalance,
+    retry: false,
+  });
+  const marginQ = useQuery({
+    queryKey: ["portfolio", "margin", "account"],
+    queryFn: getMarginAccount,
+    retry: false,
+  });
+  const symbolsQ = useQuery({
+    queryKey: ["portfolio", "md", "symbols"],
+    queryFn: getSymbols,
+    retry: false,
+  });
+
+  const refetchAll = () => {
+    custodyQ.refetch();
+    stakingQ.refetch();
+    spotQ.refetch();
+    marginQ.refetch();
+    symbolsQ.refetch();
+  };
+
+  const anyFetching =
+    custodyQ.isFetching ||
+    stakingQ.isFetching ||
+    spotQ.isFetching ||
+    marginQ.isFetching ||
+    symbolsQ.isFetching;
+
+  // -- derived aggregates --
+  const custodyRows = useMemo(
+    () => mergeBalances(custodyQ.data?.balances).filter((r) => num(r.balance) !== 0),
+    [custodyQ.data],
+  );
+
+  const stakingTotals = useMemo(() => {
+    const positions: StakingPosition[] = stakingQ.data?.positions ?? [];
+    let principal = 0;
+    let rewards = 0;
+    let total = 0;
+    for (const p of positions) {
+      principal += num(p.principal);
+      rewards += num(p.rewards);
+      total += num(p.total);
+    }
+    return { positions, principal, rewards, total };
+  }, [stakingQ.data]);
+
+  const spotRows = useMemo(
+    () =>
+      (spotQ.data?.balances ?? []).filter(
+        (b) => num(b.balance) !== 0 || num(b.available) !== 0,
+      ),
+    [spotQ.data],
+  );
+
+  const margin: MarginAccount | undefined = marginQ.data;
+
+  // symbolid -> {name, scaler} for the open position row
+  const symLookup = useMemo(() => {
+    const map = new Map<number, MarketSymbol>();
+    for (const s of symbolsQ.data?.symbols ?? []) map.set(s.symbol_id, s);
+    return (id: number | undefined) => {
+      const s = id != null ? map.get(id) : undefined;
+      return { name: s?.symbol ?? (id != null ? `#${id}` : "—"), scaler: s?.price_scaler || 1 };
+    };
+  }, [symbolsQ.data]);
+
+  const hasPosition = !!margin && num(margin.num_positions) > 0 && num(margin.pos_qty) !== 0;
+
+  // Cross-venue equity snapshot: sum only the numerically-comparable balances
+  // we can actually read. This is a raw notional sum across assets/venues (no
+  // FX/price conversion) — labelled clearly as an approximate snapshot.
+  const equity = useMemo(() => {
+    let sum = 0;
+    let sources = 0;
+    if (custodyQ.isSuccess) {
+      sum += custodyRows.reduce((a, r) => a + num(r.balance), 0);
+      sources++;
+    }
+    if (spotQ.isSuccess) {
+      sum += spotRows.reduce((a, b) => a + num(b.balance), 0);
+      sources++;
+    }
+    if (marginQ.isSuccess) {
+      sum += num(margin?.balance);
+      sources++;
+    }
+    if (stakingQ.isSuccess) {
+      sum += stakingTotals.total;
+      sources++;
+    }
+    return { sum, sources };
+  }, [
+    custodyQ.isSuccess,
+    spotQ.isSuccess,
+    marginQ.isSuccess,
+    stakingQ.isSuccess,
+    custodyRows,
+    spotRows,
+    margin,
+    stakingTotals.total,
+  ]);
+
+  const anyLoading =
+    custodyQ.isLoading || spotQ.isLoading || marginQ.isLoading || stakingQ.isLoading;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <PieChart className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold leading-tight">Portfolio</h1>
+            <p className="text-xs text-muted-foreground">
+              Read-only overview across custody, trading, margin &amp; staking.
+            </p>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" className="gap-2 self-start sm:self-auto" onClick={refetchAll}>
+          <RefreshCw className={cn("h-4 w-4", anyFetching && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Total equity */}
+      <Card>
+        <CardContent className="flex flex-col gap-1 py-6">
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">
+            Total equity — cross-venue snapshot
+          </span>
+          {anyLoading ? (
+            <Skeleton className="h-9 w-48" />
+          ) : (
+            <div className="flex items-baseline gap-2">
+              <span className="num text-3xl font-bold tabular-nums">
+                {equity.sum.toLocaleString(undefined, { maximumFractionDigits: 8 })}
+              </span>
+              {anyFetching && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+            </div>
+          )}
+          <span className="text-[11px] text-muted-foreground">
+            Approximate raw sum of readable balances from {equity.sources} of 4 venue
+            {equity.sources === 1 ? "" : "s"} — assets are NOT FX/price-converted; unavailable
+            sources are excluded.
+          </span>
+        </CardContent>
+      </Card>
+
+      {/* Per-venue breakdown */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {/* Custody vault */}
+        <VenueCard
+          title="Custody vault"
+          icon={<Vault className="h-4 w-4 text-muted-foreground" />}
+          refetch={custodyQ.refetch}
+          isFetching={custodyQ.isFetching}
+        >
+          {custodyQ.isLoading ? (
+            <RowsSkeleton />
+          ) : custodyQ.isError ? (
+            <Unavailable line={errLine(custodyQ.error, "Custody isn't enabled for this account or the edge isn't deployed here.")} />
+          ) : custodyRows.length === 0 ? (
+            <p className="py-4 text-sm text-muted-foreground">No vault balances.</p>
+          ) : (
+            <div className="divide-y divide-border/60">
+              {custodyRows.map((r) => (
+                <KV key={r.symbol} label={r.symbol} value={fmtAmount(r.balance)} />
+              ))}
+            </div>
+          )}
+          {custodyQ.data?.vault && (
+            <p className="mt-3 truncate text-[11px] text-muted-foreground" title={custodyQ.data.vault}>
+              Vault {custodyQ.data.vault} · tier {custodyQ.data.tier}
+            </p>
+          )}
+        </VenueCard>
+
+        {/* Trading spot */}
+        <VenueCard
+          title="Trading spot"
+          icon={<Coins className="h-4 w-4 text-muted-foreground" />}
+          refetch={spotQ.refetch}
+          isFetching={spotQ.isFetching}
+        >
+          {spotQ.isLoading ? (
+            <RowsSkeleton />
+          ) : spotQ.isError ? (
+            <Unavailable line={errLine(spotQ.error, "Spot balances aren't available on this backend yet.")} />
+          ) : spotRows.length === 0 ? (
+            <p className="py-4 text-sm text-muted-foreground">No spot balances.</p>
+          ) : (
+            <div className="divide-y divide-border/60">
+              {spotRows.map((b, i) => (
+                <div key={b.symbol ?? b.asset ?? i} className="flex items-center justify-between gap-3 py-1">
+                  <span className="text-muted-foreground">{b.symbol ?? `asset ${b.asset ?? "?"}`}</span>
+                  <span className="text-right">
+                    <span className="num font-medium tabular-nums">{fmtAmount(b.balance)}</span>
+                    {b.available != null && (
+                      <span className="ml-2 text-[11px] text-muted-foreground">
+                        ({fmtAmount(b.available)} avail)
+                      </span>
+                    )}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </VenueCard>
+
+        {/* Margin account */}
+        <VenueCard
+          title="Margin account"
+          icon={<Landmark className="h-4 w-4 text-muted-foreground" />}
+          refetch={marginQ.refetch}
+          isFetching={marginQ.isFetching}
+        >
+          {marginQ.isLoading ? (
+            <RowsSkeleton />
+          ) : marginQ.isError ? (
+            <Unavailable line={errLine(marginQ.error, "The margin account isn't available on this backend yet.")} />
+          ) : (
+            <div className="divide-y divide-border/60">
+              <KV label="Balance" value={fmtAmount(margin?.balance)} />
+              <KV label="Available" value={fmtAmount(margin?.available_balance)} />
+              <KV label="Reserved margin" value={fmtAmount(margin?.reserved_margin)} />
+              <KV label="Open positions" value={String(num(margin?.num_positions))} />
+              {num(margin?.is_liquidating) > 0 && (
+                <div className="pt-2">
+                  <Badge variant="outline" className="border-red-500/40 text-red-600 dark:text-red-400">
+                    Liquidating
+                  </Badge>
+                </div>
+              )}
+            </div>
+          )}
+        </VenueCard>
+
+        {/* Staking */}
+        <VenueCard
+          title="Staking"
+          icon={<Sprout className="h-4 w-4 text-muted-foreground" />}
+          refetch={stakingQ.refetch}
+          isFetching={stakingQ.isFetching}
+        >
+          {stakingQ.isLoading ? (
+            <RowsSkeleton />
+          ) : stakingQ.isError ? (
+            <Unavailable line={errLine(stakingQ.error, "Staking isn't enabled for this account or the edge isn't deployed here.")} />
+          ) : stakingTotals.positions.length === 0 ? (
+            <p className="py-4 text-sm text-muted-foreground">No staking positions.</p>
+          ) : (
+            <div className="divide-y divide-border/60">
+              <KV label="Total staked" value={fmtAmount(stakingTotals.total)} />
+              <KV label="Principal" value={fmtAmount(stakingTotals.principal)} />
+              <KV
+                label="Rewards"
+                value={fmtAmount(stakingTotals.rewards)}
+                valueColor={stakingTotals.rewards > 0 ? signColor(1) : undefined}
+              />
+              <KV label="Positions" value={String(stakingTotals.positions.length)} />
+            </div>
+          )}
+        </VenueCard>
+      </div>
+
+      {/* Open positions (margin) */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <TrendingUp className="h-4 w-4 text-muted-foreground" />
+            Open positions
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {marginQ.isLoading ? (
+            <RowsSkeleton rows={2} />
+          ) : marginQ.isError ? (
+            <Unavailable line={errLine(marginQ.error, "The margin account isn't available on this backend yet.")} />
+          ) : !hasPosition ? (
+            <p className="py-4 text-sm text-muted-foreground">No open positions.</p>
+          ) : (
+            (() => {
+              const sym = symLookup(margin?.pos_symbol_idx);
+              const pnl = num(margin?.pos_unrealized_pnl);
+              return (
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[560px] text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-xs text-muted-foreground">
+                        <th className="py-2 pr-3 font-medium">Symbol</th>
+                        <th className="py-2 pr-3 text-right font-medium">Qty</th>
+                        <th className="py-2 pr-3 text-right font-medium">Entry</th>
+                        <th className="py-2 pr-3 text-right font-medium">Liq. price</th>
+                        <th className="py-2 text-right font-medium">Unrealized PnL</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr className="border-b last:border-0">
+                        <td className="py-2 pr-3 font-medium">{sym.name}</td>
+                        <td className="num py-2 pr-3 text-right tabular-nums">
+                          {formatQty(num(margin?.pos_qty), sym.scaler)}
+                        </td>
+                        <td className="num py-2 pr-3 text-right tabular-nums">
+                          {formatPrice(num(margin?.pos_entry_price), sym.scaler)}
+                        </td>
+                        <td className="num py-2 pr-3 text-right tabular-nums">
+                          {formatPrice(num(margin?.pos_liquidation_price), sym.scaler)}
+                        </td>
+                        <td
+                          className="num py-2 text-right font-medium tabular-nums"
+                          style={{ color: signColor(pnl) }}
+                        >
+                          {formatPrice(pnl, sym.scaler)}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <Separator className="my-3" />
+                  <p className="text-[11px] text-muted-foreground">
+                    Position values are engine int64 ticks scaled by the symbol's price scaler.
+                  </p>
+                </div>
+              );
+            })()
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Continues the frontend expansion (web + Android). Read-only + degrade-on-404 throughout; no new user-facing backend beyond the edge staking-proxy/discovery-stub routes (committed separately in the testlogon-cpp clone, undeployed).

## Staking dashboard (`a7b30694`)
Custody yield-staking, backed by a REAL gateway proxy on the new edge routes `/me/staking/{providers,positions,stake}`: providers list, the caller's positions (principal/rewards/total/status), and a stake form. New Custody "Staking" tab.

## Discovery browse (`a7b30694`)
"Open stake requests" + "open auctions" read sections wired to `/me/stake_requests` + `/me/auctions` — these are edge **stubs** today (the engine has no open-listing read), so they render an honest "browsing not available yet" state and light up when the backend adds a listing.

## Portfolio / account overview (`f4f2385a`)
Read-only cross-venue snapshot aggregating existing endpoints (custody + spot + margin + staking + open positions/uPnL). Each venue degrades independently. Total equity is a source-native sum (no pricing endpoint to FX-normalize — labeled as approximate). Web `/portfolio` route + sidebar; Android Portfolio screen (More→Wallet) + a pure `PortfolioAggregator` with tests.

## Verification
Web: `npm run build` + `tsc` = 0. Android: `assembleDebug` + `testDebugUnitTest` green; +19 new contract/aggregator tests.

See `custody_missing_features.md` and `exchange_missing_features.md` (desktop) for the deploy + engine-listing backend work still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
