### PR TITLE
feat(trading): paper-mode toggle on the full trade ticket (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -48,6 +50,10 @@ import com.testlogon.android.data.exchange.EngineConfigAck
 import com.testlogon.android.feature.markets.ui.MarketColors
 import java.util.Locale
 
+/** Paper-mode accent (amber) — makes a simulated ticket unmistakable. */
+private val PaperAmber = Color(0xFFF0B90B)
+private val PaperAmberFill = Color(0x1FF0B90B)
+
 /**
  * Order ticket. Account context sits on top; the rest is split into Trade / Positions / Orders / Fills
  * sections so order entry isn't buried under a long scroll.
@@ -69,12 +75,24 @@ fun TradeTicket(
         }
     }
 
-    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp).testTag("trade_ticket")) {
+    val ticketBorder = if (state.paperMode) Modifier.border(1.5.dp, PaperAmber, RoundedCornerShape(12.dp)) else Modifier
+    Column(
+        modifier = modifier.fillMaxWidth()
+            .then(ticketBorder)
+            .then(if (state.paperMode) Modifier.background(PaperAmberFill, RoundedCornerShape(12.dp)) else Modifier)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .testTag("trade_ticket")
+    ) {
+        PaperModeHeader(state.paperMode, onToggle = viewModel::setPaperMode)
+        Spacer(Modifier.height(if (state.paperMode) 8.dp else 6.dp))
         state.pm?.let {
             PmBanner(it, lastPrice)
             Spacer(Modifier.height(10.dp))
         }
-        state.account?.let {
+        if (state.paperMode) {
+            PaperAccountStrip(state.paperCash)
+            Spacer(Modifier.height(10.dp))
+        } else state.account?.let {
             AccountStrip(it)
             Spacer(Modifier.height(10.dp))
         }
@@ -136,7 +154,16 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?
     val sideColor = if (state.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down
     var showDepositConfirm by remember { mutableStateOf(false) }
 
-    OrderTypeRow(selected = state.orderType, onSelect = viewModel::setOrderType)
+    OrderTypeRow(selected = state.orderType, paperMode = state.paperMode, onSelect = viewModel::setOrderType)
+    if (state.paperMode) {
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Simulated in paper mode: market & limit only.",
+            color = PaperAmber,
+            fontSize = 11.sp,
+            modifier = Modifier.testTag("paper_type_note"),
+        )
+    }
     Spacer(Modifier.height(10.dp))
 
     if (state.orderType != OrderType.QUOTE && state.orderType != OrderType.FUNDING) {
@@ -281,13 +308,13 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
             .background(if (state.canSubmit) submitColor else MarketColors.SurfaceAlt)
-            .clickable(enabled = state.canSubmit) { viewModel.submit() }
+            .clickable(enabled = state.canSubmit) { viewModel.submit(bestBid, bestAsk, lastPrice) }
             .testTag("trade_place")
             .padding(vertical = 14.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = if (armedMarket) "Confirm ${if (state.side == OrderSide.BUY) "Buy" else "Sell"} ${state.qtyText} @ market".trim() else submitLabel(state),
+            text = if (armedMarket) (if (state.paperMode) "Confirm paper order" else "Confirm ${if (state.side == OrderSide.BUY) "Buy" else "Sell"} ${state.qtyText} @ market".trim()) else submitLabel(state),
             color = if (state.canSubmit) Color.Black else MarketColors.TextFaint,
             fontWeight = FontWeight.Bold,
             fontSize = 15.sp,
@@ -816,6 +843,74 @@ private fun SideButton(text: String, selected: Boolean, color: Color, modifier: 
 }
 
 @Composable
+private fun PaperModeHeader(paperMode: Boolean, onToggle: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().testTag("paper_mode_header"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        if (paperMode) {
+            Text(
+                text = "PAPER",
+                color = Color.Black,
+                fontWeight = FontWeight.Bold,
+                fontSize = 11.sp,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(PaperAmber)
+                    .padding(horizontal = 8.dp, vertical = 3.dp)
+                    .testTag("paper_badge"),
+            )
+        } else {
+            Text("Paper trading", color = MarketColors.TextSecondary, fontSize = 12.sp)
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "Paper",
+                color = if (paperMode) PaperAmber else MarketColors.TextSecondary,
+                fontSize = 12.sp,
+                fontWeight = if (paperMode) FontWeight.Bold else FontWeight.Normal,
+            )
+            Spacer(Modifier.width(6.dp))
+            Switch(
+                checked = paperMode,
+                onCheckedChange = onToggle,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Color.Black,
+                    checkedTrackColor = PaperAmber,
+                    uncheckedThumbColor = MarketColors.TextSecondary,
+                    uncheckedTrackColor = MarketColors.SurfaceAlt,
+                ),
+                modifier = Modifier.testTag("paper_mode_switch"),
+            )
+        }
+    }
+    if (paperMode) {
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "Simulated orders — nothing is sent to the exchange.",
+            color = PaperAmber,
+            fontSize = 11.sp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .background(PaperAmberFill)
+                .padding(horizontal = 8.dp, vertical = 5.dp)
+                .testTag("paper_banner"),
+        )
+    }
+}
+
+@Composable
+private fun PaperAccountStrip(paperCash: Long?) {
+    Column(modifier = Modifier.fillMaxWidth().testTag("paper_account_strip")) {
+        WalletRow("Paper cash", paperCash ?: 0L)
+        Spacer(Modifier.height(3.dp))
+        WalletRow("Buying power", paperCash ?: 0L)
+    }
+}
+
+@Composable
 private fun AccountStrip(account: com.testlogon.android.data.exchange.MarginAccount) {
     Column(modifier = Modifier.fillMaxWidth()) {
         WalletRow("Balance", account.balance)
@@ -921,12 +1016,14 @@ private fun AdvancedSection(state: TradingUiState, viewModel: TradingViewModel) 
 }
 
 @Composable
-private fun OrderTypeRow(selected: OrderType, onSelect: (OrderType) -> Unit) {
+private fun OrderTypeRow(selected: OrderType, paperMode: Boolean, onSelect: (OrderType) -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        OrderType.values().filter { it.isAvailable() }.forEach { t ->
+        OrderType.values()
+            .filter { it.isAvailable() && (!paperMode || com.testlogon.android.feature.paper.PaperTicketSupport.isPaperSimulatable(it)) }
+            .forEach { t ->
             val on = t == selected
             Text(
                 text = t.label,

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -105,6 +105,9 @@ data class TradingUiState(
     val section: TicketSection = TicketSection.TRADE,
     val armed: String? = null,        // "market" | "close" -> a confirm is pending (skipped when oneTap)
     val oneTap: Boolean = false,      // when true, market/close fire without a confirm step
+    // ---- PAPER MODE (client-side simulation; shares the Paper screen's account/store) ----
+    val paperMode: Boolean = false,   // when true, submits route to PaperEngine, NOT /me/orders
+    val paperCash: Long? = null,      // simulated free cash (null until the paper account loads)
     // Position-size / risk calculator (collapsible). riskAmount + stop -> qty via OrderMath.
     val riskCalcOpen: Boolean = false,
     val riskAmountText: String = "",
@@ -213,6 +216,9 @@ data class TradingUiState(
     /** Available margin balance, or null when the account hasn't loaded. */
     val availableBalance: Long? get() = account?.availableBalance
 
+    /** Buying power the ticket sizes against: paper cash in paper mode, else real available. */
+    val effectiveBuyingPower: Long? get() = if (paperMode) paperCash else availableBalance
+
     /** The price used for preview/sizing: the entered limit price, else the stop/trigger. */
     val entryRefPrice: Long? get() = priceLong ?: stopLong
 
@@ -221,7 +227,7 @@ data class TradingUiState(
 
     /** Max whole qty affordable at the reference price from available balance (no leverage). */
     fun maxAffordableQty(refPrice: Long?): Long =
-        OrderMath.maxQtyForBalance(availableBalance, refPrice ?: entryRefPrice)
+        OrderMath.maxQtyForBalance(effectiveBuyingPower, refPrice ?: entryRefPrice)
 
     /** Risk-calculator inputs. */
     val riskAmountLong: Long? get() = riskAmountText.toLongOrNull()

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -10,6 +10,12 @@ import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.FeeSchedule
 import com.testlogon.android.data.exchange.FillsFees
 import com.testlogon.android.data.feed.CurrentUserRepository
+import com.testlogon.android.feature.paper.PaperAccountStore
+import com.testlogon.android.feature.paper.PaperEngine
+import com.testlogon.android.feature.paper.PaperEngine.PaperAccount
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrder
+import com.testlogon.android.feature.paper.PaperModeStore
+import com.testlogon.android.feature.paper.PaperTicketSupport
 import com.testlogon.android.navigation.SymbolDetailDest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -32,6 +38,8 @@ class TradingViewModel @Inject constructor(
     private val exchangeRepository: ExchangeRepository,
     private val notifier: TradingNotifier,
     private val currentUserRepository: CurrentUserRepository,
+    private val paperModeStore: PaperModeStore,
+    private val paperAccountStore: PaperAccountStore,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -43,6 +51,9 @@ class TradingViewModel @Inject constructor(
     val uiState: StateFlow<TradingUiState> = _uiState.asStateFlow()
 
     private var seq = 0
+
+    /** Cached paper account (client-side simulation) shared with the Paper screen via the store. */
+    private var paperAccount: PaperAccount = PaperEngine.newAccount(PAPER_STARTING_CASH)
 
     init {
         val sym = symbolId.toString()
@@ -69,6 +80,38 @@ class TradingViewModel @Inject constructor(
         resolveSymbols()
         loadStakeAuctionBrowse()
         if (TradingFeatures.SPOT_ENABLED) refreshSpot()
+        observePaperMode()
+        loadPaperAccount()
+    }
+
+    /** Load the shared paper account (or seed a fresh one) and project its cash into the ticket. */
+    private fun loadPaperAccount() {
+        viewModelScope.launch {
+            paperAccount = paperAccountStore.load()
+                ?: PaperEngine.newAccount(PAPER_STARTING_CASH).also { paperAccountStore.save(it) }
+            _uiState.update { it.copy(paperCash = paperAccount.cash) }
+        }
+    }
+
+    /** Mirror the durable paper-mode flag into the ticket; snap a non-paper type back to Limit on ON. */
+    private fun observePaperMode() {
+        viewModelScope.launch {
+            paperModeStore.paperMode.collect { on ->
+                _uiState.update {
+                    it.copy(
+                        paperMode = on,
+                        orderType = if (on) PaperTicketSupport.snapToPaper(it.orderType) else it.orderType,
+                        armed = null,
+                    )
+                }
+            }
+        }
+    }
+
+    /** Toggle paper mode (persisted; the observer re-projects state). */
+    fun setPaperMode(enabled: Boolean) {
+        notifier.tick()
+        viewModelScope.launch { paperModeStore.setPaperMode(enabled) }
     }
 
     /**
@@ -323,7 +366,7 @@ class TradingViewModel @Inject constructor(
 
     /** Quick-size: set qty to a % of (no-leverage) buying power = availableBalance / refPrice. */
     fun setQtyPercent(pct: Int, refPrice: Long?) {
-        val avail = _uiState.value.account?.availableBalance ?: return
+        val avail = _uiState.value.effectiveBuyingPower ?: return
         val px = refPrice ?: return
         if (px <= 0 || avail <= 0) return
         val maxQty = avail / px
@@ -334,7 +377,7 @@ class TradingViewModel @Inject constructor(
 
     /** Set qty to the maximum affordable at [refPrice] from available balance (no leverage). */
     fun setMaxQty(refPrice: Long?) {
-        val avail = _uiState.value.account?.availableBalance
+        val avail = _uiState.value.effectiveBuyingPower
         val max = OrderMath.maxQtyForBalance(avail, refPrice ?: _uiState.value.entryRefPrice)
         if (max <= 0L) return
         notifier.tick()
@@ -489,15 +532,21 @@ class TradingViewModel @Inject constructor(
         }
     }
 
-    /** Route the ticket's primary action to the right engine endpoint for the selected order type. */
-    fun submit() {
+    /**
+     * Route the ticket's primary action to the right engine endpoint for the selected order type.
+     * In PAPER mode (Market/Limit only) the order is simulated via [PaperEngine] instead of hitting
+     * `/me/orders`; [bestBid]/[bestAsk]/[last] pick the simulated fill price.
+     */
+    fun submit(bestBid: Long? = null, bestAsk: Long? = null, last: Long? = null) {
         val s = _uiState.value
-        if (s.orderType == OrderType.MARKET && !s.oneTap && s.armed != "market") {
+        val isMarketLike = s.paperMode || s.orderType == OrderType.MARKET
+        if (isMarketLike && s.orderType == OrderType.MARKET && !s.oneTap && s.armed != "market") {
             notifier.warn()
-            _uiState.update { it.copy(armed = "market", message = "Tap Confirm to send the market order", messageIsError = false) }
+            _uiState.update { it.copy(armed = "market", message = "Tap Confirm paper order".takeIf { s.paperMode } ?: "Tap Confirm to send the market order", messageIsError = false) }
             return
         }
         _uiState.update { it.copy(armed = null) }
+        if (s.paperMode) { submitPaper(bestBid, bestAsk, last); return }
         when (s.orderType) {
             OrderType.LIMIT -> place()
             OrderType.MARKET -> place()
@@ -509,6 +558,49 @@ class TradingViewModel @Inject constructor(
             OrderType.OCO -> submitOco()
             OrderType.FUNDING -> submitFunding()
         }
+    }
+
+    /**
+     * Simulate the ticket order via [PaperEngine] (paper mode). Only Market/Limit reach here (the UI
+     * restricts the selector in paper mode). MARKET fills at the crossed price; LIMIT rests (or fills
+     * if marketable). Persists the shared paper account and re-projects cash — NEVER hits /me/orders.
+     */
+    private fun submitPaper(bestBid: Long?, bestAsk: Long?, last: Long?) {
+        val s = _uiState.value
+        val isMarket = s.orderType == OrderType.MARKET
+        val qty = s.qtyLong ?: return
+        if (qty <= 0L) return
+        val limit = if (isMarket) null else (s.priceLong ?: return)
+        if (!isMarket && (limit == null || limit <= 0L)) return
+        val marketPrice = PaperTicketSupport.marketPriceFor(s.side, bestBid, bestAsk, last)
+        if (marketPrice == null) {
+            _uiState.update { it.copy(message = "No live price yet — try again", messageIsError = true) }
+            notifier.error(); return
+        }
+        val order = PaperOrder(
+            id = "pt-" + System.currentTimeMillis() + "-" + (paperAccount.orders.size + 1),
+            symbolId = symbolId,
+            side = s.side,
+            type = PaperTicketSupport.toPaperType(s.orderType),
+            qty = qty,
+            limitPrice = limit,
+            createdTsMs = System.currentTimeMillis(),
+        )
+        val before = paperAccount
+        paperAccount = PaperEngine.placeOrder(paperAccount, order, marketPrice)
+        val filled = paperAccount.fills.lastOrNull()?.orderId == order.id
+        val snapshot = paperAccount
+        viewModelScope.launch { paperAccountStore.save(snapshot) }
+        _uiState.update {
+            it.copy(
+                paperCash = paperAccount.cash,
+                qtyText = if (paperAccount !== before) "" else it.qtyText,
+                message = if (paperAccount === before) "Paper order rejected"
+                    else if (filled) "Paper order filled @ $marketPrice" else "Paper limit order working",
+                messageIsError = paperAccount === before,
+            )
+        }
+        if (paperAccount !== before) notifier.success() else notifier.error()
     }
 
     private fun digits(t: String, max: Int) = t.filter { it.isDigit() }.take(max)
@@ -1055,4 +1147,8 @@ class TradingViewModel @Inject constructor(
         }
     }
 
+    private companion object {
+        /** Seed for a fresh shared paper account (matches the Paper screen's baseline). */
+        const val PAPER_STARTING_CASH = 100_000L
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperModeStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperModeStore.kt
@@ -1,0 +1,44 @@
+package com.testlogon.android.feature.paper
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.paperModeDataStore by preferencesDataStore(name = "paper_mode")
+
+/**
+ * Tiny durable flag shared by the real trade ticket and the standalone Paper screen so both agree on
+ * whether the user is in PAPER (simulated) mode. Backed by its own one-key DataStore; every read is
+ * failure-safe (a store error degrades to `false` = real trading, never throws). Exposed as a [Flow] so
+ * the ticket header switch and any future surface observe the same source of truth. Injectable directly
+ * (@Inject constructor + @Singleton) — no Hilt module needed.
+ */
+@Singleton
+class PaperModeStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val dataStore = context.paperModeDataStore
+
+    /** Emits the current paper-mode flag (defaults to false when unset or on any store error). */
+    val paperMode: Flow<Boolean> = dataStore.data
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .map { it[KEY] ?: false }
+
+    /** Persist the paper-mode flag (no-op on a store error). */
+    suspend fun setPaperMode(enabled: Boolean) {
+        runCatching { dataStore.edit { it[KEY] = enabled } }
+    }
+
+    private companion object {
+        val KEY = booleanPreferencesKey("paper_mode_enabled")
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperTicketSupport.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperTicketSupport.kt
@@ -1,0 +1,51 @@
+package com.testlogon.android.feature.paper
+
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.markets.trade.OrderType
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+
+/**
+ * PURE, framework-free helpers backing the trade-ticket PAPER-MODE toggle. No Android / coroutine /
+ * Compose / network dependencies so every function is unit-testable in isolation.
+ *
+ * Two concerns:
+ *  - [marketPriceFor]  — pick the simulated marketPrice fed into [PaperEngine.placeOrder].
+ *  - paper order-type gating ([isPaperSimulatable] / [toPaperType] / [snapToPaper]) — in paper mode ONLY
+ *    Market & Limit are simulated; every other type snaps back to Limit.
+ */
+object PaperTicketSupport {
+
+    /**
+     * The marketPrice used to fill a paper order for [side]: a BUY lifts the best ASK, a SELL hits the
+     * best BID (crossing the spread, like a real taker). Falls back to [last] then [mid] then the
+     * opposite side of the book when a side is missing, so a one-sided book still produces a price.
+     * Returns null only when NOTHING is known (no book, no last, no mid) — the caller must then refuse
+     * the fill rather than fabricate a price.
+     */
+    fun marketPriceFor(
+        side: OrderSide,
+        bestBid: Long?,
+        bestAsk: Long?,
+        last: Long?,
+        mid: Long? = null,
+    ): Long? {
+        val primary = if (side == OrderSide.BUY) bestAsk else bestBid
+        val secondary = if (side == OrderSide.BUY) bestBid else bestAsk
+        return firstPositive(primary, last, mid, secondary)
+    }
+
+    private fun firstPositive(vararg candidates: Long?): Long? =
+        candidates.firstOrNull { it != null && it > 0L }
+
+    /** In paper mode only MARKET & LIMIT are simulated by [PaperEngine]. */
+    fun isPaperSimulatable(type: OrderType): Boolean =
+        type == OrderType.MARKET || type == OrderType.LIMIT
+
+    /** Snap a non-simulatable order-type back to LIMIT (used when paper mode turns on). */
+    fun snapToPaper(type: OrderType): OrderType =
+        if (isPaperSimulatable(type)) type else OrderType.LIMIT
+
+    /** Map the (already-gated) ticket order-type to the engine paper type. Non-market -> LIMIT. */
+    fun toPaperType(type: OrderType): PaperOrderType =
+        if (type == OrderType.MARKET) PaperOrderType.MARKET else PaperOrderType.LIMIT
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/paper/PaperTicketSupportTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/paper/PaperTicketSupportTest.kt
@@ -1,0 +1,82 @@
+package com.testlogon.android.feature.paper
+
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.markets.trade.OrderType
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the PURE [PaperTicketSupport] helpers backing the trade-ticket paper-mode toggle:
+ * marketPrice selection (buy lifts ask / sell hits bid, with fallbacks) + paper order-type gating.
+ */
+class PaperTicketSupportTest {
+
+    // ---- marketPriceFor ----
+
+    @Test
+    fun buy_takesBestAsk() {
+        assertEquals(101L, PaperTicketSupport.marketPriceFor(OrderSide.BUY, bestBid = 99, bestAsk = 101, last = 100))
+    }
+
+    @Test
+    fun sell_takesBestBid() {
+        assertEquals(99L, PaperTicketSupport.marketPriceFor(OrderSide.SELL, bestBid = 99, bestAsk = 101, last = 100))
+    }
+
+    @Test
+    fun buy_missingAsk_fallsBackToLast() {
+        assertEquals(100L, PaperTicketSupport.marketPriceFor(OrderSide.BUY, bestBid = 99, bestAsk = null, last = 100))
+    }
+
+    @Test
+    fun missingLast_fallsBackToMid() {
+        assertEquals(150L, PaperTicketSupport.marketPriceFor(OrderSide.BUY, bestBid = null, bestAsk = null, last = null, mid = 150))
+    }
+
+    @Test
+    fun buy_missingAskAndLast_fallsBackToOppositeSide() {
+        // No ask, no last, no mid -> use the bid (the only known price) rather than fabricate.
+        assertEquals(99L, PaperTicketSupport.marketPriceFor(OrderSide.BUY, bestBid = 99, bestAsk = null, last = null))
+    }
+
+    @Test
+    fun nothingKnown_returnsNull() {
+        assertNull(PaperTicketSupport.marketPriceFor(OrderSide.BUY, bestBid = null, bestAsk = null, last = null, mid = null))
+    }
+
+    @Test
+    fun nonPositivePricesAreIgnored() {
+        // A zero/negative ask is skipped in favour of the next positive candidate (last).
+        assertEquals(100L, PaperTicketSupport.marketPriceFor(OrderSide.BUY, bestBid = 0, bestAsk = 0, last = 100))
+    }
+
+    // ---- paper order-type gating ----
+
+    @Test
+    fun onlyMarketAndLimitAreSimulatable() {
+        assertTrue(PaperTicketSupport.isPaperSimulatable(OrderType.MARKET))
+        assertTrue(PaperTicketSupport.isPaperSimulatable(OrderType.LIMIT))
+        assertFalse(PaperTicketSupport.isPaperSimulatable(OrderType.STOP))
+        assertFalse(PaperTicketSupport.isPaperSimulatable(OrderType.OCO))
+        assertFalse(PaperTicketSupport.isPaperSimulatable(OrderType.FUNDING))
+    }
+
+    @Test
+    fun snapToPaper_keepsMarketAndLimit_snapsRestToLimit() {
+        assertEquals(OrderType.MARKET, PaperTicketSupport.snapToPaper(OrderType.MARKET))
+        assertEquals(OrderType.LIMIT, PaperTicketSupport.snapToPaper(OrderType.LIMIT))
+        assertEquals(OrderType.LIMIT, PaperTicketSupport.snapToPaper(OrderType.STOP_LIMIT))
+        assertEquals(OrderType.LIMIT, PaperTicketSupport.snapToPaper(OrderType.QUOTE))
+    }
+
+    @Test
+    fun toPaperType_mapsMarketElseLimit() {
+        assertEquals(PaperOrderType.MARKET, PaperTicketSupport.toPaperType(OrderType.MARKET))
+        assertEquals(PaperOrderType.LIMIT, PaperTicketSupport.toPaperType(OrderType.LIMIT))
+        assertEquals(PaperOrderType.LIMIT, PaperTicketSupport.toPaperType(OrderType.STOP))
+    }
+}

--- a/frontend/src/lib/paperMode.test.ts
+++ b/frontend/src/lib/paperMode.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { isPaperOrderType, selectMarketPrice } from "./paperMode";
+
+describe("isPaperOrderType", () => {
+  it("accepts market and limit only", () => {
+    expect(isPaperOrderType("market")).toBe(true);
+    expect(isPaperOrderType("limit")).toBe(true);
+  });
+  it("rejects every other order type", () => {
+    for (const t of ["stop", "stop_limit", "take_profit", "quote", "oto", "oco", "funding"]) {
+      expect(isPaperOrderType(t)).toBe(false);
+    }
+  });
+});
+
+describe("selectMarketPrice", () => {
+  const full = { bestBid: 100, bestAsk: 102, lastPrice: 101, refPrice: 99 };
+
+  it("buy lifts the ask, sell hits the bid", () => {
+    expect(selectMarketPrice("buy", full)).toBe(102);
+    expect(selectMarketPrice("sell", full)).toBe(100);
+  });
+
+  it("falls back to last trade when the near-side quote is missing", () => {
+    expect(selectMarketPrice("buy", { bestBid: 100, lastPrice: 101, refPrice: 99 })).toBe(101);
+    expect(selectMarketPrice("sell", { bestAsk: 102, lastPrice: 101, refPrice: 99 })).toBe(101);
+  });
+
+  it("uses the far-side quote when near-side and last trade are absent (one-sided book)", () => {
+    // buy with no ask but a bid present -> uses the bid
+    expect(selectMarketPrice("buy", { bestBid: 100, refPrice: 99 })).toBe(100);
+    // sell with no bid but an ask present -> uses the ask
+    expect(selectMarketPrice("sell", { bestAsk: 104, refPrice: 99 })).toBe(104);
+  });
+
+  it("prefers the near-side quote over the mid when both sides exist", () => {
+    expect(selectMarketPrice("buy", { bestBid: 100, bestAsk: 104 })).toBe(104);
+    expect(selectMarketPrice("sell", { bestBid: 100, bestAsk: 104 })).toBe(100);
+  });
+
+  it("uses refPrice as the last resort", () => {
+    expect(selectMarketPrice("buy", { refPrice: 99 })).toBe(99);
+    expect(selectMarketPrice("sell", { refPrice: 99 })).toBe(99);
+  });
+
+  it("ignores non-positive / non-finite quotes and returns undefined when nothing is usable", () => {
+    expect(selectMarketPrice("buy", { bestAsk: 0, bestBid: -5, lastPrice: 0, refPrice: 0 })).toBeUndefined();
+    expect(selectMarketPrice("buy", {})).toBeUndefined();
+    expect(selectMarketPrice("buy", { bestAsk: NaN, lastPrice: NaN })).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/paperMode.ts
+++ b/frontend/src/lib/paperMode.ts
@@ -1,0 +1,99 @@
+// Shared PAPER-MODE flag for the real trade ticket. When ON, order submits on
+// the full ticket are routed to the isolated client-side paper engine
+// (paperEngine.ts) instead of the live /me/orders endpoints, and share the SAME
+// `paper.account.v1` account the dedicated Paper Trading page uses.
+//
+// Framework-free + event-based, mirroring the price-alerts store pattern: writes
+// persist to localStorage under `paper.mode.v1` and dispatch a same-tab event so
+// every mounted `usePaperMode()` re-reads. Cross-tab sync rides the native
+// `storage` event.
+
+import { useCallback, useEffect, useState } from "react";
+import type { PaperOrderType, PaperSide } from "./paperEngine";
+
+export const PAPER_MODE_KEY = "paper.mode.v1";
+
+/** Fired (same-tab) whenever the paper-mode flag flips. */
+export const PAPER_MODE_EVENT = "tl:paperModeChanged";
+
+/** Read the persisted paper-mode flag (defaults to OFF). */
+export function loadPaperMode(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(PAPER_MODE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the flag and notify same-tab listeners. */
+export function savePaperMode(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PAPER_MODE_KEY, enabled ? "1" : "0");
+  } catch {
+    /* quota / private-mode — degrade to no-op */
+  }
+  try {
+    window.dispatchEvent(new Event(PAPER_MODE_EVENT));
+  } catch {
+    /* SSR — no-op */
+  }
+}
+
+/**
+ * React hook exposing the shared paper-mode flag. `setEnabled` persists + fans
+ * the change out to every other `usePaperMode()` consumer in the tab.
+ */
+export function usePaperMode(): { enabled: boolean; setEnabled: (v: boolean) => void } {
+  const [enabled, setEnabledState] = useState<boolean>(() => loadPaperMode());
+
+  useEffect(() => {
+    const reload = () => setEnabledState(loadPaperMode());
+    window.addEventListener("storage", reload);
+    window.addEventListener(PAPER_MODE_EVENT, reload);
+    return () => {
+      window.removeEventListener("storage", reload);
+      window.removeEventListener(PAPER_MODE_EVENT, reload);
+    };
+  }, []);
+
+  const setEnabled = useCallback((v: boolean) => {
+    savePaperMode(v);
+    setEnabledState(v);
+  }, []);
+
+  return { enabled, setEnabled };
+}
+
+// ── Pure routing helpers (unit-tested in paperMode.test.ts) ──────────
+
+/** Order types the paper engine supports; the ticket restricts to these in paper mode. */
+export const PAPER_ORDER_TYPES: readonly PaperOrderType[] = ["market", "limit"];
+
+/** True when `type` can be simulated by the paper engine (market & limit only). */
+export function isPaperOrderType(type: string): type is PaperOrderType {
+  return type === "market" || type === "limit";
+}
+
+/**
+ * Pick the marketPrice to fill a paper order against: a BUY lifts the ask, a SELL
+ * hits the bid; fall back to last trade, then a bid/ask mid, then the entered
+ * reference price. Ignores non-positive quotes. Returns undefined when nothing
+ * usable is available (the engine then cancels a market order / rests a limit).
+ */
+export function selectMarketPrice(
+  side: PaperSide,
+  quotes: { bestBid?: number; bestAsk?: number; lastPrice?: number; refPrice?: number },
+): number | undefined {
+  const pos = (n?: number): number | undefined =>
+    n != null && Number.isFinite(n) && n > 0 ? n : undefined;
+  const bid = pos(quotes.bestBid);
+  const ask = pos(quotes.bestAsk);
+  const primary = side === "buy" ? ask : bid;
+  // Mid is a fallback for the rare case the NEAR-side quote is missing but the
+  // far side is present (e.g. one-sided book): buy with no ask but a bid, or
+  // sell with no bid but an ask.
+  const mid = bid != null && ask != null ? Math.round((bid + ask) / 2) : (bid ?? ask);
+  return primary ?? pos(quotes.lastPrice) ?? mid ?? pos(quotes.refPrice);
+}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -43,6 +43,11 @@ import { useAuthStore } from "@/stores/authStore";
 import { EngineConfigPanel } from "./EngineConfigPanel";
 import { PmAdminPanel } from "./PmAdminPanel";
 import { StakingAuctionsPanel } from "./StakingAuctionsPanel";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "sonner";
+import { usePaperMode, selectMarketPrice, isPaperOrderType } from "@/lib/paperMode";
+import { placeOrder as placePaperOrder, type PaperAccount } from "@/lib/paperEngine";
+import { loadAccount as loadPaperAccount, saveAccount as savePaperAccount, PAPER_ACCOUNT_KEY } from "@/lib/paperStore";
 
 type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto" | "oco" | "funding";
 type Section = "trade" | "positions" | "orders" | "fills";
@@ -382,6 +387,22 @@ export function TradeTicket({
   const spot = useSpotBalance(tradingFeatures.SPOT_ENABLED);
   const spotDepositM = useSpotDeposit();
 
+  // ── PAPER MODE ──────────────────────────────────────────────────────
+  // Shared flag + shared `paper.account.v1` account (same one the Paper
+  // Trading page uses). When ON, market/limit submits route to the local
+  // paper engine instead of the live /me/orders mutations.
+  const { enabled: paperMode, setEnabled: setPaperMode } = usePaperMode();
+  const [paperAcct, setPaperAcct] = useState<PaperAccount>(() => loadPaperAccount());
+  // Re-read the paper account if another surface (Paper page / other tab) mutates it.
+  useEffect(() => {
+    const reload = (e?: StorageEvent) => {
+      if (e && e.key && e.key !== PAPER_ACCOUNT_KEY) return;
+      setPaperAcct(loadPaperAccount());
+    };
+    window.addEventListener("storage", reload);
+    return () => window.removeEventListener("storage", reload);
+  }, []);
+
   const acct = account.data;
   const pmState = pm.data?.is_binary ? pm.data : undefined;
 
@@ -463,6 +484,16 @@ export function TradeTicket({
   ], []);
   useRegisterShortcuts(tradeShortcuts);
 
+  // In paper mode only market & limit are simulated — snap the selector back
+  // to Limit if a non-paper type was active when paper mode was enabled.
+  useEffect(() => {
+    if (paperMode && !isPaperOrderType(orderType)) {
+      setOrderType("limit");
+      resetArmed();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paperMode]);
+
   // Prefill the price from the last trade while untouched.
   useEffect(() => {
     if (!price && lastPrice && lastPrice > 0) setPrice(String(lastPrice));
@@ -498,6 +529,9 @@ export function TradeTicket({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [exec.data]);
 
+  const effectiveOrderTypes = paperMode
+    ? ORDER_TYPES.filter((t) => isPaperOrderType(t.id))
+    : ORDER_TYPES;
   const priceN = parseInt(price) || 0;
   const qtyN = parseInt(qty) || 0;
   const stopN = parseInt(stop) || 0;
@@ -509,7 +543,9 @@ export function TradeTicket({
   const fundingQtyN = parseInt(fundingQty) || 0;
   const durationSecN = parseInt(durationSec) || 0;
   const refPrice = priceN || stopN || lastPrice || 0;
-  const avail = acct?.available_balance ?? 0;
+  // Buying power reflects the PAPER account cash when paper mode is on so
+  // sizing / Max / order-value all key off the simulated balance.
+  const avail = paperMode ? paperAcct.cash : (acct?.available_balance ?? 0);
   const orderValue = priceN > 0 && qtyN > 0 ? priceN * qtyN : undefined;
   // ── Order preview math (all client-side, EXACT except the clearly-labeled est.) ──
   // Notional uses the effective ticket price: limit/stop-limit use the entered
@@ -695,11 +731,53 @@ export function TradeTicket({
     if (orderType === "market" && !oneTap && armed !== "market") {
       vibrate("warn");
       setArmed("market");
-      setMsg({ text: "Tap Confirm to send the market order", error: false });
+      setMsg({
+        text: paperMode ? "Tap Confirm paper order to simulate the fill" : "Tap Confirm to send the market order",
+        error: false,
+      });
       return;
     }
     setArmed(null);
     const cl = nextClordid();
+    // PAPER MODE: simulate market & limit locally against the shared paper
+    // account. Never hits /me/orders. Other order types are unreachable here
+    // because the selector is restricted to market & limit while paper is on.
+    if (paperMode && (orderType === "market" || orderType === "limit")) {
+      const isMkt = orderType === "market";
+      const marketPrice = selectMarketPrice(side, {
+        bestBid,
+        bestAsk,
+        lastPrice,
+        refPrice: previewPrice || refPrice,
+      });
+      const { account: nextAcct, order, fill } = placePaperOrder(
+        paperAcct,
+        { symbolId, side, type: orderType, price: isMkt ? undefined : priceN, qty: qtyN },
+        marketPrice,
+      );
+      setPaperAcct(nextAcct);
+      savePaperAccount(nextAcct);
+      if (order.status === "cancelled") {
+        vibrate("error");
+        setMsg({ text: "Paper order rejected (no market price / zero qty)", error: true });
+        toast.error("Paper order rejected");
+        return;
+      }
+      if (fill) {
+        vibrate("success");
+        setMsg({ text: `Paper ${side} ${qtyN} filled @ ${formatPrice(fill.price, scaler)}`, error: false });
+        toast.success("Paper order placed");
+      } else {
+        vibrate("tick");
+        setWorkingOrders((w) => [
+          ...w,
+          { clordid: order.id, side, price: priceN, qty: qtyN },
+        ]);
+        setMsg({ text: `Paper limit resting: ${side} ${qtyN} @ ${formatPrice(priceN, scaler)}`, error: false });
+        toast.success("Paper order placed");
+      }
+      return;
+    }
     if (orderType === "limit" || orderType === "market") {
       const isMarket = orderType === "market";
       const body: PlaceOrderRequest = {
@@ -809,8 +887,14 @@ export function TradeTicket({
     );
   }
 
-  const cancelOne = (clo: string) =>
-    cancelM.mutate(
+  const cancelOne = (clo: string) => {
+    // Paper resting orders are local-only — never hit the real cancel endpoint.
+    if (paperMode) {
+      setWorkingOrders((w) => w.filter((x) => x.clordid !== clo));
+      setMsg({ text: "Paper order cancelled", error: false });
+      return;
+    }
+    return cancelM.mutate(
       { clordid: clo, symbolId },
       {
         onSuccess: (a) => {
@@ -822,6 +906,7 @@ export function TradeTicket({
         },
       }
     );
+  };
   const cancelAll = () =>
     bulkM.mutate(undefined, {
       onSuccess: (a) => {
@@ -854,7 +939,10 @@ export function TradeTicket({
   const buyLabel = isPm ? "YES" : "Buy";
   const sellLabel = isPm ? "NO" : "Sell";
   const submitLabel = useMemo(() => {
-    if (armed === "market") return `Confirm ${side === "buy" ? "Buy" : "Sell"} ${qty} @ market`;
+    if (armed === "market")
+      return paperMode
+        ? `Confirm paper order — ${side === "buy" ? "Buy" : "Sell"} ${qty} @ market`
+        : `Confirm ${side === "buy" ? "Buy" : "Sell"} ${qty} @ market`;
     const s = side === "buy" ? "Buy" : "Sell";
     switch (orderType) {
       case "limit":
@@ -878,7 +966,7 @@ export function TradeTicket({
       default:
         return "Submit";
     }
-  }, [armed, side, qty, orderType, isBorrow]);
+  }, [armed, side, qty, orderType, isBorrow, paperMode]);
 
   const sections: { id: Section; label: string; count?: number }[] = [
     { id: "trade", label: "Trade" },
@@ -889,8 +977,41 @@ export function TradeTicket({
 
   return (
     <div className="space-y-3" ref={ticketRef}>
-    <Card>
+    <Card className={cn(paperMode && "border-2 border-amber-500/70 bg-amber-500/[0.03]")}>
       <CardContent className="space-y-3 pt-6">
+        {/* Paper-mode toggle + banner */}
+        <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">Paper</span>
+            {paperMode && (
+              <Badge
+                data-testid="paper_badge"
+                className="bg-amber-500 text-amber-950 hover:bg-amber-500"
+              >
+                PAPER
+              </Badge>
+            )}
+          </div>
+          <Switch
+            checked={paperMode}
+            onCheckedChange={(v) => {
+              setPaperMode(v);
+              resetArmed();
+              vibrate("tick");
+            }}
+            aria-label="Paper trading mode"
+            data-testid="paper_toggle"
+            className="data-[state=checked]:bg-amber-500"
+          />
+        </div>
+        {paperMode && (
+          <div
+            data-testid="paper_banner"
+            className="rounded-lg border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-700 dark:text-amber-300"
+          >
+            PAPER MODE — orders are simulated locally against your paper account. Nothing is sent to the exchange.
+          </div>
+        )}
         {/* Prediction-market banner */}
         {isPm && pmState && (
           <div
@@ -936,7 +1057,35 @@ export function TradeTicket({
         )}
 
         {/* Account strip */}
-        {acct && (
+        {paperMode && (
+          <div className="rounded-lg border border-amber-500/40 bg-amber-500/[0.04] p-3 text-sm" data-testid="paper_account_strip">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Paper cash</span>
+              <span className="tabular-nums font-semibold">{formatPrice(paperAcct.cash, scaler)}</span>
+            </div>
+            <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+              <span>Buying power</span>
+              <span className="tabular-nums">{formatPrice(paperAcct.cash, scaler)}</span>
+            </div>
+            <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+              <span>Realized PnL</span>
+              <span
+                className={cn(
+                  "tabular-nums",
+                  paperAcct.realizedPnl >= 0
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-rose-600 dark:text-rose-400",
+                )}
+              >
+                {paperAcct.realizedPnl >= 0 ? "+" : ""}
+                {formatPrice(paperAcct.realizedPnl, scaler)}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Real account strip (hidden in paper mode) */}
+        {!paperMode && acct && (
           <div className="rounded-lg border p-3 text-sm">
             <div className="flex justify-between">
               <span className="text-muted-foreground">Available</span>
@@ -1029,7 +1178,7 @@ export function TradeTicket({
           <div className="space-y-3">
             {/* Order type */}
             <div className="flex gap-1.5 overflow-x-auto pb-1">
-              {ORDER_TYPES.map((t) => (
+              {effectiveOrderTypes.map((t) => (
                 <Pill
                   key={t.id}
                   active={orderType === t.id}
@@ -1044,6 +1193,11 @@ export function TradeTicket({
                 </Pill>
               ))}
             </div>
+            {paperMode && (
+              <p className="-mt-1 text-[11px] text-amber-600 dark:text-amber-400" data-testid="paper_order_type_note">
+                Simulated in paper mode: market &amp; limit only.
+              </p>
+            )}
 
             {/* One-click bid/ask + market quick-actions (prefill only — the
                 user still confirms/submits via the existing path). */}


### PR DESCRIPTION
## Paper-mode toggle on the real trade ticket

Reuses the full production `TradeTicket` in a **paper-mode toggle** rather than a separate surface. When ON, Market/Limit orders simulate through the shared paper engine (the same paper account the dedicated Paper page/screen uses) instead of hitting `/me/orders`.

### Web
- `frontend/src/lib/paperMode.ts` (new) — `paper.mode.v1` localStorage flag + `usePaperMode()`; pure `selectMarketPrice()` / `isPaperOrderType()` helpers (+ 8 vitest cases).
- `TradeTicket.tsx` — header **Paper** switch, PAPER badge + amber banner/border, order-type selector restricted to Market/Limit, submit → `placeOrder()` on the shared `paper.account.v1` store, confirm relabeled "Confirm paper order", account strip shows paper cash/buying-power. OFF = unchanged.
- Gate: `tsc` 0 · `vite build` green · vitest 34/34.

### Android
- `PaperModeStore.kt` + `PaperTicketSupport.kt` (new, + 10 JVM tests) — shared `paper_mode` DataStore flag + pure market-price/paper-type helpers.
- `TradingViewModel`/`TradingUiState`/`TradeTicket.kt` — submit routes to `PaperEngine.placeOrder` on the shared `paper.account` store; Paper switch, PAPER badge, amber styling, paper account strip, Market/Limit-only, "Confirm paper order".
- Gate: `assembleDebug` + `testDebugUnitTest` BUILD SUCCESSFUL.

No new deps. No new nav routes (MoreCatalog untouched). OFF preserves exact current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)