### PR TITLE
feat(trading): surface the paper account in blotter/PnL/portfolio views (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/blotter/TradingBlotterScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/blotter/TradingBlotterScreen.kt
@@ -207,7 +207,15 @@ fun TradingBlotterScreen(
         modifier = modifier.testTag(TradingBlotterTestTags.SCREEN),
         topBar = {
             TopAppBar(
-                title = { Text("Trading Blotter") },
+                title = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("Trading Blotter")
+                        if (state.paper) {
+                            Spacer(Modifier.width(8.dp))
+                            PaperBadge()
+                        }
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -617,6 +625,23 @@ private fun StaticHeader(
 }
 
 private fun sideColor(side: BlotterSide): Color = if (side == BlotterSide.BUY) BuyColor else SellColor
+
+/** A small PAPER pill shown in the app bar when the blotter is sourcing the shared paper account. */
+@Composable
+private fun PaperBadge() {
+    Surface(
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Text(
+            "PAPER",
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
 
 @Composable
 private fun StatusBadge(status: BlotterStatus, modifier: Modifier = Modifier) {

--- a/android/app/src/main/java/com/testlogon/android/feature/blotter/TradingBlotterViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/blotter/TradingBlotterViewModel.kt
@@ -2,11 +2,21 @@ package com.testlogon.android.feature.blotter
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.feature.paper.PaperAccountStore
+import com.testlogon.android.feature.paper.PaperEngine
+import com.testlogon.android.feature.paper.PaperModeStore
+import com.testlogon.android.feature.paper.PaperViews
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -43,6 +53,8 @@ data class BlotterUiState(
     val groupBy: BlotterGroupKey? = null,
     val collapsedGroups: Set<String> = emptySet(),
     val expandedRows: Set<String> = emptySet(),
+    /** True when [orders] is sourced from the shared PAPER account (drives the PAPER badge). */
+    val paper: Boolean = false,
 ) {
     /**
      * The Row weight to lay a column out with: the user's persisted per-column width override when
@@ -152,16 +164,85 @@ data class BlotterUiState(
 @HiltViewModel
 class TradingBlotterViewModel @Inject constructor(
     private val layoutStore: BlotterLayoutStore,
+    private val paperStore: PaperAccountStore,
+    private val paperModeStore: PaperModeStore,
+    private val exchange: ExchangeRepository,
 ) : ViewModel() {
 
     private val rng = Random(0xB107)
 
+    // Base (live/mock) blotter state + all layout facets — the single source of truth the mutators and
+    // ticker write to. When paper mode is OFF the exposed [uiState] is this verbatim.
     private val _uiState = MutableStateFlow(BlotterUiState(orders = seedOrders()))
-    val uiState: StateFlow<BlotterUiState> = _uiState.asStateFlow()
+
+    // Latest PAPER projection (blotter order rows derived from the shared paper account + live marks),
+    // refreshed by [pollPaper]. Null until the first paper poll completes.
+    private val paperOrdersFlow = MutableStateFlow<List<BlotterOrder>>(emptyList())
+
+    /** Latest known live mark per paper symbolId, so paper positions mark-to-market. */
+    private val paperMarks = HashMap<Int, Long>()
+    private var paperInstruments: List<Instrument> = emptyList()
+
+    /**
+     * The exposed state combines the base state, the paper-mode flag, and the current paper order rows.
+     * In paper mode the base state's [BlotterUiState.orders] are REPLACED by the paper rows (re-sorted
+     * with the active sort) and [BlotterUiState.paper] is set — every derived view (fills, positions,
+     * filters, grouping, export) then flows from the paper rows automatically. OFF = base verbatim.
+     */
+    val uiState: StateFlow<BlotterUiState> =
+        combine(_uiState, paperModeStore.paperMode, paperOrdersFlow) { base, paper, paperRows ->
+            if (!paper) {
+                base.copy(paper = false)
+            } else {
+                base.copy(
+                    orders = sortOrders(paperRows, base.sortColumn, base.sortDir),
+                    paper = true,
+                )
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, BlotterUiState(orders = emptyList()))
 
     init {
         restoreLayout()
         startTicker()
+        pollPaper()
+    }
+
+    /**
+     * Continuously refresh the PAPER projection while the VM is alive: reload the shared account, feed
+     * live marks into the engine (so resting limits fill as the sim market moves), and re-derive the
+     * blotter order rows. Cheap and idempotent; only meaningful output is consumed when paper mode is
+     * ON, but polling unconditionally keeps the projection warm for an instant switch.
+     */
+    private fun pollPaper() {
+        viewModelScope.launch {
+            paperInstruments = (exchange.symbols() as? ApiResult.Success)?.data ?: emptyList()
+            val names = paperInstruments.associate { it.symbolId to it.symbol }
+            while (true) {
+                val loaded = paperStore.load()
+                if (loaded != null) {
+                    // Refresh a mark for every symbol the account touches, then tick the engine.
+                    var acct: PaperEngine.PaperAccount = loaded
+                    val symbols = (acct.positions.keys + acct.orders.map { it.symbolId }).toSet()
+                    for (sid in symbols) {
+                        val mark = fetchMark(sid)
+                        if (mark != null) {
+                            paperMarks[sid] = mark
+                            acct = PaperEngine.onTick(acct, sid, mark)
+                        }
+                    }
+                    paperOrdersFlow.value = PaperViews.blotterOrders(acct, paperMarks, names)
+                }
+                delay(2_000L)
+            }
+        }
+    }
+
+    /** Best available live price for [symbolId]: last trade, else order-book mid. Null when unavailable. */
+    private suspend fun fetchMark(symbolId: Int): Long? {
+        val last = (exchange.trades(symbolId) as? ApiResult.Success)?.data?.firstOrNull()?.price
+        if (last != null) return last
+        val book = (exchange.orderBook(symbolId) as? ApiResult.Success)?.data
+        return book?.mid?.let { Math.round(it) }
     }
 
     /** Merge the persisted layout over defaults and re-sort the seed to match. Never throws. */

--- a/android/app/src/main/java/com/testlogon/android/feature/paper/PaperViews.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/paper/PaperViews.kt
@@ -1,0 +1,224 @@
+package com.testlogon.android.feature.paper
+
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.paper.PaperEngine.PaperAccount
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderStatus
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+
+/**
+ * PURE, framework-free adapters that project the shared client-side [PaperAccount] (plus live marks +
+ * symbol-name resolution) into the render shapes the read-only Blotter / PnL / Portfolio screens
+ * already consume. NO Android / coroutine / Compose deps: every function below is a deterministic
+ * transformation over immutable value types so it is unit-testable in isolation and reused by each
+ * ViewModel when paper mode is ON.
+ *
+ * When paper mode is OFF the screens keep their existing (live/mock) data source untouched; these
+ * adapters are ONLY invoked to build the paper projection. The blotter uses string symbols + Double
+ * money; the paper engine uses symbolId + raw int64 engine units (scaler = 1 today, so notional =
+ * price * qty). The conversion here is the single choke point that keeps that mapping in one place.
+ */
+object PaperViews {
+
+    /** Resolve a symbolId to its display name, falling back to a stable "#id" token. */
+    private fun name(symbolId: Int, names: Map<Int, String>): String =
+        names[symbolId] ?: "#" + symbolId
+
+    // ---- Blotter -----------------------------------------------------------
+
+    /**
+     * Project the paper account into flat blotter Order rows (the Orders tab source of truth). Each
+     * paper order becomes one [com.testlogon.android.feature.blotter.BlotterOrder]:
+     *  - WORKING limit -> LIVE (leaves = full qty, cumQty = 0).
+     *  - FILLED (market or triggered limit) -> FILLED (cumQty = qty, leaves = 0, avgPx = fill price).
+     *  - CANCELLED -> CANCELLED (leaves = 0).
+     * The matching fill (for FILLED orders) supplies the executed avg price; a working order has none.
+     * Fills + positions are DERIVED from these rows by the existing blotter state (cumQty > 0), so we
+     * only need to emit the order rows correctly.
+     */
+    fun blotterOrders(
+        acct: PaperAccount,
+        marks: Map<Int, Long>,
+        names: Map<Int, String>,
+    ): List<com.testlogon.android.feature.blotter.BlotterOrder> {
+        // Index the latest fill price per order id (a paper order fills at most once in this engine).
+        val fillPxByOrder = acct.fills.associate { it.orderId to it.price }
+        return acct.orders.map { o ->
+            val side = if (o.side == OrderSide.BUY) {
+                com.testlogon.android.feature.blotter.BlotterSide.BUY
+            } else {
+                com.testlogon.android.feature.blotter.BlotterSide.SELL
+            }
+            val qty = o.qty.toDouble()
+            val fillPx = fillPxByOrder[o.id]
+            // Row px carries the LIVE mark when known so the derived Positions tab marks each symbol at
+            // its current price (uPnl = (mark - avgCost) * net); avgPx below keeps the true fill basis.
+            val px = (marks[o.symbolId] ?: o.limitPrice ?: fillPx ?: 0L).toDouble()
+            val filled = o.status == PaperOrderStatus.FILLED
+            val cumQty = if (filled) qty else 0.0
+            val avgPx = if (filled) (fillPx ?: o.limitPrice ?: 0L).toDouble() else 0.0
+            val leaves = when (o.status) {
+                PaperOrderStatus.WORKING -> qty
+                else -> 0.0
+            }
+            val status = when (o.status) {
+                PaperOrderStatus.WORKING -> com.testlogon.android.feature.blotter.BlotterStatus.LIVE
+                PaperOrderStatus.FILLED -> com.testlogon.android.feature.blotter.BlotterStatus.FILLED
+                PaperOrderStatus.CANCELLED -> com.testlogon.android.feature.blotter.BlotterStatus.CANCELLED
+            }
+            // Market orders are effectively immediate; model TIF as IOC, resting limits as GTC.
+            val tif = if (o.type == PaperOrderType.MARKET) {
+                com.testlogon.android.feature.blotter.BlotterTif.IOC
+            } else {
+                com.testlogon.android.feature.blotter.BlotterTif.GTC
+            }
+            com.testlogon.android.feature.blotter.BlotterOrder(
+                clord = o.id,
+                sym = name(o.symbolId, names),
+                side = side,
+                px = px,
+                qty = qty,
+                cumQty = cumQty,
+                leaves = leaves,
+                avgPx = avgPx,
+                status = status,
+                tif = tif,
+            )
+        }
+    }
+
+    // ---- PnL ---------------------------------------------------------------
+
+    /**
+     * Project the paper account + marks into the [com.testlogon.android.feature.pnl.PnlStats] the PnL
+     * screen renders. Realized comes straight off the engine; unrealized is the marked total; volume +
+     * fees + trade/win counts are walked from the fill history (paper has no fees, so fees = 0). The
+     * per-symbol breakdown mirrors the same walk keyed by symbol.
+     */
+    fun pnlStats(
+        acct: PaperAccount,
+        marks: Map<Int, Long>,
+    ): com.testlogon.android.feature.pnl.PnlStats {
+        val realized = acct.realizedPnl
+        val unrealized = PaperEngine.unrealized(acct, marks)
+        var volume = 0L
+        for (f in acct.fills) volume += Math.abs(f.qty) * f.price
+        val closing = closingTradeStats(acct)
+        return com.testlogon.android.feature.pnl.PnlStats(
+            netRealized = realized,
+            unrealized = unrealized,
+            totalFees = 0L,
+            winRate = if (closing.first > 0) closing.second.toFloat() / closing.first.toFloat() else 0f,
+            closingTradeCount = closing.first,
+            tradeCount = acct.fills.size,
+            volume = volume,
+            fundingTotal = 0L,
+            liquidationPnl = 0L,
+        )
+    }
+
+    /** Per-symbol PnL rows for the paper account (realized walk per symbol, fees = 0). */
+    fun pnlBySymbol(
+        acct: PaperAccount,
+        names: Map<Int, String>,
+    ): List<com.testlogon.android.feature.pnl.SymbolRow> =
+        acct.fills.groupBy { it.symbolId }.map { (symbolId, fills) ->
+            var realized = 0L
+            var netQty = 0L
+            var avgEntry = 0L
+            var volume = 0L
+            fills.sortedBy { it.tsMs }.forEach { f ->
+                volume += Math.abs(f.qty) * f.price
+                val dir = if (f.side == OrderSide.BUY) 1 else -1
+                val signedQty = dir * f.qty
+                if (netQty == 0L || sameSign(netQty, signedQty)) {
+                    avgEntry = weightedEntry(netQty, avgEntry, f.qty, f.price)
+                    netQty += signedQty
+                } else {
+                    val closable = Math.min(f.qty, Math.abs(netQty))
+                    val posDir = if (netQty > 0) 1 else -1
+                    realized += (f.price - avgEntry) * closable * posDir
+                    val remaining = Math.abs(netQty) - closable
+                    netQty = posDir.toLong() * remaining
+                    if (netQty == 0L) {
+                        avgEntry = 0L
+                        val flip = f.qty - closable
+                        if (flip > 0L) {
+                            netQty = dir.toLong() * flip
+                            avgEntry = f.price
+                        }
+                    }
+                }
+            }
+            com.testlogon.android.feature.pnl.SymbolRow(
+                symbol = name(symbolId, names),
+                realized = realized,
+                volume = volume,
+                fees = 0L,
+                tradeCount = fills.size,
+            )
+        }.sortedByDescending { Math.abs(it.realized) }
+
+    /** (closingTradeCount, winningTradeCount) walked from the fill history. */
+    private fun closingTradeStats(acct: PaperAccount): Pair<Int, Int> {
+        var closing = 0
+        var winning = 0
+        acct.fills.groupBy { it.symbolId }.forEach { (_, fills) ->
+            var netQty = 0L
+            var avgEntry = 0L
+            fills.sortedBy { it.tsMs }.forEach { f ->
+                val dir = if (f.side == OrderSide.BUY) 1 else -1
+                val signedQty = dir * f.qty
+                if (netQty == 0L || sameSign(netQty, signedQty)) {
+                    avgEntry = weightedEntry(netQty, avgEntry, f.qty, f.price)
+                    netQty += signedQty
+                } else {
+                    val closable = Math.min(f.qty, Math.abs(netQty))
+                    val posDir = if (netQty > 0) 1 else -1
+                    val pnl = (f.price - avgEntry) * closable * posDir
+                    closing += 1
+                    if (pnl > 0) winning += 1
+                    val remaining = Math.abs(netQty) - closable
+                    netQty = posDir.toLong() * remaining
+                    if (netQty == 0L) {
+                        avgEntry = 0L
+                        val flip = f.qty - closable
+                        if (flip > 0L) {
+                            netQty = dir.toLong() * flip
+                            avgEntry = f.price
+                        }
+                    }
+                }
+            }
+        }
+        return closing to winning
+    }
+
+    // ---- Portfolio ---------------------------------------------------------
+
+    /** Open paper positions projected into the portfolio position rows (liq price unknown -> 0). */
+    fun portfolioPositions(
+        acct: PaperAccount,
+        marks: Map<Int, Long>,
+        names: Map<Int, String>,
+    ): List<com.testlogon.android.feature.portfolio.PortfolioPosition> =
+        acct.positions.entries.sortedBy { it.key }.map { (symbolId, pos) ->
+            val mark = marks[symbolId]
+            val upl = if (mark != null) PaperEngine.positionMtm(pos, mark) else 0L
+            com.testlogon.android.feature.portfolio.PortfolioPosition(
+                symbol = name(symbolId, names),
+                qty = pos.qty,
+                entryPrice = pos.avgEntry,
+                liquidationPrice = 0L,
+                unrealizedPnl = upl,
+            )
+        }
+
+    private fun sameSign(a: Long, b: Long): Boolean = (a > 0 && b > 0) || (a < 0 && b < 0)
+
+    private fun weightedEntry(heldQty: Long, heldEntry: Long, addQty: Long, addPrice: Long): Long {
+        val held = Math.abs(heldQty)
+        val total = held + addQty
+        if (total == 0L) return 0L
+        return (held * heldEntry + addQty * addPrice) / total
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -87,7 +88,15 @@ fun PnlScreen(
         modifier = modifier.fillMaxSize(),
         topBar = {
             TopAppBar(
-                title = { Text("PnL & performance") },
+                title = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("PnL & performance")
+                        if (state.paper) {
+                            Spacer(Modifier.width(8.dp))
+                            PnlPaperBadge()
+                        }
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -415,4 +424,22 @@ private fun MessageBlock(title: String, body: String, modifier: Modifier) {
 private fun signed(v: Long): String {
     val grouped = String.format(Locale.US, "%,d", Math.abs(v))
     return if (v >= 0) "+$grouped" else "-$grouped"
+}
+
+
+/** A small PAPER pill shown in the app bar when the PnL screen reflects the shared paper account. */
+@Composable
+private fun PnlPaperBadge() {
+    Surface(
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Text(
+            "PAPER",
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+        )
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlUiState.kt
@@ -16,6 +16,8 @@ data class PnlUiState(
     val stats: PnlStats? = null,
     val bySymbol: List<SymbolRow> = emptyList(),
     val equityCurve: List<EquityCurvePoint> = emptyList(),
+    /** True when the report is derived from the shared PAPER account (drives the PAPER badge). */
+    val paper: Boolean = false,
 ) {
     /** True once loaded, readable, and there was genuinely no trading activity to analyze. */
     val isEmpty: Boolean

--- a/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/pnl/PnlViewModel.kt
@@ -9,12 +9,19 @@ import com.testlogon.android.data.exchange.FundingPayments
 import com.testlogon.android.data.exchange.Instrument
 import com.testlogon.android.data.exchange.Liquidations
 import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.feature.paper.PaperAccountStore
+import com.testlogon.android.feature.paper.PaperEngine
+import com.testlogon.android.feature.paper.PaperModeStore
+import com.testlogon.android.feature.paper.PaperViews
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -33,13 +40,72 @@ import javax.inject.Inject
 class PnlViewModel @Inject constructor(
     private val trading: TradingRepository,
     private val exchange: ExchangeRepository,
+    private val paperStore: PaperAccountStore,
+    private val paperModeStore: PaperModeStore,
 ) : ViewModel() {
 
+    // Live (real-venue) PnL state produced by [refresh]. Exposed verbatim when paper mode is OFF.
     private val _uiState = MutableStateFlow(PnlUiState())
-    val uiState: StateFlow<PnlUiState> = _uiState.asStateFlow()
+
+    // Latest PAPER PnL projection (stats + per-symbol) from the shared account; null until first poll.
+    private val paperFlow = MutableStateFlow<PnlUiState?>(null)
+
+    /** Latest known live mark per paper symbolId, so paper unrealized marks-to-market. */
+    private val paperMarks = HashMap<Int, Long>()
+
+    /**
+     * The exposed state switches source on the paper-mode flag: the shared PAPER account projection when
+     * ON (loading until its first poll lands), else the live venue report. Read-only either way.
+     */
+    val uiState: StateFlow<PnlUiState> =
+        combine(_uiState, paperModeStore.paperMode, paperFlow) { live, paper, paperState ->
+            if (paper) (paperState ?: PnlUiState(loading = true, paper = true)) else live
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, PnlUiState())
 
     init {
         refresh()
+        pollPaper()
+    }
+
+    /**
+     * Continuously project the shared PAPER account into a [PnlUiState] while the VM is alive: reload the
+     * account, refresh live marks, and fold through [PaperViews]. The output is only surfaced while paper
+     * mode is ON, but polling keeps it warm for an instant switch.
+     */
+    private fun pollPaper() {
+        viewModelScope.launch {
+            val instruments = (exchange.symbols() as? ApiResult.Success)?.data ?: emptyList()
+            val names = instruments.associate { it.symbolId to it.symbol }
+            while (true) {
+                val acct = paperStore.load()
+                if (acct == null) {
+                    paperFlow.value = PnlUiState(loading = false, paper = true)
+                } else {
+                    val symbols = (acct.positions.keys + acct.orders.map { it.symbolId }).toSet()
+                    for (sid in symbols) {
+                        val mark = fetchMark(sid)
+                        if (mark != null) paperMarks[sid] = mark
+                    }
+                    val stats = PaperViews.pnlStats(acct, paperMarks)
+                    paperFlow.value = PnlUiState(
+                        loading = false,
+                        stats = stats,
+                        bySymbol = PaperViews.pnlBySymbol(acct, names),
+                        equityCurve = emptyList(),
+                        paper = true,
+                    )
+                }
+                kotlinx.coroutines.delay(2_000L)
+            }
+        }
+    }
+
+    /** Best available live price for [symbolId]: last trade, else order-book mid. Null when unavailable. */
+    private suspend fun fetchMark(symbolId: Int): Long? {
+        val last = (exchange.trades(symbolId) as? ApiResult.Success)?.data?.firstOrNull()?.price
+        if (last != null) return last
+        val book = (exchange.orderBook(symbolId) as? ApiResult.Success)?.data
+        return book?.mid?.let { Math.round(it) }
     }
 
     fun refresh() {

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -70,7 +71,15 @@ fun PortfolioScreen(
         modifier = modifier.fillMaxSize(),
         topBar = {
             TopAppBar(
-                title = { Text("Portfolio") },
+                title = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("Portfolio")
+                        if (state.paper) {
+                            Spacer(Modifier.width(8.dp))
+                            PortfolioPaperBadge()
+                        }
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -324,3 +333,21 @@ private fun fmt(v: Double): String =
 
 /** USD money format: '$' prefix, 2 decimals, grouped thousands (indicative reference value). */
 private fun usd(v: Double): String = "$" + String.format(java.util.Locale.US, "%,.2f", v)
+
+
+/** A small PAPER pill shown in the app bar when the portfolio reflects the shared paper account. */
+@Composable
+private fun PortfolioPaperBadge() {
+    Surface(
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Text(
+            "PAPER",
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioUiState.kt
@@ -26,7 +26,13 @@ enum class PortfolioVenue(val label: String) {
     SPOT("Spot"),
     MARGIN("Margin"),
     STAKING("Staking"),
+    /** The shared client-side PAPER account (only shown while paper mode is ON). */
+    PAPER("Paper"),
 }
+
+/** The four real venues shown in live mode (PAPER is surfaced only while paper mode is ON). */
+val LIVE_VENUES: List<PortfolioVenue> =
+    listOf(PortfolioVenue.CUSTODY, PortfolioVenue.SPOT, PortfolioVenue.MARGIN, PortfolioVenue.STAKING)
 
 /**
  * One venue card. When [loading] is false, a readable venue carries an [equity] contribution (a coarse
@@ -87,12 +93,14 @@ data class PortfolioPosition(
  */
 data class PortfolioUiState(
     val loading: Boolean = true,
-    val cards: List<VenueCard> = PortfolioVenue.entries.map { VenueCard(venue = it) },
+    val cards: List<VenueCard> = LIVE_VENUES.map { VenueCard(venue = it) },
     val positions: List<PortfolioPosition> = emptyList(),
     /** True when a usable USD price map valued at least one balance -> show USD equity. */
     val priced: Boolean = false,
     /** True when the priced marks are the edge STUB placeholders (indicative-only caveat). */
     val pricesStub: Boolean = false,
+    /** True when the whole screen reflects the shared PAPER account (drives the PAPER badge). */
+    val paper: Boolean = false,
 ) {
     /** Sum of the readable venues' equity contributions - a coarse cross-venue snapshot, not a settled total. */
     val totalEquity: Double get() = cards.filter { it.countsTowardTotal }.sumOf { it.equity }

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioViewModel.kt
@@ -4,14 +4,23 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.data.custody.CustodyRepository
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.PriceMap
 import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.feature.paper.PaperAccountStore
+import com.testlogon.android.feature.paper.PaperEngine
+import com.testlogon.android.feature.paper.PaperModeStore
+import com.testlogon.android.feature.paper.PaperViews
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -28,13 +37,88 @@ import javax.inject.Inject
 class PortfolioViewModel @Inject constructor(
     private val custody: CustodyRepository,
     private val trading: TradingRepository,
+    private val exchange: ExchangeRepository,
+    private val paperStore: PaperAccountStore,
+    private val paperModeStore: PaperModeStore,
 ) : ViewModel() {
 
+    // Live (cross-venue) portfolio state produced by [refresh]. Exposed verbatim when paper mode is OFF.
     private val _uiState = MutableStateFlow(PortfolioUiState())
-    val uiState: StateFlow<PortfolioUiState> = _uiState.asStateFlow()
+
+    // Latest PAPER portfolio projection (a single paper card + paper positions); null until first poll.
+    private val paperFlow = MutableStateFlow<PortfolioUiState?>(null)
+
+    /** Latest known live mark per paper symbolId, so paper positions/equity mark-to-market. */
+    private val paperMarks = HashMap<Int, Long>()
+
+    /**
+     * The exposed state switches source on the paper-mode flag: the shared PAPER account snapshot when
+     * ON (loading until its first poll lands), else the live cross-venue snapshot. Read-only either way.
+     */
+    val uiState: StateFlow<PortfolioUiState> =
+        combine(_uiState, paperModeStore.paperMode, paperFlow) { live, paper, paperState ->
+            if (paper) (paperState ?: PortfolioUiState(loading = true, cards = emptyList(), paper = true)) else live
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, PortfolioUiState())
 
     init {
         refresh()
+        pollPaper()
+    }
+
+    /**
+     * Continuously project the shared PAPER account into a single-card [PortfolioUiState] while the VM is
+     * alive: reload the account, refresh live marks, and fold cash + equity + positions through
+     * [PaperViews]. Surfaced only while paper mode is ON; polled unconditionally to stay warm.
+     */
+    private fun pollPaper() {
+        viewModelScope.launch {
+            val instruments = (exchange.symbols() as? ApiResult.Success)?.data ?: emptyList()
+            val names = instruments.associate { it.symbolId to it.symbol }
+            while (true) {
+                val acct = paperStore.load()
+                if (acct == null) {
+                    paperFlow.value = PortfolioUiState(loading = false, cards = emptyList(), paper = true)
+                } else {
+                    val symbols = (acct.positions.keys + acct.orders.map { it.symbolId }).toSet()
+                    for (sid in symbols) {
+                        val mark = fetchMark(sid)
+                        if (mark != null) paperMarks[sid] = mark
+                    }
+                    val equity = PaperEngine.equity(acct, paperMarks)
+                    val unrealized = PaperEngine.unrealized(acct, paperMarks)
+                    val card = VenueCard(
+                        venue = PortfolioVenue.PAPER,
+                        loading = false,
+                        equity = equity.toDouble(),
+                        equityUsd = 0.0,
+                        lines = listOf(
+                            PortfolioLine("Cash", acct.cash.toString()),
+                            PortfolioLine("Equity", equity.toString()),
+                            PortfolioLine("Unrealized", unrealized.toString()),
+                            PortfolioLine("Realized", acct.realizedPnl.toString()),
+                            PortfolioLine("Starting cash", acct.startingCash.toString()),
+                        ),
+                    )
+                    paperFlow.value = PortfolioUiState(
+                        loading = false,
+                        cards = listOf(card),
+                        positions = PaperViews.portfolioPositions(acct, paperMarks, names),
+                        priced = false,
+                        pricesStub = false,
+                        paper = true,
+                    )
+                }
+                delay(2_000L)
+            }
+        }
+    }
+
+    /** Best available live price for [symbolId]: last trade, else order-book mid. Null when unavailable. */
+    private suspend fun fetchMark(symbolId: Int): Long? {
+        val last = (exchange.trades(symbolId) as? ApiResult.Success)?.data?.firstOrNull()?.price
+        if (last != null) return last
+        val book = (exchange.orderBook(symbolId) as? ApiResult.Success)?.data
+        return book?.mid?.let { Math.round(it) }
     }
 
     fun refresh() {

--- a/android/app/src/test/java/com/testlogon/android/feature/paper/PaperViewsTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/paper/PaperViewsTest.kt
@@ -1,0 +1,126 @@
+package com.testlogon.android.feature.paper
+
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.blotter.BlotterSide
+import com.testlogon.android.feature.blotter.BlotterStatus
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrder
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the PURE [PaperViews] adapters that project a shared [PaperEngine.PaperAccount] into
+ * the read-only Blotter / PnL / Portfolio render shapes when paper mode is ON. Builds a small account
+ * by driving the engine, then asserts the projected rows/stats.
+ */
+class PaperViewsTest {
+
+    private val BTC = 1
+    private val ETH = 2
+    private val names = mapOf(BTC to "BTCUSDC", ETH to "ETHUSDC")
+
+    private fun order(
+        id: String,
+        side: OrderSide,
+        type: PaperOrderType,
+        qty: Long,
+        limitPrice: Long? = null,
+        symbolId: Int = BTC,
+    ) = PaperOrder(id = id, symbolId = symbolId, side = side, type = type, qty = qty, limitPrice = limitPrice)
+
+    /** Buy 2 @100 (market fill), sell 1 @150 (realizes +50 on the closed unit), leaving 1 long @100. */
+    private fun sampleAccount(): PaperEngine.PaperAccount {
+        var acct = PaperEngine.newAccount(1_000_000)
+        acct = PaperEngine.placeOrder(acct, order("o1", OrderSide.BUY, PaperOrderType.MARKET, 2), 100)
+        acct = PaperEngine.placeOrder(acct, order("o2", OrderSide.SELL, PaperOrderType.MARKET, 1), 150)
+        return acct
+    }
+
+    // ---- Blotter -----------------------------------------------------------
+
+    @Test
+    fun blotterOrders_projectsFilledMarketOrders_withLiveMarkAsPx() {
+        val acct = sampleAccount()
+        val marks = mapOf(BTC to 120L)
+        val rows = PaperViews.blotterOrders(acct, marks, names)
+        assertEquals(2, rows.size)
+        val buy = rows.first { it.clord == "o1" }
+        assertEquals("BTCUSDC", buy.sym)
+        assertEquals(BlotterSide.BUY, buy.side)
+        assertEquals(BlotterStatus.FILLED, buy.status)
+        assertEquals(2.0, buy.qty, 1e-9)
+        assertEquals(2.0, buy.cumQty, 1e-9)   // fully executed
+        assertEquals(0.0, buy.leaves, 1e-9)
+        assertEquals(100.0, buy.avgPx, 1e-9)  // true fill basis
+        assertEquals(120.0, buy.px, 1e-9)     // live mark drives px
+    }
+
+    @Test
+    fun blotterOrders_workingLimit_isLiveWithFullLeaves() {
+        var acct = PaperEngine.newAccount(1_000_000)
+        // Non-marketable buy limit (limit 90 < market 100) rests as WORKING.
+        acct = PaperEngine.placeOrder(acct, order("w1", OrderSide.BUY, PaperOrderType.LIMIT, 5, limitPrice = 90), 100)
+        val rows = PaperViews.blotterOrders(acct, emptyMap(), names)
+        val w = rows.single()
+        assertEquals(BlotterStatus.LIVE, w.status)
+        assertEquals(5.0, w.leaves, 1e-9)
+        assertEquals(0.0, w.cumQty, 1e-9)
+        // No live mark -> px falls back to the limit price.
+        assertEquals(90.0, w.px, 1e-9)
+    }
+
+    // ---- PnL ---------------------------------------------------------------
+
+    @Test
+    fun pnlStats_realizedUnrealizedAndCounts() {
+        val acct = sampleAccount()
+        val marks = mapOf(BTC to 130L)
+        val stats = PaperViews.pnlStats(acct, marks)
+        assertEquals(50L, stats.netRealized)          // closed 1 unit @ +50
+        assertEquals(30L, stats.unrealized)           // 1 long @100 marked 130
+        assertEquals(0L, stats.totalFees)
+        assertEquals(2, stats.tradeCount)             // two fills
+        assertEquals(1, stats.closingTradeCount)      // the sell closed
+        assertTrue(stats.winRate > 0.99f)             // the one closing trade won
+        // volume = |2|*100 + |1|*150 = 350
+        assertEquals(350L, stats.volume)
+    }
+
+    @Test
+    fun pnlBySymbol_splitsPerSymbol() {
+        var acct = sampleAccount()
+        // Add an ETH round-trip: buy 3 @50, sell 3 @40 -> realized -30.
+        acct = PaperEngine.placeOrder(acct, order("e1", OrderSide.BUY, PaperOrderType.MARKET, 3, symbolId = ETH), 50)
+        acct = PaperEngine.placeOrder(acct, order("e2", OrderSide.SELL, PaperOrderType.MARKET, 3, symbolId = ETH), 40)
+        val rows = PaperViews.pnlBySymbol(acct, names)
+        val btc = rows.first { it.symbol == "BTCUSDC" }
+        val eth = rows.first { it.symbol == "ETHUSDC" }
+        assertEquals(50L, btc.realized)
+        assertEquals(-30L, eth.realized)
+        assertEquals(0L, btc.fees)
+    }
+
+    // ---- Portfolio ---------------------------------------------------------
+
+    @Test
+    fun portfolioPositions_openPositionMarkedToMarket() {
+        val acct = sampleAccount()
+        val marks = mapOf(BTC to 200L)
+        val pos = PaperViews.portfolioPositions(acct, marks, names).single()
+        assertEquals("BTCUSDC", pos.symbol)
+        assertEquals(1L, pos.qty)            // 1 long remains
+        assertEquals(100L, pos.entryPrice)
+        assertEquals(0L, pos.liquidationPrice)
+        assertEquals(100L, pos.unrealizedPnl) // (200-100)*1
+        assertTrue(pos.isLong)
+        assertTrue(pos.isProfit)
+    }
+
+    @Test
+    fun portfolioPositions_noMark_zeroUpl() {
+        val acct = sampleAccount()
+        val pos = PaperViews.portfolioPositions(acct, emptyMap(), names).single()
+        assertEquals(0L, pos.unrealizedPnl)  // no mark -> not fabricated
+    }
+}

--- a/frontend/src/hooks/usePaperMarks.ts
+++ b/frontend/src/hooks/usePaperMarks.ts
@@ -1,0 +1,96 @@
+// Live-mark assembly for the shared PAPER account. Given the account's open
+// positions + working orders, this resolves a `marks` map (symbolId -> last
+// trade price) by reusing the SAME market-data feed the rest of the app uses
+// (GET /md/trades/{id} via getTrades) — it does NOT invent a new fetch. One
+// query per distinct symbol touched by the account; each polls on the live 2s
+// interval and degrades to `undefined` (no mark) when its feed is missing.
+//
+// Also exposes a symbolId -> display-name resolver from the /md/symbols catalog,
+// and re-reads the persisted paper account on the same-tab PAPER_MODE_EVENT and
+// the cross-tab `storage` event so the views stay in sync with the trade ticket.
+import { useEffect, useMemo, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { getTrades } from "@/api/endpoints/marketData";
+import { useSymbols } from "@/hooks/useMarketData";
+import { loadAccount } from "@/lib/paperStore";
+import { PAPER_MODE_EVENT } from "@/lib/paperMode";
+import type { PaperAccount } from "@/lib/paperEngine";
+import type { PaperMarks, SymName } from "@/lib/paperBlotter";
+
+const LIVE_REFETCH_MS = 2000;
+
+/**
+ * Load the persisted paper account and keep it in sync with the trade ticket /
+ * Paper page: re-reads on PAPER_MODE_EVENT (same tab) + `storage` (cross tab),
+ * and on a light interval so live fills from the ticket surface here too.
+ */
+export function usePaperAccount(enabled: boolean): PaperAccount {
+  const [acct, setAcct] = useState<PaperAccount>(() => loadAccount());
+  useEffect(() => {
+    if (!enabled) return;
+    const reload = () => setAcct(loadAccount());
+    reload();
+    window.addEventListener("storage", reload);
+    window.addEventListener(PAPER_MODE_EVENT, reload);
+    // localStorage writes from the same tab (trade ticket / onTick) don't fire
+    // `storage`, so poll lightly to pick those up.
+    const id = window.setInterval(reload, LIVE_REFETCH_MS);
+    return () => {
+      window.removeEventListener("storage", reload);
+      window.removeEventListener(PAPER_MODE_EVENT, reload);
+      window.clearInterval(id);
+    };
+  }, [enabled]);
+  return acct;
+}
+
+/** Distinct symbolIds the account has any exposure or resting order in. */
+export function accountSymbolIds(acct: PaperAccount): number[] {
+  const ids = new Set<number>();
+  for (const k of Object.keys(acct.positions)) ids.add(Number(k));
+  for (const o of acct.orders) if (o.status === "working") ids.add(o.symbolId);
+  return [...ids].sort((a, b) => a - b);
+}
+
+export interface PaperMarksResult {
+  marks: PaperMarks;
+  symName: SymName;
+}
+
+/**
+ * Assemble a live marks map for every symbol the account touches, plus a
+ * symbolId -> name resolver. `enabled=false` (paper mode OFF) issues no queries.
+ */
+export function usePaperMarks(acct: PaperAccount, enabled: boolean): PaperMarksResult {
+  const symbolsQ = useSymbols();
+  const symName = useMemo<SymName>(() => {
+    const byId = new Map<number, string>();
+    for (const s of symbolsQ.data?.symbols ?? []) byId.set(s.symbol_id, s.symbol);
+    return (id: number) => byId.get(id) ?? `#${id}`;
+  }, [symbolsQ.data]);
+
+  const ids = useMemo(() => accountSymbolIds(acct), [acct]);
+
+  const results = useQueries({
+    queries: ids.map((id) => ({
+      queryKey: ["md", "trades", id] as const,
+      queryFn: () => getTrades(id),
+      enabled: enabled && Number.isFinite(id) && id > 0,
+      refetchInterval: LIVE_REFETCH_MS,
+      staleTime: LIVE_REFETCH_MS,
+    })),
+  });
+
+  const marks = useMemo<PaperMarks>(() => {
+    const m: PaperMarks = {};
+    ids.forEach((id, i) => {
+      const px = results[i]?.data?.trades?.[0]?.price;
+      m[id] = px != null && Number.isFinite(px) && px > 0 ? px : undefined;
+    });
+    return m;
+    // results identity changes each poll; key off the mapped prices instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ids, results.map((r) => r.data?.trades?.[0]?.price).join(",")]);
+
+  return { marks, symName };
+}

--- a/frontend/src/lib/paperBlotter.test.ts
+++ b/frontend/src/lib/paperBlotter.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { newAccount, placeOrder, type PaperAccount } from "./paperEngine";
+import {
+  paperOrdersToBlotter,
+  paperFillsToBlotter,
+  paperPositionsToBlotter,
+  buildPnlSummaryFromPaper,
+} from "./paperBlotter";
+
+const BTC = 1;
+const ETH = 2;
+const symName = (id: number) => (id === BTC ? "BTCUSDC" : id === ETH ? "ETHUSDC" : `#${id}`);
+
+/** A small account: long 10 BTC @ 100 (market), plus one resting limit BUY. */
+function seedAccount(): PaperAccount {
+  let a = newAccount(100_000);
+  a = placeOrder(a, { symbolId: BTC, side: "buy", type: "market", qty: 10 }, 100).account;
+  // Resting limit BUY far below the market — stays working.
+  a = placeOrder(a, { symbolId: ETH, side: "buy", type: "limit", price: 50, qty: 4 }, 100).account;
+  return a;
+}
+
+describe("paperOrdersToBlotter", () => {
+  it("emits only working orders as live blotter rows", () => {
+    const a = seedAccount();
+    const rows = paperOrdersToBlotter(a, symName);
+    expect(rows).toHaveLength(1); // the market order filled; only the limit rests
+    const r = rows[0]!;
+    expect(r.sym).toBe("ETHUSDC");
+    expect(r.side).toBe("B");
+    expect(r.status).toBe("live");
+    expect(r.px).toBe(50);
+    expect(r.qty).toBe(4);
+    expect(r.leaves).toBe(4);
+    expect(r.cumQty).toBe(0);
+    expect(r.source).toBe("PAPR");
+  });
+
+  it("returns no rows for a fresh account", () => {
+    expect(paperOrdersToBlotter(newAccount(100_000), symName)).toHaveLength(0);
+  });
+});
+
+describe("paperFillsToBlotter", () => {
+  it("emits one filled row per fill, newest first", () => {
+    let a = newAccount(100_000);
+    a = placeOrder(a, { symbolId: BTC, side: "buy", type: "market", qty: 3 }, 100).account;
+    a = placeOrder(a, { symbolId: BTC, side: "sell", type: "market", qty: 1 }, 110).account;
+    const rows = paperFillsToBlotter(a, symName);
+    expect(rows).toHaveLength(2);
+    // newest (the sell) first
+    expect(rows[0]!.side).toBe("S");
+    expect(rows[0]!.px).toBe(110);
+    expect(rows[0]!.cumQty).toBe(1);
+    expect(rows[0]!.status).toBe("filled");
+    expect(rows[1]!.side).toBe("B");
+    expect(rows[1]!.px).toBe(100);
+    expect(rows[0]!.sym).toBe("BTCUSDC");
+  });
+});
+
+describe("paperPositionsToBlotter", () => {
+  it("marks the position to a live price with correct uPnL + side", () => {
+    const a = seedAccount(); // long 10 BTC @ 100
+    const rows = paperPositionsToBlotter(a, { [BTC]: 120 }, symName);
+    expect(rows).toHaveLength(1);
+    const r = rows[0]!;
+    expect(r.sym).toBe("BTCUSDC");
+    expect(r.side).toBe("Long");
+    expect(r.netQty).toBe(10);
+    expect(r.avgCost).toBe(100);
+    expect(r.markPx).toBe(120);
+    expect(r.unrealized).toBe((120 - 100) * 10); // 200
+  });
+
+  it("contributes 0 uPnL and undefined mark when no mark is provided", () => {
+    const a = seedAccount();
+    const rows = paperPositionsToBlotter(a, {}, symName);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.markPx).toBeUndefined();
+    expect(rows[0]!.unrealized).toBe(0);
+  });
+
+  it("sorts largest absolute exposure first", () => {
+    let a = newAccount(100_000);
+    a = placeOrder(a, { symbolId: BTC, side: "buy", type: "market", qty: 2 }, 100).account;
+    a = placeOrder(a, { symbolId: ETH, side: "sell", type: "market", qty: 9 }, 50).account;
+    const rows = paperPositionsToBlotter(a, { [BTC]: 100, [ETH]: 50 }, symName);
+    expect(rows.map((r) => r.symbolId)).toEqual([ETH, BTC]);
+    expect(rows[0]!.side).toBe("Short");
+  });
+});
+
+describe("buildPnlSummaryFromPaper", () => {
+  it("computes realized, unrealized, equity, and return%", () => {
+    let a = newAccount(100_000);
+    // Buy 10 @ 100 (cash 99,000), then sell 4 @ 110 -> realized (110-100)*4 = 40.
+    a = placeOrder(a, { symbolId: BTC, side: "buy", type: "market", qty: 10 }, 100).account;
+    a = placeOrder(a, { symbolId: BTC, side: "sell", type: "market", qty: 4 }, 110).account;
+    const s = buildPnlSummaryFromPaper(a, { [BTC]: 120 }, symName);
+    expect(s.realized).toBe(40);
+    // remaining long 6 @ 100, mark 120 -> unreal (120-100)*6 = 120
+    expect(s.unrealized).toBe(120);
+    // cash = 100000 - 1000 (buy) + 440 (sell) = 99,440; equity = cash + 6*120 = 100,160
+    expect(s.cash).toBe(99_440);
+    expect(s.equity).toBe(99_440 + 6 * 120);
+    expect(s.startingCash).toBe(100_000);
+    expect(s.returnPct).toBeCloseTo(((s.equity - 100_000) / 100_000) * 100, 10);
+    expect(s.perSymbol).toHaveLength(1);
+    expect(s.perSymbol[0]!.netQty).toBe(6);
+  });
+});

--- a/frontend/src/lib/paperBlotter.ts
+++ b/frontend/src/lib/paperBlotter.ts
@@ -1,0 +1,173 @@
+// Pure, framework-free adapters that project the shared PAPER account
+// (paperEngine.ts) into the shapes the read-only trading views already render:
+//   - the Blotter grid `Order` rows (Orders + Fills panels),
+//   - position rows with live-mark MTM / uPnL (Positions panel + Portfolio),
+//   - a PnL summary (realized / unrealized / equity) for the PnL view.
+//
+// Kept pure + dependency-light (only the paperEngine types + its unrealized/
+// equity helpers) so it is unit-testable in isolation (see paperBlotter.test.ts).
+// NOTHING here touches the network — callers pass in the live marks they already
+// source from the market-data hooks.
+import type { Order, Side } from "@/components/blotter/types";
+import {
+  unrealized as calcUnrealized,
+  equity as calcEquity,
+  type PaperAccount,
+  type PaperOrder,
+  type PaperFill,
+} from "./paperEngine";
+
+/** Resolve a symbolId to its display name (e.g. 1 -> "BTCUSDC"). */
+export type SymName = (symbolId: number) => string;
+
+/** Paper marks keyed by symbolId — the price each position/order marks against. */
+export type PaperMarks = Record<number, number | undefined>;
+
+const sideOf = (s: "buy" | "sell"): Side => (s === "buy" ? "B" : "S");
+const nsOf = (ms: number): number => ms * 1_000_000; // ms epoch -> ns epoch (blotter ts unit)
+
+/**
+ * Project the account's WORKING (resting) orders into blotter `Order` rows so the
+ * existing `orderColumns` grid (grouping / filter / column-chooser / export) works
+ * unchanged. Working paper orders are limit orders with no fills yet, so cumQty=0,
+ * leaves=qty, status='live'.
+ */
+export function paperOrdersToBlotter(acct: PaperAccount, symName: SymName): Order[] {
+  return acct.orders
+    .filter((o) => o.status === "working")
+    .map((o) => paperOrderRow(o, symName));
+}
+
+function paperOrderRow(o: PaperOrder, symName: SymName): Order {
+  const px = o.price ?? 0;
+  return {
+    clord: o.id,
+    sym: symName(o.symbolId),
+    side: sideOf(o.side),
+    venue: "IEX", // synthetic — the paper engine has no venue; a stable placeholder
+    px,
+    qty: o.qty,
+    cumQty: 0,
+    leaves: o.qty,
+    avgPx: 0,
+    status: "live",
+    tif: "DAY",
+    tRcv: nsOf(o.createdAt),
+    tLastUpd: nsOf(o.createdAt),
+    subacct: 0,
+    lots: [],
+    source: "PAPR",
+  };
+}
+
+/**
+ * Project the account's fills into blotter `Order` rows for the Fills panel — one
+ * row per fill. cumQty = the filled qty, avgPx = the fill price, status='filled'.
+ */
+export function paperFillsToBlotter(acct: PaperAccount, symName: SymName): Order[] {
+  // Newest first, mirroring the Paper page fill-history ordering.
+  return acct.fills
+    .slice()
+    .reverse()
+    .map((f) => paperFillRow(f, symName));
+}
+
+function paperFillRow(f: PaperFill, symName: SymName): Order {
+  return {
+    clord: f.id,
+    sym: symName(f.symbolId),
+    side: sideOf(f.side),
+    venue: "IEX",
+    px: f.price,
+    qty: f.qty,
+    cumQty: f.qty,
+    leaves: 0,
+    avgPx: f.price,
+    status: "filled",
+    tif: "DAY",
+    tRcv: nsOf(f.ts),
+    tLastUpd: nsOf(f.ts),
+    subacct: 0,
+    lots: [{ ts: nsOf(f.ts), qty: f.qty, px: f.price, liq: "R" }],
+    source: "PAPR",
+  };
+}
+
+/** A position row for the Positions grid / Portfolio table, MTM at a live mark. */
+export interface PaperPositionRow {
+  sym: string;
+  symbolId: number;
+  netQty: number;
+  side: "Long" | "Short";
+  avgCost: number;
+  markPx: number | undefined;
+  unrealized: number;
+}
+
+/**
+ * Project the account's open positions into position rows with live-mark MTM.
+ * uPnL = (mark - avgEntry) * qty, matching paperEngine.unrealized per-symbol;
+ * a position with no mark contributes 0 uPnL (markPx undefined).
+ */
+export function paperPositionsToBlotter(
+  acct: PaperAccount,
+  marks: PaperMarks,
+  symName: SymName,
+): PaperPositionRow[] {
+  const rows: PaperPositionRow[] = [];
+  for (const [k, pos] of Object.entries(acct.positions)) {
+    const id = Number(k);
+    if (pos.qty === 0) continue;
+    const mark = marks[id];
+    const hasMark = mark != null && Number.isFinite(mark);
+    const u = hasMark ? (mark! - pos.avgEntry) * pos.qty : 0;
+    rows.push({
+      sym: symName(id),
+      symbolId: id,
+      netQty: pos.qty,
+      side: pos.qty > 0 ? "Long" : "Short",
+      avgCost: pos.avgEntry,
+      markPx: hasMark ? mark! : undefined,
+      unrealized: u,
+    });
+  }
+  // Stable order: largest absolute exposure first.
+  rows.sort((a, b) => Math.abs(b.netQty) - Math.abs(a.netQty));
+  return rows;
+}
+
+/** Everything the PnL view needs from the paper account, at the given marks. */
+export interface PaperPnlSummary {
+  realized: number;
+  unrealized: number;
+  equity: number;
+  cash: number;
+  startingCash: number;
+  returnPct: number;
+  perSymbol: PaperPositionRow[];
+}
+
+/**
+ * Compute realized / unrealized / equity from the paper account at `marks`.
+ * realized = account cumulative realized PnL; unrealized + equity reuse the
+ * paperEngine helpers so the numbers match the Paper page exactly.
+ */
+export function buildPnlSummaryFromPaper(
+  acct: PaperAccount,
+  marks: PaperMarks,
+  symName: SymName,
+): PaperPnlSummary {
+  const unreal = calcUnrealized(acct, marks);
+  const eq = calcEquity(acct, marks);
+  const returnPct =
+    acct.startingCash > 0 ? ((eq - acct.startingCash) / acct.startingCash) * 100 : 0;
+  return {
+    realized: acct.realizedPnl,
+    unrealized: unreal,
+    equity: eq,
+    cash: acct.cash,
+    startingCash: acct.startingCash,
+    returnPct,
+    perSymbol: paperPositionsToBlotter(acct, marks, symName),
+  };
+}

--- a/frontend/src/pages/blotter/TradingBlotterPage.tsx
+++ b/frontend/src/pages/blotter/TradingBlotterPage.tsx
@@ -7,6 +7,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Blotter } from "@/components/blotter/grid";
 import { orderColumns } from "@/components/blotter/grid/columns";
 import type { Order, Side, OrderStatus, Venue, Lot } from "@/components/blotter/types";
+import { usePaperMode } from "@/lib/paperMode";
+import { paperOrdersToBlotter } from "@/lib/paperBlotter";
+import { usePaperAccount, usePaperMarks } from "@/hooks/usePaperMarks";
+import { Badge } from "@/components/ui/badge";
 
 const SYMS = ["BTC-USD", "ETH-USD", "SOL-USD", "PMKT-2028"];
 const REF: Record<string, number> = { "BTC-USD": 64000, "ETH-USD": 3400, "SOL-USD": 145, "PMKT-2028": 0.62 };
@@ -62,6 +66,10 @@ function useIsMobile(bp = 767): boolean {
 
 export default function TradingBlotterPage() {
   const isMobile = useIsMobile();
+  const { enabled: paper } = usePaperMode();
+  const paperAcct = usePaperAccount(paper);
+  const { symName } = usePaperMarks(paperAcct, paper);
+  const paperRows = paper ? paperOrdersToBlotter(paperAcct, symName) : [];
   const [orders, setOrders] = useState<Order[]>(() => Array.from({ length: 600 }, makeOrder));
   const [touched, setTouched] = useState<Set<string>>(new Set());
   const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -105,13 +113,26 @@ export default function TradingBlotterPage() {
     <div style={{ height: "calc(100vh - 3.5rem)", display: "flex", flexDirection: "column", padding: "0.75rem", gap: "0.5rem" }}>
       <div style={{ display: "flex", alignItems: "baseline", gap: "0.75rem" }}>
         <h1 style={{ fontSize: "1.1rem", fontWeight: 600 }}>Trading Blotter</h1>
-        <span style={{ fontSize: "0.8rem", opacity: 0.6 }}>{orders.length} orders · {live} working · live</span>
+        {paper ? (
+          <>
+            <Badge variant="secondary">PAPER</Badge>
+            <span style={{ fontSize: "0.8rem", opacity: 0.6 }}>{paperRows.length} working (simulated)</span>
+          </>
+        ) : (
+          <span style={{ fontSize: "0.8rem", opacity: 0.6 }}>{orders.length} orders · {live} working · live</span>
+        )}
         <span style={{ fontSize: "0.75rem", opacity: 0.5, marginLeft: "auto" }}>
           right-click a header to group / filter / choose columns · drag to reorder · layout persists
         </span>
       </div>
       <div style={{ flex: 1, minHeight: 0 }}>
-        <Blotter data={orders} columns={isMobile ? mobileOrderColumns : orderColumns} touched={touched} storageKeyPrefix="tl-blotter" onCancel={cancel} />
+        <Blotter
+          data={paper ? paperRows : orders}
+          columns={isMobile ? mobileOrderColumns : orderColumns}
+          touched={paper ? undefined : touched}
+          storageKeyPrefix="tl-blotter"
+          onCancel={paper ? undefined : cancel}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/blotter/TradingWorkspacePage.tsx
+++ b/frontend/src/pages/blotter/TradingWorkspacePage.tsx
@@ -23,6 +23,19 @@ import WorkingOrdersPanel from "@/pages/blotter/WorkingOrdersPanel";
 import TradeHistoryPanel from "@/pages/blotter/TradeHistoryPanel";
 import { formatPrice, formatQty } from "@/pages/markets/format";
 import "@/components/blotter/dock.css";
+import { orderColumns } from "@/components/blotter/grid/columns";
+import { fillsColumns } from "@/components/blotter/grid/fillsColumns";
+import { usePaperMode } from "@/lib/paperMode";
+import {
+  paperOrdersToBlotter,
+  paperFillsToBlotter,
+  paperPositionsToBlotter,
+  type PaperMarks,
+  type SymName,
+} from "@/lib/paperBlotter";
+import { usePaperAccount, usePaperMarks } from "@/hooks/usePaperMarks";
+import type { PaperAccount } from "@/lib/paperEngine";
+import { Badge } from "@/components/ui/badge";
 
 const SYMS = ["BTC-USD", "ETH-USD", "SOL-USD", "PMKT-2028"];
 const REF: Record<string, number> = { "BTC-USD": 64000, "ETH-USD": 3400, "SOL-USD": 145, "PMKT-2028": 0.62 };
@@ -142,7 +155,10 @@ function useIsMobile(bp = 767): boolean {
 }
 
 const LAYOUT_KEY = "testlogon.trading.dock.v3";
-interface Ctx { orders: Order[]; touched: Set<string>; onCancel: (c: string) => void; isMobile: boolean; sym: SymLookup; }
+interface Ctx {
+  orders: Order[]; touched: Set<string>; onCancel: (c: string) => void; isMobile: boolean; sym: SymLookup;
+  paper: boolean; paperAcct: PaperAccount; paperMarks: PaperMarks; paperSymName: SymName;
+}
 const WsCtx = createContext<Ctx | null>(null);
 const useWs = (): Ctx => { const c = useContext(WsCtx); if (!c) throw new Error("WsCtx missing"); return c; };
 
@@ -154,7 +170,18 @@ function FeedNote({ children }: { children: React.ReactNode }) {
 // Orders — the REAL working-orders MANAGEMENT surface (GET /me/orders/live
 // with per-row Amend / Cancel + confirmed Cancel-all). Replaces the former
 // mock-generator grid; the mock still feeds the Positions panel below.
-function OrdersPanel() { return <WorkingOrdersPanel />; }
+function OrdersPanel() {
+  const c = useWs();
+  if (!c.paper) return <WorkingOrdersPanel />;
+  const rows = paperOrdersToBlotter(c.paperAcct, c.paperSymName);
+  const cols = c.isMobile ? mobileFilter(orderColumns as ColumnDef<any>[], new Set(["sym", "side", "px", "qty", "status"])) : orderColumns;
+  return (
+    <div className="tl-panel-body">
+      <Blotter data={rows} columns={cols} storageKeyPrefix="tl-ws-paper-orders" />
+      {rows.length === 0 ? <FeedNote>No working paper orders. Place a limit order in Paper mode.</FeedNote> : null}
+    </div>
+  );
+}
 
 // Trade history — the REAL executed-fills feed (GET /me/fills/fees).
 function HistoryPanel() { return <TradeHistoryPanel />; }
@@ -165,10 +192,20 @@ function HistoryPanel() { return <TradeHistoryPanel />; }
 function FillsPanel() {
   const c = useWs();
   const q = useFillsFees();
+  const paperRows = c.paper ? paperFillsToBlotter(c.paperAcct, c.paperSymName) : null;
   const cols = useMemo(() => {
     const full = fillFeeColumns(c.sym);
     return c.isMobile ? mobileFilter(full as ColumnDef<any>[], new Set(["sym", "side", "price", "qty", "fee"])) : full;
   }, [c.sym, c.isMobile]);
+  if (c.paper && paperRows) {
+    const pcols = c.isMobile ? mobileFilter(fillsColumns as ColumnDef<any>[], new Set(["sym", "side", "cumQty", "avgPx"])) : fillsColumns;
+    return (
+      <div className="tl-panel-body">
+        <Blotter data={paperRows} columns={pcols} storageKeyPrefix="tl-ws-paper-fills" />
+        {paperRows.length === 0 ? <FeedNote>No paper fills yet.</FeedNote> : null}
+      </div>
+    );
+  }
   const rows = q.data?.fills ?? [];
   return (
     <div className="tl-panel-body">
@@ -218,6 +255,7 @@ function FundingPanel() {
 
 function PositionsPanel() {
   const c = useWs();
+  const paperPos = c.paper ? paperPositionsToBlotter(c.paperAcct, c.paperMarks, c.paperSymName) : null;
   const pos = useMemo(() => {
     const m = new Map<string, PosRow>();
     for (const o of c.orders) {
@@ -230,6 +268,14 @@ function PositionsPanel() {
     rows.forEach((p) => { p.unrealized = +((p.markPx - p.avgCost) * p.netQty).toFixed(2); });
     return rows;
   }, [c.orders]);
+  if (c.paper && paperPos) {
+    return (
+      <div className="tl-panel-body">
+        <Blotter data={paperPos} columns={posColumns} storageKeyPrefix="tl-ws-paper-pos" getRowId={(r: any) => r.sym} />
+        {paperPos.length === 0 ? <FeedNote>No open paper positions.</FeedNote> : null}
+      </div>
+    );
+  }
   return <div className="tl-panel-body"><Blotter data={pos} columns={posColumns} storageKeyPrefix="tl-ws-pos" getRowId={(r: any) => r.sym} /></div>;
 }
 
@@ -254,6 +300,9 @@ export default function TradingWorkspacePage() {
   // Symbol catalog for mapping symbolid -> name + price scaler on the real feeds.
   const symbolsQuery = useSymbols();
   const sym = useMemo(() => makeSymLookup(symbolsQuery.data?.symbols), [symbolsQuery.data]);
+  const { enabled: paper } = usePaperMode();
+  const paperAcct = usePaperAccount(paper);
+  const { marks: paperMarks, symName: paperSymName } = usePaperMarks(paperAcct, paper);
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -283,8 +332,8 @@ export default function TradingWorkspacePage() {
     return () => { clearInterval(id); if (clearTimer.current) clearTimeout(clearTimer.current); };
   }, []);
 
-  const ctxRef = useRef<Ctx>({ orders, touched, onCancel: cancel, isMobile, sym });
-  ctxRef.current = { orders, touched, onCancel: cancel, isMobile, sym };
+  const ctxRef = useRef<Ctx>({ orders, touched, onCancel: cancel, isMobile, sym, paper, paperAcct, paperMarks, paperSymName });
+  ctxRef.current = { orders, touched, onCancel: cancel, isMobile, sym, paper, paperAcct, paperMarks, paperSymName };
   const stableCtx = useMemo(() => new Proxy({} as Ctx, { get(_, k: string) { return (ctxRef.current as any)[k]; } }), []);
 
   const [dockApi, setDockApi] = useState<DockviewApi | null>(null);
@@ -331,7 +380,10 @@ export default function TradingWorkspacePage() {
     return (
       <WsCtx.Provider value={ctxRef.current}>
         <div style={{ height: "calc(100vh - 3.5rem)", display: "flex", flexDirection: "column" }}>
-          <h1 style={{ fontSize: "1rem", fontWeight: 600, padding: "0.5rem 0.7rem 0.35rem" }}>Trading Workspace</h1>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", padding: "0.5rem 0.7rem 0.35rem" }}>
+            <h1 style={{ fontSize: "1rem", fontWeight: 600 }}>Trading Workspace</h1>
+            {paper && <Badge variant="secondary">PAPER</Badge>}
+          </div>
           <div className="tl-mobile-tabs" style={{ overflowX: "auto" }}>
             {PANEL_META.map((m) => (
               <button key={m.id} type="button" className={activeTab === m.id ? "active" : ""} onClick={() => setActiveTab(m.id)}>{m.title}</button>
@@ -348,6 +400,7 @@ export default function TradingWorkspacePage() {
       <div style={{ height: "calc(100vh - 3.5rem)", display: "flex", flexDirection: "column", padding: "0.6rem 0.75rem", gap: "0.4rem" }}>
         <div style={{ display: "flex", alignItems: "baseline", gap: "0.75rem" }}>
           <h1 style={{ fontSize: "1.1rem", fontWeight: 600 }}>Trading Workspace</h1>
+          {paper && <Badge variant="secondary">PAPER</Badge>}
           <span style={{ fontSize: "0.78rem", opacity: 0.55 }}>drag tabs to split / float · layout persists · right-click a grid header for group / filter / columns</span>
         </div>
         <div style={{ flex: 1, minHeight: 0, position: "relative" }}>

--- a/frontend/src/pages/pnl/PnLPage.tsx
+++ b/frontend/src/pages/pnl/PnLPage.tsx
@@ -49,6 +49,9 @@ import {
   downloadCsv,
   type ReportFill,
 } from "@/lib/exportReport";
+import { usePaperMode } from "@/lib/paperMode";
+import { buildPnlSummaryFromPaper } from "@/lib/paperBlotter";
+import { usePaperAccount, usePaperMarks } from "@/hooks/usePaperMarks";
 
 // --- helpers ----------------------------------------------------
 
@@ -182,6 +185,13 @@ function StatCard({
 // --- page -------------------------------------------------------
 
 export default function PnLPage() {
+  const { enabled: paper } = usePaperMode();
+  const paperAcct = usePaperAccount(paper);
+  const { marks: paperMarks, symName: paperSymName } = usePaperMarks(paperAcct, paper);
+  const paperSummary = useMemo(
+    () => buildPnlSummaryFromPaper(paperAcct, paperMarks, paperSymName),
+    [paperAcct, paperMarks, paperSymName],
+  );
   const fillsQ = useFillsFees();
   const fundingQ = useFundingPayments();
   const liqQ = useLiquidations();
@@ -287,9 +297,14 @@ export default function PnLPage() {
         <div className="flex items-center gap-2">
           <LineChart className="h-6 w-6 text-primary" />
           <div>
-            <h1 className="text-xl font-semibold leading-tight">PnL &amp; performance</h1>
+            <h1 className="flex items-center gap-2 text-xl font-semibold leading-tight">
+              PnL &amp; performance
+              {paper && <Badge variant="secondary">PAPER</Badge>}
+            </h1>
             <p className="text-xs text-muted-foreground">
-              Realized PnL, fees, funding &amp; win rate — computed from your fills.
+              {paper
+                ? "Realized, unrealized & equity — computed from your PAPER account."
+                : "Realized PnL, fees, funding & win rate — computed from your fills."}
             </p>
           </div>
         </div>
@@ -319,7 +334,93 @@ export default function PnLPage() {
         </div>
       </div>
 
-      {loading ? (
+      {paper ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+            <StatCard
+              label="Equity"
+              value={formatPrice(paperSummary.equity, quoteScaler)}
+              icon={<BarChart2 className="h-3.5 w-3.5" />}
+              sub={`Return ${paperSummary.returnPct >= 0 ? "+" : ""}${paperSummary.returnPct.toFixed(2)}%`}
+            />
+            <StatCard
+              label="Realized PnL"
+              value={formatPrice(paperSummary.realized, quoteScaler)}
+              valueColor={signColor(paperSummary.realized)}
+              icon={paperSummary.realized >= 0 ? <TrendingUp className="h-3.5 w-3.5" /> : <TrendingDown className="h-3.5 w-3.5" />}
+              sub="Closed round-trips (simulated)"
+            />
+            <StatCard
+              label="Unrealized PnL"
+              value={formatPrice(paperSummary.unrealized, quoteScaler)}
+              valueColor={signColor(paperSummary.unrealized)}
+              icon={<BarChart2 className="h-3.5 w-3.5" />}
+              sub="Open positions at live marks"
+            />
+            <StatCard
+              label="Cash"
+              value={formatPrice(paperSummary.cash, quoteScaler)}
+              icon={<Receipt className="h-3.5 w-3.5" />}
+              sub="Free simulated cash"
+            />
+            <StatCard
+              label="Starting balance"
+              value={formatPrice(paperSummary.startingCash, quoteScaler)}
+              icon={<Hash className="h-3.5 w-3.5" />}
+              sub="Seed cash"
+            />
+            <StatCard
+              label="Open positions"
+              value={String(paperSummary.perSymbol.length)}
+              icon={<Target className="h-3.5 w-3.5" />}
+              sub="Distinct symbols held"
+            />
+          </div>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                Paper positions
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {paperSummary.perSymbol.length === 0 ? (
+                <p className="py-4 text-sm text-muted-foreground">No open paper positions.</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[560px] text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-xs text-muted-foreground">
+                        <th className="py-2 pr-3 font-medium">Symbol</th>
+                        <th className="py-2 pr-3 text-right font-medium">Qty</th>
+                        <th className="py-2 pr-3 text-right font-medium">Avg entry</th>
+                        <th className="py-2 pr-3 text-right font-medium">Mark</th>
+                        <th className="py-2 text-right font-medium">Unrealized PnL</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {paperSummary.perSymbol.map((p) => (
+                        <tr key={p.symbolId} className="border-b last:border-0">
+                          <td className="py-2 pr-3 font-medium">{p.sym}</td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">{formatQty(p.netQty, quoteScaler)}</td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">{formatPrice(p.avgCost, quoteScaler)}</td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">{p.markPx != null ? formatPrice(p.markPx, quoteScaler) : "\u2014"}</td>
+                          <td className="num py-2 text-right font-medium tabular-nums" style={{ color: signColor(p.unrealized) }}>{formatPrice(p.unrealized, quoteScaler)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  <Separator className="my-3" />
+                  <p className="text-[11px] text-muted-foreground">
+                    Simulated PnL from your isolated paper account — no real funds. Unrealized is
+                    marked to the live market price for each held symbol.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      ) : loading ? (
         <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <Skeleton key={i} className="h-24 w-full" />

--- a/frontend/src/pages/portfolio/PortfolioPage.tsx
+++ b/frontend/src/pages/portfolio/PortfolioPage.tsx
@@ -41,6 +41,9 @@ import {
 } from "@/api/endpoints/trading";
 import { getSymbols, type MarketSymbol } from "@/api/endpoints/marketData";
 import { formatPrice, formatQty } from "@/pages/markets/format";
+import { usePaperMode } from "@/lib/paperMode";
+import { buildPnlSummaryFromPaper } from "@/lib/paperBlotter";
+import { usePaperAccount, usePaperMarks } from "@/hooks/usePaperMarks";
 
 // --- helpers ----------------------------------------------------
 
@@ -183,6 +186,13 @@ function KV({ label, value, valueColor }: { label: string; value: string; valueC
 export default function PortfolioPage() {
   useIsMobile(767); // responsive grid is CSS-driven; hook kept for parity/future use
 
+  const { enabled: paper } = usePaperMode();
+  const paperAcct = usePaperAccount(paper);
+  const { marks: paperMarks, symName: paperSymName } = usePaperMarks(paperAcct, paper);
+  const paperSummary = useMemo(
+    () => buildPnlSummaryFromPaper(paperAcct, paperMarks, paperSymName),
+    [paperAcct, paperMarks, paperSymName],
+  );
   const custodyQ = useQuery({
     queryKey: ["portfolio", "custody", "balance"],
     queryFn: getBalance,
@@ -383,9 +393,14 @@ export default function PortfolioPage() {
         <div className="flex items-center gap-2">
           <PieChart className="h-6 w-6 text-primary" />
           <div>
-            <h1 className="text-xl font-semibold leading-tight">Portfolio</h1>
+            <h1 className="flex items-center gap-2 text-xl font-semibold leading-tight">
+            Portfolio
+            {paper && <Badge variant="secondary">PAPER</Badge>}
+          </h1>
             <p className="text-xs text-muted-foreground">
-              Read-only overview across custody, trading, margin &amp; staking.
+              {paper
+                ? "Simulated paper account — positions, cash & equity at live marks."
+                : "Read-only overview across custody, trading, margin & staking."}
             </p>
           </div>
         </div>
@@ -395,6 +410,86 @@ export default function PortfolioPage() {
         </Button>
       </div>
 
+      {paper ? (
+        <>
+          <Card>
+            <CardContent className="flex flex-col gap-1 py-6">
+              <span className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                Paper equity — simulated
+              </span>
+              <div className="flex items-baseline gap-2">
+                <span className="num text-3xl font-bold tabular-nums">{formatPrice(paperSummary.equity, 1)}</span>
+              </div>
+              <span className="text-[11px] text-muted-foreground">
+                Cash {formatPrice(paperSummary.cash, 1)} + open positions at live marks. Return{" "}
+                <span style={{ color: signColor(paperSummary.returnPct) }}>
+                  {paperSummary.returnPct >= 0 ? "+" : ""}{paperSummary.returnPct.toFixed(2)}%
+                </span>{" "}vs {formatPrice(paperSummary.startingCash, 1)} seed. No real funds.
+              </span>
+            </CardContent>
+          </Card>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Card><CardContent className="flex flex-col gap-1 py-4">
+              <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Cash</span>
+              <span className="num text-xl font-semibold tabular-nums">{formatPrice(paperSummary.cash, 1)}</span>
+            </CardContent></Card>
+            <Card><CardContent className="flex flex-col gap-1 py-4">
+              <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Realized PnL</span>
+              <span className="num text-xl font-semibold tabular-nums" style={{ color: signColor(paperSummary.realized) }}>{formatPrice(paperSummary.realized, 1)}</span>
+            </CardContent></Card>
+            <Card><CardContent className="flex flex-col gap-1 py-4">
+              <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Unrealized PnL</span>
+              <span className="num text-xl font-semibold tabular-nums" style={{ color: signColor(paperSummary.unrealized) }}>{formatPrice(paperSummary.unrealized, 1)}</span>
+            </CardContent></Card>
+          </div>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                Paper positions
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {paperSummary.perSymbol.length === 0 ? (
+                <p className="py-4 text-sm text-muted-foreground">No open paper positions.</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[560px] text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-xs text-muted-foreground">
+                        <th className="py-2 pr-3 font-medium">Symbol</th>
+                        <th className="py-2 pr-3 text-right font-medium">Side</th>
+                        <th className="py-2 pr-3 text-right font-medium">Qty</th>
+                        <th className="py-2 pr-3 text-right font-medium">Avg entry</th>
+                        <th className="py-2 pr-3 text-right font-medium">Mark</th>
+                        <th className="py-2 text-right font-medium">Unrealized PnL</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {paperSummary.perSymbol.map((p) => (
+                        <tr key={p.symbolId} className="border-b last:border-0">
+                          <td className="py-2 pr-3 font-medium">{p.sym}</td>
+                          <td className="py-2 pr-3 text-right">{p.side}</td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">{formatQty(Math.abs(p.netQty), 1)}</td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">{formatPrice(p.avgCost, 1)}</td>
+                          <td className="num py-2 pr-3 text-right tabular-nums">{p.markPx != null ? formatPrice(p.markPx, 1) : "\u2014"}</td>
+                          <td className="num py-2 text-right font-medium tabular-nums" style={{ color: signColor(p.unrealized) }}>{formatPrice(p.unrealized, 1)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  <Separator className="my-3" />
+                  <p className="text-[11px] text-muted-foreground">
+                    Simulated positions from your isolated paper account. Unrealized is marked to
+                    the live market price for each held symbol — no real funds.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      ) : (
+      <>
       {/* Total equity */}
       <Card>
         <CardContent className="flex flex-col gap-1 py-6">
@@ -667,6 +762,8 @@ export default function PortfolioPage() {
           )}
         </CardContent>
       </Card>
+      </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Paper account in the read-only trading views

Follow-on to the paper-mode ticket toggle (#223). When paper-mode is ON, the **Blotter**, **PnL**, and **Portfolio** views reflect the shared paper account (the same `paper.account` the ticket + Paper page write to) with live-mark MTM; OFF = unchanged. Each switched view shows a **PAPER** badge.

### Web
- `src/lib/paperBlotter.ts` (new, +7 vitest) — pure derivation: paper account → blotter `Order` rows (Orders/Fills/Positions) + PnL summary via `paperEngine` `unrealized`/`equity`.
- `src/hooks/usePaperMarks.ts` (new) — `usePaperAccount` (re-reads on `PAPER_MODE_EVENT`/`storage`) + `usePaperMarks` (per-symbol marks from the existing md trades feed — no new fetch).
- `TradingWorkspacePage` (`/blotter`) + `TradingBlotterPage` (`/blotter/single`): grid Orders/Fills/Positions source from the paper account in paper mode (columns / grouping / filter / column-chooser / export all preserved). `PnLPage` + `PortfolioPage`: paper equity / cash / realized / unrealized + live-marked positions.
- `AnalyticsPage` left unchanged (creator/content analytics, not trading).

### Android
- `feature/paper/PaperViews.kt` (new, +6 JVM tests) — pure: paper account + live marks → blotter rows / PnL stats / portfolio positions.
- `Blotter`/`Pnl`/`Portfolio` ViewModels inject `PaperAccountStore` + `PaperModeStore` and combine the paper flows; paper marks reuse `ExchangeRepository.trades`→mid (same source as `PaperViewModel`); PAPER badge in each app bar; live venues unaffected.

No new deps. No new nav routes (MoreCatalog untouched). OFF preserves exact current behavior.

### Gates
- Web: `tsc` 0 · `vite build` green · vitest paper suite 41/41 (pre-existing unrelated failures verified against a clean baseline).
- Android: `assembleDebug` + `testDebugUnitTest` BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)