### PR TITLE
feat(tokens): creator revenue-share token surface — mint/IPO/cap-table/revenue/upkeep (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokenDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokenDomain.kt
@@ -1,0 +1,102 @@
+package com.testlogon.android.data.tokens
+
+/**
+ * CREATOR REVENUE-SHARE TOKEN domain models — render-ready shapes the feature layer consumes.
+ *
+ * A content-selling creator tokenizes their revenue share into a tradeable coin: minting holds 100%
+ * of supply, sets a revenue-share % (`revenueShareBps`), and pays a $100 creation fee. Holders receive
+ * pro-rata distributions of that % of the creator's ongoing content revenue. Amounts are integer CENTS.
+ */
+enum class TokenStatus { DRAFT, MINTED, LISTED, FROZEN, DELISTED, UNKNOWN }
+
+data class Token(
+    val tokenId: String,
+    val symbolId: String? = null,
+    val creatorSub: String? = null,
+    val name: String,
+    val ticker: String,
+    val totalSupply: Long,
+    val revenueShareBps: Int,
+    val status: TokenStatus,
+    val createdTs: Long = 0,
+    val offeredPctBps: Int? = null,
+    /** Cleared IPO price in cents-per-token, when the token has listed. */
+    val clearingPrice: Long? = null,
+)
+
+/** One cap-table holder: a [sub], their [qty], and their ownership [pctBps]. */
+data class TokenHolder(
+    val sub: String,
+    val qty: Long,
+    val pctBps: Int,
+)
+
+data class TokenCapTable(
+    val tokenId: String,
+    val creatorPctBps: Int,
+    val holders: List<TokenHolder>,
+)
+
+enum class AuctionStatus { OPEN, CLEARED, CANCELLED, UNKNOWN }
+
+/** One sealed IPO bid. */
+data class TokenBid(
+    val sub: String,
+    val qty: Long,
+    val limitPrice: Long,
+)
+
+/**
+ * The single-clearing-price IPO auction: sealed bids clear at ONE price, all fills at that price.
+ * [clearingPrice]/[filledQty] are set once [status] is CLEARED.
+ */
+data class TokenAuction(
+    val auctionId: String,
+    val tokenId: String,
+    val offeredPctBps: Int,
+    val reservePrice: Long,
+    val status: AuctionStatus,
+    val clearingPrice: Long? = null,
+    val filledQty: Long? = null,
+    val closeTs: Long = 0,
+    val bids: List<TokenBid> = emptyList(),
+)
+
+/** One pro-rata revenue distribution to holders. */
+data class TokenDistribution(
+    val ts: Long,
+    val totalAmount: Long,
+    val perTokenAmount: Long,
+    val source: String,
+)
+
+data class TokenRevenue(
+    val tokenId: String,
+    val myQty: Long,
+    val myPctBps: Int,
+    val myClaimable: Long,
+    val distributions: List<TokenDistribution>,
+)
+
+enum class UpkeepStatus { COVERED, DUE, PAID, DELINQUENT, FROZEN, UNKNOWN }
+
+/**
+ * Book-upkeep for the month: $100 kept the book tradeable, charged to holders PRO-RATA by holding as a
+ * SHORTFALL top-up — `amountDue = max(0, $100 - feesGenerated)`; $0 when monthly fees >= $100.
+ * Non-payment freezes the book (reversible on payment).
+ */
+data class TokenUpkeep(
+    val tokenId: String,
+    val month: String,
+    val feesGenerated: Long,
+    val threshold: Long,
+    val amountDue: Long,
+    val myShare: Long,
+    val status: UpkeepStatus,
+)
+
+/** A simple mutation acknowledgement — [accepted] is false when the server didn't confirm. */
+data class TokenAck(
+    val accepted: Boolean,
+    val message: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokenDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokenDtos.kt
@@ -1,0 +1,135 @@
+package com.testlogon.android.data.tokens
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.network.json.LenientInt
+import com.testlogon.android.core.network.json.LenientLong
+
+/**
+ * Wire DTOs for the CREATOR REVENUE-SHARE TOKEN surface (`me/tokens/(all)`).
+ *
+ * NONE of these endpoints exist on the backend yet — the repository degrades every GET to an
+ * empty-but-honest state on 404/absence and surfaces a clear error on every failed mutation. All
+ * numeric fields are lenient (the edge may stringify ids / cents / bps) and every field is defaulted
+ * so a partial / drifted payload still parses. Amounts are integer CENTS; `Bps` are basis points.
+ */
+@JsonClass(generateAdapter = true)
+data class TokenDto(
+    @Json(name = "token_id") val tokenId: String? = null,
+    @Json(name = "symbol_id") val symbolId: String? = null,
+    @Json(name = "creator_sub") val creatorSub: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "ticker") val ticker: String? = null,
+    @LenientLong @Json(name = "total_supply") val totalSupply: Long? = null,
+    @LenientInt @Json(name = "revenue_share_bps") val revenueShareBps: Int? = null,
+    @Json(name = "status") val status: String? = null,
+    @LenientLong @Json(name = "created_ts") val createdTs: Long? = null,
+    @LenientInt @Json(name = "offered_pct_bps") val offeredPctBps: Int? = null,
+    @LenientLong @Json(name = "clearing_price") val clearingPrice: Long? = null,
+)
+
+/** `GET me/tokens` (issued) / `GET me/tokens/market` (browse listed) -> {tokens:[Token]}. */
+@JsonClass(generateAdapter = true)
+data class TokenListDto(
+    @Json(name = "tokens") val tokens: List<TokenDto>? = null,
+)
+
+/** `POST me/tokens` body — server charges the $100 creation fee. */
+@JsonClass(generateAdapter = true)
+data class MintTokenRequestDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "ticker") val ticker: String,
+    @Json(name = "total_supply") val totalSupply: Long,
+    @Json(name = "revenue_share_bps") val revenueShareBps: Int,
+)
+
+/** One cap-table holder row. */
+@JsonClass(generateAdapter = true)
+data class TokenHolderDto(
+    @Json(name = "sub") val sub: String? = null,
+    @LenientLong @Json(name = "qty") val qty: Long? = null,
+    @LenientInt @Json(name = "pct_bps") val pctBps: Int? = null,
+)
+
+/** `GET me/tokens/{id}/captable` -> {token_id, creator_pct_bps, holders:[...]}. */
+@JsonClass(generateAdapter = true)
+data class TokenCapTableDto(
+    @Json(name = "token_id") val tokenId: String? = null,
+    @LenientInt @Json(name = "creator_pct_bps") val creatorPctBps: Int? = null,
+    @Json(name = "holders") val holders: List<TokenHolderDto>? = null,
+)
+
+/** `POST me/tokens/{id}/list` body — list N% via a single-clearing-price IPO auction. */
+@JsonClass(generateAdapter = true)
+data class ListTokenRequestDto(
+    @Json(name = "offered_pct_bps") val offeredPctBps: Int,
+    @Json(name = "reserve_price") val reservePrice: Long,
+    @Json(name = "close_ts") val closeTs: Long,
+)
+
+/** One sealed IPO bid. */
+@JsonClass(generateAdapter = true)
+data class TokenBidDto(
+    @Json(name = "sub") val sub: String? = null,
+    @LenientLong @Json(name = "qty") val qty: Long? = null,
+    @LenientLong @Json(name = "limit_price") val limitPrice: Long? = null,
+)
+
+/** `GET me/tokens/{id}/auction` -> the IPO auction state (open|cleared|cancelled). */
+@JsonClass(generateAdapter = true)
+data class TokenAuctionDto(
+    @Json(name = "auction_id") val auctionId: String? = null,
+    @Json(name = "token_id") val tokenId: String? = null,
+    @LenientInt @Json(name = "offered_pct_bps") val offeredPctBps: Int? = null,
+    @LenientLong @Json(name = "reserve_price") val reservePrice: Long? = null,
+    @Json(name = "status") val status: String? = null,
+    @LenientLong @Json(name = "clearing_price") val clearingPrice: Long? = null,
+    @LenientLong @Json(name = "filled_qty") val filledQty: Long? = null,
+    @LenientLong @Json(name = "close_ts") val closeTs: Long? = null,
+    @Json(name = "bids") val bids: List<TokenBidDto>? = null,
+)
+
+/** `POST me/tokens/{id}/auction/bid` body. */
+@JsonClass(generateAdapter = true)
+data class PlaceBidRequestDto(
+    @Json(name = "qty") val qty: Long,
+    @Json(name = "limit_price") val limitPrice: Long,
+)
+
+/** One revenue distribution row. */
+@JsonClass(generateAdapter = true)
+data class TokenDistributionDto(
+    @LenientLong @Json(name = "ts") val ts: Long? = null,
+    @LenientLong @Json(name = "total_amount") val totalAmount: Long? = null,
+    @LenientLong @Json(name = "per_token_amount") val perTokenAmount: Long? = null,
+    @Json(name = "source") val source: String? = null,
+)
+
+/** `GET me/tokens/{id}/revenue` -> my pro-rata claim + the distribution history. */
+@JsonClass(generateAdapter = true)
+data class TokenRevenueDto(
+    @Json(name = "token_id") val tokenId: String? = null,
+    @LenientLong @Json(name = "my_qty") val myQty: Long? = null,
+    @LenientInt @Json(name = "my_pct_bps") val myPctBps: Int? = null,
+    @LenientLong @Json(name = "my_claimable") val myClaimable: Long? = null,
+    @Json(name = "distributions") val distributions: List<TokenDistributionDto>? = null,
+)
+
+/** `GET me/tokens/{id}/upkeep` -> the $100/month book-upkeep shortfall state. */
+@JsonClass(generateAdapter = true)
+data class TokenUpkeepDto(
+    @Json(name = "token_id") val tokenId: String? = null,
+    @Json(name = "month") val month: String? = null,
+    @LenientLong @Json(name = "fees_generated") val feesGenerated: Long? = null,
+    @LenientLong @Json(name = "threshold") val threshold: Long? = null,
+    @LenientLong @Json(name = "amount_due") val amountDue: Long? = null,
+    @LenientLong @Json(name = "my_share") val myShare: Long? = null,
+    @Json(name = "status") val status: String? = null,
+)
+
+/** Generic mutation ack ({status:"ok"|"ack", ...}); parsed defensively. */
+@JsonClass(generateAdapter = true)
+data class TokenAckDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "message") val message: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokenMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokenMappers.kt
@@ -1,0 +1,113 @@
+package com.testlogon.android.data.tokens
+
+/**
+ * DTO -> domain mappers for the CREATOR REVENUE-SHARE TOKEN surface. Every field is defensively
+ * defaulted (the endpoints don't exist yet + the edge may drift), so a partial payload maps to a
+ * sane, honest domain object rather than throwing.
+ */
+
+private fun String?.toTokenStatus(): TokenStatus = when (this?.trim()?.lowercase()) {
+    "draft" -> TokenStatus.DRAFT
+    "minted" -> TokenStatus.MINTED
+    "listed" -> TokenStatus.LISTED
+    "frozen" -> TokenStatus.FROZEN
+    "delisted" -> TokenStatus.DELISTED
+    else -> TokenStatus.UNKNOWN
+}
+
+private fun String?.toAuctionStatus(): AuctionStatus = when (this?.trim()?.lowercase()) {
+    "open" -> AuctionStatus.OPEN
+    "cleared" -> AuctionStatus.CLEARED
+    "cancelled", "canceled" -> AuctionStatus.CANCELLED
+    else -> AuctionStatus.UNKNOWN
+}
+
+private fun String?.toUpkeepStatus(): UpkeepStatus = when (this?.trim()?.lowercase()) {
+    "covered" -> UpkeepStatus.COVERED
+    "due" -> UpkeepStatus.DUE
+    "paid" -> UpkeepStatus.PAID
+    "delinquent" -> UpkeepStatus.DELINQUENT
+    "frozen" -> UpkeepStatus.FROZEN
+    else -> UpkeepStatus.UNKNOWN
+}
+
+fun TokenDto.toDomain(): Token = Token(
+    tokenId = tokenId.orEmpty(),
+    symbolId = symbolId,
+    creatorSub = creatorSub,
+    name = name.orEmpty(),
+    ticker = ticker.orEmpty(),
+    totalSupply = totalSupply ?: 0L,
+    revenueShareBps = revenueShareBps ?: 0,
+    status = status.toTokenStatus(),
+    createdTs = createdTs ?: 0L,
+    offeredPctBps = offeredPctBps,
+    clearingPrice = clearingPrice,
+)
+
+fun TokenListDto.toDomain(): List<Token> =
+    tokens.orEmpty().map { it.toDomain() }.filter { it.tokenId.isNotBlank() }
+
+fun TokenHolderDto.toDomain(): TokenHolder = TokenHolder(
+    sub = sub.orEmpty(),
+    qty = qty ?: 0L,
+    pctBps = pctBps ?: 0,
+)
+
+fun TokenCapTableDto.toDomain(fallbackId: String): TokenCapTable = TokenCapTable(
+    tokenId = tokenId ?: fallbackId,
+    creatorPctBps = creatorPctBps ?: 0,
+    holders = holders.orEmpty().map { it.toDomain() },
+)
+
+fun TokenBidDto.toDomain(): TokenBid = TokenBid(
+    sub = sub.orEmpty(),
+    qty = qty ?: 0L,
+    limitPrice = limitPrice ?: 0L,
+)
+
+fun TokenAuctionDto.toDomain(fallbackId: String): TokenAuction = TokenAuction(
+    auctionId = auctionId.orEmpty(),
+    tokenId = tokenId ?: fallbackId,
+    offeredPctBps = offeredPctBps ?: 0,
+    reservePrice = reservePrice ?: 0L,
+    status = status.toAuctionStatus(),
+    clearingPrice = clearingPrice,
+    filledQty = filledQty,
+    closeTs = closeTs ?: 0L,
+    bids = bids.orEmpty().map { it.toDomain() },
+)
+
+fun TokenDistributionDto.toDomain(): TokenDistribution = TokenDistribution(
+    ts = ts ?: 0L,
+    totalAmount = totalAmount ?: 0L,
+    perTokenAmount = perTokenAmount ?: 0L,
+    source = source.orEmpty(),
+)
+
+fun TokenRevenueDto.toDomain(fallbackId: String): TokenRevenue = TokenRevenue(
+    tokenId = tokenId ?: fallbackId,
+    myQty = myQty ?: 0L,
+    myPctBps = myPctBps ?: 0,
+    myClaimable = myClaimable ?: 0L,
+    distributions = distributions.orEmpty().map { it.toDomain() },
+)
+
+fun TokenUpkeepDto.toDomain(fallbackId: String): TokenUpkeep = TokenUpkeep(
+    tokenId = tokenId ?: fallbackId,
+    month = month.orEmpty(),
+    feesGenerated = feesGenerated ?: 0L,
+    threshold = threshold ?: 0L,
+    amountDue = amountDue ?: 0L,
+    myShare = myShare ?: 0L,
+    status = status.toUpkeepStatus(),
+)
+
+/** An ack is accepted when the server returns a positive status token (ok/ack/accepted/paid/queued). */
+fun TokenAckDto.toDomain(): TokenAck {
+    val accepted = when (status?.trim()?.lowercase()) {
+        "ok", "ack", "accepted", "paid", "queued", "success" -> true
+        else -> false
+    }
+    return TokenAck(accepted = accepted, message = message)
+}

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokensApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokensApi.kt
@@ -1,0 +1,61 @@
+package com.testlogon.android.data.tokens
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * Retrofit interface for the CREATOR REVENUE-SHARE TOKEN surface (`me/tokens/(all)`).
+ *
+ * Paths are relative (no leading slash) so they resolve against the shared Retrofit base URL; the
+ * core-network interceptor chain attaches the cookie session. All methods are `suspend` and return the
+ * typed DTO body; a non-2xx surfaces as `retrofit2.HttpException`.
+ *
+ * NONE of these endpoints exist on the backend yet. The [TokensRepository] degrades every GET to an
+ * empty-but-honest state on 404/absence and surfaces a clear error on every failed mutation (never a
+ * silent success), so this contract is a forward declaration wired for graceful "pending backend" UX.
+ */
+interface TokensApi {
+
+    @POST("me/tokens")
+    suspend fun mint(@Body body: MintTokenRequestDto): TokenDto
+
+    /** Tokens ISSUED by the caller. */
+    @GET("me/tokens")
+    suspend fun getIssued(): TokenListDto
+
+    /** LISTED tokens to browse (the market). */
+    @GET("me/tokens/market")
+    suspend fun getMarket(): TokenListDto
+
+    @GET("me/tokens/{id}")
+    suspend fun getToken(@Path("id") id: String): TokenDto
+
+    @GET("me/tokens/{id}/captable")
+    suspend fun getCapTable(@Path("id") id: String): TokenCapTableDto
+
+    @POST("me/tokens/{id}/list")
+    suspend fun list(@Path("id") id: String, @Body body: ListTokenRequestDto): TokenAuctionDto
+
+    @GET("me/tokens/{id}/auction")
+    suspend fun getAuction(@Path("id") id: String): TokenAuctionDto
+
+    @POST("me/tokens/{id}/auction/bid")
+    suspend fun placeBid(@Path("id") id: String, @Body body: PlaceBidRequestDto): TokenAckDto
+
+    @POST("me/tokens/{id}/auction/clear")
+    suspend fun clearAuction(@Path("id") id: String): TokenAuctionDto
+
+    @GET("me/tokens/{id}/revenue")
+    suspend fun getRevenue(@Path("id") id: String): TokenRevenueDto
+
+    @POST("me/tokens/{id}/revenue/claim")
+    suspend fun claimRevenue(@Path("id") id: String): TokenAckDto
+
+    @GET("me/tokens/{id}/upkeep")
+    suspend fun getUpkeep(@Path("id") id: String): TokenUpkeepDto
+
+    @POST("me/tokens/{id}/upkeep/pay")
+    suspend fun payUpkeep(@Path("id") id: String): TokenAckDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokensDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokensDataModule.kt
@@ -1,0 +1,36 @@
+package com.testlogon.android.data.tokens
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * Provides the [TokensApi] and binds [TokensRepository] to its impl for the CREATOR REVENUE-SHARE
+ * TOKEN surface. Mirrors the exchange data module: the API is built off the shared Retrofit but pinned
+ * to HTTP/1.1 on its own pool (the cpp h2 edge refuses concurrent streams under polling load).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TokensDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTokensRepository(impl: TokensRepositoryImpl): TokensRepository
+
+    companion object {
+        private fun http1(baseClient: okhttp3.OkHttpClient): okhttp3.OkHttpClient =
+            baseClient.newBuilder()
+                .protocols(listOf(okhttp3.Protocol.HTTP_1_1))
+                .connectionPool(okhttp3.ConnectionPool())
+                .build()
+
+        @Provides
+        @Singleton
+        fun provideTokensApi(retrofit: Retrofit, baseClient: okhttp3.OkHttpClient): TokensApi =
+            retrofit.newBuilder().client(http1(baseClient)).build().create(TokensApi::class.java)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokensRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokensRepository.kt
@@ -1,0 +1,143 @@
+package com.testlogon.android.data.tokens
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer over [TokensApi] for the CREATOR REVENUE-SHARE TOKEN surface.
+ *
+ * The `me/tokens/(all)` endpoints do NOT exist on the backend yet, so every READ DEGRADES to an
+ * empty-but-honest value on 404/HTTP-error (the UI shows an honest "pending backend" / empty state),
+ * while a real transport failure ([ApiResult.NetworkError]) is surfaced so the UI can offer retry.
+ * Every MUTATION passes failures through as [ApiResult.Failure]/[ApiResult.NetworkError] so a 404
+ * (undeployed) surfaces as a clear error and never a silent success.
+ */
+interface TokensRepository {
+    /** Tokens issued by the caller (degrades to empty). */
+    suspend fun issued(): ApiResult<List<Token>>
+
+    /** Listed tokens to browse — the market (degrades to empty). */
+    suspend fun market(): ApiResult<List<Token>>
+
+    /** A single token by id (degrades to null when absent/undeployed). */
+    suspend fun token(id: String): ApiResult<Token?>
+
+    /** Cap table (degrades to an empty table). */
+    suspend fun capTable(id: String): ApiResult<TokenCapTable>
+
+    /** The IPO auction (degrades to null when none / undeployed). */
+    suspend fun auction(id: String): ApiResult<TokenAuction?>
+
+    /** Revenue + my claimable (degrades to a zeroed, empty read). */
+    suspend fun revenue(id: String): ApiResult<TokenRevenue>
+
+    /** Book-upkeep state (degrades to a zeroed, empty read). */
+    suspend fun upkeep(id: String): ApiResult<TokenUpkeep>
+
+    // ---- Mutations (errors surface; never silent success) ----
+    suspend fun mint(name: String, ticker: String, totalSupply: Long, revenueShareBps: Int): ApiResult<Token>
+    suspend fun list(id: String, offeredPctBps: Int, reservePrice: Long, closeTs: Long): ApiResult<TokenAuction>
+    suspend fun placeBid(id: String, qty: Long, limitPrice: Long): ApiResult<TokenAck>
+    suspend fun clearAuction(id: String): ApiResult<TokenAuction>
+    suspend fun claimRevenue(id: String): ApiResult<TokenAck>
+    suspend fun payUpkeep(id: String): ApiResult<TokenAck>
+}
+
+@Singleton
+class TokensRepositoryImpl @Inject constructor(
+    private val api: TokensApi,
+    private val errorParser: ApiErrorParser,
+) : TokensRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun issued(): ApiResult<List<Token>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getIssued().toDomain() }
+    }
+
+    override suspend fun market(): ApiResult<List<Token>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getMarket().toDomain() }
+    }
+
+    override suspend fun token(id: String): ApiResult<Token?> = withContext(io) {
+        degradeToEmpty(null) { api.getToken(id).toDomain() }
+    }
+
+    override suspend fun capTable(id: String): ApiResult<TokenCapTable> = withContext(io) {
+        degradeToEmpty(TokenCapTable(id, 0, emptyList())) { api.getCapTable(id).toDomain(id) }
+    }
+
+    override suspend fun auction(id: String): ApiResult<TokenAuction?> = withContext(io) {
+        degradeToEmpty(null) { api.getAuction(id).toDomain(id) }
+    }
+
+    override suspend fun revenue(id: String): ApiResult<TokenRevenue> = withContext(io) {
+        degradeToEmpty(TokenRevenue(id, 0L, 0, 0L, emptyList())) { api.getRevenue(id).toDomain(id) }
+    }
+
+    override suspend fun upkeep(id: String): ApiResult<TokenUpkeep> = withContext(io) {
+        degradeToEmpty(TokenUpkeep(id, "", 0L, 0L, 0L, 0L, UpkeepStatus.UNKNOWN)) {
+            api.getUpkeep(id).toDomain(id)
+        }
+    }
+
+    override suspend fun mint(
+        name: String,
+        ticker: String,
+        totalSupply: Long,
+        revenueShareBps: Int,
+    ): ApiResult<Token> = withContext(io) {
+        apiCall { api.mint(MintTokenRequestDto(name, ticker, totalSupply, revenueShareBps)).toDomain() }
+    }
+
+    override suspend fun list(
+        id: String,
+        offeredPctBps: Int,
+        reservePrice: Long,
+        closeTs: Long,
+    ): ApiResult<TokenAuction> = withContext(io) {
+        apiCall { api.list(id, ListTokenRequestDto(offeredPctBps, reservePrice, closeTs)).toDomain(id) }
+    }
+
+    override suspend fun placeBid(id: String, qty: Long, limitPrice: Long): ApiResult<TokenAck> =
+        withContext(io) { apiCall { api.placeBid(id, PlaceBidRequestDto(qty, limitPrice)).toDomain() } }
+
+    override suspend fun clearAuction(id: String): ApiResult<TokenAuction> =
+        withContext(io) { apiCall { api.clearAuction(id).toDomain(id) } }
+
+    override suspend fun claimRevenue(id: String): ApiResult<TokenAck> =
+        withContext(io) { apiCall { api.claimRevenue(id).toDomain() } }
+
+    override suspend fun payUpkeep(id: String): ApiResult<TokenAck> =
+        withContext(io) { apiCall { api.payUpkeep(id).toDomain() } }
+
+    /**
+     * Read helper: run [block]; on an HTTP error (the endpoint doesn't exist yet -> 404) DEGRADE to
+     * [empty]; only a transport [ApiResult.NetworkError] is surfaced (so the UI can offer retry).
+     */
+    private suspend fun <T> degradeToEmpty(empty: T, block: suspend () -> T): ApiResult<T> =
+        when (val r = apiCall(block)) {
+            is ApiResult.Success -> r
+            is ApiResult.Failure -> ApiResult.Success(empty)
+            is ApiResult.NetworkError -> r
+        }
+
+    private suspend fun <T> apiCall(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1593,6 +1593,17 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),
+        // Creator revenue-share TOKENS: mint a token (100% supply, $100 fee), browse the listed
+        // market, and manage cap table / revenue / upkeep / IPO auction per token. All reads
+        // degrade-on-404 (the me/tokens/* backend is pending).
+        MoreEntry(
+            id = "tokens",
+            labelRes = R.string.more_entry_tokens,
+            icon = Icons.Outlined.Paid,
+            route = MoreRoutes.TOKENS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
         // Analysis workbench (VIEW-ONLY): historical market-data research — returns / volatility /
         // drawdown / correlation + a fast/slow MA-cross backtest over the md/ history (or recent window).
         MoreEntry(

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailScreen.kt
@@ -1,0 +1,574 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.tokens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.tokens.AuctionStatus
+import com.testlogon.android.data.tokens.Token
+import com.testlogon.android.data.tokens.TokenAuction
+import com.testlogon.android.data.tokens.TokenCapTable
+import com.testlogon.android.data.tokens.TokenRevenue
+import com.testlogon.android.data.tokens.TokenUpkeep
+import com.testlogon.android.data.tokens.UpkeepStatus
+
+/**
+ * Token detail: cap table, revenue (distributions + my claimable + Claim), upkeep (fees-this-month vs
+ * $100 + amount due + my pro-rata share + status incl. FROZEN + Pay + shortfall-assumption label), and
+ * an issuer-only List/IPO launcher + auction panel (bids, place-bid for non-issuers, clearing price,
+ * issuer Clear). Every read degrades to an honest pending/empty state on 404.
+ */
+@Composable
+fun TokenDetailRoute(
+    onBack: () -> Unit,
+    viewModel: TokenDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbar = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(state.actionMessage) {
+        state.actionMessage?.let {
+            snackbar.showSnackbar(it)
+            viewModel.consumeActionMessage()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(state.token?.ticker?.ifBlank { "Token" } ?: "Token") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbar) },
+    ) { padding ->
+        when (state.phase) {
+            TokenDetailUiState.Phase.Loading -> LoadingState(message = "Loading token")
+            TokenDetailUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Something went wrong.",
+                onRetry = viewModel::onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            TokenDetailUiState.Phase.Content -> TokenDetailContent(
+                state = state,
+                modifier = Modifier.padding(padding),
+                onList = viewModel::listIpo,
+                onBid = viewModel::placeBid,
+                onClear = viewModel::clearAuction,
+                onClaim = viewModel::claimRevenue,
+                onPayUpkeep = viewModel::payUpkeep,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TokenDetailContent(
+    state: TokenDetailUiState,
+    modifier: Modifier = Modifier,
+    onList: (offeredPctBps: Int, reservePrice: Long, closeTs: Long) -> Unit,
+    onBid: (qty: Long, limitPrice: Long) -> Unit,
+    onClear: () -> Unit,
+    onClaim: () -> Unit,
+    onPayUpkeep: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        HeaderCard(token = state.token, isIssuer = state.isIssuer)
+        CapTableSection(capTable = state.capTable)
+        RevenueSection(revenue = state.revenue, onClaim = onClaim, inFlight = state.actionInFlight)
+        UpkeepSection(upkeep = state.upkeep, onPay = onPayUpkeep, inFlight = state.actionInFlight)
+        AuctionSection(
+            token = state.token,
+            auction = state.auction,
+            isIssuer = state.isIssuer,
+            inFlight = state.actionInFlight,
+            onList = onList,
+            onBid = onBid,
+            onClear = onClear,
+        )
+        Spacer(Modifier.height(8.dp))
+    }
+}
+
+@Composable
+private fun SectionCard(title: String, content: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(8.dp))
+            content()
+        }
+    }
+}
+
+@Composable
+private fun HeaderCard(token: Token?, isIssuer: Boolean) {
+    SectionCard(title = token?.name?.ifBlank { "Creator token" } ?: "Creator token") {
+        if (token == null) {
+            Text(
+                "This token isn't available yet (backend pending).",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return@SectionCard
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(token.ticker, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.width(8.dp))
+            TokenStatusPill(token.status.label())
+            if (isIssuer) {
+                Spacer(Modifier.width(8.dp))
+                TokenStatusPill("You issued this")
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        TokenKeyValueRow("Total supply", token.totalSupply.toString())
+        TokenKeyValueRow("Revenue share", TokenMath.formatBps(token.revenueShareBps), emphasize = true)
+        token.offeredPctBps?.let { TokenKeyValueRow("Listed slice", TokenMath.formatBps(it)) }
+        token.clearingPrice?.let { TokenKeyValueRow("Clearing price", TokenMath.formatCents(it)) }
+    }
+}
+
+@Composable
+private fun CapTableSection(capTable: TokenCapTable?) {
+    SectionCard(title = "Cap table") {
+        if (capTable == null || (capTable.holders.isEmpty() && capTable.creatorPctBps == 0)) {
+            Text(
+                "No cap-table data yet. On mint the creator holds 100% of supply.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return@SectionCard
+        }
+        TokenKeyValueRow("Creator", TokenMath.formatBps(capTable.creatorPctBps), emphasize = true)
+        if (capTable.holders.isNotEmpty()) {
+            Divider(modifier = Modifier.padding(vertical = 6.dp))
+            capTable.holders.forEach { h ->
+                TokenKeyValueRow(
+                    label = shortSub(h.sub),
+                    value = "${h.qty}  ·  ${TokenMath.formatBps(h.pctBps)}",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RevenueSection(revenue: TokenRevenue?, onClaim: () -> Unit, inFlight: Boolean) {
+    SectionCard(title = "Revenue") {
+        if (revenue == null) {
+            Text(
+                "No revenue data yet (backend pending).",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return@SectionCard
+        }
+        TokenKeyValueRow("My holding", "${revenue.myQty}  ·  ${TokenMath.formatBps(revenue.myPctBps)}")
+        TokenKeyValueRow("My claimable", TokenMath.formatCents(revenue.myClaimable), emphasize = true)
+        Spacer(Modifier.height(8.dp))
+        if (revenue.distributions.isEmpty()) {
+            Text(
+                "No distributions yet. Holders receive pro-rata payouts of the creator's revenue share.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            Text("Distributions", style = MaterialTheme.typography.labelLarge)
+            revenue.distributions.forEach { d ->
+                TokenKeyValueRow(
+                    label = "${d.source.ifBlank { "revenue" }} · ${TokenMath.formatCents(d.perTokenAmount)}/tok",
+                    value = TokenMath.formatCents(d.totalAmount),
+                )
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+        Button(
+            onClick = onClaim,
+            enabled = !inFlight && revenue.myClaimable > 0L,
+            modifier = Modifier.fillMaxWidth().testTag("token_claim"),
+        ) { Text("Claim ${TokenMath.formatCents(revenue.myClaimable)}") }
+    }
+}
+
+@Composable
+private fun UpkeepSection(upkeep: TokenUpkeep?, onPay: () -> Unit, inFlight: Boolean) {
+    var showConfirm by remember { mutableStateOf(false) }
+    SectionCard(title = "Book upkeep") {
+        if (upkeep == null) {
+            Text(
+                "No upkeep data yet (backend pending).",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return@SectionCard
+        }
+        if (upkeep.status == UpkeepStatus.FROZEN) {
+            Surface(
+                color = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                shape = MaterialTheme.shapes.small,
+                modifier = Modifier.fillMaxWidth().testTag("upkeep_frozen_banner"),
+            ) {
+                Text(
+                    "Book FROZEN for non-payment. Pay upkeep to restore trading (reversible).",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(10.dp),
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+        upkeep.month.takeIf { it.isNotBlank() }?.let { TokenKeyValueRow("Month", it) }
+        TokenKeyValueRow("Fees this month", TokenMath.formatCents(upkeep.feesGenerated))
+        TokenKeyValueRow(
+            "Threshold",
+            TokenMath.formatCents(upkeep.threshold.takeIf { it > 0 } ?: TokenMath.UPKEEP_THRESHOLD_CENTS),
+        )
+        TokenKeyValueRow("Amount due (book)", TokenMath.formatCents(upkeep.amountDue), emphasize = true)
+        TokenKeyValueRow("My pro-rata share", TokenMath.formatCents(upkeep.myShare), emphasize = true)
+        TokenKeyValueRow("Status", upkeep.status.label())
+        Spacer(Modifier.height(6.dp))
+        // ASSUMPTION LABEL (flippable later): the charge is modelled as a SHORTFALL top-up, not a flat fee.
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            shape = MaterialTheme.shapes.small,
+            modifier = Modifier.fillMaxWidth().testTag("upkeep_assumption_label"),
+        ) {
+            Text(
+                "Assumption: SHORTFALL model — amountDue = max(0, \$100 − trading fees this month); \$0 once monthly fees ≥ \$100. (Flippable to a flat \$100 later.)",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(10.dp),
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        Button(
+            onClick = { showConfirm = true },
+            enabled = !inFlight && upkeep.myShare > 0L,
+            modifier = Modifier.fillMaxWidth().testTag("upkeep_pay"),
+        ) { Text("Pay my share ${TokenMath.formatCents(upkeep.myShare)}") }
+    }
+
+    if (showConfirm && upkeep != null) {
+        MoneyConfirmDialog(
+            title = "Confirm upkeep payment",
+            lines = listOf(
+                "Action" to "Pay book upkeep (my pro-rata share)",
+                "Month" to upkeep.month.ifBlank { "current" },
+                "My share" to TokenMath.formatCents(upkeep.myShare),
+            ),
+            footnote = "This charges your account ${TokenMath.formatCents(upkeep.myShare)} now.",
+            confirmLabel = "Pay",
+            confirmTag = "upkeep_pay_confirm",
+            onConfirm = { showConfirm = false; onPay() },
+            onDismiss = { showConfirm = false },
+        )
+    }
+}
+
+@Composable
+private fun AuctionSection(
+    token: Token?,
+    auction: TokenAuction?,
+    isIssuer: Boolean,
+    inFlight: Boolean,
+    onList: (Int, Long, Long) -> Unit,
+    onBid: (Long, Long) -> Unit,
+    onClear: () -> Unit,
+) {
+    SectionCard(title = "Listing / IPO") {
+        val totalSupply = token?.totalSupply ?: 0L
+        if (auction == null) {
+            // No auction yet: issuer sees the List launcher; others see a pending note.
+            if (isIssuer) {
+                Text(
+                    "List a slice of supply via a single-clearing-price IPO auction (sealed bids clear at one price).",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(10.dp))
+                ListLauncher(totalSupply = totalSupply, inFlight = inFlight, onList = onList)
+            } else {
+                Text(
+                    "Not listed yet. When the issuer lists, you'll be able to place a sealed IPO bid here.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@SectionCard
+        }
+
+        val offeredQty = TokenMath.bpsToQty(auction.offeredPctBps, totalSupply)
+        TokenKeyValueRow("Status", auction.status.label())
+        TokenKeyValueRow("Offered", "${TokenMath.formatBps(auction.offeredPctBps)}  ($offeredQty tok)")
+        TokenKeyValueRow("Reserve", TokenMath.formatCents(auction.reservePrice))
+        auction.clearingPrice?.let { TokenKeyValueRow("Clearing price", TokenMath.formatCents(it), emphasize = true) }
+        auction.filledQty?.let { TokenKeyValueRow("Filled", "$it tok") }
+
+        // Local single-clearing-price preview computed from the sealed bids (pure TokenMath).
+        val summary = remember(auction.bids, offeredQty, auction.reservePrice) {
+            TokenMath.clearingSummary(auction.bids, offeredQty, auction.reservePrice)
+        }
+        if (auction.status == AuctionStatus.OPEN && auction.bids.isNotEmpty()) {
+            Divider(modifier = Modifier.padding(vertical = 6.dp))
+            Text("Indicative clearing (from ${auction.bids.size} bids)", style = MaterialTheme.typography.labelLarge)
+            TokenKeyValueRow(
+                "Would clear at",
+                summary.clearingPrice?.let { TokenMath.formatCents(it) } ?: "below reserve",
+            )
+            TokenKeyValueRow("Would fill", "${summary.filledQty} tok · ${summary.clearedBids} bids")
+        }
+
+        if (auction.bids.isNotEmpty()) {
+            Divider(modifier = Modifier.padding(vertical = 6.dp))
+            Text("Bids", style = MaterialTheme.typography.labelLarge)
+            auction.bids.forEach { b ->
+                TokenKeyValueRow(shortSub(b.sub), "${b.qty} @ ${TokenMath.formatCents(b.limitPrice)}")
+            }
+        }
+
+        Spacer(Modifier.height(10.dp))
+        if (isIssuer) {
+            if (auction.status == AuctionStatus.OPEN) {
+                IssuerClear(inFlight = inFlight, onClear = onClear)
+            }
+        } else if (auction.status == AuctionStatus.OPEN) {
+            BidPanel(inFlight = inFlight, onBid = onBid)
+        } else {
+            Text(
+                "Auction ${auction.status.label().lowercase()} — bidding closed.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ListLauncher(
+    totalSupply: Long,
+    inFlight: Boolean,
+    onList: (Int, Long, Long) -> Unit,
+) {
+    var pctText by remember { mutableStateOf("20") }
+    var reserveText by remember { mutableStateOf("1.00") }
+    var showConfirm by remember { mutableStateOf(false) }
+
+    val offeredBps = pctText.trim().toDoubleOrNull()?.let { (it * 100).toInt() }?.takeIf { it in 1..10_000 }
+    val reserveCents = reserveText.trim().toDoubleOrNull()?.let { (it * 100).toLong() }?.takeIf { it >= 0 }
+    // Default close: 7 days out (epoch seconds), a stable client default the backend can override.
+    val closeTs = remember { (System.currentTimeMillis() / 1000L) + 7L * 24 * 3600 }
+
+    OutlinedTextField(
+        value = pctText,
+        onValueChange = { pctText = it.filter { c -> c.isDigit() || c == '.' } },
+        label = { Text("Offer % of supply") },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Decimal),
+        modifier = Modifier.fillMaxWidth().testTag("list_pct"),
+    )
+    Spacer(Modifier.height(8.dp))
+    OutlinedTextField(
+        value = reserveText,
+        onValueChange = { reserveText = it.filter { c -> c.isDigit() || c == '.' } },
+        label = { Text("Reserve price ($/token)") },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Decimal),
+        modifier = Modifier.fillMaxWidth().testTag("list_reserve"),
+    )
+    offeredBps?.let {
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "= ${TokenMath.bpsToQty(it, totalSupply)} tokens",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    Spacer(Modifier.height(10.dp))
+    Button(
+        onClick = { showConfirm = true },
+        enabled = !inFlight && offeredBps != null && reserveCents != null,
+        modifier = Modifier.fillMaxWidth().testTag("list_submit"),
+    ) { Text("List IPO") }
+
+    if (showConfirm && offeredBps != null && reserveCents != null) {
+        MoneyConfirmDialog(
+            title = "Confirm IPO listing",
+            lines = listOf(
+                "Offer" to "${TokenMath.formatBps(offeredBps)} (${TokenMath.bpsToQty(offeredBps, totalSupply)} tok)",
+                "Reserve" to TokenMath.formatCents(reserveCents),
+                "Type" to "Single-clearing-price auction",
+            ),
+            footnote = "Sealed bids clear at ONE price; all fills at that price.",
+            confirmLabel = "List",
+            confirmTag = "list_confirm",
+            onConfirm = { showConfirm = false; onList(offeredBps, reserveCents, closeTs) },
+            onDismiss = { showConfirm = false },
+        )
+    }
+}
+
+@Composable
+private fun IssuerClear(inFlight: Boolean, onClear: () -> Unit) {
+    var showConfirm by remember { mutableStateOf(false) }
+    Button(
+        onClick = { showConfirm = true },
+        enabled = !inFlight,
+        modifier = Modifier.fillMaxWidth().testTag("auction_clear"),
+    ) { Text("Clear auction (single price)") }
+
+    if (showConfirm) {
+        MoneyConfirmDialog(
+            title = "Clear the auction?",
+            lines = listOf("Action" to "Clear at the single clearing price"),
+            footnote = "All accepted bids fill at one clearing price. This closes bidding.",
+            confirmLabel = "Clear",
+            confirmTag = "auction_clear_confirm",
+            onConfirm = { showConfirm = false; onClear() },
+            onDismiss = { showConfirm = false },
+        )
+    }
+}
+
+@Composable
+private fun BidPanel(inFlight: Boolean, onBid: (Long, Long) -> Unit) {
+    var qtyText by remember { mutableStateOf("") }
+    var priceText by remember { mutableStateOf("") }
+    var showConfirm by remember { mutableStateOf(false) }
+
+    val qty = qtyText.trim().toLongOrNull()?.takeIf { it > 0 }
+    val priceCents = priceText.trim().toDoubleOrNull()?.let { (it * 100).toLong() }?.takeIf { it > 0 }
+
+    Text("Place a sealed bid", style = MaterialTheme.typography.labelLarge)
+    Spacer(Modifier.height(6.dp))
+    OutlinedTextField(
+        value = qtyText,
+        onValueChange = { qtyText = it.filter { c -> c.isDigit() } },
+        label = { Text("Quantity") },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),
+        modifier = Modifier.fillMaxWidth().testTag("bid_qty"),
+    )
+    Spacer(Modifier.height(8.dp))
+    OutlinedTextField(
+        value = priceText,
+        onValueChange = { priceText = it.filter { c -> c.isDigit() || c == '.' } },
+        label = { Text("Limit price ($/token)") },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Decimal),
+        modifier = Modifier.fillMaxWidth().testTag("bid_price"),
+    )
+    Spacer(Modifier.height(10.dp))
+    OutlinedButton(
+        onClick = { showConfirm = true },
+        enabled = !inFlight && qty != null && priceCents != null,
+        modifier = Modifier.fillMaxWidth().testTag("bid_submit"),
+    ) { Text("Place bid") }
+
+    if (showConfirm && qty != null && priceCents != null) {
+        MoneyConfirmDialog(
+            title = "Confirm bid",
+            lines = listOf(
+                "Quantity" to qty.toString(),
+                "Limit price" to TokenMath.formatCents(priceCents),
+                "Max cost" to TokenMath.formatCents(qty * priceCents),
+            ),
+            footnote = "Sealed bid — you pay the single clearing price if filled (≤ your limit).",
+            confirmLabel = "Place bid",
+            confirmTag = "bid_confirm",
+            onConfirm = { showConfirm = false; onBid(qty, priceCents) },
+            onDismiss = { showConfirm = false },
+        )
+    }
+}
+
+@Composable
+private fun MoneyConfirmDialog(
+    title: String,
+    lines: List<Pair<String, String>>,
+    footnote: String,
+    confirmLabel: String,
+    confirmTag: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column {
+                lines.forEach { (l, v) -> TokenKeyValueRow(l, v) }
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    footnote,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = onConfirm, modifier = Modifier.testTag(confirmTag)) { Text(confirmLabel) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+/** Compact holder id for the cap table / bids (keeps rows readable). */
+private fun shortSub(sub: String): String =
+    if (sub.length <= 10) sub.ifBlank { "—" } else sub.take(6) + "…" + sub.takeLast(4)

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailViewModel.kt
@@ -1,0 +1,157 @@
+package com.testlogon.android.feature.tokens
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.tokens.Token
+import com.testlogon.android.data.tokens.TokenAuction
+import com.testlogon.android.data.tokens.TokenCapTable
+import com.testlogon.android.data.tokens.TokenRevenue
+import com.testlogon.android.data.tokens.TokenUpkeep
+import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.navigation.TokenDetailDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class TokenDetailUiState(
+    val tokenId: String,
+    val phase: Phase = Phase.Loading,
+    val token: Token? = null,
+    val capTable: TokenCapTable? = null,
+    val revenue: TokenRevenue? = null,
+    val upkeep: TokenUpkeep? = null,
+    val auction: TokenAuction? = null,
+    val errorMessage: String? = null,
+    /** True when this token is one the CALLER issued (drives issuer-only List/IPO + Clear affordances). */
+    val isIssuer: Boolean = false,
+    /** A transient one-shot user message (result of a mutation) shown as a snackbar/inline note. */
+    val actionMessage: String? = null,
+    val actionInFlight: Boolean = false,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * Drives the token detail surface (cap table + revenue + upkeep + issuer List/IPO + auction panel).
+ * Every read degrades to an honest empty/pending state on 404; every mutation surfaces a clear result
+ * message (never a silent success), then refreshes the affected reads.
+ */
+@HiltViewModel
+class TokenDetailViewModel @Inject constructor(
+    private val repository: TokensRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val tokenId: String = savedStateHandle.get<String>(TokenDetailDest.ARG_TOKEN_ID).orEmpty()
+
+    private val _uiState = MutableStateFlow(TokenDetailUiState(tokenId = tokenId))
+    val uiState: StateFlow<TokenDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    fun consumeActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+
+    fun load() {
+        _uiState.update { it.copy(phase = TokenDetailUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            val token = repository.token(tokenId)
+            val cap = repository.capTable(tokenId)
+            val rev = repository.revenue(tokenId)
+            val up = repository.upkeep(tokenId)
+            val auc = repository.auction(tokenId)
+            // Issuer check: is this token among the ones the caller issued? Degrades to false on 404.
+            val issued = repository.issued()
+            val isIssuer = (issued as? ApiResult.Success)?.data?.any { it.tokenId == tokenId } == true
+
+            val netError = listOf(token, cap, rev, up, auc).firstOrNull { it is ApiResult.NetworkError }
+            if (netError != null) {
+                _uiState.update {
+                    it.copy(
+                        phase = TokenDetailUiState.Phase.Error,
+                        errorMessage = "No connection. Check your network and retry.",
+                    )
+                }
+                return@launch
+            }
+            _uiState.update {
+                it.copy(
+                    phase = TokenDetailUiState.Phase.Content,
+                    token = (token as? ApiResult.Success)?.data,
+                    capTable = (cap as? ApiResult.Success)?.data,
+                    revenue = (rev as? ApiResult.Success)?.data,
+                    upkeep = (up as? ApiResult.Success)?.data,
+                    auction = (auc as? ApiResult.Success)?.data,
+                    isIssuer = isIssuer,
+                    errorMessage = null,
+                )
+            }
+        }
+    }
+
+    fun listIpo(offeredPctBps: Int, reservePrice: Long, closeTs: Long) = mutate {
+        when (val r = repository.list(tokenId, offeredPctBps, reservePrice, closeTs)) {
+            is ApiResult.Success -> "IPO listed — auction open." to r.data
+            is ApiResult.Failure -> failMsg(r.error.message, "list this token") to null
+            is ApiResult.NetworkError -> "No connection. The token was not listed." to null
+        }
+    }
+
+    fun placeBid(qty: Long, limitPrice: Long) = mutate {
+        when (val r = repository.placeBid(tokenId, qty, limitPrice)) {
+            is ApiResult.Success ->
+                (if (r.data.accepted) "Bid placed." else (r.data.message ?: "Bid not accepted.")) to null
+            is ApiResult.Failure -> failMsg(r.error.message, "place a bid") to null
+            is ApiResult.NetworkError -> "No connection. Your bid was not placed." to null
+        }
+    }
+
+    fun clearAuction() = mutate {
+        when (val r = repository.clearAuction(tokenId)) {
+            is ApiResult.Success -> "Auction cleared." to null
+            is ApiResult.Failure -> failMsg(r.error.message, "clear the auction") to null
+            is ApiResult.NetworkError -> "No connection. The auction was not cleared." to null
+        }
+    }
+
+    fun claimRevenue() = mutate {
+        when (val r = repository.claimRevenue(tokenId)) {
+            is ApiResult.Success ->
+                (if (r.data.accepted) "Revenue claimed." else (r.data.message ?: "Nothing to claim.")) to null
+            is ApiResult.Failure -> failMsg(r.error.message, "claim revenue") to null
+            is ApiResult.NetworkError -> "No connection. Revenue was not claimed." to null
+        }
+    }
+
+    fun payUpkeep() = mutate {
+        when (val r = repository.payUpkeep(tokenId)) {
+            is ApiResult.Success ->
+                (if (r.data.accepted) "Upkeep paid — book unfrozen." else (r.data.message ?: "Upkeep not paid.")) to null
+            is ApiResult.Failure -> failMsg(r.error.message, "pay upkeep") to null
+            is ApiResult.NetworkError -> "No connection. Upkeep was not paid." to null
+        }
+    }
+
+    private fun failMsg(server: String, action: String): String =
+        server.ifBlank { "Couldn't $action (backend pending)." }
+
+    /** Runs a mutation [block] that returns (message, ignored); posts the message + refreshes reads. */
+    private fun mutate(block: suspend () -> Pair<String, Any?>) {
+        if (_uiState.value.actionInFlight) return
+        _uiState.update { it.copy(actionInFlight = true) }
+        viewModelScope.launch {
+            val (msg, _) = block()
+            _uiState.update { it.copy(actionInFlight = false, actionMessage = msg) }
+            load()
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenMath.kt
@@ -1,0 +1,125 @@
+package com.testlogon.android.feature.tokens
+
+import com.testlogon.android.data.tokens.TokenBid
+
+/**
+ * Pure, side-effect-free math for the CREATOR REVENUE-SHARE TOKEN surface. Extracted so the tricky
+ * bits (pro-rata upkeep share, pct_bps <-> qty, single-clearing-price summary) are unit-testable off
+ * the Android runtime. All amounts are integer CENTS; `Bps` are basis points (10_000 bps = 100%).
+ *
+ * The book-upkeep charge is modelled as a SHORTFALL top-up (see [upkeepAmountDue]): a flat $100/month
+ * is offset by trading fees already generated that month. This shortfall-vs-flat choice is an
+ * ASSUMPTION surfaced in the UI (see the Upkeep section label) so it can be flipped to a flat charge
+ * later without touching the rest of the surface.
+ */
+object TokenMath {
+
+    /** Basis points denominator: 10_000 bps == 100%. */
+    const val BPS_DENOM: Int = 10_000
+
+    /** The flat monthly book-upkeep threshold in cents ($100.00). */
+    const val UPKEEP_THRESHOLD_CENTS: Long = 100_00L
+
+    /** The one-time token creation fee in cents ($100.00). */
+    const val CREATION_FEE_CENTS: Long = 100_00L
+
+    /**
+     * The shortfall the book still owes this month: `max(0, threshold - feesGenerated)`. Zero once the
+     * month's trading fees already meet/exceed the threshold. Negative inputs are clamped to zero.
+     */
+    fun upkeepAmountDue(feesGeneratedCents: Long, thresholdCents: Long = UPKEEP_THRESHOLD_CENTS): Long {
+        val fees = feesGeneratedCents.coerceAtLeast(0L)
+        val threshold = thresholdCents.coerceAtLeast(0L)
+        return (threshold - fees).coerceAtLeast(0L)
+    }
+
+    /**
+     * A single holder's PRO-RATA share of an [amountDueCents] charge, by their holding fraction
+     * `myQty / totalSupply`. Rounded to the nearest cent (half-up). Guards divide-by-zero (0 supply or
+     * 0 qty -> 0) and never exceeds [amountDueCents]. Uses Long arithmetic (no Double drift on cents).
+     */
+    fun proRataShare(amountDueCents: Long, myQty: Long, totalSupply: Long): Long {
+        if (amountDueCents <= 0L || myQty <= 0L || totalSupply <= 0L) return 0L
+        val q = myQty.coerceAtMost(totalSupply)
+        // round(amountDue * q / total) via integer half-up: (a*q + total/2) / total
+        val share = (amountDueCents * q + totalSupply / 2) / totalSupply
+        return share.coerceIn(0L, amountDueCents)
+    }
+
+    /** Ownership fraction (of total supply) expressed in basis points. 0 supply -> 0. */
+    fun qtyToBps(qty: Long, totalSupply: Long): Int {
+        if (qty <= 0L || totalSupply <= 0L) return 0
+        val q = qty.coerceAtMost(totalSupply)
+        return ((q * BPS_DENOM + totalSupply / 2) / totalSupply).toInt().coerceIn(0, BPS_DENOM)
+    }
+
+    /** The token quantity a [pctBps] slice of [totalSupply] represents (floor). Negatives clamp to 0. */
+    fun bpsToQty(pctBps: Int, totalSupply: Long): Long {
+        if (pctBps <= 0 || totalSupply <= 0L) return 0L
+        val bps = pctBps.coerceAtMost(BPS_DENOM)
+        return (totalSupply * bps) / BPS_DENOM
+    }
+
+    /** Human label for a basis-points value, e.g. 2500 -> "25.00%", 10000 -> "100.00%". */
+    fun formatBps(bps: Int): String = String.format("%.2f%%", bps.coerceAtLeast(0) / 100.0)
+
+    /** Format integer cents as a dollar string, e.g. 10000 -> "$100.00". */
+    fun formatCents(cents: Long): String {
+        val sign = if (cents < 0) "-" else ""
+        val abs = kotlin.math.abs(cents)
+        return "$sign$" + String.format("%,d.%02d", abs / 100, abs % 100)
+    }
+
+    /**
+     * Summary of a single-clearing-price IPO auction over sealed [bids] for [offeredQty] tokens.
+     *
+     * Bids are filled highest-limit-first; the CLEARING PRICE is the lowest accepted bid's limit (the
+     * price the marginal filled bid is willing to pay), and ALL fills execute at that one price. A bid
+     * only clears if its limit >= [reservePrice]. If demand at/above reserve is below [offeredQty], the
+     * whole eligible demand clears (partial book); [clearingPrice] is null when nothing clears.
+     */
+    fun clearingSummary(
+        bids: List<TokenBid>,
+        offeredQty: Long,
+        reservePrice: Long,
+    ): ClearingSummary {
+        if (offeredQty <= 0L) return ClearingSummary(clearingPrice = null, filledQty = 0L, clearedBids = 0)
+        val eligible = bids
+            .filter { it.qty > 0L && it.limitPrice >= reservePrice }
+            .sortedWith(compareByDescending<TokenBid> { it.limitPrice }.thenByDescending { it.qty })
+        if (eligible.isEmpty()) return ClearingSummary(clearingPrice = null, filledQty = 0L, clearedBids = 0)
+
+        var remaining = offeredQty
+        var filled = 0L
+        var clearedBids = 0
+        var lastAcceptedPrice = 0L
+        for (bid in eligible) {
+            if (remaining <= 0L) break
+            val take = bid.qty.coerceAtMost(remaining)
+            if (take <= 0L) break
+            filled += take
+            remaining -= take
+            clearedBids += 1
+            lastAcceptedPrice = bid.limitPrice
+        }
+        return ClearingSummary(
+            clearingPrice = lastAcceptedPrice,
+            filledQty = filled,
+            clearedBids = clearedBids,
+        )
+    }
+
+    /** Total demand in cents for a set of [bids] at their own limit prices (for a "demand" read-out). */
+    fun totalDemandCents(bids: List<TokenBid>): Long =
+        bids.filter { it.qty > 0L && it.limitPrice > 0L }.sumOf { it.qty * it.limitPrice }
+
+    /**
+     * Result of [clearingSummary]: the single [clearingPrice] every fill executes at (null when nothing
+     * clears), the total [filledQty], and how many [clearedBids] were (fully or partially) filled.
+     */
+    data class ClearingSummary(
+        val clearingPrice: Long?,
+        val filledQty: Long,
+        val clearedBids: Int,
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenMintScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenMintScreen.kt
@@ -1,0 +1,208 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.tokens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Mint a creator revenue-share token: name / ticker / supply / revenue-share %. The creator holds
+ * 100% of supply on mint. Submitting arms a "$100 creation fee" money-safety CONFIRM (mirrors the
+ * trade-ticket deposit confirm) before the server-charged mint call. On success the route opens the
+ * new token's detail.
+ */
+@Composable
+fun TokenMintRoute(
+    onBack: () -> Unit,
+    onMinted: (tokenId: String) -> Unit,
+    viewModel: TokenMintViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var showFeeConfirm by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.mintedTokenId) {
+        state.mintedTokenId?.let { id ->
+            viewModel.consumeMinted()
+            onMinted(id)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Mint creator token") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(
+                "Tokenize your revenue share. You hold 100% of supply on mint; you can list a slice later via a single-clearing-price IPO.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(16.dp))
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = viewModel::onName,
+                label = { Text("Token name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().testTag("mint_name"),
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = state.ticker,
+                onValueChange = viewModel::onTicker,
+                label = { Text("Ticker") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().testTag("mint_ticker"),
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = state.supplyText,
+                onValueChange = viewModel::onSupply,
+                label = { Text("Total supply") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth().testTag("mint_supply"),
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = state.revenueSharePctText,
+                onValueChange = viewModel::onRevenueShare,
+                label = { Text("Revenue share %") },
+                supportingText = {
+                    Text(
+                        "Holders receive pro-rata distributions of this % of your ongoing content revenue.",
+                    )
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth().testTag("mint_revenue_share"),
+            )
+            Spacer(Modifier.height(16.dp))
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(14.dp)) {
+                    Text("Creation fee", style = MaterialTheme.typography.labelLarge)
+                    Text(
+                        TokenMath.formatCents(TokenMath.CREATION_FEE_CENTS),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        "Charged once when you mint. You'll confirm before we charge.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            state.errorMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.testTag("mint_error"),
+                )
+            }
+            Spacer(Modifier.height(20.dp))
+            Button(
+                onClick = { showFeeConfirm = true },
+                enabled = state.canSubmit,
+                modifier = Modifier.fillMaxWidth().testTag("mint_submit"),
+            ) {
+                if (state.submitting) {
+                    CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
+                } else {
+                    Text("Mint token")
+                }
+            }
+        }
+    }
+
+    if (showFeeConfirm) {
+        AlertDialog(
+            onDismissRequest = { showFeeConfirm = false },
+            title = { Text("Confirm creation fee") },
+            text = {
+                Column {
+                    TokenKeyValueRow("Action", "Mint creator token")
+                    TokenKeyValueRow("Name", state.name)
+                    TokenKeyValueRow("Ticker", state.ticker)
+                    TokenKeyValueRow("Total supply", state.supplyText.ifBlank { "0" })
+                    TokenKeyValueRow(
+                        "Revenue share",
+                        state.revenueShareBps?.let { TokenMath.formatBps(it) } ?: "—",
+                    )
+                    TokenKeyValueRow(
+                        "Creation fee",
+                        TokenMath.formatCents(TokenMath.CREATION_FEE_CENTS),
+                        emphasize = true,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "This charges your account ${TokenMath.formatCents(TokenMath.CREATION_FEE_CENTS)} now.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showFeeConfirm = false
+                        viewModel.confirmMint()
+                    },
+                    modifier = Modifier.testTag("mint_fee_confirm"),
+                ) { Text("Pay & mint") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showFeeConfirm = false }) { Text("Cancel") }
+            },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenMintViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenMintViewModel.kt
@@ -1,0 +1,93 @@
+package com.testlogon.android.feature.tokens
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.tokens.Token
+import com.testlogon.android.data.tokens.TokensRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class TokenMintUiState(
+    val name: String = "",
+    val ticker: String = "",
+    val supplyText: String = "1000000",
+    val revenueSharePctText: String = "10",
+    val submitting: Boolean = false,
+    val errorMessage: String? = null,
+    val mintedTokenId: String? = null,
+) {
+    /** Parsed supply, or null when blank/invalid. */
+    val supply: Long? get() = supplyText.trim().toLongOrNull()?.takeIf { it > 0 }
+
+    /** Revenue-share basis points parsed from a percent field (e.g. "10" -> 1000 bps). Null when invalid. */
+    val revenueShareBps: Int?
+        get() {
+            val pct = revenueSharePctText.trim().toDoubleOrNull() ?: return null
+            if (pct < 0.0 || pct > 100.0) return null
+            return (pct * 100.0).toInt()
+        }
+
+    val canSubmit: Boolean
+        get() = name.isNotBlank() &&
+            ticker.isNotBlank() &&
+            supply != null &&
+            revenueShareBps != null &&
+            !submitting
+}
+
+/**
+ * Drives the Mint form. The creator sets name/ticker/supply/revenue-share %; the SERVER charges the
+ * $100 creation fee on [mint] (the UI gates the call behind a money-safety confirm). On success the
+ * new token id is emitted so the route can navigate to detail. A 404 (undeployed backend) surfaces as
+ * a clear error — never a silent success.
+ */
+@HiltViewModel
+class TokenMintViewModel @Inject constructor(
+    private val repository: TokensRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TokenMintUiState())
+    val uiState: StateFlow<TokenMintUiState> = _uiState.asStateFlow()
+
+    fun onName(v: String) = _uiState.update { it.copy(name = v, errorMessage = null) }
+    fun onTicker(v: String) = _uiState.update { it.copy(ticker = v.uppercase().take(8), errorMessage = null) }
+    fun onSupply(v: String) = _uiState.update { it.copy(supplyText = v.filter { c -> c.isDigit() }, errorMessage = null) }
+    fun onRevenueShare(v: String) =
+        _uiState.update { it.copy(revenueSharePctText = v.filter { c -> c.isDigit() || c == '.' }, errorMessage = null) }
+
+    fun consumeMinted() = _uiState.update { it.copy(mintedTokenId = null) }
+
+    /** Called AFTER the $100 creation-fee confirm is accepted. */
+    fun confirmMint() {
+        val s = _uiState.value
+        val supply = s.supply
+        val bps = s.revenueShareBps
+        if (supply == null || bps == null || s.name.isBlank() || s.ticker.isBlank()) {
+            _uiState.update { it.copy(errorMessage = "Fill in every field with valid values.") }
+            return
+        }
+        _uiState.update { it.copy(submitting = true, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.mint(s.name.trim(), s.ticker.trim(), supply, bps)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(submitting = false, mintedTokenId = r.data.tokenId.ifBlank { null }, errorMessage = null)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = mintError(r.error.message))
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = "No connection. Your token was not minted.")
+                }
+            }
+        }
+    }
+
+    private fun mintError(serverMessage: String): String =
+        serverMessage.ifBlank { "Minting isn't available yet (backend pending). Your token was not minted." }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenUi.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenUi.kt
@@ -1,0 +1,83 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.tokens
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.testlogon.android.data.tokens.AuctionStatus
+import com.testlogon.android.data.tokens.TokenStatus
+import com.testlogon.android.data.tokens.UpkeepStatus
+
+/** Human label for a token lifecycle status. */
+fun TokenStatus.label(): String = when (this) {
+    TokenStatus.DRAFT -> "Draft"
+    TokenStatus.MINTED -> "Minted"
+    TokenStatus.LISTED -> "Listed"
+    TokenStatus.FROZEN -> "Frozen"
+    TokenStatus.DELISTED -> "Delisted"
+    TokenStatus.UNKNOWN -> "—"
+}
+
+fun AuctionStatus.label(): String = when (this) {
+    AuctionStatus.OPEN -> "Open"
+    AuctionStatus.CLEARED -> "Cleared"
+    AuctionStatus.CANCELLED -> "Cancelled"
+    AuctionStatus.UNKNOWN -> "—"
+}
+
+fun UpkeepStatus.label(): String = when (this) {
+    UpkeepStatus.COVERED -> "Covered"
+    UpkeepStatus.DUE -> "Due"
+    UpkeepStatus.PAID -> "Paid"
+    UpkeepStatus.DELINQUENT -> "Delinquent"
+    UpkeepStatus.FROZEN -> "FROZEN"
+    UpkeepStatus.UNKNOWN -> "—"
+}
+
+/** A label/value row used across the token detail sections and confirm dialogs. */
+@Composable
+fun TokenKeyValueRow(label: String, value: String, emphasize: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal,
+            color = if (emphasize) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+/** A small pill that renders a status string. */
+@Composable
+fun TokenStatusPill(text: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketScreen.kt
@@ -1,0 +1,184 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.tokens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.tokens.Token
+
+/**
+ * Creator revenue-share TOKEN market/browse list. Two tabs: the LISTED market (browse) and the
+ * caller's ISSUED tokens. A row taps through to detail; a FAB opens Mint. Every read degrades to an
+ * honest empty state when the (not-yet-built) backend 404s.
+ */
+@Composable
+fun TokensMarketRoute(
+    onBack: () -> Unit,
+    onOpenToken: (tokenId: String) -> Unit,
+    onMint: () -> Unit,
+    viewModel: TokensMarketViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Creator Tokens") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = onMint,
+                icon = { Icon(Icons.Filled.Add, contentDescription = null) },
+                text = { Text("Mint") },
+                modifier = Modifier.testTag("tokens_mint_fab"),
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TabRow(selectedTabIndex = if (state.tab == TokenListTab.MARKET) 0 else 1) {
+                Tab(
+                    selected = state.tab == TokenListTab.MARKET,
+                    onClick = { viewModel.selectTab(TokenListTab.MARKET) },
+                    text = { Text("Market (${state.market.size})") },
+                    modifier = Modifier.testTag("tokens_tab_market"),
+                )
+                Tab(
+                    selected = state.tab == TokenListTab.ISSUED,
+                    onClick = { viewModel.selectTab(TokenListTab.ISSUED) },
+                    text = { Text("My tokens (${state.issued.size})") },
+                    modifier = Modifier.testTag("tokens_tab_issued"),
+                )
+            }
+            Box(modifier = Modifier.fillMaxSize()) {
+                when (state.phase) {
+                    TokensMarketUiState.Phase.Loading -> LoadingState(message = "Loading tokens")
+                    TokensMarketUiState.Phase.Error -> ErrorState(
+                        message = state.errorMessage ?: "Something went wrong.",
+                        onRetry = viewModel::onRetry,
+                    )
+                    TokensMarketUiState.Phase.Content ->
+                        if (state.rows.isEmpty()) {
+                            EmptyState(
+                                title = if (state.tab == TokenListTab.MARKET) "No listed tokens" else "No tokens yet",
+                                body = if (state.tab == TokenListTab.MARKET) {
+                                    "No creator tokens are listed yet. Check back once creators list their revenue-share tokens."
+                                } else {
+                                    "You haven't minted a creator token yet. Tap Mint to tokenize your revenue share."
+                                },
+                            )
+                        } else {
+                            TokenList(rows = state.rows, onOpenToken = onOpenToken)
+                        }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TokenList(rows: List<Token>, onOpenToken: (String) -> Unit) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().testTag("tokens_list"),
+        contentPadding = PaddingValues(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(rows, key = { it.tokenId }) { token ->
+            TokenRowCard(token = token, onClick = { onOpenToken(token.tokenId) })
+        }
+    }
+}
+
+@Composable
+private fun TokenRowCard(token: Token, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .testTag("token_row_${token.tokenId}"),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = token.ticker.ifBlank { "—" },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    TokenStatusPill(text = token.status.label())
+                }
+                Text(
+                    text = token.name.ifBlank { "Unnamed token" },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "Revenue share ${TokenMath.formatBps(token.revenueShareBps)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = token.clearingPrice?.let { TokenMath.formatCents(it) } ?: "—",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "price",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+    Spacer(Modifier.height(0.dp))
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketViewModel.kt
@@ -1,0 +1,79 @@
+package com.testlogon.android.feature.tokens
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.tokens.Token
+import com.testlogon.android.data.tokens.TokensRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** Which slice of the token list is shown. */
+enum class TokenListTab { MARKET, ISSUED }
+
+data class TokensMarketUiState(
+    val phase: Phase = Phase.Loading,
+    val tab: TokenListTab = TokenListTab.MARKET,
+    val market: List<Token> = emptyList(),
+    val issued: List<Token> = emptyList(),
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+
+    val rows: List<Token> get() = if (tab == TokenListTab.MARKET) market else issued
+}
+
+/**
+ * Drives the token market/browse list. Loads both the LISTED market (browse) and the caller's ISSUED
+ * tokens; both degrade to empty on 404 so the screen shows an honest "pending backend" empty state
+ * rather than an error when the endpoints are undeployed.
+ */
+@HiltViewModel
+class TokensMarketViewModel @Inject constructor(
+    private val repository: TokensRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TokensMarketUiState())
+    val uiState: StateFlow<TokensMarketUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    fun selectTab(tab: TokenListTab) = _uiState.update { it.copy(tab = tab) }
+
+    fun load() {
+        _uiState.update { it.copy(phase = TokensMarketUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            val market = repository.market()
+            val issued = repository.issued()
+            // A transport failure (offline) on EITHER read -> Error with retry; HTTP 404s already
+            // degraded to empty inside the repository.
+            val netError = (market as? ApiResult.NetworkError) ?: (issued as? ApiResult.NetworkError)
+            if (netError != null) {
+                _uiState.update {
+                    it.copy(
+                        phase = TokensMarketUiState.Phase.Error,
+                        errorMessage = "No connection. Check your network and retry.",
+                    )
+                }
+                return@launch
+            }
+            _uiState.update {
+                it.copy(
+                    phase = TokensMarketUiState.Phase.Content,
+                    market = (market as? ApiResult.Success)?.data.orEmpty(),
+                    issued = (issued as? ApiResult.Success)?.data.orEmpty(),
+                    errorMessage = null,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -304,6 +304,9 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         adminDashboardDestination(navController)
         // Markets (exchange market-data, VIEW-ONLY): instrument list + per-symbol chart/book/tape.
         marketsDestinations(navController)
+        // Creator revenue-share TOKENS: mint + browse market + per-token detail (cap table /
+        // revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
+        tokensDestinations(navController)
         // Global search (symbols + trading destinations quick-jump); reached from the Markets header + More hub.
         globalSearchDestination(navController)
         // B5 admin queues (moderation board + video review + DMCA claims).

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -377,6 +377,10 @@ object MoreRoutes {
     // Markets (exchange market-data, VIEW-ONLY): instrument list -> per-symbol chart/book/tape.
     const val MARKETS = MarketsDest.ROUTE
 
+    // Creator revenue-share TOKENS: mint a token, browse the listed market, per-token detail
+    // (cap table / revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
+    const val TOKENS = TokensMarketDest.ROUTE
+
     // Analysis workbench: historical market-data research (stats / correlation / MA-cross backtest).
     const val ANALYSIS = AnalysisDest.ROUTE
 
@@ -669,6 +673,7 @@ object MoreRoutes {
             WEBHOOKS,
             ADMIN_DASHBOARD,
             MARKETS,
+            TOKENS,
             ANALYSIS,
             GLOBAL_SEARCH,
             TRADING_ALERTS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/TokensNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/TokensNavigation.kt
@@ -1,0 +1,64 @@
+package com.testlogon.android.navigation
+
+import android.net.Uri
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.feature.tokens.TokenDetailRoute
+import com.testlogon.android.feature.tokens.TokenMintRoute
+import com.testlogon.android.feature.tokens.TokensMarketRoute
+
+/**
+ * CREATOR REVENUE-SHARE TOKEN destinations, registered in the AUTHENTICATED nav graph.
+ *
+ * [TokensMarketDest] is the browse/market list (the navigable hub entry); [TokenMintDest] is the mint
+ * form; [TokenDetailDest] is the per-token detail addressed by the token id. All read surfaces degrade
+ * to honest empty/pending states when the (not-yet-built) `me/tokens/(all)` backend 404s.
+ */
+data object TokensMarketDest {
+    const val ROUTE = "tokens"
+}
+
+data object TokenMintDest {
+    const val ROUTE = "tokens/mint"
+}
+
+data object TokenDetailDest {
+    const val ROUTE = "tokens/detail/{tokenId}"
+    const val ARG_TOKEN_ID = "tokenId"
+
+    fun build(tokenId: String): String = "tokens/detail/${Uri.encode(tokenId)}"
+}
+
+/** Registers the token market + mint + detail destinations (Back pops the back stack). */
+fun NavGraphBuilder.tokensDestinations(navController: NavHostController) {
+    composable(TokensMarketDest.ROUTE) {
+        TokensMarketRoute(
+            onBack = { navController.popBackStack() },
+            onOpenToken = { tokenId ->
+                navController.navigate(TokenDetailDest.build(tokenId)) { launchSingleTop = true }
+            },
+            onMint = { navController.navigate(TokenMintDest.ROUTE) { launchSingleTop = true } },
+        )
+    }
+    composable(TokenMintDest.ROUTE) {
+        TokenMintRoute(
+            onBack = { navController.popBackStack() },
+            onMinted = { tokenId ->
+                // Replace Mint with the new token's detail so Back returns to the market list.
+                navController.navigate(TokenDetailDest.build(tokenId)) {
+                    launchSingleTop = true
+                    popUpTo(TokenMintDest.ROUTE) { inclusive = true }
+                }
+            },
+        )
+    }
+    composable(
+        route = TokenDetailDest.ROUTE,
+        arguments = listOf(navArgument(TokenDetailDest.ARG_TOKEN_ID) { type = NavType.StringType }),
+    ) {
+        TokenDetailRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4285,6 +4285,7 @@
     <string name="more_entry_global_search">Search</string>
     <string name="more_entry_markets">Markets</string>
     <string name="more_entry_analysis">Analysis</string>
+    <string name="more_entry_tokens">Creator Tokens</string>
     <string name="more_entry_trading_alerts">Trading alerts</string>
     <string name="admin_dashboard_title">Admin alerts</string>
     <string name="admin_dashboard_back">Back</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/tokens/TokenMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/tokens/TokenMathTest.kt
@@ -1,0 +1,143 @@
+package com.testlogon.android.feature.tokens
+
+import com.testlogon.android.data.tokens.TokenBid
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [TokenMath] — the pure math backing the creator revenue-share token surface:
+ * shortfall upkeep, pro-rata upkeep share, pct_bps <-> qty, and the single-clearing-price summary.
+ */
+class TokenMathTest {
+
+    // ---- upkeepAmountDue (shortfall model) ----
+
+    @Test
+    fun upkeep_shortfall_whenNoFees_isFullThreshold() {
+        assertEquals(100_00L, TokenMath.upkeepAmountDue(feesGeneratedCents = 0L))
+    }
+
+    @Test
+    fun upkeep_shortfall_isThresholdMinusFees() {
+        assertEquals(40_00L, TokenMath.upkeepAmountDue(feesGeneratedCents = 60_00L))
+    }
+
+    @Test
+    fun upkeep_shortfall_isZero_whenFeesMeetOrExceedThreshold() {
+        assertEquals(0L, TokenMath.upkeepAmountDue(feesGeneratedCents = 100_00L))
+        assertEquals(0L, TokenMath.upkeepAmountDue(feesGeneratedCents = 250_00L))
+    }
+
+    @Test
+    fun upkeep_negativeFees_clampToFullThreshold() {
+        assertEquals(100_00L, TokenMath.upkeepAmountDue(feesGeneratedCents = -5_00L))
+    }
+
+    // ---- proRataShare ----
+
+    @Test
+    fun proRata_halfHolding_isHalfCharge() {
+        assertEquals(50_00L, TokenMath.proRataShare(amountDueCents = 100_00L, myQty = 500L, totalSupply = 1000L))
+    }
+
+    @Test
+    fun proRata_roundsHalfUp() {
+        // 100_00 * 1 / 3 = 3333.33 -> 3333
+        assertEquals(3333L, TokenMath.proRataShare(amountDueCents = 100_00L, myQty = 1L, totalSupply = 3L))
+    }
+
+    @Test
+    fun proRata_zeroSupplyOrQty_isZero() {
+        assertEquals(0L, TokenMath.proRataShare(100_00L, myQty = 0L, totalSupply = 1000L))
+        assertEquals(0L, TokenMath.proRataShare(100_00L, myQty = 100L, totalSupply = 0L))
+    }
+
+    @Test
+    fun proRata_neverExceedsAmountDue() {
+        assertEquals(100_00L, TokenMath.proRataShare(100_00L, myQty = 5000L, totalSupply = 1000L))
+    }
+
+    // ---- pct_bps <-> qty ----
+
+    @Test
+    fun qtyToBps_quarterHolding_is2500bps() {
+        assertEquals(2500, TokenMath.qtyToBps(qty = 250L, totalSupply = 1000L))
+    }
+
+    @Test
+    fun bpsToQty_roundtripsCleanPercents() {
+        assertEquals(200L, TokenMath.bpsToQty(pctBps = 2000, totalSupply = 1000L))
+        assertEquals(1000L, TokenMath.bpsToQty(pctBps = 10_000, totalSupply = 1000L))
+        assertEquals(0L, TokenMath.bpsToQty(pctBps = 0, totalSupply = 1000L))
+    }
+
+    // ---- clearingSummary (single clearing price) ----
+
+    @Test
+    fun clearing_singlePrice_isLowestAcceptedBid() {
+        val bids = listOf(
+            TokenBid(sub = "a", qty = 100L, limitPrice = 300L),
+            TokenBid(sub = "b", qty = 100L, limitPrice = 200L),
+            TokenBid(sub = "c", qty = 100L, limitPrice = 150L), // marginal filled
+        )
+        val s = TokenMath.clearingSummary(bids, offeredQty = 300L, reservePrice = 100L)
+        assertEquals(150L, s.clearingPrice)
+        assertEquals(300L, s.filledQty)
+        assertEquals(3, s.clearedBids)
+    }
+
+    @Test
+    fun clearing_excessDemand_fillsHighestBidsOnly() {
+        val bids = listOf(
+            TokenBid(sub = "a", qty = 100L, limitPrice = 500L),
+            TokenBid(sub = "b", qty = 100L, limitPrice = 400L),
+            TokenBid(sub = "c", qty = 100L, limitPrice = 300L), // not reached
+        )
+        val s = TokenMath.clearingSummary(bids, offeredQty = 200L, reservePrice = 100L)
+        assertEquals(400L, s.clearingPrice) // lowest of the two filled
+        assertEquals(200L, s.filledQty)
+        assertEquals(2, s.clearedBids)
+    }
+
+    @Test
+    fun clearing_belowReserve_isExcluded() {
+        val bids = listOf(
+            TokenBid(sub = "a", qty = 100L, limitPrice = 90L), // below reserve
+            TokenBid(sub = "b", qty = 100L, limitPrice = 250L),
+        )
+        val s = TokenMath.clearingSummary(bids, offeredQty = 300L, reservePrice = 100L)
+        assertEquals(250L, s.clearingPrice)
+        assertEquals(100L, s.filledQty)
+        assertEquals(1, s.clearedBids)
+    }
+
+    @Test
+    fun clearing_noEligibleBids_clearsNothing() {
+        val bids = listOf(TokenBid(sub = "a", qty = 100L, limitPrice = 50L))
+        val s = TokenMath.clearingSummary(bids, offeredQty = 100L, reservePrice = 100L)
+        assertNull(s.clearingPrice)
+        assertEquals(0L, s.filledQty)
+        assertEquals(0, s.clearedBids)
+    }
+
+    @Test
+    fun clearing_partialLastBid_countsAndCaps() {
+        val bids = listOf(
+            TokenBid(sub = "a", qty = 100L, limitPrice = 300L),
+            TokenBid(sub = "b", qty = 100L, limitPrice = 200L), // only 50 of 100 taken
+        )
+        val s = TokenMath.clearingSummary(bids, offeredQty = 150L, reservePrice = 100L)
+        assertEquals(200L, s.clearingPrice)
+        assertEquals(150L, s.filledQty)
+        assertEquals(2, s.clearedBids)
+    }
+
+    @Test
+    fun formatting_centsAndBps() {
+        assertEquals("$100.00", TokenMath.formatCents(100_00L))
+        assertEquals("$1,234.56", TokenMath.formatCents(123456L))
+        assertEquals("10.00%", TokenMath.formatBps(1000))
+        assertEquals("100.00%", TokenMath.formatBps(10_000))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,9 @@ const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
 const HomePage = lazy(() => import("@/pages/home/HomePage"));
 const MarketsPage = lazy(() => import("@/pages/markets/MarketsPage"));
 const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
+const TokenMarketPage = lazy(() => import("@/pages/tokens/TokenMarketPage"));
+const MintTokenPage = lazy(() => import("@/pages/tokens/MintTokenPage"));
+const TokenDetailPage = lazy(() => import("@/pages/tokens/TokenDetailPage"));
 const MarketAnalysisPage = lazy(() => import("@/pages/analysis/MarketAnalysisPage"));
 const PaperTradingPage = lazy(() => import("@/pages/paper/PaperTradingPage"));
 const PriceAlertsPage = lazy(() => import("@/pages/alerts/PriceAlertsPage"));
@@ -745,6 +748,9 @@ export default function App() {
           <Route path="home" element={<HomePage />} />
           <Route path="markets" element={<MarketsPage />} />
           <Route path="markets/:symbolId" element={<SymbolDetailPage />} />
+          <Route path="tokens" element={<TokenMarketPage />} />
+          <Route path="tokens/new" element={<MintTokenPage />} />
+          <Route path="tokens/:id" element={<TokenDetailPage />} />
           <Route path="analysis" element={<MarketAnalysisPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />
           <Route path="paper" element={<PaperTradingPage />} />

--- a/frontend/src/api/endpoints/tokens.ts
+++ b/frontend/src/api/endpoints/tokens.ts
@@ -1,0 +1,215 @@
+import { api } from "@/api/client";
+
+/**
+ * CREATOR REVENUE-SHARE TOKEN surface (`/me/tokens/*`).
+ *
+ * A content-selling creator tokenizes their revenue share into a tradeable coin:
+ *  - MINT: create a token, hold 100% of supply, pay a $100 creation fee. The
+ *    token is a REAL revenue-share claim — holders receive PRO-RATA distributions
+ *    of `revenue_share_bps` of the creator's ongoing content revenue.
+ *  - LIST (IPO): sell N% via a single-clearing-price sealed-bid auction (one
+ *    clearing price, all fills at that price); after clearing it trades on a
+ *    continuous book (that book plugs into the existing trade surfaces later).
+ *  - UPKEEP: $100/month to keep the book tradeable, charged to holders pro-rata
+ *    by holding as a SHORTFALL top-up: amount_due = max(0, $100 - fees_this_month).
+ *    Non-payment -> book frozen (reversible on payment).
+ *
+ * CONVENTIONS: every monetary amount is INTEGER CENTS; every `_bps` field is
+ * BASIS POINTS (100% = 10_000). NONE of these endpoints exist on the backend
+ * yet — every GET degrades on 404/absent to an empty-but-honest state (callers
+ * use `retry:false` + render a "pending backend" note), and every mutation
+ * surfaces a clear error toast on 404 (never silently "succeeds").
+ */
+
+export type TokenStatus = "draft" | "minted" | "listed" | "frozen" | "delisted";
+export type AuctionStatus = "open" | "cleared" | "cancelled";
+export type UpkeepStatus = "covered" | "due" | "paid" | "delinquent" | "frozen";
+
+/** A creator revenue-share token. */
+export interface Token {
+  token_id: string;
+  /** Continuous-book symbol id, once listed (plugs into the trade surfaces). */
+  symbol_id?: number;
+  creator_sub: string;
+  name: string;
+  ticker: string;
+  /** Total token supply (whole tokens). */
+  total_supply: number;
+  /** The revenue-share claim, in basis points of the creator's content revenue. */
+  revenue_share_bps: number;
+  status: TokenStatus;
+  created_ts: number;
+  /** % of supply offered in the IPO, in bps (present once listing opens). */
+  offered_pct_bps?: number;
+  /** Uniform IPO clearing price in cents (present once the auction cleared). */
+  clearing_price?: number;
+}
+
+export interface TokensResult {
+  tokens: Token[];
+}
+
+/** One holder row in a token cap table. */
+export interface CapTableHolder {
+  sub: string;
+  qty: number;
+  pct_bps: number;
+}
+
+export interface CapTable {
+  token_id: string;
+  /** Creator retained % in bps. */
+  creator_pct_bps: number;
+  holders: CapTableHolder[];
+}
+
+/** One sealed IPO bid. */
+export interface AuctionBid {
+  sub: string;
+  qty: number;
+  /** Limit price in cents. */
+  limit_price: number;
+}
+
+/** The single-clearing-price IPO auction. */
+export interface TokenAuction {
+  auction_id: string;
+  token_id: string;
+  /** % of supply offered, in bps. */
+  offered_pct_bps: number;
+  /** Reserve (floor) clearing price in cents. */
+  reserve_price: number;
+  status: AuctionStatus;
+  /** Uniform clearing price in cents (present once cleared). */
+  clearing_price?: number;
+  /** Total qty filled at the clearing price (present once cleared). */
+  filled_qty?: number;
+  /** Auction close timestamp (seconds). */
+  close_ts: number;
+  bids?: AuctionBid[];
+}
+
+/** One pro-rata revenue distribution to holders. */
+export interface Distribution {
+  ts: number;
+  /** Total distributed this event, in cents. */
+  total_amount: number;
+  /** Per-token amount, in cents. */
+  per_token_amount: number;
+  source: string;
+}
+
+export interface RevenueSummary {
+  token_id: string;
+  my_qty: number;
+  my_pct_bps: number;
+  /** My unclaimed distribution balance, in cents. */
+  my_claimable: number;
+  distributions: Distribution[];
+}
+
+export interface UpkeepSummary {
+  token_id: string;
+  /** e.g. "2026-08". */
+  month: string;
+  /** Trading fees the book generated this month, in cents. */
+  fees_generated: number;
+  /** The flat monthly threshold, in cents (server-authoritative; $100 today). */
+  threshold: number;
+  /** Shortfall bill for the book this month = max(0, threshold - fees), in cents. */
+  amount_due: number;
+  /** MY pro-rata slice of `amount_due`, in cents. */
+  my_share: number;
+  status: UpkeepStatus;
+}
+
+/** Generic mutation ack. `status` "ok"/"ack" on success; carries a message otherwise. */
+export interface TokenAck {
+  status?: string;
+  token_id?: string;
+  auction_id?: string;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+}
+
+// ── Requests ─────────────────────────────────────────────────────────
+
+export interface MintTokenRequest {
+  name: string;
+  ticker: string;
+  total_supply: number;
+  revenue_share_bps: number;
+}
+
+export interface ListTokenRequest {
+  /** % of supply to offer, in bps. */
+  offered_pct_bps: number;
+  /** Reserve (floor) price in cents. */
+  reserve_price: number;
+  /** Auction close timestamp (seconds). */
+  close_ts: number;
+}
+
+export interface PlaceBidRequest {
+  qty: number;
+  /** Limit price in cents. */
+  limit_price: number;
+}
+
+// ── Calls (all 404 until the backend ships — callers degrade gracefully) ──
+
+/** Mint a new token (server charges the $100 creation fee). */
+export const mintToken = (body: MintTokenRequest) => api.post<Token>("/me/tokens", body);
+
+/** Tokens I issued. */
+export const getMyTokens = () => api.get<TokensResult>("/me/tokens");
+
+/** All listed creator tokens to browse. */
+export const getTokenMarket = () => api.get<TokensResult>("/me/tokens/market");
+
+export const getToken = (id: string) => api.get<Token>(`/me/tokens/${encodeURIComponent(id)}`);
+
+export const getCapTable = (id: string) =>
+  api.get<CapTable>(`/me/tokens/${encodeURIComponent(id)}/captable`);
+
+/** Open the IPO (issuer only). */
+export const listToken = (id: string, body: ListTokenRequest) =>
+  api.post<TokenAuction>(`/me/tokens/${encodeURIComponent(id)}/list`, body);
+
+export const getAuction = (id: string) =>
+  api.get<TokenAuction>(`/me/tokens/${encodeURIComponent(id)}/auction`);
+
+/** Place a sealed IPO bid (non-issuers). */
+export const placeAuctionBid = (id: string, body: PlaceBidRequest) =>
+  api.post<TokenAck>(`/me/tokens/${encodeURIComponent(id)}/auction/bid`, body);
+
+/** Trigger clearing (issuer only). */
+export const clearAuction = (id: string) =>
+  api.post<TokenAuction>(`/me/tokens/${encodeURIComponent(id)}/auction/clear`, {});
+
+export const getRevenue = (id: string) =>
+  api.get<RevenueSummary>(`/me/tokens/${encodeURIComponent(id)}/revenue`);
+
+/** Claim my accrued pro-rata distributions. */
+export const claimRevenue = (id: string) =>
+  api.post<TokenAck>(`/me/tokens/${encodeURIComponent(id)}/revenue/claim`, {});
+
+export const getUpkeep = (id: string) =>
+  api.get<UpkeepSummary>(`/me/tokens/${encodeURIComponent(id)}/upkeep`);
+
+/** Pay my pro-rata upkeep share (un-freezes a frozen book). */
+export const payUpkeep = (id: string) =>
+  api.post<TokenAck>(`/me/tokens/${encodeURIComponent(id)}/upkeep/pay`, {});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Best human message off any token ack (error / detail / reject reason). */
+export const tokenAckMessage = (a: TokenAck | null | undefined): string | undefined => {
+  if (!a) return undefined;
+  if (a.detail) return a.detail;
+  if (a.error) return a.error;
+  if (a.note) return a.note;
+  return a.reason != null ? `rejected (${a.reason})` : undefined;
+};

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -179,6 +179,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Content Revenue", i18nKey: "nav.contentRevenue", path: "/analytics/content-revenue", icon: <BarChart3 className="h-5 w-5" /> },
       { label: "Payouts", i18nKey: "nav.payouts", path: "/payouts", icon: <Wallet className="h-5 w-5" /> },
       { label: "Custody", i18nKey: "nav.custody", path: "/custody", icon: <Coins className="h-5 w-5" /> },
+      { label: "Creator Tokens", i18nKey: "nav.creatorTokens", path: "/tokens", icon: <Landmark className="h-5 w-5" /> },
       { label: "Referrals", i18nKey: "nav.referrals", path: "/referrals", icon: <Share2 className="h-5 w-5" /> },
       { label: "Promo Codes", i18nKey: "nav.promoCodes", path: "/promo", icon: <Tag className="h-5 w-5" /> },
       { label: "Affiliates", i18nKey: "nav.affiliates", path: "/affiliates", icon: <Link2 className="h-5 w-5" /> },

--- a/frontend/src/hooks/useTokens.ts
+++ b/frontend/src/hooks/useTokens.ts
@@ -1,0 +1,174 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import * as tokens from "@/api/endpoints/tokens";
+import { ApiError } from "@/api/client";
+
+/**
+ * React-query hooks for the CREATOR REVENUE-SHARE TOKEN surface. Mirrors the
+ * `useTrading` conventions: reads use `retry:false` because EVERY route 404s
+ * until the backend ships (callers render an honest empty / "pending backend"
+ * state); mutations surface a clear error toast on failure (never silent).
+ */
+
+export const tokenKeys = {
+  all: ["me", "tokens"] as const,
+  mine: ["me", "tokens", "mine"] as const,
+  market: ["me", "tokens", "market"] as const,
+  detail: (id: string) => ["me", "tokens", "detail", id] as const,
+  captable: (id: string) => ["me", "tokens", "captable", id] as const,
+  auction: (id: string) => ["me", "tokens", "auction", id] as const,
+  revenue: (id: string) => ["me", "tokens", "revenue", id] as const,
+  upkeep: (id: string) => ["me", "tokens", "upkeep", id] as const,
+};
+
+const POLL_MS = 15_000;
+
+// ── Reads (degrade on 404 — retry:false) ─────────────────────────────
+
+export function useMyTokens(enabled = true) {
+  return useQuery({
+    queryKey: tokenKeys.mine,
+    queryFn: tokens.getMyTokens,
+    enabled,
+    retry: false,
+  });
+}
+
+export function useTokenMarket(enabled = true) {
+  return useQuery({
+    queryKey: tokenKeys.market,
+    queryFn: tokens.getTokenMarket,
+    enabled,
+    retry: false,
+  });
+}
+
+export function useToken(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: tokenKeys.detail(id ?? ""),
+    queryFn: () => tokens.getToken(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+export function useCapTable(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: tokenKeys.captable(id ?? ""),
+    queryFn: () => tokens.getCapTable(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+export function useAuction(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: tokenKeys.auction(id ?? ""),
+    queryFn: () => tokens.getAuction(id!),
+    enabled: enabled && !!id,
+    retry: false,
+    refetchInterval: POLL_MS,
+  });
+}
+
+export function useRevenue(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: tokenKeys.revenue(id ?? ""),
+    queryFn: () => tokens.getRevenue(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+export function useUpkeep(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: tokenKeys.upkeep(id ?? ""),
+    queryFn: () => tokens.getUpkeep(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+/** True when a query error is the expected "backend not shipped yet" 404. */
+export function isPendingBackend(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+/** Human error message for a failed mutation (404 -> "not available yet"). */
+function mutationErrorText(err: unknown, action: string): string {
+  if (err instanceof ApiError) {
+    if (err.status === 404) return `${action} is not available yet — the backend for creator tokens has not shipped.`;
+    return err.detail || `${action} failed.`;
+  }
+  return `${action} failed.`;
+}
+
+// ── Mutations (clear error toast on failure — never silent) ──────────
+
+export function useMintToken() {
+  return useMutation({
+    mutationFn: (body: tokens.MintTokenRequest) => tokens.mintToken(body),
+    onError: (err) => toast.error(mutationErrorText(err, "Minting the token")),
+  });
+}
+
+export function useListToken(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: tokens.ListTokenRequest) => tokens.listToken(id!, body),
+    onSuccess: () => {
+      if (id) {
+        qc.invalidateQueries({ queryKey: tokenKeys.auction(id) });
+        qc.invalidateQueries({ queryKey: tokenKeys.detail(id) });
+      }
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Opening the IPO")),
+  });
+}
+
+export function usePlaceAuctionBid(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: tokens.PlaceBidRequest) => tokens.placeAuctionBid(id!, body),
+    onSuccess: () => id && qc.invalidateQueries({ queryKey: tokenKeys.auction(id) }),
+    onError: (err) => toast.error(mutationErrorText(err, "Placing the bid")),
+  });
+}
+
+export function useClearAuction(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => tokens.clearAuction(id!),
+    onSuccess: () => {
+      if (id) {
+        qc.invalidateQueries({ queryKey: tokenKeys.auction(id) });
+        qc.invalidateQueries({ queryKey: tokenKeys.detail(id) });
+        qc.invalidateQueries({ queryKey: tokenKeys.captable(id) });
+      }
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Clearing the auction")),
+  });
+}
+
+export function useClaimRevenue(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => tokens.claimRevenue(id!),
+    onSuccess: () => id && qc.invalidateQueries({ queryKey: tokenKeys.revenue(id) }),
+    onError: (err) => toast.error(mutationErrorText(err, "Claiming revenue")),
+  });
+}
+
+export function usePayUpkeep(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => tokens.payUpkeep(id!),
+    onSuccess: () => {
+      if (id) {
+        qc.invalidateQueries({ queryKey: tokenKeys.upkeep(id) });
+        qc.invalidateQueries({ queryKey: tokenKeys.detail(id) });
+      }
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Paying upkeep")),
+  });
+}

--- a/frontend/src/lib/tokens.test.ts
+++ b/frontend/src/lib/tokens.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bpsToFraction,
+  bpsToPct,
+  pctToBps,
+  formatBps,
+  formatCents,
+  bpsToQty,
+  qtyToBps,
+  proRataShareCents,
+  upkeepAmountDueCents,
+  upkeepCoverageFraction,
+  clearingSummary,
+  UPKEEP_THRESHOLD_CENTS,
+  CREATION_FEE_CENTS,
+} from "./tokens";
+
+describe("bps <-> pct/fraction", () => {
+  it("converts bps to fraction and pct", () => {
+    expect(bpsToFraction(10_000)).toBe(1);
+    expect(bpsToFraction(250)).toBe(0.025);
+    expect(bpsToPct(250)).toBeCloseTo(2.5, 6);
+    expect(bpsToFraction(undefined)).toBe(0);
+    expect(bpsToFraction(NaN)).toBe(0);
+  });
+  it("converts pct to bps with clamping + rounding", () => {
+    expect(pctToBps(2.5)).toBe(250);
+    expect(pctToBps(100)).toBe(10_000);
+    expect(pctToBps(150)).toBe(10_000); // clamp to 100%
+    expect(pctToBps(-5)).toBe(0);
+    expect(pctToBps(1.234)).toBe(123); // round
+  });
+});
+
+describe("formatters", () => {
+  it("formats bps as percent", () => {
+    expect(formatBps(250)).toBe("2.5%");
+    expect(formatBps(10_000)).toBe("100%");
+    expect(formatBps(0)).toBe("0%");
+  });
+  it("formats integer cents as dollars", () => {
+    expect(formatCents(100_00)).toBe("$100.00");
+    expect(formatCents(123456)).toBe("$1,234.56");
+    expect(formatCents(undefined)).toBe("—");
+    expect(formatCents(NaN)).toBe("—");
+  });
+});
+
+describe("bps <-> qty", () => {
+  it("computes qty from a bps slice of supply (floored)", () => {
+    expect(bpsToQty(1_000_000, 2_000)).toBe(200_000); // 20%
+    expect(bpsToQty(1000, 3333)).toBe(333); // floor
+    expect(bpsToQty(0, 5000)).toBe(0);
+    expect(bpsToQty(1000, 0)).toBe(0);
+  });
+  it("computes bps from a raw qty (rounded, clamped)", () => {
+    expect(qtyToBps(200_000, 1_000_000)).toBe(2_000);
+    expect(qtyToBps(1, 3)).toBe(3333); // round(3333.33)
+    expect(qtyToBps(5, 0)).toBe(0);
+    expect(qtyToBps(2_000_000, 1_000_000)).toBe(10_000); // clamp
+  });
+});
+
+describe("proRataShareCents", () => {
+  it("splits a bill by holding fraction (rounded)", () => {
+    expect(proRataShareCents(100_00, 250_000, 1_000_000)).toBe(2500); // 25% of $100
+    expect(proRataShareCents(100_00, 1_000_000, 1_000_000)).toBe(100_00); // sole holder
+    expect(proRataShareCents(100_00, 0, 1_000_000)).toBe(0); // no holding
+    expect(proRataShareCents(0, 500_000, 1_000_000)).toBe(0); // nothing due
+    expect(proRataShareCents(100_00, 333_333, 1_000_000)).toBe(3333); // round
+  });
+});
+
+describe("upkeep shortfall model", () => {
+  it("charges the shortfall vs the $100 threshold", () => {
+    expect(UPKEEP_THRESHOLD_CENTS).toBe(100_00);
+    expect(CREATION_FEE_CENTS).toBe(100_00);
+    expect(upkeepAmountDueCents(0)).toBe(100_00); // no fees -> full bill
+    expect(upkeepAmountDueCents(40_00)).toBe(60_00); // partial coverage
+    expect(upkeepAmountDueCents(100_00)).toBe(0); // exactly covered
+    expect(upkeepAmountDueCents(250_00)).toBe(0); // over-covered -> 0
+    expect(upkeepAmountDueCents(-5)).toBe(100_00); // negative fees treated as 0
+  });
+  it("reports a coverage fraction for the gauge", () => {
+    expect(upkeepCoverageFraction(0)).toBe(0);
+    expect(upkeepCoverageFraction(50_00)).toBe(0.5);
+    expect(upkeepCoverageFraction(100_00)).toBe(1);
+    expect(upkeepCoverageFraction(500_00)).toBe(1); // clamp
+  });
+});
+
+describe("clearingSummary (single clearing price IPO)", () => {
+  it("clears at the lowest price that fully sells the offered book", () => {
+    // Offer 100 tokens. Bids: 60@120, 60@110, 40@100. Reserve 100.
+    // demand@120=60, demand@110=120>=100, demand@100=160>=100.
+    // Lowest fully-filling price = 100 -> all fill at 100.
+    const s = clearingSummary(
+      [
+        { qty: 60, limit_price: 120 },
+        { qty: 60, limit_price: 110 },
+        { qty: 40, limit_price: 100 },
+      ],
+      100,
+      100,
+    );
+    expect(s.cleared).toBe(true);
+    expect(s.clearingPrice).toBe(100);
+    expect(s.filledQty).toBe(100);
+    expect(s.proceeds).toBe(10_000);
+  });
+  it("excludes bids below the reserve", () => {
+    const s = clearingSummary(
+      [
+        { qty: 100, limit_price: 90 }, // below reserve -> ignored
+        { qty: 50, limit_price: 100 },
+      ],
+      100,
+      100,
+    );
+    // Only 50 qty is eligible -> cannot fully fill 100 -> partial at 100.
+    expect(s.cleared).toBe(false);
+    expect(s.clearingPrice).toBe(100);
+    expect(s.filledQty).toBe(50);
+  });
+  it("returns not-cleared when nothing meets the reserve", () => {
+    const s = clearingSummary([{ qty: 100, limit_price: 50 }], 100, 100);
+    expect(s.cleared).toBe(false);
+    expect(s.clearingPrice).toBeNull();
+    expect(s.filledQty).toBe(0);
+    expect(s.proceeds).toBe(0);
+  });
+  it("guards empty bids / non-positive offer", () => {
+    expect(clearingSummary([], 100, 100).clearingPrice).toBeNull();
+    expect(clearingSummary([{ qty: 10, limit_price: 100 }], 0, 100).clearingPrice).toBeNull();
+  });
+  it("partially fills at the top price when demand is thin", () => {
+    // Offer 100 but only 70 total eligible demand -> partial at highest price.
+    const s = clearingSummary(
+      [
+        { qty: 30, limit_price: 130 },
+        { qty: 40, limit_price: 120 },
+      ],
+      100,
+      100,
+    );
+    expect(s.cleared).toBe(false);
+    expect(s.clearingPrice).toBe(130);
+    expect(s.filledQty).toBe(30); // demand at top price (130) = 30
+  });
+});

--- a/frontend/src/lib/tokens.ts
+++ b/frontend/src/lib/tokens.ts
@@ -1,0 +1,179 @@
+// Pure, dependency-free math for the CREATOR REVENUE-SHARE TOKEN surface.
+// Framework-free so it is unit-testable in isolation (see tokens.test.ts).
+// CONVENTIONS (locked): all monetary amounts are INTEGER CENTS; every `_bps`
+// value is BASIS POINTS (1% = 100 bps, 100% = 10_000 bps). None of these
+// functions perform I/O — they only compute the numbers the screens preview.
+
+/** One cent-denominated dollar figure: the flat book-upkeep threshold ($100). */
+export const UPKEEP_THRESHOLD_CENTS = 100_00;
+
+/** The flat token-creation ("mint") fee: $100. */
+export const CREATION_FEE_CENTS = 100_00;
+
+/** Full basis-points denominator (100%). */
+export const BPS_DENOM = 10_000;
+
+/** Clamp a number into [lo, hi]. */
+export function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Basis points -> fraction (0..1). 10_000 bps -> 1. Non-finite -> 0. */
+export function bpsToFraction(bps: number | undefined | null): number {
+  if (bps == null || !Number.isFinite(bps)) return 0;
+  return bps / BPS_DENOM;
+}
+
+/** Basis points -> a human percent number (e.g. 250 -> 2.5). */
+export function bpsToPct(bps: number | undefined | null): number {
+  return bpsToFraction(bps) * 100;
+}
+
+/** A human percent number -> basis points, floored to an int (2.5 -> 250). */
+export function pctToBps(pct: number | undefined | null): number {
+  if (pct == null || !Number.isFinite(pct)) return 0;
+  return Math.round(clamp(pct, 0, 100) * 100);
+}
+
+/** Format basis points as a percent string, e.g. 250 -> "2.5%". */
+export function formatBps(bps: number | undefined | null, maxFrac = 2): string {
+  const pct = bpsToPct(bps);
+  return `${pct.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: maxFrac })}%`;
+}
+
+/** Integer cents -> "$1,234.56". Non-finite -> "—". */
+export function formatCents(cents: number | undefined | null): string {
+  if (cents == null || !Number.isFinite(cents)) return "—";
+  return `$${(cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/**
+ * Token quantity implied by a basis-points slice of total supply.
+ *   qty = totalSupply * bps / 10_000  (floored to a whole token)
+ * Guards non-positive supply / bps by returning 0.
+ */
+export function bpsToQty(totalSupply: number, bps: number): number {
+  if (!(totalSupply > 0) || !(bps > 0)) return 0;
+  return Math.floor((totalSupply * clamp(bps, 0, BPS_DENOM)) / BPS_DENOM);
+}
+
+/**
+ * Basis-points slice of total supply implied by a raw token quantity.
+ *   bps = qty / totalSupply * 10_000  (rounded to a whole bp)
+ * Guards non-positive supply by returning 0; clamps to [0, 10_000].
+ */
+export function qtyToBps(qty: number, totalSupply: number): number {
+  if (!(totalSupply > 0) || !(qty > 0)) return 0;
+  return clamp(Math.round((qty / totalSupply) * BPS_DENOM), 0, BPS_DENOM);
+}
+
+/**
+ * A holder's PRO-RATA share (in cents) of a total upkeep bill, by holding.
+ *   share = amountDueCents * (myQty / totalSupply)   (rounded to a whole cent)
+ * Guards non-positive supply / due by returning 0; a holder with 0 qty owes 0.
+ */
+export function proRataShareCents(
+  amountDueCents: number,
+  myQty: number,
+  totalSupply: number,
+): number {
+  if (!(amountDueCents > 0) || !(myQty > 0) || !(totalSupply > 0)) return 0;
+  const frac = clamp(myQty / totalSupply, 0, 1);
+  return Math.round(amountDueCents * frac);
+}
+
+/**
+ * SHORTFALL top-up upkeep model (LABELLED assumption, flippable later):
+ *   amount_due = max(0, threshold - feesThisMonth)
+ * $0 once the book's monthly trading fees meet/exceed the threshold.
+ */
+export function upkeepAmountDueCents(
+  feesThisMonthCents: number,
+  thresholdCents: number = UPKEEP_THRESHOLD_CENTS,
+): number {
+  const fees = Number.isFinite(feesThisMonthCents) ? feesThisMonthCents : 0;
+  const thr = Number.isFinite(thresholdCents) ? thresholdCents : 0;
+  return Math.max(0, thr - Math.max(0, fees));
+}
+
+/**
+ * Fraction (0..1) of the upkeep threshold already covered by trading fees, for
+ * a progress gauge. 1 = fully covered (nothing due).
+ */
+export function upkeepCoverageFraction(
+  feesThisMonthCents: number,
+  thresholdCents: number = UPKEEP_THRESHOLD_CENTS,
+): number {
+  if (!(thresholdCents > 0)) return 1;
+  const fees = Math.max(0, Number.isFinite(feesThisMonthCents) ? feesThisMonthCents : 0);
+  return clamp(fees / thresholdCents, 0, 1);
+}
+
+/** One sealed bid in the single-clearing-price IPO auction. */
+export interface ClearingBid {
+  qty: number;
+  limit_price: number;
+}
+
+/** The computed outcome of clearing a sealed-bid auction. */
+export interface ClearingSummary {
+  /** The single price at which all fills execute; null when nothing clears. */
+  clearingPrice: number | null;
+  /** Total quantity filled at the clearing price (<= offeredQty). */
+  filledQty: number;
+  /** Gross proceeds in the price*qty unit (clearingPrice * filledQty). */
+  proceeds: number;
+  /** True when demand at/above the clearing price met the reserve + offered. */
+  cleared: boolean;
+}
+
+/**
+ * Single-clearing-price (uniform-price) auction summary. Bids are sealed with a
+ * per-bid limit price; we find the HIGHEST price P such that the cumulative
+ * demand from bids willing to pay >= P is at least as large as it can be while
+ * still selling into `offeredQty`. All fills execute at that one price P; P must
+ * be >= reserve. Returns a not-cleared summary when nothing meets the reserve.
+ *
+ * Algorithm: sort candidate prices (distinct bid limits) descending; for each
+ * candidate P >= reserve, demand(P) = sum of qty of bids with limit >= P. The
+ * clearing price is the LOWEST candidate P where demand(P) >= offeredQty (book
+ * fully sells) — else, if no price fully fills, the HIGHEST P>=reserve with any
+ * demand (partial fill of demand(P), capped at offeredQty).
+ */
+export function clearingSummary(
+  bids: ClearingBid[],
+  offeredQty: number,
+  reservePrice: number,
+): ClearingSummary {
+  const empty: ClearingSummary = { clearingPrice: null, filledQty: 0, proceeds: 0, cleared: false };
+  if (!(offeredQty > 0)) return empty;
+  const valid = (bids ?? []).filter((b) => b && b.qty > 0 && b.limit_price >= reservePrice);
+  if (valid.length === 0) return empty;
+
+  const demandAt = (p: number) =>
+    valid.reduce((sum, b) => (b.limit_price >= p ? sum + b.qty : sum), 0);
+
+  // Distinct candidate prices (the eligible bid limits), descending.
+  const prices = Array.from(new Set(valid.map((b) => b.limit_price))).sort((a, b) => b - a);
+
+  // Prefer the LOWEST price that still fully sells the offered book (maximizes
+  // qty sold while giving every filled bid the best single clearing price).
+  let clearing: number | null = null;
+  for (const p of prices) {
+    if (demandAt(p) >= offeredQty) clearing = p; // keep lowering while it still fills
+  }
+  if (clearing != null) {
+    const filledQty = offeredQty;
+    return { clearingPrice: clearing, filledQty, proceeds: clearing * filledQty, cleared: true };
+  }
+
+  // Nothing fully fills: partial fill at the highest eligible price.
+  const top = prices[0]!;
+  const filledQty = Math.min(offeredQty, demandAt(top));
+  if (!(filledQty > 0)) return empty;
+  return { clearingPrice: top, filledQty, proceeds: top * filledQty, cleared: false };
+}

--- a/frontend/src/pages/tokens/MintTokenPage.tsx
+++ b/frontend/src/pages/tokens/MintTokenPage.tsx
@@ -1,0 +1,211 @@
+import { useMemo, useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { ArrowLeft, Coins } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useMintToken } from "@/hooks/useTokens";
+import { CREATION_FEE_CENTS, formatCents, formatBps, pctToBps, bpsToQty } from "@/lib/tokens";
+import { tokenAckMessage } from "@/api/endpoints/tokens";
+
+export default function MintTokenPage() {
+  const navigate = useNavigate();
+  const mint = useMintToken();
+
+  const [name, setName] = useState("");
+  const [ticker, setTicker] = useState("");
+  const [supply, setSupply] = useState("1000000");
+  const [revSharePct, setRevSharePct] = useState("2.5");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const supplyN = Number(supply);
+  const revShareBps = pctToBps(Number(revSharePct));
+
+  const errors = useMemo(() => {
+    const e: string[] = [];
+    if (!name.trim()) e.push("Name is required.");
+    if (!/^[A-Za-z0-9]{2,10}$/.test(ticker.trim())) e.push("Ticker must be 2-10 letters/numbers.");
+    if (!(supplyN > 0) || !Number.isInteger(supplyN)) e.push("Total supply must be a positive whole number.");
+    if (!(Number(revSharePct) > 0)) e.push("Revenue-share % must be greater than 0.");
+    if (Number(revSharePct) > 100) e.push("Revenue-share % cannot exceed 100%.");
+    return e;
+  }, [name, ticker, supplyN, revSharePct]);
+
+  const canSubmit = errors.length === 0 && !mint.isPending;
+
+  const doMint = async () => {
+    try {
+      const token = await mint.mutateAsync({
+        name: name.trim(),
+        ticker: ticker.trim().toUpperCase(),
+        total_supply: supplyN,
+        revenue_share_bps: revShareBps,
+      });
+      setConfirmOpen(false);
+      toast.success(`Minted ${token.ticker} - you hold 100% of supply.`);
+      navigate(`/tokens/${encodeURIComponent(token.token_id)}`);
+    } catch (err) {
+      // useMintToken already surfaces a toast; keep the dialog open so the
+      // user can retry. Surface any structured ack message too.
+      const msg = tokenAckMessage((err as { body?: never })?.body as never);
+      if (msg) toast.error(msg);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-6 p-4 md:p-6">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="ghost" size="icon">
+          <Link to="/tokens" aria-label="Back to tokens">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <Coins className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold tracking-tight">Mint a creator token</h1>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Token details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="tok-name">Name</Label>
+            <Input
+              id="tok-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Jane Doe Content Revenue"
+              maxLength={64}
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="tok-ticker">Ticker</Label>
+              <Input
+                id="tok-ticker"
+                value={ticker}
+                onChange={(e) => setTicker(e.target.value.toUpperCase())}
+                placeholder="JANE"
+                maxLength={10}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tok-supply">Total supply</Label>
+              <Input
+                id="tok-supply"
+                type="number"
+                min={1}
+                step={1}
+                value={supply}
+                onChange={(e) => setSupply(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="tok-revshare">Revenue-share %</Label>
+            <Input
+              id="tok-revshare"
+              type="number"
+              min={0}
+              max={100}
+              step={0.1}
+              value={revSharePct}
+              onChange={(e) => setRevSharePct(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Holders receive pro-rata distributions of{" "}
+              <span className="font-medium text-foreground">{formatBps(revShareBps)}</span> (
+              {revShareBps.toLocaleString()} bps) of your ongoing content revenue. You mint and
+              hold 100% of {supplyN > 0 ? supplyN.toLocaleString() : "-"} tokens.
+            </p>
+          </div>
+
+          {errors.length > 0 && (
+            <ul className="list-inside list-disc space-y-0.5 text-xs text-rose-600 dark:text-rose-400">
+              {errors.map((e) => (
+                <li key={e}>{e}</li>
+              ))}
+            </ul>
+          )}
+
+          <Separator />
+
+          <div className="flex items-center justify-between rounded-lg border bg-muted/30 p-3 text-sm">
+            <span className="text-muted-foreground">One-time creation fee</span>
+            <span className="font-semibold tabular-nums">{formatCents(CREATION_FEE_CENTS)}</span>
+          </div>
+
+          <Button
+            className="w-full"
+            disabled={!canSubmit}
+            onClick={() => setConfirmOpen(true)}
+            data-testid="mint-submit"
+          >
+            Review &amp; mint
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Money-safety confirm - mirrors the trade-ticket deposit confirm. */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm token mint</DialogTitle>
+            <DialogDescription>
+              This charges a one-time {formatCents(CREATION_FEE_CENTS)} creation fee to your account.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Ticker</span>
+              <span className="font-medium tabular-nums">{ticker.toUpperCase() || "-"}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Total supply</span>
+              <span className="font-medium tabular-nums">{supplyN.toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Revenue-share</span>
+              <span className="font-medium tabular-nums">{formatBps(revShareBps)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">You retain</span>
+              <span className="font-medium tabular-nums">
+                100% ({bpsToQty(supplyN, 10_000).toLocaleString()})
+              </span>
+            </div>
+            <Separator />
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Creation fee</span>
+              <span className="font-semibold tabular-nums text-rose-600 dark:text-rose-400">
+                -{formatCents(CREATION_FEE_CENTS)}
+              </span>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={mint.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={doMint} disabled={mint.isPending} data-testid="mint-confirm">
+              {mint.isPending ? "Minting..." : `Pay ${formatCents(CREATION_FEE_CENTS)} & mint`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/tokens/PendingBackend.tsx
+++ b/frontend/src/pages/tokens/PendingBackend.tsx
@@ -1,0 +1,33 @@
+import { Info } from "lucide-react";
+
+/**
+ * Honest "pending backend" note shown when a `/me/tokens/*` read 404s (the
+ * surface is UI-complete but the backend has not shipped yet). Reused across
+ * every token screen so the empty state reads the same everywhere.
+ */
+export function PendingBackend({ label = "This data" }: { label?: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-dashed bg-muted/30 p-4 text-sm text-muted-foreground">
+      <Info className="mt-0.5 h-4 w-4 shrink-0" />
+      <div>
+        <p className="font-medium text-foreground">Pending backend</p>
+        <p>
+          {label} is not available yet — the creator-token endpoints have not shipped on this
+          environment. The surface is wired and will populate automatically once they do.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/** Small labelled note flagging the flippable shortfall-vs-flat upkeep assumption. */
+export function ShortfallAssumptionNote() {
+  return (
+    <p className="rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/40 dark:text-amber-300">
+      <span className="font-semibold">Assumption (flippable):</span> upkeep is billed as a{" "}
+      <span className="font-semibold">shortfall top-up</span> — amount due = max(0, $100 − trading
+      fees this month), $0 once the book&rsquo;s monthly fees reach $100. This can be switched to a
+      flat $100/month later.
+    </p>
+  );
+}

--- a/frontend/src/pages/tokens/TokenDetailPage.tsx
+++ b/frontend/src/pages/tokens/TokenDetailPage.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { ArrowLeft, Coins, Snowflake } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  useToken,
+  useCapTable,
+  useRevenue,
+  useUpkeep,
+  useAuction,
+  useClaimRevenue,
+  usePayUpkeep,
+} from "@/hooks/useTokens";
+import type { Token, TokenStatus } from "@/api/endpoints/tokens";
+import { formatBps, formatCents } from "@/lib/tokens";
+import { PendingBackend } from "./PendingBackend";
+import { CapTableSection } from "./sections/CapTableSection";
+import { RevenueSection } from "./sections/RevenueSection";
+import { UpkeepSection } from "./sections/UpkeepSection";
+import { AuctionSection } from "./sections/AuctionSection";
+
+const STATUS_VARIANT: Record<TokenStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "outline",
+  minted: "secondary",
+  listed: "default",
+  frozen: "destructive",
+  delisted: "outline",
+};
+
+function shortSub(sub: string | undefined): string {
+  if (!sub) return "-";
+  return sub.length > 12 ? `${sub.slice(0, 6)}...${sub.slice(-4)}` : sub;
+}
+
+export default function TokenDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const userId = useAuthStore((s) => s.userId);
+
+  const tokenQ = useToken(id);
+  const capQ = useCapTable(id);
+  const revenueQ = useRevenue(id);
+  const upkeepQ = useUpkeep(id);
+  const auctionQ = useAuction(id);
+
+  const claim = useClaimRevenue(id);
+  const payUpkeep = usePayUpkeep(id);
+
+  const token: Token | undefined = tokenQ.data;
+  const isIssuer = !!token && !!userId && token.creator_sub === userId;
+  const isFrozen = token?.status === "frozen";
+
+  const [tab, setTab] = useState("captable");
+
+  const header = useMemo(() => {
+    if (tokenQ.isLoading) return <Skeleton className="h-9 w-64" />;
+    if (!token) return <h1 className="text-2xl font-bold tracking-tight">Token</h1>;
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <Coins className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold tracking-tight">
+          {token.ticker} <span className="text-muted-foreground">- {token.name}</span>
+        </h1>
+        <Badge variant={STATUS_VARIANT[token.status] ?? "outline"}>{token.status}</Badge>
+        {isFrozen && (
+          <Badge variant="destructive" className="gap-1">
+            <Snowflake className="h-3 w-3" /> Book frozen
+          </Badge>
+        )}
+      </div>
+    );
+  }, [tokenQ.isLoading, token, isFrozen]);
+
+  const onClaim = async () => {
+    try {
+      await claim.mutateAsync();
+      toast.success("Claim submitted.");
+    } catch {
+      /* error toast handled in hook */
+    }
+  };
+
+  const onPayUpkeep = async () => {
+    try {
+      await payUpkeep.mutateAsync();
+      toast.success("Upkeep paid.");
+    } catch {
+      /* error toast handled in hook */
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="ghost" size="icon">
+          <Link to="/tokens" aria-label="Back to tokens">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        {header}
+      </div>
+
+      {tokenQ.isError ? (
+        <PendingBackend label="This token" />
+      ) : (
+        <>
+          {token && (
+            <Card>
+              <CardContent className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-4">
+                <Stat label="Revenue-share" value={formatBps(token.revenue_share_bps)} />
+                <Stat label="Total supply" value={token.total_supply.toLocaleString()} />
+                <Stat
+                  label="Offered (IPO)"
+                  value={token.offered_pct_bps != null ? formatBps(token.offered_pct_bps) : "-"}
+                />
+                <Stat
+                  label="Clearing price"
+                  value={token.clearing_price != null ? formatCents(token.clearing_price) : "-"}
+                />
+                <Stat label="Creator" value={shortSub(token.creator_sub)} />
+                <Stat label="Issuer view" value={isIssuer ? "Yes (you)" : "No"} />
+              </CardContent>
+            </Card>
+          )}
+
+          <Tabs value={tab} onValueChange={setTab}>
+            <TabsList>
+              <TabsTrigger value="captable">Cap table</TabsTrigger>
+              <TabsTrigger value="revenue">Revenue</TabsTrigger>
+              <TabsTrigger value="upkeep">Upkeep</TabsTrigger>
+              <TabsTrigger value="auction">{isIssuer ? "List / IPO" : "Auction"}</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="captable" className="pt-4">
+              <CapTableSection query={capQ} />
+            </TabsContent>
+
+            <TabsContent value="revenue" className="pt-4">
+              <RevenueSection query={revenueQ} onClaim={onClaim} claiming={claim.isPending} />
+            </TabsContent>
+
+            <TabsContent value="upkeep" className="pt-4">
+              <UpkeepSection query={upkeepQ} onPay={onPayUpkeep} paying={payUpkeep.isPending} />
+            </TabsContent>
+
+            <TabsContent value="auction" className="pt-4">
+              <AuctionSection
+                tokenId={id}
+                token={token}
+                query={auctionQ}
+                isIssuer={isIssuer}
+              />
+            </TabsContent>
+          </Tabs>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-0.5 font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/tokens/TokenMarketPage.tsx
+++ b/frontend/src/pages/tokens/TokenMarketPage.tsx
@@ -1,0 +1,146 @@
+import { Link } from "react-router-dom";
+import { Coins, Plus, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useTokenMarket, useMyTokens, isPendingBackend } from "@/hooks/useTokens";
+import type { Token, TokenStatus } from "@/api/endpoints/tokens";
+import { formatBps, formatCents } from "@/lib/tokens";
+import { PendingBackend } from "./PendingBackend";
+
+const STATUS_VARIANT: Record<TokenStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "outline",
+  minted: "secondary",
+  listed: "default",
+  frozen: "destructive",
+  delisted: "outline",
+};
+
+function StatusBadge({ status }: { status: TokenStatus }) {
+  return <Badge variant={STATUS_VARIANT[status] ?? "outline"}>{status}</Badge>;
+}
+
+function TokenTable({ tokens }: { tokens: Token[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Ticker</TableHead>
+          <TableHead>Name</TableHead>
+          <TableHead className="text-right">Rev-share</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Clearing / last</TableHead>
+          <TableHead className="w-16" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {tokens.map((t) => (
+          <TableRow key={t.token_id} data-testid="token-row">
+            <TableCell className="font-semibold tabular-nums">{t.ticker}</TableCell>
+            <TableCell className="max-w-[16rem] truncate">{t.name}</TableCell>
+            <TableCell className="text-right tabular-nums">{formatBps(t.revenue_share_bps)}</TableCell>
+            <TableCell>
+              <StatusBadge status={t.status} />
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {t.clearing_price != null ? formatCents(t.clearing_price) : "—"}
+            </TableCell>
+            <TableCell>
+              <Button asChild variant="ghost" size="sm">
+                <Link to={`/tokens/${encodeURIComponent(t.token_id)}`}>View</Link>
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export default function TokenMarketPage() {
+  const market = useTokenMarket();
+  const mine = useMyTokens();
+
+  const marketTokens = market.data?.tokens ?? [];
+  const myTokens = mine.data?.tokens ?? [];
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Coins className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Creator Tokens</h1>
+            <p className="text-sm text-muted-foreground">
+              Tradeable revenue-share claims minted by content creators.
+            </p>
+          </div>
+        </div>
+        <Button asChild data-testid="mint-token-cta">
+          <Link to="/tokens/new">
+            <Plus className="mr-1.5 h-4 w-4" /> Mint a token
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Market — listed creator tokens</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {market.isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ) : market.isError && isPendingBackend(market.error) ? (
+            <PendingBackend label="The creator-token market" />
+          ) : market.isError ? (
+            <PendingBackend label="The creator-token market" />
+          ) : marketTokens.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+              No creator tokens are listed yet. Be the first to{" "}
+              <Link to="/tokens/new" className="font-medium text-primary underline-offset-4 hover:underline">
+                mint one
+              </Link>
+              .
+            </div>
+          ) : (
+            <TokenTable tokens={marketTokens} />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <FileText className="h-4 w-4" /> My issued tokens
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {mine.isLoading ? (
+            <Skeleton className="h-8 w-full" />
+          ) : mine.isError ? (
+            <PendingBackend label="Your issued tokens" />
+          ) : myTokens.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              You haven&rsquo;t minted any tokens yet.
+            </div>
+          ) : (
+            <TokenTable tokens={myTokens} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/tokens/sections/AuctionSection.tsx
+++ b/frontend/src/pages/tokens/sections/AuctionSection.tsx
@@ -1,0 +1,380 @@
+import { useMemo, useState } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ApiError } from "@/api/client";
+import type { Token, TokenAuction } from "@/api/endpoints/tokens";
+import { useListToken, usePlaceAuctionBid, useClearAuction } from "@/hooks/useTokens";
+import {
+  formatBps,
+  formatCents,
+  pctToBps,
+  bpsToQty,
+  clearingSummary,
+  type ClearingBid,
+} from "@/lib/tokens";
+import { PendingBackend } from "../PendingBackend";
+
+/** Dollars string -> integer cents (rounded). */
+function dollarsToCents(v: string): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n * 100) : 0;
+}
+
+function shortSub(sub: string): string {
+  return sub.length > 12 ? `${sub.slice(0, 6)}...${sub.slice(-4)}` : sub;
+}
+
+export function AuctionSection({
+  tokenId,
+  token,
+  query,
+  isIssuer,
+}: {
+  tokenId: string | undefined;
+  token: Token | undefined;
+  query: UseQueryResult<TokenAuction>;
+  isIssuer: boolean;
+}) {
+  const auction = query.data;
+  const noAuction = query.isError && query.error instanceof ApiError && query.error.status === 404;
+  const hasOpenAuction = !!auction && auction.status === "open";
+
+  if (query.isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-4">
+          <Skeleton className="h-32 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Non-404 errors still degrade to the pending-backend note.
+  if (query.isError && !noAuction) {
+    return (
+      <Card>
+        <CardContent className="p-4">
+          <PendingBackend label="The auction" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {auction ? (
+        <AuctionPanel tokenId={tokenId} token={token} auction={auction} isIssuer={isIssuer} />
+      ) : isIssuer ? (
+        <ListLauncher tokenId={tokenId} token={token} />
+      ) : (
+        <Card>
+          <CardContent className="p-6 text-center text-sm text-muted-foreground">
+            {hasOpenAuction
+              ? "Loading auction..."
+              : "This token has no open IPO auction. Only the issuer can open one."}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ── Issuer: open the IPO ─────────────────────────────────────────────
+
+function ListLauncher({ tokenId, token }: { tokenId: string | undefined; token: Token | undefined }) {
+  const list = useListToken(tokenId);
+  const [offeredPct, setOfferedPct] = useState("20");
+  const [reserve, setReserve] = useState("1.00");
+  const [closeLocal, setCloseLocal] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const offeredBps = pctToBps(Number(offeredPct));
+  const reserveCents = dollarsToCents(reserve);
+  const closeTs = closeLocal ? Math.floor(new Date(closeLocal).getTime() / 1000) : 0;
+  const offeredQty = token ? bpsToQty(token.total_supply, offeredBps) : 0;
+
+  const errors: string[] = [];
+  if (!(Number(offeredPct) > 0) || Number(offeredPct) > 100) errors.push("Offered % must be 1-100.");
+  if (!(reserveCents > 0)) errors.push("Reserve price must be greater than $0.");
+  if (!closeTs || closeTs * 1000 <= Date.now()) errors.push("Close time must be in the future.");
+
+  const doList = async () => {
+    try {
+      await list.mutateAsync({
+        offered_pct_bps: offeredBps,
+        reserve_price: reserveCents,
+        close_ts: closeTs,
+      });
+      setConfirmOpen(false);
+      toast.success("IPO auction opened.");
+    } catch {
+      /* hook toasts on error */
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">List (IPO) - single-clearing-price auction</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Offer a slice of supply via a sealed-bid auction. All winning bids fill at one clearing
+          price. After clearing, the token trades on a continuous book.
+        </p>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="ipo-pct">Offered %</Label>
+            <Input id="ipo-pct" type="number" min={1} max={100} step={1} value={offeredPct} onChange={(e) => setOfferedPct(e.target.value)} />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="ipo-reserve">Reserve price ($)</Label>
+            <Input id="ipo-reserve" type="number" min={0} step={0.01} value={reserve} onChange={(e) => setReserve(e.target.value)} />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="ipo-close">Close time</Label>
+            <Input id="ipo-close" type="datetime-local" value={closeLocal} onChange={(e) => setCloseLocal(e.target.value)} />
+          </div>
+        </div>
+        <div className="rounded-lg border bg-muted/30 p-3 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Tokens offered</span>
+            <span className="font-medium tabular-nums">
+              {offeredQty.toLocaleString()} ({formatBps(offeredBps)})
+            </span>
+          </div>
+        </div>
+        {errors.length > 0 && (
+          <ul className="list-inside list-disc space-y-0.5 text-xs text-rose-600 dark:text-rose-400">
+            {errors.map((e) => (
+              <li key={e}>{e}</li>
+            ))}
+          </ul>
+        )}
+        <Button disabled={errors.length > 0 || list.isPending} onClick={() => setConfirmOpen(true)} data-testid="open-ipo">
+          Review &amp; open IPO
+        </Button>
+      </CardContent>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Open IPO auction</DialogTitle>
+            <DialogDescription>
+              This opens a sealed-bid auction offering {formatBps(offeredBps)} of supply.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-sm">
+            <Row label="Offered" value={`${offeredQty.toLocaleString()} (${formatBps(offeredBps)})`} />
+            <Row label="Reserve price" value={formatCents(reserveCents)} />
+            <Row label="Closes" value={closeTs ? new Date(closeTs * 1000).toLocaleString() : "-"} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={list.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={doList} disabled={list.isPending} data-testid="open-ipo-confirm">
+              {list.isPending ? "Opening..." : "Open IPO"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
+
+// ── Open auction panel (bids + place-bid + clearing + clear) ─────────
+
+function AuctionPanel({
+  tokenId,
+  token,
+  auction,
+  isIssuer,
+}: {
+  tokenId: string | undefined;
+  token: Token | undefined;
+  auction: TokenAuction;
+  isIssuer: boolean;
+}) {
+  const bid = usePlaceAuctionBid(tokenId);
+  const clear = useClearAuction(tokenId);
+  const [qty, setQty] = useState("");
+  const [limit, setLimit] = useState("");
+
+  const bids = auction.bids ?? [];
+  const offeredQty = token ? bpsToQty(token.total_supply, auction.offered_pct_bps) : 0;
+
+  // Implied clearing preview from the visible sealed bids (issuer-facing hint).
+  const preview = useMemo(() => {
+    const cb: ClearingBid[] = bids.map((b) => ({ qty: b.qty, limit_price: b.limit_price }));
+    return clearingSummary(cb, offeredQty, auction.reserve_price);
+  }, [bids, offeredQty, auction.reserve_price]);
+
+  const qtyN = Number(qty);
+  const limitCents = dollarsToCents(limit);
+  const canBid = qtyN > 0 && Number.isInteger(qtyN) && limitCents >= auction.reserve_price;
+
+  const doBid = async () => {
+    try {
+      await bid.mutateAsync({ qty: qtyN, limit_price: limitCents });
+      toast.success("Bid placed.");
+      setQty("");
+      setLimit("");
+    } catch {
+      /* hook toasts on error */
+    }
+  };
+
+  const doClear = async () => {
+    try {
+      await clear.mutateAsync();
+      toast.success("Auction cleared.");
+    } catch {
+      /* hook toasts on error */
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-base">IPO auction</CardTitle>
+          <Badge variant={auction.status === "open" ? "default" : "secondary"}>{auction.status}</Badge>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Metric label="Offered" value={`${offeredQty.toLocaleString()} (${formatBps(auction.offered_pct_bps)})`} />
+            <Metric label="Reserve" value={formatCents(auction.reserve_price)} />
+            <Metric
+              label="Closes"
+              value={auction.close_ts ? new Date(auction.close_ts * 1000).toLocaleString() : "-"}
+            />
+            <Metric
+              label={auction.status === "cleared" ? "Clearing price" : "Implied clearing"}
+              value={
+                auction.clearing_price != null
+                  ? formatCents(auction.clearing_price)
+                  : preview.clearingPrice != null
+                    ? `~${formatCents(preview.clearingPrice)}`
+                    : "-"
+              }
+            />
+          </div>
+          {auction.status === "open" && (
+            <p className="text-xs text-muted-foreground">
+              Implied from visible bids: {preview.cleared ? "fully subscribed" : "under-subscribed"} -
+              would fill {preview.filledQty.toLocaleString()} of {offeredQty.toLocaleString()} tokens
+              {preview.clearingPrice != null ? ` at ${formatCents(preview.clearingPrice)}` : ""}.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Place-bid (non-issuers, while open) */}
+      {!isIssuer && auction.status === "open" && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Place a sealed bid</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="bid-qty">Quantity</Label>
+                <Input id="bid-qty" type="number" min={1} step={1} value={qty} onChange={(e) => setQty(e.target.value)} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="bid-limit">Limit price ($)</Label>
+                <Input id="bid-limit" type="number" min={0} step={0.01} value={limit} onChange={(e) => setLimit(e.target.value)} />
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Limit must be at or above the {formatCents(auction.reserve_price)} reserve. All winning
+              bids fill at one clearing price.
+            </p>
+            <Button onClick={doBid} disabled={!canBid || bid.isPending} data-testid="place-bid">
+              {bid.isPending ? "Placing..." : "Place bid"}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Bids table */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-base">Bids</CardTitle>
+          {isIssuer && auction.status === "open" && (
+            <Button size="sm" onClick={doClear} disabled={clear.isPending} data-testid="clear-auction">
+              {clear.isPending ? "Clearing..." : "Clear auction"}
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {bids.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No bids yet.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Bidder</TableHead>
+                  <TableHead className="text-right">Quantity</TableHead>
+                  <TableHead className="text-right">Limit price</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {bids.map((b, i) => (
+                  <TableRow key={`${b.sub}-${i}`}>
+                    <TableCell className="font-mono text-xs">{shortSub(b.sub)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{b.qty.toLocaleString()}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatCents(b.limit_price)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border p-2.5">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-sm font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/pages/tokens/sections/CapTableSection.tsx
+++ b/frontend/src/pages/tokens/sections/CapTableSection.tsx
@@ -1,0 +1,75 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { CapTable } from "@/api/endpoints/tokens";
+import { formatBps } from "@/lib/tokens";
+import { PendingBackend } from "../PendingBackend";
+
+function shortSub(sub: string): string {
+  return sub.length > 14 ? `${sub.slice(0, 8)}...${sub.slice(-4)}` : sub;
+}
+
+export function CapTableSection({ query }: { query: UseQueryResult<CapTable> }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Cap table</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {query.isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-full" />
+            <Skeleton className="h-7 w-full" />
+          </div>
+        ) : query.isError ? (
+          <PendingBackend label="The cap table" />
+        ) : (
+          <>
+            <div className="rounded-lg border bg-muted/30 p-3 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Creator retained</span>
+                <span className="font-semibold tabular-nums">
+                  {formatBps(query.data?.creator_pct_bps)}
+                </span>
+              </div>
+            </div>
+            {(query.data?.holders ?? []).length === 0 ? (
+              <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                No outside holders yet - the creator holds 100% until the token is listed.
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Holder</TableHead>
+                    <TableHead className="text-right">Quantity</TableHead>
+                    <TableHead className="text-right">Share</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(query.data?.holders ?? []).map((h) => (
+                    <TableRow key={h.sub}>
+                      <TableCell className="font-mono text-xs">{shortSub(h.sub)}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {h.qty.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">{formatBps(h.pct_bps)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/tokens/sections/RevenueSection.tsx
+++ b/frontend/src/pages/tokens/sections/RevenueSection.tsx
@@ -1,0 +1,110 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import type { RevenueSummary } from "@/api/endpoints/tokens";
+import { formatBps, formatCents } from "@/lib/tokens";
+import { PendingBackend } from "../PendingBackend";
+
+export function RevenueSection({
+  query,
+  onClaim,
+  claiming,
+}: {
+  query: UseQueryResult<RevenueSummary>;
+  onClaim: () => void;
+  claiming: boolean;
+}) {
+  const data = query.data;
+  const claimable = data?.my_claimable ?? 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Revenue distributions</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {query.isLoading ? (
+          <Skeleton className="h-24 w-full" />
+        ) : query.isError ? (
+          <PendingBackend label="Revenue distributions" />
+        ) : (
+          <>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <Metric label="My holding" value={(data?.my_qty ?? 0).toLocaleString()} />
+              <Metric label="My share" value={formatBps(data?.my_pct_bps)} />
+              <Metric label="Claimable" value={formatCents(claimable)} accent />
+            </div>
+
+            <div className="flex items-center justify-between rounded-lg border bg-muted/30 p-3">
+              <p className="text-sm text-muted-foreground">
+                Pro-rata distributions of the creator&rsquo;s content revenue accrue to your holding.
+              </p>
+              <Button onClick={onClaim} disabled={claiming || claimable <= 0} data-testid="claim-revenue">
+                {claiming ? "Claiming..." : `Claim ${formatCents(claimable)}`}
+              </Button>
+            </div>
+
+            <Separator />
+
+            <div>
+              <p className="mb-2 text-sm font-medium">Distribution history</p>
+              {(data?.distributions ?? []).length === 0 ? (
+                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  No distributions yet.
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Date</TableHead>
+                      <TableHead>Source</TableHead>
+                      <TableHead className="text-right">Per token</TableHead>
+                      <TableHead className="text-right">Total</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(data?.distributions ?? []).map((d, i) => (
+                      <TableRow key={`${d.ts}-${i}`}>
+                        <TableCell className="tabular-nums">
+                          {new Date(d.ts * 1000).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell>{d.source}</TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatCents(d.per_token_amount)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatCents(d.total_amount)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className="rounded-lg border p-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={`mt-0.5 text-lg font-semibold tabular-nums ${accent ? "text-emerald-600 dark:text-emerald-400" : ""}`}>
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/tokens/sections/UpkeepSection.tsx
+++ b/frontend/src/pages/tokens/sections/UpkeepSection.tsx
@@ -1,0 +1,114 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { Snowflake } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import type { UpkeepSummary, UpkeepStatus } from "@/api/endpoints/tokens";
+import { formatCents, upkeepCoverageFraction } from "@/lib/tokens";
+import { PendingBackend, ShortfallAssumptionNote } from "../PendingBackend";
+
+const STATUS_VARIANT: Record<UpkeepStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  covered: "secondary",
+  due: "default",
+  paid: "secondary",
+  delinquent: "destructive",
+  frozen: "destructive",
+};
+
+export function UpkeepSection({
+  query,
+  onPay,
+  paying,
+}: {
+  query: UseQueryResult<UpkeepSummary>;
+  onPay: () => void;
+  paying: boolean;
+}) {
+  const data = query.data;
+  const threshold = data?.threshold ?? 100_00;
+  const fees = data?.fees_generated ?? 0;
+  const coveragePct = Math.round(upkeepCoverageFraction(fees, threshold) * 100);
+  const myShare = data?.my_share ?? 0;
+  const frozen = data?.status === "frozen";
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-base">Book upkeep</CardTitle>
+        {data && (
+          <Badge variant={STATUS_VARIANT[data.status] ?? "outline"} className="gap-1">
+            {frozen && <Snowflake className="h-3 w-3" />}
+            {data.status}
+          </Badge>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {query.isLoading ? (
+          <Skeleton className="h-28 w-full" />
+        ) : query.isError ? (
+          <PendingBackend label="Upkeep" />
+        ) : (
+          <>
+            <ShortfallAssumptionNote />
+
+            <div className="space-y-1.5">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">
+                  Trading fees this month{data?.month ? ` (${data.month})` : ""}
+                </span>
+                <span className="tabular-nums">
+                  {formatCents(fees)} / {formatCents(threshold)}
+                </span>
+              </div>
+              <Progress value={coveragePct} />
+              <p className="text-xs text-muted-foreground">
+                {coveragePct}% of the ${(threshold / 100).toFixed(0)} monthly threshold covered by
+                trading fees.
+              </p>
+            </div>
+
+            <Separator />
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <Metric label="Book bill (shortfall)" value={formatCents(data?.amount_due)} />
+              <Metric label="My pro-rata share" value={formatCents(myShare)} accent />
+              <Metric label="Status" value={data?.status ?? "-"} />
+            </div>
+
+            {frozen && (
+              <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                This book is <span className="font-semibold">frozen</span> (non-tradeable) for
+                non-payment. Paying your share below will reverse the freeze.
+              </div>
+            )}
+
+            <div className="flex items-center justify-end">
+              <Button
+                onClick={onPay}
+                disabled={paying || myShare <= 0}
+                variant={frozen ? "destructive" : "default"}
+                data-testid="pay-upkeep"
+              >
+                {paying ? "Paying..." : `Pay my share ${formatCents(myShare)}`}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className="rounded-lg border p-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={`mt-0.5 text-lg font-semibold tabular-nums ${accent ? "text-amber-600 dark:text-amber-400" : ""}`}>
+        {value}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Creator revenue-share token surface (frontend, degrade-on-404)

Second of the two roadmap programs. Frontend for tokenizing a creator's revenue share into a tradeable coin, built to four locked decisions.

### Locked decisions
1. **Real revenue-share claim** — holders receive pro-rata distributions of a % of the creator's ongoing content revenue.
2. **$100/month book upkeep** charged to **holders pro-rata by holding**, as a **shortfall top-up**: `amount_due = max(0, $100 − trading_fees_this_month)`; $0 when the book's monthly fees ≥ $100. Non-payment → book **frozen** (reversible). The shortfall-vs-flat assumption is visibly labelled in-UI so it can be flipped.
3. **Single-clearing-price IPO auction** for the initial N% sale.
4. **Frontend-first, degrade-on-404.**

### API contract (none deployed yet)
`POST /me/tokens` (mint, $100 fee) · `GET /me/tokens[/market|/{id}[/captable|/auction|/revenue|/upkeep]]` · `POST /me/tokens/{id}/{list|auction/bid|auction/clear|revenue/claim|upkeep/pay}`. Every read degrades to an honest empty/"pending backend" state; every mutation surfaces a clear 404 error (never silent success).

### Web (`/tokens` route tree, "Creator Tokens" nav)
- `src/lib/tokens.ts` (+14 vitest) — pure cents/bps, pro-rata share, shortfall upkeep, single-clearing-price summary; `api/endpoints/tokens.ts`; `hooks/useTokens.ts`.
- `pages/tokens`: Market/browse, Mint (+$100 money-safety confirm), Detail — CapTable / Revenue (+Claim) / Upkeep ($100 gauge, my pro-rata share, FROZEN, Pay, assumption label) / issuer IPO launcher + auction panel.

### Android (`feature/tokens` + `data/tokens`, registered in `MoreRoutes`)
- `TokenMath.kt` (+16 JVM tests) + typed `TokensApi/Dtos/Domain/Mappers/Repository/DataModule` (degrade-on-404).
- Market, Mint (+$100 confirm), Detail (cap table / revenue+claim / upkeep+FROZEN / issuer IPO launcher + auction) Compose screens + Hilt ViewModels; `MoreCatalog` entry + `MoreRoutes.REGISTERED` + `AuthenticatedGraph`.

No new deps. Gates: web tsc 0 · vite build · vitest 14/14; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (TokenMath 16/16, MoreCatalogTest 6/6).

### Backend blockers (tracked in exchange_missing_features.md)
Mint an engine symbol + seed its book, per-token cap table, revenue routing seam, monthly upkeep billing job (freeze on non-payment), single-clearing-price IPO clearing. None of this moves real value until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
