### PR TITLE
fix: scrollable section tabs + keyboard-focusable order-book rows (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -484,7 +484,12 @@ private fun EmptyHint(text: String) {
 @Composable
 private fun SectionTabs(section: TicketSection, ordersCount: Int, posCount: Int, fillsCount: Int, onSelect: (TicketSection) -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)).background(MarketColors.SurfaceAlt).padding(3.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MarketColors.SurfaceAlt)
+            .horizontalScroll(rememberScrollState())
+            .padding(3.dp),
         horizontalArrangement = Arrangement.spacedBy(3.dp),
     ) {
         TicketSection.values().forEach { s ->
@@ -498,12 +503,11 @@ private fun SectionTabs(section: TicketSection, ordersCount: Int, posCount: Int,
             val on = s == section
             Box(
                 modifier = Modifier
-                    .weight(1f)
                     .clip(RoundedCornerShape(6.dp))
                     .background(if (on) MarketColors.Surface else Color.Transparent)
                     .clickable { onSelect(s) }
                     .testTag("section_${s.name}")
-                    .padding(vertical = 8.dp),
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -198,4 +198,12 @@
   .text-info {
     color: var(--color-primary);
   }
+  /* Hide scrollbar while keeping scroll functionality (used by horizontally scrollable strips). */
+  .scrollbar-hide {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+  }
 }

--- a/frontend/src/pages/markets/SymbolDetailPage.tsx
+++ b/frontend/src/pages/markets/SymbolDetailPage.tsx
@@ -53,8 +53,17 @@ function DepthRow({
   const isBid = side === "bid";
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label={`${isBid ? "Bid" : "Ask"} ${formatPrice(price, scaler)} size ${formatQty(qty, scaler)}`}
       className="relative flex cursor-pointer items-center justify-between px-2 py-0.5 text-sm tabular-nums hover:bg-muted/40"
       onClick={() => onPick?.(price, isBid ? "sell" : "buy")}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          if (e.key === " ") e.preventDefault();
+          onPick?.(price, isBid ? "sell" : "buy");
+        }
+      }}
     >
       <div
         className={cn(
@@ -96,11 +105,20 @@ function ColumnRow({
   const isBid = side === "bid";
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label={`${isBid ? "Bid" : "Ask"} ${formatPrice(price, scaler)} size ${formatQty(qty, scaler)}`}
       className={cn(
         "relative flex cursor-pointer items-center px-2 py-0.5 text-sm tabular-nums hover:bg-muted/40",
         isBid ? "justify-end text-right" : "justify-start text-left"
       )}
       onClick={() => onPick?.(price, isBid ? "sell" : "buy")}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          if (e.key === " ") e.preventDefault();
+          onPick?.(price, isBid ? "sell" : "buy");
+        }
+      }}
     >
       <div
         className={cn(

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -880,8 +880,8 @@ export function TradeTicket({
           </div>
         )}
 
-        {/* Section tabs */}
-        <div className="flex gap-1 rounded-lg bg-muted p-1">
+        {/* Section tabs — horizontally scrollable on mobile, equal-width segmented on sm+ */}
+        <div className="flex gap-1 overflow-x-auto rounded-lg bg-muted p-1 scrollbar-hide">
           {sections.map((s) => (
             <button
               key={s.id}
@@ -891,7 +891,7 @@ export function TradeTicket({
                 resetArmed();
               }}
               className={cn(
-                "flex-1 rounded-md py-1.5 text-xs font-medium transition-colors",
+                "shrink-0 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors sm:flex-1 sm:shrink sm:px-0",
                 section === s.id ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"
               )}
             >


### PR DESCRIPTION
Two accessibility/responsive follow-ups flagged in the prior polish pass. TradeTicket section tabs scroll (content-sized) on narrow screens instead of clipping; web order-book rows are keyboard-focusable (role/aria/Enter-Space). Also defined the missing .scrollbar-hide utility. Web build+tsc 0; android assembleDebug+testDebugUnitTest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)