### PR TITLE
feat: PnL analytics, price alerts, order-entry enhancements, home dashboard (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlert.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlert.kt
@@ -1,0 +1,79 @@
+package com.testlogon.android.data.exchange.alerts
+
+/**
+ * Which way the last price must cross the [PriceAlert.priceTicks] threshold to fire.
+ *  - [ABOVE]: fires when last price crosses from at/below the threshold to strictly above it.
+ *  - [BELOW]: fires when last price crosses from at/above the threshold to strictly below it.
+ */
+enum class PriceAlertDirection { ABOVE, BELOW }
+
+/**
+ * One user-authored price alert. [priceTicks] is the threshold in the symbol's raw integer ticks
+ * (parsed from the user's decimal input via the symbol's priceScaler), NOT a display double, so it is
+ * compared directly against the raw last-trade price. [armed] is the one-shot latch: an armed alert
+ * fires once when the price CROSSES the threshold (edge trigger), which stamps [triggeredTs] and sets
+ * [armed] = false so it never re-fires until the user re-arms it.
+ */
+data class PriceAlert(
+    val id: String,
+    val symbolId: Int,
+    val direction: PriceAlertDirection,
+    val priceTicks: Long,
+    val note: String? = null,
+    val createdTs: Long,
+    val triggeredTs: Long? = null,
+    val armed: Boolean = true,
+)
+
+/**
+ * Pure, deterministic edge-trigger evaluation for a single [PriceAlert] — the unit-tested seam.
+ *
+ * An armed alert fires when the last price CROSSES its threshold between two consecutive observations
+ * (not merely when the price sits on the far side). The caller supplies [prevTicks] (the last price the
+ * evaluator saw for this symbol on the previous tick, or null if this is the first observation) and
+ * [lastTicks] (the current last price). Crossing is edge-detected so an alert armed while the price is
+ * already past the threshold does not immediately fire — it fires only on a genuine crossing.
+ *
+ * One-shot: on a fire the returned alert has [PriceAlert.armed] = false and [PriceAlert.triggeredTs]
+ * stamped with [nowMs]. A disarmed or already-triggered alert never fires; re-arming (armed = true,
+ * triggeredTs = null) makes it eligible again.
+ */
+object PriceAlertEval {
+
+    /**
+     * The outcome of evaluating one alert against one price tick: the (possibly updated) [alert] and
+     * whether it [fired] on this tick (so the caller can raise a notification exactly once).
+     */
+    data class Result(val alert: PriceAlert, val fired: Boolean)
+
+    /**
+     * Evaluate [alert] given the previous ([prevTicks]) and current ([lastTicks]) last prices.
+     *
+     *  - Returns the alert unchanged with fired=false when it is not armed, already triggered, or the
+     *    price did not cross the threshold this tick.
+     *  - On the first observation ([prevTicks] == null) an alert never fires: with no prior price there
+     *    is no edge, so opening the app while the price is already past the threshold does not fire.
+     *  - ABOVE crosses when prev <= threshold < last. BELOW crosses when prev >= threshold > last.
+     */
+    fun evaluate(
+        alert: PriceAlert,
+        prevTicks: Long?,
+        lastTicks: Long,
+        nowMs: Long,
+    ): Result {
+        if (!alert.armed || alert.triggeredTs != null) return Result(alert, false)
+        if (prevTicks == null) return Result(alert, false)
+
+        val threshold = alert.priceTicks
+        val crossed = when (alert.direction) {
+            PriceAlertDirection.ABOVE -> prevTicks <= threshold && lastTicks > threshold
+            PriceAlertDirection.BELOW -> prevTicks >= threshold && lastTicks < threshold
+        }
+        if (!crossed) return Result(alert, false)
+
+        return Result(
+            alert = alert.copy(armed = false, triggeredTs = nowMs),
+            fired = true,
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsEvaluator.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsEvaluator.kt
@@ -1,0 +1,109 @@
+package com.testlogon.android.data.exchange.alerts
+
+import com.testlogon.android.data.exchange.Instrument
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Runs the pure [PriceAlertEval] over the user's persisted [PriceAlert]s against the live last prices
+ * the Markets poll already fetches — no new always-on worker; it is driven from the on-screen poll
+ * loop (the Markets VM) exactly like the derived-alerts poller.
+ *
+ * On a fire it: (1) persists the alert as disarmed + triggered (one-shot), and (2) raises it through
+ * the SAME [TradingAlertsStore] as a [TradingAlertKind.PRICE] alert so it appears in the shared alerts
+ * inbox alongside fills/liquidations/etc. The caller receives the freshly-fired [TradingAlert]s so it
+ * can post a system notification (consistent with how the derived poller returns its new alerts).
+ *
+ * Edge-detection state (the previous last price per symbol) is held in-memory here so an alert armed
+ * while the price is already past the threshold does not fire until a genuine crossing.
+ */
+@Singleton
+class PriceAlertsEvaluator @Inject constructor(
+    private val store: PriceAlertsStore,
+    private val alertsStore: TradingAlertsStore,
+    private val clock: AlertClock,
+) {
+    /** Previous last price (raw ticks) seen per symbolId, for edge detection across ticks. */
+    private val prevTicks = HashMap<Int, Long>()
+
+    /** The user's persisted price alerts (newest-created first) for the management screen. */
+    fun alerts(): Flow<List<PriceAlert>> = store.alerts()
+
+    suspend fun add(alert: PriceAlert) = store.upsert(alert)
+    suspend fun delete(id: String) = store.delete(id)
+    suspend fun rearm(id: String) = store.rearm(id)
+
+    /**
+     * Evaluate every armed alert whose symbol has a fresh last price in [lastBySymbol] (raw ticks).
+     * Persists any one-shot fires and mirrors them into the shared alerts inbox; returns the newly
+     * raised [TradingAlert]s (empty when nothing crossed). Never throws.
+     *
+     * [instruments] is used only to render a human label ("BTC crossed above 65000") from the symbolId
+     * and to format the threshold via the symbol scaler; a missing instrument falls back to "#id".
+     */
+    suspend fun evaluate(
+        lastBySymbol: Map<Int, Long>,
+        instruments: List<Instrument>,
+    ): List<TradingAlert> {
+        if (lastBySymbol.isEmpty()) return emptyList()
+        val current = store.snapshot()
+        if (current.isEmpty()) {
+            // Still advance edge state so a later-added alert edge-detects correctly.
+            lastBySymbol.forEach { (sym, ticks) -> prevTicks[sym] = ticks }
+            return emptyList()
+        }
+
+        val now = clock.nowMs()
+        val byId = instruments.associateBy { it.symbolId }
+        val fired = ArrayList<TradingAlert>()
+        var changed = false
+
+        val updated = current.map { alert ->
+            val last = lastBySymbol[alert.symbolId] ?: return@map alert
+            val prev = prevTicks[alert.symbolId]
+            val result = PriceAlertEval.evaluate(alert, prev, last, now)
+            if (result.fired) {
+                changed = true
+                fired += toTradingAlert(result.alert, last, byId[alert.symbolId], now)
+            }
+            result.alert
+        }
+
+        // Advance edge state AFTER evaluating this tick.
+        lastBySymbol.forEach { (sym, ticks) -> prevTicks[sym] = ticks }
+
+        if (changed) store.replaceAll(updated)
+        if (fired.isNotEmpty()) alertsStore.addAlerts(fired)
+        return fired
+    }
+
+    private fun toTradingAlert(
+        alert: PriceAlert,
+        lastTicks: Long,
+        instrument: Instrument?,
+        now: Long,
+    ): TradingAlert {
+        val label = instrument?.symbol ?: ("#" + alert.symbolId)
+        val dir = if (alert.direction == PriceAlertDirection.ABOVE) "above" else "below"
+        val threshold = instrument?.display(alert.priceTicks) ?: alert.priceTicks.toDouble()
+        val lastDisp = instrument?.display(lastTicks) ?: lastTicks.toDouble()
+        val thresholdStr = fmt(threshold)
+        val body = buildString {
+            append(label).append(" crossed ").append(dir).append(' ').append(thresholdStr)
+            append(" (last ").append(fmt(lastDisp)).append(')')
+            alert.note?.takeIf { it.isNotBlank() }?.let { append(" — ").append(it) }
+        }
+        return TradingAlert(
+            id = "price:" + alert.id + ":" + alert.triggeredTs,
+            kind = TradingAlertKind.PRICE,
+            title = label + " price alert",
+            body = body,
+            eventTsNs = 0L,
+            createdAtMs = now,
+        )
+    }
+
+    private fun fmt(v: Double): String =
+        if (v == v.toLong().toDouble()) v.toLong().toString() else v.toString()
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsStore.kt
@@ -1,0 +1,156 @@
+package com.testlogon.android.data.exchange.alerts
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapter
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.priceAlertsDataStore by preferencesDataStore(name = "price_alerts")
+
+/**
+ * Durable CRUD store for user-authored [PriceAlert]s (persisted as Moshi JSON in DataStore, mirroring
+ * the derived-trading-alerts store). Interface seam so the evaluator/VM can inject an in-memory fake on
+ * the JVM. Every read/write is failure-safe (a store error degrades to "no data" / no-op, never throws).
+ */
+interface PriceAlertsStore {
+    /** The persisted alerts as a reactive stream (newest-created first). */
+    fun alerts(): Flow<List<PriceAlert>>
+
+    /** A one-shot snapshot for the evaluator hot path (no Flow collection). */
+    suspend fun snapshot(): List<PriceAlert>
+
+    /** Insert or replace an alert by [PriceAlert.id]. */
+    suspend fun upsert(alert: PriceAlert)
+
+    /** Replace the whole set (used by the evaluator to persist post-fire updates in one write). */
+    suspend fun replaceAll(alerts: List<PriceAlert>)
+
+    suspend fun delete(id: String)
+
+    /** Re-arm a triggered alert: armed = true, triggeredTs = null (no-op if the id is unknown). */
+    suspend fun rearm(id: String)
+}
+
+@Singleton
+class DataStorePriceAlertsStore @Inject constructor(
+    @ApplicationContext context: Context,
+    moshi: Moshi,
+) : PriceAlertsStore {
+
+    private val dataStore = context.priceAlertsDataStore
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private val listAdapter =
+        moshi.adapter<List<PriceAlertJson>>(
+            Types.newParameterizedType(List::class.java, PriceAlertJson::class.java),
+        )
+
+    override fun alerts(): Flow<List<PriceAlert>> = dataStore.data
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .map { prefs -> decode(prefs[Keys.ALERTS]) }
+
+    override suspend fun snapshot(): List<PriceAlert> = runCatching {
+        val prefs = dataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .first()
+        decode(prefs[Keys.ALERTS])
+    }.getOrDefault(emptyList())
+
+    override suspend fun upsert(alert: PriceAlert) {
+        runCatching {
+            dataStore.edit { prefs ->
+                val existing = decode(prefs[Keys.ALERTS]).filterNot { it.id == alert.id }
+                // Newest-created first.
+                prefs[Keys.ALERTS] = encode((listOf(alert) + existing).take(MAX_RETAINED))
+            }
+        }
+    }
+
+    override suspend fun replaceAll(alerts: List<PriceAlert>) {
+        runCatching { dataStore.edit { it[Keys.ALERTS] = encode(alerts.take(MAX_RETAINED)) } }
+    }
+
+    override suspend fun delete(id: String) {
+        runCatching {
+            dataStore.edit { prefs ->
+                prefs[Keys.ALERTS] = encode(decode(prefs[Keys.ALERTS]).filterNot { it.id == id })
+            }
+        }
+    }
+
+    override suspend fun rearm(id: String) {
+        runCatching {
+            dataStore.edit { prefs ->
+                val updated = decode(prefs[Keys.ALERTS]).map {
+                    if (it.id == id) it.copy(armed = true, triggeredTs = null) else it
+                }
+                prefs[Keys.ALERTS] = encode(updated)
+            }
+        }
+    }
+
+    private fun decode(json: String?): List<PriceAlert> = runCatching {
+        json?.let { listAdapter.fromJson(it) }?.map { it.toDomain() }
+    }.getOrNull().orEmpty()
+
+    private fun encode(alerts: List<PriceAlert>): String =
+        listAdapter.toJson(alerts.map { it.toJson() })
+
+    private object Keys {
+        val ALERTS = stringPreferencesKey("price_alerts_json")
+    }
+
+    private companion object {
+        const val MAX_RETAINED = 200
+    }
+}
+
+// ---- JSON wire model (KSP codegen adapter; unit-test-safe with a plain Moshi.Builder) ----
+
+@JsonClass(generateAdapter = true)
+internal data class PriceAlertJson(
+    val id: String,
+    val symbolId: Int,
+    val direction: String,
+    val priceTicks: Long,
+    val note: String? = null,
+    val createdTs: Long = 0L,
+    val triggeredTs: Long? = null,
+    val armed: Boolean = true,
+)
+
+internal fun PriceAlertJson.toDomain() = PriceAlert(
+    id = id,
+    symbolId = symbolId,
+    direction = runCatching { PriceAlertDirection.valueOf(direction) }
+        .getOrDefault(PriceAlertDirection.ABOVE),
+    priceTicks = priceTicks,
+    note = note,
+    createdTs = createdTs,
+    triggeredTs = triggeredTs,
+    armed = armed,
+)
+
+internal fun PriceAlert.toJson() = PriceAlertJson(
+    id = id,
+    symbolId = symbolId,
+    direction = direction.name,
+    priceTicks = priceTicks,
+    note = note,
+    createdTs = createdTs,
+    triggeredTs = triggeredTs,
+    armed = armed,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlert.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlert.kt
@@ -11,7 +11,7 @@ import com.testlogon.android.data.exchange.PmResolution
  * no backend notifications route — each kind is inferred from a new event appearing in one of the
  * polled feeds (fills / liquidations / funding / margin-distress / PM-resolution).
  */
-enum class TradingAlertKind { FILL, LIQUIDATION, FUNDING, MARGIN_DISTRESS, PM_RESOLVED }
+enum class TradingAlertKind { FILL, LIQUIDATION, FUNDING, MARGIN_DISTRESS, PM_RESOLVED, PRICE }
 
 /**
  * One derived, render-ready trading alert. [id] is a stable de-dupe key (kind + event identity) so the

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/TradingAlertsModule.kt
@@ -16,6 +16,10 @@ abstract class TradingAlertsModule {
     @Singleton
     abstract fun bindTradingAlertsStore(impl: DataStoreTradingAlertsStore): TradingAlertsStore
 
+    @Binds
+    @Singleton
+    abstract fun bindPriceAlertsStore(impl: DataStorePriceAlertsStore): PriceAlertsStore
+
     companion object {
         @Provides
         @Singleton

--- a/android/app/src/main/java/com/testlogon/android/feature/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/home/HomeScreen.kt
@@ -1,0 +1,471 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.AccountBalanceWallet
+import androidx.compose.material.icons.outlined.Circle
+import androidx.compose.material.icons.outlined.NotificationsActive
+import androidx.compose.material.icons.outlined.PieChart
+import androidx.compose.material.icons.outlined.SwapHoriz
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.util.Locale
+
+/** Green/red for change + PnL, independent of the app theme (matches the markets/portfolio convention). */
+private val Up = Color(0xFF16A34A)
+private val Down = Color(0xFFDC2626)
+
+/**
+ * Trading Home / Dashboard route. Read-only launch surface composed from existing account reads; each
+ * card degrades independently. Navigation is delegated to the caller so this feature owns no routes.
+ */
+@Composable
+fun HomeRoute(
+    onBack: () -> Unit,
+    onOpenTarget: (HomeTarget) -> Unit,
+    onOpenSymbol: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: HomeViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // Enrich the watchlist snapshot with live-ish quotes once the initial frame (with the starred
+    // rows) is present; safe to call repeatedly (it no-ops when there are no rows).
+    LaunchedEffect(state.watchlist.rows.size) { viewModel.enrichWatchlist() }
+    HomeScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onOpenTarget = onOpenTarget,
+        onOpenSymbol = onOpenSymbol,
+        onDismissOnboarding = viewModel::dismissOnboarding,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun HomeScreen(
+    state: HomeUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onOpenTarget: (HomeTarget) -> Unit,
+    onOpenSymbol: (Int) -> Unit,
+    onDismissOnboarding: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Home") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // 5. Getting-started checklist — prominent while incomplete; dismissible "all set" when done.
+            if (state.onboarding.showChecklist) {
+                item { OnboardingChecklistCard(state.onboarding, onOpenTarget) }
+            } else if (state.onboarding.showAllSet) {
+                item { OnboardingAllSetCard(onDismissOnboarding) }
+            }
+
+            // 1. Portfolio summary.
+            item { PortfolioSummaryCard(state.portfolio, onOpenTarget) }
+
+            // 4. Quick actions.
+            item { QuickActionsCard(onOpenTarget) }
+
+            // 2. Watchlist snapshot.
+            item { WatchlistCard(state.watchlist, onOpenSymbol) }
+
+            // 3. Recent activity.
+            item { RecentActivityCard(state.activity, onOpenTarget) }
+
+            item { Spacer(Modifier.height(8.dp)) }
+        }
+    }
+}
+
+// ---------------- 1. Portfolio summary ----------------
+
+@Composable
+private fun PortfolioSummaryCard(portfolio: HomePortfolio, onOpenTarget: (HomeTarget) -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                if (portfolio.priced) "Total equity (USD)" else "Total equity",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            when {
+                portfolio.loading -> InlineLoading()
+                portfolio.unavailable -> Text(
+                    "Unavailable right now.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                else -> {
+                    Text(
+                        text = portfolio.equityText,
+                        fontSize = 30.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                    if (portfolio.priced && portfolio.pricesStub) {
+                        Text(
+                            "indicative (stub prices)",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    } else if (!portfolio.priced) {
+                        Text(
+                            "source-native total (prices unavailable)",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    }
+                    Spacer(Modifier.height(10.dp))
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+                        HeadlineStat(
+                            label = "Available",
+                            value = portfolio.available?.let { fmt(it) } ?: "--",
+                        )
+                        val upnl = portfolio.unrealizedPnl
+                        HeadlineStat(
+                            label = "Unrealized PnL",
+                            value = upnl?.let { signed(it) } ?: "--",
+                            valueColor = upnl?.let { if (it >= 0) Up else Down },
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            TextButton(onClick = { onOpenTarget(HomeTarget.PORTFOLIO) }) { Text("View portfolio") }
+        }
+    }
+}
+
+@Composable
+private fun HeadlineStat(label: String, value: String, valueColor: Color? = null) {
+    Column {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        Text(
+            value,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = FontWeight.SemiBold,
+            color = valueColor ?: MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
+}
+
+// ---------------- 4. Quick actions ----------------
+
+@Composable
+private fun QuickActionsCard(onOpenTarget: (HomeTarget) -> Unit) {
+    SectionCard(title = "Quick actions") {
+        Row(
+            Modifier.fillMaxWidth().padding(top = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            QuickAction("Trade", Icons.AutoMirrored.Filled.ShowChart, Modifier.weight(1f)) { onOpenTarget(HomeTarget.TRADE) }
+            QuickAction("Deposit", Icons.Outlined.AccountBalanceWallet, Modifier.weight(1f)) { onOpenTarget(HomeTarget.DEPOSIT) }
+            QuickAction("Portfolio", Icons.Outlined.PieChart, Modifier.weight(1f)) { onOpenTarget(HomeTarget.PORTFOLIO) }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            QuickAction("PnL", Icons.Outlined.SwapHoriz, Modifier.weight(1f)) { onOpenTarget(HomeTarget.PNL) }
+            QuickAction("Alerts", Icons.Outlined.NotificationsActive, Modifier.weight(1f)) { onOpenTarget(HomeTarget.PRICE_ALERTS) }
+            Spacer(Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun QuickAction(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    FilledTonalButton(onClick = onClick, modifier = modifier) {
+        Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(6.dp))
+        Text(label, maxLines = 1)
+    }
+}
+
+// ---------------- 2. Watchlist snapshot ----------------
+
+@Composable
+private fun WatchlistCard(watchlist: HomeWatchlist, onOpenSymbol: (Int) -> Unit) {
+    SectionCard(title = "Watchlist") {
+        when {
+            watchlist.loading -> InlineLoading()
+            !watchlist.hasStarred -> Text(
+                "Star symbols in Markets to see them here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            else -> Column {
+                watchlist.rows.forEachIndexed { i, row ->
+                    if (i > 0) HorizontalDivider()
+                    WatchRowView(row, onOpenSymbol)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WatchRowView(row: HomeWatchRow, onOpenSymbol: (Int) -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable { onOpenSymbol(row.symbolId) }
+            .padding(vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(row.symbol, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+        Text(
+            row.lastPriceText ?: "--",
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.padding(end = 12.dp),
+        )
+        Text(
+            text = row.changePct?.let { String.format(Locale.US, "%+.2f%%", it) } ?: "--",
+            color = row.changePct?.let { if (it >= 0) Up else Down } ?: MaterialTheme.colorScheme.onSurfaceVariant,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+// ---------------- 3. Recent activity ----------------
+
+@Composable
+private fun RecentActivityCard(activity: HomeActivity, onOpenTarget: (HomeTarget) -> Unit) {
+    SectionCard(title = "Recent activity") {
+        when {
+            activity.loading -> InlineLoading()
+            activity.unavailable -> Text(
+                "Unavailable right now.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            activity.isEmpty -> Text(
+                "No fills yet.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            else -> Column {
+                activity.rows.forEachIndexed { i, row ->
+                    if (i > 0) HorizontalDivider()
+                    Row(
+                        Modifier.fillMaxWidth().padding(vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            row.sideLabel,
+                            color = if (row.isBuy) Up else Down,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.width(44.dp),
+                        )
+                        Text(row.symbol, fontWeight = FontWeight.Medium, modifier = Modifier.weight(1f))
+                        Text(
+                            "${row.qtyText} @ ${row.priceText}",
+                            fontFamily = FontFamily.Monospace,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            TextButton(onClick = { onOpenTarget(HomeTarget.TRADE_HISTORY) }) { Text("Trade history") }
+            TextButton(onClick = { onOpenTarget(HomeTarget.PNL) }) { Text("PnL") }
+        }
+    }
+}
+
+// ---------------- 5. Onboarding checklist ----------------
+
+@Composable
+private fun OnboardingChecklistCard(onboarding: HomeOnboarding, onOpenTarget: (HomeTarget) -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Get started",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(Modifier.height(8.dp))
+            onboarding.steps.forEach { step ->
+                StepRow(step, onOpenTarget)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StepRow(step: OnboardingStep, onOpenTarget: (HomeTarget) -> Unit) {
+    val done = step.isDone
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !done) { onOpenTarget(step.target) }
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = if (done) Icons.Filled.CheckCircle else Icons.Outlined.Circle,
+            contentDescription = null,
+            tint = if (done) Up else MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.size(22.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            step.title,
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            fontWeight = if (done) FontWeight.Normal else FontWeight.Medium,
+        )
+        if (step.state == StepState.UNKNOWN) {
+            Text(
+                "—",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OnboardingAllSetCard(onDismiss: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Filled.CheckCircle, contentDescription = null, tint = Up, modifier = Modifier.size(24.dp))
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    "You're all set",
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Text(
+                    "Custody funded, trading funded, first trade placed.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            TextButton(onClick = onDismiss) { Text("Dismiss") }
+        }
+    }
+}
+
+// ---------------- shared bits ----------------
+
+@Composable
+private fun SectionCard(title: String, content: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(8.dp))
+            content()
+        }
+    }
+}
+
+@Composable
+private fun InlineLoading() {
+    Box(Modifier.fillMaxWidth().padding(vertical = 12.dp), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+    }
+}
+
+private fun fmt(v: Long): String = String.format(Locale.US, "%,d", v)
+
+private fun signed(v: Long): String = (if (v >= 0) "+" else "") + String.format(Locale.US, "%,d", v)

--- a/android/app/src/main/java/com/testlogon/android/feature/home/HomeUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/home/HomeUiState.kt
@@ -1,0 +1,168 @@
+package com.testlogon.android.feature.home
+
+/**
+ * Read-only Trading Home / Dashboard state. Composes several INDEPENDENT reads (portfolio summary,
+ * watchlist snapshot, recent activity, onboarding progress) into one snapshot. Each card degrades on
+ * its own: a 404/empty/undeployed source renders that card as empty/unavailable while the others still
+ * show. Nothing here moves money - it is a consolidated launch surface for the trading app.
+ */
+
+/** Which navigation target a quick action / link points at (resolved by the route wiring). */
+enum class HomeTarget {
+    TRADE,
+    DEPOSIT,
+    PORTFOLIO,
+    PNL,
+    PRICE_ALERTS,
+    TRADE_HISTORY,
+}
+
+/**
+ * The portfolio summary card. [available] and [unrealizedPnl] are the headline numbers; [equityText]
+ * is the pre-formatted total-equity snapshot. [priced] is true when a USD price map valued the
+ * balances (so [equityText] is a USD figure); otherwise it is a coarse source-native sum. [unavailable]
+ * degrades the card independently (all reads failed / undeployed).
+ */
+data class HomePortfolio(
+    val loading: Boolean = true,
+    val unavailable: Boolean = false,
+    val equityText: String = "--",
+    val priced: Boolean = false,
+    val pricesStub: Boolean = false,
+    /** Margin available balance (source-native), null when the margin read was not available. */
+    val available: Long? = null,
+    /** Open-position unrealized PnL (source-native), null when no open position / unavailable. */
+    val unrealizedPnl: Long? = null,
+)
+
+/** One starred-symbol row in the watchlist snapshot. */
+data class HomeWatchRow(
+    val symbolId: Int,
+    val symbol: String,
+    /** Pre-formatted last price, or null (renders "--") when no quote could be read. */
+    val lastPriceText: String?,
+    /** Percent change over the sparkline window, null when unknown (renders "--"). */
+    val changePct: Double?,
+)
+
+/** The watchlist snapshot card. Empty [rows] with [hasStarred]=false prompts the user to star symbols. */
+data class HomeWatchlist(
+    val loading: Boolean = true,
+    val hasStarred: Boolean = false,
+    val rows: List<HomeWatchRow> = emptyList(),
+)
+
+/** One recent-activity row (a recent fill), pre-formatted for display. */
+data class HomeActivityRow(
+    val symbol: String,
+    val sideLabel: String,
+    val isBuy: Boolean,
+    val qtyText: String,
+    val priceText: String,
+)
+
+/** The recent-activity card (last few fills). [unavailable] when the fills feed could not be read. */
+data class HomeActivity(
+    val loading: Boolean = true,
+    val unavailable: Boolean = false,
+    val rows: List<HomeActivityRow> = emptyList(),
+) {
+    val isEmpty: Boolean get() = !loading && !unavailable && rows.isEmpty()
+}
+
+/**
+ * A single getting-started checklist step. [state] reflects REAL account state; UNKNOWN is neutral
+ * (data unavailable) and never rendered as a false "incomplete". [target] is where tapping the step
+ * navigates to satisfy it.
+ */
+data class OnboardingStep(
+    val id: OnboardingStepId,
+    val title: String,
+    val state: StepState,
+    val target: HomeTarget,
+) {
+    val isDone: Boolean get() = state == StepState.DONE
+    /** Actionable = still worth prompting (not done, and we actually know it is incomplete). */
+    val isActionable: Boolean get() = state == StepState.INCOMPLETE
+}
+
+enum class OnboardingStepId { FUND_CUSTODY, FUND_TRADING, FIRST_TRADE }
+
+/** DONE = satisfied; INCOMPLETE = confirmed not-yet-done; UNKNOWN = data unavailable (neutral). */
+enum class StepState { DONE, INCOMPLETE, UNKNOWN }
+
+/**
+ * The onboarding checklist card. [steps] is a stable, ordered list. The card is "all set" ONLY when
+ * every step we could evaluate is DONE and none is still INCOMPLETE (UNKNOWN steps do not block "all
+ * set", but they also never count as done). [dismissed] persists the user's dismissal of the all-set
+ * banner.
+ */
+data class HomeOnboarding(
+    val loading: Boolean = true,
+    val steps: List<OnboardingStep> = emptyList(),
+    val dismissed: Boolean = false,
+) {
+    /** Steps the user can still act on (confirmed incomplete). */
+    val actionableSteps: List<OnboardingStep> get() = steps.filter { it.isActionable }
+    /** True when nothing is confirmed-incomplete (every known step is done). */
+    val allSet: Boolean get() = !loading && steps.isNotEmpty() && actionableSteps.isEmpty()
+    /** Show the prominent checklist while there is at least one confirmed-incomplete step. */
+    val showChecklist: Boolean get() = !loading && actionableSteps.isNotEmpty()
+    /** Show the dismissible "all set" banner when everything known is done and not yet dismissed. */
+    val showAllSet: Boolean get() = allSet && !dismissed
+}
+
+/** Inputs to the pure onboarding derivation (already extracted from the raw reads). */
+data class OnboardingInputs(
+    /** True/false when known (custody has any funded row); null when the custody read was unavailable. */
+    val custodyFunded: Boolean?,
+    /** True/false when known (spot OR margin available > 0); null when BOTH reads were unavailable. */
+    val tradingFunded: Boolean?,
+    /** True/false when known (any fill exists); null when the fills feed was unavailable. */
+    val hasFirstTrade: Boolean?,
+)
+
+/**
+ * Pure derivation of the getting-started checklist from real account signals. Kept free of Android /
+ * coroutine deps so it is unit-testable in isolation (see HomeOnboardingDeriverTest). A `null` input
+ * means "data unavailable" and maps to [StepState.UNKNOWN] (neutral) - never a false "incomplete".
+ */
+object HomeOnboardingDeriver {
+
+    fun derive(inputs: OnboardingInputs): List<OnboardingStep> = listOf(
+        OnboardingStep(
+            id = OnboardingStepId.FUND_CUSTODY,
+            title = "Fund your custody vault",
+            state = stateOf(inputs.custodyFunded),
+            target = HomeTarget.DEPOSIT,
+        ),
+        OnboardingStep(
+            id = OnboardingStepId.FUND_TRADING,
+            title = "Fund a trading account",
+            state = stateOf(inputs.tradingFunded),
+            target = HomeTarget.DEPOSIT,
+        ),
+        OnboardingStep(
+            id = OnboardingStepId.FIRST_TRADE,
+            title = "Place your first trade",
+            state = stateOf(inputs.hasFirstTrade),
+            target = HomeTarget.TRADE,
+        ),
+    )
+
+    /** null -> UNKNOWN (neutral); true -> DONE; false -> INCOMPLETE. */
+    private fun stateOf(signal: Boolean?): StepState = when (signal) {
+        null -> StepState.UNKNOWN
+        true -> StepState.DONE
+        false -> StepState.INCOMPLETE
+    }
+}
+
+/** The whole Home / Dashboard screen state. Each card is independent and degrades on its own. */
+data class HomeUiState(
+    val loading: Boolean = true,
+    val portfolio: HomePortfolio = HomePortfolio(),
+    val watchlist: HomeWatchlist = HomeWatchlist(),
+    val activity: HomeActivity = HomeActivity(),
+    val onboarding: HomeOnboarding = HomeOnboarding(),
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/home/HomeViewModel.kt
@@ -1,0 +1,300 @@
+package com.testlogon.android.feature.home
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.custody.CustodyBalances
+import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.PriceMap
+import com.testlogon.android.data.exchange.SpotBalance
+import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.feature.markets.MarketSummaryMath
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.math.round
+
+/**
+ * Read-only Trading Home / Dashboard ViewModel. Fans the independent card reads out in parallel
+ * (custody balance, spot balance, margin account, indicative prices, recent fills, and the instrument
+ * catalogue used to resolve the persisted watchlist) and folds them into a single [HomeUiState]. Each
+ * card degrades on its own: any failed/undeployed source renders as empty/unavailable/UNKNOWN without
+ * dropping the others. No writes, no money movement.
+ *
+ * The watchlist is the SAME persisted set the Markets screen owns (SharedPreferences "markets_prefs" /
+ * "favorites"); the checklist "all set" dismissal persists in this feature's own prefs so re-opening
+ * Home keeps the collapsed state.
+ */
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val custody: CustodyRepository,
+    private val trading: TradingRepository,
+    private val exchange: ExchangeRepository,
+    @ApplicationContext appContext: Context,
+) : ViewModel() {
+
+    private val marketsPrefs = appContext.getSharedPreferences(MARKETS_PREFS, Context.MODE_PRIVATE)
+    private val homePrefs = appContext.getSharedPreferences(HOME_PREFS, Context.MODE_PRIVATE)
+
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.value = HomeUiState(loading = true)
+        viewModelScope.launch {
+            _uiState.value = load()
+        }
+    }
+
+    /** Persist the user's dismissal of the "all set" onboarding banner (survives re-open). */
+    fun dismissOnboarding() {
+        homePrefs.edit().putBoolean(KEY_ONBOARDING_DISMISSED, true).apply()
+        _uiState.update { it.copy(onboarding = it.onboarding.copy(dismissed = true)) }
+    }
+
+    private suspend fun load(): HomeUiState = coroutineScope {
+        val favorites = readFavorites()
+        val custodyDef = async { custody.getBalance() }
+        val spotDef = async { trading.spotBalance() }
+        val marginDef = async { trading.marginAccount() }
+        val pricesDef = async { trading.getPrices() }
+        val fillsDef = async { trading.fillsFees() }
+        val symbolsDef = async { exchange.symbols() }
+
+        val custodyRes = custodyDef.await()
+        val spotRes = spotDef.await()
+        val marginRes = marginDef.await()
+        val pricesRes = pricesDef.await()
+        val fillsRes = fillsDef.await()
+        val symbolsRes = symbolsDef.await()
+
+        val prices = (pricesRes as? ApiResult.Success)?.data ?: PriceMap.unavailable()
+        val symbols = (symbolsRes as? ApiResult.Success)?.data.orEmpty()
+
+        val portfolio = buildPortfolio(custodyRes, spotRes, marginRes, prices)
+        val watchlist = buildWatchlist(favorites, symbols)
+        val activity = buildActivity(fillsRes, symbols)
+        val onboarding = buildOnboarding(custodyRes, spotRes, marginRes, fillsRes)
+
+        HomeUiState(
+            loading = false,
+            portfolio = portfolio,
+            watchlist = watchlist,
+            activity = activity,
+            onboarding = onboarding,
+        )
+    }
+
+    // ---- Portfolio summary card ----
+
+    private fun buildPortfolio(
+        custodyRes: ApiResult<CustodyBalances>,
+        spotRes: ApiResult<SpotBalance>,
+        marginRes: ApiResult<MarginAccount>,
+        prices: PriceMap,
+    ): HomePortfolio {
+        val pm = prices.takeIf { !it.unavailable && it.hasPrices }
+        val custodyOk = custodyRes is ApiResult.Success
+        val spotOk = spotRes is ApiResult.Success
+        val marginOk = marginRes is ApiResult.Success
+        if (!custodyOk && !spotOk && !marginOk) {
+            return HomePortfolio(loading = false, unavailable = true)
+        }
+
+        // USD-normalized equity when priced; otherwise a coarse source-native sum (its own caveat).
+        var equityUsd = 0.0
+        var nativeSum = 0.0
+        var valuedSomething = false
+
+        (custodyRes as? ApiResult.Success)?.data?.rows?.filter { it.amount > 0.0 }?.forEach { row ->
+            nativeSum += row.amount
+            pm?.priceFor(row.symbol)?.let { equityUsd += it * row.amount; valuedSomething = true }
+        }
+        (spotRes as? ApiResult.Success)?.data?.assets?.filter { it.balance > 0L }?.forEach { a ->
+            nativeSum += a.balance.toDouble()
+            a.symbol.takeIf { it.isNotBlank() }?.let { pm?.priceFor(it) }
+                ?.let { equityUsd += it * a.balance.toDouble(); valuedSomething = true }
+        }
+        val margin = (marginRes as? ApiResult.Success)?.data
+        if (margin != null) {
+            nativeSum += margin.balance.toDouble()
+            (pm?.priceFor("USDC") ?: pm?.priceFor("USD"))
+                ?.let { equityUsd += it * margin.balance.toDouble(); valuedSomething = true }
+        }
+
+        val priced = pm != null && valuedSomething
+        val equityText = if (priced) formatUsd(equityUsd) else formatQty(round(nativeSum).toLong())
+        return HomePortfolio(
+            loading = false,
+            unavailable = false,
+            equityText = equityText,
+            priced = priced,
+            pricesStub = priced && prices.stub,
+            available = margin?.availableBalance,
+            unrealizedPnl = margin?.position?.takeIf { it.qty != 0L }?.unrealizedPnl,
+        )
+    }
+
+    // ---- Watchlist snapshot card ----
+
+    private fun buildWatchlist(favorites: Set<Int>, symbols: List<Instrument>): HomeWatchlist {
+        if (favorites.isEmpty()) {
+            return HomeWatchlist(loading = false, hasStarred = false, rows = emptyList())
+        }
+        val byId = symbols.associateBy { it.symbolId }
+        val rows = favorites.take(MAX_WATCH).sorted().map { id ->
+            val inst = byId[id]
+            HomeWatchRow(
+                symbolId = id,
+                symbol = inst?.symbol ?: fallbackSymbol(id),
+                lastPriceText = null,
+                changePct = null,
+            )
+        }
+        return HomeWatchlist(loading = false, hasStarred = true, rows = rows)
+    }
+
+    /**
+     * A best-effort per-row quote refresh (last trade / mid + candle % change), run after the initial
+     * frame so the watchlist snapshot shows live-ish prices. Each row is independent: a failed read
+     * simply leaves that row at "--". Called once from the screen's LaunchedEffect via [enrichWatchlist].
+     */
+    fun enrichWatchlist() {
+        val rows = _uiState.value.watchlist.rows
+        if (rows.isEmpty()) return
+        viewModelScope.launch {
+            rows.forEach { row ->
+                val id = row.symbolId
+                val last = (exchange.trades(id) as? ApiResult.Success)?.data?.firstOrNull()?.price
+                val book = (exchange.orderBook(id) as? ApiResult.Success)?.data
+                val rawPrice = last ?: book?.mid?.let { round(it).toLong() }
+                val candles = (exchange.candles(id, SPARK_INTERVAL_SEC) as? ApiResult.Success)?.data
+                val changePct = if (!candles.isNullOrEmpty()) {
+                    MarketSummaryMath.changePctOf(candles.map { it.close.toDouble() }, SPARK_POINTS)
+                } else {
+                    null
+                }
+                val priceText = rawPrice?.let { formatQty(it) }
+                _uiState.update { state ->
+                    state.copy(
+                        watchlist = state.watchlist.copy(
+                            rows = state.watchlist.rows.map {
+                                if (it.symbolId == id) {
+                                    it.copy(lastPriceText = priceText ?: it.lastPriceText, changePct = changePct ?: it.changePct)
+                                } else {
+                                    it
+                                }
+                            },
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    // ---- Recent activity card ----
+
+    private fun buildActivity(fillsRes: ApiResult<FillsFees>, symbols: List<Instrument>): HomeActivity {
+        return when (fillsRes) {
+            is ApiResult.Success -> {
+                val names = symbols.associate { it.symbolId to it.symbol }
+                val rows = fillsRes.data.fills.sortedByDescending { it.tsNs }.take(MAX_ACTIVITY).map { f ->
+                    val isBuy = f.side == OrderSide.BUY
+                    HomeActivityRow(
+                        symbol = names[f.symbolId] ?: fallbackSymbol(f.symbolId),
+                        sideLabel = when (f.side) {
+                            OrderSide.BUY -> "Buy"
+                            OrderSide.SELL -> "Sell"
+                            else -> "--"
+                        },
+                        isBuy = isBuy,
+                        qtyText = formatQty(f.qty),
+                        priceText = formatQty(f.price),
+                    )
+                }
+                HomeActivity(loading = false, unavailable = false, rows = rows)
+            }
+            is ApiResult.Failure -> HomeActivity(loading = false, unavailable = true)
+            is ApiResult.NetworkError -> HomeActivity(loading = false, unavailable = true)
+        }
+    }
+
+    // ---- Getting-started checklist ----
+
+    private fun buildOnboarding(
+        custodyRes: ApiResult<CustodyBalances>,
+        spotRes: ApiResult<SpotBalance>,
+        marginRes: ApiResult<MarginAccount>,
+        fillsRes: ApiResult<FillsFees>,
+    ): HomeOnboarding {
+        val custodyFunded: Boolean? = (custodyRes as? ApiResult.Success)?.data
+            ?.let { it.rows.any { r -> r.amount > 0.0 } }
+        // trading funded = spot OR margin available > 0. Only UNKNOWN when BOTH reads were unavailable.
+        val spotFunded = (spotRes as? ApiResult.Success)?.data?.assets?.any { it.available > 0L || it.balance > 0L }
+        val marginFunded = (marginRes as? ApiResult.Success)?.data?.let { it.availableBalance > 0L || it.balance > 0L }
+        val tradingFunded: Boolean? = when {
+            spotFunded == null && marginFunded == null -> null
+            spotFunded == true || marginFunded == true -> true
+            else -> false
+        }
+        val hasFirstTrade: Boolean? = (fillsRes as? ApiResult.Success)?.data?.let { it.fills.isNotEmpty() }
+
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(
+                custodyFunded = custodyFunded,
+                tradingFunded = tradingFunded,
+                hasFirstTrade = hasFirstTrade,
+            ),
+        )
+        return HomeOnboarding(
+            loading = false,
+            steps = steps,
+            dismissed = homePrefs.getBoolean(KEY_ONBOARDING_DISMISSED, false),
+        )
+    }
+
+    // ---- helpers ----
+
+    private fun readFavorites(): Set<Int> =
+        marketsPrefs.getStringSet(KEY_FAV, emptySet()).orEmpty().mapNotNull { it.toIntOrNull() }.toSet()
+
+    private fun formatUsd(v: Double): String = "$" + String.format(Locale.US, "%,.2f", v)
+
+    private fun formatQty(v: Long): String = String.format(Locale.US, "%,d", v)
+
+    private fun fallbackSymbol(symbolId: Int): String = when (symbolId) {
+        1 -> "BTCUSDC"
+        2 -> "ETHUSDC"
+        3 -> "SOLUSDC"
+        else -> "#" + symbolId
+    }
+
+    private companion object {
+        const val MARKETS_PREFS = "markets_prefs"
+        const val KEY_FAV = "favorites"
+        const val HOME_PREFS = "home_prefs"
+        const val KEY_ONBOARDING_DISMISSED = "onboarding_all_set_dismissed"
+        const val MAX_WATCH = 6
+        const val MAX_ACTIVITY = 5
+        const val SPARK_INTERVAL_SEC = 60
+        const val SPARK_POINTS = 30
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
@@ -8,6 +8,7 @@ import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.Instrument
 import com.testlogon.android.data.exchange.TradingUiPrefsStore
 import com.testlogon.android.data.exchange.alerts.TradingAlertKind
+import com.testlogon.android.data.exchange.alerts.PriceAlertsEvaluator
 import com.testlogon.android.data.exchange.alerts.TradingAlertsPoller
 import com.testlogon.android.feature.markets.trade.TradingNotifier
 import kotlinx.coroutines.flow.SharingStarted
@@ -34,6 +35,7 @@ class MarketsViewModel @Inject constructor(
     private val repository: ExchangeRepository,
     private val prefsStore: TradingUiPrefsStore,
     private val alertsPoller: TradingAlertsPoller,
+    private val priceAlerts: PriceAlertsEvaluator,
     private val notifier: TradingNotifier,
     @ApplicationContext appContext: Context,
 ) : ViewModel() {
@@ -140,11 +142,14 @@ class MarketsViewModel @Inject constructor(
     private suspend fun pollQuotes(instruments: List<Instrument>) {
         var tick = 0
         while (viewModelScope.isActive) {
+            val lastTicks = HashMap<Int, Long>()
             for (instrument in instruments) {
                 val book = (repository.orderBook(instrument.symbolId) as? ApiResult.Success)?.data
                 val last = (repository.trades(instrument.symbolId) as? ApiResult.Success)
                     ?.data?.firstOrNull()?.price
                 val lastPrice = last?.let { instrument.display(it) } ?: book?.mid
+                val rawLast = last ?: book?.mid?.let { kotlin.math.round(it).toLong() }
+                if (rawLast != null) lastTicks[instrument.symbolId] = rawLast
 
                 // Candle-derived sparkline + % change; refreshed less often than the quote poll.
                 var spark: List<Float>? = null
@@ -176,6 +181,9 @@ class MarketsViewModel @Inject constructor(
                         },
                     )
                 }
+            }
+            priceAlerts.evaluate(lastTicks, instruments).forEach { alert ->
+                notifier.notifyTradingAlert(title = alert.title, body = alert.body, distress = false)
             }
             tick++
             delay(POLL_MS)

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/SymbolDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/SymbolDetailScreen.kt
@@ -222,7 +222,12 @@ private fun SymbolDetailContent(
             }
 
             DetailTab.TRADE -> item {
-                TradeTicket(lastPrice = state.candles.lastOrNull()?.close, viewModel = tradingViewModel)
+                TradeTicket(
+                    lastPrice = state.candles.lastOrNull()?.close,
+                    bestBid = state.orderBook?.bestBid,
+                    bestAsk = state.orderBook?.bestAsk,
+                    viewModel = tradingViewModel,
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/TradingAlertsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/TradingAlertsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AddAlert
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material3.Icon
@@ -56,6 +57,7 @@ import com.testlogon.android.feature.markets.ui.MarketSurface
 @Composable
 fun TradingAlertsRoute(
     onBack: () -> Unit,
+    onOpenPriceAlerts: () -> Unit = {},
     viewModel: TradingAlertsViewModel = hiltViewModel(),
 ) {
     val alerts by viewModel.alerts.collectAsStateWithLifecycle()
@@ -66,6 +68,7 @@ fun TradingAlertsRoute(
                 unread = unread,
                 hasAlerts = alerts.isNotEmpty(),
                 onBack = onBack,
+                onOpenPriceAlerts = onOpenPriceAlerts,
                 onMarkAllRead = viewModel::markAllRead,
                 onClear = viewModel::clear,
             )
@@ -105,6 +108,7 @@ private fun AlertsHeader(
     unread: Int,
     hasAlerts: Boolean,
     onBack: () -> Unit,
+    onOpenPriceAlerts: () -> Unit,
     onMarkAllRead: () -> Unit,
     onClear: () -> Unit,
 ) {
@@ -124,6 +128,9 @@ private fun AlertsHeader(
                 color = if (unread > 0) MarketColors.Accent else MarketColors.TextSecondary,
                 fontSize = 12.sp,
             )
+        }
+        IconButton(onClick = onOpenPriceAlerts, modifier = Modifier.testTag("open_price_alerts")) {
+            Icon(Icons.Filled.AddAlert, contentDescription = "Price alerts", tint = MarketColors.TextSecondary)
         }
         if (hasAlerts) {
             IconButton(onClick = onMarkAllRead, modifier = Modifier.testTag("alerts_mark_read")) {
@@ -187,6 +194,7 @@ private fun kindColor(kind: TradingAlertKind): Color = when (kind) {
     TradingAlertKind.MARGIN_DISTRESS -> MarketColors.Down
     TradingAlertKind.FUNDING -> MarketColors.Accent
     TradingAlertKind.PM_RESOLVED -> MarketColors.Accent
+    TradingAlertKind.PRICE -> MarketColors.Accent
 }
 
 private fun kindLabel(kind: TradingAlertKind): String = when (kind) {
@@ -195,4 +203,5 @@ private fun kindLabel(kind: TradingAlertKind): String = when (kind) {
     TradingAlertKind.MARGIN_DISTRESS -> "MARGIN"
     TradingAlertKind.FUNDING -> "FUNDING"
     TradingAlertKind.PM_RESOLVED -> "RESOLVED"
+    TradingAlertKind.PRICE -> "PRICE"
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsScreen.kt
@@ -1,0 +1,296 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.markets.alerts.pricealerts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.alerts.PriceAlert
+import com.testlogon.android.data.exchange.alerts.PriceAlertDirection
+import com.testlogon.android.feature.markets.ui.MarketColors
+import com.testlogon.android.feature.markets.ui.MarketSurface
+
+/**
+ * Price Alerts management route: an add form (symbol picker + above/below + price + optional note) over
+ * a list of the user's active + triggered alerts, each showing the live current price with delete and
+ * (for triggered) re-arm. Reachable from the Trading Alerts screen. Renders on the dark exchange palette.
+ */
+@Composable
+fun PriceAlertsRoute(
+    onBack: () -> Unit,
+    viewModel: PriceAlertsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    MarketSurface {
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            Header(onBack = onBack)
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().testTag("price_alerts_list"),
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                item {
+                    AddAlertForm(
+                        instruments = state.instruments,
+                        onAdd = { sym, dir, price, note -> viewModel.add(sym, dir, price, note) },
+                    )
+                }
+                if (state.alerts.isEmpty()) {
+                    item { EmptyState() }
+                } else {
+                    if (state.active.isNotEmpty()) {
+                        item { SectionLabel("ACTIVE") }
+                        items(state.active, key = { it.id }) { alert ->
+                            AlertRow(alert, state.instrument(alert.symbolId), state.lastFor(alert.symbolId),
+                                onDelete = { viewModel.delete(alert.id) }, onRearm = null)
+                        }
+                    }
+                    if (state.triggered.isNotEmpty()) {
+                        item { SectionLabel("TRIGGERED") }
+                        items(state.triggered, key = { it.id }) { alert ->
+                            AlertRow(alert, state.instrument(alert.symbolId), state.lastFor(alert.symbolId),
+                                onDelete = { viewModel.delete(alert.id) }, onRearm = { viewModel.rearm(alert.id) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Header(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(start = 4.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = MarketColors.TextPrimary)
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text("Price alerts", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 22.sp)
+            Text("Notify me when a symbol crosses a price", color = MarketColors.TextSecondary, fontSize = 12.sp)
+        }
+    }
+}
+
+@Composable
+private fun AddAlertForm(
+    instruments: List<Instrument>,
+    onAdd: (Int, PriceAlertDirection, String, String?) -> Boolean,
+) {
+    var symbolId by remember(instruments) { mutableStateOf(instruments.firstOrNull()?.symbolId) }
+    var direction by remember { mutableStateOf(PriceAlertDirection.ABOVE) }
+    var price by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
+            .background(MarketColors.Surface).border(1.dp, MarketColors.Border, RoundedCornerShape(12.dp))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text("New alert", color = MarketColors.TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            SymbolPicker(instruments = instruments, selected = symbolId, onSelect = { symbolId = it },
+                modifier = Modifier.weight(1f))
+            DirectionToggle(direction = direction, onSelect = { direction = it })
+        }
+        OutlinedTextField(
+            value = price, onValueChange = { price = it; error = null },
+            label = { Text("Price") }, singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+            modifier = Modifier.fillMaxWidth().testTag("price_alert_price"),
+        )
+        OutlinedTextField(
+            value = note, onValueChange = { note = it },
+            label = { Text("Note (optional)") }, singleLine = true,
+            modifier = Modifier.fillMaxWidth().testTag("price_alert_note"),
+        )
+        error?.let { Text(it, color = MarketColors.Down, fontSize = 12.sp) }
+        Box(
+            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+                .background(MarketColors.Accent).clickable {
+                    val sym = symbolId
+                    if (sym == null) { error = "Pick a symbol" }
+                    else if (!onAdd(sym, direction, price, note)) { error = "Enter a valid price" }
+                    else { price = ""; note = ""; error = null }
+                }.padding(vertical = 12.dp).testTag("price_alert_add"),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text("Add alert", color = MarketColors.Bg, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+        }
+    }
+}
+
+@Composable
+private fun SymbolPicker(
+    instruments: List<Instrument>,
+    selected: Int?,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val label = instruments.firstOrNull { it.symbolId == selected }?.symbol ?: "Symbol"
+    Box(modifier = modifier) {
+        Box(
+            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
+                .border(1.dp, MarketColors.Border, RoundedCornerShape(8.dp))
+                .clickable { expanded = true }.padding(horizontal = 12.dp, vertical = 12.dp)
+                .testTag("price_alert_symbol"),
+        ) {
+            Text(label, color = MarketColors.TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            instruments.forEach { instrument ->
+                DropdownMenuItem(
+                    text = { Text(instrument.symbol) },
+                    onClick = { onSelect(instrument.symbolId); expanded = false },
+                    modifier = Modifier.testTag("price_alert_symbol_${instrument.symbolId}"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DirectionToggle(direction: PriceAlertDirection, onSelect: (PriceAlertDirection) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        Chip("Above", direction == PriceAlertDirection.ABOVE, MarketColors.Up) { onSelect(PriceAlertDirection.ABOVE) }
+        Chip("Below", direction == PriceAlertDirection.BELOW, MarketColors.Down) { onSelect(PriceAlertDirection.BELOW) }
+    }
+}
+
+@Composable
+private fun Chip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier.clip(RoundedCornerShape(8.dp))
+            .background(if (selected) accent else MarketColors.SurfaceAlt)
+            .border(1.dp, if (selected) accent else MarketColors.Border, RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick).padding(horizontal = 14.dp, vertical = 12.dp)
+            .testTag("price_alert_dir_${label.lowercase()}"),
+    ) {
+        Text(label, color = if (selected) MarketColors.Bg else MarketColors.TextSecondary,
+            fontWeight = FontWeight.SemiBold, fontSize = 13.sp)
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(text, color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace,
+        fontWeight = FontWeight.Bold, fontSize = 11.sp,
+        modifier = Modifier.padding(top = 6.dp, start = 4.dp))
+}
+
+@Composable
+private fun AlertRow(
+    alert: PriceAlert,
+    instrument: Instrument?,
+    lastTicks: Long?,
+    onDelete: () -> Unit,
+    onRearm: (() -> Unit)?,
+) {
+    val accent = if (alert.direction == PriceAlertDirection.ABOVE) MarketColors.Up else MarketColors.Down
+    val label = instrument?.symbol ?: ("#" + alert.symbolId)
+    val dir = if (alert.direction == PriceAlertDirection.ABOVE) "above" else "below"
+    val threshold = instrument?.display(alert.priceTicks)?.let { fmt(it) } ?: alert.priceTicks.toString()
+    val current = lastTicks?.let { instrument?.display(it)?.let(::fmt) ?: it.toString() }
+    Row(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
+            .background(MarketColors.Surface).border(1.dp, MarketColors.Border, RoundedCornerShape(12.dp))
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("$label $dir $threshold", color = MarketColors.TextPrimary,
+                    fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+                Spacer(Modifier.width(8.dp))
+                Box(modifier = Modifier.size(6.dp).clip(RoundedCornerShape(3.dp)).background(accent))
+            }
+            Spacer(Modifier.size(3.dp))
+            Text(
+                buildString {
+                    append("current ").append(current ?: "—")
+                    if (alert.triggeredTs != null) append("  •  triggered")
+                    alert.note?.let { append("  •  ").append(it) }
+                },
+                color = MarketColors.TextSecondary, fontSize = 12.sp,
+            )
+        }
+        if (onRearm != null) {
+            Box(
+                modifier = Modifier.clip(RoundedCornerShape(8.dp))
+                    .border(1.dp, MarketColors.Accent, RoundedCornerShape(8.dp))
+                    .clickable(onClick = onRearm).padding(horizontal = 12.dp, vertical = 8.dp)
+                    .testTag("price_alert_rearm_${alert.id}"),
+            ) {
+                Text("Re-arm", color = MarketColors.Accent, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+            }
+            Spacer(Modifier.width(6.dp))
+        }
+        IconButton(onClick = onDelete, modifier = Modifier.testTag("price_alert_delete_${alert.id}")) {
+            Icon(Icons.Filled.Delete, contentDescription = "Delete", tint = MarketColors.TextSecondary)
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("No price alerts", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        Spacer(Modifier.size(6.dp))
+        Text("Add one above to be notified when a symbol crosses your price.",
+            color = MarketColors.TextSecondary, fontSize = 13.sp)
+    }
+}
+
+private fun fmt(v: Double): String =
+    if (v == v.toLong().toDouble()) v.toLong().toString() else v.toString()

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsUiState.kt
@@ -1,0 +1,23 @@
+package com.testlogon.android.feature.markets.alerts.pricealerts
+
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.alerts.PriceAlert
+
+/**
+ * Immutable state for the Price Alerts management screen.
+ *
+ * [instruments] is the symbol catalogue for the add-form picker; [lastTicks] is the latest raw last
+ * price per symbolId (updated by the on-screen poll) used to render each alert's "current price" and
+ * to validate the add form. [alerts] is the persisted user-authored set (newest-created first).
+ */
+data class PriceAlertsUiState(
+    val alerts: List<PriceAlert> = emptyList(),
+    val instruments: List<Instrument> = emptyList(),
+    val lastTicks: Map<Int, Long> = emptyMap(),
+) {
+    val active: List<PriceAlert> get() = alerts.filter { it.armed && it.triggeredTs == null }
+    val triggered: List<PriceAlert> get() = alerts.filter { !(it.armed && it.triggeredTs == null) }
+
+    fun instrument(symbolId: Int): Instrument? = instruments.firstOrNull { it.symbolId == symbolId }
+    fun lastFor(symbolId: Int): Long? = lastTicks[symbolId]
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsViewModel.kt
@@ -1,0 +1,112 @@
+package com.testlogon.android.feature.markets.alerts.pricealerts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.alerts.PriceAlert
+import com.testlogon.android.data.exchange.alerts.PriceAlertDirection
+import com.testlogon.android.data.exchange.alerts.PriceAlertsEvaluator
+import com.testlogon.android.feature.markets.trade.TradingNotifier
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Drives the Price Alerts management screen. The alerts list is the persisted evaluator store stream;
+ * the VM additionally loads the symbol catalogue for the add-form picker and polls each symbol's last
+ * price (reusing [ExchangeRepository], consistent with the on-screen polling elsewhere) so each row
+ * shows its live current price. It ALSO runs the evaluator on that same poll so an alert fires + notifies
+ * even while the user is sitting on this screen (not only from the Markets list).
+ */
+@HiltViewModel
+class PriceAlertsViewModel @Inject constructor(
+    private val evaluator: PriceAlertsEvaluator,
+    private val repository: ExchangeRepository,
+    private val notifier: TradingNotifier,
+) : ViewModel() {
+
+    private val _lastTicks = MutableStateFlow<Map<Int, Long>>(emptyMap())
+    private val _instruments = MutableStateFlow<List<Instrument>>(emptyList())
+
+    val uiState: StateFlow<PriceAlertsUiState> =
+        combine(evaluator.alerts(), _instruments, _lastTicks) { alerts, instruments, ticks ->
+            PriceAlertsUiState(alerts = alerts, instruments = instruments, lastTicks = ticks)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), PriceAlertsUiState())
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            val instruments = (repository.symbols() as? ApiResult.Success)?.data.orEmpty()
+            _instruments.value = instruments
+            pollPrices(instruments)
+        }
+    }
+
+    /** Poll last prices per symbol + run the evaluator while the screen is alive. */
+    private suspend fun pollPrices(instruments: List<Instrument>) {
+        while (viewModelScope.isActive) {
+            val ticks = HashMap<Int, Long>()
+            for (instrument in instruments) {
+                val last = (repository.trades(instrument.symbolId) as? ApiResult.Success)
+                    ?.data?.firstOrNull()?.price
+                val book = (repository.orderBook(instrument.symbolId) as? ApiResult.Success)?.data
+                val raw = last ?: book?.mid?.let { kotlin.math.round(it).toLong() }
+                if (raw != null) ticks[instrument.symbolId] = raw
+            }
+            _lastTicks.update { ticks.ifEmpty { it } }
+            evaluator.evaluate(ticks, instruments).forEach { alert ->
+                notifier.notifyTradingAlert(title = alert.title, body = alert.body, distress = false)
+            }
+            delay(POLL_MS)
+        }
+    }
+
+    /**
+     * Add an alert from the form. [priceText] is the user's decimal input, converted to raw ticks via
+     * the symbol scaler ([Instrument.priceScaler]). Returns false (and adds nothing) on invalid input.
+     */
+    fun add(symbolId: Int, direction: PriceAlertDirection, priceText: String, note: String?): Boolean {
+        val instrument = _instruments.value.firstOrNull { it.symbolId == symbolId } ?: return false
+        val ticks = parseTicks(priceText, instrument) ?: return false
+        val alert = PriceAlert(
+            id = UUID.randomUUID().toString(),
+            symbolId = symbolId,
+            direction = direction,
+            priceTicks = ticks,
+            note = note?.trim()?.takeIf { it.isNotEmpty() },
+            createdTs = System.currentTimeMillis(),
+        )
+        viewModelScope.launch { evaluator.add(alert) }
+        return true
+    }
+
+    fun delete(id: String) = viewModelScope.launch { evaluator.delete(id) }
+    fun rearm(id: String) = viewModelScope.launch { evaluator.rearm(id) }
+
+    companion object {
+        private const val POLL_MS = 2_000L
+
+        /** Convert a user decimal string into raw ticks: round(decimal * priceScaler). Null if invalid. */
+        fun parseTicks(priceText: String, instrument: Instrument): Long? {
+            val value = priceText.trim().toDoubleOrNull() ?: return null
+            if (value <= 0.0 || value.isNaN() || value.isInfinite()) return null
+            val scaler = instrument.priceScaler.coerceAtLeast(1)
+            return kotlin.math.round(value * scaler).toLong()
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/OrderMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/OrderMath.kt
@@ -1,0 +1,86 @@
+package com.testlogon.android.feature.markets.trade
+
+import com.testlogon.android.data.exchange.OrderSide
+
+/**
+ * Pure order-entry math for the trade ticket. All prices/quantities are raw int64 ticks (scaler = 1),
+ * matching the rest of the trading stack. Every function is side-effect free and null/zero-guarded so
+ * it can be unit-tested and called freely from Compose recomposition.
+ *
+ * Margin impact + estimated liquidation price rely on per-symbol initial/maintenance margin bps that
+ * the live feeds do NOT currently expose to the client (only the admin config form + the liquidation-fee
+ * bps from the fee schedule are readable). When real bps aren't available the UI falls back to
+ * [DEFAULT_INITIAL_MARGIN_BPS]/[DEFAULT_MAINTENANCE_MARGIN_BPS] and tags the numbers "(est.)" so a
+ * fabricated precise figure is never shown as authoritative.
+ */
+object OrderMath {
+
+    /** Assumed venue defaults used ONLY when the symbol's real margin bps are unreadable (tag as est.). */
+    const val DEFAULT_INITIAL_MARGIN_BPS = 1000L      // 10%  (10x max leverage)
+    const val DEFAULT_MAINTENANCE_MARGIN_BPS = 500L   // 5%
+
+    /** Exact notional = price x qty. Null when either input is missing; never negative for sane inputs. */
+    fun notional(price: Long?, qty: Long?): Long? {
+        if (price == null || qty == null) return null
+        return price * qty
+    }
+
+    /**
+     * Max whole quantity affordable at [price] from [available] balance, with no leverage
+     * (available / price, floored). Returns 0 when price/available are non-positive.
+     */
+    fun maxQtyForBalance(available: Long?, price: Long?): Long {
+        if (available == null || price == null || price <= 0L || available <= 0L) return 0L
+        return available / price
+    }
+
+    /**
+     * A percentage [pct] (0..100) of the max affordable quantity at [price]. A positive pct floors to at
+     * least 1 (so "25%" of a tiny balance still stages a tradeable qty); 0 stays 0.
+     */
+    fun qtyForPercent(available: Long?, price: Long?, pct: Int): Long {
+        val max = maxQtyForBalance(available, price)
+        if (max <= 0L) return 0L
+        val q = max * pct.toLong() / 100L
+        return if (pct > 0) q.coerceAtLeast(1L) else 0L
+    }
+
+    /**
+     * Position size from a fixed risk budget: qty = floor(riskAmount / |entry - stop|). The stop distance
+     * is the per-unit loss if the stop is hit, so risk / loss-per-unit = units to buy. Returns 0 when the
+     * risk amount is non-positive or entry == stop (zero/undefined distance).
+     */
+    fun riskSizedQty(riskAmount: Long?, entry: Long?, stop: Long?): Long {
+        if (riskAmount == null || entry == null || stop == null) return 0L
+        if (riskAmount <= 0L) return 0L
+        val dist = kotlin.math.abs(entry - stop)
+        if (dist <= 0L) return 0L
+        return riskAmount / dist
+    }
+
+    /**
+     * Initial margin a position of [notional] locks at [initialMarginBps] bps (round to nearest tick).
+     * 0 when inputs are non-positive.
+     */
+    fun marginRequired(notional: Long?, initialMarginBps: Long): Long {
+        if (notional == null || notional <= 0L || initialMarginBps <= 0L) return 0L
+        return Math.round(notional.toDouble() * initialMarginBps.toDouble() / 10_000.0)
+    }
+
+    /**
+     * Estimated liquidation price for a fresh position opened at [entry] on [side], given the
+     * [maintenanceMarginBps]. Long liquidates below entry, short above, by the maintenance fraction:
+     *   long:  entry * (1 - mmr)
+     *   short: entry * (1 + mmr)
+     * where mmr = maintenanceMarginBps / 10000. Null when entry is non-positive. This is a first-order
+     * estimate (ignores fees, funding, cross-margin from other positions) and must be surfaced as "(est.)".
+     */
+    fun estLiquidationPrice(entry: Long?, side: OrderSide, maintenanceMarginBps: Long): Long? {
+        if (entry == null || entry <= 0L) return null
+        if (maintenanceMarginBps <= 0L) return null
+        val mmr = maintenanceMarginBps.toDouble() / 10_000.0
+        val factor = if (side == OrderSide.BUY) (1.0 - mmr) else (1.0 + mmr)
+        val liq = Math.round(entry.toDouble() * factor)
+        return liq.coerceAtLeast(0L)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -56,6 +56,8 @@ import java.util.Locale
 fun TradeTicket(
     lastPrice: Long?,
     modifier: Modifier = Modifier,
+    bestBid: Long? = null,
+    bestAsk: Long? = null,
     viewModel: TradingViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -87,7 +89,7 @@ fun TradeTicket(
         Spacer(Modifier.height(12.dp))
 
         when (state.section) {
-            TicketSection.TRADE -> TradeSection(state, lastPrice, viewModel)
+            TicketSection.TRADE -> TradeSection(state, lastPrice, bestBid, bestAsk, viewModel)
             TicketSection.POSITIONS -> PositionsSection(state, lastPrice, viewModel)
             TicketSection.ORDERS -> OrdersSection(state, viewModel)
             TicketSection.FILLS -> FillsSection(state)
@@ -130,7 +132,7 @@ fun TradeTicket(
 // ======================= Sections =======================
 
 @Composable
-private fun TradeSection(state: TradingUiState, lastPrice: Long?, viewModel: TradingViewModel) {
+private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?, bestAsk: Long?, viewModel: TradingViewModel) {
     val sideColor = if (state.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down
     var showDepositConfirm by remember { mutableStateOf(false) }
 
@@ -150,6 +152,18 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, viewModel: Tra
     // Reference price for %-of-buying-power sizing.
     val refPrice = state.priceLong ?: state.stopLong ?: lastPrice
 
+    // One-click bid/ask/market prefill (limit-order types only; the user still submits via the normal flow).
+    if (state.pm == null && state.orderType != OrderType.QUOTE && state.orderType != OrderType.FUNDING) {
+        QuickQuoteRow(
+            bestBid = bestBid,
+            bestAsk = bestAsk,
+            onBuyBid = { viewModel.prefillBuyAtBid(bestBid) },
+            onSellAsk = { viewModel.prefillSellAtAsk(bestAsk) },
+            onMarket = { viewModel.prefillMarket(state.side) },
+        )
+        Spacer(Modifier.height(10.dp))
+    }
+
     when (state.orderType) {
         OrderType.LIMIT -> {
             StepperField("Price", state.priceText, viewModel::setPrice) { viewModel.stepPrice(it) }
@@ -163,7 +177,8 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, viewModel: Tra
                 NumberField("Expires in (minutes)", state.expiryMinText, viewModel::setExpiryMin)
             }
             Spacer(Modifier.height(8.dp))
-            OrderValueRow(state.orderValue, state.account?.availableBalance)
+            OrderPreview(state, refPrice, viewModel)
+            RiskCalculator(state, refPrice, viewModel)
             AdvancedSection(state, viewModel)
         }
         OrderType.MARKET -> {
@@ -171,6 +186,9 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, viewModel: Tra
             QtyPercentRow { viewModel.setQtyPercent(it, refPrice) }
             Spacer(Modifier.height(4.dp))
             Text("Market order — fills immediately at the best available price.", color = MarketColors.TextSecondary, fontSize = 11.sp)
+            Spacer(Modifier.height(8.dp))
+            OrderPreview(state, refPrice, viewModel)
+            RiskCalculator(state, refPrice, viewModel)
             AdvancedSection(state, viewModel)
         }
         OrderType.STOP -> {
@@ -923,6 +941,218 @@ private fun OrderTypeRow(selected: OrderType, onSelect: (OrderType) -> Unit) {
                     .testTag("otype_${t.name}")
                     .padding(horizontal = 12.dp, vertical = 7.dp),
             )
+        }
+    }
+}
+
+@Composable
+private fun QuickQuoteRow(
+    bestBid: Long?,
+    bestAsk: Long?,
+    onBuyBid: () -> Unit,
+    onSellAsk: () -> Unit,
+    onMarket: () -> Unit,
+) {
+    Column(Modifier.fillMaxWidth()) {
+        Text("One-click", color = MarketColors.TextSecondary, fontSize = 11.sp)
+        Spacer(Modifier.height(3.dp))
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            QuickQuoteBtn(
+                label = "Buy @ bid",
+                sub = bestBid?.let { fmt(it.toDouble()) } ?: "--",
+                color = MarketColors.Up,
+                enabled = bestBid != null && bestBid > 0L,
+                tag = "quick_buy_bid",
+                modifier = Modifier.weight(1f),
+                onClick = onBuyBid,
+            )
+            QuickQuoteBtn(
+                label = "Sell @ ask",
+                sub = bestAsk?.let { fmt(it.toDouble()) } ?: "--",
+                color = MarketColors.Down,
+                enabled = bestAsk != null && bestAsk > 0L,
+                tag = "quick_sell_ask",
+                modifier = Modifier.weight(1f),
+                onClick = onSellAsk,
+            )
+            QuickQuoteBtn(
+                label = "Market",
+                sub = "now",
+                color = MarketColors.Accent,
+                enabled = true,
+                tag = "quick_market",
+                modifier = Modifier.weight(1f),
+                onClick = onMarket,
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickQuoteBtn(
+    label: String,
+    sub: String,
+    color: Color,
+    enabled: Boolean,
+    tag: String,
+    modifier: Modifier,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(MarketColors.Surface)
+            .border(1.dp, if (enabled) color else MarketColors.Border, RoundedCornerShape(8.dp))
+            .clickable(enabled = enabled, onClick = onClick)
+            .testTag(tag)
+            .padding(vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(label, color = if (enabled) color else MarketColors.TextFaint, fontWeight = FontWeight.Bold, fontSize = 11.sp)
+        Text(sub, color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 10.sp)
+    }
+}
+
+/**
+ * Live order preview: exact notional, buying power (max affordable qty) with a Max action, and - tagged
+ * "(est.)" because the symbol's real initial/maintenance margin bps aren't exposed to the client - the
+ * initial margin the order would lock plus a first-order estimated liquidation price.
+ */
+@Composable
+private fun OrderPreview(state: TradingUiState, refPrice: Long?, viewModel: TradingViewModel) {
+    val notional = OrderMath.notional(refPrice, state.qtyLong)
+    val avail = state.account?.availableBalance
+    val maxQty = OrderMath.maxQtyForBalance(avail, refPrice)
+    val exceeds = notional != null && avail != null && notional > avail
+    val imBps = OrderMath.DEFAULT_INITIAL_MARGIN_BPS
+    val mmBps = OrderMath.DEFAULT_MAINTENANCE_MARGIN_BPS
+    val margin = OrderMath.marginRequired(notional, imBps)
+    val liq = OrderMath.estLiquidationPrice(refPrice, state.side, mmBps)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MarketColors.Surface)
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(8.dp))
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+            .testTag("order_preview"),
+    ) {
+        PreviewLine("Notional", notional?.let { fmt(it.toDouble()) } ?: "--", if (exceeds) MarketColors.Down else MarketColors.TextPrimary)
+        Spacer(Modifier.height(4.dp))
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+            Text("Buying power", color = MarketColors.TextSecondary, fontSize = 12.sp)
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = if (maxQty > 0L) "$maxQty @ ${refPrice?.let { fmt(it.toDouble()) } ?: "--"}" else "--",
+                    color = MarketColors.TextPrimary,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 12.sp,
+                )
+                Text(
+                    text = "Max",
+                    color = if (maxQty > 0L) MarketColors.Accent else MarketColors.TextFaint,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 11.sp,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .border(1.dp, if (maxQty > 0L) MarketColors.Accent else MarketColors.Border, RoundedCornerShape(6.dp))
+                        .clickable(enabled = maxQty > 0L) { viewModel.setMaxQty(refPrice) }
+                        .testTag("preview_max")
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                )
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        PreviewLine("Margin impact (est.)", if (margin > 0L) fmt(margin.toDouble()) else "--", MarketColors.TextPrimary)
+        Spacer(Modifier.height(4.dp))
+        PreviewLine("Est. liquidation (est.)", liq?.let { fmt(it.toDouble()) } ?: "--", MarketColors.TextPrimary)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Margin/liq. use assumed ${imBps / 100}%/${mmBps / 100}% (venue margin bps not exposed) - indicative only.",
+            color = MarketColors.TextFaint,
+            fontSize = 10.sp,
+        )
+    }
+}
+
+@Composable
+private fun PreviewLine(label: String, value: String, valueColor: Color) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label, color = MarketColors.TextSecondary, fontSize = 12.sp)
+        Text(value, color = valueColor, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.SemiBold, fontSize = 12.sp)
+    }
+}
+
+/**
+ * Collapsible position-size / risk calculator: risk amount + stop price -> qty = risk / |entry - stop|
+ * with an apply-to-ticket action, plus 25/50/100% of buying-power quick-size shortcuts.
+ */
+@Composable
+private fun RiskCalculator(state: TradingUiState, refPrice: Long?, viewModel: TradingViewModel) {
+    Spacer(Modifier.height(8.dp))
+    Text(
+        text = if (state.riskCalcOpen) "Risk calculator ▲" else "Risk calculator ▼",
+        color = MarketColors.Accent,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.clickable { viewModel.toggleRiskCalc() }.testTag("risk_calc_toggle").padding(vertical = 4.dp),
+    )
+    if (!state.riskCalcOpen) return
+    Spacer(Modifier.height(6.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(Modifier.weight(1f)) { NumberField("Risk amount", state.riskAmountText, viewModel::setRiskAmount) }
+        Box(Modifier.weight(1f)) { NumberField("Stop price", state.riskStopText, viewModel::setRiskStop) }
+    }
+    Spacer(Modifier.height(4.dp))
+    val entry = refPrice
+    val sizedQty = state.riskSizedQty(refPrice)
+    val dist = if (entry != null && state.riskStopLong != null) kotlin.math.abs(entry - state.riskStopLong!!) else null
+    Text(
+        text = when {
+            entry == null -> "Enter a price (entry) first."
+            state.riskStopLong == null || state.riskAmountLong == null -> "Enter risk amount + stop price."
+            dist != null && dist <= 0L -> "Stop must differ from entry."
+            sizedQty <= 0L -> "Risk too small for one unit at this stop distance."
+            else -> "Suggested size: $sizedQty units  (entry ${fmt(entry.toDouble())}, stop distance ${fmt((dist ?: 0L).toDouble())})"
+        },
+        color = if (sizedQty > 0L) MarketColors.TextPrimary else MarketColors.TextFaint,
+        fontFamily = FontFamily.Monospace,
+        fontSize = 11.sp,
+    )
+    Spacer(Modifier.height(6.dp))
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .clip(RoundedCornerShape(6.dp))
+                .background(if (sizedQty > 0L) MarketColors.Accent else MarketColors.SurfaceAlt)
+                .clickable(enabled = sizedQty > 0L) { viewModel.applyRiskSize(refPrice) }
+                .testTag("risk_apply")
+                .padding(vertical = 8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text("Apply to ticket", color = if (sizedQty > 0L) Color.Black else MarketColors.TextFaint, fontWeight = FontWeight.Bold, fontSize = 11.sp)
+        }
+    }
+    Spacer(Modifier.height(6.dp))
+    Text("Or size by buying power", color = MarketColors.TextSecondary, fontSize = 11.sp)
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        listOf(25, 50, 100).forEach { pct ->
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(MarketColors.Surface)
+                    .border(1.dp, MarketColors.Border, RoundedCornerShape(6.dp))
+                    .clickable { viewModel.setQtyPercent(pct, refPrice) }
+                    .testTag("risk_pct_$pct")
+                    .padding(vertical = 6.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(if (pct == 100) "Max" else "$pct%", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -105,6 +105,10 @@ data class TradingUiState(
     val section: TicketSection = TicketSection.TRADE,
     val armed: String? = null,        // "market" | "close" -> a confirm is pending (skipped when oneTap)
     val oneTap: Boolean = false,      // when true, market/close fire without a confirm step
+    // Position-size / risk calculator (collapsible). riskAmount + stop -> qty via OrderMath.
+    val riskCalcOpen: Boolean = false,
+    val riskAmountText: String = "",
+    val riskStopText: String = "",
     val pm: com.testlogon.android.data.exchange.PmState? = null,   // set when this symbol is a binary prediction market
     val isAdmin: Boolean = false,   // resolved from CurrentUserRepository; gates the margin-config panel
     val marginConfig: MarginConfigForm = MarginConfigForm(),
@@ -203,6 +207,37 @@ data class TradingUiState(
         OrderType.OCO -> (priceLong ?: 0L) > 0L && (qtyLong ?: 0L) > 0L && (childPriceLong ?: 0L) > 0L && (childQtyLong ?: 0L) > 0L
         OrderType.FUNDING -> (fundingRateLong ?: 0L) > 0L && (fundingQtyLong ?: 0L) > 0L
     }
+
+    // ---- Order-entry math (client-computed preview + sizing) ----
+
+    /** Available margin balance, or null when the account hasn't loaded. */
+    val availableBalance: Long? get() = account?.availableBalance
+
+    /** The price used for preview/sizing: the entered limit price, else the stop/trigger. */
+    val entryRefPrice: Long? get() = priceLong ?: stopLong
+
+    /** Exact notional (price x qty) for the ticket preview. */
+    val previewNotional: Long? get() = OrderMath.notional(entryRefPrice, qtyLong)
+
+    /** Max whole qty affordable at the reference price from available balance (no leverage). */
+    fun maxAffordableQty(refPrice: Long?): Long =
+        OrderMath.maxQtyForBalance(availableBalance, refPrice ?: entryRefPrice)
+
+    /** Risk-calculator inputs. */
+    val riskAmountLong: Long? get() = riskAmountText.toLongOrNull()
+    val riskStopLong: Long? get() = riskStopText.toLongOrNull()
+
+    /** qty implied by the risk budget + stop distance (0 when inputs are incomplete). */
+    fun riskSizedQty(refPrice: Long?): Long =
+        OrderMath.riskSizedQty(riskAmountLong, refPrice ?: entryRefPrice, riskStopLong)
+
+    /** Initial margin the current order would lock, using [initialMarginBps]. */
+    fun previewMarginRequired(initialMarginBps: Long): Long =
+        OrderMath.marginRequired(previewNotional, initialMarginBps)
+
+    /** Estimated liquidation price of the current order, using [maintenanceMarginBps]. */
+    fun previewLiquidationPrice(maintenanceMarginBps: Long): Long? =
+        OrderMath.estLiquidationPrice(entryRefPrice, side, maintenanceMarginBps)
 }
 
 

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -332,6 +332,54 @@ class TradingViewModel @Inject constructor(
         _uiState.update { it.copy(qtyText = q.toString(), armed = null) }
     }
 
+    /** Set qty to the maximum affordable at [refPrice] from available balance (no leverage). */
+    fun setMaxQty(refPrice: Long?) {
+        val avail = _uiState.value.account?.availableBalance
+        val max = OrderMath.maxQtyForBalance(avail, refPrice ?: _uiState.value.entryRefPrice)
+        if (max <= 0L) return
+        notifier.tick()
+        _uiState.update { it.copy(qtyText = max.toString(), armed = null) }
+    }
+
+    // ---- Position-size / risk calculator ----
+
+    fun toggleRiskCalc() = _uiState.update { it.copy(riskCalcOpen = !it.riskCalcOpen) }
+    fun setRiskAmount(text: String) = _uiState.update { it.copy(riskAmountText = digits(text, 15)) }
+    fun setRiskStop(text: String) = _uiState.update { it.copy(riskStopText = digits(text, 12)) }
+
+    /** Apply the risk-sized qty to the ticket (qty = riskAmount / |entry - stop|). No-op when it's 0. */
+    fun applyRiskSize(refPrice: Long?) {
+        val st = _uiState.value
+        val q = st.riskSizedQty(refPrice)
+        if (q <= 0L) return
+        notifier.tick()
+        _uiState.update { it.copy(qtyText = q.toString(), armed = null) }
+    }
+
+    // ---- One-click bid/ask / market prefills (the user still submits via the normal flow) ----
+
+    /** Prefill a Buy limit at the best bid. */
+    fun prefillBuyAtBid(bestBid: Long?) {
+        val px = bestBid ?: return
+        if (px <= 0L) return
+        notifier.tick()
+        _uiState.update { it.copy(orderType = OrderType.LIMIT, side = OrderSide.BUY, priceText = px.toString(), armed = null) }
+    }
+
+    /** Prefill a Sell limit at the best ask. */
+    fun prefillSellAtAsk(bestAsk: Long?) {
+        val px = bestAsk ?: return
+        if (px <= 0L) return
+        notifier.tick()
+        _uiState.update { it.copy(orderType = OrderType.LIMIT, side = OrderSide.SELL, priceText = px.toString(), armed = null) }
+    }
+
+    /** Switch the ticket to a Market order on [side] (qty preserved; user submits via the normal flow). */
+    fun prefillMarket(side: OrderSide) {
+        notifier.tick()
+        _uiState.update { it.copy(orderType = OrderType.MARKET, side = side, message = null, amendingClordid = null, armed = null) }
+    }
+
     fun stepQty(delta: Long) {
         notifier.tick()
         val n = ((_uiState.value.qtyText.toLongOrNull() ?: 0L) + delta).coerceAtLeast(0L)

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.PieChart
+import androidx.compose.material.icons.outlined.ShowChart
 import androidx.compose.material.icons.outlined.Assessment
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.Devices
@@ -968,6 +969,14 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_portfolio,
             icon = Icons.Outlined.PieChart,
             route = MoreRoutes.PORTFOLIO,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "pnl",
+            labelRes = R.string.more_entry_pnl,
+            icon = Icons.Outlined.ShowChart,
+            route = MoreRoutes.PNL,
             hub = MoreHub.WALLET,
             section = MoreSection.APP,
         ),

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -957,6 +957,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "home",
+            labelRes = R.string.more_entry_home,
+            icon = Icons.Outlined.Dashboard,
+            route = MoreRoutes.HOME,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "custody",
             labelRes = R.string.more_entry_custody,
             icon = Icons.Outlined.AccountBalance,

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlAnalytics.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlAnalytics.kt
@@ -1,0 +1,248 @@
+package com.testlogon.android.feature.pnl
+
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayment
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidation
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.OrderSide
+
+/**
+ * PURE, unit-testable PnL & performance analytics. NO Android / coroutine / Compose deps: the ViewModel
+ * fetches the four exchange reads (fills-fees, liquidations, funding payments, margin account) and hands
+ * them here; every derived number below is computed in plain Kotlin so it can be tested in isolation.
+ *
+ * Realized PnL uses AVERAGE-COST accounting per symbol: fills are walked oldest -> newest keeping a
+ * running (netQty, avgEntry). A same-side fill (extends the position) folds into a weighted average
+ * entry; an opposite-side fill CLOSES up to the open quantity and realizes (price - avgEntry) * closed
+ * * dir, where dir = +1 while the closed position was long and -1 while it was short. Closing beyond
+ * the open quantity flips the position and re-seeds avgEntry at the fill price for the residual.
+ *
+ * Net realized rolls the trade realizations together with the other cash legs:
+ *   net = sum(realized) - sum(fees) + sum(funding.payment signed) + sum(liq.realizedPnl) - sum(liq.fee)
+ *
+ * All amounts are raw integer engine units (Long); price scalers are 1 today (identity), so the caller
+ * formats for display.
+ */
+object PnlAnalytics {
+
+    /** Signed direction of a side: BUY = +1, SELL = -1, null (unknown) = 0 (ignored for realization). */
+    private fun dirOf(side: OrderSide?): Int = when (side) {
+        OrderSide.BUY -> 1
+        OrderSide.SELL -> -1
+        null -> 0
+    }
+
+    /**
+     * Per-symbol realized-PnL + activity accumulator produced by [realizedBySymbol]. [realized] is the
+     * average-cost trade realization for this symbol BEFORE the non-trade legs (fees/funding/liq).
+     * [volume] is sum(|qty|*price) over the symbol's fills. [closingTrades]/[winningTrades] drive win rate.
+     */
+    data class SymbolPnl(
+        val symbolId: Int,
+        val realized: Long,
+        val fees: Long,
+        val volume: Long,
+        val tradeCount: Int,
+        val closingTrades: Int,
+        val winningTrades: Int,
+    )
+
+    /**
+     * The full PnL snapshot the screen renders. [netRealized] already folds every cash leg together;
+     * [unrealized] comes from the margin account (position uPnL) and is passed through untouched. The
+     * per-symbol rows are sorted by descending |realized| so the biggest movers surface first.
+     */
+    data class PnlReport(
+        val netRealized: Long,
+        val tradeRealized: Long,
+        val unrealized: Long,
+        val totalFees: Long,
+        val fundingTotal: Long,
+        val liquidationPnl: Long,
+        val winRate: Float,
+        val closingTradeCount: Int,
+        val tradeCount: Int,
+        val volume: Long,
+        val bySymbol: List<SymbolPnl>,
+        val equityCurve: List<EquityPoint>,
+    ) {
+        val isEmpty: Boolean
+            get() = tradeCount == 0 && bySymbol.isEmpty() && equityCurve.isEmpty() &&
+                fundingTotal == 0L && liquidationPnl == 0L
+    }
+
+    /** One cumulative point on the equity curve: a nanosecond timestamp + the running net total to date. */
+    data class EquityPoint(val tsNs: Long, val cumulative: Long)
+
+    /** A dated realized-cash event, used to build the time-ordered [EquityPoint] curve. */
+    private data class CashEvent(val tsNs: Long, val amount: Long)
+
+    /**
+     * Walk each symbol's fills oldest -> newest keeping (netQty, avgEntry) and accumulate average-cost
+     * realized PnL, fees, notional volume, and win stats. One [SymbolPnl] per symbol that had a fill.
+     */
+    fun realizedBySymbol(fills: List<FillFee>): List<SymbolPnl> {
+        val bySymbol = fills.groupBy { it.symbolId }
+        return bySymbol.map { (symbolId, symbolFills) ->
+            var netQty = 0L
+            var avgEntry = 0L
+            var realized = 0L
+            var fees = 0L
+            var volume = 0L
+            var closing = 0
+            var winning = 0
+            // Oldest -> newest so the running average-cost basis is chronologically correct.
+            symbolFills.sortedBy { it.tsNs }.forEach { f ->
+                val dir = dirOf(f.side)
+                fees += f.fee
+                volume += Math.abs(f.qty) * f.price
+                if (dir == 0 || f.qty <= 0L) return@forEach
+                val signedQty = dir * f.qty
+                if (netQty == 0L || sameSign(netQty, signedQty)) {
+                    // Opening or extending: weighted-average the entry price into the (growing) position.
+                    val newQty = netQty + signedQty
+                    avgEntry = weightedEntry(netQty, avgEntry, f.qty, f.price)
+                    netQty = newQty
+                } else {
+                    // Opposite side: close against the open position (up to its size), realizing PnL.
+                    val closable = Math.min(f.qty, Math.abs(netQty))
+                    val posDir = if (netQty > 0) 1 else -1
+                    val pnl = (f.price - avgEntry) * closable * posDir
+                    realized += pnl
+                    closing += 1
+                    if (pnl > 0) winning += 1
+                    val remaining = Math.abs(netQty) - closable
+                    netQty = posDir.toLong() * remaining
+                    if (netQty == 0L) {
+                        avgEntry = 0L
+                        // Any residual beyond the close flips the position, re-seeded at the fill price.
+                        val flip = f.qty - closable
+                        if (flip > 0L) {
+                            netQty = dir.toLong() * flip
+                            avgEntry = f.price
+                        }
+                    }
+                }
+            }
+            SymbolPnl(
+                symbolId = symbolId,
+                realized = realized,
+                fees = fees,
+                volume = volume,
+                tradeCount = symbolFills.size,
+                closingTrades = closing,
+                winningTrades = winning,
+            )
+        }.sortedByDescending { Math.abs(it.realized) }
+    }
+
+    private fun sameSign(a: Long, b: Long): Boolean = (a > 0 && b > 0) || (a < 0 && b < 0)
+
+    /** Weighted-average entry price when adding [addQty] @ [addPrice] onto [heldQty] @ [heldEntry]. */
+    private fun weightedEntry(heldQty: Long, heldEntry: Long, addQty: Long, addPrice: Long): Long {
+        val held = Math.abs(heldQty)
+        val total = held + addQty
+        if (total == 0L) return 0L
+        return (held * heldEntry + addQty * addPrice) / total
+    }
+
+    /**
+     * Fold the four already-fetched reads into the full [PnlReport]. [unrealizedPnl] is the margin
+     * account's position uPnL (0 when flat / unavailable). Every non-trade cash leg (fees, funding,
+     * liquidation realized/fee) is rolled into [PnlReport.netRealized], and a time-ordered cumulative
+     * equity curve is built from ALL dated cash events (per-fill realized net-of-fee + funding + liq).
+     */
+    fun analyze(
+        fills: FillsFees,
+        liquidations: Liquidations,
+        funding: FundingPayments,
+        unrealizedPnl: Long,
+    ): PnlReport {
+        val bySymbol = realizedBySymbol(fills.fills)
+        val tradeRealized = bySymbol.sumOf { it.realized }
+        val totalFees = bySymbol.sumOf { it.fees }
+        val fundingTotal = funding.payments.sumOf { it.payment }
+        val liquidationPnl = liquidations.events.sumOf { it.realizedPnl }
+        val liquidationFees = liquidations.events.sumOf { it.fee }
+        val netRealized = tradeRealized - totalFees + fundingTotal + liquidationPnl - liquidationFees
+
+        val closingCount = bySymbol.sumOf { it.closingTrades }
+        val winningCount = bySymbol.sumOf { it.winningTrades }
+        val winRate = if (closingCount > 0) winningCount.toFloat() / closingCount.toFloat() else 0f
+        val volume = bySymbol.sumOf { it.volume }
+        val tradeCount = bySymbol.sumOf { it.tradeCount }
+
+        return PnlReport(
+            netRealized = netRealized,
+            tradeRealized = tradeRealized,
+            unrealized = unrealizedPnl,
+            totalFees = totalFees,
+            fundingTotal = fundingTotal,
+            liquidationPnl = liquidationPnl,
+            winRate = winRate,
+            closingTradeCount = closingCount,
+            tradeCount = tradeCount,
+            volume = volume,
+            bySymbol = bySymbol,
+            equityCurve = equityCurve(fills.fills, liquidations.events, funding.payments),
+        )
+    }
+
+    /**
+     * Build the cumulative equity curve: every dated cash event (per-symbol per-fill realized net of
+     * that fill's fee, funding payments, liquidation realized-minus-fee) is emitted, sorted by time, and
+     * accumulated into a running total. Realized-per-fill mirrors the average-cost walk in
+     * [realizedBySymbol] so the curve's final value reconciles with the roll-up (minus uPnL).
+     */
+    fun equityCurve(
+        fills: List<FillFee>,
+        liquidations: List<Liquidation>,
+        funding: List<FundingPayment>,
+    ): List<EquityPoint> {
+        val events = mutableListOf<CashEvent>()
+
+        // Per-symbol average-cost walk, emitting a signed cash event per fill (realized - fee).
+        fills.groupBy { it.symbolId }.forEach { (_, symbolFills) ->
+            var netQty = 0L
+            var avgEntry = 0L
+            symbolFills.sortedBy { it.tsNs }.forEach { f ->
+                var realized = 0L
+                val dir = dirOf(f.side)
+                if (dir != 0 && f.qty > 0L) {
+                    val signedQty = dir * f.qty
+                    if (netQty == 0L || sameSign(netQty, signedQty)) {
+                        avgEntry = weightedEntry(netQty, avgEntry, f.qty, f.price)
+                        netQty += signedQty
+                    } else {
+                        val closable = Math.min(f.qty, Math.abs(netQty))
+                        val posDir = if (netQty > 0) 1 else -1
+                        realized = (f.price - avgEntry) * closable * posDir
+                        val remaining = Math.abs(netQty) - closable
+                        netQty = posDir.toLong() * remaining
+                        if (netQty == 0L) {
+                            avgEntry = 0L
+                            val flip = f.qty - closable
+                            if (flip > 0L) {
+                                netQty = dir.toLong() * flip
+                                avgEntry = f.price
+                            }
+                        }
+                    }
+                }
+                events += CashEvent(f.tsNs, realized - f.fee)
+            }
+        }
+
+        funding.forEach { events += CashEvent(it.tsNs, it.payment) }
+        liquidations.forEach { events += CashEvent(it.tsNs, it.realizedPnl - it.fee) }
+
+        if (events.isEmpty()) return emptyList()
+        var running = 0L
+        return events.sortedBy { it.tsNs }.map { e ->
+            running += e.amount
+            EquityPoint(e.tsNs, running)
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlScreen.kt
@@ -1,0 +1,401 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.pnl
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.util.Locale
+
+/** Green/red for PnL, independent of the app theme (matches the markets/portfolio convention). */
+private val PnlUp = Color(0xFF16A34A)
+private val PnlDown = Color(0xFFDC2626)
+
+@Composable
+fun PnlRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PnlViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PnlScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PnlScreen(
+    state: PnlUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("PnL & performance") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when {
+            state.loading -> LoadingBlock(Modifier.padding(padding))
+            state.unavailable -> MessageBlock(
+                title = "Not available",
+                body = "Performance analytics aren't available on this deployment yet.",
+                modifier = Modifier.padding(padding),
+            )
+            state.error != null -> MessageBlock(
+                title = "Couldn't load",
+                body = state.error,
+                modifier = Modifier.padding(padding),
+            )
+            state.isEmpty -> MessageBlock(
+                title = "No trading activity yet",
+                body = "Your realized PnL, fees, and equity curve will appear here once you trade.",
+                modifier = Modifier.padding(padding),
+            )
+            else -> PnlContent(state, Modifier.padding(padding))
+        }
+    }
+}
+
+@Composable
+private fun PnlContent(state: PnlUiState, modifier: Modifier) {
+    val stats = state.stats ?: return
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { NetRealizedHeader(stats) }
+        item { EquityCurveCard(state.equityCurve) }
+        item { StatCardsGrid(stats) }
+        if (state.bySymbol.isNotEmpty()) {
+            item {
+                Text(
+                    "By symbol",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+            item { SymbolHeaderRow() }
+            items(count = state.bySymbol.size, key = { "sym_" + state.bySymbol[it].symbol + it }) { i ->
+                SymbolRowView(state.bySymbol[i])
+            }
+        }
+    }
+}
+
+@Composable
+private fun NetRealizedHeader(stats: PnlStats) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Net realized PnL",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = signed(stats.netRealized),
+                fontSize = 30.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = FontFamily.Monospace,
+                color = if (stats.isRealizedProfit) PnlUp else PnlDown,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Realized net of fees, funding, and liquidations (raw units).",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EquityCurveCard(points: List<EquityCurvePoint>) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Equity curve",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(12.dp))
+            if (points.size < 2) {
+                Text(
+                    "Not enough activity to plot a curve yet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                val line = if (points.last().cumulative >= 0) PnlUp else PnlDown
+                val grid = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)
+                EquityCanvas(points, line, grid)
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        "start " + signed(points.first().cumulative),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        "now " + signed(points.last().cumulative),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = if (points.last().cumulative >= 0) PnlUp else PnlDown,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Self-contained equity-curve Canvas (no library). Cumulative values can be NEGATIVE, so the y-range
+ * spans [min(0,minVal) .. max(0,maxVal)] and a zero baseline is drawn where the running total crosses
+ * zero. x is evenly spaced by index (chronological order), matching the app's existing chart approach.
+ */
+@Composable
+private fun EquityCanvas(points: List<EquityCurvePoint>, lineColor: Color, gridColor: Color) {
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(160.dp),
+    ) {
+        val n = points.size
+        if (n < 2) return@Canvas
+        val values = points.map { it.cumulative }
+        val minV = minOf(0L, values.min())
+        val maxV = maxOf(0L, values.max())
+        val span = (maxV - minV).coerceAtLeast(1L).toFloat()
+        val w = size.width
+        val h = size.height
+
+        fun px(i: Int): Float = if (n == 1) 0f else w * i.toFloat() / (n - 1).toFloat()
+        fun py(v: Long): Float = h - ((v - minV).toFloat() / span) * h
+
+        // Zero baseline (only when zero is inside the visible range).
+        if (minV < 0L && maxV > 0L) {
+            val zeroY = py(0L)
+            drawLine(gridColor, Offset(0f, zeroY), Offset(w, zeroY), strokeWidth = 1f)
+        }
+
+        // Filled area under the curve (down to the zero baseline / clamped range bottom).
+        val baseY = py(0L).coerceIn(0f, h)
+        val fill = Path().apply {
+            moveTo(px(0), baseY)
+            points.forEachIndexed { i, p -> lineTo(px(i), py(p.cumulative)) }
+            lineTo(px(n - 1), baseY)
+            close()
+        }
+        drawPath(fill, lineColor.copy(alpha = 0.12f))
+
+        // The line itself.
+        val path = Path().apply {
+            moveTo(px(0), py(points[0].cumulative))
+            for (i in 1 until n) lineTo(px(i), py(points[i].cumulative))
+        }
+        drawPath(path, lineColor, style = Stroke(width = 3f))
+    }
+}
+
+@Composable
+private fun StatCardsGrid(stats: PnlStats) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            StatCard("Unrealized PnL", signed(stats.unrealized), if (stats.isUnrealizedProfit) PnlUp else PnlDown, Modifier.weight(1f))
+            StatCard("Total fees", stats.totalFees.toString(), MaterialTheme.colorScheme.onSurface, Modifier.weight(1f))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            StatCard(
+                "Win rate",
+                if (stats.closingTradeCount > 0) stats.winRatePercent.toString() + "%" else "--",
+                MaterialTheme.colorScheme.onSurface,
+                Modifier.weight(1f),
+                sub = stats.closingTradeCount.toString() + " closing",
+            )
+            StatCard("Trades", stats.tradeCount.toString(), MaterialTheme.colorScheme.onSurface, Modifier.weight(1f))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            StatCard("Volume", stats.volume.toString(), MaterialTheme.colorScheme.onSurface, Modifier.weight(1f))
+            StatCard(
+                "Funding",
+                signed(stats.fundingTotal),
+                if (stats.fundingTotal >= 0) PnlUp else PnlDown,
+                Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatCard(label: String, value: String, valueColor: Color, modifier: Modifier, sub: String? = null) {
+    Card(modifier = modifier) {
+        Column(Modifier.padding(14.dp)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                value,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = FontFamily.Monospace,
+                color = valueColor,
+            )
+            if (sub != null) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    sub,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SymbolHeaderRow() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Symbol", style = MaterialTheme.typography.labelSmall, modifier = Modifier.weight(1.4f), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text("Realized", style = MaterialTheme.typography.labelSmall, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text("Vol", style = MaterialTheme.typography.labelSmall, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text("Fees", style = MaterialTheme.typography.labelSmall, modifier = Modifier.weight(0.8f), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text("#", style = MaterialTheme.typography.labelSmall, modifier = Modifier.weight(0.4f), color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun SymbolRowView(row: SymbolRow) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    row.symbol,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1.4f),
+                )
+                Text(
+                    signed(row.realized),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (row.isProfit) PnlUp else PnlDown,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(row.volume.toString(), style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace, modifier = Modifier.weight(1f))
+                Text(row.fees.toString(), style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace, modifier = Modifier.weight(0.8f))
+                Text(row.tradeCount.toString(), style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace, modifier = Modifier.weight(0.4f))
+            }
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun LoadingBlock(modifier: Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Spacer(Modifier.height(12.dp))
+            Text("Loading performance…", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun MessageBlock(title: String, body: String, modifier: Modifier) {
+    Box(modifier = modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(6.dp))
+            Text(
+                body,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** Signed integer display: a leading '+' for non-negative, grouped thousands. */
+private fun signed(v: Long): String {
+    val grouped = String.format(Locale.US, "%,d", Math.abs(v))
+    return if (v >= 0) "+$grouped" else "-$grouped"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlUiState.kt
@@ -1,0 +1,56 @@
+package com.testlogon.android.feature.pnl
+
+/**
+ * UI state for the read-only PnL & performance screen. The ViewModel fetches the four exchange reads,
+ * runs the pure [PnlAnalytics.analyze], resolves symbol ids to names, and projects the result into this
+ * render-ready shape. Nothing here moves money — it is a derived analytics view.
+ *
+ * [loading] gates the initial spinner; [unavailable] is set when EVERY underlying read was undeployed
+ * (404) so the whole surface is unsupported on this deployment; [error] carries a transient failure the
+ * user can retry. When a report is present, [isEmpty] drives the "no trading activity yet" empty state.
+ */
+data class PnlUiState(
+    val loading: Boolean = true,
+    val unavailable: Boolean = false,
+    val error: String? = null,
+    val stats: PnlStats? = null,
+    val bySymbol: List<SymbolRow> = emptyList(),
+    val equityCurve: List<EquityCurvePoint> = emptyList(),
+) {
+    /** True once loaded, readable, and there was genuinely no trading activity to analyze. */
+    val isEmpty: Boolean
+        get() = !loading && !unavailable && error == null &&
+            (stats == null || (stats.tradeCount == 0 && bySymbol.isEmpty() && equityCurve.isEmpty()))
+}
+
+/** The top-of-screen stat cards, all raw integer engine units except [winRate] (0..1 fraction). */
+data class PnlStats(
+    val netRealized: Long,
+    val unrealized: Long,
+    val totalFees: Long,
+    val winRate: Float,
+    val closingTradeCount: Int,
+    val tradeCount: Int,
+    val volume: Long,
+    val fundingTotal: Long,
+    val liquidationPnl: Long,
+) {
+    val isRealizedProfit: Boolean get() = netRealized >= 0
+    val isUnrealizedProfit: Boolean get() = unrealized >= 0
+    /** Win rate as a whole-number percent for compact display. */
+    val winRatePercent: Int get() = Math.round(winRate * 100f)
+}
+
+/** One per-symbol breakdown row (symbol name / realized / volume / fees / #trades). */
+data class SymbolRow(
+    val symbol: String,
+    val realized: Long,
+    val volume: Long,
+    val fees: Long,
+    val tradeCount: Int,
+) {
+    val isProfit: Boolean get() = realized >= 0
+}
+
+/** One equity-curve point projected for the Canvas: a running cumulative net total (raw units). */
+data class EquityCurvePoint(val tsNs: Long, val cumulative: Long)

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlViewModel.kt
@@ -1,0 +1,131 @@
+package com.testlogon.android.feature.pnl
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.TradingRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel for the read-only PnL & performance screen. Fans four exchange reads out in parallel
+ * (fills-fees, liquidations, funding payments, margin account) plus the symbols catalogue for name
+ * resolution, then folds them through the pure [PnlAnalytics.analyze] and projects the result into a
+ * render-ready [PnlUiState].
+ *
+ * fills-fees / liquidations / funding already fold a 404 (undeployed) into an EMPTY success in the
+ * repository; the margin account read does NOT (it is a hard read). If EVERY analytics input degraded
+ * — the three feeds empty AND the margin read failed — the screen shows an "unavailable" state rather
+ * than a misleading all-zero report; a margin-only failure alongside real fills just drops uPnL to 0.
+ */
+@HiltViewModel
+class PnlViewModel @Inject constructor(
+    private val trading: TradingRepository,
+    private val exchange: ExchangeRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PnlUiState())
+    val uiState: StateFlow<PnlUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.value = PnlUiState(loading = true)
+        viewModelScope.launch {
+            _uiState.value = coroutineScope {
+                val fillsDef = async { trading.fillsFees() }
+                val liqDef = async { trading.liquidations() }
+                val fundingDef = async { trading.fundingPayments() }
+                val marginDef = async { trading.marginAccount() }
+                val symbolsDef = async { exchange.symbols() }
+                project(
+                    fills = fillsDef.await(),
+                    liquidations = liqDef.await(),
+                    funding = fundingDef.await(),
+                    marginResult = marginDef.await(),
+                    symbolsResult = symbolsDef.await(),
+                )
+            }
+        }
+    }
+
+    private fun project(
+        fills: ApiResult<FillsFees>,
+        liquidations: ApiResult<Liquidations>,
+        funding: ApiResult<FundingPayments>,
+        marginResult: ApiResult<com.testlogon.android.data.exchange.MarginAccount>,
+        symbolsResult: ApiResult<List<Instrument>>,
+    ): PnlUiState {
+        // Each feed already folds an undeployed 404 into an empty success; surface a transient
+        // network/failure on a feed as a retryable error rather than a silently-wrong report.
+        val fillsData = when (fills) {
+            is ApiResult.Success -> fills.data
+            is ApiResult.NetworkError -> return PnlUiState(loading = false, error = "Network error. Pull to retry.")
+            is ApiResult.Failure -> return PnlUiState(loading = false, error = "Couldn't load fills.")
+        }
+        val liqData = (liquidations as? ApiResult.Success)?.data ?: Liquidations(emptyList(), 0)
+        val fundingData = (funding as? ApiResult.Success)?.data ?: FundingPayments(emptyList(), 0)
+        val margin = (marginResult as? ApiResult.Success)?.data
+        val unrealized = margin?.position?.unrealizedPnl ?: 0L
+
+        // Whole-surface unavailable ONLY when there is nothing at all to show: no fills, no liq, no
+        // funding, and the margin account itself couldn't be read (so uPnL is unknown too).
+        if (fillsData.isEmpty && liqData.isEmpty && fundingData.isEmpty && margin == null) {
+            return PnlUiState(loading = false, unavailable = true)
+        }
+
+        val report = PnlAnalytics.analyze(fillsData, liqData, fundingData, unrealized)
+        val names = symbolNames(symbolsResult)
+
+        val stats = PnlStats(
+            netRealized = report.netRealized,
+            unrealized = report.unrealized,
+            totalFees = report.totalFees,
+            winRate = report.winRate,
+            closingTradeCount = report.closingTradeCount,
+            tradeCount = report.tradeCount,
+            volume = report.volume,
+            fundingTotal = report.fundingTotal,
+            liquidationPnl = report.liquidationPnl,
+        )
+        val rows = report.bySymbol.map { s ->
+            SymbolRow(
+                symbol = names[s.symbolId] ?: fallbackSymbol(s.symbolId),
+                realized = s.realized,
+                volume = s.volume,
+                fees = s.fees,
+                tradeCount = s.tradeCount,
+            )
+        }
+        return PnlUiState(
+            loading = false,
+            stats = stats,
+            bySymbol = rows,
+            equityCurve = report.equityCurve.map { EquityCurvePoint(it.tsNs, it.cumulative) },
+        )
+    }
+
+    private fun symbolNames(result: ApiResult<List<Instrument>>): Map<Int, String> =
+        (result as? ApiResult.Success)?.data?.associate { it.symbolId to it.symbol } ?: emptyMap()
+
+    /** Static fallback when the symbols read is unavailable (mirror of the markets catalogue). */
+    private fun fallbackSymbol(symbolId: Int): String = when (symbolId) {
+        1 -> "BTCUSDC"
+        2 -> "ETHUSDC"
+        3 -> "SOLUSDC"
+        else -> "#" + symbolId
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/settings/trading/TradingPreferencesScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/trading/TradingPreferencesScreen.kt
@@ -152,7 +152,7 @@ fun TradingPreferencesScreen(
 
             // ---- Alert kinds ----
             SectionHeader(stringResource(R.string.trading_prefs_alerts_section))
-            TradingAlertKind.entries.forEach { kind ->
+            TradingAlertKind.entries.filter { it != TradingAlertKind.PRICE }.forEach { kind ->
                 val checked = state.alertPrefs.isEnabled(kind)
                 ListItem(
                     modifier = Modifier
@@ -308,4 +308,6 @@ private fun alertKindLabel(kind: TradingAlertKind): Int = when (kind) {
     TradingAlertKind.FUNDING -> R.string.trading_prefs_alert_funding
     TradingAlertKind.MARGIN_DISTRESS -> R.string.trading_prefs_alert_margin
     TradingAlertKind.PM_RESOLVED -> R.string.trading_prefs_alert_pm
+    // PRICE alerts are user-authored (managed on the Price Alerts screen), not a derived-feed opt-out.
+    TradingAlertKind.PRICE -> R.string.trading_prefs_alert_pm
 }

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -217,6 +217,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // Custody: native crypto custody surface wired to /me/custody/* (officer approvals self-gate on the admin signal).
         custodyDestination(navController)
         portfolioDestination(navController)
+        // PnL & performance: read-only realized/unrealized analytics, equity curve, per-symbol breakdown.
+        pnlDestination(navController)
         // AND-336: backend-mediated Google Drive import picker (authenticated-only).
         driveImportDestination(navController)
         // AND-335: owner share sheet (create/list/revoke share links) + the public share screen

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -216,6 +216,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         blotterDestination(navController)
         // Custody: native crypto custody surface wired to /me/custody/* (officer approvals self-gate on the admin signal).
         custodyDestination(navController)
+        // Trading Home / Dashboard: read-only launch surface (reached from More -> Wallet hub top).
+        homeDestination(navController)
         portfolioDestination(navController)
         // PnL & performance: read-only realized/unrealized analytics, equity curve, per-symbol breakdown.
         pnlDestination(navController)

--- a/android/app/src/main/java/com/testlogon/android/navigation/HomeNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/HomeNavigation.kt
@@ -1,0 +1,44 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.home.HomeRoute
+import com.testlogon.android.feature.home.HomeTarget
+
+/**
+ * The Trading Home / Dashboard — a read-only launch surface (portfolio summary, watchlist snapshot,
+ * recent activity, quick actions, getting-started checklist), reached from the top of the More ->
+ * Wallet hub. It owns no data routes: every tap is delegated to an EXISTING authenticated-graph
+ * destination (Markets / Custody / Portfolio / PnL / Price alerts / Blotter). Not the app start
+ * destination.
+ */
+data object HomeDest {
+    const val ROUTE = "home"
+}
+
+/** Registers the Home dashboard, mapping each [HomeTarget] + a watchlist tap to an existing route. */
+fun NavGraphBuilder.homeDestination(navController: NavHostController) {
+    composable(HomeDest.ROUTE) {
+        HomeRoute(
+            onBack = { navController.popBackStack() },
+            onOpenSymbol = { symbolId ->
+                navController.navigate(SymbolDetailDest.build(symbolId)) { launchSingleTop = true }
+            },
+            onOpenTarget = { target ->
+                val route = when (target) {
+                    // Order entry lives on the per-symbol detail; the Markets list is the entry point.
+                    HomeTarget.TRADE -> MarketsDest.ROUTE
+                    // Funding surface (custody deposit / spot / margin funding bridge).
+                    HomeTarget.DEPOSIT -> CustodyDest.ROUTE
+                    HomeTarget.PORTFOLIO -> PortfolioDest.ROUTE
+                    HomeTarget.PNL -> PnlDest.ROUTE
+                    HomeTarget.PRICE_ALERTS -> PriceAlertsDest.ROUTE
+                    // Trade history = the fills blotter.
+                    HomeTarget.TRADE_HISTORY -> BlotterDest.ROUTE
+                }
+                navController.navigate(route) { launchSingleTop = true }
+            },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.navArgument
 import com.testlogon.android.feature.markets.MarketsRoute
 import com.testlogon.android.feature.markets.SymbolDetailRoute
 import com.testlogon.android.feature.markets.alerts.TradingAlertsRoute
+import com.testlogon.android.feature.markets.alerts.pricealerts.PriceAlertsRoute
 
 /**
  * Markets (exchange market-data, VIEW-ONLY) destinations, registered in the AUTHENTICATED nav graph.
@@ -31,6 +32,11 @@ data object TradingAlertsDest {
     const val ROUTE = "markets/alerts"
 }
 
+/** Price Alerts (user-authored) management — reachable from the Trading Alerts screen. */
+data object PriceAlertsDest {
+    const val ROUTE = "markets/alerts/price"
+}
+
 /** Registers the Markets list + per-symbol detail destinations (Back pops the back stack). */
 fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
     composable(MarketsDest.ROUTE) {
@@ -45,7 +51,15 @@ fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
         )
     }
     composable(TradingAlertsDest.ROUTE) {
-        TradingAlertsRoute(onBack = { navController.popBackStack() })
+        TradingAlertsRoute(
+            onBack = { navController.popBackStack() },
+            onOpenPriceAlerts = {
+                navController.navigate(PriceAlertsDest.ROUTE) { launchSingleTop = true }
+            },
+        )
+    }
+    composable(PriceAlertsDest.ROUTE) {
+        PriceAlertsRoute(onBack = { navController.popBackStack() })
     }
     composable(
         route = SymbolDetailDest.ROUTE,

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -100,6 +100,9 @@ object MoreRoutes {
     // Trading Blotter: native orders/fills/positions blotter (web parity). Sample data only.
     const val TRADING_BLOTTER = BlotterDest.ROUTE
 
+    // Home / Dashboard: read-only trading launch surface (portfolio + watchlist + activity + onboarding).
+    const val HOME = HomeDest.ROUTE
+
     // Custody: native crypto custody surface (balances / deposit / withdraw / activity / officer approvals), wired to /me/custody/*.
     const val CUSTODY = CustodyDest.ROUTE
 
@@ -564,6 +567,7 @@ object MoreRoutes {
             SELLER_SALES,
             FILES,
             TRADING_BLOTTER,
+            HOME,
             CUSTODY,
             PORTFOLIO,
             PNL,

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -106,6 +106,9 @@ object MoreRoutes {
     // Portfolio: read-only cross-venue account overview (custody / spot / margin / staking snapshot).
     const val PORTFOLIO = PortfolioDest.ROUTE
 
+    // PnL & performance: read-only realized/unrealized analytics + equity curve (Wallet hub, near Portfolio).
+    const val PNL = PnlDest.ROUTE
+
     // AND-219: the purchase history list + search.
     val PURCHASE_HISTORY: String get() = PurchaseHistoryDest.ROUTE
 
@@ -563,6 +566,7 @@ object MoreRoutes {
             TRADING_BLOTTER,
             CUSTODY,
             PORTFOLIO,
+            PNL,
             PURCHASE_HISTORY,
             PAYMENT_METHODS,
             WALLET_TRANSACTIONS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/PnlNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/PnlNavigation.kt
@@ -1,0 +1,24 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.pnl.PnlRoute
+
+/**
+ * The read-only PnL & performance surface, reached from the More -> Wallet hub (near Portfolio).
+ * Derives realized/unrealized PnL, fees, win rate, an equity curve, and a per-symbol breakdown from
+ * the exchange fills-fees / liquidations / funding / margin reads. No order entry, no money movement.
+ */
+data object PnlDest {
+    const val ROUTE = "pnl"
+}
+
+/** Registers the PnL screen in the authenticated graph. Up / Back pops the back stack. */
+fun NavGraphBuilder.pnlDestination(navController: NavHostController) {
+    composable(PnlDest.ROUTE) {
+        PnlRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1446,6 +1446,7 @@
     <string name="more_entry_gallery">Gallery</string>
     <string name="more_entry_files">Files</string>
     <string name="more_entry_trading_blotter">Trading Blotter</string>
+    <string name="more_entry_home">Home</string>
     <string name="more_entry_custody">Custody</string>
     <string name="more_entry_portfolio">Portfolio</string>
     <string name="more_entry_pnl">PnL &amp; performance</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1448,6 +1448,7 @@
     <string name="more_entry_trading_blotter">Trading Blotter</string>
     <string name="more_entry_custody">Custody</string>
     <string name="more_entry_portfolio">Portfolio</string>
+    <string name="more_entry_pnl">PnL &amp; performance</string>
     <string name="story_ring_unseen">Story from %1$s, unseen</string>
     <string name="story_ring_seen">Story from %1$s, seen</string>
     <string name="story_close">Close stories</string>

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/alerts/PriceAlertEvalTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/alerts/PriceAlertEvalTest.kt
@@ -1,0 +1,121 @@
+package com.testlogon.android.data.exchange.alerts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit coverage for the pure [PriceAlertEval.evaluate] edge-trigger logic: arm/fire, one-shot latch,
+ * re-arm, both directions, first-observation (no prior price never fires), and the disarmed/triggered
+ * short-circuits.
+ */
+class PriceAlertEvalTest {
+
+    private val NOW = 5_000L
+
+    private fun alert(
+        dir: PriceAlertDirection = PriceAlertDirection.ABOVE,
+        ticks: Long = 100,
+        armed: Boolean = true,
+        triggeredTs: Long? = null,
+    ) = PriceAlert(
+        id = "a1",
+        symbolId = 1,
+        direction = dir,
+        priceTicks = ticks,
+        note = null,
+        createdTs = 0L,
+        triggeredTs = triggeredTs,
+        armed = armed,
+    )
+
+    // ---- first observation never fires (no edge) ----
+
+    @Test
+    fun firstObservation_neverFires_evenWhenAlreadyPastThreshold() {
+        val r = PriceAlertEval.evaluate(alert(ticks = 100), prevTicks = null, lastTicks = 150, nowMs = NOW)
+        assertFalse(r.fired)
+        assertTrue(r.alert.armed)
+        assertNull(r.alert.triggeredTs)
+    }
+
+    // ---- ABOVE ----
+
+    @Test
+    fun above_firesOnUpwardCross_andIsOneShot() {
+        val r = PriceAlertEval.evaluate(alert(PriceAlertDirection.ABOVE, 100), prevTicks = 90, lastTicks = 110, nowMs = NOW)
+        assertTrue(r.fired)
+        assertFalse("must disarm on fire", r.alert.armed)
+        assertEquals(NOW, r.alert.triggeredTs)
+
+        // One-shot: re-evaluating the now-disarmed alert never fires again.
+        val again = PriceAlertEval.evaluate(r.alert, prevTicks = 110, lastTicks = 130, nowMs = NOW + 1)
+        assertFalse(again.fired)
+    }
+
+    @Test
+    fun above_firesWhenPrevSitsExactlyOnThreshold() {
+        // prev == threshold, last strictly above => crossing.
+        val r = PriceAlertEval.evaluate(alert(PriceAlertDirection.ABOVE, 100), prevTicks = 100, lastTicks = 101, nowMs = NOW)
+        assertTrue(r.fired)
+    }
+
+    @Test
+    fun above_doesNotFireWhileStayingBelow() {
+        val r = PriceAlertEval.evaluate(alert(PriceAlertDirection.ABOVE, 100), prevTicks = 80, lastTicks = 95, nowMs = NOW)
+        assertFalse(r.fired)
+        assertTrue(r.alert.armed)
+    }
+
+    @Test
+    fun above_doesNotFireWhenAlreadyAboveAndStaysAbove() {
+        // No crossing: both prev and last above threshold.
+        val r = PriceAlertEval.evaluate(alert(PriceAlertDirection.ABOVE, 100), prevTicks = 120, lastTicks = 140, nowMs = NOW)
+        assertFalse(r.fired)
+    }
+
+    // ---- BELOW ----
+
+    @Test
+    fun below_firesOnDownwardCross() {
+        val r = PriceAlertEval.evaluate(alert(PriceAlertDirection.BELOW, 100), prevTicks = 110, lastTicks = 90, nowMs = NOW)
+        assertTrue(r.fired)
+        assertFalse(r.alert.armed)
+        assertEquals(NOW, r.alert.triggeredTs)
+    }
+
+    @Test
+    fun below_doesNotFireOnUpwardMove() {
+        val r = PriceAlertEval.evaluate(alert(PriceAlertDirection.BELOW, 100), prevTicks = 90, lastTicks = 110, nowMs = NOW)
+        assertFalse(r.fired)
+    }
+
+    // ---- disarmed / already triggered short-circuit ----
+
+    @Test
+    fun disarmedAlert_neverFires() {
+        val r = PriceAlertEval.evaluate(alert(armed = false), prevTicks = 90, lastTicks = 110, nowMs = NOW)
+        assertFalse(r.fired)
+    }
+
+    @Test
+    fun alreadyTriggeredAlert_neverFires() {
+        val r = PriceAlertEval.evaluate(alert(triggeredTs = 1L), prevTicks = 90, lastTicks = 110, nowMs = NOW)
+        assertFalse(r.fired)
+    }
+
+    // ---- re-arm makes it eligible again ----
+
+    @Test
+    fun reArmedAlert_firesAgainOnNextCross() {
+        val fired = PriceAlertEval.evaluate(alert(PriceAlertDirection.ABOVE, 100), prevTicks = 90, lastTicks = 110, nowMs = NOW)
+        assertTrue(fired.fired)
+        // Simulate the store re-arm: armed=true, triggeredTs=null.
+        val rearmed = fired.alert.copy(armed = true, triggeredTs = null)
+        val r2 = PriceAlertEval.evaluate(rearmed, prevTicks = 90, lastTicks = 110, nowMs = NOW + 100)
+        assertTrue(r2.fired)
+        assertEquals(NOW + 100, r2.alert.triggeredTs)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/home/HomeOnboardingDeriverTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/home/HomeOnboardingDeriverTest.kt
@@ -1,0 +1,109 @@
+package com.testlogon.android.feature.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure getting-started checklist derivation. Covers the three real signals
+ * (custody funded / trading funded / first trade), the neutral UNKNOWN mapping for unavailable data
+ * (never a false "incomplete"), and the [HomeOnboarding] "all set" / "show checklist" gating.
+ */
+class HomeOnboardingDeriverTest {
+
+    private fun step(steps: List<OnboardingStep>, id: OnboardingStepId) =
+        steps.first { it.id == id }
+
+    @Test
+    fun `all signals true means every step DONE`() {
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(custodyFunded = true, tradingFunded = true, hasFirstTrade = true),
+        )
+        assertEquals(3, steps.size)
+        assertTrue(steps.all { it.state == StepState.DONE })
+        assertTrue(steps.all { it.isDone })
+        assertTrue(steps.none { it.isActionable })
+    }
+
+    @Test
+    fun `false signal means INCOMPLETE and actionable`() {
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(custodyFunded = false, tradingFunded = false, hasFirstTrade = false),
+        )
+        assertTrue(steps.all { it.state == StepState.INCOMPLETE })
+        assertTrue(steps.all { it.isActionable })
+        assertTrue(steps.none { it.isDone })
+    }
+
+    @Test
+    fun `null signal maps to UNKNOWN and is never a false incomplete`() {
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(custodyFunded = null, tradingFunded = null, hasFirstTrade = null),
+        )
+        assertTrue(steps.all { it.state == StepState.UNKNOWN })
+        // UNKNOWN is neutral: not done, but also not actionable (no false "incomplete").
+        assertTrue(steps.none { it.isDone })
+        assertTrue(steps.none { it.isActionable })
+    }
+
+    @Test
+    fun `mixed signals derive per-step state and correct targets`() {
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(custodyFunded = true, tradingFunded = false, hasFirstTrade = null),
+        )
+        assertEquals(StepState.DONE, step(steps, OnboardingStepId.FUND_CUSTODY).state)
+        assertEquals(StepState.INCOMPLETE, step(steps, OnboardingStepId.FUND_TRADING).state)
+        assertEquals(StepState.UNKNOWN, step(steps, OnboardingStepId.FIRST_TRADE).state)
+
+        assertEquals(HomeTarget.DEPOSIT, step(steps, OnboardingStepId.FUND_CUSTODY).target)
+        assertEquals(HomeTarget.DEPOSIT, step(steps, OnboardingStepId.FUND_TRADING).target)
+        assertEquals(HomeTarget.TRADE, step(steps, OnboardingStepId.FIRST_TRADE).target)
+    }
+
+    @Test
+    fun `onboarding shows checklist while any step is confirmed incomplete`() {
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(custodyFunded = true, tradingFunded = false, hasFirstTrade = true),
+        )
+        val onboarding = HomeOnboarding(loading = false, steps = steps)
+        assertTrue(onboarding.showChecklist)
+        assertFalse(onboarding.allSet)
+        assertFalse(onboarding.showAllSet)
+        assertEquals(1, onboarding.actionableSteps.size)
+    }
+
+    @Test
+    fun `all-known-done is all set and shows dismissible banner until dismissed`() {
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(custodyFunded = true, tradingFunded = true, hasFirstTrade = true),
+        )
+        val onboarding = HomeOnboarding(loading = false, steps = steps)
+        assertTrue(onboarding.allSet)
+        assertTrue(onboarding.showAllSet)
+        assertFalse(onboarding.showChecklist)
+
+        val dismissed = onboarding.copy(dismissed = true)
+        assertTrue(dismissed.allSet)
+        assertFalse(dismissed.showAllSet)
+    }
+
+    @Test
+    fun `unknown-only is all set (nothing confirmed incomplete) but no step is marked done`() {
+        val steps = HomeOnboardingDeriver.derive(
+            OnboardingInputs(custodyFunded = null, tradingFunded = null, hasFirstTrade = null),
+        )
+        val onboarding = HomeOnboarding(loading = false, steps = steps)
+        // No confirmed-incomplete step -> not prompting; all-set banner is allowed.
+        assertFalse(onboarding.showChecklist)
+        assertTrue(onboarding.allSet)
+    }
+
+    @Test
+    fun `loading onboarding neither shows checklist nor all-set`() {
+        val onboarding = HomeOnboarding(loading = true, steps = emptyList())
+        assertFalse(onboarding.showChecklist)
+        assertFalse(onboarding.showAllSet)
+        assertFalse(onboarding.allSet)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/markets/trade/OrderMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/markets/trade/OrderMathTest.kt
@@ -1,0 +1,132 @@
+package com.testlogon.android.feature.markets.trade
+
+import com.testlogon.android.data.exchange.OrderSide
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [OrderMath] — the pure order-entry math behind the ticket preview, buying-power sizing,
+ * and the risk calculator. All values are raw int64 ticks (scaler = 1).
+ */
+class OrderMathTest {
+
+    // ---- notional ----
+
+    @Test fun notional_multiplies() = assertEquals(200L, OrderMath.notional(100L, 2L))
+
+    @Test fun notional_nullWhenAnyMissing() {
+        assertNull(OrderMath.notional(null, 2L))
+        assertNull(OrderMath.notional(100L, null))
+    }
+
+    @Test fun notional_zeroQtyIsZero() = assertEquals(0L, OrderMath.notional(100L, 0L))
+
+    // ---- maxQtyForBalance ----
+
+    @Test fun maxQty_floorsToWholeUnits() {
+        // 1050 / 100 = 10 (floors the .5)
+        assertEquals(10L, OrderMath.maxQtyForBalance(1050L, 100L))
+    }
+
+    @Test fun maxQty_exactDivision() = assertEquals(5L, OrderMath.maxQtyForBalance(500L, 100L))
+
+    @Test fun maxQty_zeroWhenUnaffordable() = assertEquals(0L, OrderMath.maxQtyForBalance(50L, 100L))
+
+    @Test fun maxQty_guardsNonPositiveAndNull() {
+        assertEquals(0L, OrderMath.maxQtyForBalance(1000L, 0L))
+        assertEquals(0L, OrderMath.maxQtyForBalance(0L, 100L))
+        assertEquals(0L, OrderMath.maxQtyForBalance(null, 100L))
+        assertEquals(0L, OrderMath.maxQtyForBalance(1000L, null))
+        assertEquals(0L, OrderMath.maxQtyForBalance(-10L, 100L))
+    }
+
+    // ---- qtyForPercent ----
+
+    @Test fun qtyPercent_fractionsOfMax() {
+        // max = 1000/100 = 10
+        assertEquals(2L, OrderMath.qtyForPercent(1000L, 100L, 25))  // 2.5 -> floor 2
+        assertEquals(5L, OrderMath.qtyForPercent(1000L, 100L, 50))
+        assertEquals(10L, OrderMath.qtyForPercent(1000L, 100L, 100))
+    }
+
+    @Test fun qtyPercent_positivePctFloorsToOne() {
+        // max = 3, 25% = 0.75 -> floors to 0 -> bumped to 1 because pct > 0
+        assertEquals(1L, OrderMath.qtyForPercent(300L, 100L, 25))
+    }
+
+    @Test fun qtyPercent_zeroPctStaysZero() = assertEquals(0L, OrderMath.qtyForPercent(1000L, 100L, 0))
+
+    @Test fun qtyPercent_zeroWhenNoBuyingPower() = assertEquals(0L, OrderMath.qtyForPercent(50L, 100L, 100))
+
+    // ---- riskSizedQty ----
+
+    @Test fun riskSized_dividesRiskByStopDistance() {
+        // risk 1000, entry 100, stop 90 -> dist 10 -> 100 units
+        assertEquals(100L, OrderMath.riskSizedQty(1000L, 100L, 90L))
+    }
+
+    @Test fun riskSized_stopAboveEntry_usesAbsDistance() {
+        // short case: entry 100, stop 105 -> dist 5 -> 1000/5 = 200
+        assertEquals(200L, OrderMath.riskSizedQty(1000L, 100L, 105L))
+    }
+
+    @Test fun riskSized_floorsPartialUnit() {
+        // risk 1000, dist 30 -> 33.3 -> floor 33
+        assertEquals(33L, OrderMath.riskSizedQty(1000L, 100L, 130L))
+    }
+
+    @Test fun riskSized_zeroWhenEntryEqualsStop() = assertEquals(0L, OrderMath.riskSizedQty(1000L, 100L, 100L))
+
+    @Test fun riskSized_guardsNonPositiveAndNull() {
+        assertEquals(0L, OrderMath.riskSizedQty(0L, 100L, 90L))
+        assertEquals(0L, OrderMath.riskSizedQty(-5L, 100L, 90L))
+        assertEquals(0L, OrderMath.riskSizedQty(null, 100L, 90L))
+        assertEquals(0L, OrderMath.riskSizedQty(1000L, null, 90L))
+        assertEquals(0L, OrderMath.riskSizedQty(1000L, 100L, null))
+    }
+
+    // ---- marginRequired ----
+
+    @Test fun margin_appliesBps() {
+        // notional 10000 at 1000 bps (10%) = 1000
+        assertEquals(1000L, OrderMath.marginRequired(10000L, 1000L))
+    }
+
+    @Test fun margin_roundsToNearestTick() {
+        // 10005 * 500 / 10000 = 500.25 -> 500
+        assertEquals(500L, OrderMath.marginRequired(10005L, 500L))
+    }
+
+    @Test fun margin_zeroGuards() {
+        assertEquals(0L, OrderMath.marginRequired(null, 1000L))
+        assertEquals(0L, OrderMath.marginRequired(0L, 1000L))
+        assertEquals(0L, OrderMath.marginRequired(10000L, 0L))
+    }
+
+    // ---- estLiquidationPrice ----
+
+    @Test fun liq_long_belowEntry() {
+        // entry 100, mmr 500 bps (5%) -> 100 * 0.95 = 95
+        assertEquals(95L, OrderMath.estLiquidationPrice(100L, OrderSide.BUY, 500L))
+    }
+
+    @Test fun liq_short_aboveEntry() {
+        // entry 100, mmr 500 bps -> 100 * 1.05 = 105
+        assertEquals(105L, OrderMath.estLiquidationPrice(100L, OrderSide.SELL, 500L))
+    }
+
+    @Test fun liq_nullWhenEntryNonPositive() {
+        assertNull(OrderMath.estLiquidationPrice(null, OrderSide.BUY, 500L))
+        assertNull(OrderMath.estLiquidationPrice(0L, OrderSide.BUY, 500L))
+    }
+
+    @Test fun liq_nullWhenNoMaintenanceBps() {
+        assertNull(OrderMath.estLiquidationPrice(100L, OrderSide.BUY, 0L))
+    }
+
+    @Test fun liq_defaultsAreSane() {
+        assertEquals(1000L, OrderMath.DEFAULT_INITIAL_MARGIN_BPS)
+        assertEquals(500L, OrderMath.DEFAULT_MAINTENANCE_MARGIN_BPS)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/pnl/PnlAnalyticsTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/pnl/PnlAnalyticsTest.kt
@@ -1,0 +1,182 @@
+package com.testlogon.android.feature.pnl
+
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayment
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidation
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.Liquidity
+import com.testlogon.android.data.exchange.OrderSide
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the PURE [PnlAnalytics]. Covers the average-cost realized walk (a simple round-trip
+ * close, a weighted-average entry across two buys, a position flip), the win-rate denominator (closing
+ * trades only), the net roll-up folding fees/funding/liquidations, and the cumulative equity curve.
+ */
+class PnlAnalyticsTest {
+
+    private fun fill(
+        symbolId: Int,
+        side: OrderSide,
+        price: Long,
+        qty: Long,
+        fee: Long = 0L,
+        tsNs: Long,
+    ) = FillFee(
+        symbolId = symbolId,
+        price = price,
+        qty = qty,
+        side = side,
+        liquidity = Liquidity.TAKER,
+        fee = fee,
+        feeAsset = 0,
+        tsNs = tsNs,
+    )
+
+    private fun fills(vararg f: FillFee) = FillsFees(f.toList(), f.size)
+
+    // ---- average-cost realized ----
+
+    @Test
+    fun `simple round-trip close realizes price difference`() {
+        // Buy 10 @ 100, sell 10 @ 120 -> (120-100)*10 = 200 realized, one closing (winning) trade.
+        val report = PnlAnalytics.analyze(
+            fills(
+                fill(1, OrderSide.BUY, 100, 10, tsNs = 1),
+                fill(1, OrderSide.SELL, 120, 10, tsNs = 2),
+            ),
+            Liquidations(emptyList(), 0),
+            FundingPayments(emptyList(), 0),
+            unrealizedPnl = 0,
+        )
+        val sym = report.bySymbol.single()
+        assertEquals(200L, sym.realized)
+        assertEquals(1, sym.closingTrades)
+        assertEquals(1, sym.winningTrades)
+        assertEquals(200L, report.netRealized)
+        assertEquals(1f, report.winRate, 0.0001f)
+    }
+
+    @Test
+    fun `weighted average entry across two buys before a close`() {
+        // Buy 10 @ 100, buy 10 @ 200 -> avg entry 150; sell 20 @ 160 -> (160-150)*20 = 200.
+        val rows = PnlAnalytics.realizedBySymbol(
+            listOf(
+                fill(1, OrderSide.BUY, 100, 10, tsNs = 1),
+                fill(1, OrderSide.BUY, 200, 10, tsNs = 2),
+                fill(1, OrderSide.SELL, 160, 20, tsNs = 3),
+            ),
+        )
+        assertEquals(200L, rows.single().realized)
+        assertEquals(1, rows.single().closingTrades)
+    }
+
+    @Test
+    fun `short round-trip realizes when covering below entry`() {
+        // Sell 5 @ 100 (open short), buy 5 @ 90 (cover) -> (90-100)*5*(-1) = 50 profit.
+        val rows = PnlAnalytics.realizedBySymbol(
+            listOf(
+                fill(1, OrderSide.SELL, 100, 5, tsNs = 1),
+                fill(1, OrderSide.BUY, 90, 5, tsNs = 2),
+            ),
+        )
+        assertEquals(50L, rows.single().realized)
+        assertEquals(1, rows.single().winningTrades)
+    }
+
+    @Test
+    fun `position flip closes then re-seeds entry at fill price`() {
+        // Buy 10 @ 100, sell 15 @ 120: closes 10 (+200), flips to short 5 @ 120 (no further realize).
+        val rows = PnlAnalytics.realizedBySymbol(
+            listOf(
+                fill(1, OrderSide.BUY, 100, 10, tsNs = 1),
+                fill(1, OrderSide.SELL, 120, 15, tsNs = 2),
+            ),
+        )
+        assertEquals(200L, rows.single().realized)
+        assertEquals(1, rows.single().closingTrades)
+    }
+
+    // ---- win rate ----
+
+    @Test
+    fun `win rate counts only closing trades`() {
+        // sym1: one winning close. sym2: one losing close. Opening buys are not closing trades.
+        val report = PnlAnalytics.analyze(
+            fills(
+                fill(1, OrderSide.BUY, 100, 10, tsNs = 1),
+                fill(1, OrderSide.SELL, 110, 10, tsNs = 2), // +100 win
+                fill(2, OrderSide.BUY, 100, 10, tsNs = 3),
+                fill(2, OrderSide.SELL, 90, 10, tsNs = 4), // -100 loss
+            ),
+            Liquidations(emptyList(), 0),
+            FundingPayments(emptyList(), 0),
+            unrealizedPnl = 0,
+        )
+        assertEquals(2, report.closingTradeCount)
+        assertEquals(0.5f, report.winRate, 0.0001f)
+    }
+
+    // ---- net roll-up ----
+
+    @Test
+    fun `net realized folds fees funding and liquidations`() {
+        // realized 200, fees 5+5=10, funding +30, liq realized -40 with fee 3.
+        val report = PnlAnalytics.analyze(
+            fills(
+                fill(1, OrderSide.BUY, 100, 10, fee = 5, tsNs = 1),
+                fill(1, OrderSide.SELL, 120, 10, fee = 5, tsNs = 2),
+            ),
+            Liquidations(listOf(Liquidation(1, 2, 118, -40, 3, 3)), 1),
+            FundingPayments(listOf(FundingPayment(1, 5, 118, 10, 30, true, 2)), 1),
+            unrealizedPnl = 7,
+        )
+        // 200 - 10 + 30 + (-40) - 3 = 177
+        assertEquals(177L, report.netRealized)
+        assertEquals(10L, report.totalFees)
+        assertEquals(30L, report.fundingTotal)
+        assertEquals(-40L, report.liquidationPnl)
+        assertEquals(7L, report.unrealized)
+    }
+
+    // ---- equity curve ----
+
+    @Test
+    fun `equity curve is time-ordered cumulative and ends at net minus uPnL`() {
+        val report = PnlAnalytics.analyze(
+            fills(
+                fill(1, OrderSide.BUY, 100, 10, fee = 5, tsNs = 1),
+                fill(1, OrderSide.SELL, 120, 10, fee = 5, tsNs = 2),
+            ),
+            Liquidations(emptyList(), 0),
+            FundingPayments(listOf(FundingPayment(1, 5, 118, 10, 30, true, 3)), 1),
+            unrealizedPnl = 999,
+        )
+        val curve = report.equityCurve
+        // Three cash events: fill1 (-5), fill2 (+200-5=195), funding (+30). Cumulative: -5, 190, 220.
+        assertEquals(3, curve.size)
+        assertEquals(-5L, curve[0].cumulative)
+        assertEquals(190L, curve[1].cumulative)
+        assertEquals(220L, curve[2].cumulative)
+        // Curve final reconciles with netRealized (independent of uPnL).
+        assertEquals(report.netRealized, curve.last().cumulative)
+        assertTrue(curve[0].tsNs <= curve[1].tsNs && curve[1].tsNs <= curve[2].tsNs)
+    }
+
+    @Test
+    fun `empty inputs produce an empty report`() {
+        val report = PnlAnalytics.analyze(
+            FillsFees(emptyList(), 0),
+            Liquidations(emptyList(), 0),
+            FundingPayments(emptyList(), 0),
+            unrealizedPnl = 0,
+        )
+        assertTrue(report.isEmpty)
+        assertEquals(0L, report.netRealized)
+        assertTrue(report.equityCurve.isEmpty())
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ const TradingBlotterPage = lazy(() => import("@/pages/blotter/TradingBlotterPage
 const TradingWorkspacePage = lazy(() => import("@/pages/blotter/TradingWorkspacePage"));
 const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
 const PortfolioPage = lazy(() => import("@/pages/portfolio/PortfolioPage"));
+const PnLPage = lazy(() => import("@/pages/pnl/PnLPage"));
 const CatalogPage = lazy(() => import("@/pages/shop/CatalogPage"));
 const ProductDetail = lazy(() => import("@/pages/shop/ProductDetail"));
 const CartPage = lazy(() => import("@/pages/shop/CartPage"));
@@ -722,6 +723,7 @@ export default function App() {
           <Route path="blotter/single" element={<TradingBlotterPage />} />
           <Route path="custody" element={<CustodyPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
+          <Route path="pnl" element={<PnLPage />} />
           <Route path="content-calendar" element={<ContentCalendarPage />} />
           <Route path="agents/memory/:workerId" element={<AgentMemoryPage />} />
           <Route path="agents/feedback" element={<AgentFeedbackPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,7 @@ const ShopShippingAdminPage = lazy(() => import("@/pages/shop/admin/ShippingAdmi
 const FeedPage = lazy(() => import("@/pages/feed/FeedPage"));
 const PostDetailPage = lazy(() => import("@/pages/feed/PostDetailPage"));
 const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
+const HomePage = lazy(() => import("@/pages/home/HomePage"));
 const MarketsPage = lazy(() => import("@/pages/markets/MarketsPage"));
 const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
 const PriceAlertsPage = lazy(() => import("@/pages/alerts/PriceAlertsPage"));
@@ -737,6 +738,7 @@ export default function App() {
           <Route path="cart" element={<CartPage />} />
           <Route path="cart/checkout" element={<Checkout />} />
           <Route path="feed" element={<FeedPage />} />
+          <Route path="home" element={<HomePage />} />
           <Route path="markets" element={<MarketsPage />} />
           <Route path="markets/:symbolId" element={<SymbolDetailPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ const PostDetailPage = lazy(() => import("@/pages/feed/PostDetailPage"));
 const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
 const MarketsPage = lazy(() => import("@/pages/markets/MarketsPage"));
 const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
+const PriceAlertsPage = lazy(() => import("@/pages/alerts/PriceAlertsPage"));
 const SyndicatesPage = lazy(() => import("@/pages/syndicates/SyndicatesPage"));
 const SyndicateProfilePage = lazy(() => import("@/pages/syndicates/SyndicateProfilePage"));
 const SyndicateDetailPage = lazy(() => import("@/pages/syndicates/SyndicateDetailPage"));
@@ -738,6 +739,7 @@ export default function App() {
           <Route path="feed" element={<FeedPage />} />
           <Route path="markets" element={<MarketsPage />} />
           <Route path="markets/:symbolId" element={<SymbolDetailPage />} />
+          <Route path="markets/price-alerts" element={<PriceAlertsPage />} />
           <Route path="discover" element={<DiscoverPage />} />
           <Route path="discover/tags/:tag" element={<TagPage />} />
           <Route path="search" element={<SearchPage />} />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/components/ui/command";
 import ShortcutHelpDialog from "@/components/shared/ShortcutHelpDialog";
 import TradingAlertsBell from "@/components/layout/TradingAlertsBell";
+import PriceAlertEvaluator from "@/components/layout/PriceAlertEvaluator";
 import { useGlobalShortcuts, useChordShortcuts, useChordIndicator, type Shortcut, type ChordMapping } from "@/hooks/useGlobalShortcuts";
 import {
   Popover,
@@ -365,6 +366,7 @@ export default function Header({ onMobileMenuToggle }: HeaderProps) {
 
         {/* Trading alerts bell (client-derived from /me/* feeds) */}
         <TradingAlertsBell enabled={!!userId} />
+        <PriceAlertEvaluator enabled={!!userId} />
 
         {/* Alert bell with popover */}
         <Popover open={alertsOpen} onOpenChange={setAlertsOpen}>

--- a/frontend/src/components/layout/PriceAlertEvaluator.tsx
+++ b/frontend/src/components/layout/PriceAlertEvaluator.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+
+import { useCandles, useSymbols } from "@/hooks/useMarketData";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { formatPrice } from "@/pages/markets/format";
+import {
+  pushExternalTradingAlert,
+  type ExternalTradingAlert,
+} from "@/hooks/useTradingAlerts";
+import {
+  evaluate,
+  loadPriceAlerts,
+  markPriceAlertTriggered,
+  PRICE_ALERTS_EVENT,
+  PRICE_ALERTS_KEY,
+  type PriceAlert,
+} from "@/lib/priceAlerts";
+
+/** Subscribe to the current price-alert list (re-reads on same/cross-tab change). */
+function usePriceAlerts(): PriceAlert[] {
+  const [alerts, setAlerts] = React.useState<PriceAlert[]>(() => loadPriceAlerts());
+  React.useEffect(() => {
+    const reload = () => setAlerts(loadPriceAlerts());
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === PRICE_ALERTS_KEY || e.key === null) reload();
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(PRICE_ALERTS_EVENT, reload);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(PRICE_ALERTS_EVENT, reload);
+    };
+  }, []);
+  return alerts;
+}
+
+/**
+ * Watches ONE symbol's last price (candle close) and evaluates every armed
+ * alert on that symbol. On a fire it pushes a `price` alert into the trading
+ * bell (toast + OS notification) and marks the alert triggered (one-shot).
+ * Renders nothing.
+ */
+function SymbolPriceWatcher({
+  symbolId,
+  symbol,
+  alerts,
+}: {
+  symbolId: number;
+  symbol: MarketSymbol | undefined;
+  alerts: PriceAlert[];
+}) {
+  const { data } = useCandles(symbolId, 60, true, 1);
+  const bars = data?.bars;
+  const lastBar = bars && bars.length ? bars[bars.length - 1] : undefined;
+  const lastClose = lastBar?.close;
+  const scaler = symbol?.price_scaler ?? 1;
+  const name = symbol?.symbol ?? `#${symbolId}`;
+
+  React.useEffect(() => {
+    if (lastClose == null || !Number.isFinite(lastClose)) return;
+    for (const alert of alerts) {
+      if (!alert.armed) continue;
+      if (!evaluate(alert, lastClose)) continue;
+      const dir = alert.direction === "above" ? "above" : "below";
+      const priceLabel = formatPrice(alert.price, scaler);
+      const detail: ExternalTradingAlert = {
+        id: `price:${alert.id}:${alert.triggeredTs ?? "armed"}`,
+        kind: "price",
+        title: `${name} crossed ${dir} ${priceLabel}`,
+        message: alert.note
+          ? alert.note
+          : `Last ${formatPrice(lastClose, scaler)} · target ${priceLabel}`,
+        ts: Date.now(),
+      };
+      // One-shot: stamp + disarm BEFORE pushing so a fast re-render can't double-fire.
+      markPriceAlertTriggered(alert.id, detail.ts);
+      pushExternalTradingAlert(detail);
+    }
+    // Re-run when the price or the alert set for this symbol changes.
+  }, [lastClose, alerts, scaler, name]);
+
+  return null;
+}
+
+/**
+ * App-chrome-level evaluator: for each distinct symbol that has an ARMED price
+ * alert, mount a hidden watcher that polls its last price and fires crossings
+ * through the trading-alerts bell. Mount this next to <TradingAlertsBell/> so it
+ * runs whenever the user is logged in.
+ */
+export default function PriceAlertEvaluator({ enabled = true }: { enabled?: boolean }) {
+  const alerts = usePriceAlerts();
+  const { data: symbolsData } = useSymbols();
+
+  const byId = React.useMemo(() => {
+    const m = new Map<number, MarketSymbol>();
+    for (const s of symbolsData?.symbols ?? []) m.set(s.symbol_id, s);
+    return m;
+  }, [symbolsData]);
+
+  // Group armed alerts by symbol; only distinct armed symbols get a watcher.
+  const grouped = React.useMemo(() => {
+    const m = new Map<number, PriceAlert[]>();
+    if (!enabled) return m;
+    for (const a of alerts) {
+      if (!a.armed) continue;
+      const list = m.get(a.symbolId) ?? [];
+      list.push(a);
+      m.set(a.symbolId, list);
+    }
+    return m;
+  }, [alerts, enabled]);
+
+  if (!enabled) return null;
+
+  return (
+    <>
+      {[...grouped.entries()].map(([symbolId, symAlerts]) => (
+        <SymbolPriceWatcher
+          key={symbolId}
+          symbolId={symbolId}
+          symbol={byId.get(symbolId)}
+          alerts={symAlerts}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -146,6 +146,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: <Rss className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
+      { label: "PnL", i18nKey: "nav.pnl", path: "/pnl", icon: <LineChart className="h-5 w-5" /> },
       { label: "Activity", i18nKey: "nav.activity", path: "/activity", icon: <Activity className="h-5 w-5" /> },
       { label: "Discover", i18nKey: "nav.discover", path: "/discover", icon: <Compass className="h-5 w-5" /> },
       { label: "Saved", i18nKey: "nav.saved", path: "/saved", icon: <Bookmark className="h-5 w-5" /> },

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -145,6 +145,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Helpdesk", i18nKey: "nav.helpdesk", path: "/helpdesk", icon: <Headphones className="h-5 w-5" /> },
       { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: <Rss className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
+      { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
       { label: "PnL", i18nKey: "nav.pnl", path: "/pnl", icon: <LineChart className="h-5 w-5" /> },
       { label: "Activity", i18nKey: "nav.activity", path: "/activity", icon: <Activity className="h-5 w-5" /> },

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -144,6 +144,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Contacts", i18nKey: "nav.contacts", path: "/contacts", icon: <BookUser className="h-5 w-5" /> },
       { label: "Helpdesk", i18nKey: "nav.helpdesk", path: "/helpdesk", icon: <Headphones className="h-5 w-5" /> },
       { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: <Rss className="h-5 w-5" /> },
+      { label: "Trading Home", i18nKey: "nav.tradingHome", path: "/home", icon: <Gauge className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },

--- a/frontend/src/components/layout/TradingAlertsBell.tsx
+++ b/frontend/src/components/layout/TradingAlertsBell.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
+import { Link } from "react-router-dom";
 import {
   Bell,
+  BellRing,
   TrendingUp,
   AlertTriangle,
   Coins,
@@ -38,6 +40,8 @@ function KindIcon({ kind }: { kind: TradingAlertKind }) {
       return <ShieldAlert className={cn(cls, "text-destructive")} />;
     case "pm_resolved":
       return <Gavel className={cn(cls, "text-sky-500")} />;
+    case "price":
+      return <BellRing className={cn(cls, "text-primary")} />;
     default:
       return <Bell className={cls} />;
   }
@@ -171,6 +175,14 @@ export default function TradingAlertsBell({ enabled = true }: { enabled?: boolea
             </div>
           </ScrollArea>
         )}
+        <div className="border-t px-4 py-2">
+          <Button asChild variant="ghost" size="sm" className="h-7 w-full justify-start gap-2 px-2 text-xs">
+            <Link to="/markets/price-alerts" onClick={() => setOpen(false)}>
+              <BellRing className="h-3.5 w-3.5" />
+              Manage price alerts
+            </Link>
+          </Button>
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/frontend/src/hooks/useTradingAlerts.ts
+++ b/frontend/src/hooks/useTradingAlerts.ts
@@ -31,7 +31,8 @@ export type TradingAlertKind =
   | "liquidation"
   | "funding"
   | "margin"
-  | "pm_resolved";
+  | "pm_resolved"
+  | "price";
 
 export interface TradingAlert {
   /** Stable de-dupe id (kind + event key). */
@@ -42,6 +43,28 @@ export interface TradingAlert {
   /** Epoch ms for ordering + relative-time render. */
   ts: number;
   read: boolean;
+}
+
+/** A trading alert authored OUTSIDE this hook (e.g. the price-alert evaluator). */
+export type ExternalTradingAlert = Omit<TradingAlert, "read">;
+
+/** Custom-event name the hook listens on for externally-authored alerts. */
+export const EXTERNAL_ALERT_EVENT = "tl:tradingAlert";
+
+/**
+ * Push an alert into the trading-alerts bell from anywhere in the app.
+ * The mounted `useTradingAlerts()` hook listens for this event and injects the
+ * alert into its list (toast + OS notification + bell badge), so price alerts
+ * surface through the SAME path as fills/liquidations/etc.
+ */
+export function pushExternalTradingAlert(alert: ExternalTradingAlert): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent<ExternalTradingAlert>(EXTERNAL_ALERT_EVENT, { detail: alert }),
+    );
+  } catch {
+    /* SSR / no window - no-op */
+  }
 }
 
 /** Cap the retained list so a busy account never grows unbounded. */
@@ -197,6 +220,19 @@ export function useTradingAlerts(enabled = true) {
   );
 
   const persistSeen = React.useCallback(() => saveJson(LS_SEEN, seenRef.current), []);
+
+  // ── Externally-authored alerts (price-alert evaluator, etc.) ─────────
+  // Anything in the app can call pushExternalTradingAlert(); we inject it here
+  // so it toasts + OS-notifies + lands in the bell alongside the /me/* feeds.
+  React.useEffect(() => {
+    const onExternal = (e: Event) => {
+      const detail = (e as CustomEvent<ExternalTradingAlert>).detail;
+      if (!detail || !detail.id) return;
+      pushAlerts([detail], true);
+    };
+    window.addEventListener(EXTERNAL_ALERT_EVENT, onExternal);
+    return () => window.removeEventListener(EXTERNAL_ALERT_EVENT, onExternal);
+  }, [pushAlerts]);
 
   // ── Fills ──────────────────────────────────────────────────────────
   React.useEffect(() => {

--- a/frontend/src/lib/orderMath.test.ts
+++ b/frontend/src/lib/orderMath.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  notional,
+  maxQtyForBalance,
+  riskSizedQty,
+  pctOfBuyingPowerQty,
+  estLiquidationPrice,
+} from "./orderMath";
+
+describe("notional", () => {
+  it("multiplies price * qty exactly", () => {
+    expect(notional(100, 3)).toBe(300);
+    expect(notional(12345, 7)).toBe(86415);
+  });
+  it("returns 0 for non-positive inputs", () => {
+    expect(notional(0, 5)).toBe(0);
+    expect(notional(100, 0)).toBe(0);
+    expect(notional(-1, 5)).toBe(0);
+  });
+});
+
+describe("maxQtyForBalance", () => {
+  it("floors balance / price to a whole lot", () => {
+    expect(maxQtyForBalance(1000, 100)).toBe(10);
+    expect(maxQtyForBalance(1050, 100)).toBe(10);
+    expect(maxQtyForBalance(99, 100)).toBe(0);
+  });
+  it("returns 0 on non-positive price or balance", () => {
+    expect(maxQtyForBalance(1000, 0)).toBe(0);
+    expect(maxQtyForBalance(0, 100)).toBe(0);
+    expect(maxQtyForBalance(-5, 100)).toBe(0);
+  });
+});
+
+describe("riskSizedQty", () => {
+  it("sizes qty from risk / stop-distance", () => {
+    // risk 500, entry 100, stop 90 -> dist 10 -> 50
+    expect(riskSizedQty(500, 100, 90)).toBe(50);
+    // short: entry 100 stop 110 -> dist 10 -> 50
+    expect(riskSizedQty(500, 100, 110)).toBe(50);
+  });
+  it("floors partial lots", () => {
+    // 505 / 10 = 50.5 -> 50
+    expect(riskSizedQty(505, 100, 90)).toBe(50);
+  });
+  it("guards divide-by-zero when entry == stop", () => {
+    expect(riskSizedQty(500, 100, 100)).toBe(0);
+  });
+  it("returns 0 for non-positive risk", () => {
+    expect(riskSizedQty(0, 100, 90)).toBe(0);
+    expect(riskSizedQty(-10, 100, 90)).toBe(0);
+  });
+});
+
+describe("pctOfBuyingPowerQty", () => {
+  it("takes a percentage of the affordable max", () => {
+    // max = 10; 25% -> 2 (floor of 2.5), 50% -> 5, 100% -> 10
+    expect(pctOfBuyingPowerQty(1000, 100, 25)).toBe(2);
+    expect(pctOfBuyingPowerQty(1000, 100, 50)).toBe(5);
+    expect(pctOfBuyingPowerQty(1000, 100, 100)).toBe(10);
+  });
+  it("clamps pct to [0,100]", () => {
+    expect(pctOfBuyingPowerQty(1000, 100, 150)).toBe(10);
+    expect(pctOfBuyingPowerQty(1000, 100, -50)).toBe(0);
+  });
+  it("returns 0 when nothing is affordable", () => {
+    expect(pctOfBuyingPowerQty(50, 100, 100)).toBe(0);
+  });
+});
+
+describe("estLiquidationPrice (rough, assumed-bps only)", () => {
+  it("puts the long liq below entry and short liq above entry", () => {
+    const longLiq = estLiquidationPrice(100, "buy", 1000, 500);
+    const shortLiq = estLiquidationPrice(100, "sell", 1000, 500);
+    // long = 100 * (1 - 0.10 + 0.05) = 95
+    expect(longLiq).toBeCloseTo(95, 6);
+    // short = 100 * (1 + 0.10 - 0.05) = 105
+    expect(shortLiq).toBeCloseTo(105, 6);
+  });
+  it("returns null on unusable inputs", () => {
+    expect(estLiquidationPrice(0, "buy", 1000, 500)).toBeNull();
+    expect(estLiquidationPrice(100, "buy", 0, 500)).toBeNull();
+  });
+});

--- a/frontend/src/lib/orderMath.ts
+++ b/frontend/src/lib/orderMath.ts
@@ -1,0 +1,85 @@
+// Pure, dependency-free order-entry math for the markets trade ticket. Every
+// value stays in the engine's int64 "tick" space (prices/qtys are integer
+// ticks scaled by the symbol's price_scaler for display). Kept framework-free
+// so it is unit-testable in isolation (see orderMath.test.ts). None of these
+// place orders — they only compute the numbers the ticket previews.
+
+/** Order notional in quote units: price * qty. Returns 0 for non-positive inputs. */
+export function notional(price: number, qty: number): number {
+  if (!(price > 0) || !(qty > 0)) return 0;
+  return price * qty;
+}
+
+/**
+ * Max whole-lot qty affordable for `balance` at `price` (buying power / price),
+ * floored to an integer lot. Returns 0 when price/balance are non-positive.
+ */
+export function maxQtyForBalance(balance: number, price: number): number {
+  if (!(price > 0) || !(balance > 0)) return 0;
+  return Math.floor(balance / price);
+}
+
+/**
+ * Position size from a fixed risk budget and a stop distance:
+ *   qty = riskAmount / |entryPrice - stopPrice|
+ * floored to a whole lot. Guards divide-by-zero (equal entry/stop or a
+ * non-positive risk budget) by returning 0.
+ */
+export function riskSizedQty(
+  riskAmount: number,
+  entryPrice: number,
+  stopPrice: number,
+): number {
+  if (!(riskAmount > 0)) return 0;
+  const dist = Math.abs(entryPrice - stopPrice);
+  if (!(dist > 0)) return 0;
+  return Math.floor(riskAmount / dist);
+}
+
+/**
+ * A percentage (0-100) of buying power expressed as a whole-lot qty at `price`.
+ * pct is clamped to [0, 100]. Returns 0 when it can't be sized.
+ */
+export function pctOfBuyingPowerQty(
+  balance: number,
+  price: number,
+  pct: number,
+): number {
+  const max = maxQtyForBalance(balance, price);
+  if (max <= 0) return 0;
+  const p = Math.min(100, Math.max(0, pct));
+  return Math.floor((max * p) / 100);
+}
+
+/**
+ * A ROUGH, clearly-labeled estimated liquidation price for a fresh position,
+ * used ONLY when the exchange's real maintenance-margin bps are not readable
+ * client-side (the fee schedule exposes maker/taker/liq-fee bps, not
+ * initial/maintenance margin). Callers MUST surface this as "(est.)" with the
+ * assumed bps shown — never as an authoritative number.
+ *
+ * Model: with maintenance margin fraction m = maintenanceBps / 10000, a long
+ * liquidates roughly where price has fallen by (1 - m) of the entry from the
+ * collateral-per-unit cushion. We approximate the simple isolated-margin case
+ * where the trader posts `initialBps` of notional as margin:
+ *   long  liq = entry * (1 - initialFrac + maintFrac)
+ *   short liq = entry * (1 + initialFrac - maintFrac)
+ * Returns null when inputs are unusable.
+ */
+export function estLiquidationPrice(
+  entryPrice: number,
+  side: "buy" | "sell",
+  initialBps: number,
+  maintenanceBps: number,
+): number | null {
+  if (!(entryPrice > 0)) return null;
+  if (!(initialBps > 0) || !(maintenanceBps >= 0)) return null;
+  const initialFrac = initialBps / 10000;
+  const maintFrac = maintenanceBps / 10000;
+  const px =
+    side === "buy"
+      ? entryPrice * (1 - initialFrac + maintFrac)
+      : entryPrice * (1 + initialFrac - maintFrac);
+  if (!Number.isFinite(px) || px <= 0) return null;
+  return px;
+}

--- a/frontend/src/lib/pnl.test.ts
+++ b/frontend/src/lib/pnl.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computePnl,
+  walkSymbolFills,
+  buildEquityCurve,
+  type PnlFill,
+} from "./pnl";
+
+/** Build a fill with sane defaults. */
+function fill(p: Partial<PnlFill> & Pick<PnlFill, "price" | "qty" | "side" | "ts">): PnlFill {
+  return { symbolid: 1, fee: 0, ...p };
+}
+
+describe("walkSymbolFills — average-cost realized PnL", () => {
+  it("realizes a simple long round-trip (buy low, sell high)", () => {
+    const fills: PnlFill[] = [
+      fill({ price: 100, qty: 10, side: "buy", ts: 1 }),
+      fill({ price: 120, qty: 10, side: "sell", ts: 2 }),
+    ];
+    const { realized, realizedPerClose, volume } = walkSymbolFills(fills);
+    // (120 - 100) * 10 = 200
+    expect(realized).toBe(200);
+    expect(realizedPerClose).toEqual([200]);
+    // |100*10| + |120*10| = 2200
+    expect(volume).toBe(2200);
+  });
+
+  it("realizes a short round-trip (sell high, buy back low)", () => {
+    const fills: PnlFill[] = [
+      fill({ price: 120, qty: 5, side: "sell", ts: 1 }),
+      fill({ price: 100, qty: 5, side: "buy", ts: 2 }),
+    ];
+    const { realized, realizedPerClose } = walkSymbolFills(fills);
+    // short: (100 - 120) * 5 * (-1) = 100
+    expect(realized).toBe(100);
+    expect(realizedPerClose).toEqual([100]);
+  });
+
+  it("weighted-averages the entry when adding to a position", () => {
+    const fills: PnlFill[] = [
+      fill({ price: 100, qty: 10, side: "buy", ts: 1 }),
+      fill({ price: 200, qty: 10, side: "buy", ts: 2 }), // avg entry -> 150
+      fill({ price: 180, qty: 20, side: "sell", ts: 3 }), // (180-150)*20 = 600
+    ];
+    const { realized } = walkSymbolFills(fills);
+    expect(realized).toBe(600);
+  });
+
+  it("handles a partial close then a flip", () => {
+    const fills: PnlFill[] = [
+      fill({ price: 100, qty: 10, side: "buy", ts: 1 }), // long 10 @ 100
+      fill({ price: 130, qty: 15, side: "sell", ts: 2 }), // close 10 -> +300, then short 5 @ 130
+      fill({ price: 110, qty: 5, side: "buy", ts: 3 }), // cover short 5: (110-130)*5*-1 = +100
+    ];
+    const { realized, realizedPerClose } = walkSymbolFills(fills);
+    expect(realizedPerClose).toEqual([300, 100]);
+    expect(realized).toBe(400);
+  });
+
+  it("sorts fills oldest->newest by ts regardless of input order", () => {
+    const fills: PnlFill[] = [
+      fill({ price: 120, qty: 10, side: "sell", ts: 2 }),
+      fill({ price: 100, qty: 10, side: "buy", ts: 1 }),
+    ];
+    const { realized } = walkSymbolFills(fills);
+    expect(realized).toBe(200);
+  });
+});
+
+describe("computePnl — net realized, win rate, fees, funding, liquidations", () => {
+  it("nets fees, funding and liquidation pnl/fees into net realized", () => {
+    const fills: PnlFill[] = [
+      fill({ symbolid: 1, price: 100, qty: 10, side: "buy", ts: 1, fee: 5 }),
+      fill({ symbolid: 1, price: 120, qty: 10, side: "sell", ts: 2, fee: 6 }),
+    ];
+    const funding = [{ symbolid: 1, payment: -8, ts: 3 }]; // paid 8
+    const liquidations = [{ symbolid: 1, realized_pnl: 50, fee: 4, ts: 4 }];
+
+    const s = computePnl(fills, funding, liquidations);
+
+    expect(s.totalRealized).toBe(200);
+    expect(s.totalFees).toBe(11);
+    expect(s.totalFunding).toBe(-8);
+    expect(s.totalLiquidationPnl).toBe(50);
+    expect(s.totalLiquidationFees).toBe(4);
+    // 200 - 11 + (-8) + 50 - 4 = 227
+    expect(s.netRealized).toBe(227);
+    expect(s.tradeCount).toBe(2);
+    expect(s.totalVolume).toBe(2200);
+  });
+
+  it("computes win rate over position-closing trades", () => {
+    // Symbol 1: one winning close. Symbol 2: one losing close.
+    const fills: PnlFill[] = [
+      fill({ symbolid: 1, price: 100, qty: 10, side: "buy", ts: 1 }),
+      fill({ symbolid: 1, price: 120, qty: 10, side: "sell", ts: 2 }), // +200 win
+      fill({ symbolid: 2, price: 100, qty: 10, side: "buy", ts: 3 }),
+      fill({ symbolid: 2, price: 90, qty: 10, side: "sell", ts: 4 }), // -100 loss
+    ];
+    const s = computePnl(fills);
+    expect(s.closeCount).toBe(2);
+    expect(s.winCount).toBe(1);
+    expect(s.winRate).toBe(0.5);
+    expect(s.perSymbol).toHaveLength(2);
+  });
+
+  it("returns a zero-ish summary and 0 win rate for empty feeds", () => {
+    const s = computePnl();
+    expect(s.perSymbol).toEqual([]);
+    expect(s.netRealized).toBe(0);
+    expect(s.winRate).toBe(0);
+    expect(s.closeCount).toBe(0);
+    expect(s.equityCurve).toEqual([]);
+  });
+});
+
+describe("buildEquityCurve — cumulative, time-ordered", () => {
+  it("accumulates realized-minus-fees across events in ts order", () => {
+    const fills: PnlFill[] = [
+      fill({ symbolid: 1, price: 100, qty: 10, side: "buy", ts: 1, fee: 2 }),
+      fill({ symbolid: 1, price: 120, qty: 10, side: "sell", ts: 3, fee: 3 }),
+    ];
+    const funding = [{ symbolid: 1, payment: 5, ts: 2 }];
+    const curve = buildEquityCurve(fills, funding);
+
+    // ts=1 open: realized 0 - fee 2 = -2
+    // ts=2 funding: +5 -> 3
+    // ts=3 close: +200 - fee 3 -> 200 => 3 + 197 = 200
+    expect(curve.map((p) => p.ts)).toEqual([1, 2, 3]);
+    expect(curve.map((p) => p.value)).toEqual([-2, 3, 200]);
+  });
+});

--- a/frontend/src/lib/pnl.ts
+++ b/frontend/src/lib/pnl.ts
@@ -1,0 +1,320 @@
+// Pure, dependency-free PnL / performance analytics computed CLIENT-SIDE from
+// the exchange account feeds (fills-fees / funding / liquidations). Every value
+// stays in the engine's int64 "tick" space — the UI scales for display with the
+// markets `formatPrice`/`formatQty` helpers. Kept pure + framework-free so it is
+// unit-testable in isolation (see pnl.test.ts).
+
+/** One executed fill (subset of the `/me/fills/fees` feed shape used here). */
+export interface PnlFill {
+  symbolid: number;
+  /** int64 engine tick. */
+  price: number;
+  /** int64 engine tick. */
+  qty: number;
+  side: "buy" | "sell";
+  /** int64 engine tick — the REAL fee charged for this fill. */
+  fee: number;
+  /** unix ts (seconds or ms). */
+  ts: number;
+}
+
+/** One funding payment (subset of `/me/funding/payments`). */
+export interface PnlFunding {
+  symbolid: number;
+  /** int64 engine tick, SIGNED — negative = paid, positive = received. */
+  payment: number;
+  ts: number;
+}
+
+/** One forced-liquidation event (subset of `/me/liquidations`). */
+export interface PnlLiquidation {
+  symbolid: number;
+  /** int64 engine tick, SIGNED. */
+  realized_pnl: number;
+  /** int64 engine tick — the liquidation fee. */
+  fee: number;
+  ts: number;
+}
+
+/** Per-symbol realized-PnL rollup. All amounts are engine int64 ticks. */
+export interface SymbolPnl {
+  symbolid: number;
+  /** Realized PnL from average-cost round-trips (fills only, pre-fee). */
+  realized: number;
+  /** Sum of fees paid on this symbol's fills. */
+  fees: number;
+  /** Sum of signed funding payments for this symbol. */
+  funding: number;
+  /** Sum of liquidation realized_pnl for this symbol. */
+  liquidationPnl: number;
+  /** Sum of liquidation fees for this symbol. */
+  liquidationFees: number;
+  /** Net realized = realized - fees + funding + liquidationPnl - liquidationFees. */
+  net: number;
+  /** Traded notional = sum of |price*qty| over fills (magnitude only). */
+  volume: number;
+  /** Number of fills on this symbol. */
+  tradeCount: number;
+  /** Number of position-reducing/closing fills that realized PnL. */
+  closes: number;
+  /** Of those closes, how many realized a strictly-positive PnL. */
+  wins: number;
+}
+
+/** Everything the PnL page renders, derived from the three feeds + current unrealized. */
+export interface PnlSummary {
+  perSymbol: SymbolPnl[];
+  /** Sum of average-cost realized (pre-fee, fills only). */
+  totalRealized: number;
+  /** Sum of fees across all fills. */
+  totalFees: number;
+  /** Sum of signed funding. */
+  totalFunding: number;
+  /** Sum of liquidation realized_pnl. */
+  totalLiquidationPnl: number;
+  /** Sum of liquidation fees. */
+  totalLiquidationFees: number;
+  /**
+   * Net realized across everything:
+   *   realized - fees + funding + liq.realized - liq.fees.
+   */
+  netRealized: number;
+  /** Total traded notional magnitude across all fills. */
+  totalVolume: number;
+  /** Total number of fills. */
+  tradeCount: number;
+  /** Number of position-closing fills. */
+  closeCount: number;
+  /** Number of winning (positive-realized) closing fills. */
+  winCount: number;
+  /** winCount / closeCount in [0,1]; 0 when there are no closes. */
+  winRate: number;
+  /** Time-ordered cumulative equity curve (realized + funding - fees, by ts). */
+  equityCurve: EquityPoint[];
+}
+
+/** One point on the cumulative equity curve. */
+export interface EquityPoint {
+  ts: number;
+  /** Cumulative net (realized + funding - fees + liq.realized - liq.fees) up to ts. */
+  value: number;
+}
+
+/**
+ * Walk one symbol's fills oldest to newest with an average-cost running
+ * position (netQty, avgEntry) and return the realized PnL plus win/close/volume
+ * stats.
+ *
+ * - A fill on the SAME side as the current net position (or opening from flat)
+ *   INCREASES the position and updates the weighted-average entry price.
+ * - A fill on the OPPOSITE side REDUCES/closes: it realizes
+ *     (fillPrice - avgEntry) * closedQty * dir
+ *   where dir = +1 if the closed position was long, -1 if short, and closedQty
+ *   is the min of the fill qty and the open size. Any residual qty beyond the
+ *   close flips the position and opens a new leg at the fill price.
+ *
+ * `realizedPerClose` records the realized PnL of every position-reducing event
+ * so callers can compute a win rate over discrete closes.
+ */
+export function walkSymbolFills(fills: PnlFill[]): {
+  realized: number;
+  volume: number;
+  realizedPerClose: number[];
+} {
+  // Oldest to newest.
+  const ordered = [...fills].sort((a, b) => a.ts - b.ts);
+
+  let netQty = 0; // signed: >0 long, <0 short
+  let avgEntry = 0;
+  let realized = 0;
+  let volume = 0;
+  const realizedPerClose: number[] = [];
+
+  for (const f of ordered) {
+    const signed = f.side === "buy" ? f.qty : -f.qty;
+    volume += Math.abs(f.price * f.qty);
+
+    if (netQty === 0 || Math.sign(signed) === Math.sign(netQty)) {
+      // Opening or adding in the same direction — weighted-average the entry.
+      const newQty = netQty + signed;
+      const totalCost = avgEntry * Math.abs(netQty) + f.price * Math.abs(signed);
+      avgEntry = Math.abs(newQty) === 0 ? 0 : totalCost / Math.abs(newQty);
+      netQty = newQty;
+      continue;
+    }
+
+    // Opposite side — reduce/close (and maybe flip).
+    const dir = netQty > 0 ? 1 : -1; // direction of the position being closed
+    const closedQty = Math.min(Math.abs(signed), Math.abs(netQty));
+    const pnl = (f.price - avgEntry) * closedQty * dir;
+    realized += pnl;
+    realizedPerClose.push(pnl);
+
+    const residual = Math.abs(signed) - Math.abs(netQty);
+    if (residual > 0) {
+      // Fully closed then flipped — open a fresh leg at the fill price.
+      netQty = Math.sign(signed) * residual;
+      avgEntry = f.price;
+    } else {
+      netQty = netQty + signed; // shrink toward / to zero
+      if (netQty === 0) avgEntry = 0;
+    }
+  }
+
+  return { realized, volume, realizedPerClose };
+}
+
+/** Group an array by a numeric key. */
+function groupBy<T>(items: T[], key: (t: T) => number): Map<number, T[]> {
+  const m = new Map<number, T[]>();
+  for (const it of items) {
+    const k = key(it);
+    const arr = m.get(k);
+    if (arr) arr.push(it);
+    else m.set(k, [it]);
+  }
+  return m;
+}
+
+/**
+ * Compute the full PnL summary from the three account feeds.
+ * All inputs are optional (a feed may 404 -> treat as empty).
+ */
+export function computePnl(
+  fills: PnlFill[] = [],
+  funding: PnlFunding[] = [],
+  liquidations: PnlLiquidation[] = [],
+): PnlSummary {
+  const bySymbol = groupBy(fills, (f) => f.symbolid);
+  const fundingBySymbol = groupBy(funding, (f) => f.symbolid);
+  const liqBySymbol = groupBy(liquidations, (l) => l.symbolid);
+
+  const symbolIds = new Set<number>([
+    ...bySymbol.keys(),
+    ...fundingBySymbol.keys(),
+    ...liqBySymbol.keys(),
+  ]);
+
+  const perSymbol: SymbolPnl[] = [];
+
+  for (const symbolid of symbolIds) {
+    const sFills = bySymbol.get(symbolid) ?? [];
+    const sFunding = fundingBySymbol.get(symbolid) ?? [];
+    const sLiq = liqBySymbol.get(symbolid) ?? [];
+
+    const { realized, volume, realizedPerClose } = walkSymbolFills(sFills);
+    const fees = sFills.reduce((a, f) => a + (f.fee || 0), 0);
+    const fundingSum = sFunding.reduce((a, f) => a + (f.payment || 0), 0);
+    const liquidationPnl = sLiq.reduce((a, l) => a + (l.realized_pnl || 0), 0);
+    const liquidationFees = sLiq.reduce((a, l) => a + (l.fee || 0), 0);
+    const wins = realizedPerClose.filter((p) => p > 0).length;
+
+    perSymbol.push({
+      symbolid,
+      realized,
+      fees,
+      funding: fundingSum,
+      liquidationPnl,
+      liquidationFees,
+      net: realized - fees + fundingSum + liquidationPnl - liquidationFees,
+      volume,
+      tradeCount: sFills.length,
+      closes: realizedPerClose.length,
+      wins,
+    });
+  }
+
+  // Stable order: biggest traded volume first.
+  perSymbol.sort((a, b) => b.volume - a.volume);
+
+  const totalRealized = perSymbol.reduce((a, s) => a + s.realized, 0);
+  const totalFees = perSymbol.reduce((a, s) => a + s.fees, 0);
+  const totalFunding = perSymbol.reduce((a, s) => a + s.funding, 0);
+  const totalLiquidationPnl = perSymbol.reduce((a, s) => a + s.liquidationPnl, 0);
+  const totalLiquidationFees = perSymbol.reduce((a, s) => a + s.liquidationFees, 0);
+  const totalVolume = perSymbol.reduce((a, s) => a + s.volume, 0);
+  const tradeCount = perSymbol.reduce((a, s) => a + s.tradeCount, 0);
+  const closeCount = perSymbol.reduce((a, s) => a + s.closes, 0);
+  const winCount = perSymbol.reduce((a, s) => a + s.wins, 0);
+
+  return {
+    perSymbol,
+    totalRealized,
+    totalFees,
+    totalFunding,
+    totalLiquidationPnl,
+    totalLiquidationFees,
+    netRealized:
+      totalRealized - totalFees + totalFunding + totalLiquidationPnl - totalLiquidationFees,
+    totalVolume,
+    tradeCount,
+    closeCount,
+    winCount,
+    winRate: closeCount === 0 ? 0 : winCount / closeCount,
+    equityCurve: buildEquityCurve(fills, funding, liquidations),
+  };
+}
+
+/**
+ * A time-ordered cumulative running total of realized+funding-fees across ALL
+ * events. Fills contribute their per-fill realized delta (from the average-cost
+ * walk) minus their fee; funding contributes its signed payment; liquidations
+ * contribute realized_pnl - fee. Events are merged and sorted by ts, then the
+ * running sum is emitted as one point per event.
+ */
+export function buildEquityCurve(
+  fills: PnlFill[] = [],
+  funding: PnlFunding[] = [],
+  liquidations: PnlLiquidation[] = [],
+): EquityPoint[] {
+  interface Ev {
+    ts: number;
+    delta: number;
+  }
+  const events: Ev[] = [];
+
+  // Per-symbol average-cost walk to attribute a realized delta to each fill.
+  const bySymbol = groupBy(fills, (f) => f.symbolid);
+  for (const sFills of bySymbol.values()) {
+    const ordered = [...sFills].sort((a, b) => a.ts - b.ts);
+    let netQty = 0;
+    let avgEntry = 0;
+    for (const f of ordered) {
+      const signed = f.side === "buy" ? f.qty : -f.qty;
+      let realizedDelta = 0;
+      if (netQty !== 0 && Math.sign(signed) !== Math.sign(netQty)) {
+        const dir = netQty > 0 ? 1 : -1;
+        const closedQty = Math.min(Math.abs(signed), Math.abs(netQty));
+        realizedDelta = (f.price - avgEntry) * closedQty * dir;
+        const residual = Math.abs(signed) - Math.abs(netQty);
+        if (residual > 0) {
+          netQty = Math.sign(signed) * residual;
+          avgEntry = f.price;
+        } else {
+          netQty = netQty + signed;
+          if (netQty === 0) avgEntry = 0;
+        }
+      } else {
+        const newQty = netQty + signed;
+        const totalCost = avgEntry * Math.abs(netQty) + f.price * Math.abs(signed);
+        avgEntry = Math.abs(newQty) === 0 ? 0 : totalCost / Math.abs(newQty);
+        netQty = newQty;
+      }
+      events.push({ ts: f.ts, delta: realizedDelta - (f.fee || 0) });
+    }
+  }
+
+  for (const f of funding) events.push({ ts: f.ts, delta: f.payment || 0 });
+  for (const l of liquidations)
+    events.push({ ts: l.ts, delta: (l.realized_pnl || 0) - (l.fee || 0) });
+
+  events.sort((a, b) => a.ts - b.ts);
+
+  const curve: EquityPoint[] = [];
+  let running = 0;
+  for (const e of events) {
+    running += e.delta;
+    curve.push({ ts: e.ts, value: running });
+  }
+  return curve;
+}

--- a/frontend/src/lib/priceAlerts.test.ts
+++ b/frontend/src/lib/priceAlerts.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluate,
+  parsePriceToTicks,
+  type PriceAlert,
+} from "@/lib/priceAlerts";
+
+function makeAlert(over: Partial<PriceAlert>): PriceAlert {
+  return {
+    id: "a1",
+    symbolId: 1,
+    direction: "above",
+    price: 65000,
+    createdTs: 0,
+    triggeredTs: null,
+    armed: true,
+    ...over,
+  };
+}
+
+describe("evaluate (pure price-alert edge trigger)", () => {
+  it("above: does NOT fire while price is below the threshold", () => {
+    const a = makeAlert({ direction: "above", price: 65000 });
+    expect(evaluate(a, 64999)).toBe(false);
+  });
+
+  it("above: fires when price reaches / crosses the threshold", () => {
+    const a = makeAlert({ direction: "above", price: 65000 });
+    expect(evaluate(a, 65000)).toBe(true); // exactly at
+    expect(evaluate(a, 65001)).toBe(true); // above
+  });
+
+  it("below: does NOT fire while price is above the threshold", () => {
+    const a = makeAlert({ direction: "below", price: 3000 });
+    expect(evaluate(a, 3001)).toBe(false);
+  });
+
+  it("below: fires when price reaches / crosses down through the threshold", () => {
+    const a = makeAlert({ direction: "below", price: 3000 });
+    expect(evaluate(a, 3000)).toBe(true); // exactly at
+    expect(evaluate(a, 2999)).toBe(true); // below
+  });
+
+  it("one-shot: a disarmed (already-fired) alert never fires again", () => {
+    // Simulate the store's one-shot: after firing we disarm.
+    const fired = makeAlert({ direction: "above", price: 65000, armed: false, triggeredTs: 123 });
+    expect(evaluate(fired, 66000)).toBe(false);
+    expect(evaluate(fired, 70000)).toBe(false);
+  });
+
+  it("re-arm: re-arming lets the alert fire again", () => {
+    const rearmed = makeAlert({ direction: "above", price: 65000, armed: true, triggeredTs: null });
+    expect(evaluate(rearmed, 65000)).toBe(true);
+  });
+
+  it("ignores non-finite prices", () => {
+    const a = makeAlert({ direction: "above", price: 65000 });
+    expect(evaluate(a, Number.NaN)).toBe(false);
+    expect(evaluate(a, Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it("full lifecycle: armed→fires→disarm(one-shot)→re-arm→fires", () => {
+    // armed, below threshold: no fire
+    let a = makeAlert({ direction: "above", price: 65000, armed: true });
+    expect(evaluate(a, 64000)).toBe(false);
+    // crosses up: fire
+    expect(evaluate(a, 65500)).toBe(true);
+    // store disarms after firing (one-shot)
+    a = { ...a, armed: false, triggeredTs: Date.now() };
+    expect(evaluate(a, 66000)).toBe(false);
+    // user re-arms
+    a = { ...a, armed: true, triggeredTs: null };
+    expect(evaluate(a, 66000)).toBe(true);
+  });
+});
+
+describe("parsePriceToTicks", () => {
+  it("scales a decimal price into integer ticks", () => {
+    expect(parsePriceToTicks("65000", 1)).toBe(65000);
+    expect(parsePriceToTicks("3000.5", 100)).toBe(300050);
+    expect(parsePriceToTicks("150.25", 100)).toBe(15025);
+  });
+
+  it("rounds to the nearest tick", () => {
+    expect(parsePriceToTicks("1.007", 100)).toBe(101); // 100.7 -> 101
+    expect(parsePriceToTicks("1.002", 100)).toBe(100); // 100.2 -> 100
+  });
+
+  it("rejects blank / non-numeric / negative input", () => {
+    expect(parsePriceToTicks("", 1)).toBeNull();
+    expect(parsePriceToTicks("   ", 1)).toBeNull();
+    expect(parsePriceToTicks("abc", 1)).toBeNull();
+    expect(parsePriceToTicks("-5", 1)).toBeNull();
+  });
+
+  it("defaults scaler to 1 when unset", () => {
+    expect(parsePriceToTicks("42")).toBe(42);
+  });
+});

--- a/frontend/src/lib/priceAlerts.ts
+++ b/frontend/src/lib/priceAlerts.ts
@@ -1,0 +1,169 @@
+/**
+ * Price-alert store — client-side, localStorage-persisted watch list of
+ * "notify me when <symbol> crosses <price>" rules.
+ *
+ * Prices are stored as INTEGER TICKS (int64-scaled, same units the market-data
+ * endpoints use). Callers convert user-entered decimals to ticks via the
+ * symbol's `price_scaler` (see parsePriceToTicks) before persisting.
+ *
+ * The evaluator (useEvaluatePriceAlerts) polls each armed alert's symbol last
+ * price and, on an EDGE CROSS of the threshold, fires it once (one-shot).
+ */
+
+export type PriceAlertDirection = "above" | "below";
+
+export interface PriceAlert {
+  /** Stable id. */
+  id: string;
+  /** Market symbol_id this alert watches. */
+  symbolId: number;
+  /** Fire when price goes above / below the threshold. */
+  direction: PriceAlertDirection;
+  /** Threshold price in integer ticks (int64-scaled). */
+  price: number;
+  /** Optional free-text note shown on the alert. */
+  note?: string;
+  /** Epoch ms the alert was created. */
+  createdTs: number;
+  /** Epoch ms the alert last fired, or null if it has not fired. */
+  triggeredTs?: number | null;
+  /** Whether the alert is actively watching (false once fired / paused). */
+  armed: boolean;
+}
+
+export const PRICE_ALERTS_KEY = "md.priceAlerts.v1";
+
+/** Fired (same-tab) whenever the stored list changes so views re-read it. */
+export const PRICE_ALERTS_EVENT = "tl:priceAlertsChanged";
+
+// ── Persistence ─────────────────────────────────────────────────────
+
+function isPriceAlert(x: unknown): x is PriceAlert {
+  if (!x || typeof x !== "object") return false;
+  const a = x as Record<string, unknown>;
+  return (
+    typeof a.id === "string" &&
+    typeof a.symbolId === "number" &&
+    (a.direction === "above" || a.direction === "below") &&
+    typeof a.price === "number" &&
+    typeof a.createdTs === "number" &&
+    typeof a.armed === "boolean"
+  );
+}
+
+export function loadPriceAlerts(): PriceAlert[] {
+  try {
+    const raw = localStorage.getItem(PRICE_ALERTS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(isPriceAlert) : [];
+  } catch {
+    return [];
+  }
+}
+
+function savePriceAlerts(list: PriceAlert[]): void {
+  try {
+    localStorage.setItem(PRICE_ALERTS_KEY, JSON.stringify(list));
+  } catch {
+    /* quota / private-mode — degrade to no-op */
+  }
+  try {
+    window.dispatchEvent(new Event(PRICE_ALERTS_EVENT));
+  } catch {
+    /* SSR — no-op */
+  }
+}
+
+// ── CRUD ────────────────────────────────────────────────────────────
+
+function genId(): string {
+  try {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+      return crypto.randomUUID();
+    }
+  } catch {
+    /* fall through */
+  }
+  return `pa_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export interface NewPriceAlertInput {
+  symbolId: number;
+  direction: PriceAlertDirection;
+  /** Threshold in integer ticks. */
+  price: number;
+  note?: string;
+}
+
+export function addPriceAlert(input: NewPriceAlertInput): PriceAlert {
+  const alert: PriceAlert = {
+    id: genId(),
+    symbolId: input.symbolId,
+    direction: input.direction,
+    price: input.price,
+    note: input.note?.trim() ? input.note.trim() : undefined,
+    createdTs: Date.now(),
+    triggeredTs: null,
+    armed: true,
+  };
+  savePriceAlerts([alert, ...loadPriceAlerts()]);
+  return alert;
+}
+
+export function removePriceAlert(id: string): void {
+  savePriceAlerts(loadPriceAlerts().filter((a) => a.id !== id));
+}
+
+export function updatePriceAlert(id: string, patch: Partial<PriceAlert>): void {
+  savePriceAlerts(
+    loadPriceAlerts().map((a) => (a.id === id ? { ...a, ...patch, id: a.id } : a)),
+  );
+}
+
+/** Re-arm a fired alert so it watches again (clears the trigger stamp). */
+export function rearmPriceAlert(id: string): void {
+  updatePriceAlert(id, { armed: true, triggeredTs: null });
+}
+
+/** Mark an alert as fired: stamp the time and disarm (one-shot). */
+export function markPriceAlertTriggered(id: string, ts = Date.now()): void {
+  updatePriceAlert(id, { armed: false, triggeredTs: ts });
+}
+
+// ── Tick <-> decimal conversion ─────────────────────────────────────
+
+/**
+ * Parse a user-entered decimal price string into integer ticks using the
+ * symbol's price_scaler. Returns null for blank / non-numeric / negative input.
+ */
+export function parsePriceToTicks(input: string, scaler = 1): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n * (scaler || 1));
+}
+
+// ── Pure evaluation ─────────────────────────────────────────────────
+
+/**
+ * Decide whether an alert should fire given the latest price (in ticks).
+ *
+ * Edge-triggered: an armed alert fires only on the tick where the price CROSSES
+ * the threshold — i.e. the price now MEETS the condition (above: price >=
+ * threshold; below: price <= threshold). The one-shot / re-arm behavior lives in
+ * the store (markPriceAlertTriggered / rearmPriceAlert); this helper only reads
+ * `alert.armed`, so a disarmed alert never fires and a re-armed one can fire
+ * again.
+ *
+ * Returns true = fire now, false = do nothing.
+ */
+export function evaluate(alert: PriceAlert, lastPriceTicks: number): boolean {
+  if (!alert.armed) return false;
+  if (!Number.isFinite(lastPriceTicks)) return false;
+  if (alert.direction === "above") {
+    return lastPriceTicks >= alert.price;
+  }
+  return lastPriceTicks <= alert.price;
+}

--- a/frontend/src/lib/tradingPrefs.ts
+++ b/frontend/src/lib/tradingPrefs.ts
@@ -25,6 +25,7 @@ export const DEFAULT_ALERT_PREFS: AlertPrefs = {
   funding: true,
   margin: true,
   pm_resolved: true,
+  price: true,
 };
 
 export function loadAlertPrefs(): AlertPrefs {

--- a/frontend/src/pages/alerts/PriceAlertsPage.tsx
+++ b/frontend/src/pages/alerts/PriceAlertsPage.tsx
@@ -1,0 +1,321 @@
+import * as React from "react";
+import { BellRing, Plus, Trash2, RotateCcw, ArrowUp, ArrowDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSymbols, useCandles } from "@/hooks/useMarketData";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { formatPrice } from "@/pages/markets/format";
+import { relativeTime } from "@/hooks/useTradingAlerts";
+import {
+  addPriceAlert,
+  loadPriceAlerts,
+  parsePriceToTicks,
+  rearmPriceAlert,
+  removePriceAlert,
+  PRICE_ALERTS_EVENT,
+  PRICE_ALERTS_KEY,
+  type PriceAlert,
+  type PriceAlertDirection,
+} from "@/lib/priceAlerts";
+
+/** Subscribe to the stored price-alert list (re-reads on same/cross-tab change). */
+function usePriceAlerts(): PriceAlert[] {
+  const [alerts, setAlerts] = React.useState<PriceAlert[]>(() => loadPriceAlerts());
+  React.useEffect(() => {
+    const reload = () => setAlerts(loadPriceAlerts());
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === PRICE_ALERTS_KEY || e.key === null) reload();
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(PRICE_ALERTS_EVENT, reload);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(PRICE_ALERTS_EVENT, reload);
+    };
+  }, []);
+  return alerts;
+}
+
+/** Small live current-price readout for a symbol (candle close). */
+function CurrentPrice({ symbolId, scaler }: { symbolId: number; scaler: number }) {
+  const { data } = useCandles(symbolId, 60, symbolId > 0, 1);
+  const bars = data?.bars;
+  const lastBar = bars && bars.length ? bars[bars.length - 1] : undefined;
+  const last = lastBar?.close;
+  return <span className="tabular-nums">{formatPrice(last, scaler)}</span>;
+}
+
+function AlertRow({
+  alert,
+  symbol,
+  now,
+}: {
+  alert: PriceAlert;
+  symbol: MarketSymbol | undefined;
+  now: number;
+}) {
+  const scaler = symbol?.price_scaler ?? 1;
+  const name = symbol?.symbol ?? `#${alert.symbolId}`;
+  const fired = !!alert.triggeredTs;
+  const DirIcon = alert.direction === "above" ? ArrowUp : ArrowDown;
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between",
+        fired && "bg-muted/40",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{name}</span>
+          <Badge
+            variant={alert.direction === "above" ? "default" : "secondary"}
+            className="gap-1"
+          >
+            <DirIcon className="h-3 w-3" />
+            {alert.direction} {formatPrice(alert.price, scaler)}
+          </Badge>
+          {fired ? (
+            <Badge variant="outline" className="text-muted-foreground">
+              Triggered {relativeTime(alert.triggeredTs as number, now)}
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
+              Armed
+            </Badge>
+          )}
+        </div>
+        {alert.note && (
+          <p className="mt-1 truncate text-sm text-muted-foreground">{alert.note}</p>
+        )}
+        <p className="mt-1 text-xs text-muted-foreground">
+          Current: <CurrentPrice symbolId={alert.symbolId} scaler={scaler} />
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {fired && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1"
+            onClick={() => rearmPriceAlert(alert.id)}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            Re-arm
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Delete alert"
+          onClick={() => removePriceAlert(alert.id)}
+        >
+          <Trash2 className="h-4 w-4 text-destructive" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function PriceAlertsPage() {
+  const alerts = usePriceAlerts();
+  const { data: symbolsData } = useSymbols();
+  const symbols = React.useMemo(() => symbolsData?.symbols ?? [], [symbolsData]);
+  const byId = React.useMemo(() => {
+    const m = new Map<number, MarketSymbol>();
+    for (const s of symbols) m.set(s.symbol_id, s);
+    return m;
+  }, [symbols]);
+
+  // Add-form state.
+  const [symbolId, setSymbolId] = React.useState<string>("");
+  const [direction, setDirection] = React.useState<PriceAlertDirection>("above");
+  const [priceStr, setPriceStr] = React.useState("");
+  const [note, setNote] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Default the symbol select to the first symbol once loaded.
+  React.useEffect(() => {
+    const first = symbols[0];
+    if (!symbolId && first) setSymbolId(String(first.symbol_id));
+  }, [symbols, symbolId]);
+
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const selectedSymbol = symbolId ? byId.get(Number(symbolId)) : undefined;
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const sid = Number(symbolId);
+    if (!Number.isFinite(sid) || sid <= 0) {
+      setError("Choose a symbol.");
+      return;
+    }
+    const scaler = selectedSymbol?.price_scaler ?? 1;
+    const ticks = parsePriceToTicks(priceStr, scaler);
+    if (ticks == null) {
+      setError("Enter a valid price.");
+      return;
+    }
+    addPriceAlert({ symbolId: sid, direction, price: ticks, note });
+    setPriceStr("");
+    setNote("");
+  };
+
+  const active = alerts.filter((a) => a.armed);
+  const triggered = alerts.filter((a) => !a.armed);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4 sm:p-6">
+      <div className="flex items-center gap-3">
+        <BellRing className="h-6 w-6 text-primary" />
+        <div>
+          <h1 className="text-xl font-semibold">Price alerts</h1>
+          <p className="text-sm text-muted-foreground">
+            Get notified when a market crosses your target price.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">New alert</CardTitle>
+          <CardDescription>
+            Alerts fire once when the last price crosses your threshold, then pause
+            so you can re-arm them.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="pa-symbol">Symbol</Label>
+              <Select value={symbolId} onValueChange={setSymbolId}>
+                <SelectTrigger id="pa-symbol">
+                  <SelectValue placeholder="Select symbol" />
+                </SelectTrigger>
+                <SelectContent>
+                  {symbols.map((s) => (
+                    <SelectItem key={s.symbol_id} value={String(s.symbol_id)}>
+                      {s.symbol}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="pa-dir">Condition</Label>
+              <Select
+                value={direction}
+                onValueChange={(v) => setDirection(v as PriceAlertDirection)}
+              >
+                <SelectTrigger id="pa-dir">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="above">Price rises above</SelectItem>
+                  <SelectItem value="below">Price falls below</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="pa-price">Target price</Label>
+              <Input
+                id="pa-price"
+                inputMode="decimal"
+                placeholder="e.g. 65000"
+                value={priceStr}
+                onChange={(e) => setPriceStr(e.target.value)}
+              />
+              {selectedSymbol && (
+                <p className="text-xs text-muted-foreground">
+                  Current:{" "}
+                  <CurrentPrice
+                    symbolId={selectedSymbol.symbol_id}
+                    scaler={selectedSymbol.price_scaler}
+                  />
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="pa-note">Note (optional)</Label>
+              <Input
+                id="pa-note"
+                placeholder="Why this matters"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+              />
+            </div>
+
+            <div className="sm:col-span-2 flex items-center gap-3">
+              <Button type="submit" className="gap-1">
+                <Plus className="h-4 w-4" />
+                Add alert
+              </Button>
+              {error && <span className="text-sm text-destructive">{error}</span>}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-muted-foreground">
+          Active ({active.length})
+        </h2>
+        {active.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-10 text-center">
+            <BellRing className="h-6 w-6 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">No active price alerts</p>
+            <p className="text-xs text-muted-foreground">
+              Add one above to get notified on a price move.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {active.map((a) => (
+              <AlertRow key={a.id} alert={a} symbol={byId.get(a.symbolId)} now={now} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {triggered.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            Triggered ({triggered.length})
+          </h2>
+          <div className="space-y-2">
+            {triggered.map((a) => (
+              <AlertRow key={a.id} alert={a} symbol={byId.get(a.symbolId)} now={now} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -1,0 +1,630 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowUpRight,
+  Bell,
+  CandlestickChart,
+  CheckCircle2,
+  Circle,
+  Home as HomeIcon,
+  Info,
+  LineChart,
+  PieChart,
+  Plus,
+  Wallet,
+  X,
+} from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { ApiError } from "@/api/client";
+
+import { useMarginAccount, useSpotBalance } from "@/hooks/useTrading";
+import { useSymbols, useCandles } from "@/hooks/useMarketData";
+import { useTradingAlerts, relativeTime } from "@/hooks/useTradingAlerts";
+import { getBalance } from "@/api/endpoints/custody";
+import { getFillsFees, type FillFee } from "@/api/endpoints/trading";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { loadDefaultSymbol } from "@/lib/tradingPrefs";
+import { formatPrice, formatQty } from "@/pages/markets/format";
+
+// local helpers
+
+const WATCHLIST_KEY = "md.watchlist.v1";
+const ONBOARDING_DISMISSED_KEY = "home.onboardingDismissed";
+
+function loadWatchlist(): number[] {
+  try {
+    const raw = localStorage.getItem(WATCHLIST_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "number") : [];
+  } catch {
+    return [];
+  }
+}
+
+function num(v: string | number | undefined | null): number {
+  if (v == null) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// 404/403 = "not available on this backend" -> treated as UNKNOWN, not "no".
+function isUnavailable(err: unknown): boolean {
+  if (err instanceof ApiError) return err.status === 404 || err.status === 403;
+  const msg = (err as Error)?.message ?? "";
+  return /\b40[34]\b/.test(msg);
+}
+
+// nanosecond / second / ms epoch -> ms.
+function toMs(ts: number | undefined): number {
+  if (ts == null || !Number.isFinite(ts)) return 0;
+  if (ts > 1e17) return Math.floor(ts / 1_000_000);
+  if (ts < 1e12) return Math.floor(ts * 1000);
+  return Math.floor(ts);
+}
+
+function CardError({ line }: { line: string }) {
+  return (
+    <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+      <Info className="h-3.5 w-3.5 shrink-0" />
+      <span>{line}</span>
+    </div>
+  );
+}
+
+function EmptyLine({ children }: { children: React.ReactNode }) {
+  return <p className="py-2 text-xs text-muted-foreground">{children}</p>;
+}
+
+// 1. Portfolio summary
+
+function PortfolioSummaryCard() {
+  const marginQ = useMarginAccount();
+  const custodyQ = useQuery({
+    queryKey: ["home", "custody", "balance"],
+    queryFn: getBalance,
+    retry: false,
+    refetchInterval: 30_000,
+  });
+  const spotQ = useSpotBalance();
+
+  const margin = marginQ.data;
+  const available = num(margin?.available_balance);
+  const unrealized = num(margin?.pos_unrealized_pnl);
+
+  const equity = useMemo(() => {
+    let sum = 0;
+    let anySource = false;
+    if (marginQ.isSuccess) {
+      sum += num(margin?.balance);
+      anySource = true;
+    }
+    if (spotQ.isSuccess) {
+      sum += (spotQ.data?.balances ?? []).reduce((a, b) => a + num(b.balance), 0);
+      anySource = true;
+    }
+    if (custodyQ.isSuccess) {
+      for (const v of Object.values(custodyQ.data?.balances ?? {})) sum += num(v);
+      anySource = true;
+    }
+    return { sum, anySource };
+  }, [
+    marginQ.isSuccess,
+    spotQ.isSuccess,
+    custodyQ.isSuccess,
+    margin,
+    spotQ.data,
+    custodyQ.data,
+  ]);
+
+  const loading = marginQ.isLoading && spotQ.isLoading && custodyQ.isLoading;
+  const allFailed = marginQ.isError && spotQ.isError && custodyQ.isError;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div className="flex items-center gap-2">
+          <PieChart className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm">Portfolio</CardTitle>
+        </div>
+        <Link
+          to="/portfolio"
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          View portfolio <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {loading ? (
+          <Skeleton className="h-8 w-40" />
+        ) : allFailed ? (
+          <CardError line="Portfolio sources are unavailable right now." />
+        ) : (
+          <>
+            <div>
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                Snapshot equity
+              </span>
+              <div className="num text-2xl font-bold tabular-nums">
+                {equity.anySource
+                  ? equity.sum.toLocaleString(undefined, {
+                      maximumFractionDigits: 2,
+                    })
+                  : "—"}
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                  Available
+                </span>
+                <div className="num text-sm font-semibold tabular-nums">
+                  {marginQ.isSuccess
+                    ? available.toLocaleString(undefined, { maximumFractionDigits: 2 })
+                    : "—"}
+                </div>
+              </div>
+              <div>
+                <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                  Unrealized PnL
+                </span>
+                <div
+                  className={cn(
+                    "num text-sm font-semibold tabular-nums",
+                    marginQ.isSuccess && unrealized > 0 && "text-emerald-600 dark:text-emerald-400",
+                    marginQ.isSuccess && unrealized < 0 && "text-rose-600 dark:text-rose-400",
+                  )}
+                >
+                  {marginQ.isSuccess
+                    ? `${unrealized > 0 ? "+" : ""}${unrealized.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+                    : "—"}
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// 2. Watchlist snapshot
+
+function WatchRow({ sym }: { sym: MarketSymbol }) {
+  const scaler = sym.price_scaler || 1;
+  const candles = useCandles(sym.symbol_id, 60, true, 60);
+  const bars = candles.data?.bars ?? [];
+  const closes = bars.map((b) => b.close);
+  const last = closes.length ? closes[closes.length - 1]! : sym.reference_price;
+  const first = closes.length ? closes[0]! : undefined;
+  const changePct =
+    first != null && first !== 0 ? ((last - first) / first) * 100 : undefined;
+  const up = (changePct ?? 0) >= 0;
+
+  return (
+    <Link
+      to={`/markets/${sym.symbol_id}`}
+      className="flex items-center justify-between rounded-md px-2 py-1.5 hover:bg-muted/60"
+    >
+      <span className="text-sm font-medium">{sym.symbol}</span>
+      <span className="flex items-center gap-3">
+        <span className="num text-sm tabular-nums">{formatPrice(last, scaler)}</span>
+        <span
+          className={cn(
+            "num w-16 text-right text-xs tabular-nums",
+            changePct == null
+              ? "text-muted-foreground"
+              : up
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-rose-600 dark:text-rose-400",
+          )}
+        >
+          {changePct == null ? "—" : `${up ? "+" : ""}${changePct.toFixed(2)}%`}
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+function WatchlistCard() {
+  const [watchlist] = useState<number[]>(loadWatchlist);
+  const symbolsQ = useSymbols();
+
+  const rows = useMemo(() => {
+    const all = symbolsQ.data?.symbols ?? [];
+    const byId = new Map(all.map((s) => [s.symbol_id, s]));
+    return watchlist
+      .map((id) => byId.get(id))
+      .filter((s): s is MarketSymbol => Boolean(s))
+      .slice(0, 6);
+  }, [symbolsQ.data, watchlist]);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div className="flex items-center gap-2">
+          <CandlestickChart className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm">Watchlist</CardTitle>
+        </div>
+        <Link
+          to="/markets"
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          Markets <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </CardHeader>
+      <CardContent>
+        {symbolsQ.isLoading && watchlist.length > 0 ? (
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-full" />
+          </div>
+        ) : watchlist.length === 0 ? (
+          <div className="flex flex-col items-start gap-2 py-2">
+            <EmptyLine>No markets starred yet.</EmptyLine>
+            <Button asChild size="sm" variant="outline" className="gap-1">
+              <Link to="/markets">
+                <Plus className="h-3.5 w-3.5" /> Add markets
+              </Link>
+            </Button>
+          </div>
+        ) : rows.length === 0 ? (
+          <CardError line="Could not resolve your starred markets." />
+        ) : (
+          <div className="-mx-2">
+            {rows.map((s) => (
+              <WatchRow key={s.symbol_id} sym={s} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// 3. Recent activity
+
+function symbolNameFrom(symbols: MarketSymbol[] | undefined, id: number | undefined): string {
+  if (id == null) return "—";
+  const s = symbols?.find((x) => x.symbol_id === id);
+  return s?.symbol ?? `#${id}`;
+}
+
+function RecentActivityCard() {
+  const fillsQ = useQuery({
+    queryKey: ["home", "fills", "fees"],
+    queryFn: getFillsFees,
+    retry: false,
+    refetchInterval: 15_000,
+  });
+  const symbolsQ = useSymbols();
+  const { alerts } = useTradingAlerts();
+
+  const fills: FillFee[] = useMemo(
+    () => (fillsQ.data?.fills ?? []).slice(0, 5),
+    [fillsQ.data],
+  );
+  const recentAlerts = useMemo(() => alerts.slice(0, 4), [alerts]);
+
+  const fillsFailed = fillsQ.isError && !isUnavailable(fillsQ.error);
+  const fillsUnavailable = fillsQ.isError && isUnavailable(fillsQ.error);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm">Recent activity</CardTitle>
+        <span className="flex items-center gap-3 text-xs">
+          <Link to="/pnl" className="text-primary hover:underline">
+            PnL
+          </Link>
+          <Link to="/blotter" className="text-primary hover:underline">
+            History
+          </Link>
+        </span>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+            Recent fills
+          </div>
+          {fillsQ.isLoading ? (
+            <Skeleton className="h-5 w-full" />
+          ) : fillsUnavailable ? (
+            <EmptyLine>Fills feed not available on this backend.</EmptyLine>
+          ) : fillsFailed ? (
+            <CardError line="Could not load recent fills." />
+          ) : fills.length === 0 ? (
+            <EmptyLine>No fills yet.</EmptyLine>
+          ) : (
+            <div className="space-y-0.5">
+              {fills.map((f, i) => {
+                const scaler =
+                  symbolsQ.data?.symbols?.find((s) => s.symbol_id === f.symbolid)?.price_scaler || 1;
+                const buy = String(f.side).toLowerCase().includes("b");
+                return (
+                  <div
+                    key={`${f.symbolid}-${f.ts}-${i}`}
+                    className="flex items-center justify-between text-xs"
+                  >
+                    <span className="flex items-center gap-2">
+                      <Badge
+                        variant={buy ? "success" : "destructive"}
+                        className="px-1.5 py-0 text-[10px]"
+                      >
+                        {buy ? "BUY" : "SELL"}
+                      </Badge>
+                      <span className="font-medium">
+                        {symbolNameFrom(symbolsQ.data?.symbols, f.symbolid)}
+                      </span>
+                    </span>
+                    <span className="num tabular-nums text-muted-foreground">
+                      {formatQty(f.qty, scaler)} @ {formatPrice(f.price, scaler)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {recentAlerts.length > 0 && (
+          <div>
+            <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+              Trading alerts
+            </div>
+            <div className="space-y-1">
+              {recentAlerts.map((a) => (
+                <div key={a.id} className="flex items-center justify-between gap-2 text-xs">
+                  <span className="truncate">{a.title}</span>
+                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                    {relativeTime(toMs(a.ts))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// 4. Quick actions
+
+function QuickActionsCard() {
+  const navigate = useNavigate();
+  const goTrade = () => {
+    const id = loadDefaultSymbol();
+    navigate(id ? `/markets/${id}` : "/markets");
+  };
+  const actions: { label: string; icon: React.ReactNode; onClick: () => void }[] = [
+    { label: "Trade", icon: <CandlestickChart className="h-4 w-4" />, onClick: goTrade },
+    { label: "Deposit", icon: <Wallet className="h-4 w-4" />, onClick: () => navigate("/custody") },
+    { label: "Portfolio", icon: <PieChart className="h-4 w-4" />, onClick: () => navigate("/portfolio") },
+    { label: "PnL", icon: <LineChart className="h-4 w-4" />, onClick: () => navigate("/pnl") },
+    { label: "Price alerts", icon: <Bell className="h-4 w-4" />, onClick: () => navigate("/markets/price-alerts") },
+  ];
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Quick actions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap gap-2">
+          {actions.map((a) => (
+            <Button
+              key={a.label}
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={a.onClick}
+            >
+              {a.icon}
+              {a.label}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// 5. Getting-started / onboarding
+
+type StepState = "done" | "todo" | "unknown";
+
+function StepRow({
+  state,
+  label,
+  to,
+}: {
+  state: StepState;
+  label: string;
+  to: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/60"
+    >
+      {state === "done" ? (
+        <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-500" />
+      ) : (
+        <Circle
+          className={cn(
+            "h-5 w-5 shrink-0",
+            state === "unknown" ? "text-muted-foreground/50" : "text-muted-foreground",
+          )}
+        />
+      )}
+      <span
+        className={cn(
+          "flex-1 text-sm",
+          state === "done" && "text-muted-foreground line-through",
+        )}
+      >
+        {label}
+      </span>
+      {state === "unknown" && (
+        <Badge variant="outline" className="text-[10px] font-normal">
+          unknown
+        </Badge>
+      )}
+      <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground" />
+    </Link>
+  );
+}
+
+function OnboardingCard() {
+  const custodyQ = useQuery({
+    queryKey: ["home", "onboarding", "custody"],
+    queryFn: getBalance,
+    retry: false,
+    refetchInterval: 30_000,
+  });
+  const marginQ = useMarginAccount();
+  const spotQ = useSpotBalance();
+  const fillsQ = useQuery({
+    queryKey: ["home", "fills", "fees"],
+    queryFn: getFillsFees,
+    retry: false,
+    refetchInterval: 15_000,
+  });
+
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(ONBOARDING_DISMISSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  const custodyStep: StepState = custodyQ.isSuccess
+    ? Object.values(custodyQ.data?.balances ?? {}).some((v) => num(v as number | string) > 0)
+      ? "done"
+      : "todo"
+    : "unknown";
+
+  const spotFunded = spotQ.isSuccess
+    ? (spotQ.data?.balances ?? []).some((b) => num(b.available) > 0 || num(b.balance) > 0)
+    : undefined;
+  const marginFunded = marginQ.isSuccess
+    ? num(marginQ.data?.available_balance) > 0 || num(marginQ.data?.balance) > 0
+    : undefined;
+  const tradingStep: StepState =
+    spotFunded || marginFunded
+      ? "done"
+      : spotQ.isSuccess || marginQ.isSuccess
+        ? "todo"
+        : "unknown";
+
+  const tradeStep: StepState = fillsQ.isSuccess
+    ? (fillsQ.data?.fills ?? []).length > 0
+      ? "done"
+      : "todo"
+    : "unknown";
+
+  const steps: { state: StepState; label: string; to: string }[] = [
+    { state: custodyStep, label: "Fund your custody vault", to: "/custody" },
+    { state: tradingStep, label: "Fund your trading account", to: "/portfolio" },
+    { state: tradeStep, label: "Place your first trade", to: "/markets" },
+  ];
+
+  const anyLoading =
+    custodyQ.isLoading || marginQ.isLoading || spotQ.isLoading || fillsQ.isLoading;
+  const allDone = steps.every((s) => s.state === "done");
+  const anyTodo = steps.some((s) => s.state === "todo");
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(ONBOARDING_DISMISSED_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    setDismissed(true);
+  };
+
+  if (allDone && dismissed) return null;
+
+  if (allDone) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-between gap-2 py-3">
+          <span className="flex items-center gap-2 text-sm">
+            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+            You&apos;re all set &mdash; happy trading.
+          </span>
+          <Button variant="ghost" size="sm" className="h-7 gap-1 px-2" onClick={dismiss}>
+            <X className="h-3.5 w-3.5" /> Dismiss
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cn(anyTodo && "border-primary/40")}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Getting started</CardTitle>
+        <CardDescription className="text-xs">
+          Finish setting up your trading account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {anyLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+          </div>
+        ) : (
+          <div className="-mx-2">
+            {steps.map((s) => (
+              <StepRow key={s.label} state={s.state} label={s.label} to={s.to} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// Page
+
+export default function HomePage() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <HomeIcon className="h-6 w-6 text-primary" />
+        <div>
+          <h1 className="text-xl font-semibold leading-tight">Home</h1>
+          <p className="text-xs text-muted-foreground">
+            Your trading overview at a glance.
+          </p>
+        </div>
+      </div>
+
+      <OnboardingCard />
+
+      <QuickActionsCard />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <PortfolioSummaryCard />
+        <WatchlistCard />
+      </div>
+
+      <RecentActivityCard />
+    </div>
+  );
+}

--- a/frontend/src/pages/markets/SymbolDetailPage.tsx
+++ b/frontend/src/pages/markets/SymbolDetailPage.tsx
@@ -244,7 +244,7 @@ export default function SymbolDetailPage() {
         </div>
       </div>
 
-      <TradeTicket symbolId={id} scaler={scaler} lastPrice={lastPrice} prefill={prefill} />
+      <TradeTicket symbolId={id} scaler={scaler} lastPrice={lastPrice} bestBid={bestBid} bestAsk={bestAsk} prefill={prefill} />
 
       <Card>
         <CardHeader>

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -35,6 +35,7 @@ import {
 import { isAck, ackMessage, impliedYes, marginUsedFraction } from "@/api/endpoints/trading";
 import type { OrderSide, Fill, PlaceOrderRequest, MarginConfigRequest } from "@/api/endpoints/trading";
 import { formatPrice, formatQty, formatTimeNs } from "./format";
+import { notional as calcNotional, maxQtyForBalance, riskSizedQty, pctOfBuyingPowerQty, estLiquidationPrice } from "@/lib/orderMath";
 import { vibrate, notify, ensureNotifyPermission } from "@/lib/tradeFeedback";
 import { tradingFeatures } from "./tradingFeatures";
 import { useAuthStore } from "@/stores/authStore";
@@ -351,11 +352,15 @@ export function TradeTicket({
   symbolId,
   scaler,
   lastPrice,
+  bestBid,
+  bestAsk,
   prefill,
 }: {
   symbolId: number;
   scaler: number;
   lastPrice?: number;
+  bestBid?: number;
+  bestAsk?: number;
   prefill?: { price?: number; side?: OrderSide; nonce: number };
 }) {
   const account = useMarginAccount();
@@ -407,6 +412,10 @@ export function TradeTicket({
   const [workingOrders, setWorkingOrders] = useState<WorkingOrder[]>([]);
   const [fills, setFills] = useState<Fill[]>([]);
   const [msg, setMsg] = useState<{ text: string; error: boolean } | null>(null);
+  // Position-size / risk calculator (collapsible) local inputs.
+  const [riskOpen, setRiskOpen] = useState(false);
+  const [riskAmt, setRiskAmt] = useState("");
+  const [riskStop, setRiskStop] = useState("");
 
   const seq = useRef(0);
   const nextClordid = () => `t${Date.now()}${seq.current++ % 100}`;
@@ -459,6 +468,78 @@ export function TradeTicket({
   const refPrice = priceN || stopN || lastPrice || 0;
   const avail = acct?.available_balance ?? 0;
   const orderValue = priceN > 0 && qtyN > 0 ? priceN * qtyN : undefined;
+  // ── Order preview math (all client-side, EXACT except the clearly-labeled est.) ──
+  // Notional uses the effective ticket price: limit/stop-limit use the entered
+  // price; market/stop use the best available quote or last trade as a proxy.
+  const previewPrice =
+    orderType === "market"
+      ? (side === "buy" ? bestAsk : bestBid) ?? lastPrice ?? refPrice
+      : refPrice;
+  const previewNotional = calcNotional(previewPrice, qtyN);
+  const maxAffordableQty = maxQtyForBalance(avail, previewPrice);
+  // The exchange does NOT expose initial/maintenance margin bps to the client
+  // (the fee schedule only carries maker/taker/liquidation-fee bps). So any
+  // liquidation number here is a ROUGH estimate under an assumed default margin,
+  // shown with an explicit "(est.)" tag — never presented as authoritative.
+  const ASSUMED_INITIAL_MARGIN_BPS = 1000; // 10% — venue-default placeholder
+  const ASSUMED_MAINT_MARGIN_BPS = 500; // 5% — venue-default placeholder
+  const estMarginRequired =
+    previewNotional > 0 ? Math.ceil((previewNotional * ASSUMED_INITIAL_MARGIN_BPS) / 10000) : 0;
+  const estLiq =
+    previewPrice > 0 && qtyN > 0
+      ? estLiquidationPrice(previewPrice, side, ASSUMED_INITIAL_MARGIN_BPS, ASSUMED_MAINT_MARGIN_BPS)
+      : null;
+
+  // Fill the qty to the max affordable at the current price for the current side.
+  const fillMaxQty = () => {
+    if (maxAffordableQty <= 0) return;
+    setQty(String(maxAffordableQty));
+    vibrate("tick");
+    resetArmed();
+  };
+
+  // Position-size calculator outputs.
+  const riskAmtN = parseInt(riskAmt) || 0;
+  const riskStopN = parseInt(riskStop) || 0;
+  const riskEntry = refPrice;
+  const suggestedQty = riskSizedQty(riskAmtN, riskEntry, riskStopN);
+  const applyRiskQty = () => {
+    if (suggestedQty <= 0) return;
+    setQty(String(suggestedQty));
+    vibrate("tick");
+    resetArmed();
+  };
+
+  // One-click bid/ask/market prefill — sets side + price only; the user still
+  // confirms and submits through the existing money-safety path.
+  const prefillBid = () => {
+    if (!(bestBid && bestBid > 0)) return;
+    setOrderType("limit");
+    setSide("buy");
+    setPrice(String(bestBid));
+    resetArmed();
+    vibrate("tick");
+  };
+  const prefillAsk = () => {
+    if (!(bestAsk && bestAsk > 0)) return;
+    setOrderType("limit");
+    setSide("sell");
+    setPrice(String(bestAsk));
+    resetArmed();
+    vibrate("tick");
+  };
+  const prefillMarketBuy = () => {
+    setOrderType("market");
+    setSide("buy");
+    resetArmed();
+    vibrate("tick");
+  };
+  const prefillMarketSell = () => {
+    setOrderType("market");
+    setSide("sell");
+    resetArmed();
+    vibrate("tick");
+  };
   const posQty = acct?.pos_qty ?? 0;
   const hasPosition = (acct?.num_positions ?? 0) > 0 || posQty !== 0;
   const liqPrice = acct?.pos_liquidation_price ?? 0;
@@ -921,6 +1002,47 @@ export function TradeTicket({
               ))}
             </div>
 
+            {/* One-click bid/ask + market quick-actions (prefill only — the
+                user still confirms/submits via the existing path). */}
+            {!isPm && orderType !== "quote" && orderType !== "funding" && (bestBid || bestAsk) && (
+              <div className="flex flex-wrap gap-1.5">
+                <button
+                  type="button"
+                  data-testid="quick_bid"
+                  disabled={!(bestBid && bestBid > 0)}
+                  onClick={prefillBid}
+                  className="flex-1 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs font-semibold tabular-nums text-emerald-600 disabled:opacity-40 dark:text-emerald-400"
+                >
+                  Buy @ bid {bestBid ? formatPrice(bestBid, scaler) : "—"}
+                </button>
+                <button
+                  type="button"
+                  data-testid="quick_ask"
+                  disabled={!(bestAsk && bestAsk > 0)}
+                  onClick={prefillAsk}
+                  className="flex-1 rounded-md border border-rose-500/40 bg-rose-500/10 px-2 py-1 text-xs font-semibold tabular-nums text-rose-600 disabled:opacity-40 dark:text-rose-400"
+                >
+                  Sell @ ask {bestAsk ? formatPrice(bestAsk, scaler) : "—"}
+                </button>
+                <button
+                  type="button"
+                  data-testid="quick_market_buy"
+                  onClick={prefillMarketBuy}
+                  className="rounded-md border px-2 py-1 text-xs font-semibold text-muted-foreground hover:text-foreground"
+                >
+                  Mkt buy
+                </button>
+                <button
+                  type="button"
+                  data-testid="quick_market_sell"
+                  onClick={prefillMarketSell}
+                  className="rounded-md border px-2 py-1 text-xs font-semibold text-muted-foreground hover:text-foreground"
+                >
+                  Mkt sell
+                </button>
+              </div>
+            )}
+
             {/* Side (hidden for quote / funding) */}
             {orderType !== "quote" && orderType !== "funding" && (
               <div className="flex gap-2">
@@ -1118,6 +1240,137 @@ export function TradeTicket({
                     <div className="grid grid-cols-2 gap-2">
                       <Field label="Display qty (iceberg)" value={displayQty} onChange={setDisplayQty} />
                       <Field label="Min qty" value={minQty} onChange={setMinQty} />
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Order preview — live, computed client-side. */}
+            {orderType !== "funding" && orderType !== "quote" && (
+              <div className="space-y-1.5 rounded-lg border bg-muted/20 p-3 text-sm" data-testid="order_preview">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Order preview
+                  </span>
+                  {orderType === "market" && (
+                    <span className="text-[10px] text-muted-foreground">at {previewPrice ? formatPrice(previewPrice, scaler) : "—"} (proxy)</span>
+                  )}
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Notional</span>
+                  <span className="tabular-nums" data-testid="preview_notional">
+                    {previewNotional > 0 ? formatPrice(previewNotional, scaler) : "—"}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Buying power</span>
+                  <span className="tabular-nums">
+                    {formatPrice(avail, scaler)}
+                    {maxAffordableQty > 0 && (
+                      <span className="text-muted-foreground"> · max {formatQty(maxAffordableQty, scaler)}</span>
+                    )}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Max qty affordable</span>
+                  <button
+                    type="button"
+                    data-testid="preview_max"
+                    disabled={maxAffordableQty <= 0}
+                    onClick={fillMaxQty}
+                    className="rounded border px-2 py-0.5 text-xs font-semibold text-primary disabled:opacity-40"
+                  >
+                    Max {maxAffordableQty > 0 ? formatQty(maxAffordableQty, scaler) : ""}
+                  </button>
+                </div>
+                {/* Margin impact + est. liquidation — margin bps are NOT readable
+                    client-side, so these are ROUGH estimates under an assumed
+                    default, clearly tagged. */}
+                {previewNotional > 0 && (
+                  <div className="mt-1 border-t pt-1.5">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Est. margin <span className="text-[10px]">({(ASSUMED_INITIAL_MARGIN_BPS / 100).toFixed(0)}% assumed)</span>
+                      </span>
+                      <span className="tabular-nums">~{formatPrice(estMarginRequired, scaler)} (est.)</span>
+                    </div>
+                    {estLiq != null && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Est. liq. price</span>
+                        <span className="tabular-nums">~{formatPrice(Math.round(estLiq), scaler)} (est.)</span>
+                      </div>
+                    )}
+                    <p className="mt-0.5 text-[10px] text-muted-foreground">
+                      Margin figures are rough estimates — the venue's real margin
+                      rates aren't exposed to the client.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Position-size / risk calculator (collapsible). */}
+            {orderType !== "funding" && orderType !== "quote" && (
+              <div className="rounded-lg border p-3">
+                <button
+                  type="button"
+                  aria-expanded={riskOpen}
+                  data-testid="risk_calc_toggle"
+                  className="flex w-full items-center justify-between text-xs font-semibold text-primary"
+                  onClick={() => setRiskOpen((v) => !v)}
+                >
+                  <span>Position-size calculator</span>
+                  <span aria-hidden>{riskOpen ? "▲" : "▼"}</span>
+                </button>
+                {riskOpen && (
+                  <div className="mt-2 space-y-2">
+                    <div className="grid grid-cols-2 gap-2">
+                      <Field label="Risk amount (quote)" value={riskAmt} onChange={setRiskAmt} />
+                      <Field label="Stop price" value={riskStop} onChange={setRiskStop} />
+                    </div>
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-muted-foreground">
+                        Entry {riskEntry ? formatPrice(riskEntry, scaler) : "—"} · suggested qty
+                      </span>
+                      <span className="font-semibold tabular-nums" data-testid="risk_suggested_qty">
+                        {suggestedQty > 0 ? formatQty(suggestedQty, scaler) : "—"}
+                      </span>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="w-full"
+                      data-testid="risk_apply"
+                      disabled={suggestedQty <= 0}
+                      onClick={applyRiskQty}
+                    >
+                      Apply qty
+                    </Button>
+                    <div>
+                      <label className="text-xs text-muted-foreground">% of buying power</label>
+                      <div className="mt-1 flex gap-1.5">
+                        {[25, 50, 100].map((pct) => (
+                          <button
+                            key={pct}
+                            type="button"
+                            data-testid={`risk_bp_${pct}`}
+                            disabled={maxAffordableQty <= 0}
+                            onClick={() => {
+                              const q = pctOfBuyingPowerQty(avail, previewPrice, pct);
+                              if (q > 0) {
+                                setQty(String(q));
+                                vibrate("tick");
+                                resetArmed();
+                              }
+                            }}
+                            className="flex-1 rounded-md border py-1 text-xs tabular-nums text-muted-foreground hover:text-foreground disabled:opacity-40"
+                          >
+                            {pct}%
+                          </button>
+                        ))}
+                      </div>
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/pnl/PnLPage.tsx
+++ b/frontend/src/pages/pnl/PnLPage.tsx
@@ -1,0 +1,456 @@
+// PnL & performance — a READ-ONLY analytics view computed CLIENT-SIDE from the
+// exchange account feeds (fills-fees / funding / liquidations) via the pure
+// `computePnl` helper. NO new backend: it reuses the existing typed feed hooks,
+// and each feed DEGRADES INDEPENDENTLY — if the fills feed 404s (edge-undeployed)
+// the page shows an honest "unavailable" state; a missing funding/liquidation
+// feed just contributes nothing. Unrealized PnL comes from the margin account.
+// All engine values are int64 ticks scaled for display by the symbol scaler.
+import { useMemo } from "react";
+import {
+  LineChart,
+  RefreshCw,
+  TrendingUp,
+  TrendingDown,
+  Receipt,
+  Target,
+  Hash,
+  BarChart2,
+  Info,
+} from "lucide-react";
+import { ApiError } from "@/api/client";
+import { cn } from "@/lib/utils";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+
+import {
+  useFillsFees,
+  useLiquidations,
+  useFundingPayments,
+  useMarginAccount,
+} from "@/hooks/useTrading";
+import { useSymbols } from "@/hooks/useMarketData";
+import { formatPrice, formatQty } from "@/pages/markets/format";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import {
+  computePnl,
+  type PnlFill,
+  type PnlFunding,
+  type PnlLiquidation,
+  type EquityPoint,
+} from "@/lib/pnl";
+
+// --- helpers ----------------------------------------------------
+
+function num(v: number | undefined | null): number {
+  if (v == null) return 0;
+  return Number.isFinite(v) ? v : 0;
+}
+
+/** True when an error is a 404/403 — the "not available on this backend" case. */
+function isUnavailable(err: unknown): boolean {
+  if (err instanceof ApiError) return err.status === 404 || err.status === 403;
+  const msg = (err as Error)?.message ?? "";
+  return /\b40[34]\b/.test(msg);
+}
+
+const signColor = (v: number): string | undefined =>
+  v > 0
+    ? "rgb(16 185 129)" // emerald-500
+    : v < 0
+      ? "rgb(239 68 68)" // red-500
+      : undefined;
+
+// --- inline SVG equity curve ------------------------------------
+
+function EquityCurve({ points }: { points: EquityPoint[] }) {
+  const W = 640;
+  const H = 160;
+  const PAD = 6;
+
+  const path = useMemo(() => {
+    if (points.length === 0) return null;
+    const xs = points.map((p) => p.ts);
+    const ys = points.map((p) => p.value);
+    // Include a 0 baseline so the sign is visually meaningful.
+    const minY = Math.min(0, ...ys);
+    const maxY = Math.max(0, ...ys);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const spanY = maxY - minY || 1;
+    const spanX = maxX - minX || 1;
+
+    const sx = (t: number) => PAD + ((t - minX) / spanX) * (W - 2 * PAD);
+    const sy = (v: number) => H - PAD - ((v - minY) / spanY) * (H - 2 * PAD);
+
+    const firstVal = ys[0] ?? 0;
+    const pts: { x: number; y: number }[] =
+      points.length === 1
+        ? [
+            { x: PAD, y: sy(firstVal) },
+            { x: W - PAD, y: sy(firstVal) },
+          ]
+        : points.map((p) => ({ x: sx(p.ts), y: sy(p.value) }));
+
+    const line = pts.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(" ");
+    const start = pts[0]!;
+    const end = pts[pts.length - 1]!;
+    const area = `${line} L ${end.x.toFixed(1)} ${H - PAD} L ${start.x.toFixed(1)} ${H - PAD} Z`;
+    const zeroY = sy(0);
+    const last = ys[ys.length - 1] ?? 0;
+    return { line, area, zeroY, last };
+  }, [points]);
+
+  if (!path) return null;
+  const up = path.last >= 0;
+  const stroke = up ? "rgb(16 185 129)" : "rgb(239 68 68)";
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="h-40 w-full"
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Cumulative equity curve"
+    >
+      <defs>
+        <linearGradient id="pnl-eq-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={stroke} stopOpacity="0.28" />
+          <stop offset="100%" stopColor={stroke} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {/* zero baseline */}
+      <line
+        x1={PAD}
+        x2={W - PAD}
+        y1={path.zeroY}
+        y2={path.zeroY}
+        stroke="currentColor"
+        strokeOpacity="0.18"
+        strokeDasharray="4 4"
+      />
+      <path d={path.area} fill="url(#pnl-eq-fill)" stroke="none" />
+      <path d={path.line} fill="none" stroke={stroke} strokeWidth="1.75" vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+// --- stat card --------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  icon,
+  valueColor,
+  sub,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  valueColor?: string;
+  sub?: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-1 py-4">
+        <span className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+          {icon}
+          {label}
+        </span>
+        <span
+          className="num text-xl font-semibold tabular-nums"
+          style={valueColor ? { color: valueColor } : undefined}
+        >
+          {value}
+        </span>
+        {sub && <span className="text-[11px] text-muted-foreground">{sub}</span>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// --- page -------------------------------------------------------
+
+export default function PnLPage() {
+  const fillsQ = useFillsFees();
+  const fundingQ = useFundingPayments();
+  const liqQ = useLiquidations();
+  const marginQ = useMarginAccount();
+  const symbolsQ = useSymbols();
+
+  const refetchAll = () => {
+    fillsQ.refetch();
+    fundingQ.refetch();
+    liqQ.refetch();
+    marginQ.refetch();
+    symbolsQ.refetch();
+  };
+
+  const anyFetching =
+    fillsQ.isFetching ||
+    fundingQ.isFetching ||
+    liqQ.isFetching ||
+    marginQ.isFetching ||
+    symbolsQ.isFetching;
+
+  // symbolid -> {name, scaler}. Fills/funding/liq all key off the same symbolid.
+  const symLookup = useMemo(() => {
+    const map = new Map<number, MarketSymbol>();
+    for (const s of symbolsQ.data?.symbols ?? []) map.set(s.symbol_id, s);
+    return (id: number) => {
+      const s = map.get(id);
+      return { name: s?.symbol ?? `#${id}`, scaler: s?.price_scaler || 1 };
+    };
+  }, [symbolsQ.data]);
+
+  // A single scaler for the aggregate (tick) totals. The feeds share one quote
+  // asset so any traded symbol's price scaler is representative; fall back to 1.
+  const quoteScaler = useMemo(() => {
+    const first = symbolsQ.data?.symbols?.[0];
+    return first?.price_scaler || 1;
+  }, [symbolsQ.data]);
+
+  const summary = useMemo(() => {
+    const fills: PnlFill[] = (fillsQ.data?.fills ?? []).map((f) => ({
+      symbolid: f.symbolid,
+      price: f.price,
+      qty: f.qty,
+      side: f.side,
+      fee: f.fee,
+      ts: f.ts,
+    }));
+    const funding: PnlFunding[] = (fundingQ.data?.funding ?? []).map((f) => ({
+      symbolid: f.symbolid,
+      payment: f.payment,
+      ts: f.ts,
+    }));
+    const liquidations: PnlLiquidation[] = (liqQ.data?.liquidations ?? []).map((l) => ({
+      symbolid: l.symbolid,
+      realized_pnl: l.realized_pnl,
+      fee: l.fee,
+      ts: l.ts,
+    }));
+    return computePnl(fills, funding, liquidations);
+  }, [fillsQ.data, fundingQ.data, liqQ.data]);
+
+  const unrealized = num(marginQ.data?.pos_unrealized_pnl);
+  const unrealizedScaler = marginQ.data?.pos_symbol_idx != null
+    ? symLookup(marginQ.data.pos_symbol_idx).scaler
+    : quoteScaler;
+
+  // The fills feed is the analytics backbone: if it's unavailable, the whole page
+  // can't compute — show a single honest unavailable state.
+  const fillsUnavailable = fillsQ.isError && isUnavailable(fillsQ.error);
+  const fillsError = fillsQ.isError && !fillsUnavailable;
+  const loading = fillsQ.isLoading || symbolsQ.isLoading;
+
+  const netColor = signColor(summary.netRealized);
+  const winPct = (summary.winRate * 100).toFixed(summary.closeCount > 0 ? 1 : 0);
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <LineChart className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold leading-tight">PnL &amp; performance</h1>
+            <p className="text-xs text-muted-foreground">
+              Realized PnL, fees, funding &amp; win rate — computed from your fills.
+            </p>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" className="gap-2 self-start sm:self-auto" onClick={refetchAll}>
+          <RefreshCw className={cn("h-4 w-4", anyFetching && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : fillsUnavailable ? (
+        <Card>
+          <CardContent className="flex flex-col items-start gap-2 py-10">
+            <p className="text-sm text-muted-foreground">
+              The fills feed isn't available on this backend yet, so performance analytics can't be
+              computed. This page will populate once the exchange edge deploys the account feeds.
+            </p>
+            <Badge variant="outline" className="gap-1.5">
+              <Info className="h-3 w-3" /> Not available on this backend
+            </Badge>
+          </CardContent>
+        </Card>
+      ) : fillsError ? (
+        <Card>
+          <CardContent className="py-10">
+            <p className="text-sm text-muted-foreground">
+              Could not load your fills: {(fillsQ.error as Error)?.message ?? "unknown error"}.
+            </p>
+          </CardContent>
+        </Card>
+      ) : summary.tradeCount === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-start gap-2 py-10">
+            <p className="text-sm text-muted-foreground">
+              No trading activity yet. Once you have fills, your realized PnL, equity curve and win
+              rate will appear here.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Stat cards */}
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+            <StatCard
+              label="Net realized PnL"
+              value={formatPrice(summary.netRealized, quoteScaler)}
+              valueColor={netColor}
+              icon={
+                summary.netRealized >= 0 ? (
+                  <TrendingUp className="h-3.5 w-3.5" />
+                ) : (
+                  <TrendingDown className="h-3.5 w-3.5" />
+                )
+              }
+              sub="Realized − fees + funding ± liquidations"
+            />
+            <StatCard
+              label="Unrealized PnL"
+              value={
+                marginQ.isError
+                  ? "—"
+                  : formatPrice(unrealized, unrealizedScaler)
+              }
+              valueColor={signColor(unrealized)}
+              icon={<BarChart2 className="h-3.5 w-3.5" />}
+              sub={marginQ.isError ? "Margin account unavailable" : "Open position (margin)"}
+            />
+            <StatCard
+              label="Total fees paid"
+              value={formatPrice(summary.totalFees + summary.totalLiquidationFees, quoteScaler)}
+              icon={<Receipt className="h-3.5 w-3.5" />}
+              sub="Engine + liquidation fees"
+            />
+            <StatCard
+              label="Win rate"
+              value={`${winPct}%`}
+              icon={<Target className="h-3.5 w-3.5" />}
+              sub={`${summary.winCount}/${summary.closeCount} closing trades positive`}
+            />
+            <StatCard
+              label="Trades"
+              value={String(summary.tradeCount)}
+              icon={<Hash className="h-3.5 w-3.5" />}
+              sub={`${summary.closeCount} position closes`}
+            />
+            <StatCard
+              label="Total volume"
+              value={formatPrice(summary.totalVolume, quoteScaler)}
+              icon={<BarChart2 className="h-3.5 w-3.5" />}
+              sub="Traded notional (magnitude)"
+            />
+          </div>
+
+          {/* Equity curve */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                <LineChart className="h-4 w-4 text-muted-foreground" />
+                Equity curve
+                {(fundingQ.isError || liqQ.isError) && (
+                  <Badge variant="outline" className="gap-1 text-[10px] font-normal">
+                    <Info className="h-3 w-3" />
+                    {fundingQ.isError && liqQ.isError
+                      ? "funding & liquidations unavailable"
+                      : fundingQ.isError
+                        ? "funding unavailable"
+                        : "liquidations unavailable"}
+                  </Badge>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {summary.equityCurve.length === 0 ? (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  Not enough events to plot an equity curve.
+                </p>
+              ) : (
+                <div className="text-muted-foreground">
+                  <EquityCurve points={summary.equityCurve} />
+                  <Separator className="my-3" />
+                  <p className="text-[11px]">
+                    Cumulative realized + funding − fees across{" "}
+                    {summary.equityCurve.length} event
+                    {summary.equityCurve.length === 1 ? "" : "s"}, oldest → newest. Values are engine
+                    ticks scaled by the quote scaler.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Per-symbol breakdown */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                Per-symbol breakdown
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[560px] text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs text-muted-foreground">
+                      <th className="py-2 pr-3 font-medium">Symbol</th>
+                      <th className="py-2 pr-3 text-right font-medium">Net PnL</th>
+                      <th className="py-2 pr-3 text-right font-medium">Volume</th>
+                      <th className="py-2 pr-3 text-right font-medium">Fees</th>
+                      <th className="py-2 text-right font-medium">Trades</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {summary.perSymbol.map((s) => {
+                      const sym = symLookup(s.symbolid);
+                      const net = s.net;
+                      return (
+                        <tr key={s.symbolid} className="border-b last:border-0">
+                          <td className="py-2 pr-3 font-medium">{sym.name}</td>
+                          <td
+                            className="num py-2 pr-3 text-right font-medium tabular-nums"
+                            style={{ color: signColor(net) }}
+                          >
+                            {formatPrice(net, sym.scaler)}
+                          </td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">
+                            {formatQty(s.volume, sym.scaler)}
+                          </td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">
+                            {formatPrice(s.fees + s.liquidationFees, sym.scaler)}
+                          </td>
+                          <td className="num py-2 text-right tabular-nums">{s.tradeCount}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+                <Separator className="my-3" />
+                <p className="text-[11px] text-muted-foreground">
+                  Net PnL = average-cost realized − fees + funding ± liquidations, per symbol. All
+                  values are engine int64 ticks scaled by the symbol's price scaler.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/TradingSettings.tsx
+++ b/frontend/src/pages/settings/TradingSettings.tsx
@@ -39,6 +39,7 @@ const ALERT_KINDS: { kind: TradingAlertKind; label: string; hint: string }[] = [
   { kind: "funding", label: "Funding", hint: "Perpetual funding settlements" },
   { kind: "margin", label: "Margin distress", hint: "Your account nears liquidation" },
   { kind: "pm_resolved", label: "PM resolutions", hint: "A prediction market resolves" },
+  { kind: "price", label: "Price alerts", hint: "A market crosses your target price" },
 ];
 
 type NotifyStatus = "unsupported" | NotificationPermission;


### PR DESCRIPTION
Four more frontend features (web + Android), all client-side / no backend blocker:

- **PnL & performance analytics** — realized (avg-cost) + unrealized PnL, equity curve, win rate, fees, per-symbol breakdown. Pure tested helper.
- **Price alerts** — user threshold alerts (above/below), edge-trigger evaluator, surfaced via the alerts bell + OS notifications, with a management screen.
- **Order-entry enhancements** — live order preview (notional/buying-power/Max), risk-based position sizing, one-click bid/ask; margin/liq labeled (est.) since margin bps are write-only.
- **Home dashboard + onboarding** — portfolio/watchlist/activity/quick-actions + a real-state getting-started checklist.

+80 new unit tests. Each phase gated (web build+tsc, android assembleDebug+testDebugUnitTest). Known backend follow-up surfaced: a margin-config READ endpoint (initial/maintenance bps are write-only) — added to exchange_missing_features.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)