### PR TITLE
feat: order management + trade history, trading alerts, portfolio USD pricing (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -76,6 +76,14 @@ interface TradingApi {
     @POST("me/funding_order")
     suspend fun placeFunding(@Body body: FundingOrderDto): FundingAckDto
 
+    /**
+     * Reference USD prices for cross-venue valuation (indicative). STUB today:
+     * {prices:{SYMBOL:"usd-string"}, quote:"USD", source, stub, note}. 404 until deployed -> the
+     * repository degrades to an unavailable [PriceMap] (callers keep the source-native sum).
+     */
+    @GET("me/prices")
+    suspend fun getPrices(): PricesDto
+
     /** Read spot (cash) balances per asset. */
     @GET("me/spot_balance")
     suspend fun spotBalance(): SpotBalanceDto
@@ -98,6 +106,14 @@ interface TradingApi {
      */
     @GET("me/fills/fees")
     suspend fun getFillsFees(): FillsFeesDto
+
+    /**
+     * The account's LIVE working (resting) orders straight from the engine (order-management read).
+     * Unlike the session-tracked list, this survives app restarts + reflects quote/OTO legs. Parsed
+     * defensively ({orders:[{clordid,symbolid,side,price,qty,...}]}); 404/undeployed -> empty feed.
+     */
+    @GET("me/orders/live")
+    suspend fun getOrdersLive(): LiveOrdersDto
 
     /** This account's recent forced-liquidation events (symbol, qty, mark, realized PnL, fee). 404 when undeployed. */
     @GET("me/liquidations")

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -368,6 +368,42 @@ data class FillsFeesDto(
     @Json(name = "fills") val fills: List<FillFeeDto>? = null,
 )
 
+// ==== Live working orders (me/orders/live) — server-side order-management read ====
+
+/**
+ * One live (resting) working order from GET me/orders/live. Parsed defensively: every field is
+ * optional and numeric fields are lenient (the edge may stringify ids/prices). [side] is "buy"/"sell";
+ * [remainingQty]/[filledQty] may be absent (the engine only reports [qty] as the open quantity) — the
+ * mapper falls back to [qty] for the working amount. [tsNs] is a nanosecond timestamp when present.
+ */
+@JsonClass(generateAdapter = true)
+data class LiveOrderDto(
+    @Json(name = "clordid") val clordid: String? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "orderid") val orderId: Long? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "symbolid") val symbolId: Int? = null,
+    @Json(name = "side") val side: String? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "price") val price: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "qty") val qty: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "remaining_qty") val remainingQty: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "leaves_qty") val leavesQty: Long? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "filled_qty") val filledQty: Long? = null,
+    @Json(name = "tif") val tif: String? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "ts_ns") val tsNs: Long? = null,
+)
+
+/**
+ * GET me/orders/live: {status, type, count, orders:[...]}. Both [orders] and the alternate [workingOrders]
+ * key are accepted so a shape drift ({working_orders:[...]}) still parses. 404 -> repository empty feed.
+ */
+@JsonClass(generateAdapter = true)
+data class LiveOrdersDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "type") val type: String? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "count") val count: Int? = null,
+    @Json(name = "orders") val orders: List<LiveOrderDto>? = null,
+    @Json(name = "working_orders") val workingOrders: List<LiveOrderDto>? = null,
+)
+
 // ==== Liquidations (me/liquidations) — REAL ====
 
 /** One forced-liquidation event: symbol, qty closed, mark price, realized PnL (signed), fee, ts(ns). */
@@ -673,3 +709,17 @@ data class AuctionsBrowseDto(
     @Json(name = "note") val note: String? = null,
 )
 
+
+// ==== Reference USD prices (indicative). GET me/prices (STUB today). ====
+// {prices:{SYMBOL:"usd-string"}, quote:"USD", source, stub, note}. Values are strings (the edge may
+// stringify decimals) -> kept as String? and parsed tolerantly in the mapper. 404 -> repo degrades.
+
+/** GET me/prices envelope: a per-symbol USD reference price map + provenance (source/stub/note). */
+@JsonClass(generateAdapter = true)
+data class PricesDto(
+    @Json(name = "prices") val prices: Map<String, String>? = null,
+    @Json(name = "quote") val quote: String? = null,
+    @Json(name = "source") val source: String? = null,
+    @Json(name = "stub") val stub: Boolean? = null,
+    @Json(name = "note") val note: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -383,6 +383,53 @@ fun FillsFeesDto.toDomain(): FillsFees = FillsFees(
     count = count ?: fills.orEmpty().size,
 )
 
+// ==== Live working orders (me/orders/live) — server-side order-management read ====
+
+/**
+ * One live (resting) working order read from the engine. [qty] is the open (working) quantity. [side]
+ * defaults to [OrderSide.BUY] when the wire omits/garbles it (defensive), but [rawSide] preserves the
+ * unknown case so a row with no usable side can still be shown without a misleading buy/sell colour.
+ */
+data class LiveOrder(
+    val clordid: String,
+    val orderId: Long?,
+    val symbolId: Int,
+    val side: OrderSide?,
+    val price: Long,
+    val qty: Long,
+    val tif: String?,
+    val tsNs: Long,
+) {
+    /** True when this order carries the id needed to amend/cancel it. */
+    val isActionable: Boolean get() = clordid.isNotBlank()
+}
+
+/** The account's live working-order set (GET me/orders/live). [count] is the server-reported row count. */
+data class LiveOrders(
+    val orders: List<LiveOrder>,
+    val count: Int,
+) {
+    val isEmpty: Boolean get() = orders.isEmpty()
+}
+
+fun LiveOrderDto.toDomain(): LiveOrder = LiveOrder(
+    clordid = clordid.orEmpty(),
+    orderId = orderId,
+    symbolId = symbolId ?: 0,
+    side = sideOf(side),
+    price = price ?: 0L,
+    // Prefer the explicit open/leaves/remaining quantity; fall back to qty (the engine's open amount).
+    qty = remainingQty ?: leavesQty ?: qty ?: 0L,
+    tif = tif?.trim()?.takeIf { it.isNotBlank() },
+    tsNs = tsNs ?: 0L,
+)
+
+fun LiveOrdersDto.toDomain(): LiveOrders {
+    // Accept either key; keep only rows that carry a client-order-id (needed to amend/cancel).
+    val rows = (orders ?: workingOrders).orEmpty().map { it.toDomain() }.filter { it.clordid.isNotBlank() }
+    return LiveOrders(orders = rows, count = count ?: rows.size)
+}
+
 // ==== Liquidations (me/liquidations) — REAL ====
 
 /** One forced-liquidation event. [realizedPnl] is signed (green when >=0). [tsNs] is nanoseconds. */
@@ -683,3 +730,53 @@ fun AuctionsBrowseDto.toDomain(): AuctionsBrowse {
     )
 }
 
+
+// ==== Reference USD prices (indicative) ====
+
+/**
+ * A per-asset USD reference price map used to FX-normalize cross-venue balances into a single USD equity
+ * figure on the read-only Portfolio. [source] is the provenance the edge reports ("stub" while the edge
+ * serves placeholder marks); [stub] mirrors it as a bool. [unavailable] is set when the route 404s
+ * (undeployed) so callers fall back to the source-native sum. Keys are normalized to UPPER-CASE symbols
+ * (e.g. BTC/ETH/USDC) and only strictly-positive, finite prices are kept.
+ */
+data class PriceMap(
+    val prices: Map<String, Double>,
+    val quote: String,
+    val source: String?,
+    val stub: Boolean,
+    val note: String?,
+    val unavailable: Boolean = false,
+) {
+    /** True when there is at least one usable price to value balances with. */
+    val hasPrices: Boolean get() = prices.isNotEmpty()
+
+    /** USD price for [symbol] (case-insensitive), or null when unpriced. */
+    fun priceFor(symbol: String?): Double? {
+        val key = symbol?.trim()?.uppercase().orEmpty()
+        if (key.isEmpty()) return null
+        return prices[key]
+    }
+
+    companion object {
+        /** The 404 / undeployed fallback: no prices, so callers keep the source-native sum. */
+        fun unavailable(): PriceMap =
+            PriceMap(prices = emptyMap(), quote = "USD", source = null, stub = false, note = null, unavailable = true)
+    }
+}
+
+fun PricesDto.toDomain(): PriceMap {
+    val cleaned = prices.orEmpty().entries.mapNotNull { (rawKey, rawVal) ->
+        val key = rawKey.trim().uppercase()
+        val price = rawVal.trim().toDoubleOrNull()
+        if (key.isEmpty() || price == null || !price.isFinite() || price <= 0.0) null else key to price
+    }.toMap()
+    return PriceMap(
+        prices = cleaned,
+        quote = quote?.trim()?.takeIf { it.isNotBlank() } ?: "USD",
+        source = source?.trim()?.takeIf { it.isNotBlank() },
+        stub = stub == true || source?.trim()?.equals("stub", ignoreCase = true) == true,
+        note = note?.trim()?.takeIf { it.isNotBlank() },
+        unavailable = false,
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -41,6 +41,8 @@ interface TradingRepository {
     suspend fun placeOco(symbolId: Int, aSide: OrderSide, aPrice: Long, aQty: Long, bSide: OrderSide, bPrice: Long, bQty: Long): ApiResult<OcoAck>
     suspend fun placeFunding(rateBps: Long, qty: Long, isBorrow: Boolean, durationSeconds: Long?, symbolId: Int?): ApiResult<FundingAck>
     suspend fun spotBalance(): ApiResult<SpotBalance>
+    /** Reference USD prices for cross-venue valuation (indicative). 404 (undeployed) -> unavailable [PriceMap]. */
+    suspend fun getPrices(): ApiResult<PriceMap>
     suspend fun spotDeposit(asset: Int, amount: Long): ApiResult<SpotDepositAck>
     suspend fun deposit(amount: Long): ApiResult<DepositAck>
     /** ADMIN: apply per-symbol margin/fee/borrow config. */
@@ -61,6 +63,8 @@ interface TradingRepository {
     /** Fees (custody-exchange-gaps): the caller's fee schedule + the enriched fills-fees feed. */
     suspend fun feeSchedule(symbolId: Int): ApiResult<FeeSchedule>
     suspend fun fillsFees(): ApiResult<FillsFees>
+    /** LIVE working orders straight from the engine (order-management read; 404 -> empty feed). */
+    suspend fun ordersLive(): ApiResult<LiveOrders>
     /** Recent forced-liquidation events (404 -> empty feed). */
     suspend fun liquidations(): ApiResult<Liquidations>
     /** Recent perpetual funding payments (404 -> empty feed). */
@@ -154,6 +158,9 @@ class TradingRepositoryImpl @Inject constructor(
     override suspend fun spotBalance(): ApiResult<SpotBalance> =
         withContext(io) { apiCall { api.spotBalance().toDomain() } }
 
+    override suspend fun getPrices(): ApiResult<PriceMap> =
+        withContext(io) { emptyOn404(PriceMap.unavailable()) { api.getPrices().toDomain() } }
+
     override suspend fun spotDeposit(asset: Int, amount: Long): ApiResult<SpotDepositAck> =
         withContext(io) { apiCall { api.spotDeposit(SpotDepositDto(asset, amount)).toDomain() } }
 
@@ -203,6 +210,9 @@ class TradingRepositoryImpl @Inject constructor(
 
     override suspend fun fillsFees(): ApiResult<FillsFees> =
         withContext(io) { emptyOn404(FillsFees(emptyList(), 0)) { api.getFillsFees().toDomain() } }
+
+    override suspend fun ordersLive(): ApiResult<LiveOrders> =
+        withContext(io) { emptyOn404(LiveOrders(emptyList(), 0)) { api.getOrdersLive().toDomain() } }
 
     override suspend fun liquidations(): ApiResult<Liquidations> =
         withContext(io) { emptyOn404(Liquidations(emptyList(), 0)) { api.getLiquidations().toDomain() } }

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlert.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlert.kt
@@ -1,0 +1,205 @@
+package com.testlogon.android.data.exchange.alerts
+
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.PmResolution
+
+/**
+ * The five kinds of trading alert the detector derives from the existing trader feed reads. There is
+ * no backend notifications route — each kind is inferred from a new event appearing in one of the
+ * polled feeds (fills / liquidations / funding / margin-distress / PM-resolution).
+ */
+enum class TradingAlertKind { FILL, LIQUIDATION, FUNDING, MARGIN_DISTRESS, PM_RESOLVED }
+
+/**
+ * One derived, render-ready trading alert. [id] is a stable de-dupe key (kind + event identity) so the
+ * same underlying event never produces two alerts across polls; [read] is the local read state.
+ *
+ * [eventTsNs] is the source event's nanosecond timestamp when the feed carries one (fills/liquidations/
+ * funding). Margin-distress and PM-resolution rows carry [eventTsNs] = 0 (no per-event ns on the feed)
+ * and are ordered by [createdAtMs] instead. Money amounts are the engine's integer minor units, shown
+ * verbatim — the detector does no monetary math.
+ */
+data class TradingAlert(
+    val id: String,
+    val kind: TradingAlertKind,
+    val title: String,
+    val body: String,
+    val eventTsNs: Long,
+    val createdAtMs: Long,
+    val read: Boolean = false,
+)
+
+/**
+ * The high-water marks the detector remembers between polls so it only emits alerts for genuinely NEW
+ * events. Timestamp-keyed feeds (fills/liquidations/funding) advance a max-nanosecond watermark; the
+ * margin-distress signal is level-triggered (fires on a rising edge into distress/liquidating) so it
+ * remembers the last observed [marginDistressLevel] + [marginLiquidating]; PM-resolutions carry no
+ * reliable per-row id so we remember the count seen as the fingerprint.
+ *
+ * [seeded] distinguishes the very first fetch (seed the marks, emit NOTHING) from steady-state polls.
+ */
+data class TradingAlertsMarker(
+    val seeded: Boolean = false,
+    val lastFillTsNs: Long = 0L,
+    val lastLiquidationTsNs: Long = 0L,
+    val lastFundingTsNs: Long = 0L,
+    val marginDistressLevel: Int = 0,
+    val marginLiquidating: Boolean = false,
+    val pmResolutionCount: Int = 0,
+)
+
+/** The immutable inputs the detector reads for one poll (each already degraded-to-empty on 404). */
+data class TradingFeeds(
+    val fills: FillsFees,
+    val liquidations: Liquidations,
+    val funding: FundingPayments,
+    val margin: MarginAccount?,
+    val pmResolutions: List<PmResolution>,
+)
+
+/** The detector's output for one poll: the newly-detected alerts + the advanced marker to persist. */
+data class TradingAlertsResult(
+    val newAlerts: List<TradingAlert>,
+    val marker: TradingAlertsMarker,
+)
+
+/**
+ * Pure new-event detection for trading alerts. Given the current [feeds], the previously-persisted
+ * [marker], and a [nowMs] clock, returns the alerts for events not seen before plus the advanced
+ * marker. Deterministic and side-effect-free (the single unit-tested seam).
+ *
+ * De-dupe / seeding rules:
+ *  - First call (marker.seeded == false): seed all watermarks from the current feeds and emit NOTHING,
+ *    so opening the app never floods with historical fills.
+ *  - Timestamp feeds (fills/liquidations/funding): a row is new iff its tsNs > the stored watermark;
+ *    the watermark advances to the max tsNs seen.
+ *  - Margin distress: level-triggered on a RISING edge — fires only when distressLevel increases or
+ *    liquidating flips false->true (not re-firing while it stays elevated).
+ *  - PM-resolutions: new iff the feed grew; emits one alert per newly-appeared resolution (tail of the
+ *    list), keyed by market label + ts so a re-fetch of the same list never re-fires.
+ */
+object TradingAlertsDetector {
+
+    fun detect(feeds: TradingFeeds, marker: TradingAlertsMarker, nowMs: Long): TradingAlertsResult {
+        val maxFill = feeds.fills.fills.maxOfOrNull { it.tsNs } ?: 0L
+        val maxLiq = feeds.liquidations.events.maxOfOrNull { it.tsNs } ?: 0L
+        val maxFund = feeds.funding.payments.maxOfOrNull { it.tsNs } ?: 0L
+        val distressLevel = feeds.margin?.distressLevel ?: 0
+        val liquidating = feeds.margin?.isLiquidating ?: false
+        val pmCount = feeds.pmResolutions.size
+
+        if (!marker.seeded) {
+            // First fetch: adopt the current state as the baseline; emit no alerts.
+            return TradingAlertsResult(
+                newAlerts = emptyList(),
+                marker = TradingAlertsMarker(
+                    seeded = true,
+                    lastFillTsNs = maxFill,
+                    lastLiquidationTsNs = maxLiq,
+                    lastFundingTsNs = maxFund,
+                    marginDistressLevel = distressLevel,
+                    marginLiquidating = liquidating,
+                    pmResolutionCount = pmCount,
+                ),
+            )
+        }
+
+        val out = ArrayList<TradingAlert>()
+
+        // ---- fills (emitted oldest-new first so read order is chronological) ----
+        feeds.fills.fills
+            .filter { it.tsNs > marker.lastFillTsNs }
+            .sortedBy { it.tsNs }
+            .forEach { f ->
+                val sideLabel = f.side?.name?.lowercase()?.replaceFirstChar { c -> c.uppercase() } ?: "Filled"
+                out += TradingAlert(
+                    id = "fill:" + f.symbolId + ":" + f.tsNs + ":" + f.price + ":" + f.qty,
+                    kind = TradingAlertKind.FILL,
+                    title = "Order filled",
+                    body = sideLabel + " " + f.qty + " @ " + f.price + " on #" + f.symbolId + " (fee " + f.fee + ")",
+                    eventTsNs = f.tsNs,
+                    createdAtMs = nowMs,
+                )
+            }
+
+        // ---- liquidations ----
+        feeds.liquidations.events
+            .filter { it.tsNs > marker.lastLiquidationTsNs }
+            .sortedBy { it.tsNs }
+            .forEach { e ->
+                out += TradingAlert(
+                    id = "liq:" + e.symbolId + ":" + e.tsNs + ":" + e.qty,
+                    kind = TradingAlertKind.LIQUIDATION,
+                    title = "Position liquidated",
+                    body = "Force-liquidated " + e.qty + " on #" + e.symbolId + " @ " + e.markPrice + " (PnL " + e.realizedPnl + ")",
+                    eventTsNs = e.tsNs,
+                    createdAtMs = nowMs,
+                )
+            }
+
+        // ---- funding ----
+        feeds.funding.payments
+            .filter { it.tsNs > marker.lastFundingTsNs }
+            .sortedBy { it.tsNs }
+            .forEach { p ->
+                val verb = if (p.received) "Received" else "Paid"
+                val amt = kotlin.math.abs(p.payment)
+                out += TradingAlert(
+                    id = "fund:" + p.symbolId + ":" + p.tsNs + ":" + p.payment,
+                    kind = TradingAlertKind.FUNDING,
+                    title = "Funding " + (if (p.received) "received" else "paid"),
+                    body = verb + " funding " + amt + " on #" + p.symbolId + " (" + p.fundingRateBps + " bps)",
+                    eventTsNs = p.tsNs,
+                    createdAtMs = nowMs,
+                )
+            }
+
+        // ---- margin distress: rising edge only ----
+        val distressRose = distressLevel > marker.marginDistressLevel
+        val liquidationEdge = liquidating && !marker.marginLiquidating
+        if (distressRose || liquidationEdge) {
+            val body = if (liquidating) {
+                "Your account is being liquidated (distress level " + distressLevel + ")"
+            } else {
+                "Margin distress rose to level " + distressLevel + " — top up collateral to avoid liquidation"
+            }
+            out += TradingAlert(
+                // Keyed by the level/flag it rose TO, so the same elevated state never re-fires.
+                id = "margin:" + distressLevel + ":" + liquidating,
+                kind = TradingAlertKind.MARGIN_DISTRESS,
+                title = if (liquidating) "Liquidation in progress" else "Margin distress",
+                body = body,
+                eventTsNs = 0L,
+                createdAtMs = nowMs,
+            )
+        }
+
+        // ---- PM resolutions: only the rows that newly appeared (list grew) ----
+        if (pmCount > marker.pmResolutionCount) {
+            feeds.pmResolutions.drop(marker.pmResolutionCount).forEach { r ->
+                out += TradingAlert(
+                    id = "pm:" + r.marketLabel + ":" + r.outcomeLabel + ":" + r.ts,
+                    kind = TradingAlertKind.PM_RESOLVED,
+                    title = "Market resolved",
+                    body = r.marketLabel + " resolved " + r.outcomeLabel,
+                    eventTsNs = 0L,
+                    createdAtMs = nowMs,
+                )
+            }
+        }
+
+        val nextMarker = marker.copy(
+            lastFillTsNs = maxOf(marker.lastFillTsNs, maxFill),
+            lastLiquidationTsNs = maxOf(marker.lastLiquidationTsNs, maxLiq),
+            lastFundingTsNs = maxOf(marker.lastFundingTsNs, maxFund),
+            // Track distress DOWN too, so a later re-rise is a fresh rising edge.
+            marginDistressLevel = distressLevel,
+            marginLiquidating = liquidating,
+            pmResolutionCount = maxOf(marker.pmResolutionCount, pmCount),
+        )
+        return TradingAlertsResult(newAlerts = out, marker = nextMarker)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsModule.kt
@@ -1,0 +1,24 @@
+package com.testlogon.android.data.exchange.alerts
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Binds the derived-trading-alerts store + provides the wall-clock used by the poller/detector. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TradingAlertsModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTradingAlertsStore(impl: DataStoreTradingAlertsStore): TradingAlertsStore
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideAlertClock(): AlertClock = AlertClock { System.currentTimeMillis() }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsPoller.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsPoller.kt
@@ -1,0 +1,63 @@
+package com.testlogon.android.data.exchange.alerts
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.PmResolution
+import com.testlogon.android.data.exchange.TradingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Derives trading alerts by polling the existing trader feed reads (there is no backend notifications
+ * route). One [refresh] fetches the five feeds, runs the pure [TradingAlertsDetector] against the
+ * persisted [TradingAlertsMarker], persists the advanced marker + any new alerts, and returns them so a
+ * caller can raise system notifications. The very first refresh SEEDS the marker and emits nothing
+ * (opening the app never floods with historical events).
+ *
+ * Feed calls degrade to empty on 404/error (each read already folds 404 -> empty in the repository;
+ * here we additionally treat Failure/NetworkError as "no data this tick" so a transient outage doesn't
+ * spuriously reset watermarks). The margin read is the one that can hard-fail (403 when not trade-
+ * enabled) -> treated as null (no margin-distress signal), which is correct for a non-trading account.
+ */
+@Singleton
+class TradingAlertsPoller @Inject constructor(
+    private val trading: TradingRepository,
+    private val store: TradingAlertsStore,
+    private val clock: AlertClock,
+) {
+    /** The persisted recent-alerts list (newest first). */
+    fun alerts(): Flow<List<TradingAlert>> = store.alerts()
+
+    /** The persisted unread count for the bell badge. */
+    fun unreadCount(): Flow<Int> = store.unreadCount()
+
+    suspend fun markAllRead() = store.markAllRead()
+    suspend fun markRead(id: String) = store.markRead(id)
+    suspend fun clear() = store.clear()
+
+    /**
+     * Fetch the feeds, detect new events, persist, and return the freshly-detected alerts (empty on the
+     * seeding pass or when nothing new). Never throws.
+     */
+    suspend fun refresh(): List<TradingAlert> {
+        val feeds = TradingFeeds(
+            fills = (trading.fillsFees() as? ApiResult.Success)?.data ?: FillsFees(emptyList(), 0),
+            liquidations = (trading.liquidations() as? ApiResult.Success)?.data ?: Liquidations(emptyList(), 0),
+            funding = (trading.fundingPayments() as? ApiResult.Success)?.data ?: FundingPayments(emptyList(), 0),
+            margin = (trading.marginAccount() as? ApiResult.Success)?.data,
+            pmResolutions = (trading.pmResolutions() as? ApiResult.Success)?.data ?: emptyList<PmResolution>(),
+        )
+        val result = TradingAlertsDetector.detect(feeds, store.marker(), clock.nowMs())
+        store.setMarker(result.marker)
+        if (result.newAlerts.isNotEmpty()) store.addAlerts(result.newAlerts)
+        return result.newAlerts
+    }
+}
+
+/** Injectable clock so the poller + detector are deterministic under test. */
+fun interface AlertClock {
+    fun nowMs(): Long
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsStore.kt
@@ -1,0 +1,185 @@
+package com.testlogon.android.data.exchange.alerts
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapter
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.tradingAlertsDataStore by preferencesDataStore(name = "trading_alerts")
+
+/**
+ * Durable store for the derived trading alerts: the detector's [TradingAlertsMarker] (last-seen
+ * high-water marks) plus the rolling list of recent [TradingAlert]s and their read state.
+ *
+ * Interface seam so the poller/usecase can inject an in-memory fake on the JVM (no DataStore I/O in
+ * unit tests). All reads/writes are failure-safe (a store error degrades to "no data" / no-op and
+ * never throws). Only scalar event metadata is persisted — no PII, no credentials.
+ */
+interface TradingAlertsStore {
+    /** The persisted last-seen marker (default = un-seeded so the first poll seeds instead of firing). */
+    suspend fun marker(): TradingAlertsMarker
+    suspend fun setMarker(marker: TradingAlertsMarker)
+
+    /** The rolling recent-alerts list (newest first) as a reactive stream for the UI. */
+    fun alerts(): Flow<List<TradingAlert>>
+    /** Reactive unread count derived from [alerts]. */
+    fun unreadCount(): Flow<Int>
+
+    /** Prepend [newAlerts] (already de-duped by the detector) and cap the retained history. */
+    suspend fun addAlerts(newAlerts: List<TradingAlert>)
+    suspend fun markAllRead()
+    suspend fun markRead(id: String)
+    suspend fun clear()
+}
+
+@Singleton
+class DataStoreTradingAlertsStore @Inject constructor(
+    @ApplicationContext context: Context,
+    moshi: Moshi,
+) : TradingAlertsStore {
+
+    private val dataStore = context.tradingAlertsDataStore
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private val markerAdapter = moshi.adapter<MarkerJson>()
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private val listAdapter =
+        moshi.adapter<List<AlertJson>>(Types.newParameterizedType(List::class.java, AlertJson::class.java))
+
+    private suspend fun read() = dataStore.data
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .first()
+
+    override suspend fun marker(): TradingAlertsMarker = runCatching {
+        read()[Keys.MARKER]?.let { markerAdapter.fromJson(it) }?.toDomain()
+    }.getOrNull() ?: TradingAlertsMarker()
+
+    override suspend fun setMarker(marker: TradingAlertsMarker) {
+        runCatching { dataStore.edit { it[Keys.MARKER] = markerAdapter.toJson(marker.toJson()) } }
+    }
+
+    override fun alerts(): Flow<List<TradingAlert>> = dataStore.data
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .map { prefs -> decode(prefs[Keys.ALERTS]) }
+
+    override fun unreadCount(): Flow<Int> = alerts().map { list -> list.count { !it.read } }
+
+    override suspend fun addAlerts(newAlerts: List<TradingAlert>) {
+        if (newAlerts.isEmpty()) return
+        runCatching {
+            dataStore.edit { prefs ->
+                val existing = decode(prefs[Keys.ALERTS])
+                val existingIds = existing.mapTo(HashSet()) { it.id }
+                // Newest first; drop any incoming that already exist (double de-dupe on top of the detector).
+                val merged = (newAlerts.filter { it.id !in existingIds }.reversed() + existing).take(MAX_RETAINED)
+                prefs[Keys.ALERTS] = encode(merged)
+            }
+        }
+    }
+
+    override suspend fun markAllRead() {
+        runCatching {
+            dataStore.edit { prefs ->
+                val updated = decode(prefs[Keys.ALERTS]).map { if (it.read) it else it.copy(read = true) }
+                prefs[Keys.ALERTS] = encode(updated)
+            }
+        }
+    }
+
+    override suspend fun markRead(id: String) {
+        runCatching {
+            dataStore.edit { prefs ->
+                val updated = decode(prefs[Keys.ALERTS]).map { if (it.id == id) it.copy(read = true) else it }
+                prefs[Keys.ALERTS] = encode(updated)
+            }
+        }
+    }
+
+    override suspend fun clear() {
+        runCatching { dataStore.edit { it.remove(Keys.ALERTS) } }
+    }
+
+    private fun decode(json: String?): List<TradingAlert> = runCatching {
+        json?.let { listAdapter.fromJson(it) }?.map { it.toDomain() }
+    }.getOrNull().orEmpty()
+
+    private fun encode(alerts: List<TradingAlert>): String =
+        listAdapter.toJson(alerts.map { it.toJson() })
+
+    private object Keys {
+        val MARKER = stringPreferencesKey("marker_json")
+        val ALERTS = stringPreferencesKey("alerts_json")
+    }
+
+    private companion object {
+        const val MAX_RETAINED = 100
+    }
+}
+
+// ---- JSON wire models (kept separate from the domain types so persistence is explicit + stable) ----
+
+@JsonClass(generateAdapter = true)
+internal data class MarkerJson(
+    val seeded: Boolean = false,
+    val lastFillTsNs: Long = 0L,
+    val lastLiquidationTsNs: Long = 0L,
+    val lastFundingTsNs: Long = 0L,
+    val marginDistressLevel: Int = 0,
+    val marginLiquidating: Boolean = false,
+    val pmResolutionCount: Int = 0,
+)
+
+internal fun MarkerJson.toDomain() = TradingAlertsMarker(
+    seeded, lastFillTsNs, lastLiquidationTsNs, lastFundingTsNs,
+    marginDistressLevel, marginLiquidating, pmResolutionCount,
+)
+
+internal fun TradingAlertsMarker.toJson() = MarkerJson(
+    seeded, lastFillTsNs, lastLiquidationTsNs, lastFundingTsNs,
+    marginDistressLevel, marginLiquidating, pmResolutionCount,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class AlertJson(
+    val id: String,
+    val kind: String,
+    val title: String,
+    val body: String,
+    val eventTsNs: Long = 0L,
+    val createdAtMs: Long = 0L,
+    val read: Boolean = false,
+)
+
+internal fun AlertJson.toDomain() = TradingAlert(
+    id = id,
+    kind = runCatching { TradingAlertKind.valueOf(kind) }.getOrDefault(TradingAlertKind.FILL),
+    title = title,
+    body = body,
+    eventTsNs = eventTsNs,
+    createdAtMs = createdAtMs,
+    read = read,
+)
+
+internal fun TradingAlert.toJson() = AlertJson(
+    id = id,
+    kind = kind.name,
+    title = title,
+    body = body,
+    eventTsNs = eventTsNs,
+    createdAtMs = createdAtMs,
+    read = read,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
@@ -28,9 +28,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Text
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
@@ -73,12 +76,19 @@ import kotlin.math.abs
 fun MarketsRoute(
     onBack: () -> Unit,
     onOpenSymbol: (symbolId: Int) -> Unit,
+    onOpenAlerts: () -> Unit = {},
     viewModel: MarketsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val unreadAlerts by viewModel.unreadAlerts.collectAsStateWithLifecycle()
     MarketSurface {
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
-            MarketsHeader(onBack = onBack, count = state.rows.size)
+            MarketsHeader(
+                onBack = onBack,
+                count = state.rows.size,
+                unreadAlerts = unreadAlerts,
+                onOpenAlerts = onOpenAlerts,
+            )
             Box(modifier = Modifier.fillMaxSize()) {
                 when (state.phase) {
                     MarketsUiState.Phase.Loading -> LoadingState(message = "Loading markets")
@@ -103,7 +113,12 @@ fun MarketsRoute(
 }
 
 @Composable
-private fun MarketsHeader(onBack: () -> Unit, count: Int) {
+private fun MarketsHeader(
+    onBack: () -> Unit,
+    count: Int,
+    unreadAlerts: Int = 0,
+    onOpenAlerts: () -> Unit = {},
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -129,6 +144,23 @@ private fun MarketsHeader(onBack: () -> Unit, count: Int) {
                 color = MarketColors.TextSecondary,
                 fontSize = 12.sp,
             )
+        }
+        IconButton(onClick = onOpenAlerts, modifier = Modifier.testTag("markets_alerts_bell")) {
+            BadgedBox(
+                badge = {
+                    if (unreadAlerts > 0) {
+                        Badge(containerColor = MarketColors.Down, contentColor = MarketColors.TextPrimary) {
+                            Text(if (unreadAlerts > 99) "99+" else unreadAlerts.toString(), fontSize = 9.sp)
+                        }
+                    }
+                },
+            ) {
+                Icon(
+                    Icons.Filled.Notifications,
+                    contentDescription = "Trading alerts",
+                    tint = MarketColors.TextPrimary,
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
@@ -6,6 +6,11 @@ import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.alerts.TradingAlertKind
+import com.testlogon.android.data.exchange.alerts.TradingAlertsPoller
+import com.testlogon.android.feature.markets.trade.TradingNotifier
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
@@ -26,8 +31,14 @@ import javax.inject.Inject
 @HiltViewModel
 class MarketsViewModel @Inject constructor(
     private val repository: ExchangeRepository,
+    private val alertsPoller: TradingAlertsPoller,
+    private val notifier: TradingNotifier,
     @ApplicationContext appContext: Context,
 ) : ViewModel() {
+
+    /** Unread trading-alerts count for the header bell badge. */
+    val unreadAlerts = alertsPoller.unreadCount()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
 
     private val prefs = appContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -36,6 +47,24 @@ class MarketsViewModel @Inject constructor(
 
     init {
         load()
+        pollAlerts()
+    }
+
+    /** Poll the derived-alerts feeds while the Markets screen is alive; notify on each new alert. */
+    private fun pollAlerts() {
+        viewModelScope.launch {
+            while (isActive) {
+                alertsPoller.refresh().forEach { alert ->
+                    notifier.notifyTradingAlert(
+                        title = alert.title,
+                        body = alert.body,
+                        distress = alert.kind == TradingAlertKind.MARGIN_DISTRESS ||
+                            alert.kind == TradingAlertKind.LIQUIDATION,
+                    )
+                }
+                delay(ALERTS_POLL_MS)
+            }
+        }
     }
 
     fun onRetry() = load()
@@ -142,5 +171,6 @@ class MarketsViewModel @Inject constructor(
         const val OFFLINE_FALLBACK = "Couldn't reach the market-data service. Tap retry."
         const val PREFS = "markets_prefs"
         const val KEY_FAV = "favorites"
+        const val ALERTS_POLL_MS = 8_000L
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/TradingAlertsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/TradingAlertsScreen.kt
@@ -1,0 +1,187 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.markets.alerts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.exchange.alerts.TradingAlert
+import com.testlogon.android.data.exchange.alerts.TradingAlertKind
+import com.testlogon.android.feature.markets.ui.MarketColors
+import com.testlogon.android.feature.markets.ui.MarketSurface
+
+/**
+ * Trading Alerts (notifications) route. Lists the recent derived alerts (fills / liquidations /
+ * funding / margin-distress / PM-resolutions) newest-first with per-kind colour + unread dot, plus
+ * mark-all-read and clear actions. Reachable from the bell in the Markets header and the More hub.
+ */
+@Composable
+fun TradingAlertsRoute(
+    onBack: () -> Unit,
+    viewModel: TradingAlertsViewModel = hiltViewModel(),
+) {
+    val alerts by viewModel.alerts.collectAsStateWithLifecycle()
+    val unread by viewModel.unreadCount.collectAsStateWithLifecycle()
+    MarketSurface {
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            AlertsHeader(
+                unread = unread,
+                hasAlerts = alerts.isNotEmpty(),
+                onBack = onBack,
+                onMarkAllRead = viewModel::markAllRead,
+                onClear = viewModel::clear,
+            )
+            Box(modifier = Modifier.fillMaxSize()) {
+                if (alerts.isEmpty()) {
+                    Column(
+                        modifier = Modifier.fillMaxSize().padding(32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center,
+                    ) {
+                        Text("No alerts yet", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+                        Spacer(Modifier.size(6.dp))
+                        Text(
+                            "Fills, liquidations, funding payments and market resolutions will show up here.",
+                            color = MarketColors.TextSecondary,
+                            fontSize = 13.sp,
+                        )
+                    }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().testTag("trading_alerts_list"),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(alerts, key = { it.id }) { alert ->
+                            AlertCard(alert = alert, onClick = { viewModel.markRead(alert.id) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertsHeader(
+    unread: Int,
+    hasAlerts: Boolean,
+    onBack: () -> Unit,
+    onMarkAllRead: () -> Unit,
+    onClear: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 4.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = MarketColors.TextPrimary)
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text("Alerts", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 22.sp)
+            Text(
+                if (unread > 0) "$unread unread" else "up to date",
+                color = if (unread > 0) MarketColors.Accent else MarketColors.TextSecondary,
+                fontSize = 12.sp,
+            )
+        }
+        if (hasAlerts) {
+            IconButton(onClick = onMarkAllRead, modifier = Modifier.testTag("alerts_mark_read")) {
+                Icon(Icons.Filled.DoneAll, contentDescription = "Mark all read", tint = MarketColors.TextSecondary)
+            }
+            IconButton(onClick = onClear, modifier = Modifier.testTag("alerts_clear")) {
+                Icon(Icons.Filled.DeleteSweep, contentDescription = "Clear", tint = MarketColors.TextSecondary)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertCard(alert: TradingAlert, onClick: () -> Unit) {
+    val accent = kindColor(alert.kind)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(if (alert.read) MarketColors.Surface else MarketColors.SurfaceAlt)
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.size(8.dp).clip(CircleShape)
+                .background(if (alert.read) Color.Transparent else accent),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    kindLabel(alert.kind),
+                    color = accent,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 11.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(alert.title, color = MarketColors.TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+            }
+            Spacer(Modifier.size(3.dp))
+            Text(alert.body, color = MarketColors.TextSecondary, fontSize = 13.sp)
+        }
+    }
+}
+
+private fun kindColor(kind: TradingAlertKind): Color = when (kind) {
+    TradingAlertKind.FILL -> MarketColors.Up
+    TradingAlertKind.LIQUIDATION -> MarketColors.Down
+    TradingAlertKind.MARGIN_DISTRESS -> MarketColors.Down
+    TradingAlertKind.FUNDING -> MarketColors.Accent
+    TradingAlertKind.PM_RESOLVED -> MarketColors.Accent
+}
+
+private fun kindLabel(kind: TradingAlertKind): String = when (kind) {
+    TradingAlertKind.FILL -> "FILL"
+    TradingAlertKind.LIQUIDATION -> "LIQUIDATION"
+    TradingAlertKind.MARGIN_DISTRESS -> "MARGIN"
+    TradingAlertKind.FUNDING -> "FUNDING"
+    TradingAlertKind.PM_RESOLVED -> "RESOLVED"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/TradingAlertsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/TradingAlertsViewModel.kt
@@ -1,0 +1,58 @@
+package com.testlogon.android.feature.markets.alerts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.data.exchange.alerts.TradingAlert
+import com.testlogon.android.data.exchange.alerts.TradingAlertKind
+import com.testlogon.android.data.exchange.alerts.TradingAlertsPoller
+import com.testlogon.android.feature.markets.trade.TradingNotifier
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives the Trading Alerts screen. The alerts list + unread count are the persisted store streams;
+ * the VM additionally polls [TradingAlertsPoller.refresh] on a cadence and raises a system
+ * notification for each newly-detected alert (so a fill/liquidation is felt even off-screen).
+ */
+@HiltViewModel
+class TradingAlertsViewModel @Inject constructor(
+    private val poller: TradingAlertsPoller,
+    private val notifier: TradingNotifier,
+) : ViewModel() {
+
+    val alerts: StateFlow<List<TradingAlert>> = poller.alerts()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val unreadCount: StateFlow<Int> = poller.unreadCount()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
+
+    init {
+        viewModelScope.launch {
+            while (isActive) {
+                poller.refresh().forEach { alert ->
+                    notifier.notifyTradingAlert(
+                        title = alert.title,
+                        body = alert.body,
+                        distress = alert.kind == TradingAlertKind.MARGIN_DISTRESS ||
+                            alert.kind == TradingAlertKind.LIQUIDATION,
+                    )
+                }
+                delay(POLL_MS)
+            }
+        }
+    }
+
+    fun markAllRead() = viewModelScope.launch { poller.markAllRead() }
+    fun markRead(id: String) = viewModelScope.launch { poller.markRead(id) }
+    fun clear() = viewModelScope.launch { poller.clear() }
+
+    private companion object {
+        const val POLL_MS = 8_000L
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -79,7 +79,7 @@ fun TradeTicket(
 
         SectionTabs(
             section = state.section,
-            ordersCount = state.workingOrders.size,
+            ordersCount = state.ordersBadgeCount,
             posCount = if (state.account?.position != null) 1 else 0,
             fillsCount = state.fillsFees?.fills?.size?.takeIf { it > 0 } ?: state.sessionFills.size,
             onSelect = viewModel::setSection,
@@ -336,12 +336,42 @@ private fun PositionsSection(state: TradingUiState, lastPrice: Long?, viewModel:
 
 @Composable
 private fun OrdersSection(state: TradingUiState, viewModel: TradingViewModel) {
-    if (state.workingOrders.isEmpty()) {
-        EmptyHint("No resting orders this session")
+    // Prefer the LIVE server feed (survives restarts + includes quote/OTO legs); the ViewModel falls
+    // back to the session-tracked list when the /me/orders/live read is unavailable/undeployed.
+    val orders = state.displayOrders
+    val live = state.liveOrders?.orders?.isNotEmpty() == true
+
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = if (live) "Working orders (live)" else "Working orders (this session)",
+            color = MarketColors.TextSecondary,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+        )
+        Text(
+            text = "Refresh",
+            color = MarketColors.Accent,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+            modifier = Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .border(1.dp, MarketColors.Border, RoundedCornerShape(6.dp))
+                .clickable { viewModel.refreshOrdersLive() }
+                .testTag("orders_refresh")
+                .padding(horizontal = 10.dp, vertical = 4.dp),
+        )
+    }
+    if (orders.isEmpty()) {
+        EmptyHint(if (live) "No working orders" else "No resting orders this session")
     } else {
-        state.workingOrders.forEach { wo ->
+        orders.forEach { wo ->
+            val sideLabel = when (wo.side) { OrderSide.BUY -> "Buy"; OrderSide.SELL -> "Sell" }
             WorkingOrderRow(
-                label = "${if (wo.side == OrderSide.BUY) "Buy" else "Sell"}  ${fmt(wo.qty.toDouble())} @ ${fmt(wo.price.toDouble())}",
+                label = "$sideLabel  ${fmt(wo.qty.toDouble())} @ ${fmt(wo.price.toDouble())}",
                 sideColor = if (wo.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down,
                 onAmend = { viewModel.startAmend(wo); viewModel.setSection(TicketSection.TRADE) },
                 onCancel = { viewModel.cancel(wo.clordid) },

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingNotifier.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingNotifier.kt
@@ -89,6 +89,16 @@ class TradingNotifier @Inject constructor(
         post(title, body)
     }
 
+    /**
+     * Post a derived trading alert (fill / liquidation / funding / margin-distress / PM-resolved). The
+     * distress/liquidation kinds buzz [warn]; the rest buzz [success]. Routes to the same permission-
+     * gated [post] as the other notify* methods, so it is silently a no-op without POST_NOTIFICATIONS.
+     */
+    fun notifyTradingAlert(title: String, body: String, distress: Boolean) {
+        if (distress) warn() else success()
+        post(title, body)
+    }
+
     @SuppressLint("MissingPermission") // gated by NotificationPermissionState.isGranted()
     private fun post(title: String, body: String) {
         if (!permission.isGranted()) return

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -3,6 +3,8 @@ package com.testlogon.android.feature.markets.trade
 import com.testlogon.android.data.exchange.Fill
 import com.testlogon.android.data.exchange.FeeSchedule
 import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.LiveOrders
+import com.testlogon.android.data.exchange.LiveOrder
 import com.testlogon.android.data.exchange.Liquidations
 import com.testlogon.android.data.exchange.FundingPayments
 import com.testlogon.android.data.exchange.feeFor
@@ -121,6 +123,7 @@ data class TradingUiState(
     val pmResolutions: List<com.testlogon.android.data.exchange.PmResolution> = emptyList(),
     val feeSchedule: FeeSchedule? = null,
     val fillsFees: FillsFees? = null,
+    val liveOrders: LiveOrders? = null,
     val liquidations: Liquidations? = null,
     val fundingPayments: FundingPayments? = null,
     /** symbolId -> ticker, for labelling the account-wide liquidation/funding/fills feeds. */
@@ -136,6 +139,22 @@ data class TradingUiState(
 ) {
     /** Ticker for [symbolId] from the resolved catalogue, else "#<id>". */
     fun symbolLabel(symbolId: Int): String = symbolNames[symbolId] ?: ("#" + symbolId)
+
+    /**
+     * The working orders to display + manage. Prefers the LIVE server feed (survives restarts, includes
+     * quote/OTO legs) when it has loaded; otherwise falls back to this session's locally-tracked list.
+     * Both expose a clordid so per-row Amend/Cancel + Cancel-all work identically either way.
+     */
+    val displayOrders: List<WorkingOrder> get() {
+        val live = liveOrders?.orders
+        return if (live != null && live.isNotEmpty()) {
+            live.map { lo -> WorkingOrder(lo.clordid, lo.side ?: OrderSide.BUY, lo.price, lo.qty, lo.orderId) }
+        } else {
+            workingOrders
+        }
+    }
+    /** Count for the Orders tab badge: the live feed's count when loaded, else the session list size. */
+    val ordersBadgeCount: Int get() = liveOrders?.orders?.size?.takeIf { it > 0 } ?: workingOrders.size
     val isAmending: Boolean get() = amendingClordid != null
     val depositLong: Long? get() = depositText.toLongOrNull()
     val canDeposit: Boolean get() = !depositing && (depositLong ?: 0L) > 0L

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -65,6 +65,7 @@ class TradingViewModel @Inject constructor(
         pollAccount()
         refreshPm()
         loadFees()
+        refreshOrdersLive()
         resolveSymbols()
         loadStakeAuctionBrowse()
         if (TradingFeatures.SPOT_ENABLED) refreshSpot()
@@ -96,6 +97,21 @@ class TradingViewModel @Inject constructor(
         viewModelScope.launch {
             when (val r = repository.fundingPayments()) {
                 is ApiResult.Success -> _uiState.update { it.copy(fundingPayments = r.data) }
+                else -> Unit
+            }
+        }
+    }
+
+    /**
+     * Load the LIVE working-order set from the engine (order-management read). This is the source of
+     * truth for the Orders section when present: it survives app restarts and reflects quote/OTO legs
+     * the session list can't track. 404/undeployed or failure -> the section falls back to the local
+     * session-tracked orders (the state is left unchanged so nothing flickers).
+     */
+    fun refreshOrdersLive() {
+        viewModelScope.launch {
+            when (val r = repository.ordersLive()) {
+                is ApiResult.Success -> _uiState.update { it.copy(liveOrders = r.data) }
                 else -> Unit
             }
         }
@@ -568,6 +584,7 @@ class TradingViewModel @Inject constructor(
                             )
                         }
                         refreshAccount()
+                        refreshOrdersLive()
                         if (filled > 0) notifier.notifyFill("Order filled", "Filled $filled @ ${ack.fills.firstOrNull()?.price ?: price}") else notifier.success()
                     } else {
                         _uiState.update { it.copy(placing = false, message = ack.message ?: "Order rejected", messageIsError = true) }
@@ -592,6 +609,7 @@ class TradingViewModel @Inject constructor(
                         )
                     }
                     refreshAccount()
+                    refreshOrdersLive()
                 }
                 is ApiResult.Failure -> _uiState.update { it.copy(message = r.error.message, messageIsError = true) }
                 is ApiResult.NetworkError -> _uiState.update { it.copy(message = "Network error", messageIsError = true) }
@@ -658,8 +676,9 @@ class TradingViewModel @Inject constructor(
         viewModelScope.launch {
             when (val r = repository.cancelAll()) {
                 is ApiResult.Success -> {
-                    _uiState.update { it.copy(workingOrders = emptyList(), message = "Cancelled all (${r.data.cancelledCount})", messageIsError = false) }
+                    _uiState.update { it.copy(workingOrders = emptyList(), liveOrders = null, message = "Cancelled all (${r.data.cancelledCount})", messageIsError = false) }
                     refreshAccount()
+                    refreshOrdersLive()
                 }
                 is ApiResult.Failure -> _uiState.update { it.copy(message = r.error.message, messageIsError = true) }
                 is ApiResult.NetworkError -> _uiState.update { it.copy(message = "Network error", messageIsError = true) }
@@ -790,6 +809,7 @@ class TradingViewModel @Inject constructor(
                             )
                         }
                         refreshAccount()
+                        refreshOrdersLive()
                     } else _uiState.update { it.copy(placing = false, message = r.data.message ?: "Amend rejected", messageIsError = true) }
                     is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }
                     is ApiResult.NetworkError -> { _uiState.update { it.copy(placing = false, message = "Network error", messageIsError = true) }; notifier.error() }
@@ -814,6 +834,7 @@ class TradingViewModel @Inject constructor(
                                 )
                             }
                             refreshAccount()
+                            refreshOrdersLive()
                         } else _uiState.update { it.copy(placing = false, message = ack.message ?: "Replace rejected", messageIsError = true) }
                     }
                     is ApiResult.Failure -> { _uiState.update { it.copy(placing = false, message = r.error.message, messageIsError = true) }; notifier.error() }

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1549,6 +1549,16 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),
+        // Trading Alerts: derived notifications (fills / liquidations / funding / margin-distress / PM-resolved)
+        // detected from the trader feed reads. Reachable here and from the Markets header bell.
+        MoreEntry(
+            id = "trading_alerts",
+            labelRes = R.string.more_entry_trading_alerts,
+            icon = Icons.Outlined.Notifications,
+            route = MoreRoutes.TRADING_ALERTS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
         // AND-404: READ-ONLY admin EMAIL delivery dashboard (per-channel stats + recent activity). Self-gates
         // via the backend 403 -> the screen's Forbidden state; a non-admin sees no admin data.
         MoreEntry(

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -127,13 +128,13 @@ private fun TotalEquityHeader(state: PortfolioUiState) {
     ) {
         Column(Modifier.padding(16.dp)) {
             Text(
-                "Total equity",
+                if (state.priced) "Total equity (USD)" else "Total equity",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = fmt(state.totalEquity),
+                text = if (state.priced) usd(state.totalEquityUsd) else fmt(state.totalEquity),
                 fontSize = 30.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = FontFamily.Monospace,
@@ -141,7 +142,15 @@ private fun TotalEquityHeader(state: PortfolioUiState) {
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                "Cross-venue snapshot (readable sources, source-native units).",
+                if (state.priced) {
+                    if (state.pricesStub) {
+                        "USD-normalized equity - indicative (stub prices)."
+                    } else {
+                        "USD-normalized equity across readable sources."
+                    }
+                } else {
+                    "Cross-venue snapshot (readable sources, source-native units)."
+                },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
             )
@@ -196,13 +205,25 @@ private fun VenueCardView(card: VenueCard) {
                             .fillMaxWidth()
                             .padding(vertical = 2.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(line.label, style = MaterialTheme.typography.bodyMedium)
-                        Text(
-                            line.value,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontFamily = FontFamily.Monospace,
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            line.usdValue?.let { v ->
+                                Text(
+                                    "~" + usd(v),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    fontFamily = FontFamily.Monospace,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Spacer(Modifier.width(8.dp))
+                            }
+                            Text(
+                                line.value,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontFamily = FontFamily.Monospace,
+                            )
+                        }
                     }
                 }
             }
@@ -300,3 +321,6 @@ private fun EmptyBlock() {
 /** Compact number format: drop a trailing .0 for whole numbers. */
 private fun fmt(v: Double): String =
     if (v == v.toLong().toDouble()) v.toLong().toString() else v.toString()
+
+/** USD money format: '$' prefix, 2 decimals, grouped thousands (indicative reference value). */
+private fun usd(v: Double): String = "$" + String.format(java.util.Locale.US, "%,.2f", v)

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioUiState.kt
@@ -4,6 +4,7 @@ import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.data.custody.CustodyBalances
 import com.testlogon.android.data.custody.StakingDashboard
 import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.PriceMap
 import com.testlogon.android.data.exchange.SpotBalance
 
 /**
@@ -11,6 +12,12 @@ import com.testlogon.android.data.exchange.SpotBalance
  * (custody vault balances, custody staking, exchange spot balance, exchange margin account) into a
  * single snapshot. Each source degrades on its own: a 404/403/undeployed venue renders its card as
  * "unavailable" while the others still show. Nothing here moves money - it is a consolidated view.
+ *
+ * A fifth, OPTIONAL read (GET /me/prices) provides indicative per-asset USD reference prices. When it
+ * is readable, each priced balance is FX-normalized (amount * usdPrice) and summed into a real USD
+ * [PortfolioUiState.totalEquityUsd]; the header shows that USD figure (labelled "indicative (stub
+ * prices)" while the edge serves stub marks). On a 404 (undeployed) prices degrade to unavailable and
+ * the header falls back to the coarse source-native [PortfolioUiState.totalEquity] with its caveat.
  */
 
 /** Which venue a card represents, for labelling + iteration order. */
@@ -23,14 +30,17 @@ enum class PortfolioVenue(val label: String) {
 
 /**
  * One venue card. When [loading] is false, a readable venue carries an [equity] contribution (a coarse
- * cross-venue number) plus [lines] (per-asset / per-field detail); an unreadable venue carries a human
- * [unavailableReason] and [unavailable] = true.
+ * cross-venue number, source-native units) plus [lines] (per-asset / per-field detail); an unreadable
+ * venue carries a human [unavailableReason] and [unavailable] = true. [equityUsd] is the venue's USD
+ * contribution once its priced balances are FX-normalized (0.0 when no line on this venue is priced).
  */
 data class VenueCard(
     val venue: PortfolioVenue,
     val loading: Boolean = true,
     /** The venue's contribution to the cross-venue equity total (source-native units, unscaled). */
     val equity: Double = 0.0,
+    /** The venue's USD-normalized contribution (sum of amount*usdPrice over its PRICED lines). */
+    val equityUsd: Double = 0.0,
     /** True when this venue could NOT be read (404/403/undeployed/error) - render "unavailable". */
     val unavailable: Boolean = false,
     /** Human reason shown on an unavailable card. */
@@ -43,8 +53,17 @@ data class VenueCard(
     val countsTowardTotal: Boolean get() = !loading && !unavailable
 }
 
-/** One labelled detail row inside a venue card. */
-data class PortfolioLine(val label: String, val value: String)
+/**
+ * One labelled detail row inside a venue card. [usdValue] is the row's FX-normalized USD value when the
+ * asset is priced (null when unpriced or on a non-asset field row), and [usdText] renders it compactly.
+ */
+data class PortfolioLine(
+    val label: String,
+    val value: String,
+    val usdValue: Double? = null,
+) {
+    val isPriced: Boolean get() = usdValue != null
+}
 
 /** One open margin position, projected for display (symbol, qty, entry, liq, uPnL). */
 data class PortfolioPosition(
@@ -61,14 +80,24 @@ data class PortfolioPosition(
 /**
  * The whole Portfolio screen state. [cards] is always the four venues in a stable order; positions are
  * lifted out of the margin read for the dedicated open-positions section.
+ *
+ * [priced] is true when the USD price read succeeded AND at least one readable balance could be valued;
+ * only then is [totalEquityUsd] meaningful and the header shows USD. [pricesStub] flags the indicative
+ * caveat ("stub prices") when the edge reports source=="stub".
  */
 data class PortfolioUiState(
     val loading: Boolean = true,
     val cards: List<VenueCard> = PortfolioVenue.entries.map { VenueCard(venue = it) },
     val positions: List<PortfolioPosition> = emptyList(),
+    /** True when a usable USD price map valued at least one balance -> show USD equity. */
+    val priced: Boolean = false,
+    /** True when the priced marks are the edge STUB placeholders (indicative-only caveat). */
+    val pricesStub: Boolean = false,
 ) {
     /** Sum of the readable venues' equity contributions - a coarse cross-venue snapshot, not a settled total. */
     val totalEquity: Double get() = cards.filter { it.countsTowardTotal }.sumOf { it.equity }
+    /** Real USD equity: sum of each readable venue's FX-normalized (amount*usdPrice) contribution. */
+    val totalEquityUsd: Double get() = cards.filter { it.countsTowardTotal }.sumOf { it.equityUsd }
     /** True while at least one source is still loading. */
     val anyLoading: Boolean get() = cards.any { it.loading }
     /** True when every readable venue is empty AND nothing is loading (whole-screen empty state). */
@@ -78,11 +107,17 @@ data class PortfolioUiState(
 }
 
 /**
- * Pure aggregator: folds the four already-fetched [ApiResult]s into a [PortfolioUiState]. Kept free of
- * Android/coroutine deps so it is unit-testable in isolation (the ViewModel just fetches + calls this).
- * A [ApiResult.Failure] whose status is 404/403 (or a soft-unavailable domain flag) degrades that venue
- * to an "unavailable" card; any other Failure/NetworkError likewise degrades (there is nothing the user
- * can act on in a read-only overview), so one broken venue never blanks the screen.
+ * Pure aggregator: folds the four already-fetched [ApiResult]s (plus an OPTIONAL [PriceMap]) into a
+ * [PortfolioUiState]. Kept free of Android/coroutine deps so it is unit-testable in isolation (the
+ * ViewModel just fetches + calls this). A [ApiResult.Failure] whose status is 404/403 (or a soft-
+ * unavailable domain flag) degrades that venue to an "unavailable" card; any other Failure/NetworkError
+ * likewise degrades (there is nothing the user can act on in a read-only overview), so one broken venue
+ * never blanks the screen.
+ *
+ * When [prices] is a readable, non-empty [PriceMap], each readable balance line is FX-normalized to USD
+ * (amount * usdPrice) and rolled into that venue's [VenueCard.equityUsd] + the header [totalEquityUsd].
+ * If prices are unavailable (404) or value nothing, [PortfolioUiState.priced] stays false and the header
+ * keeps its coarse source-native total.
  */
 object PortfolioAggregator {
 
@@ -91,11 +126,13 @@ object PortfolioAggregator {
         staking: ApiResult<StakingDashboard>,
         spot: ApiResult<SpotBalance>,
         margin: ApiResult<MarginAccount>,
+        prices: PriceMap = PriceMap.unavailable(),
     ): PortfolioUiState {
-        val custodyCard = custodyCard(custody)
-        val stakingCard = stakingCard(staking)
-        val spotCard = spotCard(spot)
-        val marginCard = marginCard(margin)
+        val pm = prices.takeIf { !it.unavailable && it.hasPrices }
+        val custodyCard = custodyCard(custody, pm)
+        val stakingCard = stakingCard(staking, pm)
+        val spotCard = spotCard(spot, pm)
+        val marginCard = marginCard(margin, pm)
         val positions = (margin as? ApiResult.Success)?.data?.position
             ?.takeIf { it.qty != 0L }
             ?.let {
@@ -109,40 +146,53 @@ object PortfolioAggregator {
                     ),
                 )
             }.orEmpty()
+        val cards = listOf(custodyCard, spotCard, marginCard, stakingCard)
+        // priced only when we had a usable map AND it valued at least one readable line.
+        val valuedSomething = pm != null && cards.any { it.countsTowardTotal && it.equityUsd > 0.0 }
         return PortfolioUiState(
             loading = false,
-            cards = listOf(custodyCard, spotCard, marginCard, stakingCard),
+            cards = cards,
             positions = positions,
+            priced = valuedSomething,
+            pricesStub = valuedSomething && prices.stub,
         )
     }
 
-    private fun custodyCard(r: ApiResult<CustodyBalances>): VenueCard = when (r) {
+    private fun custodyCard(r: ApiResult<CustodyBalances>, pm: PriceMap?): VenueCard = when (r) {
         is ApiResult.Success -> {
             val funded = r.data.rows.filter { it.amount > 0.0 }
+            val lines = funded.map { row ->
+                val usd = pm?.priceFor(row.symbol)?.let { it * row.amount }
+                PortfolioLine(row.symbol, row.amountText, usdValue = usd)
+            }
             VenueCard(
                 venue = PortfolioVenue.CUSTODY,
                 loading = false,
                 equity = funded.sumOf { it.amount },
-                lines = funded.map { PortfolioLine(it.symbol, it.amountText) },
+                equityUsd = lines.sumOf { it.usdValue ?: 0.0 },
+                lines = lines,
             )
         }
         is ApiResult.Failure -> unavailableCard(PortfolioVenue.CUSTODY, r.error.status)
         is ApiResult.NetworkError -> networkCard(PortfolioVenue.CUSTODY)
     }
 
-    private fun stakingCard(r: ApiResult<StakingDashboard>): VenueCard = when (r) {
+    private fun stakingCard(r: ApiResult<StakingDashboard>, pm: PriceMap?): VenueCard = when (r) {
         is ApiResult.Success -> {
             if (r.data.unavailable) {
                 unavailableCard(PortfolioVenue.STAKING, 404)
             } else {
-                val total = r.data.positions.sumOf { it.total.toDoubleOrNull() ?: 0.0 }
+                val lines = r.data.positions.map { p ->
+                    val amount = p.total.toDoubleOrNull()
+                    val usd = if (amount != null) pm?.priceFor(p.asset)?.let { it * amount } else null
+                    PortfolioLine(p.asset + " (" + p.statusLabel + ")", p.total, usdValue = usd)
+                }
                 VenueCard(
                     venue = PortfolioVenue.STAKING,
                     loading = false,
-                    equity = total,
-                    lines = r.data.positions.map {
-                        PortfolioLine(it.asset + " (" + it.statusLabel + ")", it.total)
-                    },
+                    equity = r.data.positions.sumOf { it.total.toDoubleOrNull() ?: 0.0 },
+                    equityUsd = lines.sumOf { it.usdValue ?: 0.0 },
+                    lines = lines,
                 )
             }
         }
@@ -150,29 +200,38 @@ object PortfolioAggregator {
         is ApiResult.NetworkError -> networkCard(PortfolioVenue.STAKING)
     }
 
-    private fun spotCard(r: ApiResult<SpotBalance>): VenueCard = when (r) {
+    private fun spotCard(r: ApiResult<SpotBalance>, pm: PriceMap?): VenueCard = when (r) {
         is ApiResult.Success -> {
             val funded = r.data.assets.filter { it.balance > 0L }
+            val lines = funded.map { a ->
+                val label = a.symbol.ifBlank { "#" + a.asset }
+                val usd = a.symbol.takeIf { it.isNotBlank() }?.let { pm?.priceFor(it) }?.let { it * a.balance.toDouble() }
+                PortfolioLine(label, a.balance.toString(), usdValue = usd)
+            }
             VenueCard(
                 venue = PortfolioVenue.SPOT,
                 loading = false,
                 equity = funded.sumOf { it.balance.toDouble() },
-                lines = funded.map { PortfolioLine(it.symbol.ifBlank { "#" + it.asset }, it.balance.toString()) },
+                equityUsd = lines.sumOf { it.usdValue ?: 0.0 },
+                lines = lines,
             )
         }
         is ApiResult.Failure -> unavailableCard(PortfolioVenue.SPOT, r.error.status)
         is ApiResult.NetworkError -> networkCard(PortfolioVenue.SPOT)
     }
 
-    private fun marginCard(r: ApiResult<MarginAccount>): VenueCard = when (r) {
+    private fun marginCard(r: ApiResult<MarginAccount>, pm: PriceMap?): VenueCard = when (r) {
         is ApiResult.Success -> {
             val a = r.data
+            // Margin balance is a USDC-denominated cash figure; value it in USD via the quote asset.
+            val usd = (pm?.priceFor("USDC") ?: pm?.priceFor("USD"))?.let { it * a.balance.toDouble() }
             VenueCard(
                 venue = PortfolioVenue.MARGIN,
                 loading = false,
                 equity = a.balance.toDouble(),
+                equityUsd = usd ?: 0.0,
                 lines = listOf(
-                    PortfolioLine("Balance", a.balance.toString()),
+                    PortfolioLine("Balance", a.balance.toString(), usdValue = usd),
                     PortfolioLine("Available", a.availableBalance.toString()),
                     PortfolioLine("Reserved margin", a.reservedMargin.toString()),
                 ),

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioViewModel.kt
@@ -3,6 +3,8 @@ package com.testlogon.android.feature.portfolio
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.PriceMap
 import com.testlogon.android.data.exchange.TradingRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -43,11 +45,13 @@ class PortfolioViewModel @Inject constructor(
                 val stakingDef = async { custody.getStaking() }
                 val spotDef = async { trading.spotBalance() }
                 val marginDef = async { trading.marginAccount() }
+                val pricesDef = async { trading.getPrices() }
                 PortfolioAggregator.aggregate(
                     custody = custodyDef.await(),
                     staking = stakingDef.await(),
                     spot = spotDef.await(),
                     margin = marginDef.await(),
+                    prices = (pricesDef.await() as? ApiResult.Success)?.data ?: PriceMap.unavailable(),
                 )
             }
             _uiState.value = snapshot

--- a/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.testlogon.android.feature.markets.MarketsRoute
 import com.testlogon.android.feature.markets.SymbolDetailRoute
+import com.testlogon.android.feature.markets.alerts.TradingAlertsRoute
 
 /**
  * Markets (exchange market-data, VIEW-ONLY) destinations, registered in the AUTHENTICATED nav graph.
@@ -25,6 +26,11 @@ data object SymbolDetailDest {
     fun build(symbolId: Int): String = "markets/$symbolId"
 }
 
+/** Trading Alerts (derived notifications) list — reachable from the Markets header bell + More hub. */
+data object TradingAlertsDest {
+    const val ROUTE = "markets/alerts"
+}
+
 /** Registers the Markets list + per-symbol detail destinations (Back pops the back stack). */
 fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
     composable(MarketsDest.ROUTE) {
@@ -33,7 +39,13 @@ fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
             onOpenSymbol = { symbolId ->
                 navController.navigate(SymbolDetailDest.build(symbolId)) { launchSingleTop = true }
             },
+            onOpenAlerts = {
+                navController.navigate(TradingAlertsDest.ROUTE) { launchSingleTop = true }
+            },
         )
+    }
+    composable(TradingAlertsDest.ROUTE) {
+        TradingAlertsRoute(onBack = { navController.popBackStack() })
     }
     composable(
         route = SymbolDetailDest.ROUTE,

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -364,6 +364,9 @@ object MoreRoutes {
     // Markets (exchange market-data, VIEW-ONLY): instrument list -> per-symbol chart/book/tape.
     const val MARKETS = MarketsDest.ROUTE
 
+    // Trading Alerts (derived notifications: fills / liquidations / funding / margin-distress / PM-resolved).
+    const val TRADING_ALERTS = TradingAlertsDest.ROUTE
+
     // AND-404: READ-ONLY admin email/SMS delivery dashboards (per-channel stats + recent activity). Self-gate
     // via the backend 403 -> the screen's Forbidden state (cf. the AND-403 admin-dashboard pattern); a non-admin
     // sees no admin data. Two concrete entry routes off the shared `{channel}` destination template.
@@ -643,6 +646,7 @@ object MoreRoutes {
             WEBHOOKS,
             ADMIN_DASHBOARD,
             MARKETS,
+            TRADING_ALERTS,
             ADMIN_EMAIL_DASHBOARD,
             ADMIN_SMS_DASHBOARD,
             ADMIN_MODERATION,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4247,6 +4247,7 @@
     <!-- AND-403: Read-only admin alerts/dashboards. -->
     <string name="more_entry_admin_dashboard">Admin alerts</string>
     <string name="more_entry_markets">Markets</string>
+    <string name="more_entry_trading_alerts">Trading alerts</string>
     <string name="admin_dashboard_title">Admin alerts</string>
     <string name="admin_dashboard_back">Back</string>
     <string name="admin_dashboard_refresh">Refresh</string>

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/LiveOrdersMapperTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/LiveOrdersMapperTest.kt
@@ -1,0 +1,101 @@
+package com.testlogon.android.data.exchange
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit coverage for the LIVE working-orders read (GET me/orders/live) DTO -> domain mappers. Exercises
+ * the defensive parsing the endpoint needs: side resolution, the qty fallback chain
+ * (remaining -> leaves -> qty), the alternate `working_orders` key, rows dropped for a missing clordid,
+ * count fallback, and null/blank field defaulting.
+ */
+class LiveOrdersMapperTest {
+
+    @Test
+    fun row_mapsAllFields() {
+        val o = LiveOrderDto(
+            clordid = "abc",
+            orderId = 42L,
+            symbolId = 7,
+            side = "sell",
+            price = 100L,
+            qty = 5L,
+            tif = "GTC",
+            tsNs = 123L,
+        ).toDomain()
+        assertEquals("abc", o.clordid)
+        assertEquals(42L, o.orderId)
+        assertEquals(7, o.symbolId)
+        assertEquals(OrderSide.SELL, o.side)
+        assertEquals(100L, o.price)
+        assertEquals(5L, o.qty)
+        assertEquals("GTC", o.tif)
+        assertEquals(123L, o.tsNs)
+        assertTrue(o.isActionable)
+    }
+
+    @Test
+    fun side_isCaseInsensitive_andUnknownStaysNull() {
+        assertEquals(OrderSide.BUY, LiveOrderDto(clordid = "x", side = "BUY").toDomain().side)
+        assertNull(LiveOrderDto(clordid = "x", side = "cross").toDomain().side)
+        assertNull(LiveOrderDto(clordid = "x", side = null).toDomain().side)
+    }
+
+    @Test
+    fun qty_prefersRemaining_thenLeaves_thenQty() {
+        assertEquals(3L, LiveOrderDto(clordid = "x", remainingQty = 3L, leavesQty = 9L, qty = 12L).toDomain().qty)
+        assertEquals(9L, LiveOrderDto(clordid = "x", remainingQty = null, leavesQty = 9L, qty = 12L).toDomain().qty)
+        assertEquals(12L, LiveOrderDto(clordid = "x", remainingQty = null, leavesQty = null, qty = 12L).toDomain().qty)
+        assertEquals(0L, LiveOrderDto(clordid = "x").toDomain().qty)
+    }
+
+    @Test
+    fun blankTif_becomesNull() {
+        assertNull(LiveOrderDto(clordid = "x", tif = "  ").toDomain().tif)
+    }
+
+    @Test
+    fun envelope_usesOrdersKey_andFiltersRowsWithoutClordid() {
+        val dto = LiveOrdersDto(
+            count = null,
+            orders = listOf(
+                LiveOrderDto(clordid = "a", qty = 1L),
+                LiveOrderDto(clordid = "", qty = 2L),   // dropped: no client-order-id
+                LiveOrderDto(clordid = null, qty = 3L),  // dropped
+                LiveOrderDto(clordid = "b", qty = 4L),
+            ),
+        ).toDomain()
+        assertEquals(2, dto.orders.size)
+        assertEquals(listOf("a", "b"), dto.orders.map { it.clordid })
+        // count falls back to the (filtered) list size when the server omits it.
+        assertEquals(2, dto.count)
+        assertFalse(dto.isEmpty)
+    }
+
+    @Test
+    fun envelope_acceptsAlternateWorkingOrdersKey() {
+        val dto = LiveOrdersDto(
+            orders = null,
+            workingOrders = listOf(LiveOrderDto(clordid = "z", qty = 1L)),
+        ).toDomain()
+        assertEquals(1, dto.orders.size)
+        assertEquals("z", dto.orders.first().clordid)
+    }
+
+    @Test
+    fun envelope_empty_isEmpty() {
+        val dto = LiveOrdersDto(orders = emptyList()).toDomain()
+        assertTrue(dto.isEmpty)
+        assertEquals(0, dto.count)
+    }
+
+    @Test
+    fun envelope_serverCount_isPreserved() {
+        val dto = LiveOrdersDto(count = 5, orders = listOf(LiveOrderDto(clordid = "a"))).toDomain()
+        // The server-reported count is trusted even when it differs from the rendered row count.
+        assertEquals(5, dto.count)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/PriceMapMapperTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/PriceMapMapperTest.kt
@@ -1,0 +1,81 @@
+package com.testlogon.android.data.exchange
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Mapper unit tests for [PricesDto.toDomain] -> [PriceMap], the reference-USD-price map used to
+ * FX-normalize Portfolio balances. Covers: string-priced values parsed to Double, key upper-casing +
+ * case-insensitive lookup, dropping of non-numeric / non-positive / blank-key entries, the stub flag
+ * (explicit and via source=="stub"), the quote default, and the 404 unavailable fallback.
+ */
+class PriceMapMapperTest {
+
+    @Test
+    fun toDomain_parsesStringPricesAndUppercasesKeys() {
+        val pm = PricesDto(
+            prices = mapOf("btc" to "65000.5", "ETH" to "3200", "usdc" to "1.00"),
+            quote = "USD",
+            source = "coingecko",
+            stub = false,
+            note = "live",
+        ).toDomain()
+
+        assertTrue(pm.hasPrices)
+        assertFalse(pm.unavailable)
+        assertFalse(pm.stub)
+        assertEquals("USD", pm.quote)
+        // keys normalized to upper-case
+        assertEquals(65000.5, pm.prices["BTC"]!!, 0.0001)
+        assertEquals(3200.0, pm.prices["ETH"]!!, 0.0001)
+        // lookup is case-insensitive / trims
+        assertEquals(1.0, pm.priceFor(" usdc ")!!, 0.0001)
+        assertEquals(65000.5, pm.priceFor("Btc")!!, 0.0001)
+        assertNull(pm.priceFor("SOL"))
+        assertNull(pm.priceFor(null))
+    }
+
+    @Test
+    fun toDomain_dropsInvalidNonPositiveAndBlankEntries() {
+        val pm = PricesDto(
+            prices = mapOf(
+                "BTC" to "not-a-number",
+                "ETH" to "0",       // non-positive dropped
+                "SOL" to "-5",      // negative dropped
+                "" to "10",         // blank key dropped
+                "USDC" to " 1.0 ",  // trimmed + kept
+            ),
+        ).toDomain()
+
+        assertEquals(1, pm.prices.size)
+        assertEquals(1.0, pm.priceFor("USDC")!!, 0.0001)
+        assertNull(pm.priceFor("BTC"))
+        assertNull(pm.priceFor("ETH"))
+    }
+
+    @Test
+    fun toDomain_stubFlaggedByExplicitFlagOrSource() {
+        val byFlag = PricesDto(prices = mapOf("BTC" to "1"), stub = true, source = "reference").toDomain()
+        assertTrue(byFlag.stub)
+
+        val bySource = PricesDto(prices = mapOf("BTC" to "1"), source = "stub").toDomain()
+        assertTrue(bySource.stub)
+    }
+
+    @Test
+    fun toDomain_defaultsQuoteToUsdWhenMissing() {
+        val pm = PricesDto(prices = mapOf("BTC" to "1"), quote = null).toDomain()
+        assertEquals("USD", pm.quote)
+    }
+
+    @Test
+    fun unavailable_hasNoPricesAndFallsBack() {
+        val pm = PriceMap.unavailable()
+        assertTrue(pm.unavailable)
+        assertFalse(pm.hasPrices)
+        assertNull(pm.priceFor("BTC"))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/alerts/TradingAlertsDetectorTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/alerts/TradingAlertsDetectorTest.kt
@@ -1,0 +1,209 @@
+package com.testlogon.android.data.exchange.alerts
+
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayment
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidation
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.Liquidity
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.PmResolution
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit coverage for the pure [TradingAlertsDetector.detect] new-event logic: seeding (first fetch fires
+ * nothing), tsNs-watermark de-dupe on the three timestamp feeds, level-triggered margin distress, PM
+ * list-growth detection, and marker advancement / stability across repeated identical polls.
+ */
+class TradingAlertsDetectorTest {
+
+    private val NOW = 1_000L
+
+    private fun fill(ts: Long, sym: Int = 1, price: Long = 100, qty: Long = 5, fee: Long = 1) =
+        FillFee(sym, price, qty, OrderSide.BUY, Liquidity.MAKER, fee, 0, ts)
+
+    private fun liq(ts: Long, sym: Int = 2, qty: Long = 3, mark: Long = 3000, pnl: Long = -50) =
+        Liquidation(sym, qty, mark, pnl, 2, ts)
+
+    private fun fund(ts: Long, sym: Int = 1, pay: Long = 10, received: Boolean = true) =
+        FundingPayment(sym, 12, 100, 5, pay, received, ts)
+
+    private fun margin(level: Int, liquidating: Boolean) =
+        MarginAccount(1000, 900, 100, 0, null, level, liquidating, "MP")
+
+    private fun pm(sym: Int, ts: Long) =
+        PmResolution(sym, null, null, "yes", "resolver", ts, "engine")
+
+    private fun feeds(
+        fills: List<FillFee> = emptyList(),
+        liqs: List<Liquidation> = emptyList(),
+        funds: List<FundingPayment> = emptyList(),
+        margin: MarginAccount? = null,
+        pms: List<PmResolution> = emptyList(),
+    ) = TradingFeeds(
+        fills = FillsFees(fills, fills.size),
+        liquidations = Liquidations(liqs, liqs.size),
+        funding = FundingPayments(funds, funds.size),
+        margin = margin,
+        pmResolutions = pms,
+    )
+
+    // ---- seeding ----
+
+    @Test
+    fun firstFetch_seedsAndEmitsNothing() {
+        val f = feeds(
+            fills = listOf(fill(ts = 50), fill(ts = 70)),
+            liqs = listOf(liq(ts = 40)),
+            funds = listOf(fund(ts = 30)),
+            margin = margin(level = 2, liquidating = false),
+            pms = listOf(pm(1, 10), pm(2, 20)),
+        )
+        val r = TradingAlertsDetector.detect(f, TradingAlertsMarker(), NOW)
+
+        assertTrue("first fetch must fire no alerts", r.newAlerts.isEmpty())
+        assertTrue(r.marker.seeded)
+        // Watermarks adopt the current maxima so history never re-fires.
+        assertEquals(70L, r.marker.lastFillTsNs)
+        assertEquals(40L, r.marker.lastLiquidationTsNs)
+        assertEquals(30L, r.marker.lastFundingTsNs)
+        assertEquals(2, r.marker.marginDistressLevel)
+        assertEquals(2, r.marker.pmResolutionCount)
+    }
+
+    @Test
+    fun seededThenIdenticalFeeds_emitNothing() {
+        val f = feeds(fills = listOf(fill(ts = 70)), margin = margin(0, false))
+        val seeded = TradingAlertsDetector.detect(f, TradingAlertsMarker(), NOW).marker
+        val r = TradingAlertsDetector.detect(f, seeded, NOW)
+        assertTrue(r.newAlerts.isEmpty())
+    }
+
+    // ---- fills ----
+
+    @Test
+    fun newFill_beyondWatermark_fires_onlyForNewer() {
+        val seed = feeds(fills = listOf(fill(ts = 70)))
+        val marker = TradingAlertsDetector.detect(seed, TradingAlertsMarker(), NOW).marker
+
+        val next = feeds(fills = listOf(fill(ts = 70), fill(ts = 80), fill(ts = 90)))
+        val r = TradingAlertsDetector.detect(next, marker, NOW)
+
+        assertEquals(2, r.newAlerts.size)
+        assertTrue(r.newAlerts.all { it.kind == TradingAlertKind.FILL })
+        // Emitted oldest-new first (chronological read order).
+        assertEquals(80L, r.newAlerts.first().eventTsNs)
+        assertEquals(90L, r.newAlerts.last().eventTsNs)
+        assertEquals(90L, r.marker.lastFillTsNs)
+    }
+
+    @Test
+    fun sameFillTwice_dedupesById() {
+        val seed = feeds()
+        val marker = TradingAlertsDetector.detect(seed, TradingAlertsMarker(), NOW).marker
+        val next = feeds(fills = listOf(fill(ts = 80)))
+        val first = TradingAlertsDetector.detect(next, marker, NOW)
+        assertEquals(1, first.newAlerts.size)
+        // Re-poll with the same feed + advanced marker: watermark suppresses it.
+        val second = TradingAlertsDetector.detect(next, first.marker, NOW)
+        assertTrue(second.newAlerts.isEmpty())
+    }
+
+    // ---- liquidations + funding ----
+
+    @Test
+    fun newLiquidationAndFunding_fire() {
+        val marker = TradingAlertsDetector.detect(feeds(), TradingAlertsMarker(), NOW).marker
+        val next = feeds(liqs = listOf(liq(ts = 5)), funds = listOf(fund(ts = 5, pay = -20, received = false)))
+        val r = TradingAlertsDetector.detect(next, marker, NOW)
+        assertEquals(setOf(TradingAlertKind.LIQUIDATION, TradingAlertKind.FUNDING), r.newAlerts.map { it.kind }.toSet())
+        assertTrue(r.newAlerts.first { it.kind == TradingAlertKind.FUNDING }.body.contains("Paid"))
+    }
+
+    // ---- margin distress (level-triggered) ----
+
+    @Test
+    fun marginDistress_firesOnRisingEdge_notWhileElevated() {
+        var marker = TradingAlertsDetector.detect(feeds(margin = margin(0, false)), TradingAlertsMarker(), NOW).marker
+
+        // Rise 0 -> 2 fires once.
+        val rise = TradingAlertsDetector.detect(feeds(margin = margin(2, false)), marker, NOW)
+        assertEquals(1, rise.newAlerts.size)
+        assertEquals(TradingAlertKind.MARGIN_DISTRESS, rise.newAlerts.single().kind)
+        marker = rise.marker
+
+        // Staying at level 2 does NOT re-fire.
+        val stay = TradingAlertsDetector.detect(feeds(margin = margin(2, false)), marker, NOW)
+        assertTrue(stay.newAlerts.isEmpty())
+        marker = stay.marker
+
+        // Dropping to 0 then rising again is a fresh edge.
+        marker = TradingAlertsDetector.detect(feeds(margin = margin(0, false)), marker, NOW).marker
+        val reRise = TradingAlertsDetector.detect(feeds(margin = margin(2, false)), marker, NOW)
+        assertEquals(1, reRise.newAlerts.size)
+    }
+
+    @Test
+    fun liquidatingFlag_edgeFires() {
+        val marker = TradingAlertsDetector.detect(feeds(margin = margin(1, false)), TradingAlertsMarker(), NOW).marker
+        val r = TradingAlertsDetector.detect(feeds(margin = margin(1, true)), marker, NOW)
+        assertEquals(1, r.newAlerts.size)
+        assertTrue(r.newAlerts.single().title.contains("Liquidation"))
+    }
+
+    @Test
+    fun nullMargin_producesNoDistressAndDoesNotCrash() {
+        val marker = TradingAlertsDetector.detect(feeds(margin = margin(3, true)), TradingAlertsMarker(), NOW).marker
+        // Margin read failed this tick (null) -> no distress signal; distress mark resets to 0.
+        val r = TradingAlertsDetector.detect(feeds(margin = null), marker, NOW)
+        assertTrue(r.newAlerts.none { it.kind == TradingAlertKind.MARGIN_DISTRESS })
+        assertEquals(0, r.marker.marginDistressLevel)
+        assertFalse(r.marker.marginLiquidating)
+    }
+
+    // ---- PM resolutions (list growth) ----
+
+    @Test
+    fun pmResolutions_fireOnlyForNewlyAppendedRows() {
+        val marker = TradingAlertsDetector.detect(feeds(pms = listOf(pm(1, 10))), TradingAlertsMarker(), NOW).marker
+        val next = feeds(pms = listOf(pm(1, 10), pm(2, 20), pm(3, 30)))
+        val r = TradingAlertsDetector.detect(next, marker, NOW)
+        assertEquals(2, r.newAlerts.size)
+        assertTrue(r.newAlerts.all { it.kind == TradingAlertKind.PM_RESOLVED })
+        assertEquals(3, r.marker.pmResolutionCount)
+    }
+
+    // ---- combined ----
+
+    @Test
+    fun mixedNewEvents_allFire_withAdvancedMarker() {
+        val marker = TradingAlertsDetector.detect(feeds(margin = margin(0, false)), TradingAlertsMarker(), NOW).marker
+        val next = feeds(
+            fills = listOf(fill(ts = 100)),
+            liqs = listOf(liq(ts = 100)),
+            funds = listOf(fund(ts = 100)),
+            margin = margin(1, false),
+            pms = listOf(pm(9, 99)),
+        )
+        val r = TradingAlertsDetector.detect(next, marker, NOW)
+        assertEquals(
+            setOf(
+                TradingAlertKind.FILL,
+                TradingAlertKind.LIQUIDATION,
+                TradingAlertKind.FUNDING,
+                TradingAlertKind.MARGIN_DISTRESS,
+                TradingAlertKind.PM_RESOLVED,
+            ),
+            r.newAlerts.map { it.kind }.toSet(),
+        )
+        assertEquals(100L, r.marker.lastFillTsNs)
+        assertEquals(1, r.marker.pmResolutionCount)
+        // Every alert carries the injected clock.
+        assertTrue(r.newAlerts.all { it.createdAtMs == NOW })
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/markets/trade/TradingOrdersStateTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/markets/trade/TradingOrdersStateTest.kt
@@ -1,0 +1,57 @@
+package com.testlogon.android.feature.markets.trade
+
+import com.testlogon.android.data.exchange.LiveOrder
+import com.testlogon.android.data.exchange.LiveOrders
+import com.testlogon.android.data.exchange.OrderSide
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Aggregation logic for the Orders section source selection: [TradingUiState.displayOrders] prefers the
+ * LIVE server feed when it has rows, otherwise falls back to the session-tracked list; and
+ * [TradingUiState.ordersBadgeCount] mirrors that with the same precedence.
+ */
+class TradingOrdersStateTest {
+
+    private fun wo(id: String) = WorkingOrder(id, OrderSide.BUY, 100L, 1L, null)
+    private fun lo(id: String, side: OrderSide = OrderSide.SELL, price: Long = 50L, qty: Long = 3L) =
+        LiveOrder(clordid = id, orderId = null, symbolId = 1, side = side, price = price, qty = qty, tif = null, tsNs = 0L)
+
+    @Test
+    fun displayOrders_prefersLiveFeed_whenNonEmpty() {
+        val state = TradingUiState(
+            workingOrders = listOf(wo("session")),
+            liveOrders = LiveOrders(listOf(lo("live1"), lo("live2")), 2),
+        )
+        assertEquals(listOf("live1", "live2"), state.displayOrders.map { it.clordid })
+        assertEquals(2, state.ordersBadgeCount)
+    }
+
+    @Test
+    fun displayOrders_fallsBackToSession_whenLiveNullOrEmpty() {
+        val nullLive = TradingUiState(workingOrders = listOf(wo("s1"), wo("s2")), liveOrders = null)
+        assertEquals(listOf("s1", "s2"), nullLive.displayOrders.map { it.clordid })
+        assertEquals(2, nullLive.ordersBadgeCount)
+
+        val emptyLive = nullLive.copy(liveOrders = LiveOrders(emptyList(), 0))
+        assertEquals(listOf("s1", "s2"), emptyLive.displayOrders.map { it.clordid })
+        assertEquals(2, emptyLive.ordersBadgeCount)
+    }
+
+    @Test
+    fun liveOrder_mapsToWorkingOrder_preservingSidePriceQty() {
+        val state = TradingUiState(liveOrders = LiveOrders(listOf(lo("a", OrderSide.SELL, 77L, 9L)), 1))
+        val row = state.displayOrders.single()
+        assertEquals(OrderSide.SELL, row.side)
+        assertEquals(77L, row.price)
+        assertEquals(9L, row.qty)
+    }
+
+    @Test
+    fun liveOrder_nullSide_defaultsToBuyForDisplay() {
+        val state = TradingUiState(
+            liveOrders = LiveOrders(listOf(lo("a").copy(side = null)), 1),
+        )
+        assertEquals(OrderSide.BUY, state.displayOrders.single().side)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/portfolio/PortfolioAggregatorTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/portfolio/PortfolioAggregatorTest.kt
@@ -9,11 +9,13 @@ import com.testlogon.android.data.custody.StakingDashboard
 import com.testlogon.android.data.custody.StakingPosition
 import com.testlogon.android.data.exchange.MarginAccount
 import com.testlogon.android.data.exchange.PositionSnapshot
+import com.testlogon.android.data.exchange.PriceMap
 import com.testlogon.android.data.exchange.SpotAsset
 import com.testlogon.android.data.exchange.SpotBalance
 import java.io.IOException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -79,6 +81,17 @@ class PortfolioAggregatorTest {
 
     private val networkErr: ApiResult<Nothing> =
         ApiResult.NetworkError(IOException("offline"))
+
+    /** A readable USD price map (source defaults to a non-stub "ref"). */
+    private fun prices(vararg pairs: Pair<String, Double>, source: String = "ref", stub: Boolean = false): PriceMap =
+        PriceMap(
+            prices = pairs.associate { it.first.uppercase() to it.second },
+            quote = "USD",
+            source = source,
+            stub = stub,
+            note = null,
+            unavailable = false,
+        )
 
     @Test
     fun aggregate_sumsReadableVenuesIntoTotalEquity() {
@@ -184,5 +197,87 @@ class PortfolioAggregatorTest {
         // custody readable but empty, spot readable but empty, margin+staking unavailable, no positions
         assertTrue(state.allEmpty)
         assertEquals(0.0, state.totalEquity, 0.0001)
+    }
+
+    @Test
+    fun aggregate_pricedEquitySumsUsdAcrossVenues() {
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("ETH" to 2.0, "USDC" to 100.0),
+            staking = stakingWith("5"), // staking positions are asset "ETH" (see stakingWith)
+            spot = spot("BTC" to 3L),
+            margin = margin(balance = 50L),
+            prices = prices("ETH" to 3000.0, "USDC" to 1.0, "BTC" to 60000.0),
+        )
+        assertTrue(state.priced)
+        assertFalse(state.pricesStub)
+        // custody: 2*3000 + 100*1 = 6100 ; staking: 5*3000 = 15000 ; spot: 3*60000 = 180000 ; margin: 50*1 = 50
+        assertEquals(6100.0 + 15000.0 + 180000.0 + 50.0, state.totalEquityUsd, 0.0001)
+        // per-line USD present on a priced row
+        val eth = state.card(PortfolioVenue.CUSTODY)!!.lines.first { it.label == "ETH" }
+        assertEquals(6000.0, eth.usdValue!!, 0.0001)
+        assertTrue(eth.isPriced)
+    }
+
+    @Test
+    fun aggregate_stubPricesFlaggedIndicative() {
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("ETH" to 1.0),
+            staking = stakingUnavailable,
+            spot = spot(),
+            margin = failure(404),
+            prices = prices("ETH" to 2500.0, source = "stub", stub = true),
+        )
+        assertTrue(state.priced)
+        assertTrue(state.pricesStub)
+        assertEquals(2500.0, state.totalEquityUsd, 0.0001)
+    }
+
+    @Test
+    fun aggregate_unavailablePricesFallBackToNativeTotal() {
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("ETH" to 2.0),
+            staking = stakingUnavailable,
+            spot = spot("BTC" to 4L),
+            margin = margin(balance = 10L),
+            prices = PriceMap.unavailable(),
+        )
+        assertFalse(state.priced)
+        assertFalse(state.pricesStub)
+        // native coarse total still works (2 + 4 + 10)
+        assertEquals(16.0, state.totalEquity, 0.0001)
+        // nothing valued
+        assertEquals(0.0, state.totalEquityUsd, 0.0001)
+        assertNull(state.card(PortfolioVenue.CUSTODY)!!.lines.first().usdValue)
+    }
+
+    @Test
+    fun aggregate_partialPricingValuesOnlyKnownAssets() {
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("ETH" to 2.0, "DOGE" to 500.0), // DOGE unpriced
+            staking = stakingUnavailable,
+            spot = spot(),
+            margin = failure(404),
+            prices = prices("ETH" to 3000.0),
+        )
+        assertTrue(state.priced) // ETH valued
+        assertEquals(6000.0, state.totalEquityUsd, 0.0001)
+        val card = state.card(PortfolioVenue.CUSTODY)!!
+        assertEquals(6000.0, card.equityUsd, 0.0001)
+        val doge = card.lines.first { it.label == "DOGE" }
+        assertNull(doge.usdValue) // unpriced -> no USD chip
+    }
+
+    @Test
+    fun aggregate_pricesReadableButValueNothingStaysUnpriced() {
+        // Prices map is non-empty but none of the funded assets match -> priced stays false.
+        val state = PortfolioAggregator.aggregate(
+            custody = custody("DOGE" to 500.0),
+            staking = stakingUnavailable,
+            spot = spot(),
+            margin = failure(404),
+            prices = prices("ETH" to 3000.0),
+        )
+        assertFalse(state.priced)
+        assertEquals(0.0, state.totalEquityUsd, 0.0001)
     }
 }

--- a/frontend/src/api/endpoints/trading.ts
+++ b/frontend/src/api/endpoints/trading.ts
@@ -261,6 +261,52 @@ export const cancelOrder = (clordid: string, symbolId: number) =>
 
 export const bulkCancel = () => api.post<BulkCancelAck>("/me/bulk_cancel", {});
 
+// ── Live working orders (GET /me/orders/live) ────────────────────────
+// A read of the caller's CURRENTLY WORKING (open / partially-filled) orders,
+// so a fresh session can manage orders it did not place this session (Android
+// tracks only its own session locally; the web management surface reads the
+// authoritative list here). The exact engine shape is not yet documented, so
+// every field is optional and we parse DEFENSIVELY: prices / qty / ts are int64
+// engine ticks and MUST be scaled via the markets formatters. The route MAY 404
+// until the exchange edge deploys it — callers degrade gracefully (retry:false).
+
+/** One currently-working order on the caller's account (defensive / all-optional). */
+export interface LiveOrder {
+  /** Client order id — the amend / cancel handle. */
+  clordid?: string;
+  /** Engine order id (when present). */
+  orderid?: number;
+  symbolid?: number;
+  side?: OrderSide | string;
+  /** int64 engine tick — the working limit price. */
+  price?: number;
+  /** int64 engine tick — original order qty. */
+  qty?: number;
+  /** int64 engine tick — remaining (unfilled) qty, when the engine reports it. */
+  leaves_qty?: number;
+  /** int64 engine tick — cumulative filled qty, when the engine reports it. */
+  cum_qty?: number;
+  tif?: TimeInForce | string;
+  /** Timestamp (seconds or ms — detect). */
+  ts?: number;
+  status?: string;
+  [k: string]: unknown;
+}
+
+export interface OrdersLiveResult {
+  status?: string;
+  type?: string;
+  mpid?: string;
+  count?: number;
+  orders?: LiveOrder[];
+}
+
+/**
+ * The caller's live working orders. Parse defensively off `orders`. 404s until
+ * the exchange edge deploys the route — callers degrade gracefully (retry:false).
+ */
+export const getOrdersLive = () => api.get<OrdersLiveResult>("/me/orders/live");
+
 export const getMarginAccount = () => api.get<MarginAccount>("/me/margin_account");
 
 export const marginDeposit = (amount: number) => api.post<DepositAck>("/me/margin_deposit", { amount });
@@ -773,3 +819,35 @@ export const getStakeRequests = () =>
  * listing. 404s until the edge deploys — callers degrade gracefully.
  */
 export const getOpenAuctions = () => api.get<AuctionsResult>("/me/auctions");
+
+
+// ── USD price marks (`GET /me/prices`) ───────────────────────────────
+// A read of per-asset USD valuation marks used to FX-normalize cross-venue
+// balances (custody / spot / margin / staking) into a single USD equity figure.
+// STUB today: the edge returns hard-coded/indicative marks with `source:"stub"`
+// + `stub:true` + a human `note`; when the valuation engine lands it returns
+// `source:"engine"` real marks. `prices` maps an ASSET SYMBOL (e.g. "BTC",
+// "ETH", "USDC") to a USD **decimal string**. The route MAY 404 until the edge
+// deploys — callers degrade gracefully (retry:false) and fall back to the prior
+// source-native (un-converted) sum.
+
+export interface PricesResult {
+  /** asset-symbol -> USD price as a decimal string (e.g. { BTC: "64000.00" }). */
+  prices: Record<string, string>;
+  /** Quote currency for every price. Always "USD" for now. */
+  quote: string;
+  /** "stub" = indicative/hard-coded marks; "engine" = real valuation marks. */
+  source: "stub" | "engine" | string;
+  /** True while the marks are indicative (source === "stub"). */
+  stub: boolean;
+  /** Human note explaining the stub / valuation source. */
+  note?: string;
+}
+
+/**
+ * Per-asset USD price marks for cross-venue valuation. STUB (indicative marks +
+ * stub:true + note) until the valuation engine lands. 404s until the edge
+ * deploys — callers degrade gracefully (retry:false) and fall back to the prior
+ * source-native sum.
+ */
+export const getPrices = () => api.get<PricesResult>("/me/prices");

--- a/frontend/src/components/blotter/dock.css
+++ b/frontend/src/components/blotter/dock.css
@@ -66,3 +66,47 @@
   transition: border-color 100ms, color 100ms, background 100ms;
 }
 .tl-mobile-tabs button.active { background: color-mix(in oklab, var(--accent) 18%, var(--bg-2)); border-color: var(--accent); color: var(--accent); }
+
+/* ── Working-orders management + trade-history panels ──────────────── */
+.tl-wo { font: var(--font-ui); }
+.tl-wo-bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 8px; border-bottom: 1px solid var(--line);
+  font-size: 11px; flex: none;
+}
+.tl-wo-note {
+  padding: 3px 8px; font-size: 11px; flex: none;
+  color: var(--accent); background: color-mix(in oklab, var(--accent) 10%, transparent);
+  border-bottom: 1px solid var(--line);
+}
+.tl-wo-scroll { flex: 1; min-height: 0; overflow: auto; }
+.tl-wo-table { width: 100%; border-collapse: collapse; font-size: 11px; }
+.tl-wo-table thead th {
+  position: sticky; top: 0; z-index: 1; text-align: left;
+  padding: 3px 8px; background: var(--bg-2); border-bottom: 1px solid var(--line-2);
+  color: var(--fg-dim, #8b97a7); font-weight: 600; white-space: nowrap;
+}
+.tl-wo-table tbody td { padding: 2px 8px; border-bottom: 1px solid var(--line); white-space: nowrap; }
+.tl-wo-table tbody tr:hover td { background: var(--bg-3, #171c24); }
+.tl-wo-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.tl-wo-table .dim { color: var(--fg-dim, #8b97a7); }
+.tl-wo-table .sym { font-weight: 600; }
+.tl-wo-btn {
+  background: var(--bg-2); border: 1px solid var(--line-2); color: var(--fg, #c9d3e0);
+  padding: 1px 7px; margin-left: 4px; border-radius: 5px; font: 600 10.5px var(--font-ui);
+  cursor: pointer; transition: border-color 100ms, color 100ms;
+}
+.tl-wo-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.tl-wo-btn:disabled { opacity: 0.4; cursor: default; }
+.tl-wo-btn.danger:hover:not(:disabled) { border-color: #ff9a9a; color: #ff9a9a; }
+.tl-wo-btn.accent { border-color: var(--accent); color: var(--accent); }
+.tl-wo-confirm { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: #ff9a9a; }
+.tl-wo-edit td { background: var(--bg-3, #171c24); }
+.tl-wo-editrow { display: flex; align-items: center; gap: 10px; padding: 4px 4px; flex-wrap: wrap; }
+.tl-wo-editrow label { display: inline-flex; align-items: center; gap: 4px; font-size: 10.5px; color: var(--fg-dim, #8b97a7); }
+.tl-wo-editrow input {
+  width: 90px; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg, #c9d3e0); padding: 2px 5px; border-radius: 5px; font: 12px var(--font-ui);
+}
+.tl-wo-editrow input:focus { outline: none; border-color: var(--accent); }
+.tl-wo-empty { padding: 0.8rem 1rem; font-size: 0.8rem; opacity: 0.55; }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -47,6 +47,7 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import ShortcutHelpDialog from "@/components/shared/ShortcutHelpDialog";
+import TradingAlertsBell from "@/components/layout/TradingAlertsBell";
 import { useGlobalShortcuts, useChordShortcuts, useChordIndicator, type Shortcut, type ChordMapping } from "@/hooks/useGlobalShortcuts";
 import {
   Popover,
@@ -361,6 +362,9 @@ export default function Header({ onMobileMenuToggle }: HeaderProps) {
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
+
+        {/* Trading alerts bell (client-derived from /me/* feeds) */}
+        <TradingAlertsBell enabled={!!userId} />
 
         {/* Alert bell with popover */}
         <Popover open={alertsOpen} onOpenChange={setAlertsOpen}>

--- a/frontend/src/components/layout/TradingAlertsBell.tsx
+++ b/frontend/src/components/layout/TradingAlertsBell.tsx
@@ -1,0 +1,177 @@
+import * as React from "react";
+import {
+  Bell,
+  TrendingUp,
+  AlertTriangle,
+  Coins,
+  Gavel,
+  ShieldAlert,
+  CheckCheck,
+  Trash2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  useTradingAlerts,
+  relativeTime,
+  type TradingAlert,
+  type TradingAlertKind,
+} from "@/hooks/useTradingAlerts";
+
+/** Per-kind icon for the alert row. */
+function KindIcon({ kind }: { kind: TradingAlertKind }) {
+  const cls = "h-4 w-4 shrink-0";
+  switch (kind) {
+    case "fill":
+      return <TrendingUp className={cn(cls, "text-emerald-500")} />;
+    case "liquidation":
+      return <AlertTriangle className={cn(cls, "text-destructive")} />;
+    case "funding":
+      return <Coins className={cn(cls, "text-amber-500")} />;
+    case "margin":
+      return <ShieldAlert className={cn(cls, "text-destructive")} />;
+    case "pm_resolved":
+      return <Gavel className={cn(cls, "text-sky-500")} />;
+    default:
+      return <Bell className={cls} />;
+  }
+}
+
+function AlertRow({
+  alert,
+  onClick,
+  now,
+}: {
+  alert: TradingAlert;
+  onClick: () => void;
+  now: number;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-start gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent",
+        !alert.read && "bg-accent/40",
+      )}
+    >
+      <KindIcon kind={alert.kind} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">{alert.title}</span>
+          {!alert.read && (
+            <span className="ml-auto h-2 w-2 shrink-0 rounded-full bg-primary" />
+          )}
+        </div>
+        <p className="truncate text-xs text-muted-foreground">{alert.message}</p>
+        <p className="mt-0.5 text-[10px] text-muted-foreground">
+          {relativeTime(alert.ts, now)}
+        </p>
+      </div>
+    </button>
+  );
+}
+
+/**
+ * Trading notification bell — a self-contained chrome widget. It runs
+ * `useTradingAlerts()` (which derives alerts from the `/me/*` trader feeds),
+ * shows an unread badge, and lists recent alerts with mark-read / clear.
+ * Toasts are fired inside the hook on genuinely-new alerts.
+ */
+export default function TradingAlertsBell({ enabled = true }: { enabled?: boolean }) {
+  const { alerts, unreadCount, markAllRead, markRead, clearAll } =
+    useTradingAlerts(enabled);
+  const [open, setOpen] = React.useState(false);
+
+  // Re-render relative times every 30s while the popover is open.
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    if (!open) return;
+    setNow(Date.now());
+    const t = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(t);
+  }, [open]);
+
+  // Shake the bell when the unread count rises.
+  const [shake, setShake] = React.useState(false);
+  const prevUnread = React.useRef(unreadCount);
+  React.useEffect(() => {
+    if (unreadCount > prevUnread.current) {
+      setShake(true);
+      const t = setTimeout(() => setShake(false), 500);
+      prevUnread.current = unreadCount;
+      return () => clearTimeout(t);
+    }
+    prevUnread.current = unreadCount;
+  }, [unreadCount]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Trading alerts"
+        >
+          <Bell className={cn("h-5 w-5", shake && "animate-bell-shake")} />
+          {unreadCount > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-destructive-foreground">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-96 p-0">
+        <div className="flex items-center justify-between border-b px-4 py-2">
+          <span className="text-sm font-semibold">Trading alerts</span>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              onClick={markAllRead}
+              disabled={unreadCount === 0}
+            >
+              <CheckCheck className="h-3.5 w-3.5" />
+              Mark read
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              onClick={clearAll}
+              disabled={alerts.length === 0}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Clear
+            </Button>
+          </div>
+        </div>
+        {alerts.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-center">
+            <Bell className="h-6 w-6 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">No trading alerts yet</p>
+            <p className="text-xs text-muted-foreground">
+              Fills, liquidations, funding, margin &amp; market resolutions show up here.
+            </p>
+          </div>
+        ) : (
+          <ScrollArea className="max-h-96">
+            <div className="divide-y">
+              {alerts.map((a) => (
+                <AlertRow key={a.id} alert={a} now={now} onClick={() => markRead(a.id)} />
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/hooks/useTrading.ts
+++ b/frontend/src/hooks/useTrading.ts
@@ -11,6 +11,7 @@ export const tradingKeys = {
   liquidations: ["me", "liquidations"] as const,
   fundingPayments: ["me", "funding_payments"] as const,
   pmResolutions: ["me", "pm_resolutions"] as const,
+  ordersLive: ["me", "orders_live"] as const,
 };
 
 /** Exchange account-feed poll (fills-fees / liquidations / funding). */
@@ -83,6 +84,21 @@ export function useCancelOrder() {
 export function useBulkCancel() {
   const invalidate = useInvalidateAccount();
   return useMutation({ mutationFn: trading.bulkCancel, onSuccess: invalidate });
+}
+
+/**
+ * The caller's live WORKING orders (open / partially-filled). Polls ~5s.
+ * `retry: false` because the route 404s until the exchange edge deploys it —
+ * the management surface degrades to an honest "unavailable" empty state.
+ */
+export function useOrdersLive(enabled = true) {
+  return useQuery({
+    queryKey: tradingKeys.ordersLive,
+    queryFn: trading.getOrdersLive,
+    enabled,
+    retry: false,
+    refetchInterval: 5000,
+  });
 }
 
 export function useDeposit() {
@@ -306,5 +322,21 @@ export function useOpenAuctions(enabled = true) {
     enabled,
     retry: false,
     refetchInterval: FEED_REFETCH_MS,
+  });
+}
+
+/**
+ * Per-asset USD price marks for cross-venue valuation (`GET /me/prices`).
+ * STUB today (indicative marks) → `source:"engine"` when the valuation engine
+ * lands. `retry:false` so a 404 (edge-undeployed) degrades gracefully and the
+ * caller can fall back to a source-native sum.
+ */
+export function usePrices(enabled = true) {
+  return useQuery({
+    queryKey: ["me", "prices"] as const,
+    queryFn: trading.getPrices,
+    enabled,
+    retry: false,
+    refetchInterval: ACCOUNT_REFETCH_MS,
   });
 }

--- a/frontend/src/hooks/useTradingAlerts.ts
+++ b/frontend/src/hooks/useTradingAlerts.ts
@@ -1,0 +1,353 @@
+import * as React from "react";
+import { toast } from "sonner";
+import {
+  useFillsFees,
+  useLiquidations,
+  useFundingPayments,
+  useMarginAccount,
+  usePmResolutions,
+} from "@/hooks/useTrading";
+import { useSymbols } from "@/hooks/useMarketData";
+import { formatPrice, formatQty } from "@/pages/markets/format";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import type {
+  FillFee,
+  Liquidation,
+  FundingPayment,
+  MarginAccount,
+  PmResolution,
+} from "@/api/endpoints/trading";
+
+// ── Trading alerts: client-side DERIVED from the existing `/me/*` feeds ──
+// There is NO backend notifications route, so we synthesize alerts by diffing
+// the polled trader feeds against a per-feed "last-seen" marker persisted in
+// localStorage. On the FIRST fetch of each feed we SEED the marker (no toast
+// storm on load); thereafter only genuinely-new events fire an alert + toast.
+
+export type TradingAlertKind =
+  | "fill"
+  | "liquidation"
+  | "funding"
+  | "margin"
+  | "pm_resolved";
+
+export interface TradingAlert {
+  /** Stable de-dupe id (kind + event key). */
+  id: string;
+  kind: TradingAlertKind;
+  title: string;
+  message: string;
+  /** Epoch ms for ordering + relative-time render. */
+  ts: number;
+  read: boolean;
+}
+
+/** Cap the retained list so a busy account never grows unbounded. */
+const MAX_ALERTS = 50;
+const LS_ALERTS = "tl.tradingAlerts.v1";
+const LS_SEEN = "tl.tradingAlerts.seen.v1";
+
+/** Per-feed high-water marks (the newest event key we have already alerted on). */
+interface SeenMarkers {
+  /** newest fill ts seen. */
+  fillTs?: number;
+  /** newest liquidation ts seen. */
+  liqTs?: number;
+  /** newest funding ts seen. */
+  fundingTs?: number;
+  /** newest PM-resolution ts seen. */
+  pmTs?: number;
+  /** last margin distress snapshot: [is_liquidating, distress_level]. */
+  marginLiquidating?: number;
+  marginDistress?: number;
+  /** whether each feed has been primed with a first fetch (so we seed silently). */
+  fillPrimed?: boolean;
+  liqPrimed?: boolean;
+  fundingPrimed?: boolean;
+  pmPrimed?: boolean;
+  marginPrimed?: boolean;
+}
+
+function loadJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveJson(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* quota / private-mode — alerts degrade to in-memory only */
+  }
+}
+
+/** Timestamps in these feeds may be seconds OR ms — normalize to ms. */
+function toMs(ts: number | undefined): number {
+  if (ts == null || !Number.isFinite(ts)) return 0;
+  // < 1e12 => seconds; otherwise already ms (ns would be >> 1e15 but the feeds use s/ms).
+  return ts < 1e12 ? Math.floor(ts * 1000) : Math.floor(ts);
+}
+
+/** Relative "3m ago" / "just now" from an epoch-ms timestamp. */
+export function relativeTime(ts: number, now = Date.now()): string {
+  const s = Math.max(0, Math.floor((now - ts) / 1000));
+  if (s < 5) return "just now";
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+interface DeriveContext {
+  symbolName: (id: number | undefined) => string;
+  scalerFor: (id: number | undefined) => number;
+}
+
+/** Build a symbol-id -> display-name + price_scaler lookup from /md/symbols. */
+function useSymbolLookup(): DeriveContext {
+  const { data } = useSymbols();
+  return React.useMemo(() => {
+    const byId = new Map<number, MarketSymbol>();
+    for (const s of data?.symbols ?? []) byId.set(s.symbol_id, s);
+    return {
+      symbolName: (id) =>
+        (id != null && byId.get(id)?.symbol) || (id != null ? `#${id}` : "?"),
+      scalerFor: (id) => (id != null && byId.get(id)?.price_scaler) || 1,
+    };
+  }, [data]);
+}
+
+/**
+ * Subscribe to the trader feeds and surface NEW events as alerts.
+ * Returns the alert list + unread count + read/clear controls for a bell UI.
+ */
+export function useTradingAlerts(enabled = true) {
+  const fills = useFillsFees(enabled);
+  const liquidations = useLiquidations(enabled);
+  const funding = useFundingPayments(enabled);
+  const margin = useMarginAccount(enabled);
+  const pm = usePmResolutions(enabled);
+  const ctx = useSymbolLookup();
+
+  const [alerts, setAlerts] = React.useState<TradingAlert[]>(() =>
+    loadJson<TradingAlert[]>(LS_ALERTS, []),
+  );
+  const seenRef = React.useRef<SeenMarkers>(loadJson<SeenMarkers>(LS_SEEN, {}));
+
+  // Persist alerts whenever they change.
+  React.useEffect(() => {
+    saveJson(LS_ALERTS, alerts.slice(0, MAX_ALERTS));
+  }, [alerts]);
+
+  const pushAlerts = React.useCallback(
+    (incoming: Omit<TradingAlert, "read">[], primed: boolean) => {
+      if (incoming.length === 0) return;
+      setAlerts((prev) => {
+        const have = new Set(prev.map((a) => a.id));
+        const fresh = incoming.filter((a) => !have.has(a.id));
+        if (fresh.length === 0) return prev;
+        // Only toast once the feed is primed (not on the seeding first fetch).
+        if (primed) {
+          for (const a of fresh) {
+            toast(a.title, { description: a.message });
+          }
+        }
+        const merged = [
+          ...fresh.map((a) => ({ ...a, read: false })),
+          ...prev,
+        ]
+          .sort((x, y) => y.ts - x.ts)
+          .slice(0, MAX_ALERTS);
+        return merged;
+      });
+    },
+    [],
+  );
+
+  const persistSeen = React.useCallback(() => saveJson(LS_SEEN, seenRef.current), []);
+
+  // ── Fills ──────────────────────────────────────────────────────────
+  React.useEffect(() => {
+    const rows: FillFee[] | undefined = fills.data?.fills;
+    if (!rows) return;
+    const seen = seenRef.current;
+    const prevMark = seen.fillTs ?? 0;
+    const primed = seen.fillPrimed === true;
+    const newer = rows.filter((r) => toMs(r.ts) > prevMark);
+    let maxTs = prevMark;
+    const built = newer.map((r) => {
+      const ms = toMs(r.ts);
+      if (ms > maxTs) maxTs = ms;
+      const sym = ctx.symbolName(r.symbolid);
+      const sc = ctx.scalerFor(r.symbolid);
+      return {
+        id: `fill:${r.symbolid}:${r.ts}:${r.price}:${r.qty}:${r.side}`,
+        kind: "fill" as const,
+        title: `Filled: ${sym}`,
+        message: `${r.side?.toUpperCase() ?? ""} ${formatQty(r.qty, sc)} @ ${formatPrice(r.price, sc)}`.trim(),
+        ts: ms || Date.now(),
+      };
+    });
+    pushAlerts(built, primed);
+    seen.fillTs = maxTs;
+    seen.fillPrimed = true;
+    persistSeen();
+  }, [fills.data, ctx, pushAlerts, persistSeen]);
+
+  // ── Liquidations ───────────────────────────────────────────────────
+  React.useEffect(() => {
+    const rows: Liquidation[] | undefined = liquidations.data?.liquidations;
+    if (!rows) return;
+    const seen = seenRef.current;
+    const prevMark = seen.liqTs ?? 0;
+    const primed = seen.liqPrimed === true;
+    let maxTs = prevMark;
+    const built = rows
+      .filter((r) => toMs(r.ts) > prevMark)
+      .map((r) => {
+        const ms = toMs(r.ts);
+        if (ms > maxTs) maxTs = ms;
+        const sym = ctx.symbolName(r.symbolid);
+        const sc = ctx.scalerFor(r.symbolid);
+        return {
+          id: `liq:${r.symbolid}:${r.ts}:${r.qty}`,
+          kind: "liquidation" as const,
+          title: `Liquidated ${sym}`,
+          message: `${formatQty(r.qty, sc)} closed @ ${formatPrice(r.mark_price, sc)} · PnL ${formatPrice(r.realized_pnl, sc)}`,
+          ts: ms || Date.now(),
+        };
+      });
+    pushAlerts(built, primed);
+    seen.liqTs = maxTs;
+    seen.liqPrimed = true;
+    persistSeen();
+  }, [liquidations.data, ctx, pushAlerts, persistSeen]);
+
+  // ── Funding settlements ────────────────────────────────────────────
+  React.useEffect(() => {
+    const rows: FundingPayment[] | undefined = funding.data?.funding;
+    if (!rows) return;
+    const seen = seenRef.current;
+    const prevMark = seen.fundingTs ?? 0;
+    const primed = seen.fundingPrimed === true;
+    let maxTs = prevMark;
+    const built = rows
+      .filter((r) => toMs(r.ts) > prevMark)
+      .map((r) => {
+        const ms = toMs(r.ts);
+        if (ms > maxTs) maxTs = ms;
+        const sym = ctx.symbolName(r.symbolid);
+        const sc = ctx.scalerFor(r.symbolid);
+        const dir = r.received ? "received" : "paid";
+        const amt = formatPrice(Math.abs(r.payment), sc);
+        return {
+          id: `funding:${r.symbolid}:${r.ts}:${r.payment}`,
+          kind: "funding" as const,
+          title: `Funding: ${dir} ${amt}`,
+          message: `${sym} · ${r.funding_rate_bps} bps`,
+          ts: ms || Date.now(),
+        };
+      });
+    pushAlerts(built, primed);
+    seen.fundingTs = maxTs;
+    seen.fundingPrimed = true;
+    persistSeen();
+  }, [funding.data, ctx, pushAlerts, persistSeen]);
+
+  // ── Margin distress ────────────────────────────────────────────────
+  // Fires when is_liquidating turns on, or distress_level RISES above the last snapshot.
+  React.useEffect(() => {
+    const acct: MarginAccount | undefined = margin.data;
+    if (!acct) return;
+    const seen = seenRef.current;
+    const primed = seen.marginPrimed === true;
+    const isLiq = acct.is_liquidating ? 1 : 0;
+    const distress = acct.distress_level ?? 0;
+    const prevLiq = seen.marginLiquidating ?? 0;
+    const prevDistress = seen.marginDistress ?? 0;
+
+    if (primed) {
+      const turnedLiquidating = isLiq === 1 && prevLiq === 0;
+      const distressRose = distress > prevDistress && distress > 0;
+      if (turnedLiquidating || distressRose) {
+        const now = Date.now();
+        pushAlerts(
+          [
+            {
+              id: `margin:${isLiq ? "liq" : "distress"}:${distress}:${Math.floor(now / 60000)}`,
+              kind: "margin",
+              title: isLiq ? "Margin: liquidating" : "Margin distress",
+              message: isLiq
+                ? "Your account is being liquidated"
+                : `Distress level ${distress} — add margin to avoid liquidation`,
+              ts: now,
+            },
+          ],
+          true,
+        );
+      }
+    }
+    seen.marginLiquidating = isLiq;
+    seen.marginDistress = distress;
+    seen.marginPrimed = true;
+    persistSeen();
+  }, [margin.data, pushAlerts, persistSeen]);
+
+  // ── PM resolutions ─────────────────────────────────────────────────
+  React.useEffect(() => {
+    const rows: PmResolution[] | undefined = pm.data?.resolutions;
+    if (!rows) return;
+    const seen = seenRef.current;
+    const prevMark = seen.pmTs ?? 0;
+    const primed = seen.pmPrimed === true;
+    let maxTs = prevMark;
+    const built = rows
+      .filter((r) => toMs(r.ts) > prevMark)
+      .map((r) => {
+        const ms = toMs(r.ts);
+        if (ms > maxTs) maxTs = ms;
+        const sym = ctx.symbolName(r.winning_symbolid ?? r.symbolid);
+        const outcome = (r.outcome ?? "").toString().toUpperCase();
+        const label = outcome === "YES" || outcome === "NO" ? outcome : outcome || "resolved";
+        return {
+          id: `pm:${r.symbolid ?? r.group_id ?? "x"}:${r.ts}:${r.winning_symbolid ?? r.outcome ?? ""}`,
+          kind: "pm_resolved" as const,
+          title: `Market resolved ${label}`,
+          message: r.group_id != null ? `${sym} won` : `${sym} settled`,
+          ts: ms || Date.now(),
+        };
+      });
+    pushAlerts(built, primed);
+    seen.pmTs = maxTs;
+    seen.pmPrimed = true;
+    persistSeen();
+  }, [pm.data, ctx, pushAlerts, persistSeen]);
+
+  // ── Read / clear controls ──────────────────────────────────────────
+  const unreadCount = React.useMemo(
+    () => alerts.reduce((n, a) => (a.read ? n : n + 1), 0),
+    [alerts],
+  );
+
+  const markAllRead = React.useCallback(() => {
+    setAlerts((prev) => (prev.every((a) => a.read) ? prev : prev.map((a) => ({ ...a, read: true }))));
+  }, []);
+
+  const markRead = React.useCallback((id: string) => {
+    setAlerts((prev) => prev.map((a) => (a.id === id ? { ...a, read: true } : a)));
+  }, []);
+
+  const clearAll = React.useCallback(() => {
+    setAlerts([]);
+  }, []);
+
+  return { alerts, unreadCount, markAllRead, markRead, clearAll };
+}

--- a/frontend/src/pages/blotter/TradeHistoryPanel.tsx
+++ b/frontend/src/pages/blotter/TradeHistoryPanel.tsx
@@ -1,0 +1,81 @@
+// Trade History — a view of the caller's EXECUTED fills read from the REAL
+// GET /me/fills/fees feed: symbol / side / price / qty / liquidity (maker
+// vs taker) / the engine-charged fee / time. price / qty / fee are int64
+// engine ticks scaled per-symbol via the /md/symbols catalog + the markets
+// formatters; `ts` is seconds-or-ms (detected). The route MAY 404 until the
+// exchange edge deploys it — this panel degrades gracefully.
+import { useMemo } from "react";
+import { useSymbols } from "@/hooks/useMarketData";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { useFillsFees } from "@/hooks/useTrading";
+import type { FillFee } from "@/api/endpoints/trading";
+import { formatPrice, formatQty } from "@/pages/markets/format";
+
+type SymLookup = (symbolid: number | undefined) => { name: string; scaler: number };
+function makeSymLookup(symbols: MarketSymbol[] | undefined): SymLookup {
+  const byId = new Map<number, MarketSymbol>();
+  for (const s of symbols ?? []) byId.set(s.symbol_id, s);
+  return (symbolid) => {
+    const s = symbolid == null ? undefined : byId.get(symbolid);
+    return { name: s?.symbol ?? (symbolid == null ? "—" : `#${symbolid}`), scaler: s?.price_scaler || 1 };
+  };
+}
+
+const POS = "var(--pos)";
+const NEG = "var(--neg)";
+const isBuy = (side: string | undefined) => side === "buy" || side === "B" || side === "b";
+
+// `ts` may be seconds or ms — below ~year-2001-in-ms treat as seconds.
+const MS_THRESHOLD = 1e12;
+function formatFeedTime(ts: number | undefined): string {
+  if (ts == null || !Number.isFinite(ts)) return "—";
+  const ms = ts < MS_THRESHOLD ? ts * 1000 : ts;
+  return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+const rowKey = (f: FillFee, i: number) => `${f.symbolid}:${f.ts}:${f.price}:${f.qty}:${f.side}:${i}`;
+
+export default function TradeHistoryPanel() {
+  const symbolsQuery = useSymbols();
+  const sym = useMemo(() => makeSymLookup(symbolsQuery.data?.symbols), [symbolsQuery.data]);
+  const q = useFillsFees();
+  const fills: FillFee[] = Array.isArray(q.data?.fills) ? q.data!.fills! : [];
+
+  return (
+    <div className="tl-panel-body tl-wo">
+      <div className="tl-wo-bar">
+        <span className="dim">{fills.length} executed fill{fills.length === 1 ? "" : "s"}</span>
+        <span style={{ flex: 1 }} />
+        {q.isFetching && <span className="dim" style={{ fontSize: "0.7rem" }}>refreshing…</span>}
+      </div>
+      <div className="tl-wo-scroll">
+        <table className="tl-wo-table">
+          <thead>
+            <tr>
+              <th>Sym</th><th>Side</th><th>Price</th><th>Qty</th><th>Liq</th><th>Fee</th><th>Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            {fills.map((f, i) => {
+              const { name, scaler } = sym(f.symbolid);
+              return (
+                <tr key={rowKey(f, i)}>
+                  <td className="sym">{name}</td>
+                  <td style={{ color: isBuy(f.side) ? POS : NEG, textTransform: "uppercase" }}>{String(f.side ?? "—")}</td>
+                  <td className="num">{formatPrice(f.price, scaler)}</td>
+                  <td className="num">{formatQty(f.qty, scaler)}</td>
+                  <td className="dim" style={{ textTransform: "capitalize" }}>{String(f.liquidity ?? "")}</td>
+                  <td className="num">{formatQty(f.fee, scaler)}</td>
+                  <td className="num dim">{formatFeedTime(f.ts)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {q.isLoading ? <div className="tl-wo-empty">Loading trade history…</div>
+          : q.isError ? <div className="tl-wo-empty">Trade-history feed (/me/fills/fees) not available on this backend yet.</div>
+          : fills.length === 0 ? <div className="tl-wo-empty">No executed fills yet.</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/blotter/TradingWorkspacePage.tsx
+++ b/frontend/src/pages/blotter/TradingWorkspacePage.tsx
@@ -14,12 +14,13 @@ import {
 import "dockview-react/dist/styles/dockview.css";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Blotter } from "@/components/blotter/grid";
-import { orderColumns } from "@/components/blotter/grid/columns";
 import type { Order, Side, OrderStatus, Venue, Lot } from "@/components/blotter/types";
 import { useFillsFees, useLiquidations, useFundingPayments } from "@/hooks/useTrading";
 import { useSymbols } from "@/hooks/useMarketData";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
 import type { FillFee, Liquidation, FundingPayment } from "@/api/endpoints/trading";
+import WorkingOrdersPanel from "@/pages/blotter/WorkingOrdersPanel";
+import TradeHistoryPanel from "@/pages/blotter/TradeHistoryPanel";
 import { formatPrice, formatQty } from "@/pages/markets/format";
 import "@/components/blotter/dock.css";
 
@@ -127,8 +128,6 @@ function fundingColumns(sym: SymLookup): ColumnDef<FundingPayment>[] {
 
 // Compact column sets for narrow (mobile) screens — fewer columns so rows are
 // readable without horizontal scrolling.
-const MOBILE_ORDER_IDS = new Set(["sym", "side", "px", "qty", "cumQty", "status"]);
-const mobileOrderColumns = orderColumns.filter((c) => MOBILE_ORDER_IDS.has((c as any).id));
 const mobileFilter = (cols: ColumnDef<any>[], ids: Set<string>) => cols.filter((c) => ids.has((c as any).id));
 
 function useIsMobile(bp = 767): boolean {
@@ -142,7 +141,7 @@ function useIsMobile(bp = 767): boolean {
   return m;
 }
 
-const LAYOUT_KEY = "testlogon.trading.dock.v2";
+const LAYOUT_KEY = "testlogon.trading.dock.v3";
 interface Ctx { orders: Order[]; touched: Set<string>; onCancel: (c: string) => void; isMobile: boolean; sym: SymLookup; }
 const WsCtx = createContext<Ctx | null>(null);
 const useWs = (): Ctx => { const c = useContext(WsCtx); if (!c) throw new Error("WsCtx missing"); return c; };
@@ -152,7 +151,13 @@ function FeedNote({ children }: { children: React.ReactNode }) {
   return <div style={{ padding: "0.8rem 1rem", fontSize: "0.8rem", opacity: 0.55 }}>{children}</div>;
 }
 
-function OrdersPanel() { const c = useWs(); return <div className="tl-panel-body"><Blotter data={c.orders} columns={c.isMobile ? mobileOrderColumns : orderColumns} touched={c.touched} storageKeyPrefix="tl-ws-orders" onCancel={c.onCancel} /></div>; }
+// Orders — the REAL working-orders MANAGEMENT surface (GET /me/orders/live
+// with per-row Amend / Cancel + confirmed Cancel-all). Replaces the former
+// mock-generator grid; the mock still feeds the Positions panel below.
+function OrdersPanel() { return <WorkingOrdersPanel />; }
+
+// Trade history — the REAL executed-fills feed (GET /me/fills/fees).
+function HistoryPanel() { return <TradeHistoryPanel />; }
 
 // Fills — REAL /me/fills/fees feed: per-fill price/qty + the actual engine fee
 // (+ maker/taker). When the route 404s (or errors) the grid shows no rows and a
@@ -228,10 +233,11 @@ function PositionsPanel() {
   return <div className="tl-panel-body"><Blotter data={pos} columns={posColumns} storageKeyPrefix="tl-ws-pos" getRowId={(r: any) => r.sym} /></div>;
 }
 
-const COMPONENTS = { orders: OrdersPanel, fills: FillsPanel, positions: PositionsPanel, liquidations: LiquidationsPanel, funding: FundingPanel };
+const COMPONENTS = { orders: OrdersPanel, history: HistoryPanel, fills: FillsPanel, positions: PositionsPanel, liquidations: LiquidationsPanel, funding: FundingPanel };
 type PanelId = keyof typeof COMPONENTS;
 const PANEL_META: { id: PanelId; title: string }[] = [
   { id: "orders", title: "Orders" },
+  { id: "history", title: "Trade History" },
   { id: "fills", title: "Fills" },
   { id: "positions", title: "Positions" },
   { id: "liquidations", title: "Liquidations" },
@@ -288,6 +294,7 @@ export default function TradingWorkspacePage() {
   const addDefaults = (api: DockviewApi) => {
     api.addPanel({ id: "orders", title: "Orders", component: "orders", params: { ctx: stableCtx } });
     api.addPanel({ id: "fills", title: "Fills", component: "fills", params: { ctx: stableCtx }, position: { referencePanel: "orders", direction: "right" } });
+    api.addPanel({ id: "history", title: "Trade History", component: "history", params: { ctx: stableCtx }, position: { referencePanel: "fills", direction: "within" } });
     api.addPanel({ id: "positions", title: "Positions", component: "positions", params: { ctx: stableCtx }, position: { referencePanel: "fills", direction: "below" } });
     api.addPanel({ id: "liquidations", title: "Liquidations", component: "liquidations", params: { ctx: stableCtx }, position: { referencePanel: "positions", direction: "within" } });
     api.addPanel({ id: "funding", title: "Funding", component: "funding", params: { ctx: stableCtx }, position: { referencePanel: "liquidations", direction: "within" } });

--- a/frontend/src/pages/blotter/WorkingOrdersPanel.tsx
+++ b/frontend/src/pages/blotter/WorkingOrdersPanel.tsx
@@ -1,0 +1,184 @@
+// Working-orders MANAGEMENT surface — the caller's LIVE working orders read
+// from the REAL GET /me/orders/live feed with per-row Amend (price/qty →
+// PATCH /me/orders/{clordid}) and Cancel (DELETE /me/orders/{clordid}) plus a
+// confirmed Cancel-all (POST /me/bulk_cancel). Prices/qty are int64 engine
+// ticks scaled per-symbol via the /md/symbols catalog + the markets
+// formatters. The /me/orders/live route MAY 404 until the exchange edge
+// deploys it — this panel degrades gracefully (loading / unavailable / empty).
+import { useMemo, useState } from "react";
+import { useSymbols } from "@/hooks/useMarketData";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { useOrdersLive, useAmendOrder, useCancelOrder, useBulkCancel } from "@/hooks/useTrading";
+import type { LiveOrder } from "@/api/endpoints/trading";
+import { ackMessage } from "@/api/endpoints/trading";
+import { formatPrice, formatQty } from "@/pages/markets/format";
+
+type SymLookup = (symbolid: number | undefined) => { name: string; scaler: number };
+function makeSymLookup(symbols: MarketSymbol[] | undefined): SymLookup {
+  const byId = new Map<number, MarketSymbol>();
+  for (const s of symbols ?? []) byId.set(s.symbol_id, s);
+  return (symbolid) => {
+    const s = symbolid == null ? undefined : byId.get(symbolid);
+    return { name: s?.symbol ?? (symbolid == null ? "—" : `#${symbolid}`), scaler: s?.price_scaler || 1 };
+  };
+}
+
+const POS = "var(--pos)";
+const NEG = "var(--neg)";
+const isBuy = (side: string | undefined) => side === "buy" || side === "B" || side === "b";
+
+/** Remaining (working) qty — prefer leaves, else qty − cum, else qty. */
+function leavesOf(o: LiveOrder): number | undefined {
+  if (o.leaves_qty != null && Number.isFinite(o.leaves_qty)) return o.leaves_qty;
+  if (o.qty != null && o.cum_qty != null) return o.qty - o.cum_qty;
+  return o.qty;
+}
+
+/** Stable-ish row key even when clordid is absent. */
+const rowKey = (o: LiveOrder, i: number) => o.clordid ?? String(o.orderid ?? `row-${i}`);
+
+interface RowProps {
+  o: LiveOrder;
+  sym: SymLookup;
+  busy: boolean;
+  onAmend: (clordid: string, symbolId: number, newQty: number, newPrice: number) => void;
+  onCancel: (clordid: string, symbolId: number) => void;
+}
+
+function OrderRow({ o, sym, busy, onAmend, onCancel }: RowProps) {
+  const { name, scaler } = sym(o.symbolid);
+  const [editing, setEditing] = useState(false);
+  const [px, setPx] = useState("");
+  const [qty, setQty] = useState("");
+  const canManage = !!o.clordid && o.symbolid != null;
+  const leaves = leavesOf(o);
+
+  const startEdit = () => {
+    // Seed the edit fields with the current (scaled) values.
+    setPx(o.price != null ? String(o.price / (scaler || 1)) : "");
+    setQty(leaves != null ? String(leaves / (scaler || 1)) : "");
+    setEditing(true);
+  };
+  const submit = () => {
+    if (!o.clordid || o.symbolid == null) return;
+    const sc = scaler || 1;
+    const newQty = Math.round(Number(qty) * sc);
+    const newPrice = Math.round(Number(px) * sc);
+    if (!Number.isFinite(newQty) || newQty <= 0) return;
+    onAmend(o.clordid, o.symbolid, newQty, Number.isFinite(newPrice) ? newPrice : (o.price ?? 0));
+    setEditing(false);
+  };
+
+  return (
+    <>
+      <tr>
+        <td className="sym">{name}</td>
+        <td style={{ color: isBuy(o.side) ? POS : NEG, textTransform: "uppercase" }}>{String(o.side ?? "—")}</td>
+        <td className="num">{formatPrice(o.price, scaler)}</td>
+        <td className="num">{formatQty(o.qty, scaler)}</td>
+        <td className="num">{leaves != null ? formatQty(leaves, scaler) : "—"}</td>
+        <td className="dim">{String(o.tif ?? o.status ?? "")}</td>
+        <td className="dim" style={{ fontFamily: "monospace", fontSize: "0.7rem" }}>{o.clordid ?? "—"}</td>
+        <td style={{ whiteSpace: "nowrap", textAlign: "right" }}>
+          <button type="button" className="tl-wo-btn" disabled={!canManage || busy} onClick={startEdit}>Amend</button>
+          <button type="button" className="tl-wo-btn danger" disabled={!canManage || busy}
+            onClick={() => o.clordid && o.symbolid != null && onCancel(o.clordid, o.symbolid)}>Cancel</button>
+        </td>
+      </tr>
+      {editing && (
+        <tr className="tl-wo-edit">
+          <td colSpan={8}>
+            <div className="tl-wo-editrow">
+              <span className="dim">Amend {name}</span>
+              <label>Price<input value={px} onChange={(e) => setPx(e.target.value)} inputMode="decimal" /></label>
+              <label>Qty<input value={qty} onChange={(e) => setQty(e.target.value)} inputMode="decimal" /></label>
+              <button type="button" className="tl-wo-btn accent" disabled={busy} onClick={submit}>Apply</button>
+              <button type="button" className="tl-wo-btn" onClick={() => setEditing(false)}>Close</button>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+export default function WorkingOrdersPanel() {
+  const symbolsQuery = useSymbols();
+  const sym = useMemo(() => makeSymLookup(symbolsQuery.data?.symbols), [symbolsQuery.data]);
+  const q = useOrdersLive();
+  const amend = useAmendOrder();
+  const cancel = useCancelOrder();
+  const bulk = useBulkCancel();
+  const [confirming, setConfirming] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  const orders: LiveOrder[] = Array.isArray(q.data?.orders) ? q.data!.orders! : [];
+  const busy = amend.isPending || cancel.isPending || bulk.isPending;
+
+  const onAmend = (clordid: string, symbolId: number, newQty: number, newPrice: number) => {
+    setNote(null);
+    amend.mutate(
+      { clordid, body: { new_qty: newQty, new_price: newPrice, symbolid: symbolId } },
+      {
+        onSuccess: (ack) => { setNote(ackMessage(ack) ?? `Amended ${clordid}`); void q.refetch(); },
+        onError: (e: unknown) => setNote((e as Error)?.message ?? "Amend failed"),
+      },
+    );
+  };
+  const onCancel = (clordid: string, symbolId: number) => {
+    setNote(null);
+    cancel.mutate(
+      { clordid, symbolId },
+      {
+        onSuccess: (ack) => { setNote(ackMessage(ack) ?? `Cancelled ${clordid}`); void q.refetch(); },
+        onError: (e: unknown) => setNote((e as Error)?.message ?? "Cancel failed"),
+      },
+    );
+  };
+  const doCancelAll = () => {
+    setConfirming(false);
+    setNote(null);
+    bulk.mutate(undefined, {
+      onSuccess: (ack) => { setNote(ack?.cancelled_count != null ? `Cancelled ${ack.cancelled_count} order(s)` : "Cancel-all sent"); void q.refetch(); },
+      onError: (e: unknown) => setNote((e as Error)?.message ?? "Cancel-all failed"),
+    });
+  };
+
+  return (
+    <div className="tl-panel-body tl-wo">
+      <div className="tl-wo-bar">
+        <span className="dim">{orders.length} working order{orders.length === 1 ? "" : "s"}</span>
+        <span style={{ flex: 1 }} />
+        {q.isFetching && <span className="dim" style={{ fontSize: "0.7rem" }}>refreshing…</span>}
+        {!confirming ? (
+          <button type="button" className="tl-wo-btn danger" disabled={busy || orders.length === 0} onClick={() => setConfirming(true)}>Cancel all</button>
+        ) : (
+          <span className="tl-wo-confirm">
+            Cancel ALL working orders?
+            <button type="button" className="tl-wo-btn danger" disabled={busy} onClick={doCancelAll}>Yes, cancel all</button>
+            <button type="button" className="tl-wo-btn" onClick={() => setConfirming(false)}>No</button>
+          </span>
+        )}
+      </div>
+      {note && <div className="tl-wo-note">{note}</div>}
+      <div className="tl-wo-scroll">
+        <table className="tl-wo-table">
+          <thead>
+            <tr>
+              <th>Sym</th><th>Side</th><th>Price</th><th>Qty</th><th>Leaves</th>
+              <th>TIF</th><th>ClOrdID</th><th style={{ textAlign: "right" }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orders.map((o, i) => (
+              <OrderRow key={rowKey(o, i)} o={o} sym={sym} busy={busy} onAmend={onAmend} onCancel={onCancel} />
+            ))}
+          </tbody>
+        </table>
+        {q.isLoading ? <div className="tl-wo-empty">Loading working orders…</div>
+          : q.isError ? <div className="tl-wo-empty">Working-orders feed (/me/orders/live) not available on this backend yet.</div>
+          : orders.length === 0 ? <div className="tl-wo-empty">No working orders.</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/portfolio/PortfolioPage.tsx
+++ b/frontend/src/pages/portfolio/PortfolioPage.tsx
@@ -36,6 +36,7 @@ import {
 import {
   getSpotBalance,
   getMarginAccount,
+  getPrices,
   type MarginAccount,
 } from "@/api/endpoints/trading";
 import { getSymbols, type MarketSymbol } from "@/api/endpoints/marketData";
@@ -68,6 +69,19 @@ function fmtAmount(v: string | number | undefined | null): string {
   const n = num(v);
   if (n === 0) return "0";
   return n.toLocaleString(undefined, { maximumFractionDigits: 8 });
+}
+
+/** Format a USD value like "$1,234.56". */
+function fmtUsd(n: number): string {
+  return `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+/** Small muted USD sub-value shown next to an asset amount when a price exists. */
+function UsdSub({ usd }: { usd: number | undefined }) {
+  if (usd == null) return null;
+  return (
+    <span className="ml-2 text-[11px] text-muted-foreground tabular-nums">≈ {fmtUsd(usd)}</span>
+  );
 }
 
 /** True when an error is a 404/403 — the "not available on this backend" case. */
@@ -194,6 +208,13 @@ export default function PortfolioPage() {
     queryFn: getSymbols,
     retry: false,
   });
+  // USD valuation marks — STUB today; degrades on 404 (retry:false) so the total
+  // falls back to a source-native (un-converted) sum.
+  const pricesQ = useQuery({
+    queryKey: ["portfolio", "me", "prices"],
+    queryFn: getPrices,
+    retry: false,
+  });
 
   const refetchAll = () => {
     custodyQ.refetch();
@@ -201,6 +222,7 @@ export default function PortfolioPage() {
     spotQ.refetch();
     marginQ.refetch();
     symbolsQ.refetch();
+    pricesQ.refetch();
   };
 
   const anyFetching =
@@ -208,7 +230,8 @@ export default function PortfolioPage() {
     stakingQ.isFetching ||
     spotQ.isFetching ||
     marginQ.isFetching ||
-    symbolsQ.isFetching;
+    symbolsQ.isFetching ||
+    pricesQ.isFetching;
 
   // -- derived aggregates --
   const custodyRows = useMemo(
@@ -249,31 +272,93 @@ export default function PortfolioPage() {
     };
   }, [symbolsQ.data]);
 
+  // USD price marks keyed by asset symbol (case-insensitive). Returns undefined
+  // when no mark exists for the asset — callers then skip USD conversion for it.
+  const priceOf = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const [sym, px] of Object.entries(pricesQ.data?.prices ?? {})) {
+      const n = num(px);
+      if (Number.isFinite(n) && n > 0) map.set(sym.toUpperCase(), n);
+    }
+    return (symbol: string | undefined | null): number | undefined => {
+      if (!symbol) return undefined;
+      return map.get(String(symbol).toUpperCase());
+    };
+  }, [pricesQ.data]);
+
+  const pricesOk = pricesQ.isSuccess;
+  const pricesStub = pricesOk && (pricesQ.data?.stub === true || pricesQ.data?.source === "stub");
+  const pricesUnavailable = pricesQ.isError; // 404 / edge-undeployed
+
   const hasPosition = !!margin && num(margin.num_positions) > 0 && num(margin.pos_qty) !== 0;
 
-  // Cross-venue equity snapshot: sum only the numerically-comparable balances
-  // we can actually read. This is a raw notional sum across assets/venues (no
-  // FX/price conversion) — labelled clearly as an approximate snapshot.
+  // Cross-venue equity. When USD price marks are readable we FX-normalize every
+  // readable balance (amount * asset USD price) into a REAL USD total equity,
+  // summing only assets that HAVE a mark (others are excluded from the USD sum).
+  // When /me/prices 404s (edge-undeployed) we fall back to the prior source-native
+  // raw sum (no FX conversion). `usd` distinguishes the two modes for the label.
   const equity = useMemo(() => {
-    let sum = 0;
+    // Source-native raw sum (the historical fallback — no FX conversion).
+    let raw = 0;
     let sources = 0;
     if (custodyQ.isSuccess) {
-      sum += custodyRows.reduce((a, r) => a + num(r.balance), 0);
+      raw += custodyRows.reduce((a, r) => a + num(r.balance), 0);
       sources++;
     }
     if (spotQ.isSuccess) {
-      sum += spotRows.reduce((a, b) => a + num(b.balance), 0);
+      raw += spotRows.reduce((a, b) => a + num(b.balance), 0);
       sources++;
     }
     if (marginQ.isSuccess) {
-      sum += num(margin?.balance);
+      raw += num(margin?.balance);
       sources++;
     }
     if (stakingQ.isSuccess) {
-      sum += stakingTotals.total;
+      raw += stakingTotals.total;
       sources++;
     }
-    return { sum, sources };
+
+    if (!pricesOk) {
+      // No USD marks — degrade to the source-native raw sum.
+      return { sum: raw, sources, usd: false, valued: 0, unpriced: 0 };
+    }
+
+    // USD-normalized total: sum amount * USD price for every asset with a mark.
+    let usdSum = 0;
+    let valued = 0; // assets contributing a USD value
+    let unpriced = 0; // readable balances with no USD mark (excluded)
+
+    const addAsset = (symbol: string | undefined | null, amount: number) => {
+      if (amount === 0) return;
+      const px = priceOf(symbol);
+      if (px == null) {
+        unpriced++;
+        return;
+      }
+      usdSum += amount * px;
+      valued++;
+    };
+
+    if (custodyQ.isSuccess) {
+      for (const r of custodyRows) addAsset(r.symbol, num(r.balance));
+    }
+    if (spotQ.isSuccess) {
+      for (const b of spotRows) addAsset(b.symbol, num(b.balance));
+    }
+    if (marginQ.isSuccess) {
+      // Margin collateral balance is denominated in the quote currency (USD);
+      // count it directly toward the USD total.
+      const mb = num(margin?.balance);
+      if (mb !== 0) {
+        usdSum += mb;
+        valued++;
+      }
+    }
+    if (stakingQ.isSuccess) {
+      for (const pos of stakingTotals.positions) addAsset(pos.asset, num(pos.total));
+    }
+
+    return { sum: usdSum, sources, usd: true, valued, unpriced };
   }, [
     custodyQ.isSuccess,
     spotQ.isSuccess,
@@ -283,6 +368,9 @@ export default function PortfolioPage() {
     spotRows,
     margin,
     stakingTotals.total,
+    stakingTotals.positions,
+    pricesOk,
+    priceOf,
   ]);
 
   const anyLoading =
@@ -310,23 +398,50 @@ export default function PortfolioPage() {
       {/* Total equity */}
       <Card>
         <CardContent className="flex flex-col gap-1 py-6">
-          <span className="text-xs uppercase tracking-wide text-muted-foreground">
-            Total equity — cross-venue snapshot
+          <span className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+            Total equity — cross-venue{equity.usd ? " (USD)" : " snapshot"}
+            {equity.usd && pricesStub && (
+              <Badge variant="outline" className="gap-1 text-[10px] font-normal normal-case">
+                <Info className="h-3 w-3" /> indicative (stub prices)
+              </Badge>
+            )}
           </span>
           {anyLoading ? (
             <Skeleton className="h-9 w-48" />
           ) : (
             <div className="flex items-baseline gap-2">
+              {equity.usd && <span className="text-2xl font-semibold text-muted-foreground">$</span>}
               <span className="num text-3xl font-bold tabular-nums">
-                {equity.sum.toLocaleString(undefined, { maximumFractionDigits: 8 })}
+                {equity.sum.toLocaleString(undefined, {
+                  minimumFractionDigits: equity.usd ? 2 : 0,
+                  maximumFractionDigits: equity.usd ? 2 : 8,
+                })}
               </span>
               {anyFetching && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
             </div>
           )}
           <span className="text-[11px] text-muted-foreground">
-            Approximate raw sum of readable balances from {equity.sources} of 4 venue
-            {equity.sources === 1 ? "" : "s"} — assets are NOT FX/price-converted; unavailable
-            sources are excluded.
+            {equity.usd ? (
+              <>
+                {pricesStub ? "Indicative " : "Real "}USD valuation ({equity.valued} priced asset
+                {equity.valued === 1 ? "" : "s"}
+                {equity.unpriced > 0
+                  ? `, ${equity.unpriced} unpriced balance${equity.unpriced === 1 ? "" : "s"} excluded`
+                  : ""}
+                ) across {equity.sources} of 4 venue{equity.sources === 1 ? "" : "s"}
+                {pricesStub
+                  ? " — stub prices, not a live mark."
+                  : "."}
+                {" "}Unavailable sources are excluded.
+              </>
+            ) : (
+              <>
+                {pricesUnavailable ? "USD valuation unavailable on this backend — a" : "A"}pproximate
+                raw sum of readable balances from {equity.sources} of 4 venue
+                {equity.sources === 1 ? "" : "s"} — assets are NOT FX/price-converted; unavailable
+                sources are excluded.
+              </>
+            )}
           </span>
         </CardContent>
       </Card>
@@ -348,9 +463,19 @@ export default function PortfolioPage() {
             <p className="py-4 text-sm text-muted-foreground">No vault balances.</p>
           ) : (
             <div className="divide-y divide-border/60">
-              {custodyRows.map((r) => (
-                <KV key={r.symbol} label={r.symbol} value={fmtAmount(r.balance)} />
-              ))}
+              {custodyRows.map((r) => {
+                const px = priceOf(r.symbol);
+                const usd = px != null ? num(r.balance) * px : undefined;
+                return (
+                  <div key={r.symbol} className="flex items-center justify-between gap-3 py-1">
+                    <span className="text-muted-foreground">{r.symbol}</span>
+                    <span className="text-right">
+                      <span className="num font-medium tabular-nums">{fmtAmount(r.balance)}</span>
+                      <UsdSub usd={usd} />
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           )}
           {custodyQ.data?.vault && (
@@ -375,19 +500,24 @@ export default function PortfolioPage() {
             <p className="py-4 text-sm text-muted-foreground">No spot balances.</p>
           ) : (
             <div className="divide-y divide-border/60">
-              {spotRows.map((b, i) => (
-                <div key={b.symbol ?? b.asset ?? i} className="flex items-center justify-between gap-3 py-1">
-                  <span className="text-muted-foreground">{b.symbol ?? `asset ${b.asset ?? "?"}`}</span>
-                  <span className="text-right">
-                    <span className="num font-medium tabular-nums">{fmtAmount(b.balance)}</span>
-                    {b.available != null && (
-                      <span className="ml-2 text-[11px] text-muted-foreground">
-                        ({fmtAmount(b.available)} avail)
-                      </span>
-                    )}
-                  </span>
-                </div>
-              ))}
+              {spotRows.map((b, i) => {
+                const px = priceOf(b.symbol);
+                const usd = px != null ? num(b.balance) * px : undefined;
+                return (
+                  <div key={b.symbol ?? b.asset ?? i} className="flex items-center justify-between gap-3 py-1">
+                    <span className="text-muted-foreground">{b.symbol ?? `asset ${b.asset ?? "?"}`}</span>
+                    <span className="text-right">
+                      <span className="num font-medium tabular-nums">{fmtAmount(b.balance)}</span>
+                      <UsdSub usd={usd} />
+                      {b.available != null && (
+                        <span className="ml-2 text-[11px] text-muted-foreground">
+                          ({fmtAmount(b.available)} avail)
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           )}
         </VenueCard>
@@ -405,7 +535,13 @@ export default function PortfolioPage() {
             <Unavailable line={errLine(marginQ.error, "The margin account isn't available on this backend yet.")} />
           ) : (
             <div className="divide-y divide-border/60">
-              <KV label="Balance" value={fmtAmount(margin?.balance)} />
+              <div className="flex items-center justify-between gap-3 py-1">
+                <span className="text-muted-foreground">Balance</span>
+                <span className="text-right">
+                  <span className="num font-medium tabular-nums">{fmtAmount(margin?.balance)}</span>
+                  <UsdSub usd={pricesOk && num(margin?.balance) !== 0 ? num(margin?.balance) : undefined} />
+                </span>
+              </div>
               <KV label="Available" value={fmtAmount(margin?.available_balance)} />
               <KV label="Reserved margin" value={fmtAmount(margin?.reserved_margin)} />
               <KV label="Open positions" value={String(num(margin?.num_positions))} />
@@ -435,7 +571,28 @@ export default function PortfolioPage() {
             <p className="py-4 text-sm text-muted-foreground">No staking positions.</p>
           ) : (
             <div className="divide-y divide-border/60">
-              <KV label="Total staked" value={fmtAmount(stakingTotals.total)} />
+              {(() => {
+                let usd = 0;
+                let priced = 0;
+                for (const pos of stakingTotals.positions) {
+                  const px = priceOf(pos.asset);
+                  if (px != null) {
+                    usd += num(pos.total) * px;
+                    priced++;
+                  }
+                }
+                return (
+                  <div className="flex items-center justify-between gap-3 py-1">
+                    <span className="text-muted-foreground">Total staked</span>
+                    <span className="text-right">
+                      <span className="num font-medium tabular-nums">
+                        {fmtAmount(stakingTotals.total)}
+                      </span>
+                      <UsdSub usd={priced > 0 ? usd : undefined} />
+                    </span>
+                  </div>
+                );
+              })()}
               <KV label="Principal" value={fmtAmount(stakingTotals.principal)} />
               <KV
                 label="Rewards"


### PR DESCRIPTION
Three more exchange frontend surfaces (web + Android), built via a sequenced workflow. Backend routes exist or are edge-stubbed (undeployed); all surfaces 404-degrade.

## Order management + trade history
`GET /me/orders/live` wired into a working-orders view — per-row **Amend** (PATCH) / **Cancel** (DELETE) + confirmed **Cancel-all** (bulk_cancel). Web: the blotter Orders panel is now the real management surface + a new Trade History panel (real fills feed). Android: the live server feed becomes the authoritative source for the existing order section, degrading to the session list on 404.

## Trading alerts
Client-derived (no backend notifications route) from the existing feeds — fills, liquidations, funding settlements, margin distress (rising-edge), PM resolutions. Web: a notification bell (unread badge + toasts) in the header. Android: a `TradingAlertsDetector` (pure, tested) + DataStore-persisted alerts + system notifications + a Trading Alerts screen (bell in Markets + More-hub entry). Seeded on first fetch so it never floods with history.

## Portfolio USD pricing
`GET /me/prices` (edge **stub**) FX-normalizes the cross-venue balances into a **real USD total equity**, labeled "indicative (stub prices)" while stubbed, with the source-native raw sum as the 404 fallback. Per-asset `≈ $` sub-values on the venue cards.

## Verification
Web: `npm run build` + `tsc` = 0. Android: `assembleDebug` + `testDebugUnitTest` green; **+34 new tests** (live-orders 12, alerts detector 10, price/portfolio 12).

Backend still owed (see desktop `exchange_missing_features.md`): a real `/me/orders/live` + `/me/prices` (this session stubbed the latter in the testlogon-cpp clone), engine open-listing reads for stake/auction discovery, and deploying the edge routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
