### PR TITLE
feat(markets): class-filtered unified symbol picker — Spot/Perp/Prediction/Funding (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeDomain.kt
@@ -13,6 +13,8 @@ data class Instrument(
     val lotSize: Long,
     val referencePrice: Long,
     val isPerpetual: Boolean,
+    /** Funding interval in seconds for perpetuals (0 for spot / when unknown). */
+    val fundingIntervalS: Long = 0,
 ) {
     /** Scale a raw integer price/qty into a display double (divides by a >=1 scaler). */
     fun display(raw: Long): Double = raw.toDouble() / priceScaler.coerceAtLeast(1)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeMappers.kt
@@ -9,6 +9,7 @@ fun SymbolDto.toDomain(): Instrument = Instrument(
     lotSize = lotSize,
     referencePrice = referencePrice,
     isPerpetual = isPerpetual,
+    fundingIntervalS = fundingIntervalS,
 )
 
 fun OrderBookDto.toDomain(): OrderBook {

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/InstrumentClass.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/InstrumentClass.kt
@@ -1,0 +1,79 @@
+package com.testlogon.android.feature.markets
+
+import com.testlogon.android.data.exchange.Instrument
+
+/**
+ * The instrument classes the unified, class-filtered symbol picker groups markets by. Built PURELY
+ * from confirmed backend discriminators (see [classesForSymbol]); no invented fields:
+ *  - [SPOT]: a non-perpetual (cash) instrument (`isPerpetual == false`).
+ *  - [PERP]: a perpetual future (`isPerpetual == true`).
+ *  - [PREDICTION]: a symbol with a live binary prediction-market state (detected by probing the
+ *    per-symbol PM-state read; there is no list endpoint).
+ *  - [FUNDING]: a lens on perpetuals with a positive funding interval — surfaces the funding
+ *    interval + latest applied funding rate (bps).
+ *
+ * A single symbol can belong to several classes at once (a perp is also a FUNDING-book row; a
+ * PM-enabled symbol adds PREDICTION), which is why [classesForSymbol] returns a set.
+ */
+enum class InstrumentClass(val label: String) {
+    SPOT("Spot"),
+    PERP("Perp"),
+    PREDICTION("Prediction"),
+    FUNDING("Funding"),
+}
+
+/**
+ * A filter tab in the picker: either [InstrumentClass.All] (everything) or one concrete class. Kept
+ * as a small sealed hierarchy so the "All" tab is a first-class, exhaustive option rather than a
+ * nullable class.
+ */
+sealed interface MarketClassTab {
+    val label: String
+
+    data object All : MarketClassTab {
+        override val label: String = "All"
+    }
+
+    data class Of(val clazz: InstrumentClass) : MarketClassTab {
+        override val label: String = clazz.label
+    }
+}
+
+/** The ordered tab row shown across the top of the picker: All, then Spot, Perp, Prediction, Funding. */
+val MARKET_CLASS_TABS: List<MarketClassTab> = buildList {
+    add(MarketClassTab.All)
+    // Preserve the enum declaration order for the concrete tabs.
+    InstrumentClass.entries.forEach { add(MarketClassTab.Of(it)) }
+}
+
+/**
+ * PURE classifier: the set of [InstrumentClass]es a [symbol] belongs to.
+ *
+ * @param isPrediction whether a live PM state was observed for this symbol (probed elsewhere; treat
+ *   404/error/unknown as false so a non-PM symbol never claims [InstrumentClass.PREDICTION]).
+ *
+ * Rules (all from confirmed discriminators):
+ *  - exactly one of SPOT / PERP by `isPerpetual`.
+ *  - a perp with `fundingIntervalS > 0` is ALSO a FUNDING-book row.
+ *  - `isPrediction` adds PREDICTION on top of its spot/perp base class.
+ */
+fun classesForSymbol(symbol: Instrument, isPrediction: Boolean): Set<InstrumentClass> {
+    val classes = LinkedHashSet<InstrumentClass>()
+    if (symbol.isPerpetual) {
+        classes.add(InstrumentClass.PERP)
+        if (symbol.fundingIntervalS > 0) classes.add(InstrumentClass.FUNDING)
+    } else {
+        classes.add(InstrumentClass.SPOT)
+    }
+    if (isPrediction) classes.add(InstrumentClass.PREDICTION)
+    return classes
+}
+
+/**
+ * Whether a symbol (with its probed [isPrediction] flag) belongs under the given [tab]. "All" always
+ * matches; a concrete tab matches when the symbol's class set contains that class.
+ */
+fun matchesTab(symbol: Instrument, isPrediction: Boolean, tab: MarketClassTab): Boolean = when (tab) {
+    is MarketClassTab.All -> true
+    is MarketClassTab.Of -> classesForSymbol(symbol, isPrediction).contains(tab.clazz)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -199,15 +200,23 @@ private fun MarketsList(
 ) {
     var query by remember { mutableStateOf("") }
     var filter by remember { mutableStateOf(MarketsFilter.All) }
-    // Apply the watchlist tab, then the search text, then float starred instruments to the top
-    // (stable within each group so the starred order is deterministic across quote ticks).
-    val displayed = remember(rows, favorites, query, filter) {
-        rows.filter { filter == MarketsFilter.All || favorites.contains(it.instrument.symbolId) }
+    // The unified class filter (All / Spot / Perp / Prediction / Funding), applied via the pure classifier.
+    var classTab by remember { mutableStateOf<MarketClassTab>(MarketClassTab.All) }
+    // Apply the class filter, then the watchlist tab, then the search text, then float starred
+    // instruments to the top (stable within each group so starred order is deterministic across ticks).
+    val displayed = remember(rows, favorites, query, filter, classTab) {
+        rows.filter { matchesTab(it.instrument, it.isPrediction == true, classTab) }
+            .filter { filter == MarketsFilter.All || favorites.contains(it.instrument.symbolId) }
             .filter { query.isBlank() || it.instrument.symbol.contains(query.trim(), ignoreCase = true) }
             .sortedByDescending { favorites.contains(it.instrument.symbolId) }
     }
     Column(modifier = Modifier.fillMaxSize()) {
         MarketSearchField(query = query, onQuery = { query = it })
+        MarketsClassTabs(
+            rows = rows,
+            selected = classTab,
+            onSelect = { classTab = it },
+        )
         MarketsFilterTabs(
             filter = filter,
             allCount = rows.size,
@@ -215,7 +224,7 @@ private fun MarketsList(
             onSelect = { filter = it },
         )
         if (displayed.isEmpty()) {
-            MarketsEmpty(filter = filter, query = query)
+            MarketsEmpty(filter = filter, query = query, classTab = classTab)
             return@Column
         }
         val compact = LocalAppUiDensity.current.isCompact
@@ -231,10 +240,42 @@ private fun MarketsList(
                 MarketRowCard(
                     row = row,
                     favorite = favorites.contains(row.instrument.symbolId),
+                    classTab = classTab,
                     onClick = { onOpenSymbol(row.instrument.symbolId) },
                     onToggleFavorite = { onToggleFavorite(row.instrument.symbolId) },
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun MarketsClassTabs(
+    rows: List<MarketRow>,
+    selected: MarketClassTab,
+    onSelect: (MarketClassTab) -> Unit,
+) {
+    // Live per-tab counts via the pure classifier so each chip shows how many instruments it holds.
+    val counts = remember(rows) {
+        MARKET_CLASS_TABS.associateWith { tab ->
+            rows.count { matchesTab(it.instrument, it.isPrediction == true, tab) }
+        }
+    }
+    LazyRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .testTag("markets_class_tabs"),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(MARKET_CLASS_TABS) { tab ->
+            MarketFilterChip(
+                label = tab.label,
+                count = counts[tab] ?: 0,
+                selected = tab == selected,
+                onClick = { onSelect(tab) },
+                tag = "class_" + tab.label.lowercase(),
+            )
         }
     }
 }
@@ -307,12 +348,18 @@ private fun MarketFilterChip(
 }
 
 @Composable
-private fun MarketsEmpty(filter: MarketsFilter, query: String) {
+private fun MarketsEmpty(filter: MarketsFilter, query: String, classTab: MarketClassTab) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         val text = when {
             query.isNotBlank() -> "No markets match \"$query\"."
             filter == MarketsFilter.Watchlist ->
                 "Your watchlist is empty. Tap the star on any market to add it."
+            classTab is MarketClassTab.Of -> when (classTab.clazz) {
+                InstrumentClass.SPOT -> "No spot markets available."
+                InstrumentClass.PERP -> "No perpetual markets available."
+                InstrumentClass.PREDICTION -> "No prediction markets right now."
+                InstrumentClass.FUNDING -> "No funding-book instruments right now."
+            }
             else -> "No markets available."
         }
         Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(24.dp)) {
@@ -379,6 +426,7 @@ private fun MarketSearchField(query: String, onQuery: (String) -> Unit) {
 private fun MarketRowCard(
     row: MarketRow,
     favorite: Boolean,
+    classTab: MarketClassTab,
     onClick: () -> Unit,
     onToggleFavorite: () -> Unit,
 ) {
@@ -399,7 +447,7 @@ private fun MarketRowCard(
         val base = baseMonogram(row.instrument.symbol)
         TokenBadge(monogram = base, symbol = row.instrument.symbol)
         Spacer(Modifier.width(12.dp))
-        Column(modifier = Modifier.width(88.dp)) {
+        Column(modifier = Modifier.width(104.dp)) {
             Text(
                 text = row.instrument.symbol,
                 color = MarketColors.TextPrimary,
@@ -408,9 +456,16 @@ private fun MarketRowCard(
                 maxLines = 1,
             )
             Text(
-                text = if (row.instrument.isPerpetual) "Perp" else "Spot",
-                color = MarketColors.TextSecondary,
+                text = rowSubtitle(row, classTab),
+                color = when (classTab) {
+                    is MarketClassTab.Of -> if (classTab.clazz == InstrumentClass.PREDICTION ||
+                        classTab.clazz == InstrumentClass.FUNDING
+                    ) MarketColors.Accent else MarketColors.TextSecondary
+                    else -> MarketColors.TextSecondary
+                },
                 fontSize = 11.sp,
+                maxLines = 1,
+                modifier = Modifier.testTag("market_sub_" + row.instrument.symbolId),
             )
         }
         Spacer(Modifier.width(8.dp))
@@ -556,6 +611,41 @@ private fun badgeColors(symbol: String): Pair<Color, Color> {
     val h = abs(symbol.hashCode())
     return palettes[h % palettes.size]
 }
+
+/**
+ * The per-row secondary label, chosen by the active class tab so each lens surfaces its own datum:
+ *  - Funding tab: funding interval + latest applied rate (bps), "—" when the rate is unknown.
+ *  - Prediction tab: implied-YES %, "—" when not yet known.
+ *  - otherwise: the base Perp/Spot badge (identical to the pre-filter behaviour).
+ */
+internal fun rowSubtitle(row: MarketRow, classTab: MarketClassTab): String {
+    val base = if (row.instrument.isPerpetual) "Perp" else "Spot"
+    return when {
+        classTab is MarketClassTab.Of && classTab.clazz == InstrumentClass.FUNDING -> {
+            val interval = formatFundingInterval(row.instrument.fundingIntervalS)
+            val rate = row.latestFundingRateBps?.let { formatBps(it) } ?: "—"
+            "$interval · $rate"
+        }
+        classTab is MarketClassTab.Of && classTab.clazz == InstrumentClass.PREDICTION -> {
+            val yes = row.impliedYes?.let { String.format("%.0f%%", it * 100f) } ?: "—"
+            "YES $yes"
+        }
+        else -> base
+    }
+}
+
+/** Funding interval seconds -> compact human label (e.g. 3600 -> "1h", 28800 -> "8h"). */
+internal fun formatFundingInterval(seconds: Long): String {
+    if (seconds <= 0) return "—"
+    return when {
+        seconds % 3600L == 0L -> "${seconds / 3600L}h"
+        seconds % 60L == 0L -> "${seconds / 60L}m"
+        else -> "${seconds}s"
+    }
+}
+
+/** Signed basis-points label for a funding rate (e.g. 12 -> "+12 bps", -5 -> "-5 bps"). */
+internal fun formatBps(bps: Int): String = (if (bps >= 0) "+" else "") + "$bps bps"
 
 /** Locale-agnostic grouped price format (no currency symbol; instruments are already quote-named). */
 internal fun formatPrice(value: Double): String {

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsUiState.kt
@@ -13,6 +13,15 @@ data class MarketRow(
     val bestAsk: Long? = null,
     val spark: List<Float> = emptyList(),
     val changePct: Double? = null,
+    /**
+     * Whether this symbol has a live binary prediction market (probed lazily; null = not yet probed,
+     * false = probed and not a PM). Drives the PREDICTION class + the implied-YES surface.
+     */
+    val isPrediction: Boolean? = null,
+    /** Implied YES probability (0..1) from the latest PM state x last price, when known. */
+    val impliedYes: Float? = null,
+    /** Latest applied funding rate (bps) for this perp from the funding-payments feed; null = unknown. */
+    val latestFundingRateBps: Int? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.data.exchange.PmState
 import com.testlogon.android.data.exchange.TradingUiPrefsStore
 import com.testlogon.android.data.exchange.alerts.TradingAlertKind
 import com.testlogon.android.data.exchange.alerts.PriceAlertsEvaluator
@@ -33,6 +35,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MarketsViewModel @Inject constructor(
     private val repository: ExchangeRepository,
+    private val trading: TradingRepository,
     private val prefsStore: TradingUiPrefsStore,
     private val alertsPoller: TradingAlertsPoller,
     private val priceAlerts: PriceAlertsEvaluator,
@@ -48,6 +51,13 @@ class MarketsViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(MarketsUiState(favorites = readFavorites()))
     val uiState: StateFlow<MarketsUiState> = _uiState.asStateFlow()
+
+    /**
+     * Per-symbol PM-probe cache for this VM instance: a real [PmState] when the symbol is a binary
+     * prediction market, or the [PM_NOT_A_MARKET] sentinel once probed-and-not (so we never re-probe
+     * a plain spot/perp). Absent = not yet probed.
+     */
+    private val pmProbeCache = HashMap<Int, PmState>()
 
     /**
      * One-shot auto-open of the saved default market. Emits the target symbolId exactly ONCE per app
@@ -129,6 +139,8 @@ class MarketsViewModel @Inject constructor(
                             )
                         }
                         maybeAutoOpenDefault(instruments)
+                        refreshFundingRates(instruments)
+                        probePredictionMarkets(instruments)
                         pollQuotes(instruments)
                     }
                 }
@@ -190,6 +202,85 @@ class MarketsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Read the account's recent perpetual funding payments once and fold the MOST-RECENT applied
+     * rate (bps) per symbol onto its row. Degrades silently (empty feed / 404) leaving rates unknown.
+     * Only perps carry a funding rate; spot rows are left untouched.
+     */
+    private fun refreshFundingRates(instruments: List<Instrument>) {
+        viewModelScope.launch {
+            val payments = (trading.fundingPayments() as? ApiResult.Success)?.data?.payments.orEmpty()
+            if (payments.isEmpty()) return@launch
+            // Most-recent payment per symbol wins (feed is not guaranteed ordered).
+            val latestBySymbol = HashMap<Int, Int>()
+            val latestTs = HashMap<Int, Long>()
+            for (fp in payments) {
+                val prev = latestTs[fp.symbolId]
+                if (prev == null || fp.tsNs >= prev) {
+                    latestTs[fp.symbolId] = fp.tsNs
+                    latestBySymbol[fp.symbolId] = fp.fundingRateBps
+                }
+            }
+            if (latestBySymbol.isEmpty()) return@launch
+            _uiState.update { state ->
+                state.copy(
+                    rows = state.rows.map { row ->
+                        val bps = latestBySymbol[row.instrument.symbolId]
+                        if (bps != null) row.copy(latestFundingRateBps = bps) else row
+                    },
+                )
+            }
+        }
+    }
+
+    /**
+     * LAZILY probe each listed symbol's binary prediction-market state (there is NO list endpoint) to
+     * detect the PREDICTION class + surface implied-YES. Runs one sequential pass over the loaded
+     * symbols (no storm), caches the yes/no result per symbolId for the process, and treats any
+     * 404/failure as "not a PM" so a non-PM symbol never errors the list. Implied-YES is derived
+     * whenever the row already has a last price.
+     */
+    private fun probePredictionMarkets(instruments: List<Instrument>) {
+        viewModelScope.launch {
+            for (instrument in instruments) {
+                val id = instrument.symbolId
+                val cached = pmProbeCache[id]
+                val pm = if (cached == null) {
+                    when (val r = trading.pmState(id)) {
+                        is ApiResult.Success -> {
+                            val isPm = r.data.isBinary
+                            pmProbeCache[id] = if (isPm) r.data else PM_NOT_A_MARKET
+                            if (isPm) r.data else null
+                        }
+                        // 404/error/offline -> definitively treat as not-a-PM and cache so we don't re-probe.
+                        else -> { pmProbeCache[id] = PM_NOT_A_MARKET; null }
+                    }
+                } else if (cached === PM_NOT_A_MARKET) {
+                    null
+                } else {
+                    cached
+                }
+                _uiState.update { state ->
+                    state.copy(
+                        rows = state.rows.map { row ->
+                            if (row.instrument.symbolId == id) {
+                                val impliedRaw = pm?.impliedYes(
+                                    row.lastPrice?.let { kotlin.math.round(it).toLong() },
+                                )
+                                row.copy(
+                                    isPrediction = pm != null,
+                                    impliedYes = impliedRaw ?: row.impliedYes,
+                                )
+                            } else {
+                                row
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+
     private fun reduceError(message: String) {
         _uiState.update {
             if (it.rows.isNotEmpty()) {
@@ -201,6 +292,15 @@ class MarketsViewModel @Inject constructor(
     }
 
     private companion object {
+        /** Sentinel meaning "probed, and this symbol is NOT a prediction market" (cache negatives). */
+        private val PM_NOT_A_MARKET = PmState(
+            symbolId = -1,
+            isBinary = false,
+            resolved = false,
+            outcomeYes = null,
+            faceValue = 0L,
+            resolverId = "",
+        )
         /** Process-lifetime guard so the default-market auto-open fires at most once per app launch. */
         @Volatile
         private var autoOpened = false

--- a/android/app/src/test/java/com/testlogon/android/feature/markets/InstrumentClassTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/markets/InstrumentClassTest.kt
@@ -1,0 +1,93 @@
+package com.testlogon.android.feature.markets
+
+import com.testlogon.android.data.exchange.Instrument
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure [classesForSymbol] / [matchesTab] classifier that backs the unified,
+ * class-filtered symbol picker. No Android or network dependency — pure JVM.
+ */
+class InstrumentClassTest {
+
+    private fun inst(
+        symbol: String = "BTCUSDC",
+        id: Int = 1,
+        perp: Boolean = false,
+        fundingIntervalS: Long = 0,
+    ) = Instrument(
+        symbol = symbol,
+        symbolId = id,
+        priceScaler = 1,
+        lotSize = 1,
+        referencePrice = 0,
+        isPerpetual = perp,
+        fundingIntervalS = fundingIntervalS,
+    )
+
+    @Test
+    fun spot_isOnlySpot() {
+        val classes = classesForSymbol(inst(perp = false), isPrediction = false)
+        assertEquals(setOf(InstrumentClass.SPOT), classes)
+    }
+
+    @Test
+    fun perp_withFunding_isPerpAndFunding() {
+        val classes = classesForSymbol(inst(perp = true, fundingIntervalS = 3600), isPrediction = false)
+        assertEquals(setOf(InstrumentClass.PERP, InstrumentClass.FUNDING), classes)
+    }
+
+    @Test
+    fun perp_withoutFundingInterval_isPerpOnly_notFunding() {
+        val classes = classesForSymbol(inst(perp = true, fundingIntervalS = 0), isPrediction = false)
+        assertTrue(classes.contains(InstrumentClass.PERP))
+        assertFalse(classes.contains(InstrumentClass.FUNDING))
+    }
+
+    @Test
+    fun predictionFlag_addsPrediction_ontoBaseClass() {
+        val spotPm = classesForSymbol(inst(perp = false), isPrediction = true)
+        assertEquals(setOf(InstrumentClass.SPOT, InstrumentClass.PREDICTION), spotPm)
+
+        val perpPm = classesForSymbol(inst(perp = true, fundingIntervalS = 28800), isPrediction = true)
+        assertEquals(
+            setOf(InstrumentClass.PERP, InstrumentClass.FUNDING, InstrumentClass.PREDICTION),
+            perpPm,
+        )
+    }
+
+    @Test
+    fun spot_isNeverPerpOrFunding() {
+        val classes = classesForSymbol(inst(perp = false, fundingIntervalS = 3600), isPrediction = false)
+        // Even if a stray funding interval leaks onto a non-perp, FUNDING is gated on isPerpetual.
+        assertFalse(classes.contains(InstrumentClass.PERP))
+        assertFalse(classes.contains(InstrumentClass.FUNDING))
+    }
+
+    @Test
+    fun matchesTab_all_matchesEverything() {
+        val spot = inst(perp = false)
+        assertTrue(matchesTab(spot, isPrediction = false, MarketClassTab.All))
+    }
+
+    @Test
+    fun matchesTab_concreteClass_filtersCorrectly() {
+        val perp = inst(perp = true, fundingIntervalS = 3600)
+        assertTrue(matchesTab(perp, false, MarketClassTab.Of(InstrumentClass.PERP)))
+        assertTrue(matchesTab(perp, false, MarketClassTab.Of(InstrumentClass.FUNDING)))
+        assertFalse(matchesTab(perp, false, MarketClassTab.Of(InstrumentClass.SPOT)))
+        assertFalse(matchesTab(perp, false, MarketClassTab.Of(InstrumentClass.PREDICTION)))
+        assertTrue(matchesTab(perp, true, MarketClassTab.Of(InstrumentClass.PREDICTION)))
+    }
+
+    @Test
+    fun tabRow_hasAllPlusEveryClass_inOrder() {
+        assertEquals(1 + InstrumentClass.entries.size, MARKET_CLASS_TABS.size)
+        assertTrue(MARKET_CLASS_TABS.first() is MarketClassTab.All)
+        val classTabs = MARKET_CLASS_TABS.filterIsInstance<MarketClassTab.Of>().map { it.clazz }
+        assertEquals(InstrumentClass.entries.toList(), classTabs)
+        assertEquals(listOf("All", "Spot", "Perp", "Prediction", "Funding"), MARKET_CLASS_TABS.map { it.label })
+    }
+}

--- a/frontend/src/components/layout/CommandPalette.tsx
+++ b/frontend/src/components/layout/CommandPalette.tsx
@@ -37,6 +37,13 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { useSymbols } from "@/hooks/useMarketData";
+import { usePredictionProbe } from "@/hooks/useInstrumentClasses";
+import {
+  CLASS_ORDER,
+  CLASS_LABELS,
+  classesForSymbol,
+  type InstrumentClass,
+} from "@/lib/instrumentClass";
 import { useUiStore } from "@/stores/uiStore";
 import { globalSearch, type SearchResultItem } from "@/api/endpoints/search";
 import { openShortcutsHelp } from "@/components/layout/KeyboardShortcutsHost";
@@ -296,6 +303,30 @@ export default function CommandPalette() {
   const hasQuery = debouncedQuery.length >= 2;
   const q = query.toLowerCase();
 
+  // Substring-filtered symbols shown in the palette. We probe PM state only for
+  // this (already small, cmdk-visible) slice so the palette + Markets list use
+  // the SAME classifier without a catalog-wide probe storm.
+  const filteredSymbols = React.useMemo(
+    () => symbols.filter((sc) => !query || sc.symbol.toLowerCase().includes(q)),
+    [symbols, query, q],
+  );
+  const probeIds = React.useMemo(() => filteredSymbols.map((sc) => sc.symbol_id), [filteredSymbols]);
+  // Only probe while the palette is open; capped inside the hook.
+  const probe = usePredictionProbe(probeIds, open);
+
+  // Group the visible symbols by instrument class (a symbol may appear under
+  // several headings — a perp is also in the funding book).
+  const symbolsByClass = React.useMemo(() => {
+    const groups = new Map<InstrumentClass, typeof filteredSymbols>();
+    for (const cls of CLASS_ORDER) groups.set(cls, []);
+    for (const sc of filteredSymbols) {
+      const classes = classesForSymbol(sc, { isPrediction: probe.isPrediction(sc.symbol_id) });
+      for (const cls of classes) groups.get(cls)!.push(sc);
+    }
+    return groups;
+  }, [filteredSymbols, probe]);
+
+
   return (
     <CommandDialog open={open} onOpenChange={setOpen} shouldFilter={false}>
       <CommandInput
@@ -319,20 +350,24 @@ export default function CommandPalette() {
           </CommandGroup>
         )}
 
-        <CommandGroup heading="Symbols">
-          {symbols
-            .filter((s) => !query || s.symbol.toLowerCase().includes(q))
-            .map((s) => (
-              <CommandItem
-                key={`symbol-${s.symbol_id}`}
-                value={`symbol ${s.symbol}`}
-                onSelect={() => go(`symbol:${s.symbol_id}`, `/markets/${s.symbol_id}`)}
-              >
-                <TrendingUp className="mr-2 h-4 w-4 text-muted-foreground" />
-                {s.symbol}
-              </CommandItem>
-            ))}
-        </CommandGroup>
+        {CLASS_ORDER.map((cls) => {
+          const group = symbolsByClass.get(cls) ?? [];
+          if (group.length === 0) return null;
+          return (
+            <CommandGroup key={`symbols-${cls}`} heading={CLASS_LABELS[cls]}>
+              {group.map((sc) => (
+                <CommandItem
+                  key={`symbol-${cls}-${sc.symbol_id}`}
+                  value={`symbol ${cls} ${sc.symbol}`}
+                  onSelect={() => go(`symbol:${sc.symbol_id}`, `/markets/${sc.symbol_id}`)}
+                >
+                  <TrendingUp className="mr-2 h-4 w-4 text-muted-foreground" />
+                  {sc.symbol}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          );
+        })}
 
         <CommandGroup heading="Pages">
           {PAGES.filter(

--- a/frontend/src/hooks/useInstrumentClasses.ts
+++ b/frontend/src/hooks/useInstrumentClasses.ts
@@ -1,0 +1,101 @@
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import * as trading from "@/api/endpoints/trading";
+import { tradingKeys } from "@/hooks/useTrading";
+import { useFundingPayments } from "@/hooks/useTrading";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import type { PmState } from "@/api/endpoints/trading";
+
+/**
+ * Prediction-market probe + funding-rate lens shared by the Markets list and
+ * the Cmd+K palette so both are ONE logical, class-filtered picker.
+ *
+ * PM probing: there is NO list endpoint for prediction markets — the only way
+ * to know a symbol is a PM is to read its per-symbol PM state (which 404s for a
+ * non-PM symbol). We probe with react-query (`retry:false`, cached, staleTime)
+ * so a 404 is a cheap one-shot "not a PM". To avoid a probe storm we probe ONLY
+ * the caller-supplied `symbolIds` (the Markets page passes them only when the
+ * Prediction tab is active; the palette passes at most a small filtered slice).
+ */
+
+/** Hard cap so we never fan out an unbounded number of PM probes at once. */
+export const PM_PROBE_CAP = 40;
+
+export interface PredictionProbe {
+  /** symbol_id -> live PM state (present only for symbols that ARE prediction markets). */
+  pmById: Map<number, PmState>;
+  /** True when at least one probe is still in flight. */
+  isProbing: boolean;
+  /** Predicate: has this symbol resolved to a live PM state? */
+  isPrediction: (symbolId: number) => boolean;
+}
+
+/**
+ * Probe PM state for a bounded set of symbol ids. Pass `enabled: false` to skip
+ * the network entirely (e.g. when the Prediction tab is not active) — it still
+ * returns any already-cached probes so classification stays consistent.
+ */
+export function usePredictionProbe(symbolIds: number[], enabled = true): PredictionProbe {
+  const ids = useMemo(() => {
+    const uniq = Array.from(new Set(symbolIds.filter((n) => Number.isFinite(n) && n > 0)));
+    return uniq.slice(0, PM_PROBE_CAP);
+  }, [symbolIds]);
+
+  const results = useQueries({
+    queries: ids.map((id) => ({
+      queryKey: tradingKeys.pmState(id),
+      queryFn: () => trading.getPmState(id),
+      enabled,
+      retry: false,
+      // A symbol’s PM-ness rarely changes; cache generously to keep probes cheap.
+      staleTime: 60_000,
+      gcTime: 300_000,
+    })),
+  });
+
+  return useMemo(() => {
+    const pmById = new Map<number, PmState>();
+    let isProbing = false;
+    results.forEach((r, i) => {
+      if (r.isFetching) isProbing = true;
+      const data = r.data as PmState | undefined;
+      // A real PM state carries is_binary / state / face_value. A 404 lands in
+      // r.error (retry:false) and leaves data undefined -> treated as not-a-PM.
+      if (data && (data.is_binary != null || data.state != null || data.face_value != null)) {
+        pmById.set(ids[i]!, data);
+      }
+    });
+    return {
+      pmById,
+      isProbing,
+      isPrediction: (symbolId: number) => pmById.has(symbolId),
+    };
+  }, [results, ids]);
+}
+
+/**
+ * Latest funding rate (bps) per symbol, derived from the caller’s funding
+ * payments feed (`/me/funding/payments`, newest-first). Returns "—"-able data:
+ * a symbol with no funding row simply has no entry. The feed 404s until the
+ * edge deploys (retry:false) — callers degrade to an empty map.
+ */
+export function useLatestFundingRates(enabled = true): Map<number, number> {
+  const feed = useFundingPayments(enabled);
+  return useMemo(() => {
+    const latest = new Map<number, number>();
+    const latestTs = new Map<number, number>();
+    for (const p of feed.data?.funding ?? []) {
+      const prev = latestTs.get(p.symbolid);
+      if (prev == null || p.ts > prev) {
+        latestTs.set(p.symbolid, p.ts);
+        latest.set(p.symbolid, p.funding_rate_bps);
+      }
+    }
+    return latest;
+  }, [feed.data]);
+}
+
+/** Funding interval (seconds) for a symbol, or undefined when not a perp/funding book. */
+export function fundingIntervalOf(sym: MarketSymbol): number | undefined {
+  return sym.is_perpetual && (sym.funding_interval_s ?? 0) > 0 ? sym.funding_interval_s : undefined;
+}

--- a/frontend/src/lib/instrumentClass.test.ts
+++ b/frontend/src/lib/instrumentClass.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import {
+  classesForSymbol,
+  symbolInClass,
+  CLASS_ORDER,
+  CLASS_TAB_ORDER,
+  CLASS_LABELS,
+} from "./instrumentClass";
+
+function mk(over: Partial<MarketSymbol>): MarketSymbol {
+  return {
+    symbol: "TEST",
+    symbol_id: 1,
+    instrument_id: 1,
+    price_scaler: 1,
+    lot_size: 1,
+    reference_price: 100,
+    matching_algo: "price_time",
+    is_perpetual: false,
+    funding_interval_s: 0,
+    ...over,
+  };
+}
+
+describe("classesForSymbol", () => {
+  it("classifies a non-perpetual as spot only", () => {
+    expect(classesForSymbol(mk({ is_perpetual: false }))).toEqual(["spot"]);
+  });
+
+  it("classifies a perpetual with funding interval as perp AND funding", () => {
+    expect(classesForSymbol(mk({ is_perpetual: true, funding_interval_s: 3600 }))).toEqual([
+      "perp",
+      "funding",
+    ]);
+  });
+
+  it("classifies a perpetual with NO funding interval as perp only", () => {
+    expect(classesForSymbol(mk({ is_perpetual: true, funding_interval_s: 0 }))).toEqual(["perp"]);
+  });
+
+  it("adds prediction to a spot symbol when isPrediction is set", () => {
+    expect(classesForSymbol(mk({ is_perpetual: false }), { isPrediction: true })).toEqual([
+      "spot",
+      "prediction",
+    ]);
+  });
+
+  it("adds prediction to a perp+funding symbol and keeps canonical order", () => {
+    expect(
+      classesForSymbol(mk({ is_perpetual: true, funding_interval_s: 3600 }), { isPrediction: true }),
+    ).toEqual(["perp", "prediction", "funding"]);
+  });
+
+  it("does not add prediction when isPrediction is false/undefined", () => {
+    expect(classesForSymbol(mk({ is_perpetual: false }), { isPrediction: false })).toEqual(["spot"]);
+    expect(classesForSymbol(mk({ is_perpetual: false }), {})).toEqual(["spot"]);
+  });
+
+  it("always returns classes in canonical CLASS_ORDER", () => {
+    const classes = classesForSymbol(
+      mk({ is_perpetual: true, funding_interval_s: 60 }),
+      { isPrediction: true },
+    );
+    const idx = classes.map((c) => CLASS_ORDER.indexOf(c));
+    expect(idx).toEqual([...idx].sort((a, b) => a - b));
+  });
+});
+
+describe("symbolInClass", () => {
+  const perp = mk({ is_perpetual: true, funding_interval_s: 3600 });
+  const spot = mk({ is_perpetual: false });
+
+  it("matches everything for the all tab", () => {
+    expect(symbolInClass(spot, "all")).toBe(true);
+    expect(symbolInClass(perp, "all")).toBe(true);
+  });
+
+  it("matches a perp in both perp and funding tabs", () => {
+    expect(symbolInClass(perp, "perp")).toBe(true);
+    expect(symbolInClass(perp, "funding")).toBe(true);
+    expect(symbolInClass(perp, "spot")).toBe(false);
+  });
+
+  it("matches a spot only in the spot tab", () => {
+    expect(symbolInClass(spot, "spot")).toBe(true);
+    expect(symbolInClass(spot, "perp")).toBe(false);
+    expect(symbolInClass(spot, "funding")).toBe(false);
+  });
+
+  it("respects the prediction flag", () => {
+    expect(symbolInClass(spot, "prediction")).toBe(false);
+    expect(symbolInClass(spot, "prediction", { isPrediction: true })).toBe(true);
+  });
+});
+
+describe("class metadata", () => {
+  it("has a label for every tab", () => {
+    for (const tab of CLASS_TAB_ORDER) {
+      expect(CLASS_LABELS[tab]).toBeTruthy();
+    }
+  });
+
+  it("starts the tab order with all", () => {
+    expect(CLASS_TAB_ORDER[0]).toBe("all");
+  });
+});

--- a/frontend/src/lib/instrumentClass.ts
+++ b/frontend/src/lib/instrumentClass.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure instrument classifier — the single source of truth for which "class"
+ * a market symbol belongs to, shared by the Markets list and the Cmd+K palette
+ * so they behave as ONE logical symbol picker.
+ *
+ * A symbol can belong to SEVERAL classes at once:
+ *   - a perpetual is BOTH a "perp" AND (when funding_interval_s > 0) a "funding" book entry;
+ *   - a symbol with a live prediction-market state ADDS "prediction".
+ * Discriminators are the CONFIRMED backend fields only — do NOT invent new ones:
+ *   - spot        := is_perpetual === false
+ *   - perp        := is_perpetual === true
+ *   - funding     := is_perpetual === true && funding_interval_s > 0 (a lens on perps)
+ *   - prediction  := has a live PM state (detected out-of-band; passed in as a flag)
+ */
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+
+export type InstrumentClass = "spot" | "perp" | "prediction" | "funding";
+
+/** The "All" pseudo-tab value used by the filter UI (not a real class). */
+export const ALL_CLASS = "all" as const;
+export type ClassTab = typeof ALL_CLASS | InstrumentClass;
+
+/** Human labels for each class + the All pseudo-tab. */
+export const CLASS_LABELS: Record<ClassTab, string> = {
+  all: "All",
+  spot: "Spot",
+  perp: "Perp",
+  prediction: "Prediction",
+  funding: "Funding",
+};
+
+/** Display order for the class tabs / palette headings (All first). */
+export const CLASS_TAB_ORDER: ClassTab[] = ["all", "spot", "perp", "prediction", "funding"];
+
+/** Display order of the real classes (no All) — used for palette headings. */
+export const CLASS_ORDER: InstrumentClass[] = ["spot", "perp", "prediction", "funding"];
+
+/** Honest empty-state copy per class (shown when a filtered group is empty). */
+export const CLASS_EMPTY_COPY: Record<InstrumentClass, string> = {
+  spot: "No spot markets listed.",
+  perp: "No perpetual contracts listed.",
+  prediction: "No prediction markets listed.",
+  funding: "No funding-book contracts listed.",
+};
+
+export interface ClassifyOpts {
+  /** True when the symbol has a live prediction-market state (probed out-of-band). */
+  isPrediction?: boolean;
+}
+
+/**
+ * All classes a symbol belongs to, in {@link CLASS_ORDER}. A perp is also in
+ * the funding book; a PM-enabled symbol additionally gets "prediction".
+ */
+export function classesForSymbol(sym: MarketSymbol, opts: ClassifyOpts = {}): InstrumentClass[] {
+  const out: InstrumentClass[] = [];
+  if (sym.is_perpetual) {
+    out.push("perp");
+    if ((sym.funding_interval_s ?? 0) > 0) out.push("funding");
+  } else {
+    out.push("spot");
+  }
+  if (opts.isPrediction) out.push("prediction");
+  // Normalize to the canonical display order.
+  return CLASS_ORDER.filter((c) => out.includes(c));
+}
+
+/** True when the symbol belongs to the given class tab ("all" always matches). */
+export function symbolInClass(
+  sym: MarketSymbol,
+  tab: ClassTab,
+  opts: ClassifyOpts = {},
+): boolean {
+  if (tab === ALL_CLASS) return true;
+  return classesForSymbol(sym, opts).includes(tab);
+}

--- a/frontend/src/pages/markets/MarketsPage.tsx
+++ b/frontend/src/pages/markets/MarketsPage.tsx
@@ -11,6 +11,21 @@ import { useSymbols, useCandles } from "@/hooks/useMarketData";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
 import { formatPrice } from "./format";
 import { loadDefaultSymbol } from "@/lib/tradingPrefs";
+import {
+  ALL_CLASS,
+  CLASS_EMPTY_COPY,
+  CLASS_LABELS,
+  CLASS_TAB_ORDER,
+  symbolInClass,
+  type ClassTab,
+  type InstrumentClass,
+} from "@/lib/instrumentClass";
+import {
+  usePredictionProbe,
+  useLatestFundingRates,
+  fundingIntervalOf,
+} from "@/hooks/useInstrumentClasses";
+import { impliedYes, type PmState } from "@/api/endpoints/trading";
 
 // Fallback catalog if the symbols endpoint errors or returns empty.
 const FALLBACK_SYMBOLS: MarketSymbol[] = [
@@ -30,6 +45,14 @@ function loadWatchlist(): number[] {
   } catch {
     return [];
   }
+}
+
+/** Format a funding interval (seconds) as a compact human string. */
+function formatInterval(seconds: number | undefined): string {
+  if (!seconds || seconds <= 0) return "—";
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
 }
 
 /** Tiny inline SVG sparkline of recent closes. */
@@ -64,7 +87,26 @@ function Sparkline({ closes, up }: { closes: number[]; up: boolean }) {
   );
 }
 
-function MarketRow({ sym, fav, onToggleFav }: { sym: MarketSymbol; fav: boolean; onToggleFav: (id: number) => void }) {
+interface RowExtras {
+  /** Funding tab: latest funding rate in bps (undefined -> em dash). */
+  fundingRateBps?: number;
+  /** Prediction tab: the live PM state, for the implied-YES column. */
+  pm?: PmState;
+}
+
+function MarketRow({
+  sym,
+  fav,
+  onToggleFav,
+  activeClass,
+  extras,
+}: {
+  sym: MarketSymbol;
+  fav: boolean;
+  onToggleFav: (id: number) => void;
+  activeClass: ClassTab;
+  extras: RowExtras;
+}) {
   const navigate = useNavigate();
   const scaler = sym.price_scaler || 1;
   // 60s candles, most-recent window; bars are ordered oldest -> newest.
@@ -76,6 +118,8 @@ function MarketRow({ sym, fav, onToggleFav }: { sym: MarketSymbol; fav: boolean;
   const first = closes.length ? closes[0]! : undefined;
   const changePct = first != null && first !== 0 ? ((last - first) / first) * 100 : undefined;
   const up = (changePct ?? 0) >= 0;
+
+  const yes = activeClass === "prediction" ? impliedYes(last, extras.pm?.face_value) : null;
 
   return (
     <TableRow className="cursor-pointer" onClick={() => navigate(`/markets/${sym.symbol_id}`)}>
@@ -101,6 +145,19 @@ function MarketRow({ sym, fav, onToggleFav }: { sym: MarketSymbol; fav: boolean;
       >
         {changePct == null ? "—" : `${up ? "+" : ""}${changePct.toFixed(2)}%`}
       </TableCell>
+      {activeClass === "funding" && (
+        <>
+          <TableCell className="text-right tabular-nums">{formatInterval(fundingIntervalOf(sym))}</TableCell>
+          <TableCell className="text-right tabular-nums">
+            {extras.fundingRateBps == null ? "—" : `${extras.fundingRateBps} bps`}
+          </TableCell>
+        </>
+      )}
+      {activeClass === "prediction" && (
+        <TableCell className="text-right tabular-nums">
+          {yes == null ? "—" : `${(yes * 100).toFixed(1)}%`}
+        </TableCell>
+      )}
       <TableCell className="hidden text-right sm:table-cell">
         <div className="flex justify-end">
           <Sparkline closes={closes} up={up} />
@@ -110,7 +167,7 @@ function MarketRow({ sym, fav, onToggleFav }: { sym: MarketSymbol; fav: boolean;
   );
 }
 
-type FilterTab = "all" | "watchlist";
+type WatchTab = "all" | "watchlist";
 
 export default function MarketsPage() {
   const symbolsQuery = useSymbols();
@@ -135,7 +192,8 @@ export default function MarketsPage() {
   }, [symbolsQuery.data, apiSymbols, navigate]);
 
   const [query, setQuery] = useState("");
-  const [tab, setTab] = useState<FilterTab>("all");
+  const [watchTab, setWatchTab] = useState<WatchTab>("all");
+  const [classTab, setClassTab] = useState<ClassTab>(ALL_CLASS);
   const [watchlist, setWatchlist] = useState<number[]>(loadWatchlist);
 
   useEffect(() => {
@@ -151,20 +209,49 @@ export default function MarketsPage() {
 
   const isFav = (id: number) => watchlist.includes(id);
 
-  const rows = useMemo(() => {
+  // Search + watchlist pre-filter (class-agnostic), shared by both the class
+  // probe scope and the final rows so we only probe what could be shown.
+  const preClass = useMemo(() => {
     const q = query.trim().toLowerCase();
     let filtered = q ? base.filter((s) => s.symbol.toLowerCase().includes(q)) : base.slice();
-    if (tab === "watchlist") {
-      // Preserve stable starred order (order in which they were added).
+    if (watchTab === "watchlist") {
       const order = new Map(watchlist.map((id, i) => [id, i]));
       filtered = filtered
         .filter((s) => order.has(s.symbol_id))
         .sort((a, b) => order.get(a.symbol_id)! - order.get(b.symbol_id)!);
     }
     return filtered;
-  }, [base, query, tab, watchlist]);
+  }, [base, query, watchTab, watchlist]);
 
-  const emptyWatchlist = tab === "watchlist" && watchlist.length === 0;
+  // PM probe: ONLY probe the currently-visible slice, and only when the
+  // Prediction tab is active (avoids a probe storm across the whole catalog).
+  const predictionActive = classTab === "prediction";
+  const probe = usePredictionProbe(
+    predictionActive ? preClass.map((s) => s.symbol_id) : [],
+    predictionActive,
+  );
+
+  // Funding rates: only needed for the Funding tab; the feed is cheap + shared.
+  const fundingActive = classTab === "funding";
+  const fundingRates = useLatestFundingRates(fundingActive);
+
+  const rows = useMemo(
+    () =>
+      preClass.filter((s) =>
+        symbolInClass(s, classTab, { isPrediction: probe.isPrediction(s.symbol_id) }),
+      ),
+    [preClass, classTab, probe],
+  );
+
+  const emptyWatchlist = watchTab === "watchlist" && watchlist.length === 0;
+
+  // Column span for the "no rows" cell adapts to the extra columns.
+  const colSpan = 5 + (classTab === "funding" ? 2 : 0) + (classTab === "prediction" ? 1 : 0);
+
+  const emptyClassCopy =
+    classTab !== ALL_CLASS && rows.length === 0 && !emptyWatchlist && !query
+      ? CLASS_EMPTY_COPY[classTab as InstrumentClass]
+      : null;
 
   return (
     <div className="space-y-6">
@@ -182,21 +269,32 @@ export default function MarketsPage() {
           <CardDescription>Prices update live. Star a market to add it to your watchlist.</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <Tabs value={tab} onValueChange={(v) => setTab(v as FilterTab)}>
+          <div className="mb-3 flex flex-col gap-3">
+            <Tabs value={classTab} onValueChange={(v) => setClassTab(v as ClassTab)}>
               <TabsList>
-                <TabsTrigger value="all">All</TabsTrigger>
-                <TabsTrigger value="watchlist">
-                  Watchlist{watchlist.length > 0 ? ` (${watchlist.length})` : ""}
-                </TabsTrigger>
+                {CLASS_TAB_ORDER.map((t) => (
+                  <TabsTrigger key={t} value={t}>
+                    {CLASS_LABELS[t]}
+                  </TabsTrigger>
+                ))}
               </TabsList>
             </Tabs>
-            <Input
-              placeholder="Search symbol…"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              className="max-w-xs"
-            />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <Tabs value={watchTab} onValueChange={(v) => setWatchTab(v as WatchTab)}>
+                <TabsList>
+                  <TabsTrigger value="all">All</TabsTrigger>
+                  <TabsTrigger value="watchlist">
+                    Watchlist{watchlist.length > 0 ? ` (${watchlist.length})` : ""}
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <Input
+                placeholder="Search symbol…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="max-w-xs"
+              />
+            </div>
           </div>
           {symbolsQuery.isLoading ? (
             <div className="space-y-2">
@@ -212,6 +310,14 @@ export default function MarketsPage() {
                 Tap the star on any market in the “All” tab to add it here.
               </p>
             </div>
+          ) : emptyClassCopy ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-center">
+              <CandlestickChart className="h-8 w-8 text-muted-foreground" />
+              <p className="text-sm font-medium">{emptyClassCopy}</p>
+              {predictionActive && probe.isProbing && (
+                <p className="text-sm text-muted-foreground">Checking for live prediction markets…</p>
+              )}
+            </div>
           ) : (
             <Table>
               <TableHeader>
@@ -220,6 +326,13 @@ export default function MarketsPage() {
                   <TableHead>Symbol</TableHead>
                   <TableHead className="text-right">Last</TableHead>
                   <TableHead className="text-right">Chg %</TableHead>
+                  {classTab === "funding" && (
+                    <>
+                      <TableHead className="text-right">Interval</TableHead>
+                      <TableHead className="text-right">Rate (bps)</TableHead>
+                    </>
+                  )}
+                  {classTab === "prediction" && <TableHead className="text-right">Implied YES</TableHead>}
                   <TableHead className="hidden text-right sm:table-cell">Trend</TableHead>
                 </TableRow>
               </TableHeader>
@@ -230,12 +343,17 @@ export default function MarketsPage() {
                     sym={sym}
                     fav={isFav(sym.symbol_id)}
                     onToggleFav={toggleFav}
+                    activeClass={classTab}
+                    extras={{
+                      fundingRateBps: fundingRates.get(sym.symbol_id),
+                      pm: probe.pmById.get(sym.symbol_id),
+                    }}
                   />
                 ))}
                 {rows.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={5} className="py-4 text-center text-sm text-muted-foreground">
-                      No symbols match “{query}”.
+                    <TableCell colSpan={colSpan} className="py-4 text-center text-sm text-muted-foreground">
+                      {query ? `No symbols match “${query}”.` : "No symbols to show."}
                     </TableCell>
                   </TableRow>
                 )}


### PR DESCRIPTION
## Unified, class-filtered symbol picker

Groups the single flat `/md/symbols` catalog by **instrument class** instead of one undifferentiated list, across both selection surfaces (Markets list + `Cmd+K` palette). Answers "do we have a unified picker across spot / perps / prediction / funding book" — now yes, with real class grouping.

### Discriminators (no new backend fields required)
- **Spot** = `!is_perpetual` · **Perp** = `is_perpetual`.
- **Funding book** = perpetual contracts (`funding_interval_s > 0`) shown with funding **interval** + **latest `funding_rate_bps`** (most-recent per symbol from `/me/funding/payments`; "—" when unknown). A lens on perps.
- **Prediction** = symbols with a live PM state — detected per-symbol (the PM-state read 404s on non-PM symbols, `retry:false`), cached; shows **implied-YES %**. Probes are bounded/lazy (web caps at 40, only when the Prediction tab/palette is active; Android caches with a negative sentinel).

### Web
- `src/lib/instrumentClass.ts` (new, +13 vitest) — pure classifier; `src/hooks/useInstrumentClasses.ts` (bounded PM probe + latest funding rate).
- `MarketsPage` — All / Spot / Perp / Prediction / Funding segmented control (Funding adds interval+rate columns; Prediction adds implied-YES %); honest per-class empty states.
- `CommandPalette` — Symbols results grouped by class heading via the same classifier.

### Android
- `feature/markets/InstrumentClass.kt` (new, +8 JVM tests) — classifier + tab model.
- `ExchangeDomain`/`ExchangeMappers` — thread `funding_interval_s` into the `Instrument` domain (it was dropped in the mapper; the funding discriminator needs it).
- `MarketsViewModel` injects `TradingRepository` (latest funding rate + lazy cached PM probe); `MarketsScreen` gets a scrollable class-tab row with live counts, Funding=`interval·±bps`, Prediction=`YES %`, per-class empty states.

"All" behaves exactly as before. No new deps, no new nav routes (MoreCatalog untouched).

### Backend asks logged (for cheaper backing)
PM-enabled symbol list, per-symbol current funding rate, and an umbrella `instrument_class` field on `/md/symbols` — so Prediction/Funding become one read instead of inference/probing.

### Gates
- Web: `tsc` 0 · `vite build` green · vitest `instrumentClass` 13/13.
- Android: `assembleDebug` + `testDebugUnitTest` BUILD SUCCESSFUL (`InstrumentClassTest` 8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)