### PR TITLE
feat: depth chart + time&sales, export/reporting, keyboard shortcuts, PWA/density/accent (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/MainActivity.kt
+++ b/android/app/src/main/java/com/testlogon/android/MainActivity.kt
@@ -20,8 +20,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
+import com.testlogon.android.core.network.AppAccent
+import com.testlogon.android.core.network.AppDensity
 import com.testlogon.android.core.network.AppThemeMode
 import com.testlogon.android.core.network.ThemePreferencesStore
+import com.testlogon.android.core.ui.theme.AppUiDensity
 import com.testlogon.android.core.ui.theme.TestLogonTheme
 import com.testlogon.android.data.gcal.GoogleCalendarReturnHandler
 import com.testlogon.android.data.payments.PaymentReturnDispatcher
@@ -143,8 +146,22 @@ class MainActivity : FragmentActivity() {
             }
             val dynamicColor = appearance.dynamicColor &&
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+            // Density + accent theming: map the persisted accent preset to a Compose seed color
+            // (null for the DEFAULT preset so the current brand look is untouched) and the density
+            // preset to the core-ui CompositionLocal value the app root provides.
+            val accentSeed = if (appearance.accent == AppAccent.DEFAULT) null
+                else Color(appearance.accent.seedArgb)
+            val uiDensity = when (appearance.density) {
+                AppDensity.COMPACT -> AppUiDensity.COMPACT
+                AppDensity.COMFORTABLE -> AppUiDensity.COMFORTABLE
+            }
 
-            TestLogonTheme(darkTheme = darkTheme, dynamicColor = dynamicColor) {
+            TestLogonTheme(
+                darkTheme = darkTheme,
+                dynamicColor = dynamicColor,
+                accentSeed = accentSeed,
+                density = uiDensity,
+            ) {
                 // Expose Compose testTags to UIAutomator as view resource-ids so on-device UI
                 // automation (Maestro feature-demo capture, instrumented device tests) can target
                 // every tagged node by id. Recommended by Google for production UI automation; no

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
@@ -62,6 +62,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.theme.LocalAppUiDensity
+import com.testlogon.android.core.ui.theme.isCompact
 import com.testlogon.android.core.ui.state.EmptyState
 import com.testlogon.android.core.ui.state.ErrorState
 import com.testlogon.android.core.ui.state.LoadingState
@@ -216,10 +218,14 @@ private fun MarketsList(
             MarketsEmpty(filter = filter, query = query)
             return@Column
         }
+        val compact = LocalAppUiDensity.current.isCompact
         LazyColumn(
             modifier = Modifier.fillMaxSize().testTag("markets_list"),
-            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(
+                horizontal = 12.dp,
+                vertical = if (compact) 6.dp else 10.dp,
+            ),
+            verticalArrangement = Arrangement.spacedBy(if (compact) 4.dp else 8.dp),
         ) {
             items(displayed, key = { it.instrument.symbolId }) { row ->
                 MarketRowCard(
@@ -384,7 +390,10 @@ private fun MarketRowCard(
             .background(MarketColors.Surface)
             .border(1.dp, MarketColors.Border, RoundedCornerShape(14.dp))
             .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 12.dp),
+            .padding(
+                horizontal = 12.dp,
+                vertical = if (LocalAppUiDensity.current.isCompact) 7.dp else 12.dp,
+            ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         val base = baseMonogram(row.instrument.symbol)

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/SymbolDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/SymbolDetailScreen.kt
@@ -50,6 +50,7 @@ import com.testlogon.android.data.exchange.Trade
 import com.testlogon.android.feature.markets.book.BookStyle
 import com.testlogon.android.feature.markets.book.OrderBookL2
 import com.testlogon.android.feature.markets.chart.CandlestickChart
+import com.testlogon.android.feature.markets.chart.DepthChart
 import com.testlogon.android.feature.markets.chart.ChartDrawing
 import com.testlogon.android.feature.markets.chart.ChartType
 import com.testlogon.android.feature.markets.chart.DrawingTool
@@ -201,6 +202,30 @@ private fun SymbolDetailContent(
                     },
                     modifier = Modifier.padding(horizontal = 12.dp),
                 )
+            }
+
+            DetailTab.DEPTH -> {
+                item {
+                    DepthSectionHeader()
+                    DepthChart(
+                        book = state.orderBook,
+                        priceScaler = PRICE_SCALER,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    TimeAndSalesHeader()
+                }
+                items(state.trades.take(TAPE_ROWS)) { trade -> TimeAndSalesRow(trade) }
+                if (state.trades.isEmpty()) {
+                    item {
+                        Text(
+                            "No trades yet.",
+                            color = MarketColors.TextFaint,
+                            fontSize = 12.sp,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                        )
+                    }
+                }
             }
 
             DetailTab.TRADES -> {
@@ -436,7 +461,7 @@ private fun DrawingToolbar(
 }
 
 /** Top-level panel selector for the symbol detail: Chart / Book / Trades. */
-private enum class DetailTab(val label: String) { CHART("Chart"), BOOK("Book"), TRADES("Trades"), TRADE("Order") }
+private enum class DetailTab(val label: String) { CHART("Chart"), BOOK("Book"), DEPTH("Depth"), TRADES("Trades"), TRADE("Order") }
 
 @Composable
 private fun DetailTabBar(selected: DetailTab, onSelect: (DetailTab) -> Unit) {
@@ -579,6 +604,80 @@ private fun TradeRow(trade: Trade) {
         Text(
             text = tapeTimeFormat.format(Date(trade.tsNs / 1_000_000L)),
             color = MarketColors.TextFaint,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp,
+            textAlign = androidx.compose.ui.text.style.TextAlign.End,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+
+/** Cap for the compact live Time & Sales tape on the Depth tab (newest-first, ~50 recent prints). */
+private const val TAPE_ROWS = 50
+
+@Composable
+private fun DepthSectionHeader() {
+    Text(
+        text = "Market Depth",
+        color = MarketColors.TextPrimary,
+        fontWeight = FontWeight.Bold,
+        fontSize = 14.sp,
+        modifier = Modifier.fillMaxWidth().padding(start = 12.dp, end = 12.dp, top = 16.dp, bottom = 4.dp),
+    )
+}
+
+/** Header row for the compact Time & Sales tape (Time / Price / Size). */
+@Composable
+private fun TimeAndSalesHeader() {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Time & Sales", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 13.sp, modifier = Modifier.weight(1f))
+    }
+    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 2.dp)) {
+        Text("Time", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, modifier = Modifier.weight(1f))
+        Text("Price", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, textAlign = androidx.compose.ui.text.style.TextAlign.End, modifier = Modifier.weight(1.2f))
+        Text("Size", color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, textAlign = androidx.compose.ui.text.style.TextAlign.End, modifier = Modifier.weight(1f))
+    }
+}
+
+/** One side-colored print in the compact Time & Sales tape (buy green / sell red), time-first. */
+@Composable
+private fun TimeAndSalesRow(trade: Trade) {
+    val color = when (trade.aggressor) {
+        Aggressor.BUY -> MarketColors.Up
+        Aggressor.SELL -> MarketColors.Down
+        Aggressor.UNKNOWN -> MarketColors.TextSecondary
+    }
+    val bg = when (trade.aggressor) {
+        Aggressor.BUY -> MarketColors.UpFill
+        Aggressor.SELL -> MarketColors.DownFill
+        Aggressor.UNKNOWN -> Color.Transparent
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().background(bg).padding(horizontal = 12.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = tapeTimeFormat.format(Date(trade.tsNs / 1_000_000L)),
+            color = MarketColors.TextFaint,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = formatPrice(trade.price.toDouble()),
+            color = color,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp,
+            textAlign = androidx.compose.ui.text.style.TextAlign.End,
+            modifier = Modifier.weight(1.2f),
+        )
+        Text(
+            text = trade.qty.toString(),
+            color = MarketColors.TextPrimary,
             fontFamily = FontFamily.Monospace,
             fontSize = 12.sp,
             textAlign = androidx.compose.ui.text.style.TextAlign.End,

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/chart/DepthChart.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/chart/DepthChart.kt
@@ -1,0 +1,223 @@
+package com.testlogon.android.feature.markets.chart
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.testlogon.android.data.exchange.OrderBook
+import com.testlogon.android.feature.markets.ui.MarketColors
+import java.util.Locale
+
+private const val MAX_LEVELS = 40
+
+/**
+ * Full market-depth chart drawn on a Compose [Canvas], dependency-free (no charting library). Renders
+ * the two cumulative-depth curves from an [OrderBook] as mirrored step areas about the mid price:
+ * bids in green filling from the mid leftward (best bid nearest the centre), asks in red filling
+ * rightward. The mid/spread is marked with a vertical divider + a header readout. A touch crosshair
+ * (drag or tap) reports the price under the finger and the cumulative size available to that price.
+ *
+ * All pure axis/curve math lives in [DepthMath] (unit-tested); this composable only maps the model
+ * into pixels and paints it. Prices are raw integer ticks scaled by [priceScaler] for display.
+ */
+@Composable
+fun DepthChart(
+    book: OrderBook?,
+    priceScaler: Long,
+    modifier: Modifier = Modifier,
+) {
+    val model = remember(book) { DepthMath.model(book, maxLevels = MAX_LEVELS) }
+    val scaler = priceScaler.coerceAtLeast(1L)
+
+    if (model.isEmpty) {
+        Text(
+            "No depth available.",
+            color = MarketColors.TextFaint,
+            fontSize = 12.sp,
+            modifier = modifier.padding(horizontal = 12.dp, vertical = 24.dp).testTag("depth_chart_empty"),
+        )
+        return
+    }
+
+    // Crosshair as a horizontal fraction across the price axis (null = hidden). Kept as a fraction so
+    // it stays valid across canvas-size changes; resolved to a price/cum readout via DepthMath.
+    var crossFrac by remember { mutableStateOf<Float?>(null) }
+    val density = LocalDensity.current
+
+    Box(modifier = modifier.fillMaxWidth().testTag("depth_chart_full")) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(220.dp)
+                .pointerInput(model) {
+                    detectDragGestures(
+                        onDragStart = { crossFrac = (it.x / size.width).coerceIn(0f, 1f) },
+                        onDragEnd = { crossFrac = null },
+                        onDragCancel = { crossFrac = null },
+                        onDrag = { change, _ -> crossFrac = (change.position.x / size.width).coerceIn(0f, 1f) },
+                    )
+                }
+                .pointerInput(model) {
+                    detectTapGestures(
+                        onPress = {
+                            crossFrac = (it.x / size.width).coerceIn(0f, 1f)
+                            tryAwaitRelease()
+                            crossFrac = null
+                        },
+                    )
+                },
+        ) {
+            drawDepth(model = model)
+            crossFrac?.let { f -> drawCrosshair(model = model, fracX = f, densityScale = density.density) }
+        }
+
+        DepthHeader(model = model, scaler = scaler, crossFrac = crossFrac)
+    }
+}
+
+/** Draw the mirrored cumulative-depth step areas + the mid divider. */
+private fun DrawScope.drawDepth(model: DepthMath.DepthModel) {
+    val w = size.width
+    val h = size.height
+    val priceSpan = (model.maxPrice - model.minPrice).toDouble().coerceAtLeast(1.0)
+    fun xOf(price: Long): Float = (((price - model.minPrice).toDouble() / priceSpan) * w).toFloat().coerceIn(0f, w)
+    fun yOf(cum: Long): Float = (h * (1f - (cum.toFloat() / model.maxCum.toFloat()))).coerceIn(0f, h)
+
+    // Bids: best bid is nearest the mid; walk outward to lower prices (leftward). Build a step area
+    // anchored to the baseline so the fill reads as classic accumulated depth.
+    if (model.bids.isNotEmpty()) {
+        val pts = model.bids // best-first (descending price)
+        val fill = Path()
+        val line = Path()
+        val startX = xOf(pts.first().price)
+        fill.moveTo(startX, h)
+        var firstLine = true
+        var prevX = startX
+        pts.forEach { p ->
+            val x = xOf(p.price)
+            val y = yOf(p.cumQty)
+            // step: horizontal to this price at the previous height, then vertical to the new cum
+            fill.lineTo(prevX, y)
+            fill.lineTo(x, y)
+            if (firstLine) { line.moveTo(prevX, y); firstLine = false } else line.lineTo(prevX, y)
+            line.lineTo(x, y)
+            prevX = x
+        }
+        fill.lineTo(prevX, h)
+        fill.close()
+        drawPath(fill, Brush.verticalGradient(listOf(MarketColors.Up.copy(alpha = 0.38f), MarketColors.Up.copy(alpha = 0.05f))))
+        drawPath(line, MarketColors.Up, style = Stroke(width = 2f))
+    }
+
+    // Asks: best ask nearest the mid; walk outward to higher prices (rightward).
+    if (model.asks.isNotEmpty()) {
+        val pts = model.asks // best-first (ascending price)
+        val fill = Path()
+        val line = Path()
+        val startX = xOf(pts.first().price)
+        fill.moveTo(startX, h)
+        var firstLine = true
+        var prevX = startX
+        pts.forEach { p ->
+            val x = xOf(p.price)
+            val y = yOf(p.cumQty)
+            fill.lineTo(prevX, y)
+            fill.lineTo(x, y)
+            if (firstLine) { line.moveTo(prevX, y); firstLine = false } else line.lineTo(prevX, y)
+            line.lineTo(x, y)
+            prevX = x
+        }
+        fill.lineTo(prevX, h)
+        fill.close()
+        drawPath(fill, Brush.verticalGradient(listOf(MarketColors.Down.copy(alpha = 0.38f), MarketColors.Down.copy(alpha = 0.05f))))
+        drawPath(line, MarketColors.Down, style = Stroke(width = 2f))
+    }
+
+    // Mid divider.
+    val midPrice = model.mid ?: ((model.minPrice + model.maxPrice) / 2.0)
+    val midX = (((midPrice - model.minPrice) / priceSpan) * w).toFloat().coerceIn(0f, w)
+    drawLine(
+        color = MarketColors.TextFaint,
+        start = Offset(midX, 0f),
+        end = Offset(midX, h),
+        strokeWidth = 1.5f,
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 6f)),
+    )
+}
+
+/** Draw the crosshair vertical line + a small dot at the depth curve under the finger. */
+private fun DrawScope.drawCrosshair(
+    model: DepthMath.DepthModel,
+    fracX: Float,
+    densityScale: Float,
+) {
+    val cross = DepthMath.crosshairAt(model, fracX) ?: return
+    val w = size.width
+    val h = size.height
+    val x = (fracX.coerceIn(0f, 1f) * w)
+    val color = if (cross.isBid) MarketColors.Up else MarketColors.Down
+    drawLine(color = color.copy(alpha = 0.7f), start = Offset(x, 0f), end = Offset(x, h), strokeWidth = 1f)
+    val y = (h * (1f - (cross.cumQty.toFloat() / model.maxCum.toFloat()))).coerceIn(0f, h)
+    drawCircle(color = color, radius = 4f * densityScale, center = Offset(x, y))
+}
+
+/**
+ * Overlaid header: mid/spread on the left and a live crosshair readout (price + cumulative size) on
+ * the right when the user is touching the chart. Drawn as Compose text (crisp) rather than on canvas.
+ */
+@Composable
+private fun DepthHeader(model: DepthMath.DepthModel, scaler: Long, crossFrac: Float?) {
+    val cross = crossFrac?.let { DepthMath.crosshairAt(model, it) }
+    androidx.compose.foundation.layout.Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 6.dp),
+        horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceBetween,
+    ) {
+        val mid = model.mid
+        val spread = model.spread
+        Text(
+            text = "Mid " + (mid?.let { fmtPrice(it / scaler) } ?: "--") +
+                (spread?.let { "  Spread " + fmtPrice(it.toDouble() / scaler) } ?: ""),
+            color = MarketColors.TextSecondary,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+        )
+        if (cross != null) {
+            val c = if (cross.isBid) MarketColors.Up else MarketColors.Down
+            Text(
+                text = fmtPrice(cross.price.toDouble() / scaler) + "  x " + cross.cumQty.toString(),
+                color = c,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 11.sp,
+            )
+        }
+    }
+}
+
+private fun fmtPrice(v: Double): String {
+    val whole = v == v.toLong().toDouble()
+    return if (whole) String.format(Locale.US, "%,d", v.toLong())
+    else String.format(Locale.US, "%,.2f", v)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/chart/DepthMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/chart/DepthMath.kt
@@ -1,0 +1,152 @@
+package com.testlogon.android.feature.markets.chart
+
+import com.testlogon.android.data.exchange.OrderBook
+import com.testlogon.android.data.exchange.OrderBookLevel
+
+/**
+ * Pure, framework-free math backing the [DepthChart] Canvas. Kept UI-free so it can be unit-tested
+ * in isolation (no Compose, no Android). All prices/quantities are raw integer ticks; scaling for
+ * display happens in the Canvas layer.
+ *
+ * The depth model is the classic cumulative "market depth" curve:
+ *  - bids are summed from the BEST bid (highest price) outward to worse prices,
+ *  - asks are summed from the BEST ask (lowest price) outward to worse prices,
+ * so the two cumulative curves both grow as you move AWAY from the mid, mirrored about it.
+ */
+object DepthMath {
+
+    /** One point on a cumulative-depth curve: a [price] tick and the running [cumQty] to that level. */
+    data class DepthPoint(val price: Long, val cumQty: Long)
+
+    /**
+     * A render-ready depth model: the two cumulative curves plus the shared axis extents used to map
+     * price to x and cumQty to y in the Canvas. [maxCum] is the larger of the two curves' totals
+     * (>=1 so callers can divide safely); [minPrice]/[maxPrice] bound the visible price axis.
+     */
+    data class DepthModel(
+        val bids: List<DepthPoint>,
+        val asks: List<DepthPoint>,
+        val minPrice: Long,
+        val maxPrice: Long,
+        val maxCum: Long,
+        val bestBid: Long?,
+        val bestAsk: Long?,
+    ) {
+        val isEmpty: Boolean get() = bids.isEmpty() && asks.isEmpty()
+
+        /** Mid price (average of best bid/ask), or null when either side is empty. */
+        val mid: Double?
+            get() = if (bestBid != null && bestAsk != null) (bestBid + bestAsk) / 2.0 else null
+
+        /** Ask minus bid, or null when either side is empty. */
+        val spread: Long?
+            get() = if (bestBid != null && bestAsk != null) bestAsk - bestBid else null
+    }
+
+    /**
+     * Accumulate bid levels from the best bid outward. Input [bids] are expected sorted descending by
+     * price (best first), matching [OrderBook.bids]; unsorted input is tolerated by sorting a copy so
+     * the "from the top of book" invariant always holds. Zero/negative-qty levels are skipped.
+     */
+    fun cumulativeBids(bids: List<OrderBookLevel>): List<DepthPoint> {
+        val ordered = bids.filter { it.qty > 0 }.sortedByDescending { it.price }
+        var run = 0L
+        return ordered.map { run += it.qty; DepthPoint(it.price, run) }
+    }
+
+    /**
+     * Accumulate ask levels from the best ask outward. Input [asks] are expected sorted ascending by
+     * price (best first), matching [OrderBook.asks]; unsorted input is tolerated by sorting a copy.
+     * Zero/negative-qty levels are skipped.
+     */
+    fun cumulativeAsks(asks: List<OrderBookLevel>): List<DepthPoint> {
+        val ordered = asks.filter { it.qty > 0 }.sortedBy { it.price }
+        var run = 0L
+        return ordered.map { run += it.qty; DepthPoint(it.price, run) }
+    }
+
+    /**
+     * Build the full [DepthModel] from an [OrderBook], optionally capping each side to [maxLevels]
+     * levels outward from the mid (a null/<=0 cap keeps all levels). Returns an empty model when the
+     * book is null or both sides are empty.
+     */
+    fun model(book: OrderBook?, maxLevels: Int? = null): DepthModel {
+        if (book == null) return EMPTY
+        var bids = cumulativeBids(book.bids)
+        var asks = cumulativeAsks(book.asks)
+        if (maxLevels != null && maxLevels > 0) {
+            bids = bids.take(maxLevels)
+            asks = asks.take(maxLevels)
+        }
+        if (bids.isEmpty() && asks.isEmpty()) return EMPTY
+
+        val bestBid = book.bestBid ?: bids.firstOrNull()?.price
+        val bestAsk = book.bestAsk ?: asks.firstOrNull()?.price
+        // Price axis spans the outermost visible bid to the outermost visible ask; fall back to the
+        // populated side alone when one side is empty.
+        val lowCandidates = listOfNotNull(bids.lastOrNull()?.price, asks.firstOrNull()?.price, bestBid, bestAsk)
+        val highCandidates = listOfNotNull(asks.lastOrNull()?.price, bids.firstOrNull()?.price, bestAsk, bestBid)
+        val minPrice = lowCandidates.minOrNull() ?: 0L
+        val maxPrice = highCandidates.maxOrNull() ?: 0L
+        val maxCum = maxOf(bids.lastOrNull()?.cumQty ?: 0L, asks.lastOrNull()?.cumQty ?: 0L).coerceAtLeast(1L)
+        return DepthModel(
+            bids = bids,
+            asks = asks,
+            minPrice = minPrice,
+            maxPrice = maxPrice,
+            maxCum = maxCum,
+            bestBid = bestBid,
+            bestAsk = bestAsk,
+        )
+    }
+
+    /**
+     * Map a horizontal fraction [fracX] in [0,1] across the price axis to the nearest depth point,
+     * used by the touch crosshair. Returns the cumulative depth AT that price on whichever side the
+     * price falls (bid side left of mid, ask side right). Null when the model is empty or the axis is
+     * degenerate.
+     */
+    fun crosshairAt(model: DepthModel, fracX: Float): Crosshair? {
+        if (model.isEmpty) return null
+        if (model.maxPrice <= model.minPrice) {
+            // Degenerate axis (single price level): report that level directly if present.
+            val only = (model.bids + model.asks).minByOrNull { it.price } ?: return null
+            return Crosshair(only.price, only.cumQty, isBid = model.asks.isEmpty())
+        }
+        val span = (model.maxPrice - model.minPrice).toDouble()
+        val price = model.minPrice + (fracX.coerceIn(0f, 1f) * span).toLong()
+        val mid = model.mid ?: ((model.minPrice + model.maxPrice) / 2.0)
+        val isBid = price <= mid
+        val cum = if (isBid) cumAtBid(model.bids, price) else cumAtAsk(model.asks, price)
+        return Crosshair(price = price, cumQty = cum, isBid = isBid)
+    }
+
+    /** Crosshair readout: the [price] under the finger and cumulative [cumQty] on that [isBid] side. */
+    data class Crosshair(val price: Long, val cumQty: Long, val isBid: Boolean)
+
+    /**
+     * Cumulative bid depth available at or above [price] (i.e. everything that would fill a sell down
+     * to [price]). Points are best-first (descending price). Zero when [price] is above the best bid.
+     */
+    private fun cumAtBid(bids: List<DepthPoint>, price: Long): Long {
+        var last = 0L
+        for (p in bids) {
+            if (p.price >= price) last = p.cumQty else break
+        }
+        return last
+    }
+
+    /**
+     * Cumulative ask depth available at or below [price] (everything that would fill a buy up to
+     * [price]). Points are best-first (ascending price). Zero when [price] is below the best ask.
+     */
+    private fun cumAtAsk(asks: List<DepthPoint>, price: Long): Long {
+        var last = 0L
+        for (p in asks) {
+            if (p.price <= price) last = p.cumQty else break
+        }
+        return last
+    }
+
+    val EMPTY = DepthModel(emptyList(), emptyList(), 0L, 0L, 1L, null, null)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -990,6 +990,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "reports",
+            labelRes = R.string.more_entry_reports,
+            icon = Icons.Outlined.Description,
+            route = MoreRoutes.REPORTS,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "catalog",
             labelRes = R.string.more_entry_catalog,
             icon = Icons.Outlined.Storefront,

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -37,12 +38,15 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.feature.reports.ReportCsv
+import com.testlogon.android.feature.reports.shareReportCsv
 import java.util.Locale
 
 /** Green/red for PnL, independent of the app theme (matches the markets/portfolio convention). */
@@ -56,10 +60,17 @@ fun PnlRoute(
     viewModel: PnlViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     PnlScreen(
         state = state,
         onBack = onBack,
         onRefresh = viewModel::refresh,
+        onExport = {
+            val stats = state.stats
+            if (stats != null) {
+                shareReportCsv(context, ReportCsv.pnlScreenSummary(state.bySymbol, stats), "pnl-summary")
+            }
+        },
         modifier = modifier,
     )
 }
@@ -69,6 +80,7 @@ fun PnlScreen(
     state: PnlUiState,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
+    onExport: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -82,6 +94,11 @@ fun PnlScreen(
                     }
                 },
                 actions = {
+                    if (state.stats != null) {
+                        IconButton(onClick = onExport) {
+                            Icon(Icons.Filled.Share, contentDescription = "Export CSV")
+                        }
+                    }
                     IconButton(onClick = onRefresh) {
                         Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
                     }

--- a/android/app/src/main/java/com/testlogon/android/feature/reports/ReportCsv.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/reports/ReportCsv.kt
@@ -1,0 +1,176 @@
+package com.testlogon.android.feature.reports
+
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.pnl.PnlAnalytics
+import com.testlogon.android.feature.pnl.PnlStats
+import com.testlogon.android.feature.pnl.SymbolRow
+import java.util.Locale
+
+/**
+ * PURE, unit-testable CSV builders for the Export & Reporting surface. NO Android / coroutine /
+ * Compose deps: the ViewModel hands already-fetched, already-period-scoped exchange reads (fills-fees,
+ * the derived [PnlAnalytics] roll-up, the margin account) and these functions emit RFC 4180 CSV text.
+ *
+ * All amounts are raw integer engine units (Long) rendered as plain integers so an export never loses
+ * precision to a display scaler. Timestamps are nanosecond ticks formatted human-readably in UTC.
+ * CSV escaping matches the blotter's RFC 4180 convention (quote a field containing the delimiter, a
+ * quote, CR or LF; embedded quotes doubled); rows join with CRLF so the document opens cleanly in a
+ * spreadsheet on any platform.
+ */
+object ReportCsv {
+
+    /** The delimiter is fixed to a comma for these reports (spreadsheet-friendly). */
+    private const val DELIM = ','
+
+    /** RFC 4180 escaping: wrap in quotes + double embedded quotes when the field needs it. */
+    fun csvField(raw: String): String {
+        val needsQuote = raw.any { it == DELIM || it == '"' || it == '\n' || it == '\r' }
+        return if (needsQuote) "\"" + raw.replace("\"", "\"\"") + "\"" else raw
+    }
+
+    /** Join a row's cells with the delimiter, escaping each. */
+    private fun row(vararg cells: String): String = cells.joinToString(DELIM.toString()) { csvField(it) }
+
+    /** Join header + body lines with CRLF (RFC 4180). */
+    private fun document(vararg lines: String): String = lines.joinToString("\r\n")
+
+    private fun sideLabel(side: OrderSide?): String = when (side) {
+        OrderSide.BUY -> "BUY"
+        OrderSide.SELL -> "SELL"
+        null -> "--"
+    }
+
+    /** Notional for a fill: |qty| * price, in raw units. */
+    private fun notionalOf(f: FillFee): Long = Math.abs(f.qty) * f.price
+
+    /**
+     * Format a nanosecond tick as an ISO-8601-ish UTC timestamp (yyyy-MM-dd HH:mm:ss 'UTC'). A tick of
+     * 0 (unknown) renders as an empty string so an export never invents a 1970 date.
+     */
+    fun formatTs(tsNs: Long): String {
+        if (tsNs <= 0L) return ""
+        val millis = tsNs / 1_000_000L
+        val fmt = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+        fmt.timeZone = java.util.TimeZone.getTimeZone("UTC")
+        return fmt.format(java.util.Date(millis)) + " UTC"
+    }
+
+    /**
+     * Trade-history CSV: one row per fill (oldest -> newest) with time / symbol / side / price / qty /
+     * fee / notional. [symbolNames] resolves symbol ids to names (falls back to '#id'). Always emits a
+     * header even when there are no fills.
+     */
+    fun tradeHistory(fills: List<FillFee>, symbolNames: Map<Int, String>): String {
+        val header = row("Time", "Symbol", "Side", "Price", "Qty", "Fee", "Notional")
+        val body = fills.sortedBy { it.tsNs }.map { f ->
+            row(
+                formatTs(f.tsNs),
+                symbolNames[f.symbolId] ?: ("#" + f.symbolId),
+                sideLabel(f.side),
+                f.price.toString(),
+                f.qty.toString(),
+                f.fee.toString(),
+                notionalOf(f).toString(),
+            )
+        }
+        return document(*(listOf(header) + body).toTypedArray())
+    }
+
+    /**
+     * PnL-summary CSV: one row per symbol (realized / fees / volume / trades) plus a TOTAL row folding
+     * the per-symbol figures together with the account-level net (net-of-fees-funding-liquidations),
+     * unrealized, funding, and liquidation legs. [symbolNames] resolves ids to names.
+     */
+    fun pnlSummary(report: PnlAnalytics.PnlReport, symbolNames: Map<Int, String>): String {
+        val header = row("Symbol", "Realized", "Fees", "Volume", "Trades")
+        val perSymbol = report.bySymbol.map { s ->
+            row(
+                symbolNames[s.symbolId] ?: ("#" + s.symbolId),
+                s.realized.toString(),
+                s.fees.toString(),
+                s.volume.toString(),
+                s.tradeCount.toString(),
+            )
+        }
+        val totalRow = row(
+            "TOTAL",
+            report.tradeRealized.toString(),
+            report.totalFees.toString(),
+            report.volume.toString(),
+            report.tradeCount.toString(),
+        )
+        // Account-level legs that are not per-symbol, as labelled key/value rows below the table.
+        val legs = listOf(
+            row("Net realized", report.netRealized.toString(), "", "", ""),
+            row("Unrealized", report.unrealized.toString(), "", "", ""),
+            row("Funding", report.fundingTotal.toString(), "", "", ""),
+            row("Liquidation PnL", report.liquidationPnl.toString(), "", "", ""),
+        )
+        return document(*(listOf(header) + perSymbol + listOf(totalRow) + legs).toTypedArray())
+    }
+
+    /**
+     * PnL-summary CSV built directly from the PnL SCREEN's already-projected [rows] + [stats] (no raw
+     * fills needed). Mirrors [pnlSummary] so the PnL screen's Share action reuses this helper without
+     * re-deriving. Symbol names are already resolved on [SymbolRow.symbol].
+     */
+    fun pnlScreenSummary(rows: List<SymbolRow>, stats: PnlStats): String {
+        val header = row("Symbol", "Realized", "Fees", "Volume", "Trades")
+        val perSymbol = rows.map { r ->
+            row(r.symbol, r.realized.toString(), r.fees.toString(), r.volume.toString(), r.tradeCount.toString())
+        }
+        val legs = listOf(
+            row("Net realized", stats.netRealized.toString(), "", "", ""),
+            row("Unrealized", stats.unrealized.toString(), "", "", ""),
+            row("Total fees", stats.totalFees.toString(), "", "", ""),
+            row("Volume", stats.volume.toString(), "", "", ""),
+            row("Trades", stats.tradeCount.toString(), "", "", ""),
+            row("Funding", stats.fundingTotal.toString(), "", "", ""),
+            row("Liquidation PnL", stats.liquidationPnl.toString(), "", "", ""),
+        )
+        return document(*(listOf(header) + perSymbol + legs).toTypedArray())
+    }
+
+    /**
+     * Account-statement CSV for a period: a labelled key/value block of the period bounds, the margin
+     * account balances (balance / available / reserved margin), the open position (symbol / qty /
+     * entry / unrealized), and the period's realized-net roll-up. [margin] may be null when the margin
+     * read was unavailable; balances then render as '--'.
+     */
+    fun accountStatement(
+        report: PnlAnalytics.PnlReport,
+        margin: MarginAccount?,
+        symbolNames: Map<Int, String>,
+        periodLabel: String,
+        fromTsNs: Long,
+        toTsNs: Long,
+    ): String {
+        val header = row("Field", "Value")
+        fun kv(k: String, v: String) = row(k, v)
+        val lines = mutableListOf(header)
+        lines += kv("Period", periodLabel)
+        lines += kv("From", formatTs(fromTsNs))
+        lines += kv("To", formatTs(toTsNs))
+        lines += kv("Balance", margin?.balance?.toString() ?: "--")
+        lines += kv("Available balance", margin?.availableBalance?.toString() ?: "--")
+        lines += kv("Reserved margin", margin?.reservedMargin?.toString() ?: "--")
+        val pos = margin?.position
+        if (pos != null) {
+            lines += kv("Position symbol", symbolNames[pos.symbolId] ?: ("#" + pos.symbolId))
+            lines += kv("Position qty", pos.qty.toString())
+            lines += kv("Position entry", pos.entryPrice.toString())
+            lines += kv("Position unrealized", pos.unrealizedPnl.toString())
+        } else {
+            lines += kv("Position", "flat")
+        }
+        lines += kv("Realized (net)", report.netRealized.toString())
+        lines += kv("Total fees", report.totalFees.toString())
+        lines += kv("Funding", report.fundingTotal.toString())
+        lines += kv("Liquidation PnL", report.liquidationPnl.toString())
+        lines += kv("Trades", report.tradeCount.toString())
+        lines += kv("Volume", report.volume.toString())
+        return document(*lines.toTypedArray())
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/reports/ReportPeriod.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/reports/ReportPeriod.kt
@@ -1,0 +1,54 @@
+package com.testlogon.android.feature.reports
+
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.FundingPayment
+import com.testlogon.android.data.exchange.Liquidation
+
+/**
+ * PURE period scoping for the Export & Reporting surface. A [ReportPeriod] is a rolling look-back
+ * window (24h / 7d / 30d) or ALL; [filterFills] (and the sibling helpers) drop any event whose
+ * nanosecond tick falls before [cutoffNs] computed from a caller-supplied 'now'. ALL keeps everything.
+ *
+ * Keeping this pure (no clock, no Android) makes the window boundary unit-testable: the caller passes
+ * the reference 'now' in nanoseconds so tests are deterministic.
+ */
+enum class ReportPeriod(val label: String, private val lookbackNs: Long?) {
+    DAY("24h", 24L * 60L * 60L * 1_000_000_000L),
+    WEEK("7d", 7L * 24L * 60L * 60L * 1_000_000_000L),
+    MONTH("30d", 30L * 24L * 60L * 60L * 1_000_000_000L),
+    ALL("All", null);
+
+    /** The inclusive lower-bound tick for this window relative to [nowNs], or 0 for [ALL]. */
+    fun cutoffNs(nowNs: Long): Long {
+        val lb = lookbackNs ?: return 0L
+        val c = nowNs - lb
+        return if (c < 0L) 0L else c
+    }
+
+    /** True when [tsNs] falls inside this window relative to [nowNs]. */
+    fun contains(tsNs: Long, nowNs: Long): Boolean = tsNs >= cutoffNs(nowNs)
+}
+
+/** Keep only fills at/after the period cutoff (ALL keeps everything). */
+fun filterFills(fills: List<FillFee>, period: ReportPeriod, nowNs: Long): List<FillFee> {
+    if (period == ReportPeriod.ALL) return fills
+    val cutoff = period.cutoffNs(nowNs)
+    return fills.filter { it.tsNs >= cutoff }
+}
+
+/** Keep only liquidations at/after the period cutoff. */
+fun filterLiquidations(events: List<Liquidation>, period: ReportPeriod, nowNs: Long): List<Liquidation> {
+    if (period == ReportPeriod.ALL) return events
+    val cutoff = period.cutoffNs(nowNs)
+    return events.filter { it.tsNs >= cutoff }
+}
+
+/** Keep only funding payments at/after the period cutoff. */
+fun filterFunding(payments: List<FundingPayment>, period: ReportPeriod, nowNs: Long): List<FundingPayment> {
+    if (period == ReportPeriod.ALL) return payments
+    val cutoff = period.cutoffNs(nowNs)
+    return payments.filter { it.tsNs >= cutoff }
+}
+
+/** Current wall-clock time as a nanosecond tick (epoch millis * 1e6). */
+fun nowTicksNs(): Long = System.currentTimeMillis() * 1_000_000L

--- a/android/app/src/main/java/com/testlogon/android/feature/reports/ReportShare.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/reports/ReportShare.kt
@@ -1,0 +1,68 @@
+package com.testlogon.android.feature.reports
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
+
+/** Cap for the EXTRA_TEXT fast-path — larger exports are shared as a file stream only. */
+private const val REPORT_TEXT_MAX_CHARS = 8000
+
+/**
+ * Android side of the Export & Reporting surface: writes the built CSV [content] to a shareable cache
+ * file and hands it to the system share sheet via [Intent.ACTION_SEND] (mime text/csv).
+ *
+ * The file is written under cacheDir/attachments/ — an already-declared FileProvider cache-path root
+ * (res/xml/file_paths.xml is not edited here). The authority is derived from the package name
+ * (== ${applicationId}.fileprovider) so it never drifts from the manifest, mirroring the blotter's
+ * share path. FLAG_GRANT_READ_URI_PERMISSION lets the receiver read the content:// uri; for small
+ * exports the text is also placed in EXTRA_TEXT as a fast path. If the FileProvider grant fails for
+ * any reason we fall back to a plain-text ACTION_SEND (EXTRA_TEXT only) so the export still shares.
+ * The whole body is wrapped in try/catch so a missing chooser / provider misconfig never crashes.
+ */
+fun shareReportCsv(context: Context, content: String, baseName: String) {
+    if (content.isEmpty()) return
+    try {
+        val dir = File(context.cacheDir, "attachments").apply { mkdirs() }
+        val file = File(dir, "$baseName.csv")
+        file.writeText(content)
+
+        val authority = context.packageName + ".fileprovider"
+        val uri = FileProvider.getUriForFile(context, authority, file)
+
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/csv"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            if (content.length < REPORT_TEXT_MAX_CHARS) {
+                putExtra(Intent.EXTRA_TEXT, content)
+            }
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        startChooser(context, send)
+    } catch (_: ActivityNotFoundException) {
+        // No share target available (e.g. a bare emulator): swallow so we never crash.
+    } catch (_: Exception) {
+        // Provider misconfig / IO error: fall back to plain-text sharing so the export still works.
+        shareReportText(context, content)
+    }
+}
+
+/** Plain-text ACTION_SEND fallback (no FileProvider) — used when the file grant path fails. */
+private fun shareReportText(context: Context, content: String) {
+    try {
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, content)
+        }
+        startChooser(context, send)
+    } catch (_: Exception) {
+        // Best-effort: never crash the screen.
+    }
+}
+
+private fun startChooser(context: Context, send: Intent) {
+    val chooser = Intent.createChooser(send, "Export report")
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(chooser)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/reports/ReportsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/reports/ReportsScreen.kt
@@ -1,0 +1,275 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.reports
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.util.Locale
+
+/** Green/red for PnL, matching the PnL/markets/portfolio convention. */
+private val UpColor = Color(0xFF16A34A)
+private val DownColor = Color(0xFFDC2626)
+
+@Composable
+fun ReportsRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ReportsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    ReportsScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onPeriod = viewModel::setPeriod,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ReportsScreen(
+    state: ReportsUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onPeriod: (ReportPeriod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Export & reporting") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when {
+            state.loading -> LoadingBlock(Modifier.padding(padding))
+            state.unavailable -> MessageBlock(
+                title = "Not available",
+                body = "Reporting isn't available on this deployment yet.",
+                modifier = Modifier.padding(padding),
+            )
+            state.error != null -> MessageBlock(
+                title = "Couldn't load",
+                body = state.error,
+                modifier = Modifier.padding(padding),
+            )
+            else -> ReportsContent(state, onPeriod, Modifier.padding(padding))
+        }
+    }
+}
+
+@Composable
+private fun ReportsContent(state: ReportsUiState, onPeriod: (ReportPeriod) -> Unit, modifier: Modifier) {
+    val context = LocalContext.current
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { PeriodChips(state.period, onPeriod) }
+        item {
+            if (state.isEmpty) {
+                Card(Modifier.fillMaxWidth()) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text("No activity in this period", style = MaterialTheme.typography.titleSmall)
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            "Pick a wider period, or trade to populate reports. You can still export an empty report (headers only).",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                StatsHeader(state.stats)
+            }
+        }
+        val exports = state.exports
+        if (exports != null) {
+            item {
+                Text(
+                    "Exports",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+            item {
+                ExportCard(
+                    title = "Trade history",
+                    subtitle = "Every fill: time / symbol / side / price / qty / fee / notional.",
+                    onExport = { shareReportCsv(context, exports.tradeHistoryCsv, exports.tradeHistoryName) },
+                )
+            }
+            item {
+                ExportCard(
+                    title = "PnL summary",
+                    subtitle = "Per-symbol realized / fees / volume / trades + totals.",
+                    onExport = { shareReportCsv(context, exports.pnlSummaryCsv, exports.pnlSummaryName) },
+                )
+            }
+            item {
+                ExportCard(
+                    title = "Account statement",
+                    subtitle = "Period balances, open position, and realized roll-up.",
+                    onExport = { shareReportCsv(context, exports.accountStatementCsv, exports.accountStatementName) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeriodChips(selected: ReportPeriod, onPeriod: (ReportPeriod) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        ReportPeriod.entries.forEach { p ->
+            FilterChip(
+                selected = p == selected,
+                onClick = { onPeriod(p) },
+                label = { Text(p.label) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatsHeader(stats: ReportStats?) {
+    if (stats == null) return
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+            ),
+        ) {
+            Column(Modifier.padding(16.dp)) {
+                Text(
+                    "Net realized (period)",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = signed(stats.netRealized),
+                    fontSize = 28.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace,
+                    color = if (stats.isProfit) UpColor else DownColor,
+                )
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            StatCard("Fills", stats.fillCount.toString(), Modifier.weight(1f))
+            StatCard("Trades", stats.tradeCount.toString(), Modifier.weight(1f))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            StatCard("Fees", stats.totalFees.toString(), Modifier.weight(1f))
+            StatCard("Volume", stats.volume.toString(), Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun StatCard(label: String, value: String, modifier: Modifier) {
+    Card(modifier = modifier) {
+        Column(Modifier.padding(14.dp)) {
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(6.dp))
+            Text(value, fontSize = 18.sp, fontWeight = FontWeight.Bold, fontFamily = FontFamily.Monospace)
+        }
+    }
+}
+
+@Composable
+private fun ExportCard(title: String, subtitle: String, onExport: () -> Unit) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(4.dp))
+            Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(12.dp))
+            Button(onClick = onExport) {
+                Icon(Icons.Filled.Share, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("Export CSV")
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingBlock(modifier: Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Spacer(Modifier.height(12.dp))
+            Text("Loading reports…", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun MessageBlock(title: String, body: String, modifier: Modifier) {
+    Box(modifier = modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(6.dp))
+            Text(body, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+/** Signed integer display: a leading '+' for non-negative, grouped thousands. */
+private fun signed(v: Long): String {
+    val grouped = String.format(Locale.US, "%,d", Math.abs(v))
+    return if (v >= 0) "+$grouped" else "-$grouped"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/reports/ReportsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/reports/ReportsUiState.kt
@@ -1,0 +1,49 @@
+package com.testlogon.android.feature.reports
+
+/**
+ * UI state for the Export & Reporting screen. The ViewModel fetches the exchange reads once, then
+ * re-derives [stats] + the CSV export payloads whenever the selected [period] changes (period scoping
+ * is a pure local filter — no re-fetch). Nothing here moves money; it is a read-only reporting view.
+ *
+ * [loading] gates the initial spinner; [unavailable] mirrors the PnL screen's whole-surface-degraded
+ * state (every read undeployed); [error] carries a retryable transient failure. When loaded, [isEmpty]
+ * drives the 'no activity in this period' empty state for the CURRENT period.
+ */
+data class ReportsUiState(
+    val loading: Boolean = true,
+    val unavailable: Boolean = false,
+    val error: String? = null,
+    val period: ReportPeriod = ReportPeriod.MONTH,
+    val stats: ReportStats? = null,
+    /** Prepared CSV payloads for the current period, ready to hand to the share sheet. */
+    val exports: ReportExports? = null,
+) {
+    /** True once loaded/readable and there was genuinely no fill activity in the selected window. */
+    val isEmpty: Boolean
+        get() = !loading && !unavailable && error == null &&
+            (stats == null || (stats.tradeCount == 0 && stats.fillCount == 0))
+}
+
+/** Headline stats for the selected period (raw integer engine units, [winRate] a 0..1 fraction). */
+data class ReportStats(
+    val netRealized: Long,
+    val totalFees: Long,
+    val volume: Long,
+    val tradeCount: Int,
+    val fillCount: Int,
+    val winRate: Float,
+    val closingTradeCount: Int,
+) {
+    val isProfit: Boolean get() = netRealized >= 0
+    val winRatePercent: Int get() = Math.round(winRate * 100f)
+}
+
+/** The three built CSV documents + their file base-names, one export action each. */
+data class ReportExports(
+    val tradeHistoryCsv: String,
+    val pnlSummaryCsv: String,
+    val accountStatementCsv: String,
+    val tradeHistoryName: String,
+    val pnlSummaryName: String,
+    val accountStatementName: String,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/reports/ReportsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/reports/ReportsViewModel.kt
@@ -1,0 +1,161 @@
+package com.testlogon.android.feature.reports
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.feature.pnl.PnlAnalytics
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel for the Export & Reporting screen. Fans the same exchange reads the PnL screen uses out in
+ * parallel (fills-fees / liquidations / funding / margin + symbols for name resolution), caches the raw
+ * reads, then projects a period-scoped [ReportsUiState] purely on the client. Changing the period only
+ * re-derives (no re-fetch): the pure [filterFills]/[filterFunding]/[filterLiquidations] + [PnlAnalytics]
+ * + [ReportCsv] path runs again against the cached reads.
+ *
+ * The unavailable / error degradation mirrors the PnL screen: a transient failure on the fills read is
+ * a retryable error; when every input degraded (three feeds empty AND the margin read failed) the whole
+ * surface is 'unavailable'. A 'now' reference tick is captured per refresh so windows are stable.
+ */
+@HiltViewModel
+class ReportsViewModel @Inject constructor(
+    private val trading: TradingRepository,
+    private val exchange: ExchangeRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ReportsUiState())
+    val uiState: StateFlow<ReportsUiState> = _uiState.asStateFlow()
+
+    // Cached raw reads from the last successful fetch, re-projected when the period changes.
+    private var cachedFills: FillsFees? = null
+    private var cachedLiq: Liquidations = Liquidations(emptyList(), 0)
+    private var cachedFunding: FundingPayments = FundingPayments(emptyList(), 0)
+    private var cachedMargin: MarginAccount? = null
+    private var cachedNames: Map<Int, String> = emptyMap()
+    private var nowNs: Long = nowTicksNs()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        val period = _uiState.value.period
+        _uiState.value = ReportsUiState(loading = true, period = period)
+        nowNs = nowTicksNs()
+        viewModelScope.launch {
+            _uiState.value = coroutineScope {
+                val fillsDef = async { trading.fillsFees() }
+                val liqDef = async { trading.liquidations() }
+                val fundingDef = async { trading.fundingPayments() }
+                val marginDef = async { trading.marginAccount() }
+                val symbolsDef = async { exchange.symbols() }
+                fetchAndProject(
+                    fills = fillsDef.await(),
+                    liquidations = liqDef.await(),
+                    funding = fundingDef.await(),
+                    marginResult = marginDef.await(),
+                    symbolsResult = symbolsDef.await(),
+                    period = period,
+                )
+            }
+        }
+    }
+
+    /** Switch the reporting window; re-derives from the cached reads without a network round-trip. */
+    fun setPeriod(period: ReportPeriod) {
+        if (period == _uiState.value.period) return
+        val fills = cachedFills
+        if (fills == null) {
+            _uiState.value = _uiState.value.copy(period = period)
+            return
+        }
+        _uiState.value = project(fills, period)
+    }
+
+    private fun fetchAndProject(
+        fills: ApiResult<FillsFees>,
+        liquidations: ApiResult<Liquidations>,
+        funding: ApiResult<FundingPayments>,
+        marginResult: ApiResult<MarginAccount>,
+        symbolsResult: ApiResult<List<Instrument>>,
+        period: ReportPeriod,
+    ): ReportsUiState {
+        val fillsData = when (fills) {
+            is ApiResult.Success -> fills.data
+            is ApiResult.NetworkError -> return ReportsUiState(loading = false, period = period, error = "Network error. Pull to retry.")
+            is ApiResult.Failure -> return ReportsUiState(loading = false, period = period, error = "Couldn't load trade data.")
+        }
+        val liqData = (liquidations as? ApiResult.Success)?.data ?: Liquidations(emptyList(), 0)
+        val fundingData = (funding as? ApiResult.Success)?.data ?: FundingPayments(emptyList(), 0)
+        val margin = (marginResult as? ApiResult.Success)?.data
+
+        if (fillsData.isEmpty && liqData.isEmpty && fundingData.isEmpty && margin == null) {
+            return ReportsUiState(loading = false, period = period, unavailable = true)
+        }
+
+        cachedFills = fillsData
+        cachedLiq = liqData
+        cachedFunding = fundingData
+        cachedMargin = margin
+        cachedNames = symbolNames(symbolsResult)
+        return project(fillsData, period)
+    }
+
+    /** Pure re-projection from cached reads for the given [period]. */
+    private fun project(fills: FillsFees, period: ReportPeriod): ReportsUiState {
+        val scopedFills = filterFills(fills.fills, period, nowNs)
+        val scopedLiq = filterLiquidations(cachedLiq.events, period, nowNs)
+        val scopedFunding = filterFunding(cachedFunding.payments, period, nowNs)
+        val unrealized = cachedMargin?.position?.unrealizedPnl ?: 0L
+
+        val report = PnlAnalytics.analyze(
+            FillsFees(scopedFills, scopedFills.size),
+            Liquidations(scopedLiq, scopedLiq.size),
+            FundingPayments(scopedFunding, scopedFunding.size),
+            unrealized,
+        )
+        val names = cachedNames
+        val stats = ReportStats(
+            netRealized = report.netRealized,
+            totalFees = report.totalFees,
+            volume = report.volume,
+            tradeCount = report.tradeCount,
+            fillCount = scopedFills.size,
+            winRate = report.winRate,
+            closingTradeCount = report.closingTradeCount,
+        )
+        val exports = ReportExports(
+            tradeHistoryCsv = ReportCsv.tradeHistory(scopedFills, names),
+            pnlSummaryCsv = ReportCsv.pnlSummary(report, names),
+            accountStatementCsv = ReportCsv.accountStatement(
+                report = report,
+                margin = cachedMargin,
+                symbolNames = names,
+                periodLabel = period.label,
+                fromTsNs = period.cutoffNs(nowNs),
+                toTsNs = nowNs,
+            ),
+            tradeHistoryName = "trade-history-" + period.label,
+            pnlSummaryName = "pnl-summary-" + period.label,
+            accountStatementName = "account-statement-" + period.label,
+        )
+        return ReportsUiState(loading = false, period = period, stats = stats, exports = exports)
+    }
+
+    private fun symbolNames(result: ApiResult<List<Instrument>>): Map<Int, String> =
+        (result as? ApiResult.Success)?.data?.associate { it.symbolId to it.symbol } ?: emptyMap()
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/settings/trading/TradingPreferencesScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/trading/TradingPreferencesScreen.kt
@@ -4,11 +4,14 @@ import android.Manifest
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
@@ -41,12 +44,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.FilterChip
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.R
+import com.testlogon.android.core.network.AppAccent
+import com.testlogon.android.core.network.AppDensity
 import com.testlogon.android.core.network.AppThemeMode
 import com.testlogon.android.data.exchange.TradingUiPrefsStore
 import com.testlogon.android.data.exchange.alerts.TradingAlertKind
@@ -63,6 +75,8 @@ fun TradingPreferencesRoute(
         state = state,
         onBack = onBack,
         onModeSelected = viewModel::onModeSelected,
+        onAccentSelected = viewModel::onAccentSelected,
+        onDensitySelected = viewModel::onDensitySelected,
         onDefaultMarketSelected = viewModel::onDefaultMarketSelected,
         onAlertKindToggled = viewModel::onAlertKindToggled,
         onRefreshNotifications = viewModel::refreshNotificationState,
@@ -78,6 +92,8 @@ fun TradingPreferencesScreen(
     state: TradingPreferencesUiState,
     onBack: () -> Unit,
     onModeSelected: (AppThemeMode) -> Unit,
+    onAccentSelected: (AppAccent) -> Unit,
+    onDensitySelected: (AppDensity) -> Unit,
     onDefaultMarketSelected: (Int) -> Unit,
     onAlertKindToggled: (TradingAlertKind, Boolean) -> Unit,
     onRefreshNotifications: () -> Unit,
@@ -137,6 +153,24 @@ fun TradingPreferencesScreen(
                     },
                 )
             }
+
+            HorizontalDivider()
+
+            // ---- Accent color ----
+            SectionHeader(stringResource(R.string.trading_prefs_accent_section))
+            AccentPicker(
+                selected = state.appearance.accent,
+                onSelected = onAccentSelected,
+            )
+
+            HorizontalDivider()
+
+            // ---- Density ----
+            SectionHeader(stringResource(R.string.trading_prefs_density_section))
+            DensityToggle(
+                selected = state.appearance.density,
+                onSelected = onDensitySelected,
+            )
 
             HorizontalDivider()
 
@@ -240,6 +274,91 @@ fun TradingPreferencesScreen(
             }
         }
     }
+}
+
+@Composable
+private fun AccentPicker(
+    selected: AppAccent,
+    onSelected: (AppAccent) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("trading_prefs_accent_row")
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AppAccent.entries.forEach { accent ->
+            val isSel = accent == selected
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(Color(accent.seedArgb))
+                    .border(
+                        width = if (isSel) 3.dp else 1.dp,
+                        color = if (isSel) MaterialTheme.colorScheme.onSurface
+                            else MaterialTheme.colorScheme.outline,
+                        shape = CircleShape,
+                    )
+                    .selectable(
+                        selected = isSel,
+                        role = Role.RadioButton,
+                        onClick = { onSelected(accent) },
+                    )
+                    .testTag("trading_prefs_accent_${accent.name.lowercase()}"),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (isSel) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = stringResource(accentLabel(accent)),
+                        tint = Color.White,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DensityToggle(
+    selected: AppDensity,
+    onSelected: (AppDensity) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("trading_prefs_density_row")
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AppDensity.entries.forEach { density ->
+            FilterChip(
+                selected = selected == density,
+                onClick = { onSelected(density) },
+                label = { Text(stringResource(densityLabel(density))) },
+                modifier = Modifier.testTag("trading_prefs_density_${density.name.lowercase()}"),
+            )
+        }
+    }
+}
+
+private fun accentLabel(accent: AppAccent): Int = when (accent) {
+    AppAccent.DEFAULT -> R.string.trading_prefs_accent_default
+    AppAccent.VIOLET -> R.string.trading_prefs_accent_violet
+    AppAccent.TEAL -> R.string.trading_prefs_accent_teal
+    AppAccent.AMBER -> R.string.trading_prefs_accent_amber
+    AppAccent.ROSE -> R.string.trading_prefs_accent_rose
+    AppAccent.GREEN -> R.string.trading_prefs_accent_green
+}
+
+private fun densityLabel(density: AppDensity): Int = when (density) {
+    AppDensity.COMFORTABLE -> R.string.trading_prefs_density_comfortable
+    AppDensity.COMPACT -> R.string.trading_prefs_density_compact
 }
 
 @Composable

--- a/android/app/src/main/java/com/testlogon/android/feature/settings/trading/TradingPreferencesViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/trading/TradingPreferencesViewModel.kt
@@ -3,6 +3,8 @@ package com.testlogon.android.feature.settings.trading
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.AppAccent
+import com.testlogon.android.core.network.AppDensity
 import com.testlogon.android.core.network.AppThemeMode
 import com.testlogon.android.core.network.AppearancePreferences
 import com.testlogon.android.core.network.ThemePreferencesStore
@@ -95,6 +97,12 @@ class TradingPreferencesViewModel @Inject constructor(
     }
 
     fun onModeSelected(mode: AppThemeMode) = themeStore.setMode(mode)
+
+    /** Density + accent theming: persist the chosen accent; the whole app re-accents live. */
+    fun onAccentSelected(accent: AppAccent) = themeStore.setAccent(accent)
+
+    /** Density + accent theming: persist the chosen UI density; high-traffic surfaces retighten live. */
+    fun onDensitySelected(density: AppDensity) = themeStore.setDensity(density)
 
     fun onDefaultMarketSelected(symbolId: Int) {
         if (symbolId == TradingUiPrefsStore.NO_DEFAULT) tradingUiPrefs.clearDefaultSymbol()

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -221,6 +221,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         portfolioDestination(navController)
         // PnL & performance: read-only realized/unrealized analytics, equity curve, per-symbol breakdown.
         pnlDestination(navController)
+        // Export & reporting: read-only period-scoped CSV export (trade history / PnL / statement).
+        reportsDestination(navController)
         // AND-336: backend-mediated Google Drive import picker (authenticated-only).
         driveImportDestination(navController)
         // AND-335: owner share sheet (create/list/revoke share links) + the public share screen

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -112,6 +112,9 @@ object MoreRoutes {
     // PnL & performance: read-only realized/unrealized analytics + equity curve (Wallet hub, near Portfolio).
     const val PNL = PnlDest.ROUTE
 
+    // Export & reporting: read-only period-scoped CSV export (Wallet hub, near PnL).
+    const val REPORTS = ReportsDest.ROUTE
+
     // AND-219: the purchase history list + search.
     val PURCHASE_HISTORY: String get() = PurchaseHistoryDest.ROUTE
 
@@ -574,6 +577,7 @@ object MoreRoutes {
             CUSTODY,
             PORTFOLIO,
             PNL,
+            REPORTS,
             PURCHASE_HISTORY,
             PAYMENT_METHODS,
             WALLET_TRANSACTIONS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/ReportsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/ReportsNavigation.kt
@@ -1,0 +1,24 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.reports.ReportsRoute
+
+/**
+ * The read-only Export & Reporting surface, reached from the More -> Wallet hub (near PnL). Picks a
+ * period (24h/7d/30d/All), shows headline stats over the period-scoped fills, and exports trade
+ * history / PnL summary / account statement as CSV via the system share sheet. No money movement.
+ */
+data object ReportsDest {
+    const val ROUTE = "reports"
+}
+
+/** Registers the Export & Reporting screen in the authenticated graph. Up / Back pops the back stack. */
+fun NavGraphBuilder.reportsDestination(navController: NavHostController) {
+    composable(ReportsDest.ROUTE) {
+        ReportsRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/testlogon/android/ui/theme/Theme.kt
@@ -1,6 +1,8 @@
 package com.testlogon.android.ui.theme
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.testlogon.android.core.ui.theme.AppUiDensity
 import com.testlogon.android.core.ui.theme.TestLogonTheme as CoreTestLogonTheme
 
 /**
@@ -9,6 +11,10 @@ import com.testlogon.android.core.ui.theme.TestLogonTheme as CoreTestLogonTheme
  * sites referencing the local name keep compiling; prefer importing the core-ui theme directly.
  */
 @Composable
-fun TestLogonTheme(content: @Composable () -> Unit) {
-    CoreTestLogonTheme(content = content)
+fun TestLogonTheme(
+    accentSeed: Color? = null,
+    density: AppUiDensity = AppUiDensity.COMFORTABLE,
+    content: @Composable () -> Unit,
+) {
+    CoreTestLogonTheme(accentSeed = accentSeed, density = density, content = content)
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -183,6 +183,16 @@
     <string name="settings_section_trading_subtitle">Theme, default market &amp; trade alerts</string>
     <string name="trading_prefs_title">Trading preferences</string>
     <string name="trading_prefs_theme_section">Theme</string>
+    <string name="trading_prefs_accent_section">Accent color</string>
+    <string name="trading_prefs_accent_default">Default (Blue)</string>
+    <string name="trading_prefs_accent_violet">Violet</string>
+    <string name="trading_prefs_accent_teal">Teal</string>
+    <string name="trading_prefs_accent_amber">Amber</string>
+    <string name="trading_prefs_accent_rose">Rose</string>
+    <string name="trading_prefs_accent_green">Green</string>
+    <string name="trading_prefs_density_section">Density</string>
+    <string name="trading_prefs_density_comfortable">Comfortable</string>
+    <string name="trading_prefs_density_compact">Compact</string>
     <string name="trading_prefs_default_market_section">Default market</string>
     <string name="trading_prefs_default_market_label">Market</string>
     <string name="trading_prefs_default_market_none">No default (use first available)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1450,6 +1450,7 @@
     <string name="more_entry_custody">Custody</string>
     <string name="more_entry_portfolio">Portfolio</string>
     <string name="more_entry_pnl">PnL &amp; performance</string>
+    <string name="more_entry_reports">Export &amp; reporting</string>
     <string name="story_ring_unseen">Story from %1$s, unseen</string>
     <string name="story_ring_seen">Story from %1$s, seen</string>
     <string name="story_close">Close stories</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/markets/chart/DepthMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/markets/chart/DepthMathTest.kt
@@ -1,0 +1,166 @@
+package com.testlogon.android.feature.markets.chart
+
+import com.testlogon.android.data.exchange.OrderBook
+import com.testlogon.android.data.exchange.OrderBookLevel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure cumulative-depth math in [DepthMath] that backs the [DepthChart] Canvas.
+ * No Compose / Android here — this is the extracted, framework-free layer.
+ */
+class DepthMathTest {
+
+    private fun lvl(price: Long, qty: Long) = OrderBookLevel(price, qty)
+
+    private fun book(
+        bids: List<OrderBookLevel>,
+        asks: List<OrderBookLevel>,
+        bestBid: Long? = bids.firstOrNull()?.price,
+        bestAsk: Long? = asks.firstOrNull()?.price,
+    ) = OrderBook(symbolId = 1, bids = bids, asks = asks, bestBid = bestBid, bestAsk = bestAsk)
+
+    @Test
+    fun cumulativeBids_accumulateFromBestOutward() {
+        // best bid highest price first
+        val out = DepthMath.cumulativeBids(listOf(lvl(100, 5), lvl(99, 3), lvl(98, 2)))
+        assertEquals(listOf(5L, 8L, 10L), out.map { it.cumQty })
+        assertEquals(listOf(100L, 99L, 98L), out.map { it.price })
+    }
+
+    @Test
+    fun cumulativeAsks_accumulateFromBestOutward() {
+        val out = DepthMath.cumulativeAsks(listOf(lvl(101, 4), lvl(102, 1), lvl(103, 5)))
+        assertEquals(listOf(4L, 5L, 10L), out.map { it.cumQty })
+        assertEquals(listOf(101L, 102L, 103L), out.map { it.price })
+    }
+
+    @Test
+    fun cumulative_tolerateUnsortedInput_andSkipZeroQty() {
+        // deliberately scrambled + a zero-qty level that must be dropped
+        val bids = DepthMath.cumulativeBids(listOf(lvl(98, 2), lvl(100, 5), lvl(99, 0), lvl(97, 1)))
+        assertEquals(listOf(100L, 98L, 97L), bids.map { it.price })
+        assertEquals(listOf(5L, 7L, 8L), bids.map { it.cumQty })
+
+        val asks = DepthMath.cumulativeAsks(listOf(lvl(103, 5), lvl(101, 4), lvl(102, 0)))
+        assertEquals(listOf(101L, 103L), asks.map { it.price })
+        assertEquals(listOf(4L, 9L), asks.map { it.cumQty })
+    }
+
+    @Test
+    fun model_computesAxisMidSpreadAndMaxCum() {
+        val m = DepthMath.model(
+            book(
+                bids = listOf(lvl(100, 5), lvl(99, 3)),
+                asks = listOf(lvl(101, 4), lvl(102, 6)),
+            ),
+        )
+        assertFalse(m.isEmpty)
+        assertEquals(99L, m.minPrice)
+        assertEquals(102L, m.maxPrice)
+        assertEquals(100L, m.bestBid)
+        assertEquals(101L, m.bestAsk)
+        assertEquals(100.5, m.mid!!, 1e-9)
+        assertEquals(1L, m.spread)
+        // bid total 8, ask total 10 -> maxCum 10
+        assertEquals(10L, m.maxCum)
+    }
+
+    @Test
+    fun model_maxCumNeverZero_evenForEmptyOrTinyBook() {
+        assertTrue(DepthMath.model(null).isEmpty)
+        assertEquals(1L, DepthMath.model(null).maxCum)
+        val emptyBook = DepthMath.model(book(emptyList(), emptyList(), null, null))
+        assertTrue(emptyBook.isEmpty)
+    }
+
+    @Test
+    fun model_capsEachSideToMaxLevels() {
+        val bids = (1..10).map { lvl(100L - it, 1L) }        // 99..90
+        val asks = (1..10).map { lvl(100L + it, 1L) }        // 101..110
+        val m = DepthMath.model(book(bids, asks, 99, 101), maxLevels = 3)
+        assertEquals(3, m.bids.size)
+        assertEquals(3, m.asks.size)
+        // capped cumulative maxima are 3 each
+        assertEquals(3L, m.maxCum)
+    }
+
+    @Test
+    fun model_oneSidedBook_stillProducesModel() {
+        val m = DepthMath.model(book(bids = listOf(lvl(100, 5), lvl(99, 2)), asks = emptyList(), bestAsk = null))
+        assertFalse(m.isEmpty)
+        assertNull(m.mid)      // no ask -> no mid
+        assertNull(m.spread)
+        assertEquals(7L, m.maxCum)
+        assertTrue(m.asks.isEmpty())
+    }
+
+    @Test
+    fun crosshair_onBidSide_reportsCumAtOrAbovePrice() {
+        val m = DepthMath.model(
+            book(
+                bids = listOf(lvl(100, 5), lvl(99, 3), lvl(98, 2)), // cum 5,8,10
+                asks = listOf(lvl(101, 4), lvl(102, 6)),            // cum 4,10
+            ),
+        )
+        // axis 98..102, span 4. price 99 -> fracX = (99-98)/4 = 0.25
+        val c = DepthMath.crosshairAt(m, 0.25f)
+        assertNotNull(c)
+        assertTrue(c!!.isBid)
+        assertEquals(99L, c.price)
+        // cumulative bid depth at/above 99 = 5 + 3 = 8
+        assertEquals(8L, c.cumQty)
+    }
+
+    @Test
+    fun crosshair_onAskSide_reportsCumAtOrBelowPrice() {
+        val m = DepthMath.model(
+            book(
+                bids = listOf(lvl(100, 5), lvl(99, 3), lvl(98, 2)),
+                asks = listOf(lvl(101, 4), lvl(102, 6)),            // cum 4,10
+            ),
+        )
+        // price 102 -> fracX = (102-98)/4 = 1.0, right of mid 100.5 -> ask side
+        val c = DepthMath.crosshairAt(m, 1.0f)!!
+        assertFalse(c.isBid)
+        assertEquals(102L, c.price)
+        assertEquals(10L, c.cumQty)
+    }
+
+    @Test
+    fun crosshair_farLeft_reportsBestBidOnly() {
+        val m = DepthMath.model(
+            book(
+                bids = listOf(lvl(100, 5), lvl(99, 3), lvl(98, 2)),
+                asks = listOf(lvl(101, 4), lvl(102, 6)),
+            ),
+        )
+        // fracX 0 -> price 98, at/above 98 = full bid stack 10
+        val c = DepthMath.crosshairAt(m, 0f)!!
+        assertTrue(c.isBid)
+        assertEquals(98L, c.price)
+        assertEquals(10L, c.cumQty)
+    }
+
+    @Test
+    fun crosshair_emptyModel_isNull() {
+        assertNull(DepthMath.crosshairAt(DepthMath.EMPTY, 0.5f))
+    }
+
+    @Test
+    fun crosshair_clampsFractionOutOfRange() {
+        val m = DepthMath.model(
+            book(
+                bids = listOf(lvl(100, 5)),
+                asks = listOf(lvl(101, 4)),
+            ),
+        )
+        // out-of-range fractions clamp into [0,1] rather than throwing
+        assertNotNull(DepthMath.crosshairAt(m, -3f))
+        assertNotNull(DepthMath.crosshairAt(m, 5f))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/reports/ReportCsvTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/reports/ReportCsvTest.kt
@@ -1,0 +1,212 @@
+package com.testlogon.android.feature.reports
+
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidity
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.PositionSnapshot
+import com.testlogon.android.feature.pnl.PnlAnalytics
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the PURE reporting helpers: [ReportCsv] (headers, RFC 4180 comma/quote escaping,
+ * per-fill rows, the PnL-summary total roll-up, the account statement) and [ReportPeriod] period
+ * scoping (24h/7d/30d/All window boundaries against a deterministic 'now').
+ */
+class ReportCsvTest {
+
+    private val ns = 1_000_000_000L // 1 second in nanoseconds
+
+    private fun fill(
+        symbolId: Int,
+        side: OrderSide,
+        price: Long,
+        qty: Long,
+        fee: Long = 0L,
+        tsNs: Long,
+    ) = FillFee(
+        symbolId = symbolId,
+        price = price,
+        qty = qty,
+        side = side,
+        liquidity = Liquidity.TAKER,
+        fee = fee,
+        feeAsset = 0,
+        tsNs = tsNs,
+    )
+
+    private val names = mapOf(1 to "BTCUSDC", 2 to "ETHUSDC")
+
+    // ---- CSV field escaping (RFC 4180) ----
+
+    @Test
+    fun `plain field is not quoted`() {
+        assertEquals("BTCUSDC", ReportCsv.csvField("BTCUSDC"))
+    }
+
+    @Test
+    fun `field with comma is quoted`() {
+        assertEquals("\"a,b\"", ReportCsv.csvField("a,b"))
+    }
+
+    @Test
+    fun `embedded quote is doubled and wrapped`() {
+        // a"b -> "a""b"
+        assertEquals("\"a\"\"b\"", ReportCsv.csvField("a\"b"))
+    }
+
+    @Test
+    fun `field with newline is quoted`() {
+        assertEquals("\"a\nb\"", ReportCsv.csvField("a\nb"))
+    }
+
+    // ---- trade history ----
+
+    @Test
+    fun `trade history has header and one row per fill oldest first`() {
+        val csv = ReportCsv.tradeHistory(
+            listOf(
+                fill(1, OrderSide.SELL, 120, 10, fee = 2, tsNs = 2 * ns),
+                fill(1, OrderSide.BUY, 100, 10, fee = 1, tsNs = 1 * ns),
+            ),
+            names,
+        )
+        val lines = csv.split("\r\n")
+        assertEquals("Time,Symbol,Side,Price,Qty,Fee,Notional", lines[0])
+        assertEquals(3, lines.size) // header + 2 rows
+        // Oldest (BUY @ 100, ts=1) sorts first; notional = |10|*100 = 1000.
+        assertTrue(lines[1].contains(",BTCUSDC,BUY,100,10,1,1000"))
+        // Then SELL @ 120; notional = 1200.
+        assertTrue(lines[2].contains(",BTCUSDC,SELL,120,10,2,1200"))
+    }
+
+    @Test
+    fun `trade history emits header only when there are no fills`() {
+        val csv = ReportCsv.tradeHistory(emptyList(), names)
+        assertEquals("Time,Symbol,Side,Price,Qty,Fee,Notional", csv)
+    }
+
+    @Test
+    fun `unknown symbol id falls back to hash id`() {
+        val csv = ReportCsv.tradeHistory(
+            listOf(fill(99, OrderSide.BUY, 5, 1, tsNs = ns)),
+            names,
+        )
+        assertTrue(csv.contains(",#99,BUY,5,1,"))
+    }
+
+    // ---- PnL summary ----
+
+    @Test
+    fun `pnl summary has per-symbol rows plus a TOTAL row`() {
+        // Round-trip on symbol 1: buy 10@100, sell 10@120 -> realized 200.
+        val report = PnlAnalytics.analyze(
+            FillsFees(
+                listOf(
+                    fill(1, OrderSide.BUY, 100, 10, fee = 1, tsNs = 1 * ns),
+                    fill(1, OrderSide.SELL, 120, 10, fee = 1, tsNs = 2 * ns),
+                ),
+                2,
+            ),
+            Liquidations(emptyList(), 0),
+            FundingPayments(emptyList(), 0),
+            unrealizedPnl = 0,
+        )
+        val csv = ReportCsv.pnlSummary(report, names)
+        val lines = csv.split("\r\n")
+        assertEquals("Symbol,Realized,Fees,Volume,Trades", lines[0])
+        assertTrue(lines.any { it.startsWith("BTCUSDC,200,") })
+        assertTrue(lines.any { it.startsWith("TOTAL,200,") })
+        assertTrue(lines.any { it.startsWith("Net realized,198,") }) // 200 - 2 fees
+    }
+
+    // ---- account statement ----
+
+    @Test
+    fun `account statement includes period balances and open position`() {
+        val report = PnlAnalytics.analyze(
+            FillsFees(emptyList(), 0),
+            Liquidations(emptyList(), 0),
+            FundingPayments(emptyList(), 0),
+            unrealizedPnl = 50,
+        )
+        val margin = MarginAccount(
+            balance = 10_000,
+            availableBalance = 9_000,
+            reservedMargin = 1_000,
+            numPositions = 1,
+            position = PositionSnapshot(
+                symbolId = 1,
+                qty = 5,
+                entryPrice = 100,
+                liquidationPrice = 80,
+                unrealizedPnl = 50,
+            ),
+            distressLevel = 0,
+            isLiquidating = false,
+            mpid = "MP1",
+        )
+        val csv = ReportCsv.accountStatement(
+            report = report,
+            margin = margin,
+            symbolNames = names,
+            periodLabel = "7d",
+            fromTsNs = 0,
+            toTsNs = 0,
+        )
+        assertTrue(csv.contains("Field,Value"))
+        assertTrue(csv.contains("Period,7d"))
+        assertTrue(csv.contains("Balance,10000"))
+        assertTrue(csv.contains("Available balance,9000"))
+        assertTrue(csv.contains("Position symbol,BTCUSDC"))
+        assertTrue(csv.contains("Position qty,5"))
+    }
+
+    @Test
+    fun `account statement renders dashes and flat when margin is null`() {
+        val report = PnlAnalytics.analyze(
+            FillsFees(emptyList(), 0),
+            Liquidations(emptyList(), 0),
+            FundingPayments(emptyList(), 0),
+            unrealizedPnl = 0,
+        )
+        val csv = ReportCsv.accountStatement(report, null, names, "All", 0, 0)
+        assertTrue(csv.contains("Balance,--"))
+        assertTrue(csv.contains("Position,flat"))
+    }
+
+    // ---- period scoping ----
+
+    @Test
+    fun `period cutoff drops events older than the window`() {
+        val now = 100L * 24 * 60 * 60 * ns // day 100
+        val oldFill = fill(1, OrderSide.BUY, 1, 1, tsNs = now - 40L * 24 * 60 * 60 * ns) // 40 days ago
+        val recentFill = fill(1, OrderSide.BUY, 1, 1, tsNs = now - 3L * 24 * 60 * 60 * ns) // 3 days ago
+        val all = listOf(oldFill, recentFill)
+
+        // 7d keeps only the 3-day-old fill.
+        val week = filterFills(all, ReportPeriod.WEEK, now)
+        assertEquals(1, week.size)
+        assertEquals(recentFill.tsNs, week.single().tsNs)
+
+        // 30d still drops the 40-day-old fill.
+        assertEquals(1, filterFills(all, ReportPeriod.MONTH, now).size)
+
+        // ALL keeps everything.
+        assertEquals(2, filterFills(all, ReportPeriod.ALL, now).size)
+    }
+
+    @Test
+    fun `period contains is inclusive at the boundary`() {
+        val now = 10L * 24 * 60 * 60 * ns
+        val cutoff = ReportPeriod.DAY.cutoffNs(now)
+        assertTrue(ReportPeriod.DAY.contains(cutoff, now)) // exactly at the boundary is kept
+        assertFalse(ReportPeriod.DAY.contains(cutoff - 1, now)) // one tick before is dropped
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/settings/trading/ThemePreferencesStoreTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/settings/trading/ThemePreferencesStoreTest.kt
@@ -1,0 +1,71 @@
+package com.testlogon.android.feature.settings.trading
+
+import com.testlogon.android.core.network.AppAccent
+import com.testlogon.android.core.network.AppDensity
+import com.testlogon.android.core.network.AppThemeMode
+import com.testlogon.android.core.network.ThemePreferencesStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Density + accent theming: pure-JVM coverage of [ThemePreferencesStore.readFrom], the accent/density/
+ * mode/dynamic decode. Uses fake string/boolean getters so no Android Context is needed. Lives in the
+ * app test source set (the core-network unit-test source set has a pre-existing AGP friend-paths compile
+ * break unrelated to this change; the app source set is the one the required gate compiles + runs).
+ */
+class ThemePreferencesStoreTest {
+
+    private fun getter(vararg pairs: Pair<String, String>): (String, String?) -> String? {
+        val map = pairs.toMap()
+        return { key, default -> map[key] ?: default }
+    }
+
+    @Test
+    fun defaults_whenNothingPersisted() {
+        val prefs = ThemePreferencesStore.readFrom(
+            getString = { _, default -> default },
+            getBoolean = { _, default -> default },
+        )
+        assertEquals(AppThemeMode.SYSTEM, prefs.mode)
+        assertEquals(true, prefs.dynamicColor)
+        assertEquals(AppAccent.DEFAULT, prefs.accent)
+        assertEquals(AppDensity.COMFORTABLE, prefs.density)
+    }
+
+    @Test
+    fun readsPersistedAccentAndDensity() {
+        val prefs = ThemePreferencesStore.readFrom(
+            getString = getter(
+                ThemePreferencesStore.KEY_MODE to AppThemeMode.DARK.name,
+                ThemePreferencesStore.KEY_ACCENT to AppAccent.TEAL.name,
+                ThemePreferencesStore.KEY_DENSITY to AppDensity.COMPACT.name,
+            ),
+            getBoolean = { _, _ -> false },
+        )
+        assertEquals(AppThemeMode.DARK, prefs.mode)
+        assertEquals(false, prefs.dynamicColor)
+        assertEquals(AppAccent.TEAL, prefs.accent)
+        assertEquals(AppDensity.COMPACT, prefs.density)
+    }
+
+    @Test
+    fun malformedValues_fallBackToDefaults() {
+        val prefs = ThemePreferencesStore.readFrom(
+            getString = getter(
+                ThemePreferencesStore.KEY_ACCENT to "NOT_AN_ACCENT",
+                ThemePreferencesStore.KEY_DENSITY to "NOT_A_DENSITY",
+                ThemePreferencesStore.KEY_MODE to "garbage",
+            ),
+            getBoolean = { _, default -> default },
+        )
+        assertEquals(AppThemeMode.SYSTEM, prefs.mode)
+        assertEquals(AppAccent.DEFAULT, prefs.accent)
+        assertEquals(AppDensity.COMFORTABLE, prefs.density)
+    }
+
+    @Test
+    fun defaultAccentSeedMatchesCurrentBrandBlue() {
+        // Guards the promise that an untouched install renders the existing brand accent.
+        assertEquals(0xFF2962FFL, AppAccent.DEFAULT.seedArgb)
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/ThemePreferencesStore.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/ThemePreferencesStore.kt
@@ -10,22 +10,46 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * AND-081 — device-local appearance preference (theme mode + dynamic-color flag).
+ * AND-081 — device-local appearance preference (theme mode + dynamic-color flag + accent + density).
  *
  * Backed by [SharedPreferences] (like [SettingsStore]) so the value is available synchronously at
- * app startup with no flash, and exposed as a [StateFlow] so a write from the Appearance screen
- * re-themes the whole app immediately. Theme is intentionally device-local (offline-instant), not
- * synced to the unreliable dev backend — a roaming follow-up could map it onto
- * `PreferencesPatchReq.theme`.
+ * app startup with no flash, and exposed as a [StateFlow] so a write from the Appearance / Trading-
+ * preferences screen re-themes the whole app immediately. Theme is intentionally device-local
+ * (offline-instant), not synced to the unreliable dev backend.
  *
  * Kept in core-network (not a feature module) because the app shell / MainActivity must read it,
- * and the app module must not depend on a feature for its theme bootstrap.
+ * and the app module must not depend on a feature for its theme bootstrap. This module has no Compose
+ * dependency, so the accent is stored as an ARGB [Long] seed that the app/core-ui boundary converts
+ * to a Compose Color; density is a plain enum the app maps onto a CompositionLocal.
  */
 enum class AppThemeMode { SYSTEM, LIGHT, DARK }
+
+/**
+ * Accent presets for the app's primary color. [seedArgb] is the 0xAARRGGBB seed the theme derives
+ * its primary/secondary tones from. [DEFAULT] reproduces the current brand blue so an untouched
+ * install looks identical.
+ */
+enum class AppAccent(val seedArgb: Long) {
+    DEFAULT(0xFF2962FFL), // current BrandPrimary (blue) — keep as the default
+    VIOLET(0xFF7C4DFFL),
+    TEAL(0xFF00897BL),
+    AMBER(0xFFF9A825L),
+    ROSE(0xFFE91E63L),
+    GREEN(0xFF2E7D32L);
+
+    companion object {
+        val Default = DEFAULT
+    }
+}
+
+/** UI density. COMFORTABLE is the default (unchanged spacing); COMPACT tightens key list surfaces. */
+enum class AppDensity { COMFORTABLE, COMPACT }
 
 data class AppearancePreferences(
     val mode: AppThemeMode = AppThemeMode.SYSTEM,
     val dynamicColor: Boolean = true,
+    val accent: AppAccent = AppAccent.DEFAULT,
+    val density: AppDensity = AppDensity.COMFORTABLE,
 )
 
 @Singleton
@@ -35,7 +59,7 @@ class ThemePreferencesStore @Inject constructor(
     private val prefs: SharedPreferences =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-    private val _preferences = MutableStateFlow(read())
+    private val _preferences = MutableStateFlow(readFrom(prefs::getString, prefs::getBoolean))
 
     /** Hot stream of the current appearance preference. Re-emits on every write. */
     val preferences: StateFlow<AppearancePreferences> = _preferences.asStateFlow()
@@ -50,17 +74,48 @@ class ThemePreferencesStore @Inject constructor(
         _preferences.value = _preferences.value.copy(dynamicColor = enabled)
     }
 
-    private fun read(): AppearancePreferences {
-        val mode = prefs.getString(KEY_MODE, null)
-            ?.let { runCatching { AppThemeMode.valueOf(it) }.getOrNull() }
-            ?: AppThemeMode.SYSTEM
-        val dynamic = prefs.getBoolean(KEY_DYNAMIC, true)
-        return AppearancePreferences(mode = mode, dynamicColor = dynamic)
+    fun setAccent(accent: AppAccent) {
+        prefs.edit().putString(KEY_ACCENT, accent.name).apply()
+        _preferences.value = _preferences.value.copy(accent = accent)
     }
 
-    private companion object {
+    fun setDensity(density: AppDensity) {
+        prefs.edit().putString(KEY_DENSITY, density.name).apply()
+        _preferences.value = _preferences.value.copy(density = density)
+    }
+
+    companion object {
         const val PREFS_NAME = "tl_appearance_prefs"
         const val KEY_MODE = "theme_mode"
         const val KEY_DYNAMIC = "dynamic_color"
+        const val KEY_ACCENT = "accent"
+        const val KEY_DENSITY = "density"
+
+        /**
+         * Pure decode of the four persisted values into [AppearancePreferences]. Extracted from
+         * [SharedPreferences] so it is unit-testable without an Android [Context]: callers pass a
+         * string- and boolean-getter (both defaulting when the key is absent / malformed).
+         */
+        fun readFrom(
+            getString: (String, String?) -> String?,
+            getBoolean: (String, Boolean) -> Boolean,
+        ): AppearancePreferences {
+            val mode = getString(KEY_MODE, null)
+                ?.let { runCatching { AppThemeMode.valueOf(it) }.getOrNull() }
+                ?: AppThemeMode.SYSTEM
+            val dynamic = getBoolean(KEY_DYNAMIC, true)
+            val accent = getString(KEY_ACCENT, null)
+                ?.let { runCatching { AppAccent.valueOf(it) }.getOrNull() }
+                ?: AppAccent.DEFAULT
+            val density = getString(KEY_DENSITY, null)
+                ?.let { runCatching { AppDensity.valueOf(it) }.getOrNull() }
+                ?: AppDensity.COMFORTABLE
+            return AppearancePreferences(
+                mode = mode,
+                dynamicColor = dynamic,
+                accent = accent,
+                density = density,
+            )
+        }
     }
 }

--- a/android/core-ui/src/main/java/com/testlogon/android/core/ui/theme/AppDensity.kt
+++ b/android/core-ui/src/main/java/com/testlogon/android/core/ui/theme/AppDensity.kt
@@ -1,0 +1,21 @@
+package com.testlogon.android.core.ui.theme
+
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * App-wide UI density knob (density + accent theming feature). COMPACT tightens the padding / row
+ * height of a few high-traffic list & card surfaces; the default is COMFORTABLE (spacing unchanged).
+ *
+ * Provided once at the app root ([TestLogonTheme]) so any composable can read it; only a handful of
+ * high-traffic surfaces honor it deliberately — this is a global knob, not a full restyle.
+ */
+enum class AppUiDensity { COMFORTABLE, COMPACT }
+
+/** True when the current density is COMPACT. */
+val AppUiDensity.isCompact: Boolean get() = this == AppUiDensity.COMPACT
+
+/**
+ * CompositionLocal carrying the current [AppUiDensity]. Defaults to COMFORTABLE so any composable
+ * read outside an explicit provider (previews, isolated tests) behaves exactly as before.
+ */
+val LocalAppUiDensity = compositionLocalOf { AppUiDensity.COMFORTABLE }

--- a/android/core-ui/src/main/java/com/testlogon/android/core/ui/theme/Theme.kt
+++ b/android/core-ui/src/main/java/com/testlogon/android/core/ui/theme/Theme.kt
@@ -8,7 +8,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -22,29 +25,73 @@ import androidx.core.view.WindowCompat
  *   (previews, tests) may override.
  * @param dynamicColor when `true` (default) AND running on Android 12+ (API 31+), uses the
  *   wallpaper-derived dynamic palette; otherwise falls back to the static brand scheme.
+ * @param accentSeed optional accent color the user picked (density + accent theming feature). When
+ *   non-null AND [dynamicColor] is not in effect, it recolors the scheme's primary/secondary tones so
+ *   the whole app re-accents live. Null (default) or dynamic-color-on keeps the current look.
+ * @param density the app UI density, provided as [LocalAppUiDensity] for high-traffic surfaces.
  * @param content the themed content.
  */
 @Composable
 fun TestLogonTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = true,
+    accentSeed: Color? = null,
+    density: AppUiDensity = AppUiDensity.COMFORTABLE,
     content: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
-    val colorScheme: ColorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
+    val useDynamic = dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val baseScheme: ColorScheme = when {
+        useDynamic ->
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         darkTheme -> DarkColors
         else -> LightColors
     }
+    // Apply the chosen accent only when NOT using the wallpaper-derived dynamic palette (dynamic
+    // color already owns the accent in that mode). Accent recolors the primary/secondary channels.
+    val colorScheme: ColorScheme =
+        if (!useDynamic && accentSeed != null) baseScheme.withAccent(accentSeed) else baseScheme
 
     ApplySystemBarAppearance(darkTheme = darkTheme)
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = TestLogonTypography,
-        shapes = TestLogonShapes,
-        content = content,
+    CompositionLocalProvider(LocalAppUiDensity provides density) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = TestLogonTypography,
+            shapes = TestLogonShapes,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Recolor the primary/secondary channels of [this] scheme from a single [seed] accent. Container /
+ * on-container tones are lightened/darkened from the seed and the on-color is chosen for contrast, so
+ * an arbitrary preset stays legible in both light and dark schemes.
+ */
+private fun ColorScheme.withAccent(seed: Color): ColorScheme {
+    val onSeed = if (seed.luminance() > 0.5f) Color.Black else Color.White
+    val container = seed.copy(alpha = 1f).blendTowards(surface, 0.72f)
+    val onContainer = if (container.luminance() > 0.5f) Color.Black else Color.White
+    return copy(
+        primary = seed,
+        onPrimary = onSeed,
+        primaryContainer = container,
+        onPrimaryContainer = onContainer,
+        secondary = seed.blendTowards(secondary, 0.35f),
+        onSecondary = onSeed,
+        tertiary = seed,
+    )
+}
+
+/** Linear blend of [this] toward [other] by [fraction] (0 = this, 1 = other). */
+private fun Color.blendTowards(other: Color, fraction: Float): Color {
+    val f = fraction.coerceIn(0f, 1f)
+    return Color(
+        red = red + (other.red - red) * f,
+        green = green + (other.green - green) * f,
+        blue = blue + (other.blue - blue) * f,
+        alpha = 1f,
     )
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ const TradingWorkspacePage = lazy(() => import("@/pages/blotter/TradingWorkspace
 const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
 const PortfolioPage = lazy(() => import("@/pages/portfolio/PortfolioPage"));
 const PnLPage = lazy(() => import("@/pages/pnl/PnLPage"));
+const ReportsPage = lazy(() => import("@/pages/reports/ReportsPage"));
 const CatalogPage = lazy(() => import("@/pages/shop/CatalogPage"));
 const ProductDetail = lazy(() => import("@/pages/shop/ProductDetail"));
 const CartPage = lazy(() => import("@/pages/shop/CartPage"));
@@ -726,6 +727,7 @@ export default function App() {
           <Route path="custody" element={<CustodyPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
           <Route path="pnl" element={<PnLPage />} />
+          <Route path="reports" element={<ReportsPage />} />
           <Route path="content-calendar" element={<ContentCalendarPage />} />
           <Route path="agents/memory/:workerId" element={<AgentMemoryPage />} />
           <Route path="agents/feedback" element={<AgentFeedbackPage />} />

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import Sidebar from "./Sidebar";
 import Header from "./Header";
 import MobileNav from "./MobileNav";
 import CommandPalette from "./CommandPalette";
+import KeyboardShortcutsHost from "./KeyboardShortcutsHost";
 import ImpersonationBanner from "@/components/shared/ImpersonationBanner";
 import { PageTransition } from "@/components/shared/PageTransition";
 import { OfflineBanner } from "@/components/shared/OfflineBanner";
@@ -125,11 +126,13 @@ export default function AppShell() {
           <ImpersonationBanner />
           <SessionExpiryWarning />
 
+          <KeyboardShortcutsHost>
           <main id="main-content" tabIndex={-1} className="flex flex-col flex-1 overflow-y-auto pb-16 md:pb-0 outline-none">
             <PageTransition>
               <Outlet />
             </PageTransition>
           </main>
+          </KeyboardShortcutsHost>
         </div>
 
         {/* Mobile bottom tab bar */}

--- a/frontend/src/components/layout/CommandPalette.tsx
+++ b/frontend/src/components/layout/CommandPalette.tsx
@@ -25,6 +25,7 @@ import {
   Users,
   Play,
   Calendar as CalendarIcon,
+  Keyboard,
 } from "lucide-react";
 import {
   CommandDialog,
@@ -38,6 +39,7 @@ import {
 import { useSymbols } from "@/hooks/useMarketData";
 import { useUiStore } from "@/stores/uiStore";
 import { globalSearch, type SearchResultItem } from "@/api/endpoints/search";
+import { openShortcutsHelp } from "@/components/layout/KeyboardShortcutsHost";
 
 /**
  * Unified global command palette (Cmd/Ctrl+K quick-switcher).
@@ -111,6 +113,13 @@ const ACTIONS: ActionDest[] = [
     keywords: "buy sell order ticket",
     run: ({ navigate, defaultSymbolId }) =>
       navigate(defaultSymbolId != null ? `/markets/${defaultSymbolId}` : "/markets"),
+  },
+  {
+    id: "action:shortcuts",
+    label: "Keyboard shortcuts",
+    icon: Keyboard,
+    keywords: "hotkeys keys help shortcuts kbd",
+    run: () => openShortcutsHelp(),
   },
 ];
 

--- a/frontend/src/components/layout/CommandPalette.tsx
+++ b/frontend/src/components/layout/CommandPalette.tsx
@@ -69,6 +69,7 @@ const PAGES: PageDest[] = [
   { id: "page:price-alerts", label: "Price Alerts", path: "/markets/price-alerts", icon: Bell, keywords: "alerts notify" },
   { id: "page:portfolio", label: "Portfolio", path: "/portfolio", icon: PieChart, keywords: "positions holdings balances" },
   { id: "page:pnl", label: "PnL", path: "/pnl", icon: LineChart, keywords: "profit loss realized unrealized" },
+  { id: "page:reports", label: "Reports", path: "/reports", icon: FileText, keywords: "export csv pdf statement trades print" },
   { id: "page:blotter", label: "Blotter / Workspace", path: "/blotter", icon: LayoutGrid, keywords: "orders fills positions workspace" },
   { id: "page:blotter-single", label: "Blotter (single panel)", path: "/blotter/single", icon: LayoutGrid, keywords: "orders fills" },
   { id: "page:custody", label: "Custody", path: "/custody", icon: Coins, keywords: "wallet deposit withdraw" },

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -25,10 +25,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import ShortcutHelpDialog from "@/components/shared/ShortcutHelpDialog";
 import TradingAlertsBell from "@/components/layout/TradingAlertsBell";
 import PriceAlertEvaluator from "@/components/layout/PriceAlertEvaluator";
-import { useGlobalShortcuts, useChordShortcuts, useChordIndicator, type Shortcut, type ChordMapping } from "@/hooks/useGlobalShortcuts";
+import { useGlobalShortcuts, type Shortcut } from "@/hooks/useGlobalShortcuts";
 import {
   Popover,
   PopoverContent,
@@ -80,7 +79,6 @@ export default function Header({ onMobileMenuToggle }: HeaderProps) {
   });
 
   const [alertsOpen, setAlertsOpen] = React.useState(false);
-  const [shortcutHelpOpen, setShortcutHelpOpen] = React.useState(false);
 
   // Real-time alert stream
   const { unreadCount, resetUnread } = useAlertStream(true);
@@ -115,12 +113,6 @@ export default function Header({ onMobileMenuToggle }: HeaderProps) {
   // ─── Global keyboard shortcuts ────────────────────────────────
   const shortcuts = React.useMemo<Shortcut[]>(() => [
     {
-      key: "shift+?",
-      label: "Show keyboard shortcuts",
-      group: "General",
-      action: () => setShortcutHelpOpen(true),
-    },
-    {
       key: "ctrl+shift+d",
       label: "Toggle dark mode",
       group: "Actions",
@@ -149,23 +141,6 @@ export default function Header({ onMobileMenuToggle }: HeaderProps) {
 
   useGlobalShortcuts(shortcuts);
 
-  // ─── Navigation chord shortcuts (g + key) ────────────────────
-  const navigationChords = React.useMemo<ChordMapping[]>(
-    () => [
-      { first: "g", second: "m", label: "Go to Messages", group: "Navigation", action: () => navigate("/messages") },
-      { first: "g", second: "f", label: "Go to Feed", group: "Navigation", action: () => navigate("/feed") },
-      { first: "g", second: "c", label: "Go to Calendar", group: "Navigation", action: () => navigate("/calendar") },
-      { first: "g", second: "s", label: "Go to Settings", group: "Navigation", action: () => navigate("/settings") },
-      { first: "g", second: "t", label: "Go to Tickets", group: "Navigation", action: () => navigate("/tickets") },
-      { first: "g", second: "i", label: "Go to Files", group: "Navigation", action: () => navigate("/files") },
-      { first: "n", second: "m", label: "New message", group: "Actions", action: () => navigate("/messages?new=1") },
-      { first: "n", second: "p", label: "New post", group: "Actions", action: () => navigate("/feed?compose=1") },
-    ],
-    [navigate],
-  );
-
-  const { pendingKey, onChordStart, onChordEnd } = useChordIndicator();
-  useChordShortcuts(navigationChords, onChordStart, onChordEnd);
 
   const handleLogout = async () => {
     try {
@@ -462,34 +437,6 @@ export default function Header({ onMobileMenuToggle }: HeaderProps) {
           </DropdownMenuContent>
         </DropdownMenu>
       </header>
-
-      {/* Keyboard shortcuts help overlay */}
-      <ShortcutHelpDialog
-        open={shortcutHelpOpen}
-        onOpenChange={setShortcutHelpOpen}
-        shortcuts={shortcuts}
-        chords={navigationChords}
-      />
-
-      {/* Chord indicator — shows pending first key */}
-      {pendingKey && (
-        <div
-          data-testid="chord-indicator"
-          className="fixed bottom-4 right-4 z-50 animate-in fade-in slide-in-from-bottom-2 duration-150"
-        >
-          <div className="rounded-lg border border-border bg-card p-3 shadow-lg">
-            <div className="flex items-center gap-2">
-              <kbd className="rounded bg-primary/10 px-2 py-0.5 font-mono text-sm font-bold text-primary">
-                {pendingKey.toUpperCase()}
-              </kbd>
-              <span className="text-sm text-muted-foreground">+ ...</span>
-            </div>
-            <p className="mt-1 text-[10px] text-muted-foreground">
-              Press a key within 1s
-            </p>
-          </div>
-        </div>
-      )}
     </>
   );
 

--- a/frontend/src/components/layout/KeyboardShortcutsHost.tsx
+++ b/frontend/src/components/layout/KeyboardShortcutsHost.tsx
@@ -1,0 +1,130 @@
+import * as React from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  KeyboardShortcutsProvider,
+  useKeyboardShortcutsApi,
+  type ShortcutEntry,
+} from "@/hooks/useKeyboardShortcuts";
+import ShortcutsHelp from "@/components/layout/ShortcutsHelp";
+
+/**
+ * Opens the global command palette by dispatching the synthetic Cmd/Ctrl+K
+ * keydown that CommandPalette's single global listener owns. Keeping this as a
+ * dispatch (rather than shared state) avoids coupling to the palette internals.
+ */
+function openCommandPalette() {
+  const isMac =
+    typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "k",
+      ctrlKey: !isMac,
+      metaKey: isMac,
+      bubbles: true,
+    }),
+  );
+}
+
+/**
+ * Floating indicator that shows the pending chord first-key (e.g. after "g").
+ */
+function ChordIndicator() {
+  const api = useKeyboardShortcutsApi();
+  const pending = api?.pendingFirst;
+  if (!pending) return null;
+  return (
+    <div
+      data-testid="kbd-chord-indicator"
+      className="fixed bottom-4 right-4 z-50 animate-in fade-in slide-in-from-bottom-2 duration-150"
+    >
+      <div className="rounded-lg border border-border bg-card p-3 shadow-lg">
+        <div className="flex items-center gap-2">
+          <kbd className="rounded bg-primary/10 px-2 py-0.5 font-mono text-sm font-bold text-primary">
+            {pending.toUpperCase()}
+          </kbd>
+          <span className="text-sm text-muted-foreground">then a key...</span>
+        </div>
+        <p className="mt-1 text-[10px] text-muted-foreground">
+          Press a key within 1s (Esc cancels)
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Listens for the app-wide "open-shortcuts-help" custom event so the command
+ * palette / settings can open the overlay without prop drilling.
+ */
+function useHelpOpener(setOpen: (v: boolean) => void) {
+  React.useEffect(() => {
+    const handler = () => setOpen(true);
+    window.addEventListener("open-shortcuts-help", handler);
+    return () => window.removeEventListener("open-shortcuts-help", handler);
+  }, [setOpen]);
+}
+
+/**
+ * App-chrome host for the keyboard-shortcut engine. Mount once (in AppShell)
+ * inside the authenticated layout so shortcuts are active when logged in.
+ *
+ * Provides the always-on Navigation + General shortcuts. Trade-view shortcuts
+ * (b/s/p/q/Esc) register themselves via useRegisterShortcuts when the trade
+ * ticket is mounted.
+ */
+export default function KeyboardShortcutsHost({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const navigate = useNavigate();
+  const [helpOpen, setHelpOpen] = React.useState(false);
+  useHelpOpener(setHelpOpen);
+
+  const baseEntries = React.useMemo<ShortcutEntry[]>(() => {
+    const nav = (
+      second: string,
+      label: string,
+      path: string,
+    ): ShortcutEntry => ({
+      def: { kind: "chord", first: "g", second, label, group: "Navigation" },
+      action: () => navigate(path),
+    });
+
+    return [
+      // --- Navigation (g + key) ---
+      nav("h", "Go to Home", "/home"),
+      nav("m", "Go to Markets", "/markets"),
+      nav("p", "Go to Portfolio", "/portfolio"),
+      nav("l", "Go to PnL", "/pnl"),
+      nav("r", "Go to Reports", "/reports"),
+      nav("w", "Go to Watchlist", "/markets"),
+      nav("b", "Go to Blotter", "/blotter"),
+      nav("a", "Go to Price alerts", "/markets/price-alerts"),
+      nav("s", "Go to Settings", "/settings"),
+
+      // --- General ---
+      {
+        def: { kind: "single", key: "/", label: "Search (command palette)", group: "General" },
+        action: openCommandPalette,
+      },
+      {
+        def: { kind: "single", key: "?", label: "Show this help", group: "General" },
+        action: () => setHelpOpen(true),
+      },
+    ];
+  }, [navigate]);
+
+  return (
+    <KeyboardShortcutsProvider baseEntries={baseEntries}>
+      {children}
+      <ChordIndicator />
+      <ShortcutsHelp open={helpOpen} onOpenChange={setHelpOpen} />
+    </KeyboardShortcutsProvider>
+  );
+}
+
+/** Fire the app-wide event that opens the shortcuts help overlay. */
+export function openShortcutsHelp() {
+  window.dispatchEvent(new CustomEvent("open-shortcuts-help"));
+}

--- a/frontend/src/components/layout/ShortcutsHelp.tsx
+++ b/frontend/src/components/layout/ShortcutsHelp.tsx
@@ -1,0 +1,150 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  useKeyboardShortcutsApi,
+  type ShortcutDef,
+  type ShortcutEntry,
+  type ShortcutGroup,
+} from "@/hooks/useKeyboardShortcuts";
+
+const GROUP_ORDER: ShortcutGroup[] = ["Navigation", "Trading", "General"];
+
+const KEY_LABELS: Record<string, string> = {
+  escape: "Esc",
+  enter: "Enter",
+  " ": "Space",
+};
+
+function keyLabel(k: string): string {
+  return KEY_LABELS[k] ?? (k.length === 1 ? k.toUpperCase() : k);
+}
+
+/** Render the key hint for a definition as one or two <kbd> chips. */
+function KeyHint({ def }: { def: ShortcutDef }) {
+  if (def.hint) {
+    return (
+      <kbd className="rounded border border-border bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
+        {def.hint}
+      </kbd>
+    );
+  }
+  if (def.kind === "chord") {
+    return (
+      <span className="flex items-center gap-1">
+        <kbd className="rounded border border-border bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
+          {keyLabel(def.first)}
+        </kbd>
+        <span className="text-[10px] text-muted-foreground">then</span>
+        <kbd className="rounded border border-border bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
+          {keyLabel(def.second)}
+        </kbd>
+      </span>
+    );
+  }
+  return (
+    <kbd className="rounded border border-border bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
+      {keyLabel(def.key)}
+    </kbd>
+  );
+}
+
+function groupEntries(entries: ShortcutEntry[]): Record<string, ShortcutEntry[]> {
+  const out: Record<string, ShortcutEntry[]> = {};
+  const seen = new Set<string>();
+  for (const e of entries) {
+    // De-dupe by label so scoped re-registrations do not double up in the list.
+    const id = `${e.def.group}:${e.def.label}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    (out[e.def.group] ??= []).push(e);
+  }
+  return out;
+}
+
+/**
+ * Shortcuts help overlay. Opened by "?" (and from Settings / the command
+ * palette). Lists every registered shortcut grouped by category and exposes
+ * the enable/disable toggle.
+ */
+export default function ShortcutsHelp({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const api = useKeyboardShortcutsApi();
+  // Snapshot the registry each time the dialog opens so scoped (trade-view)
+  // shortcuts that are active right now are reflected.
+  const entries = open && api ? api.getEntries() : [];
+  const grouped = groupEntries(entries);
+
+  const enabled = api?.enabled ?? true;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Speed up navigation and trading. Shortcuts are ignored while you are
+            typing in a field.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2">
+          <Label htmlFor="kbd-enabled" className="text-sm">
+            Enable keyboard shortcuts
+          </Label>
+          <Switch
+            id="kbd-enabled"
+            checked={enabled}
+            onCheckedChange={(v) => api?.setEnabled(v)}
+            aria-label="Enable keyboard shortcuts"
+          />
+        </div>
+
+        <Separator />
+
+        <div
+          className={
+            "space-y-4 max-h-[55vh] overflow-y-auto pr-1" +
+            (enabled ? "" : " opacity-50")
+          }
+        >
+          {GROUP_ORDER.filter((g) => grouped[g]?.length).map((group) => (
+            <div key={group}>
+              <h3 className="mb-2 text-sm font-semibold text-muted-foreground">
+                {group}
+              </h3>
+              <div className="space-y-1">
+                {grouped[group]!.map((e) => (
+                  <div
+                    key={`${e.def.group}:${e.def.label}`}
+                    className="flex items-center justify-between gap-4 py-1"
+                  >
+                    <span className="text-sm">{e.def.label}</span>
+                    <KeyHint def={e.def} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+          {entries.length === 0 && (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No shortcuts registered.
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -149,6 +149,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
       { label: "PnL", i18nKey: "nav.pnl", path: "/pnl", icon: <LineChart className="h-5 w-5" /> },
+      { label: "Reports", i18nKey: "nav.reports", path: "/reports", icon: <FileText className="h-5 w-5" /> },
       { label: "Activity", i18nKey: "nav.activity", path: "/activity", icon: <Activity className="h-5 w-5" /> },
       { label: "Discover", i18nKey: "nav.discover", path: "/discover", icon: <Compass className="h-5 w-5" /> },
       { label: "Saved", i18nKey: "nav.saved", path: "/saved", icon: <Bookmark className="h-5 w-5" /> },

--- a/frontend/src/hooks/useKeyboardShortcuts.matcher.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.matcher.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  matchSequence,
+  IDLE_SEQUENCE,
+  CHORD_WINDOW_MS,
+  type ShortcutEntry,
+} from "@/hooks/useKeyboardShortcuts";
+
+/** Build a small registry: one single ("/"), one single ("b"), two chords. */
+function makeEntries() {
+  const fired: string[] = [];
+  const entries: ShortcutEntry[] = [
+    {
+      def: { kind: "single", key: "/", label: "Search", group: "General" },
+      action: () => fired.push("search"),
+    },
+    {
+      def: { kind: "single", key: "b", label: "Buy", group: "Trading" },
+      action: () => fired.push("buy"),
+    },
+    {
+      def: { kind: "chord", first: "g", second: "m", label: "Markets", group: "Navigation" },
+      action: () => fired.push("markets"),
+    },
+    {
+      def: { kind: "chord", first: "g", second: "h", label: "Home", group: "Navigation" },
+      action: () => fired.push("home"),
+    },
+  ];
+  return { entries, fired };
+}
+
+describe("matchSequence (keyboard shortcut sequence matcher)", () => {
+  it("fires a bare single-key shortcut immediately", () => {
+    const { entries, fired } = makeEntries();
+    const r = matchSequence(IDLE_SEQUENCE, "b", entries, 1000);
+    expect(r.consumed).toBe(true);
+    expect(r.matched).not.toBeNull();
+    r.matched!.action();
+    expect(fired).toEqual(["buy"]);
+    expect(r.state).toEqual(IDLE_SEQUENCE);
+  });
+
+  it("matches the special '/' single key", () => {
+    const { entries } = makeEntries();
+    const r = matchSequence(IDLE_SEQUENCE, "/", entries, 1000);
+    expect(r.consumed).toBe(true);
+    expect(r.matched?.def.label).toBe("Search");
+  });
+
+  it("enters a pending state on a chord first-key and does not fire yet", () => {
+    const { entries } = makeEntries();
+    const r = matchSequence(IDLE_SEQUENCE, "g", entries, 1000);
+    expect(r.consumed).toBe(true);
+    expect(r.matched).toBeNull();
+    expect(r.state.pendingFirst).toBe("g");
+    expect(r.state.pendingAt).toBe(1000);
+  });
+
+  it("completes a g-m chord within the window", () => {
+    const { entries, fired } = makeEntries();
+    const first = matchSequence(IDLE_SEQUENCE, "g", entries, 1000);
+    const second = matchSequence(first.state, "m", entries, 1500);
+    expect(second.consumed).toBe(true);
+    expect(second.matched?.def.label).toBe("Markets");
+    second.matched!.action();
+    expect(fired).toEqual(["markets"]);
+    expect(second.state).toEqual(IDLE_SEQUENCE);
+  });
+
+  it("completes a different g-h chord from the same first key", () => {
+    const { entries } = makeEntries();
+    const first = matchSequence(IDLE_SEQUENCE, "g", entries, 0);
+    const second = matchSequence(first.state, "h", entries, 100);
+    expect(second.matched?.def.label).toBe("Home");
+  });
+
+  it("is case-insensitive for keys", () => {
+    const { entries } = makeEntries();
+    const first = matchSequence(IDLE_SEQUENCE, "G", entries, 0);
+    expect(first.state.pendingFirst).toBe("g");
+    const second = matchSequence(first.state, "M", entries, 100);
+    expect(second.matched?.def.label).toBe("Markets");
+  });
+
+  it("expires the pending chord after the window and re-evaluates fresh", () => {
+    const { entries } = makeEntries();
+    const first = matchSequence(IDLE_SEQUENCE, "g", entries, 1000);
+    // Second key arrives after the window: the pending 'g' is dropped.
+    const second = matchSequence(first.state, "m", entries, 1000 + CHORD_WINDOW_MS + 1);
+    // 'm' is not a single shortcut nor a chord-start, so nothing matches.
+    expect(second.matched).toBeNull();
+    expect(second.state).toEqual(IDLE_SEQUENCE);
+  });
+
+  it("cancels a pending chord when a non-matching key follows, re-evaluating it", () => {
+    const { entries } = makeEntries();
+    const first = matchSequence(IDLE_SEQUENCE, "g", entries, 0);
+    // 'b' is not a valid second key for 'g'; the chord cancels and 'b' fires as a single.
+    const second = matchSequence(first.state, "b", entries, 100);
+    expect(second.matched?.def.label).toBe("Buy");
+    expect(second.state).toEqual(IDLE_SEQUENCE);
+  });
+
+  it("does not consume an unmapped key when idle", () => {
+    const { entries } = makeEntries();
+    const r = matchSequence(IDLE_SEQUENCE, "z", entries, 0);
+    expect(r.consumed).toBe(false);
+    expect(r.matched).toBeNull();
+    expect(r.state).toEqual(IDLE_SEQUENCE);
+  });
+
+  it("restarts a pending chord if the follow-up key is itself a chord start", () => {
+    const { entries } = makeEntries();
+    const first = matchSequence(IDLE_SEQUENCE, "g", entries, 0);
+    // Second 'g' is not a valid second key, but IS a chord start -> new pending.
+    const second = matchSequence(first.state, "g", entries, 100);
+    expect(second.matched).toBeNull();
+    expect(second.state.pendingFirst).toBe("g");
+    expect(second.state.pendingAt).toBe(100);
+  });
+});

--- a/frontend/src/hooks/useKeyboardShortcuts.tsx
+++ b/frontend/src/hooks/useKeyboardShortcuts.tsx
@@ -1,0 +1,319 @@
+import * as React from "react";
+
+/**
+ * Global keyboard-shortcut engine for power-user trading + navigation.
+ *
+ * Design goals:
+ *  - Fires shortcuts ONLY when the user is not typing in an input / textarea /
+ *    contenteditable, and no modal owns focus.
+ *  - Supports gmail-style "g then key" chord sequences with a ~1s window.
+ *  - Never intercepts Cmd/Ctrl/Alt combinations already owned elsewhere
+ *    (Cmd/Ctrl+K stays with the command palette).
+ *  - Respects a persisted user toggle (localStorage "kbd.enabled", default on).
+ *  - The pure sequence-matching logic (matchSequence) is exported for testing.
+ */
+
+// --- Types -------------------------------------------------------------------
+
+export type ShortcutGroup = "Navigation" | "Trading" | "General";
+
+/** A single-key (bare) shortcut, e.g. "/" or "?" or "b". */
+export interface SingleShortcut {
+  kind: "single";
+  /** The bare key, lower-cased (e.g. "/", "?", "b"). */
+  key: string;
+  label: string;
+  group: ShortcutGroup;
+  /** Human-readable key hint for the help overlay (defaults derived from key). */
+  hint?: string;
+}
+
+/** A two-key chord shortcut, e.g. g then m. */
+export interface ChordShortcut {
+  kind: "chord";
+  /** First key, lower-cased (e.g. "g"). */
+  first: string;
+  /** Second key, lower-cased (e.g. "m"). */
+  second: string;
+  label: string;
+  group: ShortcutGroup;
+  hint?: string;
+}
+
+export type ShortcutDef = SingleShortcut | ChordShortcut;
+
+/** An entry in the registry: a definition plus the action to run. */
+export interface ShortcutEntry {
+  def: ShortcutDef;
+  action: () => void;
+}
+
+// --- localStorage toggle -----------------------------------------------------
+
+const ENABLED_KEY = "kbd.enabled";
+
+export function readKbdEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(ENABLED_KEY);
+    // Default ON: only "false" disables it.
+    return raw !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function writeKbdEnabled(enabled: boolean): void {
+  try {
+    localStorage.setItem(ENABLED_KEY, enabled ? "true" : "false");
+  } catch {
+    // ignore storage failures (private mode etc.)
+  }
+}
+
+// --- Focus / modal guards ----------------------------------------------------
+
+/**
+ * True when the currently focused element is an input, textarea, select, or
+ * contenteditable -- i.e. the user is typing and shortcuts must NOT hijack keys.
+ */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  const el =
+    (target as HTMLElement | null) ??
+    (typeof document !== "undefined" ? (document.activeElement as HTMLElement | null) : null);
+  if (!el) return false;
+  const tag = el.tagName?.toLowerCase();
+  if (tag === "input" || tag === "textarea" || tag === "select") return true;
+  if (el.isContentEditable) return true;
+  return false;
+}
+
+/**
+ * True when a modal/dialog currently owns focus. Radix dialogs render an
+ * element with role="dialog" and data-state="open"; when one is open we let it
+ * own the keyboard (Esc, arrow keys, etc.) and stay out of the way.
+ */
+export function isModalOpen(): boolean {
+  if (typeof document === "undefined") return false;
+  return !!document.querySelector(
+    '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
+  );
+}
+
+// --- Pure sequence matcher (unit-tested) -------------------------------------
+
+export interface SequenceState {
+  /** The pending first chord key, or null when idle. */
+  pendingFirst: string | null;
+  /** Epoch ms when the pending key was recorded (for the timeout window). */
+  pendingAt: number;
+}
+
+export const IDLE_SEQUENCE: SequenceState = { pendingFirst: null, pendingAt: 0 };
+
+/** How long (ms) the second key of a chord is awaited. */
+export const CHORD_WINDOW_MS = 1000;
+
+export interface SequenceMatchResult {
+  /** Next sequence state after processing this key. */
+  state: SequenceState;
+  /** The matched entry to fire, if any. */
+  matched: ShortcutEntry | null;
+  /** True when the key was consumed (caller should preventDefault). */
+  consumed: boolean;
+}
+
+/**
+ * Pure reducer for the shortcut sequence state machine.
+ *
+ * Given the current pending state, the pressed key, the registry, and the
+ * current time, it returns the next state, whether a shortcut matched, and
+ * whether the key was consumed. It performs NO DOM or side effects, so it is
+ * fully unit-testable.
+ *
+ * Rules:
+ *  - If a chord first-key is pending and still within CHORD_WINDOW_MS, a
+ *    matching second key fires that chord; any other key cancels the pending
+ *    chord (and is then evaluated fresh as a potential new sequence start).
+ *  - A bare key matching a single shortcut fires it.
+ *  - A bare key that is the first of any chord starts a pending sequence.
+ */
+export function matchSequence(
+  state: SequenceState,
+  key: string,
+  entries: ShortcutEntry[],
+  now: number,
+): SequenceMatchResult {
+  const k = key.toLowerCase();
+
+  // Resolve an expired pending chord back to idle before evaluating.
+  let pending = state.pendingFirst;
+  if (pending && now - state.pendingAt > CHORD_WINDOW_MS) {
+    pending = null;
+  }
+
+  if (pending) {
+    const chord = entries.find(
+      (e) => e.def.kind === "chord" && e.def.first === pending && e.def.second === k,
+    );
+    if (chord) {
+      return { state: IDLE_SEQUENCE, matched: chord, consumed: true };
+    }
+    // No match: cancel the pending chord and re-evaluate this key fresh.
+    return matchSequence(IDLE_SEQUENCE, k, entries, now);
+  }
+
+  // No pending chord. First, a bare single-key shortcut?
+  const single = entries.find((e) => e.def.kind === "single" && e.def.key === k);
+  if (single) {
+    return { state: IDLE_SEQUENCE, matched: single, consumed: true };
+  }
+
+  // Does this key start a chord?
+  const startsChord = entries.some((e) => e.def.kind === "chord" && e.def.first === k);
+  if (startsChord) {
+    return {
+      state: { pendingFirst: k, pendingAt: now },
+      matched: null,
+      consumed: true,
+    };
+  }
+
+  // Nothing matched; leave idle, do not consume.
+  return { state: IDLE_SEQUENCE, matched: null, consumed: false };
+}
+
+// --- Registry context (for the trade view to register scoped handlers) -------
+
+interface RegistryApi {
+  register: (entries: ShortcutEntry[]) => () => void;
+  getEntries: () => ShortcutEntry[];
+  enabled: boolean;
+  setEnabled: (v: boolean) => void;
+  pendingFirst: string | null;
+}
+
+const RegistryContext = React.createContext<RegistryApi | null>(null);
+
+/**
+ * Provider that owns the global keydown listener, the shortcut registry, the
+ * enabled toggle, and the chord state machine. Mount once in the app chrome.
+ */
+export function KeyboardShortcutsProvider({
+  baseEntries,
+  children,
+}: {
+  /** Always-on entries (navigation + general) contributed by the provider host. */
+  baseEntries: ShortcutEntry[];
+  children: React.ReactNode;
+}) {
+  const [extra, setExtra] = React.useState<ShortcutEntry[][]>([]);
+  const [enabled, setEnabledState] = React.useState<boolean>(() => readKbdEnabled());
+  const [pendingFirst, setPendingFirst] = React.useState<string | null>(null);
+
+  const seqRef = React.useRef<SequenceState>(IDLE_SEQUENCE);
+  const clearTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const setEnabled = React.useCallback((v: boolean) => {
+    setEnabledState(v);
+    writeKbdEnabled(v);
+  }, []);
+
+  const register = React.useCallback((entries: ShortcutEntry[]) => {
+    setExtra((prev) => [...prev, entries]);
+    return () => {
+      setExtra((prev) => prev.filter((e) => e !== entries));
+    };
+  }, []);
+
+  // Flatten base + scoped entries. Base first so scoped can shadow if needed.
+  const allEntries = React.useMemo<ShortcutEntry[]>(
+    () => [...baseEntries, ...extra.flat()],
+    [baseEntries, extra],
+  );
+  const entriesRef = React.useRef(allEntries);
+  entriesRef.current = allEntries;
+
+  const getEntries = React.useCallback(() => entriesRef.current, []);
+
+  const enabledRef = React.useRef(enabled);
+  enabledRef.current = enabled;
+
+  React.useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (!enabledRef.current) return;
+      if (e.defaultPrevented) return;
+      // Leave all Cmd/Ctrl/Alt combos to their owners (palette, browser, etc.).
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      // IME composition must never be intercepted.
+      if (e.isComposing) return;
+      // A modal owns its own keyboard (Esc, arrows, etc.) -- stay out.
+      if (isModalOpen()) return;
+
+      // Normalize the pressed key. Single printable keys pass through as-is;
+      // a small allow-list of named keys (Escape) also participates so the
+      // trade view can bind Esc. Everything else (Tab, arrows, F-keys, bare
+      // modifier presses) is ignored.
+      const raw = e.key;
+      let key: string;
+      if (raw.length === 1) {
+        key = raw;
+      } else if (raw === "Escape") {
+        key = "escape";
+      } else {
+        return;
+      }
+
+      // Never hijack keys while typing -- EXCEPT Escape, which is never text
+      // input and is how the user blurs/clears the trade-ticket fields.
+      if (key !== "escape" && isTypingTarget(e.target)) return;
+
+      const result = matchSequence(seqRef.current, key, entriesRef.current, Date.now());
+      seqRef.current = result.state;
+      setPendingFirst(result.state.pendingFirst);
+
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+      if (result.state.pendingFirst) {
+        clearTimerRef.current = setTimeout(() => {
+          seqRef.current = IDLE_SEQUENCE;
+          setPendingFirst(null);
+        }, CHORD_WINDOW_MS);
+      }
+
+      if (result.consumed) e.preventDefault();
+      if (result.matched) {
+        result.matched.action();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    };
+  }, []);
+
+  const api = React.useMemo<RegistryApi>(
+    () => ({ register, getEntries, enabled, setEnabled, pendingFirst }),
+    [register, getEntries, enabled, setEnabled, pendingFirst],
+  );
+
+  return <RegistryContext.Provider value={api}>{children}</RegistryContext.Provider>;
+}
+
+/** Access the registry API (enabled toggle, pending chord key, etc.). */
+export function useKeyboardShortcutsApi(): RegistryApi | null {
+  return React.useContext(RegistryContext);
+}
+
+/**
+ * Register a set of scoped shortcut entries for as long as the calling
+ * component is mounted. Used by the trade view for b/s/p/q/Esc.
+ */
+export function useRegisterShortcuts(entries: ShortcutEntry[]): void {
+  const api = React.useContext(RegistryContext);
+  React.useEffect(() => {
+    if (!api) return;
+    return api.register(entries);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, entries]);
+}

--- a/frontend/src/lib/depth.test.ts
+++ b/frontend/src/lib/depth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDepth, cumulativeSide, type Level } from "./depth";
+
+describe("cumulativeSide", () => {
+  it("cumulates bids from the highest price outward", () => {
+    const bids: Level[] = [
+      [100, 5],
+      [98, 3],
+      [99, 2],
+    ];
+    const pts = cumulativeSide(bids, true);
+    expect(pts.map((p) => p.price)).toEqual([100, 99, 98]);
+    expect(pts.map((p) => p.cum)).toEqual([5, 7, 10]);
+  });
+
+  it("cumulates asks from the lowest price outward", () => {
+    const asks: Level[] = [
+      [103, 4],
+      [101, 1],
+      [102, 2],
+    ];
+    const pts = cumulativeSide(asks, false);
+    expect(pts.map((p) => p.price)).toEqual([101, 102, 103]);
+    expect(pts.map((p) => p.cum)).toEqual([1, 3, 7]);
+  });
+
+  it("returns [] for empty/undefined input", () => {
+    expect(cumulativeSide(undefined, true)).toEqual([]);
+    expect(cumulativeSide([], false)).toEqual([]);
+  });
+
+  it("drops non-positive / non-finite levels", () => {
+    const dirty: Level[] = [
+      [100, 5],
+      [0, 3],
+      [99, 0],
+      [98, -2],
+      [Number.NaN, 4],
+      [97, Number.POSITIVE_INFINITY],
+      [96, 1],
+    ];
+    const pts = cumulativeSide(dirty, true);
+    expect(pts.map((p) => p.price)).toEqual([100, 96]);
+    expect(pts.map((p) => p.cum)).toEqual([5, 6]);
+  });
+
+  it("coalesces duplicate price levels by summing qty", () => {
+    const bids: Level[] = [
+      [100, 5],
+      [100, 3],
+      [99, 2],
+    ];
+    const pts = cumulativeSide(bids, true);
+    expect(pts).toHaveLength(2);
+    expect(pts[0]).toEqual({ price: 100, qty: 8, cum: 8 });
+    expect(pts[1]).toEqual({ price: 99, qty: 2, cum: 10 });
+  });
+});
+
+describe("computeDepth", () => {
+  it("computes best bid/ask, mid, spread and axis bounds", () => {
+    const bids: Level[] = [
+      [100, 5],
+      [99, 2],
+    ];
+    const asks: Level[] = [
+      [102, 3],
+      [104, 1],
+    ];
+    const d = computeDepth(bids, asks);
+    expect(d.bestBid).toBe(100);
+    expect(d.bestAsk).toBe(102);
+    expect(d.mid).toBe(101);
+    expect(d.spread).toBe(2);
+    expect(d.maxCum).toBe(7); // bids cum 7 > asks cum 4
+    expect(d.minPrice).toBe(99);
+    expect(d.maxPrice).toBe(104);
+    expect(d.bids.map((p) => p.cum)).toEqual([5, 7]);
+    expect(d.asks.map((p) => p.cum)).toEqual([3, 4]);
+  });
+
+  it("leaves mid/spread undefined when a side is empty", () => {
+    const onlyBids = computeDepth([[100, 5]], []);
+    expect(onlyBids.bestBid).toBe(100);
+    expect(onlyBids.bestAsk).toBeUndefined();
+    expect(onlyBids.mid).toBeUndefined();
+    expect(onlyBids.spread).toBeUndefined();
+    expect(onlyBids.maxCum).toBe(5);
+  });
+
+  it("handles a fully empty book", () => {
+    const d = computeDepth([], []);
+    expect(d.bids).toEqual([]);
+    expect(d.asks).toEqual([]);
+    expect(d.maxCum).toBe(0);
+    expect(d.mid).toBeUndefined();
+    expect(d.minPrice).toBeUndefined();
+    expect(d.maxPrice).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/depth.ts
+++ b/frontend/src/lib/depth.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure cumulative-depth math for the depth chart.
+ *
+ * Book levels are integer [price, qty] tuples (int64 ticks). All functions
+ * here are unit-scaled-agnostic: they operate on the raw integers and leave
+ * display scaling to the caller (markets `formatPrice`/`formatQty`).
+ */
+
+export type Level = [number, number];
+
+export interface DepthPoint {
+  /** Price at this level (raw integer tick). */
+  price: number;
+  /** Size resting at exactly this level. */
+  qty: number;
+  /** Cumulative size from the best price out to (and including) this level. */
+  cum: number;
+}
+
+export interface DepthSeries {
+  /** Bids, cumulated from best (highest) price outward to lower prices. */
+  bids: DepthPoint[];
+  /** Asks, cumulated from best (lowest) price outward to higher prices. */
+  asks: DepthPoint[];
+  /** Best bid price, or undefined if no bids. */
+  bestBid?: number;
+  /** Best ask price, or undefined if no asks. */
+  bestAsk?: number;
+  /** Mid price ((bestBid+bestAsk)/2), or undefined if either side is empty. */
+  mid?: number;
+  /** Spread (bestAsk-bestBid), or undefined if either side is empty. */
+  spread?: number;
+  /** Largest cumulative size across both sides (for y-axis scaling). */
+  maxCum: number;
+  /** Lowest price plotted across both sides (for x-axis scaling). */
+  minPrice?: number;
+  /** Highest price plotted across both sides (for x-axis scaling). */
+  maxPrice?: number;
+}
+
+/** Drop null/NaN/negative levels; coerce to finite integer-ish tuples. */
+function sanitize(levels: readonly Level[] | undefined): Level[] {
+  if (!levels) return [];
+  const out: Level[] = [];
+  for (const lvl of levels) {
+    if (!lvl) continue;
+    const price = lvl[0];
+    const qty = lvl[1];
+    if (
+      !Number.isFinite(price) ||
+      !Number.isFinite(qty) ||
+      price <= 0 ||
+      qty <= 0
+    ) {
+      continue;
+    }
+    out.push([price, qty]);
+  }
+  return out;
+}
+
+/**
+ * Merge levels that share a price (defensive against a book that lists a
+ * price more than once) and sum their sizes.
+ */
+function coalesce(levels: Level[]): Level[] {
+  const byPrice = new Map<number, number>();
+  for (const [price, qty] of levels) {
+    byPrice.set(price, (byPrice.get(price) ?? 0) + qty);
+  }
+  return [...byPrice.entries()].map(([price, qty]) => [price, qty] as Level);
+}
+
+/**
+ * Build a cumulative-depth curve for one side of the book.
+ *
+ * `descending` = bids (cumulate from the highest price down); otherwise asks
+ * (cumulate from the lowest price up). The returned points are ordered from
+ * the best price outward, each carrying the running cumulative size.
+ */
+export function cumulativeSide(
+  levels: readonly Level[] | undefined,
+  descending: boolean
+): DepthPoint[] {
+  const clean = coalesce(sanitize(levels));
+  clean.sort((a, b) => (descending ? b[0] - a[0] : a[0] - b[0]));
+  let cum = 0;
+  const out: DepthPoint[] = [];
+  for (const [price, qty] of clean) {
+    cum += qty;
+    out.push({ price, qty, cum });
+  }
+  return out;
+}
+
+/**
+ * Compute the full cumulative-depth series for both sides plus the mid/spread
+ * and the axis bounds needed to render a mirrored depth chart.
+ */
+export function computeDepth(
+  bids: readonly Level[] | undefined,
+  asks: readonly Level[] | undefined
+): DepthSeries {
+  const bidPts = cumulativeSide(bids, true);
+  const askPts = cumulativeSide(asks, false);
+
+  const bestBid = bidPts.length ? bidPts[0]!.price : undefined;
+  const bestAsk = askPts.length ? askPts[0]!.price : undefined;
+
+  const mid =
+    bestBid != null && bestAsk != null ? (bestBid + bestAsk) / 2 : undefined;
+  const spread =
+    bestBid != null && bestAsk != null ? bestAsk - bestBid : undefined;
+
+  const maxCum = Math.max(
+    bidPts.length ? bidPts[bidPts.length - 1]!.cum : 0,
+    askPts.length ? askPts[askPts.length - 1]!.cum : 0
+  );
+
+  const prices: number[] = [];
+  for (const p of bidPts) prices.push(p.price);
+  for (const p of askPts) prices.push(p.price);
+  const minPrice = prices.length ? Math.min(...prices) : undefined;
+  const maxPrice = prices.length ? Math.max(...prices) : undefined;
+
+  return {
+    bids: bidPts,
+    asks: askPts,
+    bestBid,
+    bestAsk,
+    mid,
+    spread,
+    maxCum,
+    minPrice,
+    maxPrice,
+  };
+}

--- a/frontend/src/lib/exportReport.test.ts
+++ b/frontend/src/lib/exportReport.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  scaleTick,
+  tsToIso,
+  csvEscape,
+  toCsv,
+  buildTradeHistoryCsv,
+  buildPnlSummaryCsv,
+  buildStatementCsv,
+  TRADE_HISTORY_HEADER,
+  PNL_SUMMARY_HEADER,
+  type ReportFill,
+  type ReportSymbolPnl,
+  type ReportPnlTotals,
+  type SymbolResolver,
+} from "./exportReport";
+
+// A scaler of 100 (2dp) named per symbolid; unknown ids fall back to "#id".
+const resolve: SymbolResolver = (id) =>
+  id === 1 ? { name: "BTC", scaler: 100 } : id === 2 ? { name: "ETH", scaler: 100 } : { name: `#${id}`, scaler: 1 };
+
+describe("scaleTick", () => {
+  it("scales an int64 tick by the price scaler", () => {
+    expect(scaleTick(123456, 100, 2)).toBe("1234.56");
+  });
+  it("emits no thousands grouping (delimiter-safe)", () => {
+    expect(scaleTick(1234567890, 100, 2)).toBe("12345678.9");
+  });
+  it("returns empty string for null / non-finite", () => {
+    expect(scaleTick(null)).toBe("");
+    expect(scaleTick(undefined)).toBe("");
+    expect(scaleTick(NaN)).toBe("");
+  });
+  it("tolerates a zero scaler (treats as 1)", () => {
+    expect(scaleTick(42, 0, 2)).toBe("42");
+  });
+});
+
+describe("tsToIso", () => {
+  it("treats a small value as seconds", () => {
+    expect(tsToIso(1_700_000_000)).toBe(new Date(1_700_000_000 * 1000).toISOString());
+  });
+  it("treats a large value as milliseconds", () => {
+    expect(tsToIso(1_700_000_000_000)).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+  it("returns empty string for null", () => {
+    expect(tsToIso(null)).toBe("");
+  });
+});
+
+describe("csvEscape", () => {
+  it("leaves plain values untouched", () => {
+    expect(csvEscape("BTC")).toBe("BTC");
+    expect(csvEscape(42)).toBe("42");
+  });
+  it("quotes and doubles embedded quotes", () => {
+    expect(csvEscape('a"b')).toBe('"a""b"');
+  });
+  it("quotes values containing a comma", () => {
+    expect(csvEscape("a,b")).toBe('"a,b"');
+  });
+  it("quotes values containing a newline", () => {
+    expect(csvEscape("a\nb")).toBe('"a\nb"');
+  });
+  it("renders null/undefined as empty", () => {
+    expect(csvEscape(null)).toBe("");
+    expect(csvEscape(undefined)).toBe("");
+  });
+});
+
+describe("toCsv", () => {
+  it("joins a header + rows with \\n and escapes fields", () => {
+    const csv = toCsv(["A", "B"], [["1", "x,y"], ["2", 'q"q']]);
+    expect(csv).toBe('A,B\n1,"x,y"\n2,"q""q"');
+  });
+});
+
+describe("buildTradeHistoryCsv", () => {
+  const fills: ReportFill[] = [
+    { symbolid: 1, price: 12000, qty: 200, side: "sell", liquidity: "taker", fee: 5, ts: 1_700_000_100 },
+    { symbolid: 1, price: 10000, qty: 100, side: "buy", liquidity: "maker", fee: 3, ts: 1_700_000_050 },
+  ];
+
+  it("emits the documented header", () => {
+    const csv = buildTradeHistoryCsv(fills, resolve);
+    expect(csv.split("\n")[0]).toBe(TRADE_HISTORY_HEADER.join(","));
+  });
+
+  it("orders rows oldest-first and scales price/qty/notional", () => {
+    const lines = buildTradeHistoryCsv(fills, resolve).split("\n");
+    // Row 1 = the older buy (ts 50): price 10000/100=100, qty 100/100=1, notional (10000*100)/(100*100)=100
+    expect(lines[1]).toBe("2023-11-14T22:14:10.000Z,BTC,BUY,maker,100,1,0.03,100");
+    // Row 2 = the newer sell (ts 100): price 12000/100=120, qty 200/100=2, notional 240
+    expect(lines[2]).toBe("2023-11-14T22:15:00.000Z,BTC,SELL,taker,120,2,0.05,240");
+  });
+
+  it("produces only a header for no fills", () => {
+    expect(buildTradeHistoryCsv([], resolve)).toBe(TRADE_HISTORY_HEADER.join(","));
+  });
+});
+
+describe("buildPnlSummaryCsv", () => {
+  const perSymbol: ReportSymbolPnl[] = [
+    { symbolid: 1, net: 20000, realized: 20500, fees: 50, funding: 0, volume: 220000, tradeCount: 2, closes: 1, wins: 1 },
+    { symbolid: 2, net: -10000, realized: -9500, fees: 50, funding: 0, volume: 110000, tradeCount: 2, closes: 1, wins: 0 },
+  ];
+  const totals: ReportPnlTotals = {
+    netRealized: 10000,
+    totalRealized: 11000,
+    totalFees: 100,
+    totalFunding: 0,
+    totalVolume: 330000,
+    tradeCount: 4,
+    closeCount: 2,
+    winCount: 1,
+    winRate: 0.5,
+  };
+
+  it("emits header + one row per symbol + a TOTAL row", () => {
+    const lines = buildPnlSummaryCsv(perSymbol, totals, resolve, 100).split("\n");
+    expect(lines[0]).toBe(PNL_SUMMARY_HEADER.join(","));
+    expect(lines).toHaveLength(4); // header + 2 symbols + TOTAL
+    expect(lines[3]?.startsWith("TOTAL,")).toBe(true);
+  });
+
+  it("scales net PnL + win% correctly", () => {
+    const lines = buildPnlSummaryCsv(perSymbol, totals, resolve, 100).split("\n");
+    // BTC net 20000/100 = 200, win% 100.0
+    expect(lines[1]).toBe("BTC,200,205,0.5,0,22,2,1,1,100.0");
+    // TOTAL net 10000/100 = 100, win% 50.0
+    expect(lines[3]).toBe("TOTAL,100,110,1,0,33,4,2,1,50.0");
+  });
+});
+
+describe("buildStatementCsv", () => {
+  it("emits a self-describing preamble + header + rows", () => {
+    const csv = buildStatementCsv(
+      [
+        { section: "Spot", label: "USD", amount: 500000, scaler: 100, note: "available" },
+        { section: "Margin", label: "Balance", amount: 250000, scaler: 100 },
+      ],
+      { period: "Last 7 days", generatedAt: 1_700_000_000_000 },
+    );
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("# Account statement — Last 7 days");
+    expect(lines[1]).toBe(`# Generated ${new Date(1_700_000_000_000).toISOString()}`);
+    expect(lines[2]).toBe("");
+    expect(lines[3]).toBe("Section,Account / Asset,Amount,Note");
+    expect(lines[4]).toBe("Spot,USD,5000,available");
+    expect(lines[5]).toBe("Margin,Balance,2500,");
+  });
+});

--- a/frontend/src/lib/exportReport.ts
+++ b/frontend/src/lib/exportReport.ts
@@ -1,0 +1,231 @@
+// Pure, dependency-free CSV report builders for the EXPORT & REPORTING surface.
+// Every builder takes already-computed analytics (fills / PnL summary / balance
+// snapshot) and returns a CSV STRING — no DOM, no I/O — so they are trivially
+// unit-testable (see exportReport.test.ts). Engine int64 "tick" values are
+// scaled to human-readable decimals with the SAME scaler the UI uses; timestamps
+// are emitted as ISO-8601. `downloadCsv` is the only impure helper (blob + <a>).
+
+// ── scalar formatting ────────────────────────────────────────────────
+
+/** Scale an engine int64 tick to a plain decimal string (no thousands grouping,
+ *  up to `maxFrac` fraction digits). Grouping is deliberately OFF so the CSV
+ *  never embeds locale commas that would collide with the delimiter. */
+export function scaleTick(value: number | undefined | null, scaler = 1, maxFrac = 8): string {
+  if (value == null || !Number.isFinite(value)) return "";
+  const scaled = value / (scaler || 1);
+  // toLocaleString with useGrouping:false gives a clean, delimiter-safe decimal.
+  return scaled.toLocaleString("en-US", {
+    useGrouping: false,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: maxFrac,
+  });
+}
+
+/** `ts` may be seconds OR milliseconds — below ~year-2001-in-ms treat as seconds. */
+const MS_THRESHOLD = 1e12;
+export function tsToIso(ts: number | undefined | null): string {
+  if (ts == null || !Number.isFinite(ts)) return "";
+  const ms = ts < MS_THRESHOLD ? ts * 1000 : ts;
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? "" : d.toISOString();
+}
+
+// ── CSV serialization ────────────────────────────────────────────────
+
+const CSV_NEEDS_QUOTE = /[",\r\n]/;
+/** RFC-4180 field escaping: wrap in quotes + double any embedded quote. */
+export function csvEscape(value: unknown): string {
+  const s = value == null ? "" : String(value);
+  if (!CSV_NEEDS_QUOTE.test(s)) return s;
+  return '"' + s.replace(/"/g, '""') + '"';
+}
+
+/** Join a header + rows of cells into a single CSV string (\n line endings). */
+export function toCsv(header: string[], rows: (string | number)[][]): string {
+  const lines: string[] = [header.map(csvEscape).join(",")];
+  for (const row of rows) lines.push(row.map(csvEscape).join(","));
+  return lines.join("\n");
+}
+
+// ── shared input shapes ──────────────────────────────────────────────
+
+/** A symbol name + price scaler resolver, keyed by engine symbolid. */
+export type SymbolResolver = (symbolid: number) => { name: string; scaler: number };
+
+/** One executed fill (mirror of the /me/fills/fees feed subset we export). */
+export interface ReportFill {
+  symbolid: number;
+  price: number;
+  qty: number;
+  side: string;
+  liquidity?: string;
+  fee: number;
+  ts: number;
+}
+
+/** Per-symbol PnL rollup (mirror of pnl.ts SymbolPnl, only the exported fields). */
+export interface ReportSymbolPnl {
+  symbolid: number;
+  net: number;
+  realized: number;
+  fees: number;
+  funding: number;
+  volume: number;
+  tradeCount: number;
+  closes: number;
+  wins: number;
+}
+
+/** Aggregate PnL totals (mirror of pnl.ts PnlSummary, only the exported fields). */
+export interface ReportPnlTotals {
+  netRealized: number;
+  totalRealized: number;
+  totalFees: number;
+  totalFunding: number;
+  totalVolume: number;
+  tradeCount: number;
+  closeCount: number;
+  winCount: number;
+  winRate: number;
+}
+
+/** One balance / position line for the account statement. */
+export interface StatementLine {
+  /** e.g. "Spot", "Margin", "Position". */
+  section: string;
+  /** Asset or symbol label. */
+  label: string;
+  /** Engine tick value; scaled by `scaler` on export. */
+  amount: number;
+  scaler: number;
+  note?: string;
+}
+
+// ── (a) trade history ────────────────────────────────────────────────
+
+export const TRADE_HISTORY_HEADER = [
+  "Time (ISO)",
+  "Symbol",
+  "Side",
+  "Liquidity",
+  "Price",
+  "Qty",
+  "Fee",
+  "Notional",
+];
+
+/** Build a trade-history CSV: one row per fill, oldest-first. */
+export function buildTradeHistoryCsv(fills: ReportFill[], resolve: SymbolResolver): string {
+  const ordered = [...fills].sort((a, b) => a.ts - b.ts);
+  const rows: (string | number)[][] = ordered.map((f) => {
+    const { name, scaler } = resolve(f.symbolid);
+    const notional = Math.abs(f.price * f.qty);
+    return [
+      tsToIso(f.ts),
+      name,
+      String(f.side ?? "").toUpperCase(),
+      f.liquidity ?? "",
+      scaleTick(f.price, scaler, 2),
+      scaleTick(f.qty, scaler, 4),
+      scaleTick(f.fee, scaler, 8),
+      // notional is price*qty i.e. scaled by scaler^2 back to a single scaler.
+      scaleTick(notional, scaler * (scaler || 1), 2),
+    ];
+  });
+  return toCsv(TRADE_HISTORY_HEADER, rows);
+}
+
+// ── (b) PnL summary ──────────────────────────────────────────────────
+
+export const PNL_SUMMARY_HEADER = [
+  "Symbol",
+  "Net PnL",
+  "Realized",
+  "Fees",
+  "Funding",
+  "Volume",
+  "Trades",
+  "Closes",
+  "Wins",
+  "Win %",
+];
+
+/** Build a per-symbol PnL CSV with a trailing TOTAL row. `quoteScaler` scales
+ *  the aggregate TOTAL line (the feeds share one quote asset). */
+export function buildPnlSummaryCsv(
+  perSymbol: ReportSymbolPnl[],
+  totals: ReportPnlTotals,
+  resolve: SymbolResolver,
+  quoteScaler = 1,
+): string {
+  const rows: (string | number)[][] = perSymbol.map((s) => {
+    const { name, scaler } = resolve(s.symbolid);
+    const winPct = s.closes > 0 ? ((s.wins / s.closes) * 100).toFixed(1) : "";
+    return [
+      name,
+      scaleTick(s.net, scaler, 2),
+      scaleTick(s.realized, scaler, 2),
+      scaleTick(s.fees, scaler, 8),
+      scaleTick(s.funding, scaler, 8),
+      scaleTick(s.volume, scaler * (scaler || 1), 2),
+      s.tradeCount,
+      s.closes,
+      s.wins,
+      winPct,
+    ];
+  });
+  // TOTAL row (aggregate values scaled by the quote scaler).
+  rows.push([
+    "TOTAL",
+    scaleTick(totals.netRealized, quoteScaler, 2),
+    scaleTick(totals.totalRealized, quoteScaler, 2),
+    scaleTick(totals.totalFees, quoteScaler, 8),
+    scaleTick(totals.totalFunding, quoteScaler, 8),
+    scaleTick(totals.totalVolume, quoteScaler * (quoteScaler || 1), 2),
+    totals.tradeCount,
+    totals.closeCount,
+    totals.winCount,
+    (totals.winRate * 100).toFixed(1),
+  ]);
+  return toCsv(PNL_SUMMARY_HEADER, rows);
+}
+
+// ── (c) account statement ────────────────────────────────────────────
+
+export const STATEMENT_HEADER = ["Section", "Account / Asset", "Amount", "Note"];
+
+/** Build an account-statement CSV (a point-in-time balance/position snapshot).
+ *  A period label + generated-at line are emitted as leading comment rows so the
+ *  file is self-describing; the table header follows. */
+export function buildStatementCsv(
+  lines: StatementLine[],
+  meta: { period: string; generatedAt?: number },
+): string {
+  const gen = tsToIso(meta.generatedAt ?? Date.now());
+  const preamble: string[] = [
+    csvEscape(`# Account statement — ${meta.period}`),
+    csvEscape(`# Generated ${gen}`),
+    "",
+    STATEMENT_HEADER.map(csvEscape).join(","),
+  ];
+  const rows = lines.map((l) =>
+    [l.section, l.label, scaleTick(l.amount, l.scaler, 8), l.note ?? ""].map(csvEscape).join(","),
+  );
+  return [...preamble, ...rows].join("\n");
+}
+
+// ── download helper (only impure fn) ─────────────────────────────────
+
+/** Trigger a client-side CSV file download (UTF-8 BOM so Excel reads it right). */
+export function downloadCsv(filename: string, content: string): void {
+  const blob = new Blob(["﻿" + content], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 5_000);
+}

--- a/frontend/src/lib/reportPeriod.ts
+++ b/frontend/src/lib/reportPeriod.ts
@@ -1,0 +1,85 @@
+// Period scoping for EXPORT & REPORTING. Pure helpers to turn a preset (24h /
+// 7d / 30d / all / custom) into a [from, to] window (ms) and to filter fills by
+// their `ts` (which may be seconds OR ms). Kept framework-free so the reports
+// page, the PnL page and the blotter panel all scope identically.
+
+export type PeriodPreset = "24h" | "7d" | "30d" | "all" | "custom";
+
+export interface PeriodRange {
+  preset: PeriodPreset;
+  /** inclusive lower bound in ms; null = unbounded (All). */
+  fromMs: number | null;
+  /** inclusive upper bound in ms; null = now/unbounded. */
+  toMs: number | null;
+}
+
+export const PERIOD_LABELS: Record<PeriodPreset, string> = {
+  "24h": "Last 24 hours",
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+  all: "All time",
+  custom: "Custom range",
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Resolve a rolling preset to a concrete [fromMs, toMs] window relative to `now`. */
+export function presetRange(preset: Exclude<PeriodPreset, "custom">, now = Date.now()): PeriodRange {
+  switch (preset) {
+    case "24h":
+      return { preset, fromMs: now - DAY_MS, toMs: now };
+    case "7d":
+      return { preset, fromMs: now - 7 * DAY_MS, toMs: now };
+    case "30d":
+      return { preset, fromMs: now - 30 * DAY_MS, toMs: now };
+    case "all":
+    default:
+      return { preset: "all", fromMs: null, toMs: null };
+  }
+}
+
+/** Build a custom [from, to] range from date-input strings (YYYY-MM-DD or ISO).
+ *  Empty bounds are treated as unbounded. `to` is pushed to end-of-day when it is
+ *  a bare date so the last day is inclusive. */
+export function customRange(from: string, to: string): PeriodRange {
+  const fromMs = from ? Date.parse(from) : NaN;
+  let toMs = to ? Date.parse(to) : NaN;
+  // Bare YYYY-MM-DD parses to UTC midnight — extend to end-of-day for inclusivity.
+  if (!Number.isNaN(toMs) && /^\d{4}-\d{2}-\d{2}$/.test(to)) toMs += DAY_MS - 1;
+  return {
+    preset: "custom",
+    fromMs: Number.isNaN(fromMs) ? null : fromMs,
+    toMs: Number.isNaN(toMs) ? null : toMs,
+  };
+}
+
+/** Normalize a fill `ts` (seconds OR ms) to ms. */
+const MS_THRESHOLD = 1e12;
+export function tsToMs(ts: number): number {
+  return ts < MS_THRESHOLD ? ts * 1000 : ts;
+}
+
+/** Filter any `{ ts }`-bearing rows to a period window. `all`/null bounds keep everything. */
+export function filterByPeriod<T extends { ts: number }>(rows: T[], range: PeriodRange): T[] {
+  if (range.fromMs == null && range.toMs == null) return rows;
+  return rows.filter((r) => {
+    const ms = tsToMs(r.ts);
+    if (range.fromMs != null && ms < range.fromMs) return false;
+    if (range.toMs != null && ms > range.toMs) return false;
+    return true;
+  });
+}
+
+/** A short human label for the active range (for headers / filenames / statements). */
+export function periodLabel(range: PeriodRange): string {
+  if (range.preset !== "custom") return PERIOD_LABELS[range.preset];
+  const fmt = (ms: number | null) => (ms == null ? "…" : new Date(ms).toISOString().slice(0, 10));
+  return `${fmt(range.fromMs)} → ${fmt(range.toMs)}`;
+}
+
+/** A filename-safe slug for the active range (used in export filenames). */
+export function periodSlug(range: PeriodRange): string {
+  if (range.preset !== "custom") return range.preset;
+  const fmt = (ms: number | null) => (ms == null ? "start" : new Date(ms).toISOString().slice(0, 10));
+  return `${fmt(range.fromMs)}_${fmt(range.toMs)}`;
+}

--- a/frontend/src/pages/blotter/TradeHistoryPanel.tsx
+++ b/frontend/src/pages/blotter/TradeHistoryPanel.tsx
@@ -10,6 +10,7 @@ import type { MarketSymbol } from "@/api/endpoints/marketData";
 import { useFillsFees } from "@/hooks/useTrading";
 import type { FillFee } from "@/api/endpoints/trading";
 import { formatPrice, formatQty } from "@/pages/markets/format";
+import { buildTradeHistoryCsv, downloadCsv, type ReportFill } from "@/lib/exportReport";
 
 type SymLookup = (symbolid: number | undefined) => { name: string; scaler: number };
 function makeSymLookup(symbols: MarketSymbol[] | undefined): SymLookup {
@@ -41,12 +42,43 @@ export default function TradeHistoryPanel() {
   const q = useFillsFees();
   const fills: FillFee[] = Array.isArray(q.data?.fills) ? q.data!.fills! : [];
 
+  const exportCsv = () => {
+    const rows: ReportFill[] = fills.map((f) => ({
+      symbolid: f.symbolid,
+      price: f.price,
+      qty: f.qty,
+      side: String(f.side ?? ""),
+      liquidity: f.liquidity,
+      fee: f.fee,
+      ts: f.ts,
+    }));
+    downloadCsv(
+      "testlogon-trades.csv",
+      buildTradeHistoryCsv(rows, (id) => sym(id)),
+    );
+  };
+
   return (
     <div className="tl-panel-body tl-wo">
       <div className="tl-wo-bar">
         <span className="dim">{fills.length} executed fill{fills.length === 1 ? "" : "s"}</span>
         <span style={{ flex: 1 }} />
         {q.isFetching && <span className="dim" style={{ fontSize: "0.7rem" }}>refreshing…</span>}
+        <button
+          type="button"
+          className="tl-wo-btn"
+          onClick={exportCsv}
+          disabled={fills.length === 0}
+          title="Export trade history to CSV"
+          style={{
+            marginLeft: "0.5rem",
+            fontSize: "0.7rem",
+            cursor: fills.length === 0 ? "default" : "pointer",
+            opacity: fills.length === 0 ? 0.5 : 1,
+          }}
+        >
+          Export CSV
+        </button>
       </div>
       <div className="tl-wo-scroll">
         <table className="tl-wo-table">

--- a/frontend/src/pages/markets/DepthChart.tsx
+++ b/frontend/src/pages/markets/DepthChart.tsx
@@ -1,0 +1,270 @@
+import { useMemo, useRef, useState } from "react";
+import { computeDepth, type DepthPoint, type Level } from "@/lib/depth";
+import { formatPrice, formatQty } from "./format";
+
+interface DepthChartProps {
+  bids: Level[];
+  asks: Level[];
+  scaler?: number;
+  height?: number;
+}
+
+const BID = "#059669"; // emerald-600
+const ASK = "#e11d48"; // rose-600
+const PAD_TOP = 10;
+const PAD_BOTTOM = 22;
+const PAD_LEFT = 8;
+const PAD_RIGHT = 8;
+
+interface Hover {
+  x: number;
+  y: number;
+  price: number;
+  cum: number;
+  side: "bid" | "ask";
+}
+
+/**
+ * Cumulative-depth (market-depth) chart. Bids are drawn as a green step-area
+ * rising from the mid toward lower prices (left); asks as a red step-area
+ * rising toward higher prices (right). The pure cumulative math lives in
+ * `@/lib/depth`; this component is purely presentational/SVG.
+ */
+export default function DepthChart({
+  bids,
+  asks,
+  scaler = 1,
+  height = 260,
+}: DepthChartProps) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [hover, setHover] = useState<Hover | null>(null);
+  const [width, setWidth] = useState(640);
+
+  const depth = useMemo(() => computeDepth(bids, asks), [bids, asks]);
+
+  const hasData =
+    depth.minPrice != null && depth.maxPrice != null && depth.maxCum > 0;
+
+  const plotW = Math.max(1, width - PAD_LEFT - PAD_RIGHT);
+  const plotH = Math.max(1, height - PAD_TOP - PAD_BOTTOM);
+
+  // x maps price -> px across [minPrice, maxPrice]; y maps cum -> px (0 at bottom).
+  const geom = useMemo(() => {
+    if (!hasData) return null;
+    const minP = depth.minPrice!;
+    const maxP = depth.maxPrice!;
+    const span = maxP - minP || 1;
+    const x = (price: number) => PAD_LEFT + ((price - minP) / span) * plotW;
+    const y = (cum: number) => PAD_TOP + plotH - (cum / depth.maxCum) * plotH;
+    return { x, y, minP, maxP, span };
+  }, [hasData, depth, plotW, plotH]);
+
+  const anchor = depth.mid ?? depth.bestBid ?? depth.bestAsk ?? 0;
+  const baseY = PAD_TOP + plotH;
+
+  // Build an SVG step-area path for one cumulative side, anchored at the mid.
+  const buildPath = (points: DepthPoint[]): string => {
+    if (!geom || points.length === 0) return "";
+    const { x, y } = geom;
+    const ordered = [...points].sort((a, b) => a.price - b.price);
+    let d = `M ${x(anchor)} ${baseY}`;
+    let prevCum = 0;
+    for (const p of ordered) {
+      d += ` L ${x(p.price)} ${y(prevCum)}`;
+      d += ` L ${x(p.price)} ${y(p.cum)}`;
+      prevCum = p.cum;
+    }
+    const last = ordered[ordered.length - 1]!;
+    d += ` L ${x(last.price)} ${baseY} Z`;
+    return d;
+  };
+
+  const bidPath = useMemo(
+    () => buildPath(depth.bids),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [depth.bids, geom, anchor]
+  );
+  const askPath = useMemo(
+    () => buildPath(depth.asks),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [depth.asks, geom, anchor]
+  );
+
+  const onMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (!geom) return;
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const px = e.clientX - rect.left;
+    const price = geom.minP + ((px - PAD_LEFT) / plotW) * geom.span;
+    const side: "bid" | "ask" =
+      depth.mid != null
+        ? price <= depth.mid
+          ? "bid"
+          : "ask"
+        : price <= anchor
+          ? "bid"
+          : "ask";
+    const pts = side === "bid" ? depth.bids : depth.asks;
+    if (pts.length === 0) {
+      setHover(null);
+      return;
+    }
+    let best = pts[0]!;
+    let bestD = Math.abs(best.price - price);
+    for (const p of pts) {
+      const dd = Math.abs(p.price - price);
+      if (dd < bestD) {
+        bestD = dd;
+        best = p;
+      }
+    }
+    setHover({
+      x: geom.x(best.price),
+      y: geom.y(best.cum),
+      price: best.price,
+      cum: best.cum,
+      side,
+    });
+  };
+
+  // Track container width for responsiveness.
+  const measureRef = (node: HTMLDivElement | null) => {
+    if (node && node.clientWidth && node.clientWidth !== width) {
+      setWidth(node.clientWidth);
+    }
+  };
+
+  if (!hasData) {
+    return (
+      <div
+        ref={measureRef}
+        className="flex items-center justify-center text-sm text-muted-foreground"
+        style={{ height }}
+      >
+        No depth data.
+      </div>
+    );
+  }
+
+  const midX = depth.mid != null ? geom!.x(depth.mid) : null;
+
+  return (
+    <div ref={measureRef} className="relative w-full">
+      <svg
+        ref={svgRef}
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        onMouseMove={onMove}
+        onMouseLeave={() => setHover(null)}
+        role="img"
+        aria-label="Cumulative market-depth chart"
+      >
+        <defs>
+          <linearGradient id="depth-bid" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={BID} stopOpacity="0.35" />
+            <stop offset="100%" stopColor={BID} stopOpacity="0.05" />
+          </linearGradient>
+          <linearGradient id="depth-ask" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={ASK} stopOpacity="0.35" />
+            <stop offset="100%" stopColor={ASK} stopOpacity="0.05" />
+          </linearGradient>
+        </defs>
+
+        <line
+          x1={PAD_LEFT}
+          y1={baseY}
+          x2={width - PAD_RIGHT}
+          y2={baseY}
+          stroke="currentColor"
+          strokeOpacity="0.15"
+        />
+
+        <path d={bidPath} fill="url(#depth-bid)" stroke={BID} strokeWidth={1.25} />
+        <path d={askPath} fill="url(#depth-ask)" stroke={ASK} strokeWidth={1.25} />
+
+        {midX != null && (
+          <line
+            x1={midX}
+            y1={PAD_TOP}
+            x2={midX}
+            y2={baseY}
+            stroke="currentColor"
+            strokeOpacity="0.35"
+            strokeDasharray="3 3"
+          />
+        )}
+
+        {hover && (
+          <g>
+            <line
+              x1={hover.x}
+              y1={PAD_TOP}
+              x2={hover.x}
+              y2={baseY}
+              stroke="currentColor"
+              strokeOpacity="0.4"
+            />
+            <line
+              x1={PAD_LEFT}
+              y1={hover.y}
+              x2={width - PAD_RIGHT}
+              y2={hover.y}
+              stroke="currentColor"
+              strokeOpacity="0.25"
+            />
+            <circle cx={hover.x} cy={hover.y} r={3.5} fill={hover.side === "bid" ? BID : ASK} />
+          </g>
+        )}
+
+        <text x={PAD_LEFT} y={height - 6} fontSize="10" fill="currentColor" fillOpacity="0.5">
+          {formatPrice(geom!.minP, scaler)}
+        </text>
+        {midX != null && (
+          <text
+            x={midX}
+            y={height - 6}
+            fontSize="10"
+            textAnchor="middle"
+            fill="currentColor"
+            fillOpacity="0.6"
+          >
+            {formatPrice(depth.mid!, scaler)}
+          </text>
+        )}
+        <text
+          x={width - PAD_RIGHT}
+          y={height - 6}
+          fontSize="10"
+          textAnchor="end"
+          fill="currentColor"
+          fillOpacity="0.5"
+        >
+          {formatPrice(geom!.maxP, scaler)}
+        </text>
+      </svg>
+
+      {hover && (
+        <div
+          className="pointer-events-none absolute z-10 rounded-md border bg-popover px-2 py-1 text-xs shadow-md tabular-nums"
+          style={{
+            left: Math.min(width - 130, Math.max(0, hover.x + 8)),
+            top: Math.max(0, hover.y - 44),
+          }}
+        >
+          <div
+            className={
+              hover.side === "bid"
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-rose-600 dark:text-rose-400"
+            }
+          >
+            {hover.side === "bid" ? "Bid" : "Ask"} {formatPrice(hover.price, scaler)}
+          </div>
+          <div className="text-muted-foreground">Cum size {formatQty(hover.cum, scaler)}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/markets/SymbolDetailPage.tsx
+++ b/frontend/src/pages/markets/SymbolDetailPage.tsx
@@ -5,12 +5,15 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { useSymbols, useOrderBook, useCandles, useTrades } from "@/hooks/useMarketData";
 import { useMdStream } from "@/hooks/useMdStream";
 import type { BookLevel, Candle } from "@/api/endpoints/marketData";
 import type { OrderSide } from "@/api/endpoints/trading";
 import CandleChart from "./CandleChart";
+import DepthChart from "./DepthChart";
+import TimeSales from "./TimeSales";
 import { TradeTicket } from "./TradeTicket";
 import { formatPrice, formatQty, formatTimeNs } from "./format";
 
@@ -455,6 +458,44 @@ export default function SymbolDetailPage() {
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Market Depth &amp; Time &amp; Sales</CardTitle>
+          <CardDescription>
+            Cumulative depth curve and the live prints tape.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Tabs defaultValue="depth">
+            <TabsList>
+              <TabsTrigger value="depth">Depth Chart</TabsTrigger>
+              <TabsTrigger value="tape">Time &amp; Sales</TabsTrigger>
+            </TabsList>
+            <TabsContent value="depth" className="mt-3">
+              {book.isLoading && !liveBook ? (
+                <Skeleton className="h-64 w-full" />
+              ) : (
+                <div className="text-muted-foreground">
+                  <DepthChart
+                    bids={liveBook?.bids ?? []}
+                    asks={liveBook?.asks ?? []}
+                    scaler={scaler}
+                  />
+                </div>
+              )}
+            </TabsContent>
+            <TabsContent value="tape" className="mt-3">
+              <TimeSales
+                trades={recentTrades}
+                scaler={scaler}
+                isLoading={trades.isLoading}
+                unavailable={trades.isError}
+              />
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/pages/markets/TimeSales.tsx
+++ b/frontend/src/pages/markets/TimeSales.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { Trade } from "@/api/endpoints/marketData";
+import { formatPrice, formatQty, formatTimeNs } from "./format";
+
+interface TimeSalesProps {
+  trades: Trade[];
+  scaler?: number;
+  /** Max rows kept in the visible tape. */
+  maxRows?: number;
+  isLoading?: boolean;
+  /** True when the trades feed is unavailable (query error). */
+  unavailable?: boolean;
+}
+
+type Flash = "up" | "down" | null;
+
+/** Stable-ish key for a trade so React reconciles rows and flashes correctly. */
+function tradeKey(t: Trade): string {
+  return `${t.ts_ns}:${t.price}:${t.qty}:${t.aggressor}`;
+}
+
+/**
+ * Time & Sales tape: a compact, live-scrolling list of the most recent prints,
+ * newest on top, colored by aggressor (buy = green, sell = red). The latest
+ * print flashes briefly, tinted by whether price ticked up or down vs the
+ * previous print.
+ */
+export default function TimeSales({
+  trades,
+  scaler = 1,
+  maxRows = 50,
+  isLoading = false,
+  unavailable = false,
+}: TimeSalesProps) {
+  const rows = useMemo(() => trades.slice(0, maxRows), [trades, maxRows]);
+
+  // Flash the top row when a new print arrives; tint by tick direction.
+  const prevTopKey = useRef<string | null>(null);
+  const prevTopPrice = useRef<number | null>(null);
+  const [flash, setFlash] = useState<Flash>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const top = rows[0];
+    if (!top) return;
+    const key = tradeKey(top);
+    if (prevTopKey.current !== null && key !== prevTopKey.current) {
+      const dir: Flash =
+        prevTopPrice.current == null
+          ? null
+          : top.price > prevTopPrice.current
+            ? "up"
+            : top.price < prevTopPrice.current
+              ? "down"
+              : null;
+      setFlash(dir ?? "up");
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setFlash(null), 260);
+    }
+    prevTopKey.current = key;
+    prevTopPrice.current = top.price;
+  }, [rows]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  if (isLoading && rows.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">Loading tape…</p>
+    );
+  }
+  if (unavailable) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        Time &amp; sales unavailable.
+      </p>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">No prints yet.</p>
+    );
+  }
+
+  return (
+    <div>
+      <div className="grid grid-cols-3 gap-2 px-2 pb-1 text-xs uppercase text-muted-foreground">
+        <span>Time</span>
+        <span className="text-right">Price</span>
+        <span className="text-right">Qty</span>
+      </div>
+      <div className="max-h-72 overflow-y-auto">
+        {rows.map((t, i) => {
+          const isBuy = t.aggressor === "buy";
+          const isTop = i === 0;
+          return (
+            <div
+              key={tradeKey(t)}
+              className={cn(
+                "grid grid-cols-3 gap-2 px-2 py-0.5 text-sm tabular-nums transition-colors duration-200",
+                isTop && flash === "up" && "bg-emerald-500/15",
+                isTop && flash === "down" && "bg-rose-500/15"
+              )}
+            >
+              <span className="text-muted-foreground">{formatTimeNs(t.ts_ns)}</span>
+              <span
+                className={cn(
+                  "text-right font-medium",
+                  isBuy
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-rose-600 dark:text-rose-400"
+                )}
+              >
+                {formatPrice(t.price, scaler)}
+              </span>
+              <span className="text-right text-muted-foreground">
+                {formatQty(t.qty, scaler)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRegisterShortcuts, type ShortcutEntry } from "@/hooks/useKeyboardShortcuts";
 import { useQuery } from "@tanstack/react-query";
 import { getFeeSchedule } from "@/api/endpoints/custody";
 import { cn } from "@/lib/utils";
@@ -102,11 +103,13 @@ function Field({
   value,
   onChange,
   onStep,
+  dataField,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   onStep?: (delta: number) => void;
+  dataField?: string;
 }) {
   return (
     <div className="w-full">
@@ -121,6 +124,7 @@ function Field({
           value={value}
           inputMode="numeric"
           placeholder="0"
+          data-trade-field={dataField}
           onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ""))}
           className="tabular-nums"
         />
@@ -419,6 +423,45 @@ export function TradeTicket({
 
   const seq = useRef(0);
   const nextClordid = () => `t${Date.now()}${seq.current++ % 100}`;
+
+  // ── Trade-view keyboard shortcuts (scoped to the ticket) ─────────────
+  const ticketRef = useRef<HTMLDivElement>(null);
+  const focusTradeField = (field: "price" | "qty") => {
+    const root = ticketRef.current;
+    if (!root) return;
+    const el = root.querySelector<HTMLInputElement>(`input[data-trade-field="${field}"]`);
+    if (el) {
+      el.focus();
+      el.select();
+    }
+  };
+  const tradeShortcuts = useMemo<ShortcutEntry[]>(() => [
+    {
+      def: { kind: "single", key: "b", label: "Buy side", group: "Trading" },
+      action: () => { setSide("buy"); setArmed((a) => (a ? null : a)); },
+    },
+    {
+      def: { kind: "single", key: "s", label: "Sell side", group: "Trading" },
+      action: () => { setSide("sell"); setArmed((a) => (a ? null : a)); },
+    },
+    {
+      def: { kind: "single", key: "p", label: "Focus price", group: "Trading" },
+      action: () => focusTradeField("price"),
+    },
+    {
+      def: { kind: "single", key: "q", label: "Focus quantity", group: "Trading" },
+      action: () => focusTradeField("qty"),
+    },
+    {
+      def: { kind: "single", key: "escape", label: "Clear / blur inputs", group: "Trading" },
+      action: () => {
+        const active = document.activeElement as HTMLElement | null;
+        if (active && ticketRef.current?.contains(active)) active.blur();
+        setArmed((a) => (a ? null : a));
+      },
+    },
+  ], []);
+  useRegisterShortcuts(tradeShortcuts);
 
   // Prefill the price from the last trade while untouched.
   useEffect(() => {
@@ -845,7 +888,7 @@ export function TradeTicket({
   ];
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" ref={ticketRef}>
     <Card>
       <CardContent className="space-y-3 pt-6">
         {/* Prediction-market banner */}
@@ -1076,8 +1119,8 @@ export function TradeTicket({
             {/* Type-specific fields */}
             {orderType === "limit" && (
               <>
-                <Field label="Price" value={price} onChange={setPrice} onStep={(d) => stepField(setPrice, price, d)} />
-                <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} />
+                <Field label="Price" value={price} onChange={setPrice} onStep={(d) => stepField(setPrice, price, d)} dataField="price" />
+                <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} dataField="qty" />
               </>
             )}
             {orderType === "market" && <Field label="Quantity" value={qty} onChange={setQty} onStep={(d) => stepField(setQty, qty, d)} />}

--- a/frontend/src/pages/pnl/PnLPage.tsx
+++ b/frontend/src/pages/pnl/PnLPage.tsx
@@ -16,6 +16,7 @@ import {
   Hash,
   BarChart2,
   Info,
+  Download,
 } from "lucide-react";
 import { ApiError } from "@/api/client";
 import { cn } from "@/lib/utils";
@@ -42,6 +43,12 @@ import {
   type PnlLiquidation,
   type EquityPoint,
 } from "@/lib/pnl";
+import {
+  buildTradeHistoryCsv,
+  buildPnlSummaryCsv,
+  downloadCsv,
+  type ReportFill,
+} from "@/lib/exportReport";
 
 // --- helpers ----------------------------------------------------
 
@@ -236,6 +243,29 @@ export default function PnLPage() {
     return computePnl(fills, funding, liquidations);
   }, [fillsQ.data, fundingQ.data, liqQ.data]);
 
+  // Raw fills for CSV export (keeps liquidity + raw ts). A SymbolResolver over
+  // the same symbol catalog the table uses.
+  const reportFills: ReportFill[] = useMemo(
+    () =>
+      (fillsQ.data?.fills ?? []).map((f) => ({
+        symbolid: f.symbolid,
+        price: f.price,
+        qty: f.qty,
+        side: f.side,
+        liquidity: f.liquidity,
+        fee: f.fee,
+        ts: f.ts,
+      })),
+    [fillsQ.data],
+  );
+  const exportTrades = () =>
+    downloadCsv("testlogon-trades.csv", buildTradeHistoryCsv(reportFills, symLookup));
+  const exportPnl = () =>
+    downloadCsv(
+      "testlogon-pnl.csv",
+      buildPnlSummaryCsv(summary.perSymbol, summary, symLookup, quoteScaler),
+    );
+
   const unrealized = num(marginQ.data?.pos_unrealized_pnl);
   const unrealizedScaler = marginQ.data?.pos_symbol_idx != null
     ? symLookup(marginQ.data.pos_symbol_idx).scaler
@@ -263,10 +293,30 @@ export default function PnLPage() {
             </p>
           </div>
         </div>
-        <Button variant="outline" size="sm" className="gap-2 self-start sm:self-auto" onClick={refetchAll}>
-          <RefreshCw className={cn("h-4 w-4", anyFetching && "animate-spin")} />
-          Refresh
-        </Button>
+        <div className="flex flex-wrap gap-2 self-start sm:self-auto">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={exportTrades}
+            disabled={summary.tradeCount === 0}
+          >
+            <Download className="h-4 w-4" /> Trades CSV
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={exportPnl}
+            disabled={summary.tradeCount === 0}
+          >
+            <Download className="h-4 w-4" /> PnL CSV
+          </Button>
+          <Button variant="outline" size="sm" className="gap-2" onClick={refetchAll}>
+            <RefreshCw className={cn("h-4 w-4", anyFetching && "animate-spin")} />
+            Refresh
+          </Button>
+        </div>
       </div>
 
       {loading ? (

--- a/frontend/src/pages/reports/ReportsPage.tsx
+++ b/frontend/src/pages/reports/ReportsPage.tsx
@@ -1,0 +1,560 @@
+// EXPORT & REPORTING — a READ-ONLY reporting surface built CLIENT-SIDE from the
+// same exchange account feeds the PnL page uses (fills-fees / funding /
+// liquidations) plus the margin + spot balance snapshots. Pick a period, preview
+// the headline stats over the scoped fills, then export CSV (trades / PnL /
+// statement) or open a print-optimized view and Save-as-PDF via window.print().
+// No new deps, no new backend: every feed degrades independently (a 404 feed
+// just contributes nothing), and each value stays in engine int64 ticks scaled
+// for display by the markets formatters.
+import { useMemo, useState } from "react";
+import {
+  FileSpreadsheet,
+  Download,
+  Printer,
+  RefreshCw,
+  TrendingUp,
+  TrendingDown,
+  Receipt,
+  Target,
+  Hash,
+  BarChart2,
+  Info,
+} from "lucide-react";
+import { ApiError } from "@/api/client";
+import { cn } from "@/lib/utils";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import { Input } from "@/components/ui/input";
+
+import {
+  useFillsFees,
+  useLiquidations,
+  useFundingPayments,
+  useMarginAccount,
+  useSpotBalance,
+} from "@/hooks/useTrading";
+import { useSymbols } from "@/hooks/useMarketData";
+import { formatPrice } from "@/pages/markets/format";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import {
+  computePnl,
+  type PnlFill,
+  type PnlFunding,
+  type PnlLiquidation,
+} from "@/lib/pnl";
+import {
+  buildTradeHistoryCsv,
+  buildPnlSummaryCsv,
+  buildStatementCsv,
+  downloadCsv,
+  type ReportFill,
+  type StatementLine,
+  type SymbolResolver,
+} from "@/lib/exportReport";
+import {
+  presetRange,
+  customRange,
+  filterByPeriod,
+  periodLabel,
+  periodSlug,
+  PERIOD_LABELS,
+  type PeriodPreset,
+  type PeriodRange,
+} from "@/lib/reportPeriod";
+
+// --- helpers ----------------------------------------------------
+
+function isUnavailable(err: unknown): boolean {
+  if (err instanceof ApiError) return err.status === 404 || err.status === 403;
+  const msg = (err as Error)?.message ?? "";
+  return /\b40[34]\b/.test(msg);
+}
+
+const signColor = (v: number): string | undefined =>
+  v > 0 ? "rgb(16 185 129)" : v < 0 ? "rgb(239 68 68)" : undefined;
+
+const PRESETS: PeriodPreset[] = ["24h", "7d", "30d", "all", "custom"];
+
+// --- period selector --------------------------------------------
+
+export function PeriodSelector({
+  range,
+  onChange,
+}: {
+  range: PeriodRange;
+  onChange: (r: PeriodRange) => void;
+}) {
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  const pick = (p: PeriodPreset) => {
+    if (p === "custom") onChange(customRange(from, to));
+    else onChange(presetRange(p));
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-1.5">
+        {PRESETS.map((p) => (
+          <Button
+            key={p}
+            size="sm"
+            variant={range.preset === p ? "default" : "outline"}
+            onClick={() => pick(p)}
+            className="h-8"
+          >
+            {p === "custom" ? "Custom" : PERIOD_LABELS[p].replace("Last ", "")}
+          </Button>
+        ))}
+      </div>
+      {range.preset === "custom" && (
+        <div className="flex flex-wrap items-center gap-2 print:hidden">
+          <Input
+            type="date"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            onBlur={() => onChange(customRange(from, to))}
+            className="h-8 w-[9.5rem]"
+            aria-label="From date"
+          />
+          <span className="text-xs text-muted-foreground">to</span>
+          <Input
+            type="date"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            onBlur={() => onChange(customRange(from, to))}
+            className="h-8 w-[9.5rem]"
+            aria-label="To date"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- stat card --------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  icon,
+  valueColor,
+  sub,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  valueColor?: string;
+  sub?: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-1 py-4">
+        <span className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+          {icon}
+          {label}
+        </span>
+        <span
+          className="num text-xl font-semibold tabular-nums"
+          style={valueColor ? { color: valueColor } : undefined}
+        >
+          {value}
+        </span>
+        {sub && <span className="text-[11px] text-muted-foreground">{sub}</span>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// --- page -------------------------------------------------------
+
+export default function ReportsPage() {
+  const fillsQ = useFillsFees();
+  const fundingQ = useFundingPayments();
+  const liqQ = useLiquidations();
+  const marginQ = useMarginAccount();
+  const spotQ = useSpotBalance();
+  const symbolsQ = useSymbols();
+
+  const [range, setRange] = useState<PeriodRange>(() => presetRange("7d"));
+
+  const refetchAll = () => {
+    fillsQ.refetch();
+    fundingQ.refetch();
+    liqQ.refetch();
+    marginQ.refetch();
+    spotQ.refetch();
+    symbolsQ.refetch();
+  };
+
+  const anyFetching =
+    fillsQ.isFetching ||
+    fundingQ.isFetching ||
+    liqQ.isFetching ||
+    marginQ.isFetching ||
+    spotQ.isFetching ||
+    symbolsQ.isFetching;
+
+  // symbolid -> {name, scaler}.
+  const resolve: SymbolResolver = useMemo(() => {
+    const map = new Map<number, MarketSymbol>();
+    for (const s of symbolsQ.data?.symbols ?? []) map.set(s.symbol_id, s);
+    return (id: number) => {
+      const s = map.get(id);
+      return { name: s?.symbol ?? `#${id}`, scaler: s?.price_scaler || 1 };
+    };
+  }, [symbolsQ.data]);
+
+  const quoteScaler = useMemo(() => symbolsQ.data?.symbols?.[0]?.price_scaler || 1, [symbolsQ.data]);
+
+  // Raw fills, then period-scoped.
+  const allFills: ReportFill[] = useMemo(
+    () =>
+      (fillsQ.data?.fills ?? []).map((f) => ({
+        symbolid: f.symbolid,
+        price: f.price,
+        qty: f.qty,
+        side: f.side,
+        liquidity: f.liquidity,
+        fee: f.fee,
+        ts: f.ts,
+      })),
+    [fillsQ.data],
+  );
+  const scopedFills = useMemo(() => filterByPeriod(allFills, range), [allFills, range]);
+
+  const scopedFunding = useMemo(
+    () => filterByPeriod(fundingQ.data?.funding ?? [], range),
+    [fundingQ.data, range],
+  );
+  const scopedLiq = useMemo(
+    () => filterByPeriod(liqQ.data?.liquidations ?? [], range),
+    [liqQ.data, range],
+  );
+
+  // PnL over the scoped window.
+  const summary = useMemo(() => {
+    const fills: PnlFill[] = scopedFills.map((f) => ({
+      symbolid: f.symbolid,
+      price: f.price,
+      qty: f.qty,
+      side: f.side === "sell" ? "sell" : "buy",
+      fee: f.fee,
+      ts: f.ts,
+    }));
+    const funding: PnlFunding[] = scopedFunding.map((f) => ({
+      symbolid: f.symbolid,
+      payment: f.payment,
+      ts: f.ts,
+    }));
+    const liquidations: PnlLiquidation[] = scopedLiq.map((l) => ({
+      symbolid: l.symbolid,
+      realized_pnl: l.realized_pnl,
+      fee: l.fee,
+      ts: l.ts,
+    }));
+    return computePnl(fills, funding, liquidations);
+  }, [scopedFills, scopedFunding, scopedLiq]);
+
+  // Account statement snapshot lines (point-in-time balances/positions).
+  const statementLines: StatementLine[] = useMemo(() => {
+    const lines: StatementLine[] = [];
+    for (const b of spotQ.data?.balances ?? []) {
+      const s = b.asset != null ? resolve(b.asset) : { name: b.symbol ?? "—", scaler: 1 };
+      const label = b.symbol ?? s.name;
+      if (b.balance != null) lines.push({ section: "Spot", label, amount: b.balance, scaler: s.scaler, note: "balance" });
+      if (b.available != null)
+        lines.push({ section: "Spot", label, amount: b.available, scaler: s.scaler, note: "available" });
+    }
+    const m = marginQ.data;
+    if (m) {
+      if (m.balance != null) lines.push({ section: "Margin", label: "Balance", amount: m.balance, scaler: quoteScaler });
+      if (m.available_balance != null)
+        lines.push({ section: "Margin", label: "Available", amount: m.available_balance, scaler: quoteScaler });
+      if (m.reserved_margin != null)
+        lines.push({ section: "Margin", label: "Reserved margin", amount: m.reserved_margin, scaler: quoteScaler });
+      if (m.pos_symbol_idx != null && m.pos_qty) {
+        const sym = resolve(m.pos_symbol_idx);
+        lines.push({ section: "Position", label: sym.name, amount: m.pos_qty, scaler: sym.scaler, note: "qty" });
+        if (m.pos_entry_price != null)
+          lines.push({ section: "Position", label: sym.name, amount: m.pos_entry_price, scaler: sym.scaler, note: "entry" });
+        if (m.pos_unrealized_pnl != null)
+          lines.push({
+            section: "Position",
+            label: sym.name,
+            amount: m.pos_unrealized_pnl,
+            scaler: sym.scaler,
+            note: "unrealized PnL",
+          });
+      }
+    }
+    return lines;
+  }, [spotQ.data, marginQ.data, quoteScaler, resolve]);
+
+  // --- export handlers ---
+  const doExportTrades = () =>
+    downloadCsv(`testlogon-trades-${periodSlug(range)}.csv`, buildTradeHistoryCsv(scopedFills, resolve));
+  const doExportPnl = () =>
+    downloadCsv(
+      `testlogon-pnl-${periodSlug(range)}.csv`,
+      buildPnlSummaryCsv(summary.perSymbol, summary, resolve, quoteScaler),
+    );
+  const doExportStatement = () =>
+    downloadCsv(
+      `testlogon-statement-${periodSlug(range)}.csv`,
+      buildStatementCsv(statementLines, { period: periodLabel(range) }),
+    );
+
+  const fillsUnavailable = fillsQ.isError && isUnavailable(fillsQ.error);
+  const fillsError = fillsQ.isError && !fillsUnavailable;
+  const loading = fillsQ.isLoading || symbolsQ.isLoading;
+  const hasData = summary.tradeCount > 0;
+
+  const netColor = signColor(summary.netRealized);
+  const winPct = (summary.winRate * 100).toFixed(summary.closeCount > 0 ? 1 : 0);
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between print:hidden">
+        <div className="flex items-center gap-2">
+          <FileSpreadsheet className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold leading-tight">Export &amp; reporting</h1>
+            <p className="text-xs text-muted-foreground">
+              Scope a period, preview headline stats, then export CSV or print / save as PDF.
+            </p>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" className="gap-2 self-start sm:self-auto" onClick={refetchAll}>
+          <RefreshCw className={cn("h-4 w-4", anyFetching && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Controls */}
+      <Card className="print:hidden">
+        <CardContent className="flex flex-col gap-4 py-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Period</span>
+            <PeriodSelector range={range} onChange={setRange} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" className="gap-1.5" onClick={doExportTrades} disabled={!hasData}>
+              <Download className="h-4 w-4" /> Trades CSV
+            </Button>
+            <Button size="sm" variant="outline" className="gap-1.5" onClick={doExportPnl} disabled={!hasData}>
+              <Download className="h-4 w-4" /> PnL CSV
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={doExportStatement}
+              disabled={statementLines.length === 0}
+            >
+              <Download className="h-4 w-4" /> Statement CSV
+            </Button>
+            <Button size="sm" className="gap-1.5" onClick={() => window.print()} disabled={!hasData}>
+              <Printer className="h-4 w-4" /> Print / Save PDF
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Print-only report heading */}
+      <div className="hidden print:block">
+        <h1 className="text-2xl font-semibold">TestLogon — trading report</h1>
+        <p className="text-sm text-muted-foreground">
+          {periodLabel(range)} · generated {new Date().toISOString().slice(0, 19).replace("T", " ")}Z
+        </p>
+        <Separator className="my-3" />
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : fillsUnavailable ? (
+        <Card>
+          <CardContent className="flex flex-col items-start gap-2 py-10">
+            <p className="text-sm text-muted-foreground">
+              The fills feed isn't available on this backend yet, so reports can't be computed. This
+              page will populate once the exchange edge deploys the account feeds.
+            </p>
+            <Badge variant="outline" className="gap-1.5">
+              <Info className="h-3 w-3" /> Not available on this backend
+            </Badge>
+          </CardContent>
+        </Card>
+      ) : fillsError ? (
+        <Card>
+          <CardContent className="py-10">
+            <p className="text-sm text-muted-foreground">
+              Could not load your fills: {(fillsQ.error as Error)?.message ?? "unknown error"}.
+            </p>
+          </CardContent>
+        </Card>
+      ) : !hasData ? (
+        <Card>
+          <CardContent className="flex flex-col items-start gap-2 py-10">
+            <p className="text-sm text-muted-foreground">
+              No trading activity in {periodLabel(range).toLowerCase()}. Pick a wider period or place
+              some trades — your headline stats and exports will appear here.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Headline stats */}
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+            <StatCard
+              label="Net realized PnL"
+              value={formatPrice(summary.netRealized, quoteScaler)}
+              valueColor={netColor}
+              icon={
+                summary.netRealized >= 0 ? (
+                  <TrendingUp className="h-3.5 w-3.5" />
+                ) : (
+                  <TrendingDown className="h-3.5 w-3.5" />
+                )
+              }
+              sub="Realized − fees + funding ± liquidations"
+            />
+            <StatCard
+              label="Total fees paid"
+              value={formatPrice(summary.totalFees + summary.totalLiquidationFees, quoteScaler)}
+              icon={<Receipt className="h-3.5 w-3.5" />}
+              sub="Engine + liquidation fees"
+            />
+            <StatCard
+              label="Win rate"
+              value={`${winPct}%`}
+              icon={<Target className="h-3.5 w-3.5" />}
+              sub={`${summary.winCount}/${summary.closeCount} closing trades positive`}
+            />
+            <StatCard
+              label="Trades"
+              value={String(summary.tradeCount)}
+              icon={<Hash className="h-3.5 w-3.5" />}
+              sub={`${summary.closeCount} position closes`}
+            />
+            <StatCard
+              label="Total volume"
+              value={formatPrice(summary.totalVolume, quoteScaler)}
+              icon={<BarChart2 className="h-3.5 w-3.5" />}
+              sub="Traded notional (magnitude)"
+            />
+            <StatCard
+              label="Fills in period"
+              value={String(scopedFills.length)}
+              icon={<FileSpreadsheet className="h-3.5 w-3.5" />}
+              sub={periodLabel(range)}
+            />
+          </div>
+
+          {/* Per-symbol breakdown */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                Per-symbol breakdown
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[560px] text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs text-muted-foreground">
+                      <th className="py-2 pr-3 font-medium">Symbol</th>
+                      <th className="py-2 pr-3 text-right font-medium">Net PnL</th>
+                      <th className="py-2 pr-3 text-right font-medium">Volume</th>
+                      <th className="py-2 pr-3 text-right font-medium">Fees</th>
+                      <th className="py-2 text-right font-medium">Trades</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {summary.perSymbol.map((s) => {
+                      const sym = resolve(s.symbolid);
+                      return (
+                        <tr key={s.symbolid} className="border-b last:border-0">
+                          <td className="py-2 pr-3 font-medium">{sym.name}</td>
+                          <td
+                            className="num py-2 pr-3 text-right font-medium tabular-nums"
+                            style={{ color: signColor(s.net) }}
+                          >
+                            {formatPrice(s.net, sym.scaler)}
+                          </td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">
+                            {formatPrice(s.volume, sym.scaler * sym.scaler)}
+                          </td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">
+                            {formatPrice(s.fees + s.liquidationFees, sym.scaler)}
+                          </td>
+                          <td className="num py-2 text-right tabular-nums">{s.tradeCount}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Account statement snapshot */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                <Receipt className="h-4 w-4 text-muted-foreground" />
+                Account statement (snapshot)
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {statementLines.length === 0 ? (
+                <p className="py-4 text-sm text-muted-foreground">
+                  No balance or position data available in this session.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[420px] text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-xs text-muted-foreground">
+                        <th className="py-2 pr-3 font-medium">Section</th>
+                        <th className="py-2 pr-3 font-medium">Account / Asset</th>
+                        <th className="py-2 pr-3 text-right font-medium">Amount</th>
+                        <th className="py-2 font-medium">Note</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {statementLines.map((l, i) => (
+                        <tr key={`${l.section}:${l.label}:${l.note ?? ""}:${i}`} className="border-b last:border-0">
+                          <td className="py-2 pr-3">{l.section}</td>
+                          <td className="py-2 pr-3 font-medium">{l.label}</td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">
+                            {formatPrice(l.amount, l.scaler)}
+                          </td>
+                          <td className="py-2 text-muted-foreground">{l.note ?? ""}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+              <Separator className="my-3" />
+              <p className="text-[11px] text-muted-foreground">
+                A point-in-time snapshot of your spot + margin balances and open position. Engine int64
+                ticks scaled per symbol.
+              </p>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import { Phone } from "lucide-react";
+import { Phone, Keyboard } from "lucide-react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -11,6 +11,7 @@ import { Appearance } from "./Appearance";
 import { AppearanceSection } from "./AppearanceSection";
 import { JiraIntegrationSettings } from "./JiraIntegrationSettings";
 import { TradingSettings } from "./TradingSettings";
+import { openShortcutsHelp } from "@/components/layout/KeyboardShortcutsHost";
 
 export default function SettingsPage() {
   const { t } = useTranslation();
@@ -88,6 +89,26 @@ export default function SettingsPage() {
             <Link to="/settings/call-rate" data-testid="call-rate-settings-link">
               Manage Call Rate
             </Link>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Keyboard className="h-4 w-4" />
+            Keyboard shortcuts
+          </CardTitle>
+        </CardHeader>
+        <Separator />
+        <CardContent className="pt-4">
+          <p className="mb-3 text-sm text-muted-foreground">
+            Power-user navigation and trading hotkeys. Press{" "}
+            <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs">?</kbd>{" "}
+            anywhere to view them, or toggle them on and off.
+          </p>
+          <Button variant="outline" onClick={() => openShortcutsHelp()}>
+            View keyboard shortcuts
           </Button>
         </CardContent>
       </Card>

--- a/frontend/src/pages/settings/TradingSettings.tsx
+++ b/frontend/src/pages/settings/TradingSettings.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useUiStore, type Theme } from "@/stores/uiStore";
+import { useUiStore, type Theme, type AccentColor, type Density } from "@/stores/uiStore";
 import { useSymbols } from "@/hooks/useMarketData";
 import type { TradingAlertKind } from "@/hooks/useTradingAlerts";
 import {
@@ -31,6 +31,22 @@ const THEME_OPTIONS: { value: Theme; label: string }[] = [
   { value: "light", label: "Light" },
   { value: "dark", label: "Dark" },
   { value: "system", label: "System" },
+];
+
+// Accent presets (subset of the full appearance palette) - swatches shown inline.
+const ACCENT_OPTIONS: { value: AccentColor; label: string; color: string }[] = [
+  { value: "blue",   label: "Blue",   color: "hsl(221.2 83.2% 53.3%)" },
+  { value: "purple", label: "Purple", color: "hsl(262 83% 58%)" },
+  { value: "green",  label: "Green",  color: "hsl(142 71% 45%)" },
+  { value: "orange", label: "Orange", color: "hsl(25 95% 53%)" },
+  { value: "pink",   label: "Pink",   color: "hsl(330 81% 60%)" },
+  { value: "teal",   label: "Teal",   color: "hsl(173 80% 40%)" },
+];
+
+// Density options (default = comfortable, matching the current look).
+const DENSITY_OPTIONS: { value: Density; label: string }[] = [
+  { value: "compact",     label: "Compact" },
+  { value: "comfortable", label: "Comfortable" },
 ];
 
 const ALERT_KINDS: { kind: TradingAlertKind; label: string; hint: string }[] = [
@@ -52,6 +68,10 @@ function currentNotifyStatus(): NotifyStatus {
 export function TradingSettings() {
   const theme = useUiStore((s) => s.theme);
   const setTheme = useUiStore((s) => s.setTheme);
+  const density = useUiStore((s) => s.density);
+  const setDensity = useUiStore((s) => s.setDensity);
+  const accentColor = useUiStore((s) => s.accentColor);
+  const setAccentColor = useUiStore((s) => s.setAccentColor);
 
   const symbolsQuery = useSymbols();
   const symbols = symbolsQuery.data?.symbols ?? [];
@@ -135,6 +155,64 @@ export function TradingSettings() {
               ))}
             </SelectContent>
           </Select>
+        </div>
+
+        <Separator />
+
+        {/* Density */}
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Density</Label>
+          <p className="text-xs text-muted-foreground">
+            Comfortable spacing, or compact to fit more on screen.
+          </p>
+          <div className="inline-flex rounded-md border p-0.5" role="group" data-testid="trading-density-toggle">
+            {DENSITY_OPTIONS.map((d) => (
+              <Button
+                key={d.value}
+                type="button"
+                size="sm"
+                variant={density === d.value ? "default" : "ghost"}
+                className="h-8 px-3"
+                aria-pressed={density === d.value}
+                onClick={() => setDensity(d.value)}
+              >
+                {d.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* Accent color */}
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Accent color</Label>
+          <p className="text-xs text-muted-foreground">
+            Tints buttons, links, and highlights across the app.
+          </p>
+          <div className="flex flex-wrap gap-2" role="group" data-testid="trading-accent-picker">
+            {ACCENT_OPTIONS.map((a) => (
+              <button
+                key={a.value}
+                type="button"
+                title={a.label}
+                aria-label={a.label}
+                aria-pressed={accentColor === a.value}
+                onClick={() => setAccentColor(a.value)}
+                className={
+                  "flex h-8 w-8 items-center justify-center rounded-full border-2 transition-transform hover:scale-110 " +
+                  (accentColor === a.value
+                    ? "border-foreground ring-2 ring-offset-2 ring-offset-background ring-foreground/30"
+                    : "border-transparent")
+                }
+                style={{ backgroundColor: a.color }}
+              >
+                {accentColor === a.value ? (
+                  <Check className="h-4 w-4 text-white drop-shadow" />
+                ) : null}
+              </button>
+            ))}
+          </div>
         </div>
 
         <Separator />


### PR DESCRIPTION
Four more frontend features:

- **Depth chart + time & sales** — cumulative order-book depth (tested depth math) + a live trade tape, tabbed into the symbol view (web SVG / android Canvas).
- **Export & reporting** — period-scoped CSV (trades/PnL/statement) + web Print-to-PDF + android share-sheet; tested CSV builders.
- **Keyboard shortcuts** (web-only) — g-nav sequences, trade-view hotkeys, help overlay; no auto-submit (money-safety).
- **PWA + density/accent** — web PWA (installable/offline, API never cached) with density+accent controls surfaced in settings; android accent picker + compact density through the theme.

~65 new unit tests; each phase gated (web build+tsc+vitest, android assembleDebug+testDebugUnitTest) and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)