### PR TITLE
feat(analysis): historical market-data analysis workbench (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeApi.kt
@@ -33,4 +33,19 @@ interface ExchangeApi {
     suspend fun getTrades(
         @Path("symbolId") symbolId: Int,
     ): TradesResponseDto
+
+    /**
+     * Long-range HISTORICAL bars for the Analysis workbench. NEW endpoint — the backend may 404 it,
+     * in which case the repository degrades to [getCandles] (recent window). [interval] is the
+     * candle interval label (e.g. "1m","1h","1d"); [from]/[to] are epoch-second bounds (optional);
+     * [cursor] paginates a large range.
+     */
+    @GET("md/history/{symbolId}")
+    suspend fun getHistory(
+        @Path("symbolId") symbolId: Int,
+        @Query("interval") interval: String,
+        @Query("from") from: Long? = null,
+        @Query("to") to: Long? = null,
+        @Query("cursor") cursor: String? = null,
+    ): HistoryResponseDto
 }

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeDomain.kt
@@ -75,3 +75,31 @@ data class Trade(
     val aggressor: Aggressor,
     val tsNs: Long,
 )
+
+/**
+ * One historical OHLCV bar for the Analysis workbench. [ts] is the bar-start in epoch SECONDS (the
+ * long-range history endpoint keys by seconds, unlike [Candle.tsStartNs]). Prices/volume are raw
+ * integers; scale for display via the owning [Instrument].
+ */
+data class HistoryBar(
+    val ts: Long,
+    val open: Long,
+    val high: Long,
+    val low: Long,
+    val close: Long,
+    val volume: Long,
+)
+
+/**
+ * A page of [HistoryBar]s for one symbol+interval. [nextCursor] paginates a large range (null when
+ * the page is terminal). [stub] is true when this was DEGRADED from the recent-window candles read
+ * because the long-range `md/history` endpoint was absent (404) — the UI shows a "recent window
+ * only" banner in that case.
+ */
+data class HistoryBars(
+    val symbolId: Int,
+    val interval: String,
+    val bars: List<HistoryBar>,
+    val nextCursor: String? = null,
+    val stub: Boolean = false,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeDtos.kt
@@ -77,3 +77,29 @@ data class TradeDto(
     val qty: Long = 0,
     @Json(name = "ts_ns") val tsNs: Long = 0,
 )
+
+/**
+ * Transport for the NEW long-range history endpoint (`GET md/history/{symbolId}`). Every field has a
+ * default so a partial/absent payload never fails to decode. [nextCursor] paginates; [bars] carry the
+ * OHLCV timeline. Prices/quantities are integers on the wire (divide by the symbol's price scaler).
+ */
+@JsonClass(generateAdapter = true)
+data class HistoryResponseDto(
+    val symbol: Int = 0,
+    val interval: String = "",
+    val from: Long = 0,
+    val to: Long = 0,
+    val count: Int = 0,
+    @Json(name = "next_cursor") val nextCursor: String? = null,
+    val bars: List<HistoryBarDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class HistoryBarDto(
+    @Json(name = "ts") val ts: Long = 0,
+    @Json(name = "o") val open: Long = 0,
+    @Json(name = "h") val high: Long = 0,
+    @Json(name = "l") val low: Long = 0,
+    @Json(name = "c") val close: Long = 0,
+    @Json(name = "v") val volume: Long = 0,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeMappers.kt
@@ -44,3 +44,41 @@ fun TradeDto.toDomain(): Trade = Trade(
     },
     tsNs = tsNs,
 )
+
+fun HistoryBarDto.toDomain(): HistoryBar = HistoryBar(
+    ts = ts,
+    open = open,
+    high = high,
+    low = low,
+    close = close,
+    volume = volume,
+)
+
+fun HistoryResponseDto.toDomain(symbolId: Int): HistoryBars = HistoryBars(
+    symbolId = if (symbol != 0) symbol else symbolId,
+    interval = interval,
+    bars = bars.map { it.toDomain() },
+    nextCursor = nextCursor?.takeIf { it.isNotBlank() },
+    stub = false,
+)
+
+/**
+ * Adapt a recent-window [Candle] list (nanosecond timestamps) into [HistoryBar]s (second timestamps)
+ * so the workbench degrades onto the existing candles read when `md/history` is absent.
+ */
+fun List<Candle>.toHistoryBars(symbolId: Int, interval: String): HistoryBars = HistoryBars(
+    symbolId = symbolId,
+    interval = interval,
+    bars = map {
+        HistoryBar(
+            ts = it.tsStartNs / 1_000_000_000L,
+            open = it.open,
+            high = it.high,
+            low = it.low,
+            close = it.close,
+            volume = it.volume,
+        )
+    },
+    nextCursor = null,
+    stub = true,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/ExchangeRepository.kt
@@ -24,6 +24,20 @@ interface ExchangeRepository {
     suspend fun orderBook(symbolId: Int, depth: Int = 20): ApiResult<OrderBook>
     suspend fun candles(symbolId: Int, intervalSec: Int = 60): ApiResult<List<Candle>>
     suspend fun trades(symbolId: Int): ApiResult<List<Trade>>
+
+    /**
+     * Long-range historical bars for the Analysis workbench. Calls the NEW `md/history` endpoint; on
+     * 404/absence it DEGRADES to the recent-window [candles] read and returns a [HistoryBars] with
+     * `stub = true` so the caller can show the "recent window only" banner. [interval] is the label
+     * ("1m","5m","15m","1h","1d"); [from]/[to] are optional epoch-second bounds; [cursor] paginates.
+     */
+    suspend fun getHistory(
+        symbolId: Int,
+        interval: String,
+        from: Long? = null,
+        to: Long? = null,
+        cursor: String? = null,
+    ): ApiResult<HistoryBars>
 }
 
 @Singleton
@@ -53,6 +67,31 @@ class ExchangeRepositoryImpl @Inject constructor(
     override suspend fun trades(symbolId: Int): ApiResult<List<Trade>> =
         withContext(io) { apiCall { api.getTrades(symbolId).trades.map { it.toDomain() } } }
 
+    override suspend fun getHistory(
+        symbolId: Int,
+        interval: String,
+        from: Long?,
+        to: Long?,
+        cursor: String?,
+    ): ApiResult<HistoryBars> = withContext(io) {
+        when (val result = apiCall { api.getHistory(symbolId, interval, from, to, cursor).toDomain(symbolId) }) {
+            is ApiResult.Success -> result
+            // The long-range endpoint does NOT exist yet: DEGRADE to the recent-window candles read
+            // and flag the result as a stub so the workbench can show its "recent window only" banner.
+            // A network error (offline) is NOT degraded — surface it so the UI can offer retry.
+            is ApiResult.Failure -> degradeToRecentWindow(symbolId, interval)
+            is ApiResult.NetworkError -> result
+        }
+    }
+
+    /** Fallback path: reuse [candles] and adapt to [HistoryBars] (stub=true) when history is absent. */
+    private suspend fun degradeToRecentWindow(symbolId: Int, interval: String): ApiResult<HistoryBars> =
+        when (val c = apiCall { api.getCandles(symbolId, intervalToSeconds(interval)).bars.map { it.toDomain() } }) {
+            is ApiResult.Success -> ApiResult.Success(c.data.toHistoryBars(symbolId, interval))
+            is ApiResult.Failure -> c
+            is ApiResult.NetworkError -> c
+        }
+
     private suspend fun <T> apiCall(block: suspend () -> T): ApiResult<T> = try {
         ApiResult.Success(block())
     } catch (e: CancellationException) {
@@ -64,6 +103,17 @@ class ExchangeRepositoryImpl @Inject constructor(
     }
 
     private companion object {
+        /** Map an interval LABEL to the candle interval seconds for the degraded recent-window read. */
+        fun intervalToSeconds(interval: String): Int = when (interval.trim().lowercase()) {
+            "1m" -> 60
+            "5m" -> 300
+            "15m" -> 900
+            "1h" -> 3_600
+            "4h" -> 14_400
+            "1d" -> 86_400
+            else -> 60
+        }
+
         /** Known instrument catalogue used when `md/symbols` is unavailable/empty. */
         val FALLBACK_SYMBOLS = listOf(
             Instrument("BTCUSDC", 1, 1, 1, 100_000, false),

--- a/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketAnalysisScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketAnalysisScreen.kt
@@ -1,0 +1,547 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.analysis
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.exchange.Candle
+import com.testlogon.android.data.exchange.HistoryBar
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.feature.markets.MARKET_CLASS_TABS
+import com.testlogon.android.feature.markets.MarketClassTab
+import com.testlogon.android.feature.markets.chart.CandlestickChart
+import com.testlogon.android.feature.markets.matchesTab
+import com.testlogon.android.feature.markets.ui.MarketColors
+import com.testlogon.android.feature.markets.ui.MarketSurface
+import kotlin.math.abs
+
+/**
+ * Analysis workbench route: symbol + class filter + range select, a history chart (degrading to the
+ * recent window with a banner), a stats panel, a multi-symbol normalized overlay + correlation grid,
+ * and a fast/slow MA-cross backtest runner. Read-only research surface over the market-data feeds.
+ */
+@Composable
+fun MarketAnalysisRoute(
+    onBack: () -> Unit,
+    viewModel: MarketAnalysisViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    MarketSurface {
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            AnalysisHeader(onBack = onBack)
+            Box(modifier = Modifier.fillMaxSize()) {
+                when (state.phase) {
+                    MarketAnalysisUiState.Phase.Loading -> LoadingState(message = "Loading analysis")
+                    MarketAnalysisUiState.Phase.Empty -> EmptyState(
+                        title = "No markets",
+                        body = "No instruments are available to analyze right now.",
+                    )
+                    MarketAnalysisUiState.Phase.Error -> ErrorState(
+                        message = state.errorMessage ?: "Something went wrong.",
+                        onRetry = viewModel::onRetry,
+                    )
+                    MarketAnalysisUiState.Phase.Content -> AnalysisContent(
+                        state = state,
+                        onSelectSymbol = viewModel::onSelectSymbol,
+                        onSelectClassTab = viewModel::onSelectClassTab,
+                        onSelectRange = viewModel::onSelectRange,
+                        onToggleCompare = viewModel::onToggleCompare,
+                        onBacktestParams = viewModel::onBacktestParams,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnalysisHeader(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = MarketColors.TextPrimary)
+        }
+        Text(
+            "Analysis",
+            color = MarketColors.TextPrimary,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun AnalysisContent(
+    state: MarketAnalysisUiState,
+    onSelectSymbol: (Int) -> Unit,
+    onSelectClassTab: (MarketClassTab) -> Unit,
+    onSelectRange: (AnalysisRange) -> Unit,
+    onToggleCompare: (Int) -> Unit,
+    onBacktestParams: (Int, Int) -> Unit,
+) {
+    val filtered = state.instruments.filter { matchesTab(it, isPrediction = false, tab = state.classTab) }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().testTag("analysis_content"),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { ClassTabRow(state.classTab, onSelectClassTab) }
+        item {
+            SymbolChips(
+                instruments = filtered,
+                selectedId = state.selectedSymbolId,
+                label = "Symbol",
+                onSelect = onSelectSymbol,
+            )
+        }
+        item { RangeRow(state.range, onSelectRange) }
+
+        if (state.degraded) {
+            item { DegradedBanner() }
+        }
+
+        item { SectionTitle("Price history") }
+        item {
+            val candles = barsToCandles(state.primary?.bars.orEmpty())
+            if (candles.isEmpty()) {
+                EmptyHint("No bars for this range.")
+            } else {
+                CandlestickChart(
+                    candles = candles,
+                    priceScaler = state.selectedInstrument?.priceScaler ?: 1L,
+                    showTimeframes = false,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                )
+            }
+        }
+
+        item { SectionTitle("Statistics") }
+        item { StatsPanel(state.primary?.stats) }
+
+        item { SectionTitle("Compare (normalized overlay)") }
+        item {
+            SymbolChips(
+                instruments = filtered.filter { it.symbolId != state.selectedSymbolId },
+                selectedId = null,
+                selectedSet = state.compareSymbolIds,
+                label = "Add to compare",
+                onSelect = onToggleCompare,
+            )
+        }
+        item { CompareOverlay(state) }
+
+        if (state.correlation.isNotEmpty()) {
+            item { SectionTitle("Correlation") }
+            item { CorrelationGrid(state) }
+        }
+
+        item { SectionTitle("MA-cross backtest") }
+        item { BacktestPanel(state.backtest, onBacktestParams) }
+    }
+}
+
+@Composable
+private fun ClassTabRow(selected: MarketClassTab, onSelect: (MarketClassTab) -> Unit) {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        items(MARKET_CLASS_TABS) { tab ->
+            FilterChip(
+                selected = tab.label == selected.label,
+                onClick = { onSelect(tab) },
+                label = { Text(tab.label) },
+                modifier = Modifier.testTag("class_tab_${tab.label}"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SymbolChips(
+    instruments: List<Instrument>,
+    selectedId: Int?,
+    label: String,
+    onSelect: (Int) -> Unit,
+    selectedSet: Set<Int> = emptySet(),
+) {
+    Column(modifier = Modifier.padding(horizontal = 8.dp)) {
+        Text(label, color = MarketColors.TextSecondary, fontSize = 12.sp)
+        Spacer(Modifier.height(4.dp))
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            items(instruments) { inst ->
+                val on = inst.symbolId == selectedId || inst.symbolId in selectedSet
+                FilterChip(
+                    selected = on,
+                    onClick = { onSelect(inst.symbolId) },
+                    label = { Text(inst.symbol) },
+                    modifier = Modifier.testTag("symbol_chip_${inst.symbol}"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RangeRow(selected: AnalysisRange, onSelect: (AnalysisRange) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        AnalysisRange.entries.forEach { r ->
+            FilterChip(
+                selected = r == selected,
+                onClick = { onSelect(r) },
+                label = { Text(r.label) },
+                modifier = Modifier.testTag("range_chip_${r.label}"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DegradedBanner() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MarketColors.DownPill)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .testTag("degraded_banner"),
+    ) {
+        Text(
+            "Recent window only — long-range history pending backend (/md/history).",
+            color = MarketColors.TextPrimary,
+            fontSize = 12.sp,
+        )
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text,
+        color = MarketColors.TextPrimary,
+        fontSize = 15.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = 12.dp),
+    )
+}
+
+@Composable
+private fun EmptyHint(text: String) {
+    Text(text, color = MarketColors.TextSecondary, fontSize = 13.sp, modifier = Modifier.padding(horizontal = 12.dp))
+}
+
+@Composable
+private fun StatsPanel(stats: SymbolStats?) {
+    if (stats == null) {
+        EmptyHint("Not enough data for statistics.")
+        return
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MarketColors.Surface)
+            .padding(12.dp)
+            .testTag("stats_panel"),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        StatRow("Period return", pct(stats.periodReturnPct), signColor(stats.periodReturnPct))
+        StatRow("Cumulative return", pct(stats.cumulativeReturnPct), signColor(stats.cumulativeReturnPct))
+        StatRow("Volatility (ann.)", pct(stats.annualizedVolPct), MarketColors.TextPrimary)
+        StatRow("Max drawdown", pct(stats.maxDrawdownPct?.let { -it }), MarketColors.Down)
+        StatRow("High", num(stats.high), MarketColors.TextPrimary)
+        StatRow("Low", num(stats.low), MarketColors.TextPrimary)
+        StatRow("Avg volume", num(stats.avgVolume), MarketColors.TextPrimary)
+        StatRow("Total volume", num(stats.totalVolume), MarketColors.TextPrimary)
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String, valueColor: Color) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, color = MarketColors.TextSecondary, fontSize = 13.sp)
+        Text(value, color = valueColor, fontSize = 13.sp, fontFamily = FontFamily.Monospace)
+    }
+}
+
+@Composable
+private fun CompareOverlay(state: MarketAnalysisUiState) {
+    val primary = state.primary
+    if (primary == null || primary.closes.size < 2) {
+        EmptyHint("Select a symbol with data to overlay.")
+        return
+    }
+    val series = listOf(primary) + state.compareSeries
+    val normalized = series.map { it.instrument.symbol to MarketStats.normalizeToBase(it.closes) }
+        .filter { it.second.size >= 2 }
+    if (normalized.isEmpty()) {
+        EmptyHint("No overlay data.")
+        return
+    }
+    val palette = listOf(MarketColors.Accent, MarketColors.Up, MarketColors.Down, Color(0xFFF0B90B), Color(0xFF6C8CFF))
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(180.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(MarketColors.Surface)
+                .padding(8.dp)
+                .testTag("compare_overlay"),
+        ) {
+            val allVals = normalized.flatMap { it.second }
+            val minV = allVals.min()
+            val maxV = allVals.max()
+            val span = (maxV - minV).takeIf { it > 0.0 } ?: 1.0
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                normalized.forEachIndexed { idx, (_, vals) ->
+                    val color = palette[idx % palette.size]
+                    val stepX = if (vals.size > 1) size.width / (vals.size - 1) else size.width
+                    for (i in 1 until vals.size) {
+                        val x0 = stepX * (i - 1)
+                        val x1 = stepX * i
+                        val y0 = size.height - ((vals[i - 1] - minV) / span).toFloat() * size.height
+                        val y1 = size.height - ((vals[i] - minV) / span).toFloat() * size.height
+                        drawLine(color, Offset(x0, y0), Offset(x1, y1), strokeWidth = 2.5f, cap = StrokeCap.Round)
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.horizontalScroll(rememberScrollState())) {
+            normalized.forEachIndexed { idx, (sym, _) ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(modifier = Modifier.width(12.dp).height(3.dp).background(palette[idx % palette.size]))
+                    Spacer(Modifier.width(4.dp))
+                    Text(sym, color = MarketColors.TextSecondary, fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CorrelationGrid(state: MarketAnalysisUiState) {
+    val symbols = (listOf(state.primary) + state.compareSeries)
+        .mapNotNull { it?.instrument?.symbol }
+    val byKey = state.correlation.associateBy { it.rowSymbol to it.colSymbol }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MarketColors.Surface)
+            .padding(8.dp)
+            .horizontalScroll(rememberScrollState())
+            .testTag("correlation_grid"),
+    ) {
+        // Header row.
+        Row {
+            CorrCell("", header = true)
+            symbols.forEach { CorrCell(it, header = true) }
+        }
+        symbols.forEach { rowSym ->
+            Row {
+                CorrCell(rowSym, header = true)
+                symbols.forEach { colSym ->
+                    val r = byKey[rowSym to colSym]?.r
+                    CorrCell(r?.let { String.format("%.2f", it) } ?: "--", corr = r)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CorrCell(text: String, header: Boolean = false, corr: Double? = null) {
+    val bg = when {
+        header -> Color.Transparent
+        corr == null -> MarketColors.SurfaceAlt
+        corr >= 0 -> MarketColors.UpFill
+        else -> MarketColors.DownFill
+    }
+    Box(
+        modifier = Modifier
+            .width(54.dp)
+            .height(30.dp)
+            .background(bg),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text,
+            color = if (header) MarketColors.TextSecondary else MarketColors.TextPrimary,
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+@Composable
+private fun BacktestPanel(state: BacktestState, onParams: (Int, Int) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MarketColors.Surface)
+            .padding(12.dp)
+            .testTag("backtest_panel"),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        StepperRow("Fast SMA", state.fast) { onParams(it.coerceIn(1, state.slow - 1), state.slow) }
+        StepperRow("Slow SMA", state.slow) { onParams(state.fast, it.coerceIn(state.fast + 1, 200)) }
+        val result = state.result
+        if (result == null || result.trades == 0) {
+            EmptyHint("Not enough bars (or no crossover) to backtest.")
+        } else {
+            StatRow("Total return", pct(result.totalReturn * 100.0), signColor(result.totalReturn * 100.0))
+            StatRow("Win rate", pct(result.winRate * 100.0), MarketColors.TextPrimary)
+            StatRow("Trades", result.trades.toString(), MarketColors.TextPrimary)
+            Spacer(Modifier.height(2.dp))
+            EquityCurve(result.equityCurve)
+        }
+    }
+}
+
+@Composable
+private fun StepperRow(label: String, value: Int, onChange: (Int) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, color = MarketColors.TextSecondary, fontSize = 13.sp)
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            StepButton("-") { onChange(value - 1) }
+            Text(value.toString(), color = MarketColors.TextPrimary, fontSize = 14.sp, fontFamily = FontFamily.Monospace)
+            StepButton("+") { onChange(value + 1) }
+        }
+    }
+}
+
+@Composable
+private fun StepButton(text: String, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .width(32.dp)
+            .height(32.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(MarketColors.SurfaceAlt)
+            .testTag("step_$text"),
+        contentAlignment = Alignment.Center,
+    ) {
+        androidx.compose.material3.TextButton(onClick = onClick, modifier = Modifier.fillMaxSize()) {
+            Text(text, color = MarketColors.TextPrimary, fontSize = 16.sp)
+        }
+    }
+}
+
+@Composable
+private fun EquityCurve(curve: List<Double>) {
+    if (curve.size < 2) return
+    val minV = curve.min()
+    val maxV = curve.max()
+    val span = (maxV - minV).takeIf { it > 0.0 } ?: 1.0
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MarketColors.SurfaceAlt)
+            .padding(6.dp)
+            .testTag("equity_curve"),
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val stepX = if (curve.size > 1) size.width / (curve.size - 1) else size.width
+            val up = curve.last() >= curve.first()
+            val color = if (up) MarketColors.Up else MarketColors.Down
+            for (i in 1 until curve.size) {
+                val x0 = stepX * (i - 1)
+                val x1 = stepX * i
+                val y0 = size.height - ((curve[i - 1] - minV) / span).toFloat() * size.height
+                val y1 = size.height - ((curve[i] - minV) / span).toFloat() * size.height
+                drawLine(color, Offset(x0, y0), Offset(x1, y1), strokeWidth = 2.5f, cap = StrokeCap.Round)
+            }
+        }
+    }
+}
+
+/** Adapt the workbench's [HistoryBar]s (second timestamps) into [Candle]s for the shared chart. */
+private fun barsToCandles(bars: List<HistoryBar>): List<Candle> = bars.map {
+    Candle(
+        tsStartNs = it.ts * 1_000_000_000L,
+        open = it.open,
+        high = it.high,
+        low = it.low,
+        close = it.close,
+        volume = it.volume,
+        trades = 0L,
+    )
+}
+
+private fun signColor(pct: Double?): Color = when {
+    pct == null -> MarketColors.TextPrimary
+    pct >= 0 -> MarketColors.Up
+    else -> MarketColors.Down
+}
+
+private fun pct(v: Double?): String = if (v == null) "--" else String.format("%+.2f%%", v)
+
+private fun num(v: Double?): String = when {
+    v == null -> "--"
+    abs(v) >= 1000 -> String.format("%,.0f", v)
+    else -> String.format("%.2f", v)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketAnalysisUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketAnalysisUiState.kt
@@ -1,0 +1,78 @@
+package com.testlogon.android.feature.analysis
+
+import com.testlogon.android.data.exchange.HistoryBar
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.feature.markets.MarketClassTab
+
+/** Time-range presets the workbench requests over the history/candles feed. */
+enum class AnalysisRange(val label: String, val interval: String, val lookbackSeconds: Long) {
+    D1("1D", "5m", 86_400L),
+    W1("1W", "1h", 604_800L),
+    M1("1M", "1h", 2_592_000L),
+    M3("3M", "1d", 7_776_000L),
+    Y1("1Y", "1d", 31_536_000L),
+}
+
+/**
+ * Render-ready computed statistics for a single symbol's loaded bars. All values are display-scaled
+ * fractions/prices; a null field means "not enough data" and the panel shows a dash.
+ */
+data class SymbolStats(
+    val periodReturnPct: Double?,
+    val cumulativeReturnPct: Double?,
+    val annualizedVolPct: Double?,
+    val maxDrawdownPct: Double?,
+    val high: Double?,
+    val low: Double?,
+    val avgVolume: Double?,
+    val totalVolume: Double,
+)
+
+/** One symbol's loaded history plus its derived close series (display-scaled) for charts + stats. */
+data class SymbolSeries(
+    val instrument: Instrument,
+    val bars: List<HistoryBar>,
+    val closes: List<Double>,
+    val stats: SymbolStats?,
+)
+
+/** A backtest run's inputs + result for the summary card + equity curve. */
+data class BacktestState(
+    val fast: Int = 5,
+    val slow: Int = 20,
+    val result: BacktestResult? = null,
+)
+
+/** One cell of the compact correlation grid (i,j -> pearson r over aligned closes). */
+data class CorrelationCell(
+    val rowSymbol: String,
+    val colSymbol: String,
+    val r: Double?,
+)
+
+/**
+ * Single immutable Analysis-workbench state. [phase] drives the top-level surface; [degraded] is true
+ * when the long-range history endpoint was absent and we fell back to the recent-window candles read
+ * (the UI shows the "recent window only" banner then).
+ */
+data class MarketAnalysisUiState(
+    val phase: Phase = Phase.Loading,
+    val instruments: List<Instrument> = emptyList(),
+    val classTab: MarketClassTab = MarketClassTab.All,
+    val selectedSymbolId: Int? = null,
+    val compareSymbolIds: Set<Int> = emptySet(),
+    val range: AnalysisRange = AnalysisRange.W1,
+    val primary: SymbolSeries? = null,
+    val compareSeries: List<SymbolSeries> = emptyList(),
+    val correlation: List<CorrelationCell> = emptyList(),
+    val backtest: BacktestState = BacktestState(),
+    val degraded: Boolean = false,
+    val hasMore: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Empty, Error }
+
+    /** The selected instrument, resolved from the loaded catalogue. */
+    val selectedInstrument: Instrument?
+        get() = instruments.firstOrNull { it.symbolId == selectedSymbolId }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketAnalysisViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketAnalysisViewModel.kt
@@ -1,0 +1,209 @@
+package com.testlogon.android.feature.analysis
+
+import com.testlogon.android.core.model.ApiResult
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.HistoryBar
+import com.testlogon.android.data.exchange.HistoryBars
+import com.testlogon.android.data.exchange.Instrument
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives [MarketAnalysisUiState] from [ExchangeRepository]. Loads the instrument catalogue, then for
+ * the selected symbol + range loads long-range history (degrading to the recent-window candles read
+ * when `md/history` is absent, surfaced via [MarketAnalysisUiState.degraded]). Computes the stats
+ * panel ([MarketStats]), a multi-symbol normalized overlay + a compact correlation grid, and runs the
+ * fast/slow MA-cross backtest. All heavy math is delegated to the pure [MarketStats] helpers.
+ */
+@HiltViewModel
+class MarketAnalysisViewModel @Inject constructor(
+    private val repository: ExchangeRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MarketAnalysisUiState())
+    val uiState: StateFlow<MarketAnalysisUiState> = _uiState.asStateFlow()
+
+    /** Per (symbolId,interval) history cache for this VM instance (avoids re-fetching on re-select). */
+    private val historyCache = HashMap<String, HistoryBars>()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update { it.copy(phase = MarketAnalysisUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            when (val result = repository.symbols()) {
+                is ApiResult.Success -> {
+                    val instruments = result.data
+                    if (instruments.isEmpty()) {
+                        _uiState.update { it.copy(phase = MarketAnalysisUiState.Phase.Empty) }
+                    } else {
+                        val defaultId = instruments.first().symbolId
+                        _uiState.update {
+                            it.copy(
+                                phase = MarketAnalysisUiState.Phase.Content,
+                                instruments = instruments,
+                                selectedSymbolId = it.selectedSymbolId ?: defaultId,
+                            )
+                        }
+                        refreshAll()
+                    }
+                }
+                is ApiResult.Failure -> reduceError(result.error.message)
+                is ApiResult.NetworkError -> reduceError(OFFLINE_FALLBACK)
+            }
+        }
+    }
+
+    fun onSelectSymbol(symbolId: Int) {
+        if (_uiState.value.selectedSymbolId == symbolId) return
+        _uiState.update {
+            // Never compare a symbol against itself in the overlay/grid.
+            it.copy(selectedSymbolId = symbolId, compareSymbolIds = it.compareSymbolIds - symbolId)
+        }
+        viewModelScope.launch { refreshAll() }
+    }
+
+    fun onSelectRange(range: AnalysisRange) {
+        if (_uiState.value.range == range) return
+        _uiState.update { it.copy(range = range) }
+        viewModelScope.launch { refreshAll() }
+    }
+
+    fun onSelectClassTab(tab: com.testlogon.android.feature.markets.MarketClassTab) {
+        _uiState.update { it.copy(classTab = tab) }
+    }
+
+    fun onToggleCompare(symbolId: Int) {
+        val state = _uiState.value
+        if (symbolId == state.selectedSymbolId) return
+        val next = state.compareSymbolIds.toMutableSet().apply {
+            if (!add(symbolId)) remove(symbolId)
+        }
+        _uiState.update { it.copy(compareSymbolIds = next) }
+        viewModelScope.launch { refreshAll() }
+    }
+
+    fun onBacktestParams(fast: Int, slow: Int) {
+        _uiState.update { it.copy(backtest = it.backtest.copy(fast = fast, slow = slow)) }
+        recomputeBacktest()
+    }
+
+    /** Reload primary + compare series for the current selection/range, then recompute all derived data. */
+    private suspend fun refreshAll() {
+        val state = _uiState.value
+        val primaryId = state.selectedSymbolId ?: return
+        val range = state.range
+
+        val primaryInstrument = state.instruments.firstOrNull { it.symbolId == primaryId } ?: return
+        val primaryBars = loadBars(primaryInstrument, range)
+        val primarySeries = primaryInstrument.toSeries(primaryBars.bars)
+
+        val compareSeries = state.compareSymbolIds
+            .mapNotNull { id -> state.instruments.firstOrNull { it.symbolId == id } }
+            .map { inst -> inst.toSeries(loadBars(inst, range).bars) }
+
+        val correlation = buildCorrelation(primarySeries, compareSeries)
+
+        _uiState.update {
+            it.copy(
+                primary = primarySeries,
+                compareSeries = compareSeries,
+                correlation = correlation,
+                degraded = primaryBars.stub,
+                hasMore = primaryBars.nextCursor != null,
+            )
+        }
+        recomputeBacktest()
+    }
+
+    private fun recomputeBacktest() {
+        _uiState.update { state ->
+            val closes = state.primary?.closes.orEmpty()
+            val bt = state.backtest
+            val result = MarketStats.backtestMaCross(closes, bt.fast, bt.slow)
+            state.copy(backtest = bt.copy(result = result))
+        }
+    }
+
+    /** Load (and cache) a symbol's bars for a range; degrade-on-404 handled inside the repository. */
+    private suspend fun loadBars(instrument: Instrument, range: AnalysisRange): HistoryBars {
+        val key = "${instrument.symbolId}:${range.interval}:${range.name}"
+        historyCache[key]?.let { return it }
+        val nowSec = System.currentTimeMillis() / 1000L
+        val from = nowSec - range.lookbackSeconds
+        val bars = when (
+            val r = repository.getHistory(
+                symbolId = instrument.symbolId,
+                interval = range.interval,
+                from = from,
+                to = nowSec,
+            )
+        ) {
+            is ApiResult.Success -> r.data
+            // On a hard failure (offline etc.), return an empty non-stub page; the panel shows dashes.
+            else -> HistoryBars(instrument.symbolId, range.interval, emptyList())
+        }
+        historyCache[key] = bars
+        return bars
+    }
+
+    private fun Instrument.toSeries(bars: List<HistoryBar>): SymbolSeries {
+        val closes = bars.map { display(it.close) }
+        val volumes = bars.map { it.volume.toDouble() }
+        val stats = if (closes.isEmpty()) null else SymbolStats(
+            periodReturnPct = MarketStats.cumulativeReturnPct(closes),
+            cumulativeReturnPct = MarketStats.cumulativeReturnPct(closes),
+            annualizedVolPct = MarketStats.annualizedVolatility(closes)?.let { it * 100.0 },
+            maxDrawdownPct = MarketStats.maxDrawdown(closes)?.let { it * 100.0 },
+            high = MarketStats.high(closes),
+            low = MarketStats.low(closes),
+            avgVolume = MarketStats.average(volumes),
+            totalVolume = MarketStats.total(volumes),
+        )
+        return SymbolSeries(instrument = this, bars = bars, closes = closes, stats = stats)
+    }
+
+    /** Build the compact NxN correlation grid over the primary + compare series (aligned closes). */
+    private fun buildCorrelation(
+        primary: SymbolSeries,
+        compare: List<SymbolSeries>,
+    ): List<CorrelationCell> {
+        val all = listOf(primary) + compare
+        if (all.size < 2) return emptyList()
+        val cells = ArrayList<CorrelationCell>(all.size * all.size)
+        for (row in all) {
+            for (col in all) {
+                val r = if (row.instrument.symbolId == col.instrument.symbolId) {
+                    1.0
+                } else {
+                    MarketStats.correlation(row.closes, col.closes)
+                }
+                cells.add(CorrelationCell(row.instrument.symbol, col.instrument.symbol, r))
+            }
+        }
+        return cells
+    }
+
+    private fun reduceError(message: String) {
+        _uiState.update {
+            if (it.instruments.isNotEmpty()) {
+                it.copy(phase = MarketAnalysisUiState.Phase.Content)
+            } else {
+                it.copy(phase = MarketAnalysisUiState.Phase.Error, errorMessage = message)
+            }
+        }
+    }
+
+    private companion object {
+        const val OFFLINE_FALLBACK = "Couldn't reach the market-data service. Tap retry."
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketStats.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/analysis/MarketStats.kt
@@ -1,0 +1,202 @@
+package com.testlogon.android.feature.analysis
+
+import kotlin.math.ln
+import kotlin.math.sqrt
+
+/**
+ * Pure, framework-free market-statistics math for the Analysis workbench. No Android/Compose imports
+ * so it can be unit-tested on the JVM (see MarketStatsTest). Every helper takes plain price/return
+ * series (chronological, oldest-first) and returns render-ready primitives. Edge cases (empty / single
+ * bar / zero baseline) return null or an identity value rather than throwing.
+ */
+object MarketStats {
+
+    /** ~trading periods per year used to annualize a per-bar volatility (approx calendar days). */
+    const val ANNUALIZATION_PERIODS = 365.0
+
+    /** Simple period return (last-first)/first as a fraction. Null when <2 points or a zero baseline. */
+    fun periodReturn(closes: List<Double>): Double? {
+        if (closes.size < 2) return null
+        val first = closes.first()
+        if (first == 0.0) return null
+        return (closes.last() - first) / first
+    }
+
+    /** Alias for [periodReturn] as a percent (x100). */
+    fun cumulativeReturnPct(closes: List<Double>): Double? = periodReturn(closes)?.let { it * 100.0 }
+
+    /**
+     * Per-step log returns ln(p_i / p_prev), aligned to the gaps between consecutive closes (so a
+     * series of N closes yields N-1 returns). Non-positive prices are skipped (log undefined).
+     */
+    fun logReturns(closes: List<Double>): List<Double> {
+        if (closes.size < 2) return emptyList()
+        val out = ArrayList<Double>(closes.size - 1)
+        for (i in 1 until closes.size) {
+            val prev = closes[i - 1]
+            val cur = closes[i]
+            if (prev > 0.0 && cur > 0.0) out.add(ln(cur / prev))
+        }
+        return out
+    }
+
+    /** Sample standard deviation of a series. Null when fewer than two samples. */
+    fun stdev(values: List<Double>): Double? {
+        if (values.size < 2) return null
+        val mean = values.average()
+        val variance = values.sumOf { (it - mean) * (it - mean) } / (values.size - 1)
+        return sqrt(variance)
+    }
+
+    /**
+     * Annualized volatility: sample stdev of log-returns scaled by sqrt([periodsPerYear]). Null when
+     * there are not enough returns to form a stdev. Returned as a fraction (0.25 == 25% vol).
+     */
+    fun annualizedVolatility(
+        closes: List<Double>,
+        periodsPerYear: Double = ANNUALIZATION_PERIODS,
+    ): Double? {
+        val sd = stdev(logReturns(closes)) ?: return null
+        return sd * sqrt(periodsPerYear)
+    }
+
+    /**
+     * Maximum drawdown as a POSITIVE fraction: the largest peak-to-trough decline over the series.
+     * 0.0 for a monotonically non-decreasing series; null for empty input. A 100 to 50 dip returns 0.5.
+     */
+    fun maxDrawdown(closes: List<Double>): Double? {
+        if (closes.isEmpty()) return null
+        var peak = closes.first()
+        var maxDd = 0.0
+        for (c in closes) {
+            if (c > peak) peak = c
+            if (peak > 0.0) {
+                val dd = (peak - c) / peak
+                if (dd > maxDd) maxDd = dd
+            }
+        }
+        return maxDd
+    }
+
+    /** Highest close in the series, or null when empty. */
+    fun high(closes: List<Double>): Double? = closes.maxOrNull()
+
+    /** Lowest close in the series, or null when empty. */
+    fun low(closes: List<Double>): Double? = closes.minOrNull()
+
+    /** Average of a series, or null when empty. */
+    fun average(values: List<Double>): Double? = if (values.isEmpty()) null else values.average()
+
+    /** Sum of a series (0.0 when empty). */
+    fun total(values: List<Double>): Double = values.sum()
+
+    /**
+     * Pearson correlation of two aligned series over their common leading length. Null when fewer
+     * than two overlapping points or when either side has zero variance (undefined correlation).
+     * Result is clamped to the range minus-one..one to absorb floating-point overshoot.
+     */
+    fun correlation(a: List<Double>, b: List<Double>): Double? {
+        val n = minOf(a.size, b.size)
+        if (n < 2) return null
+        val xs = a.subList(0, n)
+        val ys = b.subList(0, n)
+        val mx = xs.average()
+        val my = ys.average()
+        var sxy = 0.0
+        var sxx = 0.0
+        var syy = 0.0
+        for (i in 0 until n) {
+            val dx = xs[i] - mx
+            val dy = ys[i] - my
+            sxy += dx * dy
+            sxx += dx * dx
+            syy += dy * dy
+        }
+        if (sxx == 0.0 || syy == 0.0) return null
+        val r = sxy / sqrt(sxx * syy)
+        return r.coerceIn(-1.0, 1.0)
+    }
+
+    /**
+     * Normalize a close series to a base of 100 at its first point, for a multi-symbol overlay. Empty
+     * or zero-baseline input returns an empty list (nothing meaningful to overlay).
+     */
+    fun normalizeToBase(closes: List<Double>, base: Double = 100.0): List<Double> {
+        val first = closes.firstOrNull() ?: return emptyList()
+        if (first == 0.0) return emptyList()
+        return closes.map { it / first * base }
+    }
+
+    /**
+     * A simple fast/slow SMA-cross backtest over [closes]. Position is LONG when fast SMA > slow SMA,
+     * else FLAT; entries/exits act on the NEXT bar (no look-ahead). Returns a [BacktestResult] with
+     * the equity curve (starts at 1.0), total return fraction, win rate, and trade count.
+     */
+    fun backtestMaCross(closes: List<Double>, fast: Int, slow: Int): BacktestResult {
+        if (fast <= 0 || slow <= 0 || fast >= slow || closes.size < slow + 1) {
+            return BacktestResult(equityCurve = listOf(1.0), totalReturn = 0.0, winRate = 0.0, trades = 0)
+        }
+        val fastSma = sma(closes, fast)
+        val slowSma = sma(closes, slow)
+
+        val equity = ArrayList<Double>(closes.size)
+        var cash = 1.0
+        equity.add(cash)
+
+        var inPosition = false
+        var entryPrice = 0.0
+        var trades = 0
+        var wins = 0
+
+        // Signal at bar i (using SMAs up to i) is acted on the return from i to i+1.
+        for (i in 0 until closes.size - 1) {
+            val f = fastSma[i]
+            val s = slowSma[i]
+            val wantLong = f != null && s != null && f > s
+
+            if (wantLong && !inPosition) {
+                inPosition = true
+                entryPrice = closes[i]
+                trades++
+            } else if (!wantLong && inPosition) {
+                inPosition = false
+                if (closes[i] > entryPrice) wins++
+            }
+
+            // Apply this bar-to-next return only while holding.
+            if (inPosition && closes[i] != 0.0) {
+                cash *= closes[i + 1] / closes[i]
+            }
+            equity.add(cash)
+        }
+        // Close any open position at the final bar for win/trade accounting.
+        if (inPosition) {
+            if (closes.last() > entryPrice) wins++
+        }
+
+        val total = cash - 1.0
+        val winRate = if (trades == 0) 0.0 else wins.toDouble() / trades
+        return BacktestResult(equityCurve = equity, totalReturn = total, winRate = winRate, trades = trades)
+    }
+
+    /** Simple moving average aligned 1:1 with [values]; null until [period] samples are available. */
+    fun sma(values: List<Double>, period: Int): List<Double?> {
+        if (period <= 0) return values.map { null }
+        val out = ArrayList<Double?>(values.size)
+        var sum = 0.0
+        for (i in values.indices) {
+            sum += values[i]
+            if (i >= period) sum -= values[i - period]
+            out.add(if (i >= period - 1) sum / period else null)
+        }
+        return out
+    }
+}
+
+/** Result of [MarketStats.backtestMaCross]: the equity curve plus summary stats. */
+data class BacktestResult(
+    val equityCurve: List<Double>,
+    val totalReturn: Double,
+    val winRate: Double,
+    val trades: Int,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1593,6 +1593,16 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),
+        // Analysis workbench (VIEW-ONLY): historical market-data research — returns / volatility /
+        // drawdown / correlation + a fast/slow MA-cross backtest over the md/ history (or recent window).
+        MoreEntry(
+            id = "analysis",
+            labelRes = R.string.more_entry_analysis,
+            icon = Icons.Outlined.Insights,
+            route = MoreRoutes.ANALYSIS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
         // Trading Alerts: derived notifications (fills / liquidations / funding / margin-distress / PM-resolved)
         // detected from the trader feed reads. Reachable here and from the Markets header bell.
         MoreEntry(

--- a/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
@@ -9,6 +9,7 @@ import com.testlogon.android.feature.markets.MarketsRoute
 import com.testlogon.android.feature.markets.SymbolDetailRoute
 import com.testlogon.android.feature.markets.alerts.TradingAlertsRoute
 import com.testlogon.android.feature.markets.alerts.pricealerts.PriceAlertsRoute
+import com.testlogon.android.feature.analysis.MarketAnalysisRoute
 
 /**
  * Markets (exchange market-data, VIEW-ONLY) destinations, registered in the AUTHENTICATED nav graph.
@@ -37,6 +38,11 @@ data object PriceAlertsDest {
     const val ROUTE = "markets/alerts/price"
 }
 
+/** Analysis workbench (historical market-data research/backtest) — a new navigable destination. */
+data object AnalysisDest {
+    const val ROUTE = "markets/analysis"
+}
+
 /** Registers the Markets list + per-symbol detail destinations (Back pops the back stack). */
 fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
     composable(MarketsDest.ROUTE) {
@@ -63,6 +69,9 @@ fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
     }
     composable(PriceAlertsDest.ROUTE) {
         PriceAlertsRoute(onBack = { navController.popBackStack() })
+    }
+    composable(AnalysisDest.ROUTE) {
+        MarketAnalysisRoute(onBack = { navController.popBackStack() })
     }
     composable(
         route = SymbolDetailDest.ROUTE,

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -377,6 +377,9 @@ object MoreRoutes {
     // Markets (exchange market-data, VIEW-ONLY): instrument list -> per-symbol chart/book/tape.
     const val MARKETS = MarketsDest.ROUTE
 
+    // Analysis workbench: historical market-data research (stats / correlation / MA-cross backtest).
+    const val ANALYSIS = AnalysisDest.ROUTE
+
     // Global search: quick-jump over exchange symbols + trading destinations + curated actions.
     const val GLOBAL_SEARCH = GlobalSearchDest.ROUTE
 
@@ -666,6 +669,7 @@ object MoreRoutes {
             WEBHOOKS,
             ADMIN_DASHBOARD,
             MARKETS,
+            ANALYSIS,
             GLOBAL_SEARCH,
             TRADING_ALERTS,
             ADMIN_EMAIL_DASHBOARD,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4284,6 +4284,7 @@
     <string name="more_entry_admin_dashboard">Admin alerts</string>
     <string name="more_entry_global_search">Search</string>
     <string name="more_entry_markets">Markets</string>
+    <string name="more_entry_analysis">Analysis</string>
     <string name="more_entry_trading_alerts">Trading alerts</string>
     <string name="admin_dashboard_title">Admin alerts</string>
     <string name="admin_dashboard_back">Back</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/analysis/MarketStatsTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/analysis/MarketStatsTest.kt
@@ -1,0 +1,149 @@
+package com.testlogon.android.feature.analysis
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+class MarketStatsTest {
+
+    private fun close(a: Double, b: Double, eps: Double = 1e-9) =
+        assertTrue("expected $a ~= $b", abs(a - b) < eps)
+
+    @Test
+    fun periodReturn_basic() {
+        close(MarketStats.periodReturn(listOf(100.0, 110.0))!!, 0.10)
+    }
+
+    @Test
+    fun periodReturn_emptyAndSingle_null() {
+        assertNull(MarketStats.periodReturn(emptyList()))
+        assertNull(MarketStats.periodReturn(listOf(100.0)))
+    }
+
+    @Test
+    fun periodReturn_zeroBaseline_null() {
+        assertNull(MarketStats.periodReturn(listOf(0.0, 100.0)))
+    }
+
+    @Test
+    fun cumulativeReturnPct_isPercent() {
+        close(MarketStats.cumulativeReturnPct(listOf(100.0, 150.0))!!, 50.0)
+    }
+
+    @Test
+    fun logReturns_lengthIsNMinusOne() {
+        val r = MarketStats.logReturns(listOf(100.0, 105.0, 102.0))
+        assertEquals(2, r.size)
+    }
+
+    @Test
+    fun logReturns_emptyForSingle() {
+        assertTrue(MarketStats.logReturns(listOf(100.0)).isEmpty())
+    }
+
+    @Test
+    fun stdev_singleIsNull_andKnownValue() {
+        assertNull(MarketStats.stdev(listOf(1.0)))
+        // sample stdev of [2,4,4,4,5,5,7,9] = 2.138... (sample, n-1)
+        close(MarketStats.stdev(listOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0))!!, 2.1380899353, 1e-6)
+    }
+
+    @Test
+    fun annualizedVolatility_nullForTooFewBars() {
+        // 1 bar -> no returns -> no stdev -> null
+        assertNull(MarketStats.annualizedVolatility(listOf(100.0)))
+    }
+
+    @Test
+    fun annualizedVolatility_positiveForVaryingSeries() {
+        val v = MarketStats.annualizedVolatility(listOf(100.0, 101.0, 99.0, 102.0, 98.0))
+        assertTrue(v != null && v > 0.0)
+    }
+
+    @Test
+    fun maxDrawdown_dipHalf() {
+        close(MarketStats.maxDrawdown(listOf(100.0, 120.0, 60.0, 80.0))!!, 0.5)
+    }
+
+    @Test
+    fun maxDrawdown_monotonicIsZero_andEmptyNull() {
+        close(MarketStats.maxDrawdown(listOf(1.0, 2.0, 3.0))!!, 0.0)
+        assertNull(MarketStats.maxDrawdown(emptyList()))
+    }
+
+    @Test
+    fun hiLo_avgTotal() {
+        val s = listOf(3.0, 1.0, 4.0, 2.0)
+        close(MarketStats.high(s)!!, 4.0)
+        close(MarketStats.low(s)!!, 1.0)
+        close(MarketStats.average(s)!!, 2.5)
+        close(MarketStats.total(s), 10.0)
+        assertNull(MarketStats.high(emptyList()))
+        assertNull(MarketStats.average(emptyList()))
+        close(MarketStats.total(emptyList()), 0.0)
+    }
+
+    @Test
+    fun correlation_perfectPositive() {
+        close(MarketStats.correlation(listOf(1.0, 2.0, 3.0), listOf(2.0, 4.0, 6.0))!!, 1.0, 1e-9)
+    }
+
+    @Test
+    fun correlation_perfectNegative() {
+        close(MarketStats.correlation(listOf(1.0, 2.0, 3.0), listOf(6.0, 4.0, 2.0))!!, -1.0, 1e-9)
+    }
+
+    @Test
+    fun correlation_zeroVarianceOrTooShort_null() {
+        assertNull(MarketStats.correlation(listOf(1.0, 1.0, 1.0), listOf(2.0, 4.0, 6.0)))
+        assertNull(MarketStats.correlation(listOf(1.0), listOf(2.0)))
+    }
+
+    @Test
+    fun normalizeToBase_startsAt100() {
+        val n = MarketStats.normalizeToBase(listOf(50.0, 75.0, 100.0))
+        close(n.first(), 100.0)
+        close(n.last(), 200.0)
+        assertTrue(MarketStats.normalizeToBase(emptyList()).isEmpty())
+        assertTrue(MarketStats.normalizeToBase(listOf(0.0, 1.0)).isEmpty())
+    }
+
+    @Test
+    fun backtest_degenerateInputs_flat() {
+        val r = MarketStats.backtestMaCross(listOf(1.0, 2.0), fast = 2, slow = 5)
+        assertEquals(0, r.trades)
+        close(r.totalReturn, 0.0)
+        assertEquals(listOf(1.0), r.equityCurve)
+    }
+
+    @Test
+    fun backtest_uptrend_profitsAndTrades() {
+        // A rising series: fast SMA crosses above slow, position held -> positive return, >=1 trade.
+        val closes = (1..40).map { 100.0 + it * 2.0 }
+        val r = MarketStats.backtestMaCross(closes, fast = 3, slow = 8)
+        assertTrue("expected >=1 trade", r.trades >= 1)
+        assertTrue("expected positive return", r.totalReturn > 0.0)
+        assertTrue(r.winRate in 0.0..1.0)
+        // equity curve grows to closes.size length (starts at 1.0).
+        assertEquals(closes.size, r.equityCurve.size)
+        close(r.equityCurve.first(), 1.0)
+    }
+
+    @Test
+    fun backtest_invalidFastSlow_flat() {
+        val closes = (1..40).map { 100.0 + it.toDouble() }
+        val r = MarketStats.backtestMaCross(closes, fast = 8, slow = 3) // fast >= slow
+        assertEquals(0, r.trades)
+    }
+
+    @Test
+    fun sma_alignmentAndWarmup() {
+        val s = MarketStats.sma(listOf(1.0, 2.0, 3.0, 4.0), 2)
+        assertNull(s[0])
+        close(s[1]!!, 1.5)
+        close(s[2]!!, 2.5)
+        close(s[3]!!, 3.5)
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,7 @@ const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
 const HomePage = lazy(() => import("@/pages/home/HomePage"));
 const MarketsPage = lazy(() => import("@/pages/markets/MarketsPage"));
 const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
+const MarketAnalysisPage = lazy(() => import("@/pages/analysis/MarketAnalysisPage"));
 const PaperTradingPage = lazy(() => import("@/pages/paper/PaperTradingPage"));
 const PriceAlertsPage = lazy(() => import("@/pages/alerts/PriceAlertsPage"));
 const SyndicatesPage = lazy(() => import("@/pages/syndicates/SyndicatesPage"));
@@ -744,6 +745,7 @@ export default function App() {
           <Route path="home" element={<HomePage />} />
           <Route path="markets" element={<MarketsPage />} />
           <Route path="markets/:symbolId" element={<SymbolDetailPage />} />
+          <Route path="analysis" element={<MarketAnalysisPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />
           <Route path="paper" element={<PaperTradingPage />} />
           <Route path="discover" element={<DiscoverPage />} />

--- a/frontend/src/api/endpoints/marketHistory.ts
+++ b/frontend/src/api/endpoints/marketHistory.ts
@@ -1,0 +1,115 @@
+import { api, ApiError } from "@/api/client";
+import { getCandles, type CandlesResponse } from "@/api/endpoints/marketData";
+
+/**
+ * Long-range historical market data.
+ *
+ * The backend endpoint (`GET /md/history/{symbolId}`) does NOT exist yet. When
+ * it 404s (or otherwise reports absent), {@link getHistory} DEGRADES to the
+ * existing recent-window `/md/candles` feed so the Analysis workbench still
+ * works on whatever window it can pull, flagging the degrade via `stub: true`
+ * so the UI can show the "recent window only" banner.
+ *
+ * Prices in `bars` are RAW integers (scaled by the symbol's `price_scaler`),
+ * exactly as `/md/candles` returns them; callers de-scale for display/stats.
+ */
+
+/** One OHLCV bar. `ts` is epoch-ms. Prices/volume are raw (unscaled) values. */
+export interface HistoryBar {
+  ts: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v: number;
+}
+
+export interface HistoryResponse {
+  symbol_id: number;
+  interval: string;
+  bars: HistoryBar[];
+  next_cursor?: string | null;
+  /** True when this came from the recent-window fallback, not real history. */
+  stub?: boolean;
+}
+
+/** Raw shape of the (not-yet-existing) history endpoint. */
+interface RawHistoryResponse {
+  symbol_id: number;
+  interval: string;
+  bars: { ts: number; o: number; h: number; l: number; c: number; v: number }[];
+  next_cursor?: string | null;
+  stub?: boolean;
+}
+
+export interface HistoryParams {
+  /** Interval token, e.g. "1m", "5m", "1h", "1d". */
+  interval: string;
+  /** Inclusive lower bound, epoch-ms. */
+  from?: number;
+  /** Inclusive upper bound, epoch-ms. */
+  to?: number;
+  /** Opaque pagination cursor from a prior `next_cursor`. */
+  cursor?: string;
+}
+
+/** Map an interval token to the candle-endpoint's second granularity. */
+const INTERVAL_SECONDS: Record<string, number> = {
+  "1m": 60,
+  "5m": 300,
+  "15m": 900,
+  "1h": 3600,
+  "4h": 14400,
+  "1d": 86400,
+};
+
+export function intervalToSeconds(interval: string): number {
+  return INTERVAL_SECONDS[interval] ?? 60;
+}
+
+/** Convert a recent-window candle response into the history bar shape. */
+function candlesToHistory(symbolId: number, interval: string, res: CandlesResponse): HistoryResponse {
+  const bars: HistoryBar[] = (res.bars ?? []).map((b) => ({
+    ts: Math.floor(b.ts_start_ns / 1_000_000),
+    o: b.open,
+    h: b.high,
+    l: b.low,
+    c: b.close,
+    v: b.volume,
+  }));
+  return { symbol_id: symbolId, interval, bars, next_cursor: null, stub: true };
+}
+
+/** Cap on the recent-window fallback fetch (candles endpoint hard-limits anyway). */
+const FALLBACK_LIMIT = 1000;
+
+/**
+ * Fetch historical bars for a symbol. Tries the real long-range endpoint first;
+ * on a 404 (endpoint absent) falls back to the recent-window candle feed and
+ * marks the result `stub: true`.
+ */
+export async function getHistory(symbolId: number, params: HistoryParams): Promise<HistoryResponse> {
+  const query: Record<string, string> = { interval: params.interval };
+  if (params.from != null) query.from = String(params.from);
+  if (params.to != null) query.to = String(params.to);
+  if (params.cursor) query.cursor = params.cursor;
+
+  try {
+    const raw = await api.get<RawHistoryResponse>(`/md/history/${symbolId}`, query);
+    return {
+      symbol_id: raw.symbol_id ?? symbolId,
+      interval: raw.interval ?? params.interval,
+      bars: Array.isArray(raw.bars) ? raw.bars : [],
+      next_cursor: raw.next_cursor ?? null,
+      stub: raw.stub ?? false,
+    };
+  } catch (err) {
+    // Endpoint absent (404) or unimplemented (501): degrade to the recent window.
+    if (err instanceof ApiError && (err.status === 404 || err.status === 501 || err.status === 0)) {
+      const sec = intervalToSeconds(params.interval);
+      const res = await getCandles(symbolId, sec, FALLBACK_LIMIT);
+      return candlesToHistory(symbolId, params.interval, res);
+    }
+    throw err;
+  }
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -147,6 +147,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: <Rss className="h-5 w-5" /> },
       { label: "Trading Home", i18nKey: "nav.tradingHome", path: "/home", icon: <Gauge className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
+      { label: "Analysis", i18nKey: "nav.analysis", path: "/analysis", icon: <LineChart className="h-5 w-5" /> },
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Paper Trading", i18nKey: "nav.paperTrading", path: "/paper", icon: <TrendingUp className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },

--- a/frontend/src/lib/marketStats.test.ts
+++ b/frontend/src/lib/marketStats.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type Bar,
+  backtestMaCross,
+  barsPerYear,
+  computeStats,
+  correlation,
+  logReturns,
+  maxDrawdown,
+  mean,
+  normalizeTo100,
+  seriesCorrelation,
+  simpleReturns,
+  sma,
+  stdev,
+} from "./marketStats";
+
+/** Build a bar series from a close array; ts is index-based hourly spacing. */
+function barsFromCloses(closes: number[], volumes?: number[]): Bar[] {
+  return closes.map((c, i) => ({
+    ts: i * 3_600_000,
+    o: i === 0 ? c : closes[i - 1]!,
+    h: c,
+    l: c,
+    c,
+    v: volumes ? volumes[i]! : 1,
+  }));
+}
+
+describe("mean / stdev", () => {
+  it("mean of empty is 0; stdev needs >=2 samples", () => {
+    expect(mean([])).toBe(0);
+    expect(stdev([])).toBe(0);
+    expect(stdev([5])).toBe(0);
+  });
+
+  it("computes a known sample stdev", () => {
+    // [2,4,4,4,5,5,7,9] has sample stdev ~2.1381 (n-1).
+    const s = stdev([2, 4, 4, 4, 5, 5, 7, 9]);
+    expect(s).toBeCloseTo(2.1381, 3);
+  });
+});
+
+describe("logReturns / simpleReturns", () => {
+  it("empty and single-bar series yield no returns", () => {
+    expect(logReturns([])).toEqual([]);
+    expect(simpleReturns(barsFromCloses([100]))).toEqual([]);
+  });
+
+  it("simple return of a doubling is 1.0", () => {
+    const r = simpleReturns(barsFromCloses([100, 200]));
+    expect(r).toHaveLength(1);
+    expect(r[0]).toBeCloseTo(1, 10);
+  });
+
+  it("log return of a doubling is ln(2)", () => {
+    const r = logReturns(barsFromCloses([100, 200]));
+    expect(r[0]).toBeCloseTo(Math.log(2), 10);
+  });
+});
+
+describe("sma", () => {
+  it("nulls the warmup then averages", () => {
+    expect(sma([1, 2, 3, 4], 2)).toEqual([null, 1.5, 2.5, 3.5]);
+  });
+
+  it("period <= 0 yields all nulls", () => {
+    expect(sma([1, 2, 3], 0)).toEqual([null, null, null]);
+  });
+});
+
+describe("maxDrawdown", () => {
+  it("is 0 for a monotonically rising series", () => {
+    expect(maxDrawdown(barsFromCloses([1, 2, 3, 4])).maxDrawdown).toBe(0);
+  });
+
+  it("is 0 for <2 bars", () => {
+    expect(maxDrawdown([]).maxDrawdown).toBe(0);
+    expect(maxDrawdown(barsFromCloses([10])).maxDrawdown).toBe(0);
+  });
+
+  it("captures the deepest peak-to-trough decline", () => {
+    // peak 100 -> trough 50 = -0.5.
+    const dd = maxDrawdown(barsFromCloses([80, 100, 70, 50, 90]));
+    expect(dd.maxDrawdown).toBeCloseTo(-0.5, 10);
+    expect(dd.peakIndex).toBe(1);
+    expect(dd.troughIndex).toBe(3);
+  });
+});
+
+describe("barsPerYear", () => {
+  it("hourly bars ~ 8760/yr, daily ~365", () => {
+    expect(barsPerYear(3600)).toBeCloseTo(8760, 6);
+    expect(barsPerYear(86400)).toBeCloseTo(365, 6);
+  });
+
+  it("guards non-positive intervals", () => {
+    expect(barsPerYear(0)).toBe(0);
+    expect(barsPerYear(-1)).toBe(0);
+  });
+});
+
+describe("computeStats", () => {
+  it("returns a zeroed pack for an empty series", () => {
+    const s = computeStats([], 3600);
+    expect(s.bars).toBe(0);
+    expect(s.first).toBeNull();
+    expect(s.cumulativeReturn).toBe(0);
+    expect(s.annualizedVolatility).toBe(0);
+  });
+
+  it("handles a single bar (no returns, hi/lo defined)", () => {
+    const s = computeStats(barsFromCloses([100]), 3600);
+    expect(s.bars).toBe(1);
+    expect(s.first).toBe(100);
+    expect(s.last).toBe(100);
+    expect(s.volatility).toBe(0);
+    expect(s.cumulativeReturn).toBe(0);
+  });
+
+  it("computes cumulative return, hi/lo and volume aggregates", () => {
+    const s = computeStats(barsFromCloses([100, 110, 105, 120], [2, 4, 6, 8]), 3600);
+    expect(s.cumulativeReturn).toBeCloseTo(0.2, 10);
+    expect(s.hi).toBe(120);
+    expect(s.lo).toBe(100);
+    expect(s.totalVolume).toBe(20);
+    expect(s.avgVolume).toBe(5);
+    expect(s.annualizedVolatility).toBeGreaterThan(s.volatility);
+  });
+});
+
+describe("correlation", () => {
+  it("is +1 for a perfectly linear relationship", () => {
+    expect(correlation([1, 2, 3, 4], [2, 4, 6, 8])).toBeCloseTo(1, 10);
+  });
+
+  it("is -1 for a perfectly inverse relationship", () => {
+    expect(correlation([1, 2, 3, 4], [4, 3, 2, 1])).toBeCloseTo(-1, 10);
+  });
+
+  it("is 0 when a series has zero variance or is too short", () => {
+    expect(correlation([1, 1, 1], [1, 2, 3])).toBe(0);
+    expect(correlation([1], [1])).toBe(0);
+  });
+
+  it("seriesCorrelation aligns on shared timestamps", () => {
+    const closesA = [100, 110, 105, 120, 118];
+    const a = barsFromCloses(closesA);
+    // b is a exactly scaled by 2 -> identical log-returns -> correlation +1.
+    const b = barsFromCloses(closesA.map((c) => c * 2));
+    expect(seriesCorrelation(a, b)).toBeCloseTo(1, 10);
+  });
+});
+
+describe("normalizeTo100", () => {
+  it("rebases the first bar to 100", () => {
+    const n = normalizeTo100(barsFromCloses([50, 75, 25]));
+    expect(n.map((p) => p.v)).toEqual([100, 150, 50]);
+  });
+
+  it("empty in -> empty out", () => {
+    expect(normalizeTo100([])).toEqual([]);
+  });
+});
+
+describe("backtestMaCross", () => {
+  it("degrades safely on bad params / short series", () => {
+    const r = backtestMaCross(barsFromCloses([1, 2, 3]), 5, 2); // fast >= slow
+    expect(r.numTrades).toBe(0);
+    expect(r.totalReturn).toBe(0);
+    const short = backtestMaCross(barsFromCloses([1, 2]), 2, 3);
+    expect(short.numTrades).toBe(0);
+  });
+
+  it("produces an equity curve of the right length and takes trades on a trend", () => {
+    // A rise then fall should trigger at least one long entry and exit.
+    const closes = [10, 10, 10, 11, 12, 13, 14, 15, 14, 12, 10, 9, 8, 9, 11, 13];
+    const r = backtestMaCross(barsFromCloses(closes), 2, 4);
+    expect(r.equity).toHaveLength(closes.length);
+    expect(r.equity[0]).toBe(1);
+    expect(r.numTrades).toBeGreaterThan(0);
+    expect(r.winRate).toBeGreaterThanOrEqual(0);
+    expect(r.winRate).toBeLessThanOrEqual(1);
+  });
+
+  it("a flat market takes no profitable trades and keeps equity ~1", () => {
+    const r = backtestMaCross(barsFromCloses(new Array(20).fill(100)), 3, 6);
+    expect(r.totalReturn).toBeCloseTo(0, 10);
+  });
+});

--- a/frontend/src/lib/marketStats.ts
+++ b/frontend/src/lib/marketStats.ts
@@ -1,0 +1,355 @@
+/**
+ * Pure, framework-free statistics over a market bar series.
+ *
+ * A "bar" is the normalized OHLCV shape used by the history endpoint
+ * ({@link Bar}); the Analysis workbench maps the exchange `Candle`
+ * (integer prices scaled by `price_scaler`, nanosecond timestamps) into this
+ * shape before calling in, so everything here is plain floating-point math.
+ *
+ * Nothing here touches React, the network, or the DOM: it is deterministic and
+ * unit-tested in `marketStats.test.ts`.
+ */
+
+/** One OHLCV bar. `ts` is epoch-ms; prices/volume are already de-scaled. */
+export interface Bar {
+  ts: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v: number;
+}
+
+/** The number of bars of a given interval that make up one calendar year. */
+export function barsPerYear(intervalSec: number): number {
+  if (!Number.isFinite(intervalSec) || intervalSec <= 0) return 0;
+  const SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
+  return SECONDS_PER_YEAR / intervalSec;
+}
+
+/** Natural-log returns between consecutive closes (length = bars.length - 1). */
+export function logReturns(bars: Bar[]): number[] {
+  const out: number[] = [];
+  for (let i = 1; i < bars.length; i++) {
+    const prev = bars[i - 1]!.c;
+    const cur = bars[i]!.c;
+    if (prev > 0 && cur > 0) out.push(Math.log(cur / prev));
+    else out.push(0);
+  }
+  return out;
+}
+
+/** Simple (arithmetic) returns between consecutive closes. */
+export function simpleReturns(bars: Bar[]): number[] {
+  const out: number[] = [];
+  for (let i = 1; i < bars.length; i++) {
+    const prev = bars[i - 1]!.c;
+    const cur = bars[i]!.c;
+    out.push(prev !== 0 ? cur / prev - 1 : 0);
+  }
+  return out;
+}
+
+/** Arithmetic mean of a numeric array (0 for empty). */
+export function mean(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  let s = 0;
+  for (const x of xs) s += x;
+  return s / xs.length;
+}
+
+/**
+ * Sample standard deviation (n-1 denominator). Returns 0 for series with
+ * fewer than two observations.
+ */
+export function stdev(xs: number[]): number {
+  const n = xs.length;
+  if (n < 2) return 0;
+  const m = mean(xs);
+  let acc = 0;
+  for (const x of xs) {
+    const d = x - m;
+    acc += d * d;
+  }
+  return Math.sqrt(acc / (n - 1));
+}
+
+/** Simple moving average; entries before `period-1` are null. */
+export function sma(vals: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  if (period <= 0) return vals.map(() => null);
+  let sum = 0;
+  for (let i = 0; i < vals.length; i++) {
+    sum += vals[i]!;
+    if (i >= period) sum -= vals[i - period]!;
+    out.push(i >= period - 1 ? sum / period : null);
+  }
+  return out;
+}
+
+export interface DrawdownResult {
+  /** Max drawdown as a negative fraction (e.g. -0.25 = a 25% peak-to-trough fall). */
+  maxDrawdown: number;
+  /** Index of the peak that precedes the worst trough (-1 if not defined). */
+  peakIndex: number;
+  /** Index of the worst trough (-1 if not defined). */
+  troughIndex: number;
+}
+
+/**
+ * Maximum drawdown of the close series: the deepest peak-to-trough decline as a
+ * negative fraction of the peak. Zero for a non-decreasing series or <2 bars.
+ */
+export function maxDrawdown(bars: Bar[]): DrawdownResult {
+  if (bars.length < 2) return { maxDrawdown: 0, peakIndex: -1, troughIndex: -1 };
+  let peak = bars[0]!.c;
+  let peakIdx = 0;
+  let worst = 0;
+  let worstPeakIdx = -1;
+  let worstTroughIdx = -1;
+  for (let i = 1; i < bars.length; i++) {
+    const c = bars[i]!.c;
+    if (c > peak) {
+      peak = c;
+      peakIdx = i;
+    } else if (peak > 0) {
+      const dd = c / peak - 1; // <= 0
+      if (dd < worst) {
+        worst = dd;
+        worstPeakIdx = peakIdx;
+        worstTroughIdx = i;
+      }
+    }
+  }
+  return { maxDrawdown: worst, peakIndex: worstPeakIdx, troughIndex: worstTroughIdx };
+}
+
+export interface SeriesStats {
+  bars: number;
+  first: number | null;
+  last: number | null;
+  hi: number | null;
+  lo: number | null;
+  /** Total (cumulative) return over the window: last/first - 1. */
+  cumulativeReturn: number;
+  /** Mean of per-bar simple returns. */
+  avgReturn: number;
+  /** Sample stdev of per-bar log returns (per-bar, not annualized). */
+  volatility: number;
+  /** {@link volatility} annualized by sqrt(barsPerYear(interval)). */
+  annualizedVolatility: number;
+  maxDrawdown: number;
+  avgVolume: number;
+  totalVolume: number;
+}
+
+/** Full stat pack for a bar series at a given interval (seconds). */
+export function computeStats(bars: Bar[], intervalSec: number): SeriesStats {
+  const n = bars.length;
+  if (n === 0) {
+    return {
+      bars: 0, first: null, last: null, hi: null, lo: null,
+      cumulativeReturn: 0, avgReturn: 0, volatility: 0, annualizedVolatility: 0,
+      maxDrawdown: 0, avgVolume: 0, totalVolume: 0,
+    };
+  }
+  const first = bars[0]!.c;
+  const last = bars[n - 1]!.c;
+  let hi = bars[0]!.h;
+  let lo = bars[0]!.l;
+  let volSum = 0;
+  for (const b of bars) {
+    if (b.h > hi) hi = b.h;
+    if (b.l < lo) lo = b.l;
+    volSum += b.v || 0;
+  }
+  const logRets = logReturns(bars);
+  const simpleRets = simpleReturns(bars);
+  const perBarVol = stdev(logRets);
+  const annFactor = Math.sqrt(barsPerYear(intervalSec));
+  return {
+    bars: n,
+    first,
+    last,
+    hi,
+    lo,
+    cumulativeReturn: first !== 0 ? last / first - 1 : 0,
+    avgReturn: mean(simpleRets),
+    volatility: perBarVol,
+    annualizedVolatility: perBarVol * annFactor,
+    maxDrawdown: maxDrawdown(bars).maxDrawdown,
+    avgVolume: volSum / n,
+    totalVolume: volSum,
+  };
+}
+
+/**
+ * Pearson correlation of two equal-length numeric series. Returns 0 when the
+ * series differ in length, are shorter than 2, or either has zero variance.
+ */
+export function correlation(a: number[], b: number[]): number {
+  const n = Math.min(a.length, b.length);
+  if (n < 2) return 0;
+  const ma = mean(a.slice(0, n));
+  const mb = mean(b.slice(0, n));
+  let cov = 0;
+  let va = 0;
+  let vb = 0;
+  for (let i = 0; i < n; i++) {
+    const da = a[i]! - ma;
+    const db = b[i]! - mb;
+    cov += da * db;
+    va += da * da;
+    vb += db * db;
+  }
+  if (va === 0 || vb === 0) return 0;
+  return cov / Math.sqrt(va * vb);
+}
+
+/**
+ * Align two bar series on their shared timestamps and return the paired
+ * log-return vectors (one entry per shared consecutive-timestamp pair). Used to
+ * correlate two instruments that may not share every bar.
+ */
+export function alignedLogReturns(a: Bar[], b: Bar[]): { a: number[]; b: number[] } {
+  const mapB = new Map<number, number>();
+  for (const bar of b) mapB.set(bar.ts, bar.c);
+  // Common timestamps in a's order.
+  const common: { ts: number; ca: number; cb: number }[] = [];
+  for (const bar of a) {
+    const cb = mapB.get(bar.ts);
+    if (cb != null) common.push({ ts: bar.ts, ca: bar.c, cb });
+  }
+  const ra: number[] = [];
+  const rb: number[] = [];
+  for (let i = 1; i < common.length; i++) {
+    const p = common[i - 1]!;
+    const q = common[i]!;
+    ra.push(p.ca > 0 && q.ca > 0 ? Math.log(q.ca / p.ca) : 0);
+    rb.push(p.cb > 0 && q.cb > 0 ? Math.log(q.cb / p.cb) : 0);
+  }
+  return { a: ra, b: rb };
+}
+
+/** Correlation of two bar series over their aligned log-returns. */
+export function seriesCorrelation(a: Bar[], b: Bar[]): number {
+  const { a: ra, b: rb } = alignedLogReturns(a, b);
+  return correlation(ra, rb);
+}
+
+/**
+ * Normalize a close series to a base of 100 at the first bar, for overlay
+ * compare charts. Empty in -> empty out; a zero first close yields all-100.
+ */
+export function normalizeTo100(bars: Bar[]): { ts: number; v: number }[] {
+  if (bars.length === 0) return [];
+  const base = bars[0]!.c;
+  return bars.map((b) => ({ ts: b.ts, v: base !== 0 ? (b.c / base) * 100 : 100 }));
+}
+
+export interface BacktestTrade {
+  entryIndex: number;
+  exitIndex: number;
+  entryPrice: number;
+  exitPrice: number;
+  ret: number;
+}
+
+export interface BacktestResult {
+  /** Equity curve (starts at 1.0), one entry per bar. */
+  equity: number[];
+  totalReturn: number;
+  trades: BacktestTrade[];
+  numTrades: number;
+  wins: number;
+  /** Fraction of closed trades that were profitable (0 when no trades). */
+  winRate: number;
+  fast: number;
+  slow: number;
+}
+
+/**
+ * Long/flat SMA-crossover backtest. Go LONG on the bar after fast SMA crosses
+ * above slow SMA; go FLAT on the bar after it crosses back below. The position
+ * held into a bar is applied to that bar's simple return (no look-ahead).
+ * Frictionless.
+ */
+export function backtestMaCross(bars: Bar[], fast: number, slow: number): BacktestResult {
+  const empty: BacktestResult = {
+    equity: bars.length ? [1] : [],
+    totalReturn: 0,
+    trades: [],
+    numTrades: 0,
+    wins: 0,
+    winRate: 0,
+    fast,
+    slow,
+  };
+  if (fast <= 0 || slow <= 0 || fast >= slow || bars.length < slow + 1) return empty;
+
+  const closes = bars.map((b) => b.c);
+  const fastMa = sma(closes, fast);
+  const slowMa = sma(closes, slow);
+
+  const equity: number[] = new Array(bars.length).fill(1);
+  const trades: BacktestTrade[] = [];
+  let eq = 1;
+  let position = 0; // 0 flat, 1 long
+  let entryIndex = -1;
+  let entryPrice = 0;
+
+  for (let i = 0; i < bars.length; i++) {
+    // Apply the position held coming into bar i to this bar's return.
+    if (i > 0 && position === 1) {
+      const prev = closes[i - 1]!;
+      const cur = closes[i]!;
+      if (prev !== 0) eq *= cur / prev;
+    }
+    equity[i] = eq;
+
+    // Decide the signal from THIS bar's completed MAs; it takes effect next bar.
+    const f = fastMa[i];
+    const s = slowMa[i];
+    if (f != null && s != null) {
+      const wantLong = f > s;
+      if (wantLong && position === 0) {
+        position = 1;
+        entryIndex = i;
+        entryPrice = closes[i]!;
+      } else if (!wantLong && position === 1) {
+        const exitPrice = closes[i]!;
+        trades.push({
+          entryIndex,
+          exitIndex: i,
+          entryPrice,
+          exitPrice,
+          ret: entryPrice !== 0 ? exitPrice / entryPrice - 1 : 0,
+        });
+        position = 0;
+      }
+    }
+  }
+  // Close any open position at the final bar for accounting.
+  if (position === 1 && entryIndex >= 0) {
+    const exitPrice = closes[bars.length - 1]!;
+    trades.push({
+      entryIndex,
+      exitIndex: bars.length - 1,
+      entryPrice,
+      exitPrice,
+      ret: entryPrice !== 0 ? exitPrice / entryPrice - 1 : 0,
+    });
+  }
+
+  const wins = trades.filter((t) => t.ret > 0).length;
+  return {
+    equity,
+    totalReturn: eq - 1,
+    trades,
+    numTrades: trades.length,
+    wins,
+    winRate: trades.length ? wins / trades.length : 0,
+    fast,
+    slow,
+  };
+}

--- a/frontend/src/pages/analysis/MarketAnalysisPage.tsx
+++ b/frontend/src/pages/analysis/MarketAnalysisPage.tsx
@@ -1,0 +1,717 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { LineChart as LineChartIcon, AlertTriangle, X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import { useSymbols } from "@/hooks/useMarketData";
+import type { MarketSymbol, Candle } from "@/api/endpoints/marketData";
+import {
+  getHistory,
+  intervalToSeconds,
+  type HistoryResponse,
+} from "@/api/endpoints/marketHistory";
+import {
+  backtestMaCross,
+  computeStats,
+  normalizeTo100,
+  seriesCorrelation,
+  type Bar,
+} from "@/lib/marketStats";
+import {
+  ALL_CLASS,
+  CLASS_LABELS,
+  CLASS_TAB_ORDER,
+  symbolInClass,
+  type ClassTab,
+} from "@/lib/instrumentClass";
+import CandleChart from "@/pages/markets/CandleChart";
+import { formatPrice } from "@/pages/markets/format";
+
+// ── Config ─────────────────────────────────────────────────────────
+
+const INTERVALS = [
+  { label: "1m", token: "1m" },
+  { label: "5m", token: "5m" },
+  { label: "15m", token: "15m" },
+  { label: "1h", token: "1h" },
+  { label: "1d", token: "1d" },
+] as const;
+
+/** Range = target number of bars to assemble (paginating history if needed). */
+const RANGES = [
+  { label: "200", bars: 200 },
+  { label: "500", bars: 500 },
+  { label: "1k", bars: 1000 },
+  { label: "2k", bars: 2000 },
+] as const;
+
+const MAX_COMPARE = 4;
+const MAX_PAGES = 6; // cap history pagination so we never loop unbounded
+
+// Overlay colors for the compare chart / correlation headers.
+const SERIES_COLORS = ["#0ea5e9", "#f59e0b", "#8b5cf6", "#ec4899", "#22c55e"];
+
+// ── History assembly hook ──────────────────────────────────────────
+
+/** Contract bar type is raw-integer priced; de-scale for display/stats. */
+function toBars(res: HistoryResponse, scaler: number): Bar[] {
+  const s = scaler || 1;
+  return res.bars.map((b) => ({
+    ts: b.ts,
+    o: b.o / s,
+    h: b.h / s,
+    l: b.l / s,
+    c: b.c / s,
+    v: b.v,
+  }));
+}
+
+/** Bars mapped back to the exchange `Candle` shape CandleChart expects. */
+function toCandles(bars: Bar[], scaler: number): Candle[] {
+  const s = scaler || 1;
+  return bars.map((b) => ({
+    open: b.o * s,
+    high: b.h * s,
+    low: b.l * s,
+    close: b.c * s,
+    volume: b.v,
+    trades: 0,
+    ts_start_ns: b.ts * 1_000_000,
+  }));
+}
+
+interface AssembledHistory {
+  bars: Bar[];
+  stub: boolean;
+}
+
+/**
+ * Fetch and assemble up to `targetBars` of history for one symbol, following
+ * `next_cursor` when present (capped at {@link MAX_PAGES}). De-scales prices.
+ */
+function useHistory(symbolId: number | null, interval: string, targetBars: number, scaler: number) {
+  return useQuery<AssembledHistory>({
+    queryKey: ["md", "history", symbolId, interval, targetBars],
+    enabled: symbolId != null && symbolId > 0,
+    staleTime: 30_000,
+    queryFn: async () => {
+      const id = symbolId as number;
+      const acc: Bar[] = [];
+      let stub = false;
+      let cursor: string | undefined;
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const res = await getHistory(id, { interval, cursor });
+        stub = stub || !!res.stub;
+        acc.push(...toBars(res, scaler));
+        if (res.stub || !res.next_cursor || acc.length >= targetBars) break;
+        cursor = res.next_cursor;
+      }
+      // Keep chronological order; trim to the most recent `targetBars`.
+      acc.sort((a, b) => a.ts - b.ts);
+      const trimmed = acc.length > targetBars ? acc.slice(acc.length - targetBars) : acc;
+      return { bars: trimmed, stub };
+    },
+  });
+}
+
+// ── Small presentational helpers ───────────────────────────────────
+
+function pct(x: number | null | undefined, digits = 2): string {
+  if (x == null || !Number.isFinite(x)) return "—";
+  return `${(x * 100).toFixed(digits)}%`;
+}
+
+function StatRow({ label, value, tone }: { label: string; value: string; tone?: "up" | "down" }) {
+  return (
+    <div className="flex items-center justify-between py-1 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "tabular-nums font-medium",
+          tone === "up" && "text-emerald-600 dark:text-emerald-400",
+          tone === "down" && "text-rose-600 dark:text-rose-400",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** Overlay of several normalized-to-100 close series. */
+function CompareChart({
+  series,
+  height = 260,
+}: {
+  series: { symbol: string; color: string; points: { ts: number; v: number }[] }[];
+  height?: number;
+}) {
+  const width = 720;
+  const PAD = { t: 8, r: 48, b: 8, l: 8 };
+  const layout = useMemo(() => {
+    const withData = series.filter((s) => s.points.length > 1);
+    if (!withData.length) return null;
+    let min = Infinity;
+    let max = -Infinity;
+    let n = 0;
+    for (const s of withData) {
+      n = Math.max(n, s.points.length);
+      for (const p of s.points) {
+        if (p.v < min) min = p.v;
+        if (p.v > max) max = p.v;
+      }
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+    if (min === max) {
+      min -= 1;
+      max += 1;
+    }
+    const plotW = width - PAD.l - PAD.r;
+    const plotH = height - PAD.t - PAD.b;
+    const yOf = (v: number) => PAD.t + ((max - v) / (max - min)) * plotH;
+    const lines = withData.map((s) => {
+      const step = s.points.length > 1 ? plotW / (s.points.length - 1) : 0;
+      const pts = s.points
+        .map((p, i) => `${(PAD.l + i * step).toFixed(1)},${yOf(p.v).toFixed(1)}`)
+        .join(" ");
+      const lastV = s.points[s.points.length - 1]!.v;
+      return { symbol: s.symbol, color: s.color, pts, lastV };
+    });
+    const ticks = 4;
+    const labels = Array.from({ length: ticks + 1 }, (_, i) => {
+      const v = max - ((max - min) * i) / ticks;
+      return { y: yOf(v), value: v };
+    });
+    const baseY = min <= 100 && max >= 100 ? yOf(100) : null;
+    return { lines, labels, baseY };
+  }, [series, height]);
+
+  if (!layout) {
+    return (
+      <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
+        Select at least one symbol with data to compare.
+      </div>
+    );
+  }
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full" style={{ height }} preserveAspectRatio="none" role="img" aria-label="Normalized compare chart">
+      {layout.labels.map((l, i) => (
+        <g key={`g${i}`}>
+          <line x1={PAD.l} x2={width - PAD.r} y1={l.y} y2={l.y} stroke="currentColor" strokeOpacity={0.1} />
+          <text x={width - PAD.r + 4} y={l.y + 3} fontSize={10} fill="currentColor" fillOpacity={0.6}>
+            {l.value.toFixed(0)}
+          </text>
+        </g>
+      ))}
+      {layout.baseY != null && (
+        <line x1={PAD.l} x2={width - PAD.r} y1={layout.baseY} y2={layout.baseY} stroke="currentColor" strokeOpacity={0.25} strokeDasharray="4 3" />
+      )}
+      {layout.lines.map((ln) => (
+        <polyline key={ln.symbol} points={ln.pts} fill="none" stroke={ln.color} strokeWidth={1.4} strokeOpacity={0.95} vectorEffect="non-scaling-stroke" />
+      ))}
+    </svg>
+  );
+}
+
+/** Equity curve line (starts at 1.0). */
+function EquityChart({ equity, height = 160 }: { equity: number[]; height?: number }) {
+  const width = 720;
+  const PAD = { t: 8, r: 48, b: 8, l: 8 };
+  const layout = useMemo(() => {
+    if (equity.length < 2) return null;
+    let min = Math.min(...equity);
+    let max = Math.max(...equity);
+    if (min === max) {
+      min -= 0.01;
+      max += 0.01;
+    }
+    const plotW = width - PAD.l - PAD.r;
+    const plotH = height - PAD.t - PAD.b;
+    const step = plotW / (equity.length - 1);
+    const yOf = (v: number) => PAD.t + ((max - v) / (max - min)) * plotH;
+    const pts = equity.map((v, i) => `${(PAD.l + i * step).toFixed(1)},${yOf(v).toFixed(1)}`).join(" ");
+    const oneY = min <= 1 && max >= 1 ? yOf(1) : null;
+    const labels = [max, (max + min) / 2, min].map((v) => ({ y: yOf(v), value: v }));
+    return { pts, oneY, labels };
+  }, [equity, height]);
+
+  if (!layout) {
+    return (
+      <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
+        Not enough bars to backtest.
+      </div>
+    );
+  }
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full" style={{ height }} preserveAspectRatio="none" role="img" aria-label="Backtest equity curve">
+      {layout.labels.map((l, i) => (
+        <g key={`e${i}`}>
+          <line x1={PAD.l} x2={width - PAD.r} y1={l.y} y2={l.y} stroke="currentColor" strokeOpacity={0.1} />
+          <text x={width - PAD.r + 4} y={l.y + 3} fontSize={10} fill="currentColor" fillOpacity={0.6}>
+            {l.value.toFixed(2)}x
+          </text>
+        </g>
+      ))}
+      {layout.oneY != null && (
+        <line x1={PAD.l} x2={width - PAD.r} y1={layout.oneY} y2={layout.oneY} stroke="currentColor" strokeOpacity={0.25} strokeDasharray="4 3" />
+      )}
+      <polyline points={layout.pts} fill="none" stroke="#0ea5e9" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+// ── Page ───────────────────────────────────────────────────────────
+
+export default function MarketAnalysisPage() {
+  const symbolsQuery = useSymbols();
+  const symbols = symbolsQuery.data?.symbols ?? [];
+
+  const [classTab, setClassTab] = useState<ClassTab>(ALL_CLASS);
+  const [interval, setInterval] = useState<string>("1h");
+  const [rangeBars, setRangeBars] = useState<number>(500);
+  const [primaryId, setPrimaryId] = useState<number | null>(null);
+  const [compareIds, setCompareIds] = useState<number[]>([]);
+  const [search, setSearch] = useState("");
+  const [fast, setFast] = useState(10);
+  const [slow, setSlow] = useState(30);
+
+  // Default primary to the first symbol once loaded.
+  useEffect(() => {
+    if (primaryId == null && symbols.length > 0) setPrimaryId(symbols[0]!.symbol_id);
+  }, [symbols, primaryId]);
+
+  const symById = useMemo(() => {
+    const m = new Map<number, MarketSymbol>();
+    for (const s of symbols) m.set(s.symbol_id, s);
+    return m;
+  }, [symbols]);
+
+  const filteredSymbols = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return symbols.filter(
+      (s) => symbolInClass(s, classTab) && (!q || s.symbol.toLowerCase().includes(q)),
+    );
+  }, [symbols, classTab, search]);
+
+  const primary = primaryId != null ? symById.get(primaryId) ?? null : null;
+  const primaryScaler = primary?.price_scaler || 1;
+
+  // Primary history (drives the chart + stats + backtest).
+  const primaryHist = useHistory(primaryId, interval, rangeBars, primaryScaler);
+  const primaryBars = primaryHist.data?.bars ?? [];
+  const isStub = !!primaryHist.data?.stub;
+
+  const stats = useMemo(
+    () => computeStats(primaryBars, intervalToSeconds(interval)),
+    [primaryBars, interval],
+  );
+
+  // Compare set = primary + the selected compare symbols (deduped, capped).
+  const compareSet = useMemo(() => {
+    const ids: number[] = [];
+    if (primaryId != null) ids.push(primaryId);
+    for (const id of compareIds) if (!ids.includes(id)) ids.push(id);
+    return ids.slice(0, MAX_COMPARE + 1);
+  }, [primaryId, compareIds]);
+
+  // One history query per compare symbol.
+  const compareQueries = useQueries({
+    queries: compareSet.map((id) => {
+      const sc = symById.get(id)?.price_scaler || 1;
+      return {
+        queryKey: ["md", "history", id, interval, rangeBars],
+        enabled: id > 0,
+        staleTime: 30_000,
+        queryFn: async (): Promise<AssembledHistory> => {
+          const acc: Bar[] = [];
+          let stub = false;
+          let cursor: string | undefined;
+          for (let page = 0; page < MAX_PAGES; page++) {
+            const res = await getHistory(id, { interval, cursor });
+            stub = stub || !!res.stub;
+            acc.push(...toBars(res, sc));
+            if (res.stub || !res.next_cursor || acc.length >= rangeBars) break;
+            cursor = res.next_cursor;
+          }
+          acc.sort((a, b) => a.ts - b.ts);
+          const trimmed = acc.length > rangeBars ? acc.slice(acc.length - rangeBars) : acc;
+          return { bars: trimmed, stub };
+        },
+      };
+    }),
+  });
+
+  const compareData = useMemo(
+    () =>
+      compareSet.map((id, i) => ({
+        id,
+        symbol: symById.get(id)?.symbol ?? `#${id}`,
+        color: SERIES_COLORS[i % SERIES_COLORS.length]!,
+        bars: (compareQueries[i]?.data as AssembledHistory | undefined)?.bars ?? [],
+      })),
+    [compareSet, compareQueries, symById],
+  );
+
+  const compareSeries = useMemo(
+    () =>
+      compareData.map((d) => ({
+        symbol: d.symbol,
+        color: d.color,
+        points: normalizeTo100(d.bars),
+      })),
+    [compareData],
+  );
+
+  // Correlation matrix over aligned log-returns.
+  const corrMatrix = useMemo(() => {
+    const n = compareData.length;
+    const m: number[][] = Array.from({ length: n }, () => new Array(n).fill(0));
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        m[i]![j] = i === j ? 1 : seriesCorrelation(compareData[i]!.bars, compareData[j]!.bars);
+      }
+    }
+    return m;
+  }, [compareData]);
+
+  const backtest = useMemo(() => backtestMaCross(primaryBars, fast, slow), [primaryBars, fast, slow]);
+
+  const chartCandles = useMemo(() => toCandles(primaryBars, primaryScaler), [primaryBars, primaryScaler]);
+
+  function toggleCompare(id: number) {
+    setCompareIds((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id);
+      if (prev.length >= MAX_COMPARE) return prev;
+      return [...prev, id];
+    });
+  }
+
+  const cumTone = stats.cumulativeReturn > 0 ? "up" : stats.cumulativeReturn < 0 ? "down" : undefined;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-semibold">
+          <LineChartIcon className="h-6 w-6" /> Analysis
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Historical market-data research workbench: long-range charting, statistics, multi-symbol
+          compare, correlation, and a moving-average crossover backtest.
+        </p>
+      </div>
+
+      {isStub && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            Recent window only — long-range history pending backend (<code>/md/history</code>).
+          </span>
+        </div>
+      )}
+
+      {/* Controls */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Instrument &amp; range</CardTitle>
+          <CardDescription>Pick a primary symbol, interval and how many bars to analyze.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex items-center gap-1">
+              <span className="mr-1 text-xs text-muted-foreground">Interval</span>
+              {INTERVALS.map((iv) => (
+                <Button
+                  key={iv.token}
+                  type="button"
+                  size="sm"
+                  variant={interval === iv.token ? "default" : "outline"}
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setInterval(iv.token)}
+                >
+                  {iv.label}
+                </Button>
+              ))}
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="mr-1 text-xs text-muted-foreground">Bars</span>
+              {RANGES.map((r) => (
+                <Button
+                  key={r.bars}
+                  type="button"
+                  size="sm"
+                  variant={rangeBars === r.bars ? "default" : "outline"}
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setRangeBars(r.bars)}
+                >
+                  {r.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <Tabs value={classTab} onValueChange={(v) => setClassTab(v as ClassTab)}>
+            <TabsList className="h-8">
+              {CLASS_TAB_ORDER.map((t) => (
+                <TabsTrigger key={t} value={t} className="text-xs">
+                  {CLASS_LABELS[t]}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+
+          <Input
+            placeholder="Filter symbols…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 max-w-xs"
+          />
+
+          {symbolsQuery.isLoading ? (
+            <Skeleton className="h-24 w-full" />
+          ) : (
+            <div className="flex max-h-40 flex-wrap gap-1.5 overflow-y-auto">
+              {filteredSymbols.map((s) => {
+                const isPrimary = s.symbol_id === primaryId;
+                const isCompare = compareIds.includes(s.symbol_id);
+                return (
+                  <div key={s.symbol_id} className="flex items-center">
+                    <button
+                      type="button"
+                      onClick={() => setPrimaryId(s.symbol_id)}
+                      className={cn(
+                        "rounded-l border px-2 py-1 text-xs transition-colors",
+                        isPrimary
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border hover:bg-foreground/5",
+                      )}
+                      aria-pressed={isPrimary}
+                    >
+                      {s.symbol}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => toggleCompare(s.symbol_id)}
+                      disabled={isPrimary}
+                      title={isCompare ? "Remove from compare" : "Add to compare"}
+                      className={cn(
+                        "rounded-r border border-l-0 px-1.5 py-1 text-xs transition-colors",
+                        isCompare
+                          ? "border-sky-500 bg-sky-500/20 text-sky-700 dark:text-sky-300"
+                          : "border-border text-muted-foreground hover:bg-foreground/5",
+                        isPrimary && "opacity-30",
+                      )}
+                    >
+                      {isCompare ? "✓" : "+"}
+                    </button>
+                  </div>
+                );
+              })}
+              {filteredSymbols.length === 0 && (
+                <span className="text-sm text-muted-foreground">No symbols match.</span>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Chart + stats */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">
+              {primary?.symbol ?? "—"} · {interval} · {primaryBars.length} bars
+            </CardTitle>
+            <CardDescription>Long-range candles (green up / red down).</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {primaryHist.isLoading ? (
+              <Skeleton className="h-[320px] w-full" />
+            ) : chartCandles.length ? (
+              <div className="text-muted-foreground">
+                <CandleChart bars={chartCandles} scaler={primaryScaler} intervalSec={intervalToSeconds(interval)} />
+              </div>
+            ) : (
+              <div className="flex h-[320px] items-center justify-center text-sm text-muted-foreground">
+                No history available for this symbol.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Statistics</CardTitle>
+            <CardDescription>Over the selected range.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {primaryHist.isLoading ? (
+              <Skeleton className="h-48 w-full" />
+            ) : (
+              <div className="divide-y">
+                <StatRow label="Bars" value={String(stats.bars)} />
+                <StatRow label="Cumulative return" value={pct(stats.cumulativeReturn)} tone={cumTone} />
+                <StatRow label="Avg per-bar return" value={pct(stats.avgReturn, 3)} />
+                <StatRow label="Volatility (per bar)" value={pct(stats.volatility, 3)} />
+                <StatRow label="Volatility (annualized)" value={pct(stats.annualizedVolatility)} />
+                <StatRow label="Max drawdown" value={pct(stats.maxDrawdown)} tone={stats.maxDrawdown < 0 ? "down" : undefined} />
+                <StatRow label="High" value={stats.hi != null ? formatPrice(stats.hi * primaryScaler, primaryScaler) : "—"} />
+                <StatRow label="Low" value={stats.lo != null ? formatPrice(stats.lo * primaryScaler, primaryScaler) : "—"} />
+                <StatRow label="Avg volume" value={stats.avgVolume.toLocaleString(undefined, { maximumFractionDigits: 2 })} />
+                <StatRow label="Total volume" value={stats.totalVolume.toLocaleString(undefined, { maximumFractionDigits: 2 })} />
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Compare + correlation */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="pb-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <CardTitle className="text-base">Compare (normalized to 100)</CardTitle>
+                <CardDescription>Relative performance of the primary + compare symbols.</CardDescription>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {compareData.map((d) => (
+                  <Badge key={d.id} variant="outline" className="gap-1" style={{ borderColor: d.color, color: d.color }}>
+                    {d.symbol}
+                    {d.id !== primaryId && (
+                      <button type="button" onClick={() => toggleCompare(d.id)} aria-label={`Remove ${d.symbol}`}>
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CompareChart series={compareSeries} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Correlation</CardTitle>
+            <CardDescription>Log-return correlation across the compare set.</CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            {compareData.length < 2 ? (
+              <p className="text-sm text-muted-foreground">Add at least one compare symbol.</p>
+            ) : (
+              <table className="w-full border-collapse text-xs tabular-nums">
+                <thead>
+                  <tr>
+                    <th className="p-1" />
+                    {compareData.map((d) => (
+                      <th key={d.id} className="p-1 text-center" style={{ color: d.color }}>
+                        {d.symbol}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {compareData.map((row, i) => (
+                    <tr key={row.id}>
+                      <th className="p-1 text-left" style={{ color: row.color }}>
+                        {row.symbol}
+                      </th>
+                      {compareData.map((col, j) => {
+                        const v = corrMatrix[i]?.[j] ?? 0;
+                        const bg =
+                          v > 0
+                            ? `rgba(16,185,129,${Math.min(0.6, Math.abs(v) * 0.6)})`
+                            : `rgba(225,29,72,${Math.min(0.6, Math.abs(v) * 0.6)})`;
+                        return (
+                          <td key={col.id} className="p-1 text-center" style={{ backgroundColor: i === j ? undefined : bg }}>
+                            {v.toFixed(2)}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Backtest */}
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <CardTitle className="text-base">MA-crossover backtest</CardTitle>
+              <CardDescription>
+                Long when fast SMA &gt; slow SMA, flat otherwise. {primary?.symbol ?? "—"} · {interval}.
+              </CardDescription>
+            </div>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1 text-xs text-muted-foreground">
+                Fast
+                <Input
+                  type="number"
+                  min={1}
+                  value={fast}
+                  onChange={(e) => setFast(Math.max(1, Number(e.target.value) || 1))}
+                  className="h-7 w-16"
+                />
+              </label>
+              <label className="flex items-center gap-1 text-xs text-muted-foreground">
+                Slow
+                <Input
+                  type="number"
+                  min={2}
+                  value={slow}
+                  onChange={(e) => setSlow(Math.max(2, Number(e.target.value) || 2))}
+                  className="h-7 w-16"
+                />
+              </label>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {fast >= slow && (
+            <p className="text-sm text-amber-600 dark:text-amber-400">Fast period must be smaller than slow.</p>
+          )}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <div>
+              <div className="text-xs text-muted-foreground">Total return</div>
+              <div
+                className={cn(
+                  "text-lg font-semibold tabular-nums",
+                  backtest.totalReturn > 0 && "text-emerald-600 dark:text-emerald-400",
+                  backtest.totalReturn < 0 && "text-rose-600 dark:text-rose-400",
+                )}
+              >
+                {pct(backtest.totalReturn)}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Trades</div>
+              <div className="text-lg font-semibold tabular-nums">{backtest.numTrades}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Win rate</div>
+              <div className="text-lg font-semibold tabular-nums">{pct(backtest.winRate, 1)}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Buy &amp; hold</div>
+              <div className="text-lg font-semibold tabular-nums">{pct(stats.cumulativeReturn)}</div>
+            </div>
+          </div>
+          <EquityChart equity={backtest.equity} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Historical market-data analysis workbench

A research/analysis surface over historical bars, on a new **Analysis** route/screen. First of the two roadmap programs (historical analysis → tokenized contracts).

### Data contract (degrade-on-404)
`GET /md/history/{symbol}?interval=&from=&to=&cursor=` → paginated OHLCV. The endpoint does not exist yet, so it **degrades to the existing recent-window `/md/candles`** with a banner ("Recent window only — long-range history pending backend") and paginates via `next_cursor` when present. Backend ask already logged in the doc.

### Web (`/analysis`, "Analysis" nav)
- `src/lib/marketStats.ts` (new, +24 vitest) — pure: returns, annualized volatility, max drawdown, hi/lo, avg/total volume, cumulative return, correlation, normalize-to-100, and an MA-cross backtest (equity curve / total return / win rate / #trades; no look-ahead).
- `src/api/endpoints/marketHistory.ts` (new) — `getHistory` + 404-degrade to candles.
- `pages/analysis/MarketAnalysisPage.tsx` (new) — class-filtered symbol picker, interval/range, long-range chart (reuses `CandleChart`), stats panel, multi-symbol normalized compare + correlation matrix, MA-cross backtest runner. `App.tsx` lazy route + Sidebar entry.

### Android (new screen in the More/GROWTH hub, registered in `MoreRoutes`)
- `feature/analysis/MarketStats.kt` (new, +20 JVM tests) — same pure stats.
- `feature/analysis/{MarketAnalysisScreen,ViewModel,UiState}.kt` — class-filter tabs, range chips, degrade banner, `CandlestickChart`, stats panel, normalized overlay + correlation grid, MA-cross backtest + equity curve.
- Exchange data layer `getHistory` (Api/Dtos/Domain/Mappers/Repository) with 404-degrade + `nextCursor` pagination; `MarketsNavigation` + `MoreCatalog` entry + `MoreRoutes.REGISTERED` (`MoreCatalogTest` passes).

No new deps. Additive/reversible; reuses existing chart + client indicator math.

### Gates
- Web: `tsc` 0 · `vite build` green · vitest `marketStats` 24/24.
- Android: `assembleDebug` + `testDebugUnitTest` BUILD SUCCESSFUL (`MarketStats` 20/20, `MoreCatalogTest` 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)