### PR TITLE
feat: paper trading — client-side simulation (web + android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.PieChart
 import androidx.compose.material.icons.outlined.ShowChart
+import androidx.compose.material.icons.outlined.Science
 import androidx.compose.material.icons.outlined.Assessment
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.Devices
@@ -986,6 +987,14 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_pnl,
             icon = Icons.Outlined.ShowChart,
             route = MoreRoutes.PNL,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "paper_trading",
+            labelRes = R.string.more_entry_paper_trading,
+            icon = Icons.Outlined.Science,
+            route = MoreRoutes.PAPER,
             hub = MoreHub.WALLET,
             section = MoreSection.APP,
         ),

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperAccountStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperAccountStore.kt
@@ -1,0 +1,177 @@
+package com.testlogon.android.feature.paper
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapter
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.paper.PaperEngine.PaperAccount
+import com.testlogon.android.feature.paper.PaperEngine.PaperFill
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrder
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderStatus
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+import com.testlogon.android.feature.paper.PaperEngine.PaperPosition
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.paperTradingDataStore by preferencesDataStore(name = "paper_trading")
+
+/**
+ * Durable snapshot store for the client-side paper-trading [PaperAccount] (persisted as one Moshi JSON
+ * blob in DataStore). The account is a self-contained value graph, so the whole thing is serialized/
+ * deserialized on every save/load — cheap for a single account. Interface seam so the VM can inject an
+ * in-memory fake on the JVM. Every read/write is failure-safe (a store error degrades to "no data" /
+ * no-op, never throws).
+ */
+interface PaperAccountStore {
+    /** Load the persisted account, or null when nothing has been saved yet. */
+    suspend fun load(): PaperAccount?
+
+    /** Persist the whole account snapshot (overwrites the prior save). */
+    suspend fun save(account: PaperAccount)
+
+    /** Drop the persisted account entirely (a subsequent [load] returns null). */
+    suspend fun clear()
+}
+
+@Singleton
+class DataStorePaperAccountStore @Inject constructor(
+    @ApplicationContext context: Context,
+    moshi: Moshi,
+) : PaperAccountStore {
+
+    private val dataStore = context.paperTradingDataStore
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private val adapter = moshi.adapter<PaperAccountJson>()
+
+    override suspend fun load(): PaperAccount? = runCatching {
+        val prefs = dataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .first()
+        prefs[Keys.ACCOUNT]?.let { adapter.fromJson(it) }?.toDomain()
+    }.getOrNull()
+
+    override suspend fun save(account: PaperAccount) {
+        runCatching { dataStore.edit { it[Keys.ACCOUNT] = adapter.toJson(account.toJson()) } }
+    }
+
+    override suspend fun clear() {
+        runCatching { dataStore.edit { it.remove(Keys.ACCOUNT) } }
+    }
+
+    private object Keys {
+        val ACCOUNT = stringPreferencesKey("paper_account_json")
+    }
+}
+
+// ---- JSON wire model (KSP codegen adapters; unit-test-safe with a plain Moshi.Builder) ----
+
+@JsonClass(generateAdapter = true)
+internal data class PaperAccountJson(
+    val cash: Long,
+    val positions: List<PaperPositionJson> = emptyList(),
+    val orders: List<PaperOrderJson> = emptyList(),
+    val fills: List<PaperFillJson> = emptyList(),
+    val realizedPnl: Long = 0L,
+    val startingCash: Long,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PaperPositionJson(
+    val symbolId: Int,
+    val qty: Long,
+    val avgEntry: Long,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PaperOrderJson(
+    val id: String,
+    val symbolId: Int,
+    val side: String,
+    val type: String,
+    val qty: Long,
+    val limitPrice: Long? = null,
+    val status: String,
+    val createdTsMs: Long = 0L,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PaperFillJson(
+    val orderId: String,
+    val symbolId: Int,
+    val side: String,
+    val price: Long,
+    val qty: Long,
+    val tsMs: Long = 0L,
+)
+
+private fun sideOf(s: String): OrderSide =
+    runCatching { OrderSide.valueOf(s) }.getOrDefault(OrderSide.BUY)
+
+internal fun PaperAccountJson.toDomain() = PaperAccount(
+    cash = cash,
+    positions = positions.associate { it.symbolId to PaperPosition(it.qty, it.avgEntry) },
+    orders = orders.map { o ->
+        PaperOrder(
+            id = o.id,
+            symbolId = o.symbolId,
+            side = sideOf(o.side),
+            type = runCatching { PaperOrderType.valueOf(o.type) }.getOrDefault(PaperOrderType.MARKET),
+            qty = o.qty,
+            limitPrice = o.limitPrice,
+            status = runCatching { PaperOrderStatus.valueOf(o.status) }
+                .getOrDefault(PaperOrderStatus.WORKING),
+            createdTsMs = o.createdTsMs,
+        )
+    },
+    fills = fills.map { f ->
+        PaperFill(
+            orderId = f.orderId,
+            symbolId = f.symbolId,
+            side = sideOf(f.side),
+            price = f.price,
+            qty = f.qty,
+            tsMs = f.tsMs,
+        )
+    },
+    realizedPnl = realizedPnl,
+    startingCash = startingCash,
+)
+
+internal fun PaperAccount.toJson() = PaperAccountJson(
+    cash = cash,
+    positions = positions.map { (symbolId, p) -> PaperPositionJson(symbolId, p.qty, p.avgEntry) },
+    orders = orders.map { o ->
+        PaperOrderJson(
+            id = o.id,
+            symbolId = o.symbolId,
+            side = o.side.name,
+            type = o.type.name,
+            qty = o.qty,
+            limitPrice = o.limitPrice,
+            status = o.status.name,
+            createdTsMs = o.createdTsMs,
+        )
+    },
+    fills = fills.map { f ->
+        PaperFillJson(
+            orderId = f.orderId,
+            symbolId = f.symbolId,
+            side = f.side.name,
+            price = f.price,
+            qty = f.qty,
+            tsMs = f.tsMs,
+        )
+    },
+    realizedPnl = realizedPnl,
+    startingCash = startingCash,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperEngine.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperEngine.kt
@@ -1,0 +1,262 @@
+package com.testlogon.android.feature.paper
+
+import com.testlogon.android.data.exchange.OrderSide
+
+/**
+ * PURE, framework-free paper-trading engine -- the client-side simulation core. NO Android / coroutine /
+ * Compose / network dependencies: every function below is a plain, deterministic transformation over
+ * immutable value types so it can be unit-tested in isolation and called freely from a ViewModel.
+ *
+ * This engine NEVER touches the real order/matching stack -- it exists only to let a user practise with
+ * simulated funds. All money / price / quantity are raw int64 engine units (Long), matching the rest of
+ * the trading stack (price scalers are 1 today, so notional = price * qty). Position [qty] is SIGNED:
+ * positive = long, negative = short.
+ *
+ * Accounting is AVERAGE-COST: extending a position folds the fill into a weighted-average entry; reducing
+ * or closing realizes (fillPrice - avgEntry) * closedQty * dir (dir = +1 while long, -1 while short); a
+ * fill larger than the open position cleanly flips it, re-seeding avgEntry at the fill price for the
+ * residual. Cash moves on every fill (buy: cash -= price*qty ; sell: cash += price*qty), so a short sale
+ * credits cash and a buy-to-cover debits it, exactly like the real venue's cash leg.
+ */
+object PaperEngine {
+
+    /** Order type for a paper order. */
+    enum class PaperOrderType { MARKET, LIMIT }
+
+    /** Lifecycle of a paper order. MARKET orders are FILLED immediately; LIMIT orders start WORKING. */
+    enum class PaperOrderStatus { WORKING, FILLED, CANCELLED }
+
+    /**
+     * A simulated order. [limitPrice] is required for LIMIT and ignored for MARKET. [qty] is always a
+     * positive magnitude; [side] carries the direction. [id] is a caller-supplied stable identifier.
+     */
+    data class PaperOrder(
+        val id: String,
+        val symbolId: Int,
+        val side: OrderSide,
+        val type: PaperOrderType,
+        val qty: Long,
+        val limitPrice: Long? = null,
+        val status: PaperOrderStatus = PaperOrderStatus.WORKING,
+        val createdTsMs: Long = 0L,
+    )
+
+    /** A simulated fill (audit trail + history UI). [qty] is a positive magnitude; [side] the direction. */
+    data class PaperFill(
+        val orderId: String,
+        val symbolId: Int,
+        val side: OrderSide,
+        val price: Long,
+        val qty: Long,
+        val tsMs: Long = 0L,
+    )
+
+    /** A held position. [qty] is SIGNED (negative = short). [avgEntry] is the average-cost basis (>=0). */
+    data class PaperPosition(
+        val qty: Long,
+        val avgEntry: Long,
+    )
+
+    /**
+     * The whole simulated account. [cash] is free simulated cash (can go negative under leverage/shorts,
+     * matching a real cash leg). [positions] is keyed by symbolId; a symbol with a flat position is
+     * removed. [realizedPnl] accumulates closed-trade PnL. [startingCash] is retained for the account
+     * panel + reset baseline.
+     */
+    data class PaperAccount(
+        val cash: Long,
+        val positions: Map<Int, PaperPosition>,
+        val orders: List<PaperOrder>,
+        val fills: List<PaperFill>,
+        val realizedPnl: Long,
+        val startingCash: Long,
+    )
+
+    /** A fresh account seeded with [startingCash] free cash and nothing open. */
+    fun newAccount(startingCash: Long): PaperAccount = PaperAccount(
+        cash = startingCash,
+        positions = emptyMap(),
+        orders = emptyList(),
+        fills = emptyList(),
+        realizedPnl = 0L,
+        startingCash = startingCash,
+    )
+
+    private fun dirOf(side: OrderSide): Int = if (side == OrderSide.BUY) 1 else -1
+
+    /**
+     * Place [order] against the current [marketPrice]. A MARKET order (and a LIMIT order already
+     * marketable at placement) fills IMMEDIATELY: MARKET at [marketPrice], a marketable LIMIT at its
+     * limit price (never worse than the limit). A non-marketable LIMIT is appended as a WORKING order to
+     * be filled later by [onTick]. Orders with a non-positive qty, or a LIMIT with no limit price, are
+     * ignored (returned unchanged) rather than corrupting the book.
+     */
+    fun placeOrder(acct: PaperAccount, order: PaperOrder, marketPrice: Long): PaperAccount {
+        if (order.qty <= 0L) return acct
+        return when (order.type) {
+            PaperOrderType.MARKET ->
+                fillOrder(acct, order.copy(status = PaperOrderStatus.FILLED), marketPrice)
+            PaperOrderType.LIMIT -> {
+                val limit = order.limitPrice ?: return acct
+                if (isMarketable(order.side, limit, marketPrice)) {
+                    // Marketable on arrival -- fill at the limit (price improvement kept by the venue-sim).
+                    fillOrder(acct, order.copy(status = PaperOrderStatus.FILLED), limit)
+                } else {
+                    acct.copy(orders = acct.orders + order.copy(status = PaperOrderStatus.WORKING))
+                }
+            }
+        }
+    }
+
+    /** A LIMIT is marketable when a BUY limit >= market, or a SELL limit <= market. */
+    private fun isMarketable(side: OrderSide, limit: Long, marketPrice: Long): Boolean =
+        if (side == OrderSide.BUY) marketPrice <= limit else marketPrice >= limit
+
+    /**
+     * Feed a new [marketPrice] for [symbolId] to the account, filling any WORKING LIMIT order on that
+     * symbol that the price has reached: a BUY limit fills when marketPrice <= limit; a SELL limit fills
+     * when marketPrice >= limit. Each triggered order fills at ITS OWN limit price (the sim assumes the
+     * resting order is filled at its posted price). Orders are processed oldest-first.
+     */
+    fun onTick(acct: PaperAccount, symbolId: Int, marketPrice: Long): PaperAccount {
+        var current = acct
+        // Snapshot the working orders to fill so we iterate a stable list while `current` mutates.
+        val toFill = acct.orders.filter {
+            it.status == PaperOrderStatus.WORKING &&
+                it.symbolId == symbolId &&
+                it.type == PaperOrderType.LIMIT &&
+                it.limitPrice != null &&
+                triggers(it.side, it.limitPrice, marketPrice)
+        }
+        for (order in toFill) {
+            val limit = order.limitPrice ?: continue
+            current = fillOrder(current, order.copy(status = PaperOrderStatus.FILLED), limit)
+        }
+        return current
+    }
+
+    /** A resting BUY limit triggers at marketPrice <= limit; a resting SELL limit at marketPrice >= limit. */
+    private fun triggers(side: OrderSide, limit: Long, marketPrice: Long): Boolean =
+        if (side == OrderSide.BUY) marketPrice <= limit else marketPrice >= limit
+
+    /**
+     * Cancel the WORKING order with [orderId] (no-op if it's absent or already terminal). The order is
+     * marked CANCELLED in place so it stays in history rather than vanishing.
+     */
+    fun cancelOrder(acct: PaperAccount, orderId: String): PaperAccount {
+        val idx = acct.orders.indexOfFirst { it.id == orderId && it.status == PaperOrderStatus.WORKING }
+        if (idx < 0) return acct
+        val updated = acct.orders.toMutableList()
+        updated[idx] = updated[idx].copy(status = PaperOrderStatus.CANCELLED)
+        return acct.copy(orders = updated)
+    }
+
+    /**
+     * Apply a fill of [order] at [fillPrice] to [acct]: average-cost position update + realized PnL +
+     * cash leg + fill-history append + the order marked FILLED (replacing its WORKING entry when present,
+     * else appended). The single choke point every fill path routes through.
+     */
+    private fun fillOrder(acct: PaperAccount, order: PaperOrder, fillPrice: Long): PaperAccount {
+        val dir = dirOf(order.side)
+        val signedQty = dir * order.qty
+        val existing = acct.positions[order.symbolId] ?: PaperPosition(0L, 0L)
+
+        var netQty = existing.qty
+        var avgEntry = existing.avgEntry
+        var realized = 0L
+
+        if (netQty == 0L || sameSign(netQty, signedQty)) {
+            // Opening or extending: weighted-average the entry over the (growing) absolute size.
+            avgEntry = weightedEntry(netQty, avgEntry, order.qty, fillPrice)
+            netQty += signedQty
+        } else {
+            // Opposite side: close against the open position (up to its size), realizing PnL.
+            val closable = minOf(order.qty, Math.abs(netQty))
+            val posDir = if (netQty > 0) 1 else -1
+            realized = (fillPrice - avgEntry) * closable * posDir
+            val remaining = Math.abs(netQty) - closable
+            netQty = posDir.toLong() * remaining
+            if (netQty == 0L) {
+                avgEntry = 0L
+                // Any residual beyond the close flips the position, re-seeded at the fill price.
+                val flip = order.qty - closable
+                if (flip > 0L) {
+                    netQty = dir.toLong() * flip
+                    avgEntry = fillPrice
+                }
+            }
+        }
+
+        // Cash leg: buy debits price*qty, sell credits price*qty (short sale credits, cover debits).
+        val cashDelta = -signedQty * fillPrice
+        val newPositions = acct.positions.toMutableMap()
+        if (netQty == 0L) {
+            newPositions.remove(order.symbolId)
+        } else {
+            newPositions[order.symbolId] = PaperPosition(qty = netQty, avgEntry = avgEntry)
+        }
+
+        val fill = PaperFill(
+            orderId = order.id,
+            symbolId = order.symbolId,
+            side = order.side,
+            price = fillPrice,
+            qty = order.qty,
+            tsMs = order.createdTsMs,
+        )
+
+        // Replace the working order in place (limit fill) or append (market / marketable-on-arrival).
+        val orders = if (acct.orders.any { it.id == order.id }) {
+            acct.orders.map { if (it.id == order.id) order else it }
+        } else {
+            acct.orders + order
+        }
+
+        return acct.copy(
+            cash = acct.cash + cashDelta,
+            positions = newPositions,
+            orders = orders,
+            fills = acct.fills + fill,
+            realizedPnl = acct.realizedPnl + realized,
+        )
+    }
+
+    private fun sameSign(a: Long, b: Long): Boolean = (a > 0 && b > 0) || (a < 0 && b < 0)
+
+    /** Weighted-average entry when adding [addQty] @ [addPrice] onto |[heldQty]| @ [heldEntry]. */
+    private fun weightedEntry(heldQty: Long, heldEntry: Long, addQty: Long, addPrice: Long): Long {
+        val held = Math.abs(heldQty)
+        val total = held + addQty
+        if (total == 0L) return 0L
+        return (held * heldEntry + addQty * addPrice) / total
+    }
+
+    /**
+     * Mark-to-market value of a single [position] at [markPrice]: signed unrealized PnL =
+     * (mark - avgEntry) * qty (qty already carries the sign, so a short profits as the mark falls).
+     */
+    fun positionMtm(position: PaperPosition, markPrice: Long): Long =
+        (markPrice - position.avgEntry) * position.qty
+
+    /**
+     * Total unrealized PnL across all open positions, given a [marks] map of symbolId -> mark price.
+     * A position with no available mark contributes 0 (unknown, not fabricated).
+     */
+    fun unrealized(acct: PaperAccount, marks: Map<Int, Long>): Long =
+        acct.positions.entries.sumOf { (symbolId, pos) ->
+            val mark = marks[symbolId] ?: return@sumOf 0L
+            positionMtm(pos, mark)
+        }
+
+    /**
+     * Account equity = free cash + mark value of every open position (avg-entry basis + its unrealized).
+     * Equivalently cash + sum(qty * mark) over positions with a known mark; a position with no mark
+     * contributes its cost basis only (mark treated as avgEntry -> 0 unrealized) so equity never jumps on
+     * missing data.
+     */
+    fun equity(acct: PaperAccount, marks: Map<Int, Long>): Long =
+        acct.cash + acct.positions.entries.sumOf { (symbolId, pos) ->
+            val mark = marks[symbolId] ?: pos.avgEntry
+            pos.qty * mark
+        }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperModule.kt
@@ -1,0 +1,17 @@
+package com.testlogon.android.feature.paper
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Binds the durable paper-trading account store (DataStore + Moshi) for injection into the ViewModel. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PaperModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindPaperAccountStore(impl: DataStorePaperAccountStore): PaperAccountStore
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperScreen.kt
@@ -1,0 +1,442 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.paper
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.RestartAlt
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.Button
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.markets.trade.OrderMath
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+import java.util.Locale
+
+private val Up = Color(0xFF16A34A)
+private val Down = Color(0xFFDC2626)
+
+@Composable
+fun PaperRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PaperViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PaperScreen(
+        state = state,
+        onBack = onBack,
+        onSelectSymbol = viewModel::onSelectSymbol,
+        onSideChange = viewModel::onSideChange,
+        onTypeChange = viewModel::onTypeChange,
+        onQtyChange = viewModel::onQtyChange,
+        onLimitPriceChange = viewModel::onLimitPriceChange,
+        onSubmit = viewModel::onSubmit,
+        onCancelOrder = viewModel::onCancelOrder,
+        onReset = viewModel::onReset,
+        onConsumeToast = viewModel::consumeToast,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PaperScreen(
+    state: PaperUiState,
+    onBack: () -> Unit,
+    onSelectSymbol: (Int) -> Unit,
+    onSideChange: (OrderSide) -> Unit,
+    onTypeChange: (PaperOrderType) -> Unit,
+    onQtyChange: (String) -> Unit,
+    onLimitPriceChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onCancelOrder: (String) -> Unit,
+    onReset: () -> Unit,
+    onConsumeToast: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackbar = remember { SnackbarHostState() }
+    var confirmReset by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.toast) {
+        state.toast?.let {
+            snackbar.showSnackbar(it)
+            onConsumeToast()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackbar) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Paper Trading") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { confirmReset = true }) {
+                        Icon(Icons.Filled.RestartAlt, contentDescription = "Reset paper account")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (state.loading) {
+            Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { PaperBanner() }
+            item {
+                SymbolAndPrice(state = state, onSelectSymbol = onSelectSymbol)
+            }
+            item { AccountPanel(state) }
+            item {
+                OrderTicket(
+                    state = state,
+                    onSideChange = onSideChange,
+                    onTypeChange = onTypeChange,
+                    onQtyChange = onQtyChange,
+                    onLimitPriceChange = onLimitPriceChange,
+                    onSubmit = onSubmit,
+                )
+            }
+            item { SectionHeader("Positions") }
+            if (state.positions.isEmpty()) {
+                item { EmptyRow("No open positions") }
+            } else {
+                items(state.positions, key = { it.symbolId }) { PositionRow(it) }
+            }
+            item { SectionHeader("Working orders") }
+            if (state.workingOrders.isEmpty()) {
+                item { EmptyRow("No working orders") }
+            } else {
+                items(state.workingOrders, key = { it.id }) { WorkingOrderRow(it, onCancelOrder) }
+            }
+            item { SectionHeader("Fill history") }
+            if (state.fills.isEmpty()) {
+                item { EmptyRow("No fills yet") }
+            } else {
+                items(state.fills) { FillRow(it) }
+            }
+        }
+    }
+
+    if (confirmReset) {
+        AlertDialog(
+            onDismissRequest = { confirmReset = false },
+            title = { Text("Reset paper account?") },
+            text = { Text("This clears all simulated positions, orders, fills, and PnL, and restores the starting balance. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = { confirmReset = false; onReset() }) { Text("Reset") }
+            },
+            dismissButton = { TextButton(onClick = { confirmReset = false }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun PaperBanner() {
+    Surface(
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            "PAPER — simulated trading, not real funds",
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+        )
+    }
+}
+
+@Composable
+private fun SymbolAndPrice(state: PaperUiState, onSelectSymbol: (Int) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    val selected = state.selectedSymbol
+    Card(Modifier.fillMaxWidth()) {
+        Row(
+            Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+                OutlinedTextField(
+                    value = selected?.symbol ?: "Select symbol",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Symbol") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier.menuAnchor().width(190.dp),
+                )
+                ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    state.symbols.forEach { s ->
+                        DropdownMenuItem(
+                            text = { Text(s.symbol) },
+                            onClick = { expanded = false; onSelectSymbol(s.symbolId) },
+                        )
+                    }
+                }
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text("Mark", style = MaterialTheme.typography.labelSmall)
+                Text(
+                    state.markPrice?.let { fmt(it) } ?: "—",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountPanel(state: PaperUiState) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            StatLine("Starting balance", fmt(state.startingCash))
+            StatLine("Cash", fmt(state.cash))
+            StatLine("Equity", fmt(state.equity), if (state.isEquityUp) Up else Down)
+            HorizontalDivider(Modifier.padding(vertical = 4.dp))
+            StatLine("Realized PnL", signed(state.realizedPnl), pnlColor(state.realizedPnl))
+            StatLine("Unrealized PnL", signed(state.unrealizedPnl), pnlColor(state.unrealizedPnl))
+            StatLine("Total PnL", signed(state.totalPnl), pnlColor(state.totalPnl), bold = true)
+        }
+    }
+}
+
+@Composable
+private fun StatLine(label: String, value: String, color: Color? = null, bold: Boolean = false) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = if (bold) FontWeight.Bold else FontWeight.Normal,
+            color = color ?: MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun OrderTicket(
+    state: PaperUiState,
+    onSideChange: (OrderSide) -> Unit,
+    onTypeChange: (PaperOrderType) -> Unit,
+    onQtyChange: (String) -> Unit,
+    onLimitPriceChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    val ticket = state.ticket
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("New paper order", style = MaterialTheme.typography.titleMedium)
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(selected = ticket.side == OrderSide.BUY, onClick = { onSideChange(OrderSide.BUY) }, label = { Text("Buy") })
+                FilterChip(selected = ticket.side == OrderSide.SELL, onClick = { onSideChange(OrderSide.SELL) }, label = { Text("Sell") })
+                Spacer(Modifier.width(8.dp))
+                FilterChip(selected = ticket.type == PaperOrderType.MARKET, onClick = { onTypeChange(PaperOrderType.MARKET) }, label = { Text("Market") })
+                FilterChip(selected = ticket.type == PaperOrderType.LIMIT, onClick = { onTypeChange(PaperOrderType.LIMIT) }, label = { Text("Limit") })
+            }
+            OutlinedTextField(
+                value = ticket.qtyInput,
+                onValueChange = onQtyChange,
+                label = { Text("Quantity") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (ticket.type == PaperOrderType.LIMIT) {
+                OutlinedTextField(
+                    value = ticket.limitPriceInput,
+                    onValueChange = onLimitPriceChange,
+                    label = { Text("Limit price") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            // Reuse OrderMath for the notional preview at the effective price.
+            val price = if (ticket.type == PaperOrderType.LIMIT) ticket.limitPrice else state.markPrice
+            val notional = OrderMath.notional(price, ticket.qty)
+            Text(
+                "Est. notional: " + (notional?.let { fmt(it) } ?: "—"),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Button(
+                onClick = onSubmit,
+                enabled = ticket.isValid() && state.markPrice != null,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    (if (ticket.side == OrderSide.BUY) "Buy" else "Sell") + " " +
+                        (if (ticket.type == PaperOrderType.MARKET) "market" else "limit") + " (paper)",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PositionRow(row: PaperPositionRow) {
+    Card(Modifier.fillMaxWidth(), colors = CardDefaults.cardColors()) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text(row.symbol, fontWeight = FontWeight.Bold)
+                Text(
+                    (if (row.isLong) "Long " else "Short ") + Math.abs(row.qty) + " @ " + fmt(row.avgEntry),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text("Mark " + (row.mark?.let { fmt(it) } ?: "—"), style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace)
+                Text(
+                    signed(row.unrealized),
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Bold,
+                    color = pnlColor(row.unrealized),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkingOrderRow(row: PaperOrderRow, onCancel: (String) -> Unit) {
+    Card(Modifier.fillMaxWidth()) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 16.dp, top = 4.dp, bottom = 4.dp, end = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text(row.symbol, fontWeight = FontWeight.Bold)
+                Text(
+                    (if (row.side == OrderSide.BUY) "Buy" else "Sell") + " " + row.qty +
+                        (row.limitPrice?.let { " limit @ " + fmt(it) } ?: ""),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = { onCancel(row.id) }) {
+                Icon(Icons.Filled.Close, contentDescription = "Cancel order")
+            }
+        }
+    }
+}
+
+@Composable
+private fun FillRow(row: PaperFillRow) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 6.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            row.symbol + "  " + (if (row.side == OrderSide.BUY) "Buy" else "Sell"),
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (row.side == OrderSide.BUY) Up else Down,
+        )
+        Text(
+            row.qty.toString() + " @ " + fmt(row.price),
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}
+
+@Composable
+private fun EmptyRow(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(vertical = 4.dp),
+    )
+}
+
+@Composable
+private fun pnlColor(v: Long): Color = if (v >= 0) Up else Down
+
+private fun fmt(ticks: Long): String = "$" + String.format(Locale.US, "%,d", ticks)
+
+private fun signed(ticks: Long): String =
+    (if (ticks >= 0) "+" else "-") + "$" + String.format(Locale.US, "%,d", Math.abs(ticks))

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperUiState.kt
@@ -1,0 +1,85 @@
+package com.testlogon.android.feature.paper
+
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+
+/**
+ * Render-ready UI state for the self-contained Paper Trading screen. The ViewModel keeps the pure
+ * [PaperEngine.PaperAccount] internally and projects it (plus the selected symbol, live mark, and the
+ * user's staged order-ticket inputs) into this immutable shape. Nothing here moves real money.
+ */
+data class PaperUiState(
+    val loading: Boolean = true,
+    // ---- market data ----
+    val symbols: List<Instrument> = emptyList(),
+    val selectedSymbolId: Int? = null,
+    /** Latest simulated mark price for the selected symbol (raw ticks), null until first quote. */
+    val markPrice: Long? = null,
+    // ---- account panel ----
+    val startingCash: Long = 0L,
+    val cash: Long = 0L,
+    val equity: Long = 0L,
+    val realizedPnl: Long = 0L,
+    val unrealizedPnl: Long = 0L,
+    // ---- tables ----
+    val positions: List<PaperPositionRow> = emptyList(),
+    val workingOrders: List<PaperOrderRow> = emptyList(),
+    val fills: List<PaperFillRow> = emptyList(),
+    // ---- order ticket ----
+    val ticket: PaperTicket = PaperTicket(),
+    // ---- transient one-shot user feedback (consumed by the screen) ----
+    val toast: String? = null,
+) {
+    val selectedSymbol: Instrument?
+        get() = symbols.firstOrNull { it.symbolId == selectedSymbolId }
+
+    val totalPnl: Long get() = realizedPnl + unrealizedPnl
+    val isEquityUp: Boolean get() = equity >= startingCash
+}
+
+/** The user's staged order-ticket inputs (raw strings so the field can hold partial/invalid text). */
+data class PaperTicket(
+    val side: OrderSide = OrderSide.BUY,
+    val type: PaperOrderType = PaperOrderType.MARKET,
+    val qtyInput: String = "",
+    val limitPriceInput: String = "",
+) {
+    val qty: Long? get() = qtyInput.trim().toLongOrNull()?.takeIf { it > 0 }
+    val limitPrice: Long? get() = limitPriceInput.trim().toLongOrNull()?.takeIf { it > 0 }
+
+    /** True when the ticket has enough valid input to submit (limit requires a price). */
+    fun isValid(): Boolean =
+        qty != null && (type == PaperOrderType.MARKET || limitPrice != null)
+}
+
+/** One open-position row (signed qty long/short, avg entry, live mark, unrealized). */
+data class PaperPositionRow(
+    val symbolId: Int,
+    val symbol: String,
+    val qty: Long,
+    val avgEntry: Long,
+    val mark: Long?,
+    val unrealized: Long,
+) {
+    val isLong: Boolean get() = qty >= 0
+    val isProfit: Boolean get() = unrealized >= 0
+}
+
+/** One working (resting) order row (cancellable). */
+data class PaperOrderRow(
+    val id: String,
+    val symbol: String,
+    val side: OrderSide,
+    val qty: Long,
+    val limitPrice: Long?,
+)
+
+/** One historical fill row (newest first in the list). */
+data class PaperFillRow(
+    val symbol: String,
+    val side: OrderSide,
+    val price: Long,
+    val qty: Long,
+    val tsMs: Long,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperViewModel.kt
@@ -1,0 +1,224 @@
+package com.testlogon.android.feature.paper
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.paper.PaperEngine.PaperAccount
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrder
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderStatus
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives the self-contained Paper Trading screen. The pure [PaperEngine.PaperAccount] is the single
+ * source of truth; the VM loads/persists it via [PaperAccountStore], loads the instrument catalogue for
+ * the symbol picker, and polls the market-data feed for a live mark price. Each poll feeds the mark into
+ * [PaperEngine.onTick] so resting LIMIT orders fill as the (simulated) market moves, then re-projects +
+ * persists. NOTHING here touches the real order/matching stack — it is a client-side simulation.
+ */
+@HiltViewModel
+class PaperViewModel @Inject constructor(
+    private val exchange: ExchangeRepository,
+    private val store: PaperAccountStore,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PaperUiState())
+    val uiState: StateFlow<PaperUiState> = _uiState.asStateFlow()
+
+    /** The authoritative simulated account; the UI state is always a projection of this + live marks. */
+    private var account: PaperAccount = PaperEngine.newAccount(STARTING_CASH)
+    private var instruments: List<Instrument> = emptyList()
+
+    /** Latest known mark per symbol, so equity/unrealized use every position's price, not just the open one. */
+    private val marks = HashMap<Int, Long>()
+
+    init {
+        bootstrap()
+    }
+
+    private fun bootstrap() {
+        viewModelScope.launch {
+            account = store.load() ?: PaperEngine.newAccount(STARTING_CASH).also { store.save(it) }
+            val symbolsResult = exchange.symbols()
+            instruments = (symbolsResult as? ApiResult.Success)?.data ?: FALLBACK
+            val selected = _uiState.value.selectedSymbolId
+                ?: instruments.firstOrNull()?.symbolId
+            _uiState.update {
+                it.copy(loading = false, symbols = instruments, selectedSymbolId = selected)
+            }
+            project()
+            pollMarks()
+        }
+    }
+
+    /** Continuously refresh the selected symbol's mark and feed it into onTick while the VM is alive. */
+    private fun pollMarks() {
+        viewModelScope.launch {
+            while (isActive) {
+                val symbolId = _uiState.value.selectedSymbolId
+                if (symbolId != null) {
+                    val mark = fetchMark(symbolId)
+                    if (mark != null) {
+                        marks[symbolId] = mark
+                        // Feed the live price into the engine so limit orders fill as the market moves.
+                        val before = account
+                        account = PaperEngine.onTick(account, symbolId, mark)
+                        _uiState.update { it.copy(markPrice = mark) }
+                        if (account !== before) persist()
+                        project()
+                    }
+                }
+                delay(POLL_MS)
+            }
+        }
+    }
+
+    /** Best available live price for [symbolId]: last trade, else order-book mid. Null when unavailable. */
+    private suspend fun fetchMark(symbolId: Int): Long? {
+        val last = (exchange.trades(symbolId) as? ApiResult.Success)?.data?.firstOrNull()?.price
+        if (last != null) return last
+        val book = (exchange.orderBook(symbolId) as? ApiResult.Success)?.data
+        return book?.mid?.let { Math.round(it) }
+    }
+
+    fun onSelectSymbol(symbolId: Int) {
+        if (symbolId == _uiState.value.selectedSymbolId) return
+        _uiState.update { it.copy(selectedSymbolId = symbolId, markPrice = marks[symbolId]) }
+        // Kick an immediate mark fetch so the readout + preview update without waiting a full poll.
+        viewModelScope.launch {
+            val mark = fetchMark(symbolId)
+            if (mark != null) {
+                marks[symbolId] = mark
+                account = PaperEngine.onTick(account, symbolId, mark)
+                _uiState.update { it.copy(markPrice = mark) }
+                persist()
+                project()
+            }
+        }
+    }
+
+    // ---- ticket editing ----
+
+    fun onSideChange(side: OrderSide) = _uiState.update { it.copy(ticket = it.ticket.copy(side = side)) }
+    fun onTypeChange(type: PaperOrderType) = _uiState.update { it.copy(ticket = it.ticket.copy(type = type)) }
+    fun onQtyChange(v: String) = _uiState.update { it.copy(ticket = it.ticket.copy(qtyInput = v.filter { c -> c.isDigit() })) }
+    fun onLimitPriceChange(v: String) =
+        _uiState.update { it.copy(ticket = it.ticket.copy(limitPriceInput = v.filter { c -> c.isDigit() })) }
+
+    /** Submit the staged ticket. MARKET fills at the live mark; LIMIT rests (or fills if marketable). */
+    fun onSubmit() {
+        val state = _uiState.value
+        val ticket = state.ticket
+        val symbolId = state.selectedSymbolId ?: return
+        val qty = ticket.qty ?: run { toast("Enter a quantity"); return }
+        val mark = state.markPrice ?: run { toast("No live price yet — try again"); return }
+        if (ticket.type == PaperOrderType.LIMIT && ticket.limitPrice == null) {
+            toast("Enter a limit price"); return
+        }
+        val order = PaperOrder(
+            id = "po-" + System.currentTimeMillis() + "-" + (account.orders.size + 1),
+            symbolId = symbolId,
+            side = ticket.side,
+            type = ticket.type,
+            qty = qty,
+            limitPrice = if (ticket.type == PaperOrderType.LIMIT) ticket.limitPrice else null,
+            createdTsMs = System.currentTimeMillis(),
+        )
+        account = PaperEngine.placeOrder(account, order, mark)
+        val filled = account.fills.lastOrNull()?.orderId == order.id
+        toast(if (filled) "Order filled" else "Limit order working")
+        _uiState.update { it.copy(ticket = ticket.copy(qtyInput = "", limitPriceInput = "")) }
+        persist()
+        project()
+    }
+
+    fun onCancelOrder(orderId: String) {
+        account = PaperEngine.cancelOrder(account, orderId)
+        toast("Order cancelled")
+        persist()
+        project()
+    }
+
+    /** Reset to a fresh account (confirmed in the UI) and re-persist. */
+    fun onReset() {
+        account = PaperEngine.newAccount(STARTING_CASH)
+        marks.clear()
+        toast("Paper account reset")
+        persist()
+        project()
+        // Re-seed a mark for the current symbol on the next poll tick.
+    }
+
+    fun consumeToast() = _uiState.update { it.copy(toast = null) }
+
+    private fun toast(msg: String) = _uiState.update { it.copy(toast = msg) }
+
+    private fun persist() {
+        val snapshot = account
+        viewModelScope.launch { store.save(snapshot) }
+    }
+
+    /** Project the authoritative account + live marks into the render-ready [PaperUiState]. */
+    private fun project() {
+        val names = instruments.associate { it.symbolId to it.symbol }
+        fun name(id: Int) = names[id] ?: FALLBACK.firstOrNull { it.symbolId == id }?.symbol ?: "#$id"
+
+        val positionRows = account.positions.entries
+            .sortedBy { it.key }
+            .map { (symbolId, pos) ->
+                val mark = marks[symbolId]
+                val upl = if (mark != null) PaperEngine.positionMtm(pos, mark) else 0L
+                PaperPositionRow(
+                    symbolId = symbolId,
+                    symbol = name(symbolId),
+                    qty = pos.qty,
+                    avgEntry = pos.avgEntry,
+                    mark = mark,
+                    unrealized = upl,
+                )
+            }
+
+        val workingRows = account.orders
+            .filter { it.status == PaperOrderStatus.WORKING }
+            .map { PaperOrderRow(it.id, name(it.symbolId), it.side, it.qty, it.limitPrice) }
+
+        val fillRows = account.fills
+            .asReversed()
+            .map { PaperFillRow(name(it.symbolId), it.side, it.price, it.qty, it.tsMs) }
+
+        _uiState.update { s ->
+            s.copy(
+                symbols = instruments,
+                startingCash = account.startingCash,
+                cash = account.cash,
+                equity = PaperEngine.equity(account, marks),
+                realizedPnl = account.realizedPnl,
+                unrealizedPnl = PaperEngine.unrealized(account, marks),
+                positions = positionRows,
+                workingOrders = workingRows,
+                fills = fillRows,
+            )
+        }
+    }
+
+    private companion object {
+        const val STARTING_CASH = 100_000L
+        const val POLL_MS = 2_000L
+        val FALLBACK = listOf(
+            Instrument("BTCUSDC", 1, 1, 1, 100_000, false),
+            Instrument("ETHUSDC", 2, 1, 1, 3_000, false),
+            Instrument("SOLUSDC", 3, 1, 1, 150, false),
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -221,6 +221,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         portfolioDestination(navController)
         // PnL & performance: read-only realized/unrealized analytics, equity curve, per-symbol breakdown.
         pnlDestination(navController)
+        // Paper Trading: self-contained client-side trading simulation (isolated paper account; no real orders).
+        paperDestination(navController)
         // Export & reporting: read-only period-scoped CSV export (trade history / PnL / statement).
         reportsDestination(navController)
         // AND-336: backend-mediated Google Drive import picker (authenticated-only).

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -112,6 +112,10 @@ object MoreRoutes {
     // PnL & performance: read-only realized/unrealized analytics + equity curve (Wallet hub, near Portfolio).
     const val PNL = PnlDest.ROUTE
 
+    // Paper Trading: a SELF-CONTAINED client-side trading simulation (isolated paper account; NO real
+    // order calls). Reached from the More -> Wallet hub.
+    const val PAPER = PaperDest.ROUTE
+
     // Export & reporting: read-only period-scoped CSV export (Wallet hub, near PnL).
     const val REPORTS = ReportsDest.ROUTE
 
@@ -577,6 +581,7 @@ object MoreRoutes {
             CUSTODY,
             PORTFOLIO,
             PNL,
+            PAPER,
             REPORTS,
             PURCHASE_HISTORY,
             PAYMENT_METHODS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/PaperNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/PaperNavigation.kt
@@ -1,0 +1,25 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.paper.PaperRoute
+
+/**
+ * The self-contained PAPER TRADING surface, reached from the More -> Wallet hub. A client-side
+ * simulation: an isolated paper account (starting balance + positions + orders + fills + PnL) driven by
+ * the pure PaperEngine, fed live market-data marks so limit orders fill as the market moves. It NEVER
+ * touches the real order/matching stack — no real order is ever placed.
+ */
+data object PaperDest {
+    const val ROUTE = "paper/trade"
+}
+
+/** Registers the Paper Trading screen in the authenticated graph. Up / Back pops the back stack. */
+fun NavGraphBuilder.paperDestination(navController: NavHostController) {
+    composable(PaperDest.ROUTE) {
+        PaperRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1460,6 +1460,7 @@
     <string name="more_entry_custody">Custody</string>
     <string name="more_entry_portfolio">Portfolio</string>
     <string name="more_entry_pnl">PnL &amp; performance</string>
+    <string name="more_entry_paper_trading">Paper Trading</string>
     <string name="more_entry_reports">Export &amp; reporting</string>
     <string name="story_ring_unseen">Story from %1$s, unseen</string>
     <string name="story_ring_seen">Story from %1$s, seen</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/paper/PaperEngineTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/paper/PaperEngineTest.kt
@@ -1,0 +1,222 @@
+package com.testlogon.android.feature.paper
+
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrder
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderStatus
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Thorough unit tests for the PURE [PaperEngine]: market fills (buy & sell), limit fills (working ->
+ * triggered, buy & sell), average-cost realized PnL, weighted-average entry, short-selling, position
+ * flip, cash legs, equity/unrealized marks, and cancel.
+ */
+class PaperEngineTest {
+
+    private val BTC = 1
+    private val ETH = 2
+
+    private fun order(
+        id: String,
+        side: OrderSide,
+        type: PaperOrderType,
+        qty: Long,
+        limitPrice: Long? = null,
+        symbolId: Int = BTC,
+    ) = PaperOrder(id = id, symbolId = symbolId, side = side, type = type, qty = qty, limitPrice = limitPrice)
+
+    // ---- market fills ----
+
+    @Test
+    fun marketBuy_fillsImmediately_debitsCash_opensLong() {
+        val acct = PaperEngine.newAccount(1_000_000)
+        val after = PaperEngine.placeOrder(acct, order("o1", OrderSide.BUY, PaperOrderType.MARKET, 3), 100)
+        val pos = after.positions.getValue(BTC)
+        assertEquals(3L, pos.qty)
+        assertEquals(100L, pos.avgEntry)
+        assertEquals(1_000_000 - 300, after.cash)
+        assertEquals(1, after.fills.size)
+        assertEquals(PaperOrderStatus.FILLED, after.orders.single().status)
+    }
+
+    @Test
+    fun marketSell_fromFlat_opensShort_creditsCash() {
+        val acct = PaperEngine.newAccount(1_000_000)
+        val after = PaperEngine.placeOrder(acct, order("s1", OrderSide.SELL, PaperOrderType.MARKET, 2), 100)
+        val pos = after.positions.getValue(BTC)
+        assertEquals(-2L, pos.qty)
+        assertEquals(100L, pos.avgEntry)
+        assertEquals(1_000_000 + 200, after.cash)
+    }
+
+    // ---- average-cost realized (round trip) ----
+
+    @Test
+    fun buyThenSellHigher_realizesProfit_flatClosesPosition() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("b", OrderSide.BUY, PaperOrderType.MARKET, 10), 100)
+        acct = PaperEngine.placeOrder(acct, order("s", OrderSide.SELL, PaperOrderType.MARKET, 10), 130)
+        // realized = (130-100)*10 = 300
+        assertEquals(300L, acct.realizedPnl)
+        assertNull(acct.positions[BTC])
+        // cash: -1000 (buy) + 1300 (sell) = +300 over start
+        assertEquals(1_000_000 + 300, acct.cash)
+    }
+
+    @Test
+    fun weightedAverageEntry_acrossTwoBuys() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("b1", OrderSide.BUY, PaperOrderType.MARKET, 10), 100)
+        acct = PaperEngine.placeOrder(acct, order("b2", OrderSide.BUY, PaperOrderType.MARKET, 30), 200)
+        // avg = (10*100 + 30*200) / 40 = 7000/40 = 175
+        assertEquals(175L, acct.positions.getValue(BTC).avgEntry)
+        assertEquals(40L, acct.positions.getValue(BTC).qty)
+    }
+
+    @Test
+    fun partialClose_realizesOnClosedQtyOnly_keepsRemainingAtSameAvg() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("b", OrderSide.BUY, PaperOrderType.MARKET, 10), 100)
+        acct = PaperEngine.placeOrder(acct, order("s", OrderSide.SELL, PaperOrderType.MARKET, 4), 150)
+        // realized on 4: (150-100)*4 = 200; remaining 6 @ avg 100
+        assertEquals(200L, acct.realizedPnl)
+        assertEquals(6L, acct.positions.getValue(BTC).qty)
+        assertEquals(100L, acct.positions.getValue(BTC).avgEntry)
+    }
+
+    // ---- short realized ----
+
+    @Test
+    fun shortThenCoverLower_realizesProfit() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("s", OrderSide.SELL, PaperOrderType.MARKET, 5), 200)
+        acct = PaperEngine.placeOrder(acct, order("b", OrderSide.BUY, PaperOrderType.MARKET, 5), 120)
+        // short realized = (120-200)*5*(-1) = 400
+        assertEquals(400L, acct.realizedPnl)
+        assertNull(acct.positions[BTC])
+    }
+
+    // ---- flip ----
+
+    @Test
+    fun sellThroughLong_flipsToShort_reseedsAvgAtFill() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("b", OrderSide.BUY, PaperOrderType.MARKET, 10), 100)
+        acct = PaperEngine.placeOrder(acct, order("s", OrderSide.SELL, PaperOrderType.MARKET, 15), 130)
+        // close 10 long @ (130-100)*10 = 300 realized; residual 5 opens short @ 130
+        assertEquals(300L, acct.realizedPnl)
+        val pos = acct.positions.getValue(BTC)
+        assertEquals(-5L, pos.qty)
+        assertEquals(130L, pos.avgEntry)
+    }
+
+    // ---- limit fills via onTick ----
+
+    @Test
+    fun limitBuy_belowMarket_rests_thenFillsWhenPriceDrops() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        // market is 100, buy limit 90 is not marketable -> works
+        acct = PaperEngine.placeOrder(acct, order("lb", OrderSide.BUY, PaperOrderType.LIMIT, 5, 90), 100)
+        assertTrue(acct.positions.isEmpty())
+        assertEquals(PaperOrderStatus.WORKING, acct.orders.single().status)
+        // price ticks down to 90 -> fills at limit 90
+        acct = PaperEngine.onTick(acct, BTC, 90)
+        assertEquals(5L, acct.positions.getValue(BTC).qty)
+        assertEquals(90L, acct.positions.getValue(BTC).avgEntry)
+        assertEquals(PaperOrderStatus.FILLED, acct.orders.single().status)
+        assertEquals(1_000_000 - 450, acct.cash)
+    }
+
+    @Test
+    fun limitSell_aboveMarket_rests_thenFillsWhenPriceRises() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("ls", OrderSide.SELL, PaperOrderType.LIMIT, 5, 110), 100)
+        assertEquals(PaperOrderStatus.WORKING, acct.orders.single().status)
+        acct = PaperEngine.onTick(acct, BTC, 111) // >= 110 triggers
+        assertEquals(-5L, acct.positions.getValue(BTC).qty)
+        assertEquals(110L, acct.positions.getValue(BTC).avgEntry) // fills at limit, not the tick
+    }
+
+    @Test
+    fun marketableLimit_fillsImmediatelyAtLimit() {
+        val acct = PaperEngine.newAccount(1_000_000)
+        // buy limit 120 with market at 100 -> already marketable -> fills at 120
+        val after = PaperEngine.placeOrder(acct, order("mb", OrderSide.BUY, PaperOrderType.LIMIT, 2, 120), 100)
+        assertEquals(2L, after.positions.getValue(BTC).qty)
+        assertEquals(120L, after.positions.getValue(BTC).avgEntry)
+        assertEquals(PaperOrderStatus.FILLED, after.orders.single().status)
+    }
+
+    @Test
+    fun onTick_onlyFillsMatchingSymbol() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("lb", OrderSide.BUY, PaperOrderType.LIMIT, 5, 90, symbolId = BTC), 100)
+        // a tick for ETH should not touch the BTC working order
+        acct = PaperEngine.onTick(acct, ETH, 50)
+        assertEquals(PaperOrderStatus.WORKING, acct.orders.single().status)
+        assertTrue(acct.positions.isEmpty())
+    }
+
+    // ---- cancel ----
+
+    @Test
+    fun cancel_marksWorkingOrderCancelled_leavesNoPosition() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("lb", OrderSide.BUY, PaperOrderType.LIMIT, 5, 90), 100)
+        acct = PaperEngine.cancelOrder(acct, "lb")
+        assertEquals(PaperOrderStatus.CANCELLED, acct.orders.single().status)
+        // a later tick to the limit must NOT fill a cancelled order
+        acct = PaperEngine.onTick(acct, BTC, 80)
+        assertTrue(acct.positions.isEmpty())
+    }
+
+    @Test
+    fun cancel_unknownOrFilled_isNoOp() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("b", OrderSide.BUY, PaperOrderType.MARKET, 1), 100)
+        val same = PaperEngine.cancelOrder(acct, "b")     // already filled
+        assertEquals(acct, same)
+        val same2 = PaperEngine.cancelOrder(acct, "nope") // unknown
+        assertEquals(acct, same2)
+    }
+
+    // ---- equity / unrealized ----
+
+    @Test
+    fun equityAndUnrealized_markLong() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("b", OrderSide.BUY, PaperOrderType.MARKET, 10), 100)
+        // cash 999_000, position 10 @ 100. Mark 150 -> unrealized (150-100)*10 = 500
+        val marks = mapOf(BTC to 150L)
+        assertEquals(500L, PaperEngine.unrealized(acct, marks))
+        // equity = cash + qty*mark = 999_000 + 10*150 = 1_000_500
+        assertEquals(1_000_500L, PaperEngine.equity(acct, marks))
+    }
+
+    @Test
+    fun unrealized_short_profitsAsMarkFalls() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("s", OrderSide.SELL, PaperOrderType.MARKET, 4), 200)
+        // short 4 @ 200. Mark 150 -> unrealized (150-200)*(-4) = 200
+        assertEquals(200L, PaperEngine.unrealized(acct, mapOf(BTC to 150L)))
+    }
+
+    @Test
+    fun equity_missingMark_usesCostBasis_noJump() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("b", OrderSide.BUY, PaperOrderType.MARKET, 10), 100)
+        // no mark provided -> position valued at cost basis; equity == startingCash
+        assertEquals(1_000_000L, PaperEngine.equity(acct, emptyMap()))
+        assertEquals(0L, PaperEngine.unrealized(acct, emptyMap()))
+    }
+
+    @Test
+    fun zeroQtyOrder_ignored() {
+        val acct = PaperEngine.newAccount(1_000_000)
+        val after = PaperEngine.placeOrder(acct, order("z", OrderSide.BUY, PaperOrderType.MARKET, 0), 100)
+        assertEquals(acct, after)
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,7 @@ const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
 const HomePage = lazy(() => import("@/pages/home/HomePage"));
 const MarketsPage = lazy(() => import("@/pages/markets/MarketsPage"));
 const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
+const PaperTradingPage = lazy(() => import("@/pages/paper/PaperTradingPage"));
 const PriceAlertsPage = lazy(() => import("@/pages/alerts/PriceAlertsPage"));
 const SyndicatesPage = lazy(() => import("@/pages/syndicates/SyndicatesPage"));
 const SyndicateProfilePage = lazy(() => import("@/pages/syndicates/SyndicateProfilePage"));
@@ -744,6 +745,7 @@ export default function App() {
           <Route path="markets" element={<MarketsPage />} />
           <Route path="markets/:symbolId" element={<SymbolDetailPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />
+          <Route path="paper" element={<PaperTradingPage />} />
           <Route path="discover" element={<DiscoverPage />} />
           <Route path="discover/tags/:tag" element={<TagPage />} />
           <Route path="search" element={<SearchPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -104,6 +104,7 @@ import {
   Award,
   CandlestickChart,
   PieChart,
+  TrendingUp,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -147,6 +148,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Trading Home", i18nKey: "nav.tradingHome", path: "/home", icon: <Gauge className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
+      { label: "Paper Trading", i18nKey: "nav.paperTrading", path: "/paper", icon: <TrendingUp className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
       { label: "PnL", i18nKey: "nav.pnl", path: "/pnl", icon: <LineChart className="h-5 w-5" /> },
       { label: "Reports", i18nKey: "nav.reports", path: "/reports", icon: <FileText className="h-5 w-5" /> },

--- a/frontend/src/lib/paperEngine.test.ts
+++ b/frontend/src/lib/paperEngine.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  newAccount,
+  placeOrder,
+  onTick,
+  cancelOrder,
+  resetAccount,
+  unrealized,
+  equity,
+  positionMtm,
+  DEFAULT_STARTING_CASH,
+  type PaperAccount,
+} from "./paperEngine";
+
+const SYM = 1;
+
+describe("newAccount", () => {
+  it("seeds cash + startingCash and is empty", () => {
+    const a = newAccount(100_000);
+    expect(a.cash).toBe(100_000);
+    expect(a.startingCash).toBe(100_000);
+    expect(a.realizedPnl).toBe(0);
+    expect(a.orders).toHaveLength(0);
+    expect(a.fills).toHaveLength(0);
+    expect(Object.keys(a.positions)).toHaveLength(0);
+  });
+  it("defaults + guards bad input", () => {
+    expect(newAccount().cash).toBe(DEFAULT_STARTING_CASH);
+    expect(newAccount(-5).cash).toBe(DEFAULT_STARTING_CASH);
+    expect(newAccount(0).cash).toBe(DEFAULT_STARTING_CASH);
+    expect(newAccount(NaN).cash).toBe(DEFAULT_STARTING_CASH);
+  });
+});
+
+describe("market orders", () => {
+  it("buy market fills immediately, moves cash + opens long", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1, order, fill } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "market", qty: 10 },
+      100,
+    );
+    expect(order.status).toBe("filled");
+    expect(fill).toBeDefined();
+    expect(fill!.price).toBe(100);
+    expect(fill!.qty).toBe(10);
+    expect(a1.cash).toBe(100_000 - 100 * 10);
+    expect(a1.positions[SYM]).toEqual({ qty: 10, avgEntry: 100 });
+    expect(a1.realizedPnl).toBe(0);
+    // Immutability: original untouched.
+    expect(a0.cash).toBe(100_000);
+    expect(a0.positions[SYM]).toBeUndefined();
+  });
+
+  it("sell market with no position opens a short and adds cash", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1 } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "sell", type: "market", qty: 5 },
+      200,
+    );
+    expect(a1.cash).toBe(100_000 + 200 * 5);
+    expect(a1.positions[SYM]).toEqual({ qty: -5, avgEntry: 200 });
+  });
+
+  it("market order with no market price is cancelled, no state change", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1, order } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "market", qty: 5 },
+      undefined,
+    );
+    expect(order.status).toBe("cancelled");
+    expect(a1.cash).toBe(100_000);
+    expect(a1.positions[SYM]).toBeUndefined();
+  });
+
+  it("non-positive qty is rejected", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1, order } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "market", qty: 0 },
+      100,
+    );
+    expect(order.status).toBe("cancelled");
+    expect(a1.cash).toBe(100_000);
+  });
+});
+
+describe("limit orders", () => {
+  it("buy limit BELOW market rests as working", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1, order, fill } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "limit", price: 90, qty: 3 },
+      100,
+    );
+    expect(order.status).toBe("working");
+    expect(fill).toBeUndefined();
+    expect(a1.cash).toBe(100_000);
+    expect(a1.positions[SYM]).toBeUndefined();
+  });
+
+  it("buy limit AT/ABOVE market crosses and fills at the limit price", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1, order, fill } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "limit", price: 110, qty: 2 },
+      100,
+    );
+    expect(order.status).toBe("filled");
+    expect(fill!.price).toBe(110);
+    expect(a1.cash).toBe(100_000 - 110 * 2);
+    expect(a1.positions[SYM]).toEqual({ qty: 2, avgEntry: 110 });
+  });
+
+  it("sell limit ABOVE market rests as working", () => {
+    const a0 = newAccount(100_000);
+    const { order } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "sell", type: "limit", price: 120, qty: 2 },
+      100,
+    );
+    expect(order.status).toBe("working");
+  });
+
+  it("sell limit AT/BELOW market crosses and fills", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1, order, fill } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "sell", type: "limit", price: 90, qty: 2 },
+      100,
+    );
+    expect(order.status).toBe("filled");
+    expect(fill!.price).toBe(90);
+    expect(a1.positions[SYM]).toEqual({ qty: -2, avgEntry: 90 });
+  });
+});
+
+describe("onTick — fills working orders as the market moves", () => {
+  it("buy limit does NOT fill until price drops to/below the limit", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1 } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "limit", price: 90, qty: 4 },
+      100,
+    );
+    // Still above -> no fill.
+    const a2 = onTick(a1, SYM, 95);
+    expect(a2.positions[SYM]).toBeUndefined();
+    expect(a2.orders[0]?.status).toBe("working");
+    // Price crosses down -> fills at the limit (90), not the tick (89).
+    const a3 = onTick(a2, SYM, 89);
+    expect(a3.positions[SYM]).toEqual({ qty: 4, avgEntry: 90 });
+    expect(a3.cash).toBe(100_000 - 90 * 4);
+    expect(a3.orders[0]?.status).toBe("filled");
+  });
+
+  it("sell limit fills when price rises to/above the limit", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1 } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "sell", type: "limit", price: 120, qty: 3 },
+      100,
+    );
+    const a2 = onTick(a1, SYM, 119);
+    expect(a2.positions[SYM]).toBeUndefined();
+    const a3 = onTick(a2, SYM, 125);
+    expect(a3.positions[SYM]).toEqual({ qty: -3, avgEntry: 120 });
+    expect(a3.orders[0]?.status).toBe("filled");
+  });
+
+  it("only ticks the matching symbol and ignores non-working orders", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1 } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "limit", price: 90, qty: 4 },
+      100,
+    );
+    const untouched = onTick(a1, 999, 50);
+    expect(untouched).toBe(a1); // no working order for that symbol -> same ref
+  });
+});
+
+describe("average-cost + realized PnL", () => {
+  it("weighted-averages entry when adding to a long", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: SYM, side: "buy", type: "market", qty: 10 }, 100).account;
+    a = placeOrder(a, { symbolId: SYM, side: "buy", type: "market", qty: 10 }, 200).account;
+    // (100*10 + 200*10)/20 = 150
+    expect(a.positions[SYM]).toEqual({ qty: 20, avgEntry: 150 });
+  });
+
+  it("realizes PnL on a partial close, keeps avgEntry", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: SYM, side: "buy", type: "market", qty: 10 }, 100).account;
+    a = placeOrder(a, { symbolId: SYM, side: "sell", type: "market", qty: 4 }, 150).account;
+    // realized = (150-100)*4 = 200
+    expect(a.realizedPnl).toBe(200);
+    expect(a.positions[SYM]).toEqual({ qty: 6, avgEntry: 100 });
+    const lastFill = a.fills[a.fills.length - 1];
+    expect(lastFill?.realized).toBe(200);
+  });
+
+  it("realizes on a full close and goes flat", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: SYM, side: "buy", type: "market", qty: 10 }, 100).account;
+    a = placeOrder(a, { symbolId: SYM, side: "sell", type: "market", qty: 10 }, 130).account;
+    expect(a.realizedPnl).toBe((130 - 100) * 10);
+    expect(a.positions[SYM]).toBeUndefined();
+  });
+
+  it("flips long -> short cleanly, realizing only the closed leg", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: SYM, side: "buy", type: "market", qty: 10 }, 100).account;
+    // Sell 15 at 120: close 10 (realize (120-100)*10=200) + open short 5 @ 120.
+    a = placeOrder(a, { symbolId: SYM, side: "sell", type: "market", qty: 15 }, 120).account;
+    expect(a.realizedPnl).toBe(200);
+    expect(a.positions[SYM]).toEqual({ qty: -5, avgEntry: 120 });
+  });
+
+  it("realizes profit on covering a short", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: SYM, side: "sell", type: "market", qty: 10 }, 200).account;
+    // Buy back 10 at 150: short profit (200-150)*10 = 500.
+    a = placeOrder(a, { symbolId: SYM, side: "buy", type: "market", qty: 10 }, 150).account;
+    expect(a.realizedPnl).toBe(500);
+    expect(a.positions[SYM]).toBeUndefined();
+  });
+});
+
+describe("unrealized / equity / positionMtm", () => {
+  it("unrealized reflects mark vs avg entry (long & short)", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: 1, side: "buy", type: "market", qty: 10 }, 100).account;
+    a = placeOrder(a, { symbolId: 2, side: "sell", type: "market", qty: 5 }, 200).account;
+    // long: (150-100)*10 = 500 ; short: (180-200)*-5 = 100
+    const marks = { 1: 150, 2: 180 };
+    expect(unrealized(a, marks)).toBe(600);
+  });
+
+  it("equity = cash + Σ position MTM", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: 1, side: "buy", type: "market", qty: 10 }, 100).account;
+    // cash = 1,000,000 - 1000 = 999,000 ; MTM at 150 = 1500 ; equity = 1,000,500
+    expect(equity(a, { 1: 150 })).toBe(1_000_500);
+  });
+
+  it("positions without a mark contribute 0", () => {
+    let a: PaperAccount = newAccount(1_000_000);
+    a = placeOrder(a, { symbolId: 1, side: "buy", type: "market", qty: 10 }, 100).account;
+    expect(unrealized(a, {})).toBe(0);
+    expect(equity(a, {})).toBe(a.cash);
+  });
+
+  it("positionMtm handles flat / missing mark", () => {
+    expect(positionMtm({ qty: 0, avgEntry: 0 }, 100)).toBe(0);
+    expect(positionMtm({ qty: 5, avgEntry: 10 }, undefined)).toBe(0);
+    expect(positionMtm({ qty: 5, avgEntry: 10 }, 20)).toBe(100);
+  });
+});
+
+describe("cancelOrder", () => {
+  it("cancels a working order and stops it filling on tick", () => {
+    const a0 = newAccount(100_000);
+    const { account: a1, order } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "limit", price: 90, qty: 4 },
+      100,
+    );
+    const a2 = cancelOrder(a1, order.id);
+    expect(a2.orders[0]?.status).toBe("cancelled");
+    const a3 = onTick(a2, SYM, 80);
+    expect(a3.positions[SYM]).toBeUndefined();
+  });
+
+  it("no-op for unknown / already-terminal orders", () => {
+    const a0 = newAccount(100_000);
+    expect(cancelOrder(a0, "nope")).toBe(a0);
+    const { account: a1, order } = placeOrder(
+      a0,
+      { symbolId: SYM, side: "buy", type: "market", qty: 1 },
+      100,
+    );
+    expect(cancelOrder(a1, order.id)).toBe(a1); // filled -> unchanged
+  });
+});
+
+describe("resetAccount", () => {
+  it("returns a fresh empty account with the given starting cash", () => {
+    const a = resetAccount(50_000);
+    expect(a.cash).toBe(50_000);
+    expect(a.startingCash).toBe(50_000);
+    expect(a.orders).toHaveLength(0);
+    expect(a.fills).toHaveLength(0);
+  });
+  it("defaults when no cash passed", () => {
+    expect(resetAccount().cash).toBe(DEFAULT_STARTING_CASH);
+  });
+});

--- a/frontend/src/lib/paperEngine.ts
+++ b/frontend/src/lib/paperEngine.ts
@@ -1,0 +1,356 @@
+// Pure, framework-free client-side PAPER-TRADING engine. Everything stays in the
+// exchange engine's int64 "tick" space (prices/qtys/money are integer ticks; the
+// UI scales for display with the markets format helpers). NOTHING here touches
+// the network or the real /me/orders — this is an isolated local simulation.
+//
+// Kept pure so it is unit-testable in isolation (see paperEngine.test.ts). Every
+// mutating function returns a NEW account object (immutably); callers persist.
+
+export type PaperSide = "buy" | "sell";
+export type PaperOrderType = "market" | "limit";
+
+/** A working (resting) or already-filled paper order. */
+export interface PaperOrder {
+  id: string;
+  symbolId: number;
+  side: PaperSide;
+  type: PaperOrderType;
+  /** Limit price in ticks (undefined for market orders). */
+  price?: number;
+  /** Order qty in ticks (always positive). */
+  qty: number;
+  status: "working" | "filled" | "cancelled";
+  /** Creation time (ms epoch). */
+  createdAt: number;
+}
+
+/** One executed paper fill. */
+export interface PaperFill {
+  id: string;
+  orderId: string;
+  symbolId: number;
+  side: PaperSide;
+  /** Fill price in ticks. */
+  price: number;
+  /** Fill qty in ticks (always positive). */
+  qty: number;
+  /** Realized PnL (ticks) attributed to this fill (0 when purely opening/adding). */
+  realized: number;
+  ts: number;
+}
+
+/** An open position under average-cost accounting. */
+export interface PaperPosition {
+  /** Signed qty in ticks — negative = short, positive = long, 0 = flat. */
+  qty: number;
+  /** Average entry price in ticks (0 when flat). */
+  avgEntry: number;
+}
+
+export interface PaperAccount {
+  /** Free quote cash in ticks. */
+  cash: number;
+  /** Open positions keyed by symbolId. */
+  positions: Record<number, PaperPosition>;
+  /** All orders (working + terminal), newest last. */
+  orders: PaperOrder[];
+  /** All fills, newest last. */
+  fills: PaperFill[];
+  /** Cumulative realized PnL in ticks. */
+  realizedPnl: number;
+  /** The cash the account was seeded with (for reset / return-% display). */
+  startingCash: number;
+}
+
+/** Default seed: 100,000 quote units. Callers pass the value already in ticks. */
+export const DEFAULT_STARTING_CASH = 100_000;
+
+let idCounter = 0;
+/** Monotonic-ish unique id; not persisted, only needs per-session uniqueness. */
+function nextId(prefix: string): string {
+  idCounter += 1;
+  return `${prefix}_${Date.now().toString(36)}_${idCounter.toString(36)}`;
+}
+
+/** A fresh, empty paper account seeded with `startingCash` ticks. */
+export function newAccount(startingCash: number = DEFAULT_STARTING_CASH): PaperAccount {
+  const seed =
+    Number.isFinite(startingCash) && startingCash > 0
+      ? Math.floor(startingCash)
+      : DEFAULT_STARTING_CASH;
+  return {
+    cash: seed,
+    positions: {},
+    orders: [],
+    fills: [],
+    realizedPnl: 0,
+    startingCash: seed,
+  };
+}
+
+/** Shallow-clone an account into a fresh mutable working copy. */
+function cloneAccount(acct: PaperAccount): PaperAccount {
+  const positions: Record<number, PaperPosition> = {};
+  for (const [k, v] of Object.entries(acct.positions)) {
+    positions[Number(k)] = { qty: v.qty, avgEntry: v.avgEntry };
+  }
+  return {
+    cash: acct.cash,
+    positions,
+    orders: acct.orders.slice(),
+    fills: acct.fills.slice(),
+    realizedPnl: acct.realizedPnl,
+    startingCash: acct.startingCash,
+  };
+}
+
+/**
+ * Apply one execution against the working account copy IN PLACE. Updates the
+ * position via average-cost, realizes PnL when reducing/closing (with clean
+ * flips), moves cash (buy: -price*qty, sell: +price*qty), and appends a fill.
+ * Returns the realized PnL of this fill.
+ */
+function applyFill(
+  acct: PaperAccount,
+  order: PaperOrder,
+  fillPrice: number,
+  fillQty: number,
+  ts: number,
+): number {
+  const side = order.side;
+  const signed = side === "buy" ? fillQty : -fillQty;
+
+  // Cash leg.
+  acct.cash += side === "buy" ? -fillPrice * fillQty : fillPrice * fillQty;
+
+  const pos = acct.positions[order.symbolId] ?? { qty: 0, avgEntry: 0 };
+  const netQty = pos.qty;
+  let realized = 0;
+
+  if (netQty === 0 || Math.sign(signed) === Math.sign(netQty)) {
+    // Opening from flat or adding in the same direction — weighted-average entry.
+    const newQty = netQty + signed;
+    const totalCost = pos.avgEntry * Math.abs(netQty) + fillPrice * Math.abs(signed);
+    pos.avgEntry = Math.abs(newQty) === 0 ? 0 : totalCost / Math.abs(newQty);
+    pos.qty = newQty;
+  } else {
+    // Opposite side — reduce/close, and maybe flip.
+    const dir = netQty > 0 ? 1 : -1;
+    const closedQty = Math.min(Math.abs(signed), Math.abs(netQty));
+    realized = (fillPrice - pos.avgEntry) * closedQty * dir;
+    acct.realizedPnl += realized;
+
+    const residual = Math.abs(signed) - Math.abs(netQty);
+    if (residual > 0) {
+      // Closed the old leg entirely then flipped — open a fresh leg.
+      pos.qty = Math.sign(signed) * residual;
+      pos.avgEntry = fillPrice;
+    } else {
+      pos.qty = netQty + signed;
+      if (pos.qty === 0) pos.avgEntry = 0;
+    }
+  }
+
+  if (pos.qty === 0) {
+    delete acct.positions[order.symbolId];
+  } else {
+    acct.positions[order.symbolId] = pos;
+  }
+
+  acct.fills.push({
+    id: nextId("fill"),
+    orderId: order.id,
+    symbolId: order.symbolId,
+    side,
+    price: fillPrice,
+    qty: fillQty,
+    realized,
+    ts,
+  });
+
+  return realized;
+}
+
+export interface PlaceOrderInput {
+  symbolId: number;
+  side: PaperSide;
+  type: PaperOrderType;
+  /** Required for limit orders; ignored for market. */
+  price?: number;
+  qty: number;
+}
+
+export interface PlaceOrderResult {
+  account: PaperAccount;
+  order: PaperOrder;
+  /** The immediate fill, when the order executed on placement. */
+  fill?: PaperFill;
+}
+
+/**
+ * Place a paper order.
+ * - MARKET: fills immediately at `marketPrice`.
+ * - LIMIT: if it already crosses `marketPrice` it fills immediately at the
+ *   limit price; otherwise it rests as a working order and fills later on tick.
+ *   (buy crosses when marketPrice <= limit; sell crosses when marketPrice >= limit)
+ */
+export function placeOrder(
+  acct: PaperAccount,
+  input: PlaceOrderInput,
+  marketPrice: number | undefined,
+  ts: number = Date.now(),
+): PlaceOrderResult {
+  const next = cloneAccount(acct);
+  const qty = Math.floor(input.qty);
+
+  const order: PaperOrder = {
+    id: nextId("ord"),
+    symbolId: input.symbolId,
+    side: input.side,
+    type: input.type,
+    price: input.type === "limit" ? input.price : undefined,
+    qty,
+    status: "working",
+    createdAt: ts,
+  };
+
+  if (!(qty > 0)) {
+    // Nothing to do — reject by returning a cancelled order, no state change.
+    order.status = "cancelled";
+    next.orders.push(order);
+    return { account: next, order };
+  }
+
+  if (order.type === "market") {
+    if (!(marketPrice != null && marketPrice > 0)) {
+      // No market to fill against — cannot rest a market order, so cancel it.
+      order.status = "cancelled";
+      next.orders.push(order);
+      return { account: next, order };
+    }
+    applyFill(next, order, marketPrice, qty, ts);
+    order.status = "filled";
+    next.orders.push(order);
+    const fill = next.fills[next.fills.length - 1];
+    return { account: next, order, fill };
+  }
+
+  // Limit order.
+  const limit = order.price;
+  if (!(limit != null && limit > 0)) {
+    order.status = "cancelled";
+    next.orders.push(order);
+    return { account: next, order };
+  }
+
+  const crosses =
+    marketPrice != null &&
+    marketPrice > 0 &&
+    ((order.side === "buy" && marketPrice <= limit) ||
+      (order.side === "sell" && marketPrice >= limit));
+
+  if (crosses) {
+    applyFill(next, order, limit, qty, ts);
+    order.status = "filled";
+    next.orders.push(order);
+    const fill = next.fills[next.fills.length - 1];
+    return { account: next, order, fill };
+  }
+
+  // Rests as a working order.
+  next.orders.push(order);
+  return { account: next, order };
+}
+
+/**
+ * Feed a new market price for `symbolId`; fills every working order the price now
+ * satisfies (limit BUY fills when marketPrice <= limit; limit SELL fills when
+ * marketPrice >= limit), each at ITS limit price. Returns a new account.
+ */
+export function onTick(
+  acct: PaperAccount,
+  symbolId: number,
+  marketPrice: number | undefined,
+  ts: number = Date.now(),
+): PaperAccount {
+  if (!(marketPrice != null && marketPrice > 0)) return acct;
+
+  const working = acct.orders.filter(
+    (o) =>
+      o.status === "working" &&
+      o.symbolId === symbolId &&
+      o.type === "limit" &&
+      o.price != null,
+  );
+  if (working.length === 0) return acct;
+
+  const willFill = working.filter((o) =>
+    o.side === "buy" ? marketPrice <= o.price! : marketPrice >= o.price!,
+  );
+  if (willFill.length === 0) return acct;
+
+  const next = cloneAccount(acct);
+  // Deterministic order: oldest working order first.
+  const fillIds = new Set(willFill.map((o) => o.id));
+  const ordered = next.orders
+    .filter((o) => fillIds.has(o.id))
+    .sort((a, b) => a.createdAt - b.createdAt);
+
+  for (const o of ordered) {
+    applyFill(next, o, o.price!, o.qty, ts);
+    o.status = "filled";
+  }
+  return next;
+}
+
+/** Cancel a working order by id (no-op if not working). Returns a new account. */
+export function cancelOrder(acct: PaperAccount, id: string): PaperAccount {
+  const target = acct.orders.find((o) => o.id === id);
+  if (!target || target.status !== "working") return acct;
+  const next = cloneAccount(acct);
+  const o = next.orders.find((x) => x.id === id)!;
+  o.status = "cancelled";
+  return next;
+}
+
+/** Reset to a fresh account, preserving the original starting cash by default. */
+export function resetAccount(startingCash?: number): PaperAccount {
+  return newAccount(startingCash ?? DEFAULT_STARTING_CASH);
+}
+
+/** Mark-to-market value of a single position at `mark` (ticks). */
+export function positionMtm(pos: PaperPosition, mark: number | undefined): number {
+  if (pos.qty === 0 || mark == null || !Number.isFinite(mark)) return 0;
+  return pos.qty * mark;
+}
+
+/**
+ * Unrealized PnL across all positions given a map of symbolId -> mark price.
+ * A position with no mark contributes 0.
+ */
+export function unrealized(
+  acct: PaperAccount,
+  marks: Record<number, number | undefined>,
+): number {
+  let total = 0;
+  for (const [k, pos] of Object.entries(acct.positions)) {
+    const mark = marks[Number(k)];
+    if (mark == null || !Number.isFinite(mark)) continue;
+    total += (mark - pos.avgEntry) * pos.qty;
+  }
+  return total;
+}
+
+/** Account equity = cash + Σ position mark-to-market. */
+export function equity(
+  acct: PaperAccount,
+  marks: Record<number, number | undefined>,
+): number {
+  let total = acct.cash;
+  for (const [k, pos] of Object.entries(acct.positions)) {
+    const mark = marks[Number(k)];
+    if (mark == null || !Number.isFinite(mark)) continue;
+    total += positionMtm(pos, mark);
+  }
+  return total;
+}

--- a/frontend/src/lib/paperStore.ts
+++ b/frontend/src/lib/paperStore.ts
@@ -1,0 +1,58 @@
+// localStorage persistence for the isolated paper-trading account. Survives
+// reloads under the `paper.account.v1` key. Framework-free; the page loads once
+// on mount and saves after every state change.
+
+import { newAccount, resetAccount, type PaperAccount } from "./paperEngine";
+
+export const PAPER_ACCOUNT_KEY = "paper.account.v1";
+
+/**
+ * Load the persisted account, or seed a fresh one. Any parse/shape error falls
+ * back to a new account so a corrupt value can never wedge the page.
+ */
+export function loadAccount(startingCash?: number): PaperAccount {
+  if (typeof window === "undefined") return newAccount(startingCash);
+  try {
+    const raw = window.localStorage.getItem(PAPER_ACCOUNT_KEY);
+    if (!raw) return newAccount(startingCash);
+    const parsed = JSON.parse(raw) as Partial<PaperAccount>;
+    if (
+      parsed &&
+      typeof parsed.cash === "number" &&
+      typeof parsed.startingCash === "number" &&
+      typeof parsed.realizedPnl === "number" &&
+      parsed.positions &&
+      Array.isArray(parsed.orders) &&
+      Array.isArray(parsed.fills)
+    ) {
+      return {
+        cash: parsed.cash,
+        positions: parsed.positions,
+        orders: parsed.orders,
+        fills: parsed.fills,
+        realizedPnl: parsed.realizedPnl,
+        startingCash: parsed.startingCash,
+      };
+    }
+  } catch {
+    // fall through to fresh
+  }
+  return newAccount(startingCash);
+}
+
+/** Persist the account. Silently ignores quota/serialisation errors. */
+export function saveAccount(acct: PaperAccount): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PAPER_ACCOUNT_KEY, JSON.stringify(acct));
+  } catch {
+    // ignore
+  }
+}
+
+/** Reset to a fresh account (same starting cash) AND persist it. Returns it. */
+export function resetAndSave(startingCash?: number): PaperAccount {
+  const fresh = resetAccount(startingCash);
+  saveAccount(fresh);
+  return fresh;
+}

--- a/frontend/src/pages/paper/PaperTradingPage.tsx
+++ b/frontend/src/pages/paper/PaperTradingPage.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, RotateCcw, TrendingUp } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+import { useSymbols, useOrderBook, useTrades } from "@/hooks/useMarketData";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import {
+  placeOrder,
+  onTick,
+  cancelOrder,
+  unrealized as calcUnrealized,
+  equity as calcEquity,
+  DEFAULT_STARTING_CASH,
+  type PaperAccount,
+  type PaperSide,
+  type PaperOrderType,
+} from "@/lib/paperEngine";
+import { loadAccount, saveAccount, resetAndSave } from "@/lib/paperStore";
+import { notional as calcNotional } from "@/lib/orderMath";
+import { formatPrice, formatQty } from "@/pages/markets/format";
+
+// Fallback catalog mirrors MarketsPage so the page still works if /md/symbols errors.
+const FALLBACK_SYMBOLS: MarketSymbol[] = [
+  { symbol: "BTCUSDC", symbol_id: 1, instrument_id: 1, price_scaler: 1, lot_size: 1, reference_price: 100000, matching_algo: "price_time", is_perpetual: false, funding_interval_s: 0 },
+  { symbol: "ETHUSDC", symbol_id: 2, instrument_id: 2, price_scaler: 1, lot_size: 1, reference_price: 3000, matching_algo: "price_time", is_perpetual: false, funding_interval_s: 0 },
+  { symbol: "SOLUSDC", symbol_id: 3, instrument_id: 3, price_scaler: 1, lot_size: 1, reference_price: 150, matching_algo: "price_time", is_perpetual: false, funding_interval_s: 0 },
+];
+
+/** A signed +/- coloured amount, scaled for display. */
+function Pnl({ value, scaler }: { value: number; scaler: number }) {
+  const positive = value >= 0;
+  return (
+    <span
+      className={cn(
+        "font-medium tabular-nums",
+        positive ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400",
+      )}
+    >
+      {positive ? "+" : "−"}
+      {formatPrice(Math.abs(value), scaler)}
+    </span>
+  );
+}
+
+function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-lg font-semibold tabular-nums">{children}</span>
+    </div>
+  );
+}
+
+export default function PaperTradingPage() {
+  const symbolsQuery = useSymbols();
+  const symbols = symbolsQuery.data?.symbols?.length ? symbolsQuery.data.symbols : FALLBACK_SYMBOLS;
+
+  const DEFAULT_SYMBOL = FALLBACK_SYMBOLS[0]!;
+  const [symbolId, setSymbolId] = useState<number>(DEFAULT_SYMBOL.symbol_id);
+  const activeSymbol: MarketSymbol =
+    symbols.find((s) => s.symbol_id === symbolId) ?? symbols[0] ?? DEFAULT_SYMBOL;
+  const scaler = activeSymbol.price_scaler || 1;
+
+  // ── Account (loaded once, persisted after every mutation) ────────────
+  const [account, setAccount] = useState<PaperAccount>(() =>
+    loadAccount(DEFAULT_STARTING_CASH),
+  );
+
+  // ── Live market price for the selected symbol ────────────────────────
+  const book = useOrderBook(symbolId, 5);
+  const trades = useTrades(symbolId, true, 4000);
+  const bestBid = book.data?.bid_px ?? book.data?.bids?.[0]?.[0];
+  const bestAsk = book.data?.ask_px ?? book.data?.asks?.[0]?.[0];
+  const lastTrade = trades.data?.trades?.[0]?.price;
+  const mid =
+    bestBid != null && bestAsk != null ? Math.round((bestBid + bestAsk) / 2) : undefined;
+  // "Market price" = last trade, else book mid, else a best-side, else reference.
+  const marketPrice =
+    lastTrade ?? mid ?? bestAsk ?? bestBid ?? activeSymbol.reference_price ?? undefined;
+
+  // ── Fill-simulator: feed the live price into onTick + persist ────────
+  const acctRef = useRef(account);
+  acctRef.current = account;
+  useEffect(() => {
+    if (marketPrice == null || !(marketPrice > 0)) return;
+    const next = onTick(acctRef.current, symbolId, marketPrice);
+    if (next !== acctRef.current) {
+      setAccount(next);
+      saveAccount(next);
+    }
+  }, [marketPrice, symbolId]);
+
+  // Mark map for MTM: mark the selected symbol at its live price. Positions in
+  // other symbols keep marking at their avg entry (0 unrealized) until selected.
+  const marks = useMemo<Record<number, number | undefined>>(() => {
+    const m: Record<number, number | undefined> = {};
+    for (const [k, pos] of Object.entries(account.positions)) {
+      const id = Number(k);
+      m[id] = id === symbolId ? marketPrice : pos.avgEntry;
+    }
+    return m;
+  }, [account.positions, symbolId, marketPrice]);
+
+  const unreal = calcUnrealized(account, marks);
+  const equity = calcEquity(account, marks);
+  const returnPct =
+    account.startingCash > 0 ? ((equity - account.startingCash) / account.startingCash) * 100 : 0;
+
+  // ── Order form state ─────────────────────────────────────────────────
+  const [side, setSide] = useState<PaperSide>("buy");
+  const [orderType, setOrderType] = useState<PaperOrderType>("market");
+  const [priceStr, setPriceStr] = useState("");
+  const [qtyStr, setQtyStr] = useState("");
+
+  const qtyNum = Number(qtyStr);
+  const priceNum = Number(priceStr);
+  // Limit price is entered in display units; convert to ticks to match qty/market.
+  const previewPriceTicks =
+    orderType === "limit" ? Math.round(priceNum * scaler) : marketPrice ?? 0;
+  const previewNotional = calcNotional(previewPriceTicks, qtyNum);
+
+  const canSubmit =
+    Number.isFinite(qtyNum) &&
+    qtyNum > 0 &&
+    (orderType === "market"
+      ? marketPrice != null && marketPrice > 0
+      : Number.isFinite(priceNum) && priceNum > 0);
+
+  function submitOrder() {
+    if (!canSubmit) return;
+    const { account: next } = placeOrder(
+      account,
+      {
+        symbolId,
+        side,
+        type: orderType,
+        price: orderType === "limit" ? Math.round(priceNum * scaler) : undefined,
+        qty: Math.floor(qtyNum),
+      },
+      marketPrice,
+    );
+    setAccount(next);
+    saveAccount(next);
+    setQtyStr("");
+  }
+
+  function cancel(id: string) {
+    const next = cancelOrder(account, id);
+    setAccount(next);
+    saveAccount(next);
+  }
+
+  function doReset() {
+    const fresh = resetAndSave(DEFAULT_STARTING_CASH);
+    setAccount(fresh);
+  }
+
+  const workingOrders = account.orders.filter((o) => o.status === "working");
+  const positions = Object.entries(account.positions);
+  const recentFills = account.fills.slice().reverse().slice(0, 40);
+  const symLabel = (id: number) => symbols.find((s) => s.symbol_id === id)?.symbol ?? `#${id}`;
+
+  return (
+    <div className="space-y-6">
+      {/* Banner */}
+      <div className="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+        <div>
+          <p className="font-semibold text-amber-700 dark:text-amber-300">
+            Paper — simulated, not real funds
+          </p>
+          <p className="text-sm text-muted-foreground">
+            This is an isolated client-side simulator. It uses live market data but never
+            places real orders. Your paper account is stored only in this browser.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-semibold">Paper Trading</h1>
+          <Badge variant="secondary">PAPER</Badge>
+        </div>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="outline" size="sm">
+              <RotateCcw className="mr-2 h-4 w-4" /> Reset account
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Reset paper account?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This clears all positions, working orders, and fill history, and restores the
+                starting balance of {formatPrice(DEFAULT_STARTING_CASH, scaler)}. This cannot be
+                undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={doReset}>Reset</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      {/* Account panel */}
+      <Card>
+        <CardContent className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3 lg:grid-cols-6">
+          <Stat label="Equity">{formatPrice(equity, scaler)}</Stat>
+          <Stat label="Cash">{formatPrice(account.cash, scaler)}</Stat>
+          <Stat label="Realized PnL">
+            <Pnl value={account.realizedPnl} scaler={scaler} />
+          </Stat>
+          <Stat label="Unrealized PnL">
+            <Pnl value={unreal} scaler={scaler} />
+          </Stat>
+          <Stat label="Starting balance">{formatPrice(account.startingCash, scaler)}</Stat>
+          <Stat label="Return">
+            <span
+              className={cn(
+                "tabular-nums",
+                returnPct >= 0
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-rose-600 dark:text-rose-400",
+              )}
+            >
+              {returnPct >= 0 ? "+" : ""}
+              {returnPct.toFixed(2)}%
+            </span>
+          </Stat>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+        {/* Order form */}
+        <Card className="h-fit">
+          <CardHeader>
+            <CardTitle className="text-base">Paper order</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-xs text-muted-foreground">Symbol</label>
+              <Select value={String(symbolId)} onValueChange={(v) => setSymbolId(Number(v))}>
+                <SelectTrigger className="mt-1">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {symbols.map((s) => (
+                    <SelectItem key={s.symbol_id} value={String(s.symbol_id)}>
+                      {s.symbol}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="rounded-md border bg-muted/30 p-3">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Market price</span>
+                <span className="text-lg font-semibold tabular-nums">
+                  {marketPrice != null ? formatPrice(marketPrice, scaler) : "—"}
+                </span>
+              </div>
+              <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
+                <span>Bid {bestBid != null ? formatPrice(bestBid, scaler) : "—"}</span>
+                <span>Ask {bestAsk != null ? formatPrice(bestAsk, scaler) : "—"}</span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant={side === "buy" ? "default" : "outline"}
+                className={cn(side === "buy" && "bg-emerald-600 hover:bg-emerald-700")}
+                onClick={() => setSide("buy")}
+              >
+                Buy
+              </Button>
+              <Button
+                type="button"
+                variant={side === "sell" ? "default" : "outline"}
+                className={cn(side === "sell" && "bg-rose-600 hover:bg-rose-700")}
+                onClick={() => setSide("sell")}
+              >
+                Sell
+              </Button>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant={orderType === "market" ? "secondary" : "outline"}
+                onClick={() => setOrderType("market")}
+              >
+                Market
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={orderType === "limit" ? "secondary" : "outline"}
+                onClick={() => setOrderType("limit")}
+              >
+                Limit
+              </Button>
+            </div>
+
+            {orderType === "limit" && (
+              <div>
+                <label className="text-xs text-muted-foreground">Limit price</label>
+                <Input
+                  className="mt-1"
+                  inputMode="decimal"
+                  placeholder={marketPrice != null ? formatPrice(marketPrice, scaler) : "0"}
+                  value={priceStr}
+                  onChange={(e) => setPriceStr(e.target.value)}
+                />
+              </div>
+            )}
+
+            <div>
+              <label className="text-xs text-muted-foreground">Quantity</label>
+              <Input
+                className="mt-1"
+                inputMode="numeric"
+                placeholder="0"
+                value={qtyStr}
+                onChange={(e) => setQtyStr(e.target.value)}
+              />
+            </div>
+
+            <div className="flex items-center justify-between rounded-md bg-muted/30 px-3 py-2 text-sm">
+              <span className="text-muted-foreground">Order notional</span>
+              <span className="font-medium tabular-nums">
+                {previewNotional > 0 ? formatPrice(previewNotional, scaler) : "—"}
+              </span>
+            </div>
+
+            <Button
+              type="button"
+              className={cn(
+                "w-full",
+                side === "buy" ? "bg-emerald-600 hover:bg-emerald-700" : "bg-rose-600 hover:bg-rose-700",
+              )}
+              disabled={!canSubmit}
+              onClick={submitOrder}
+            >
+              {side === "buy" ? "Buy" : "Sell"} {activeSymbol.symbol} ({orderType})
+            </Button>
+            {orderType === "limit" && (
+              <p className="text-xs text-muted-foreground">
+                Limit orders rest until the live market crosses your price, then fill
+                automatically.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Positions / orders / fills */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Positions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {positions.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No open positions.</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-xs text-muted-foreground">
+                        <th className="pb-2">Symbol</th>
+                        <th className="pb-2">Side</th>
+                        <th className="pb-2 text-right">Qty</th>
+                        <th className="pb-2 text-right">Avg entry</th>
+                        <th className="pb-2 text-right">Mark</th>
+                        <th className="pb-2 text-right">Unrealized</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {positions.map(([k, pos]) => {
+                        const id = Number(k);
+                        const mark = marks[id];
+                        const u = mark != null ? (mark - pos.avgEntry) * pos.qty : 0;
+                        const isLong = pos.qty > 0;
+                        return (
+                          <tr key={k} className="border-t">
+                            <td className="py-2 font-medium">{symLabel(id)}</td>
+                            <td className="py-2">
+                              <Badge variant={isLong ? "default" : "destructive"}>
+                                {isLong ? "Long" : "Short"}
+                              </Badge>
+                            </td>
+                            <td className="py-2 text-right tabular-nums">
+                              {formatQty(Math.abs(pos.qty), scaler)}
+                            </td>
+                            <td className="py-2 text-right tabular-nums">
+                              {formatPrice(pos.avgEntry, scaler)}
+                            </td>
+                            <td className="py-2 text-right tabular-nums">
+                              {mark != null ? formatPrice(mark, scaler) : "—"}
+                            </td>
+                            <td className="py-2 text-right">
+                              <Pnl value={u} scaler={scaler} />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Working orders {workingOrders.length > 0 && `(${workingOrders.length})`}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {workingOrders.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No working orders.</p>
+              ) : (
+                <div className="space-y-2">
+                  {workingOrders.map((o) => (
+                    <div
+                      key={o.id}
+                      className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Badge variant={o.side === "buy" ? "default" : "destructive"}>
+                          {o.side.toUpperCase()}
+                        </Badge>
+                        <span className="font-medium">{symLabel(o.symbolId)}</span>
+                        <span className="text-muted-foreground">
+                          {formatQty(o.qty, scaler)} @ {formatPrice(o.price, scaler)} (limit)
+                        </span>
+                      </div>
+                      <Button variant="ghost" size="sm" onClick={() => cancel(o.id)}>
+                        Cancel
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Fill history</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {recentFills.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No fills yet.</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-xs text-muted-foreground">
+                        <th className="pb-2">Time</th>
+                        <th className="pb-2">Symbol</th>
+                        <th className="pb-2">Side</th>
+                        <th className="pb-2 text-right">Qty</th>
+                        <th className="pb-2 text-right">Price</th>
+                        <th className="pb-2 text-right">Realized</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {recentFills.map((f) => (
+                        <tr key={f.id} className="border-t">
+                          <td className="py-1.5 text-muted-foreground">
+                            {new Date(f.ts).toLocaleTimeString([], {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              second: "2-digit",
+                            })}
+                          </td>
+                          <td className="py-1.5 font-medium">{symLabel(f.symbolId)}</td>
+                          <td
+                            className={cn(
+                              "py-1.5 font-medium",
+                              f.side === "buy"
+                                ? "text-emerald-600 dark:text-emerald-400"
+                                : "text-rose-600 dark:text-rose-400",
+                            )}
+                          >
+                            {f.side.toUpperCase()}
+                          </td>
+                          <td className="py-1.5 text-right tabular-nums">
+                            {formatQty(f.qty, scaler)}
+                          </td>
+                          <td className="py-1.5 text-right tabular-nums">
+                            {formatPrice(f.price, scaler)}
+                          </td>
+                          <td className="py-1.5 text-right">
+                            {f.realized !== 0 ? (
+                              <Pnl value={f.realized} scaler={scaler} />
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Separator />
+      <p className="text-center text-xs text-muted-foreground">
+        Paper Trading is fully isolated from live trading. No order here ever reaches the exchange.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
A self-contained Paper Trading surface, fully isolated from live trading (never calls a real order endpoint). Pure tested simulation engine (avg-cost positions incl. shorts, market + limit fills against the live market, realized/unrealized PnL, equity, cancel, reset), persisted client-side, with a dedicated page/screen (order form + account/positions/orders/fills + reset + 'simulated, not real funds' banner) and a while-mounted fill-simulator. Web build+tsc 0, +26 engine tests; android assembleDebug+testDebugUnitTest green, +17 tests. From the roadmap note in exchange_missing_features.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)