### PR TITLE
feat: auto-open saved default market on the markets landing (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,6 +82,15 @@ fun MarketsRoute(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val unreadAlerts by viewModel.unreadAlerts.collectAsStateWithLifecycle()
+    val autoOpenSymbolId by viewModel.autoOpenSymbolId.collectAsStateWithLifecycle()
+    // One-shot: when a saved default market resolves to a loaded symbol, open its detail once per
+    // process via the same nav lambda used for row taps, then clear it so the list stays reachable.
+    LaunchedEffect(autoOpenSymbolId) {
+        autoOpenSymbolId?.let { id ->
+            viewModel.consumeAutoOpen()
+            onOpenSymbol(id)
+        }
+    }
     MarketSurface {
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
             MarketsHeader(

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.TradingUiPrefsStore
 import com.testlogon.android.data.exchange.alerts.TradingAlertKind
 import com.testlogon.android.data.exchange.alerts.TradingAlertsPoller
 import com.testlogon.android.feature.markets.trade.TradingNotifier
@@ -31,6 +32,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MarketsViewModel @Inject constructor(
     private val repository: ExchangeRepository,
+    private val prefsStore: TradingUiPrefsStore,
     private val alertsPoller: TradingAlertsPoller,
     private val notifier: TradingNotifier,
     @ApplicationContext appContext: Context,
@@ -44,6 +46,34 @@ class MarketsViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(MarketsUiState(favorites = readFavorites()))
     val uiState: StateFlow<MarketsUiState> = _uiState.asStateFlow()
+
+    /**
+     * One-shot auto-open of the saved default market. Emits the target symbolId exactly ONCE per app
+     * process, only after the catalogue has loaded AND the saved default resolves to a symbol present
+     * in the loaded list. The route consumes it and navigates via its existing onOpenSymbol lambda;
+     * after consuming, [consumeAutoOpen] flips [autoOpened] so returning to the list shows the full
+     * list (no loop; the list is always reachable).
+     */
+    private val _autoOpenSymbolId = MutableStateFlow<Int?>(null)
+    val autoOpenSymbolId: StateFlow<Int?> = _autoOpenSymbolId.asStateFlow()
+
+    /** Called by the route once it has consumed the auto-open target so it never re-fires. */
+    fun consumeAutoOpen() {
+        _autoOpenSymbolId.value = null
+    }
+
+    /**
+     * Decide the auto-open target once symbols are loaded: fire only if a default is set, it exists in
+     * the loaded catalogue, and the process-lifetime guard has not already fired.
+     */
+    private fun maybeAutoOpenDefault(instruments: List<Instrument>) {
+        if (autoOpened) return
+        val defaultId = prefsStore.currentDefaultSymbol()
+        if (defaultId == TradingUiPrefsStore.NO_DEFAULT) return
+        if (instruments.none { it.symbolId == defaultId }) return
+        autoOpened = true
+        _autoOpenSymbolId.value = defaultId
+    }
 
     init {
         load()
@@ -96,6 +126,7 @@ class MarketsViewModel @Inject constructor(
                                 rows = instruments.map { i -> MarketRow(instrument = i) },
                             )
                         }
+                        maybeAutoOpenDefault(instruments)
                         pollQuotes(instruments)
                     }
                 }
@@ -162,6 +193,9 @@ class MarketsViewModel @Inject constructor(
     }
 
     private companion object {
+        /** Process-lifetime guard so the default-market auto-open fires at most once per app launch. */
+        @Volatile
+        private var autoOpened = false
         const val POLL_MS = 2_000L
         const val SPARK_EVERY = 5          // refresh sparkline/change every ~10s
         const val SPARK_INTERVAL_SEC = 60

--- a/frontend/src/pages/markets/MarketsPage.tsx
+++ b/frontend/src/pages/markets/MarketsPage.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { useSymbols, useCandles } from "@/hooks/useMarketData";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
 import { formatPrice } from "./format";
+import { loadDefaultSymbol } from "@/lib/tradingPrefs";
 
 // Fallback catalog if the symbols endpoint errors or returns empty.
 const FALLBACK_SYMBOLS: MarketSymbol[] = [
@@ -115,6 +116,23 @@ export default function MarketsPage() {
   const symbolsQuery = useSymbols();
   const apiSymbols = symbolsQuery.data?.symbols ?? [];
   const base = apiSymbols.length > 0 ? apiSymbols : FALLBACK_SYMBOLS;
+
+  // One-time-per-session auto-open of the saved default market. Fires only
+  // after real symbols have loaded and only if the saved id is still valid.
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (!symbolsQuery.data) return; // wait for the query to resolve
+    if (sessionStorage.getItem("md.defaultOpened") === "1") return;
+    const id = loadDefaultSymbol();
+    if (id == null) return;
+    if (!apiSymbols.some((s) => s.symbol_id === id)) return; // stale/removed
+    try {
+      sessionStorage.setItem("md.defaultOpened", "1");
+    } catch {
+      /* ignore */
+    }
+    navigate(`/markets/${id}`, { replace: true });
+  }, [symbolsQuery.data, apiSymbols, navigate]);
 
   const [query, setQuery] = useState("");
   const [tab, setTab] = useState<FilterTab>("all");


### PR DESCRIPTION
The last of the flagged follow-ups. The persisted default-market preference now auto-opens on the markets landing once per session/app-process (validated against the loaded symbols; guarded so the full list stays reachable — no redirect loop). Web build+tsc 0; android assembleDebug+testDebugUnitTest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)