### PR TITLE
feat(bailout): pre-emptive margin distress / bailout auction surface (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutApi.kt
@@ -1,0 +1,58 @@
+package com.testlogon.android.data.bailout
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+/**
+ * Retrofit interface for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION surface.
+ *
+ * Paths are relative (no leading slash) so they resolve against the shared Retrofit base URL; the
+ * core-network interceptor chain attaches the cookie session. All methods are `suspend` and return the
+ * typed DTO body; a non-2xx surfaces as `retrofit2.HttpException`.
+ *
+ * NONE of these endpoints exist on the backend yet. [BailoutRepository] degrades every GET to an
+ * empty-but-honest state on 404/absence (never fabricating distress) and surfaces a clear error on
+ * every failed mutation (never a silent success), so this contract is a forward declaration wired for
+ * graceful "pending backend" UX. Positions are addressed by the numeric symbolId.
+ */
+interface BailoutApi {
+
+    /** The caller's distressed-but-solvent margin positions (server-authoritative). */
+    @GET("me/margin/distress")
+    suspend fun getDistress(): DistressResponseDto
+
+    /** Open bailout auctions to browse (the rescuer opportunity board). */
+    @GET("me/bailouts")
+    suspend fun getBailouts(): BailoutListDto
+
+    /** The bailout auction (if any) for one of the caller's positions. */
+    @GET("me/positions/{symbolId}/bailout")
+    suspend fun getPositionBailout(@Path("symbolId") symbolId: Int): BailoutAuctionDto
+
+    /** Open a pre-emptive bailout auction on a distressed-but-solvent position. */
+    @POST("me/positions/{symbolId}/bailout")
+    suspend fun openBailout(
+        @Path("symbolId") symbolId: Int,
+        @Body body: OpenBailoutRequestDto,
+    ): BailoutAuctionDto
+
+    /** Inject rescue capital for a position-share (a sealed rescue bid). */
+    @POST("me/bailouts/{auctionId}/bid")
+    suspend fun placeBid(
+        @Path("auctionId") auctionId: String,
+        @Body body: BailoutBidRequestDto,
+    ): BailoutAckDto
+
+    /** Owner-only: clear the auction at the single least-dilutive clearing share. */
+    @POST("me/bailouts/{auctionId}/clear")
+    suspend fun clear(@Path("auctionId") auctionId: String): BailoutAuctionDto
+
+    @GET("me/prefs/bailout")
+    suspend fun getPrefs(): BailoutPrefsDto
+
+    @PUT("me/prefs/bailout")
+    suspend fun putPrefs(@Body body: BailoutPrefsDto): BailoutPrefsDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutDataModule.kt
@@ -1,0 +1,37 @@
+package com.testlogon.android.data.bailout
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * Provides the [BailoutApi] and binds [BailoutRepository] to its impl for the MARGIN DISTRESS /
+ * PRE-EMPTIVE BAILOUT AUCTION surface. Mirrors the tokens/exchange data module: the API is built off
+ * the shared Retrofit but pinned to HTTP/1.1 on its own pool (the cpp h2 edge refuses concurrent
+ * streams under polling load).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class BailoutDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindBailoutRepository(impl: BailoutRepositoryImpl): BailoutRepository
+
+    companion object {
+        private fun http1(baseClient: okhttp3.OkHttpClient): okhttp3.OkHttpClient =
+            baseClient.newBuilder()
+                .protocols(listOf(okhttp3.Protocol.HTTP_1_1))
+                .connectionPool(okhttp3.ConnectionPool())
+                .build()
+
+        @Provides
+        @Singleton
+        fun provideBailoutApi(retrofit: Retrofit, baseClient: okhttp3.OkHttpClient): BailoutApi =
+            retrofit.newBuilder().client(http1(baseClient)).build().create(BailoutApi::class.java)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutDomain.kt
@@ -1,0 +1,93 @@
+package com.testlogon.android.data.bailout
+
+/**
+ * MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION domain models — render-ready shapes the feature layer
+ * consumes.
+ *
+ * A leveraged margin position approaching a margin call can open a PRE-EMPTIVE bailout auction to raise
+ * rescue capital and avoid forced liquidation. The auction exists ONLY while the position is in a
+ * volatility-scaled DISTRESS band but STILL SOLVENT (`equity > maintenance`); once equity <= maintenance
+ * a bailout is impossible (that is liquidation). Rescuers inject capital for a POSITION-SHARE (they
+ * co-own a slice of the position + its uPnL). The auction clears at a SINGLE clearing share (the least
+ * total position-share the owner must give up to raise the capital needed). All amounts are integer
+ * CENTS; `Bps` are basis points (10_000 bps == 100%). Server-authoritative — the client renders the
+ * read and never fabricates distress.
+ */
+
+/** Which side the underlying margin position is. */
+enum class PositionSide { LONG, SHORT, UNKNOWN }
+
+/** The three health zones derived from the buffer vs the volatility-scaled danger line + solvency. */
+enum class HealthZone { HEALTHY, DISTRESS, LIQUIDATION }
+
+/**
+ * One margin position projected with its distress read. [inBand] is the server's authoritative
+ * "in the distress band AND solvent" flag; [eligible] is whether a pre-emptive bailout can be opened
+ * right now. [auctionId] is set when an auction already exists for this position.
+ */
+data class DistressPosition(
+    val symbolId: Int,
+    val symbol: String,
+    val side: PositionSide,
+    val qty: Long,
+    val entryPrice: Long,
+    val markPrice: Long,
+    val liqPrice: Long,
+    val equityCents: Long,
+    val maintenanceCents: Long,
+    val bufferBps: Int,
+    val volatilityBps: Int,
+    val dangerBps: Int,
+    val inBand: Boolean,
+    val eligible: Boolean,
+    val auctionId: String? = null,
+)
+
+enum class BailoutStatus { OPEN, CLEARED, CANCELLED, LIQUIDATED, UNKNOWN }
+
+/** One rescuer's injected capital and the position-share they receive for it. */
+data class BailoutRescuer(
+    val sub: String,
+    val capitalCents: Long,
+    val shareBps: Int,
+)
+
+/**
+ * A pre-emptive bailout auction over a distressed-but-solvent margin position. Rescuers bid capital for
+ * a position-share; the auction clears at a SINGLE clearing share ([clearingShareBps]) — the least
+ * total share given up to raise [capitalNeededCents]. If the mark hits [liqPrice] mid-auction the
+ * position breaches maintenance, the auction auto-cancels ([BailoutStatus.LIQUIDATED]) and normal
+ * liquidation proceeds.
+ */
+data class BailoutAuction(
+    val auctionId: String,
+    val symbolId: Int,
+    val ownerSub: String,
+    val side: PositionSide,
+    val qty: Long,
+    val capitalNeededCents: Long,
+    val maxShareBps: Int,
+    val status: BailoutStatus,
+    val clearingShareBps: Int? = null,
+    val raisedCents: Long? = null,
+    val rescuers: List<BailoutRescuer> = emptyList(),
+    val liqPrice: Long,
+    val markPrice: Long,
+    val closeTs: Long = 0,
+)
+
+/**
+ * The account-level auto-bailout preference: when [autoEnabled] a bailout auction auto-opens on
+ * band-entry (else the trader must open it manually), offering up to [defaultMaxShareBps] of the
+ * position-share.
+ */
+data class BailoutPrefs(
+    val autoEnabled: Boolean,
+    val defaultMaxShareBps: Int,
+)
+
+/** A simple mutation acknowledgement — [accepted] is false when the server didn't confirm. */
+data class BailoutAck(
+    val accepted: Boolean,
+    val message: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutDtos.kt
@@ -1,0 +1,102 @@
+package com.testlogon.android.data.bailout
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.network.json.LenientInt
+import com.testlogon.android.core.network.json.LenientLong
+
+/**
+ * Wire DTOs for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION surface (`me/margin/distress`,
+ * `me/bailouts`, `me/positions/{id}/bailout`, `me/prefs/bailout`).
+ *
+ * NONE of these endpoints exist on the backend yet — every READ degrades to an empty-but-honest state
+ * on 404/absence (the UI shows an honest "pending backend" state and NEVER fabricates distress), and
+ * every failed MUTATION surfaces a clear error (never a silent success). All numeric fields are lenient
+ * (the edge may stringify ids / cents / bps) and every field is defaulted so a partial / drifted
+ * payload still parses. Amounts are integer CENTS; `Bps` are basis points.
+ */
+@JsonClass(generateAdapter = true)
+data class DistressPositionDto(
+    @LenientInt @Json(name = "symbol_id") val symbolId: Int? = null,
+    @Json(name = "symbol") val symbol: String? = null,
+    @Json(name = "side") val side: String? = null,
+    @LenientLong @Json(name = "qty") val qty: Long? = null,
+    @LenientLong @Json(name = "entry_price") val entryPrice: Long? = null,
+    @LenientLong @Json(name = "mark_price") val markPrice: Long? = null,
+    @LenientLong @Json(name = "liq_price") val liqPrice: Long? = null,
+    @LenientLong @Json(name = "equity_cents") val equityCents: Long? = null,
+    @LenientLong @Json(name = "maintenance_cents") val maintenanceCents: Long? = null,
+    @LenientInt @Json(name = "buffer_bps") val bufferBps: Int? = null,
+    @LenientInt @Json(name = "volatility_bps") val volatilityBps: Int? = null,
+    @LenientInt @Json(name = "danger_bps") val dangerBps: Int? = null,
+    @Json(name = "in_band") val inBand: Boolean? = null,
+    @Json(name = "eligible") val eligible: Boolean? = null,
+    @Json(name = "auction_id") val auctionId: String? = null,
+)
+
+/** `GET me/margin/distress` -> {positions:[DistressPosition]}. */
+@JsonClass(generateAdapter = true)
+data class DistressResponseDto(
+    @Json(name = "positions") val positions: List<DistressPositionDto>? = null,
+)
+
+/** One rescuer row on an auction. */
+@JsonClass(generateAdapter = true)
+data class BailoutRescuerDto(
+    @Json(name = "sub") val sub: String? = null,
+    @LenientLong @Json(name = "capital_cents") val capitalCents: Long? = null,
+    @LenientInt @Json(name = "share_bps") val shareBps: Int? = null,
+)
+
+/** `GET me/bailouts/{id}` / `GET me/positions/{id}/bailout` -> the bailout auction state. */
+@JsonClass(generateAdapter = true)
+data class BailoutAuctionDto(
+    @Json(name = "auction_id") val auctionId: String? = null,
+    @LenientInt @Json(name = "symbol_id") val symbolId: Int? = null,
+    @Json(name = "owner_sub") val ownerSub: String? = null,
+    @Json(name = "side") val side: String? = null,
+    @LenientLong @Json(name = "qty") val qty: Long? = null,
+    @LenientLong @Json(name = "capital_needed_cents") val capitalNeededCents: Long? = null,
+    @LenientInt @Json(name = "max_share_bps") val maxShareBps: Int? = null,
+    @Json(name = "status") val status: String? = null,
+    @LenientInt @Json(name = "clearing_share_bps") val clearingShareBps: Int? = null,
+    @LenientLong @Json(name = "raised_cents") val raisedCents: Long? = null,
+    @Json(name = "rescuers") val rescuers: List<BailoutRescuerDto>? = null,
+    @LenientLong @Json(name = "liq_price") val liqPrice: Long? = null,
+    @LenientLong @Json(name = "mark_price") val markPrice: Long? = null,
+    @LenientLong @Json(name = "close_ts") val closeTs: Long? = null,
+)
+
+/** `GET me/bailouts` -> {auctions:[BailoutAuction]} (the rescuer opportunity board). */
+@JsonClass(generateAdapter = true)
+data class BailoutListDto(
+    @Json(name = "auctions") val auctions: List<BailoutAuctionDto>? = null,
+)
+
+/** `POST me/positions/{id}/bailout` body — open a pre-emptive bailout auction. */
+@JsonClass(generateAdapter = true)
+data class OpenBailoutRequestDto(
+    @Json(name = "max_share_bps") val maxShareBps: Int,
+    @Json(name = "close_ts") val closeTs: Long? = null,
+)
+
+/** `POST me/bailouts/{id}/bid` body — inject capital for a position-share. */
+@JsonClass(generateAdapter = true)
+data class BailoutBidRequestDto(
+    @Json(name = "capital_cents") val capitalCents: Long,
+    @Json(name = "share_bps") val shareBps: Int,
+)
+
+/** Generic mutation ack ({status:"ok"|"ack", ...}); parsed defensively. */
+@JsonClass(generateAdapter = true)
+data class BailoutAckDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "message") val message: String? = null,
+)
+
+/** `GET me/prefs/bailout` / `PUT me/prefs/bailout` -> the auto-bailout preference. */
+@JsonClass(generateAdapter = true)
+data class BailoutPrefsDto(
+    @Json(name = "auto_enabled") val autoEnabled: Boolean? = null,
+    @LenientInt @Json(name = "default_max_share_bps") val defaultMaxShareBps: Int? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutMappers.kt
@@ -1,0 +1,83 @@
+package com.testlogon.android.data.bailout
+
+/**
+ * DTO -> domain mappers for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION surface. Every field is
+ * defensively defaulted (the endpoints don't exist yet + the edge may drift), so a partial payload maps
+ * to a sane, honest domain object rather than throwing. NOTHING here fabricates distress: absent
+ * flags map to false, absent numbers to zero.
+ */
+
+private fun String?.toPositionSide(): PositionSide = when (this?.trim()?.lowercase()) {
+    "long", "buy", "b" -> PositionSide.LONG
+    "short", "sell", "s" -> PositionSide.SHORT
+    else -> PositionSide.UNKNOWN
+}
+
+private fun String?.toBailoutStatus(): BailoutStatus = when (this?.trim()?.lowercase()) {
+    "open" -> BailoutStatus.OPEN
+    "cleared" -> BailoutStatus.CLEARED
+    "cancelled", "canceled" -> BailoutStatus.CANCELLED
+    "liquidated" -> BailoutStatus.LIQUIDATED
+    else -> BailoutStatus.UNKNOWN
+}
+
+fun DistressPositionDto.toDomain(): DistressPosition = DistressPosition(
+    symbolId = symbolId ?: 0,
+    symbol = symbol.orEmpty(),
+    side = side.toPositionSide(),
+    qty = qty ?: 0L,
+    entryPrice = entryPrice ?: 0L,
+    markPrice = markPrice ?: 0L,
+    liqPrice = liqPrice ?: 0L,
+    equityCents = equityCents ?: 0L,
+    maintenanceCents = maintenanceCents ?: 0L,
+    bufferBps = bufferBps ?: 0,
+    volatilityBps = volatilityBps ?: 0,
+    dangerBps = dangerBps ?: 0,
+    inBand = inBand ?: false,
+    eligible = eligible ?: false,
+    auctionId = auctionId?.takeIf { it.isNotBlank() },
+)
+
+fun DistressResponseDto.toDomain(): List<DistressPosition> =
+    positions.orEmpty().map { it.toDomain() }.filter { it.symbolId != 0 || it.symbol.isNotBlank() }
+
+fun BailoutRescuerDto.toDomain(): BailoutRescuer = BailoutRescuer(
+    sub = sub.orEmpty(),
+    capitalCents = capitalCents ?: 0L,
+    shareBps = shareBps ?: 0,
+)
+
+fun BailoutAuctionDto.toDomain(fallbackId: String = ""): BailoutAuction = BailoutAuction(
+    auctionId = auctionId?.takeIf { it.isNotBlank() } ?: fallbackId,
+    symbolId = symbolId ?: 0,
+    ownerSub = ownerSub.orEmpty(),
+    side = side.toPositionSide(),
+    qty = qty ?: 0L,
+    capitalNeededCents = capitalNeededCents ?: 0L,
+    maxShareBps = maxShareBps ?: 0,
+    status = status.toBailoutStatus(),
+    clearingShareBps = clearingShareBps,
+    raisedCents = raisedCents,
+    rescuers = rescuers.orEmpty().map { it.toDomain() },
+    liqPrice = liqPrice ?: 0L,
+    markPrice = markPrice ?: 0L,
+    closeTs = closeTs ?: 0L,
+)
+
+fun BailoutListDto.toDomain(): List<BailoutAuction> =
+    auctions.orEmpty().map { it.toDomain() }.filter { it.auctionId.isNotBlank() }
+
+fun BailoutPrefsDto.toDomain(): BailoutPrefs = BailoutPrefs(
+    autoEnabled = autoEnabled ?: false,
+    defaultMaxShareBps = defaultMaxShareBps ?: 0,
+)
+
+/** An ack is accepted when the server returns a positive status token. */
+fun BailoutAckDto.toDomain(): BailoutAck {
+    val accepted = when (status?.trim()?.lowercase()) {
+        "ok", "ack", "accepted", "queued", "success", "opened" -> true
+        else -> false
+    }
+    return BailoutAck(accepted = accepted, message = message)
+}

--- a/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutPrefsStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutPrefsStore.kt
@@ -1,0 +1,42 @@
+package com.testlogon.android.data.bailout
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Device-local fallback for the AUTO-BAILOUT preference.
+ *
+ * The authoritative store is the server (`GET/PUT me/prefs/bailout`), but that endpoint is not built
+ * yet, so the settings surface degrades to this SharedPreferences-backed local copy (labelled "saved on
+ * this device" in the UI). When the backend lands, the server read wins and this simply mirrors the
+ * last chosen value so the toggle is never blank. Amounts in basis points (10_000 == 100%).
+ */
+@Singleton
+class BailoutPrefsStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun read(): BailoutPrefs = BailoutPrefs(
+        autoEnabled = prefs.getBoolean(KEY_AUTO_ENABLED, false),
+        defaultMaxShareBps = prefs.getInt(KEY_MAX_SHARE_BPS, DEFAULT_MAX_SHARE_BPS),
+    )
+
+    fun write(prefsValue: BailoutPrefs) {
+        prefs.edit()
+            .putBoolean(KEY_AUTO_ENABLED, prefsValue.autoEnabled)
+            .putInt(KEY_MAX_SHARE_BPS, prefsValue.defaultMaxShareBps)
+            .apply()
+    }
+
+    companion object {
+        const val DEFAULT_MAX_SHARE_BPS = 2_000 // 20%
+        private const val PREFS_NAME = "tl_bailout_prefs"
+        private const val KEY_AUTO_ENABLED = "auto_enabled"
+        private const val KEY_MAX_SHARE_BPS = "default_max_share_bps"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/bailout/BailoutRepository.kt
@@ -1,0 +1,131 @@
+package com.testlogon.android.data.bailout
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer over [BailoutApi] for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION surface.
+ *
+ * The endpoints do NOT exist on the backend yet, so every READ DEGRADES to an empty-but-honest value on
+ * 404/HTTP-error (the UI shows an honest "pending backend" / empty state and NEVER fabricates distress),
+ * while a real transport failure ([ApiResult.NetworkError]) is surfaced so the UI can offer retry.
+ * Every MUTATION passes failures through as [ApiResult.Failure]/[ApiResult.NetworkError] so a 404
+ * (undeployed) surfaces as a clear error and never a silent success.
+ *
+ * The auto-bailout preference read additionally degrades to a DEVICE-LOCAL copy ([BailoutPrefsStore])
+ * when the server endpoint 404s, so the settings toggle always reflects the last chosen value.
+ */
+interface BailoutRepository {
+    /** The caller's distressed-but-solvent positions (degrades to empty — never fabricated). */
+    suspend fun distress(): ApiResult<List<DistressPosition>>
+
+    /** Open bailout auctions to browse — the rescuer board (degrades to empty). */
+    suspend fun bailouts(): ApiResult<List<BailoutAuction>>
+
+    /** The bailout auction for one position (degrades to null when none / undeployed). */
+    suspend fun positionBailout(symbolId: Int): ApiResult<BailoutAuction?>
+
+    /** The auto-bailout preference (degrades to the device-local copy on 404). */
+    suspend fun prefs(): ApiResult<BailoutPrefs>
+
+    // ---- Mutations (errors surface; never silent success) ----
+    suspend fun openBailout(symbolId: Int, maxShareBps: Int, closeTs: Long?): ApiResult<BailoutAuction>
+    suspend fun placeBid(auctionId: String, capitalCents: Long, shareBps: Int): ApiResult<BailoutAck>
+    suspend fun clear(auctionId: String): ApiResult<BailoutAuction>
+    suspend fun putPrefs(autoEnabled: Boolean, defaultMaxShareBps: Int): ApiResult<BailoutPrefs>
+}
+
+@Singleton
+class BailoutRepositoryImpl @Inject constructor(
+    private val api: BailoutApi,
+    private val prefsStore: BailoutPrefsStore,
+    private val errorParser: ApiErrorParser,
+) : BailoutRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun distress(): ApiResult<List<DistressPosition>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getDistress().toDomain() }
+    }
+
+    override suspend fun bailouts(): ApiResult<List<BailoutAuction>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getBailouts().toDomain() }
+    }
+
+    override suspend fun positionBailout(symbolId: Int): ApiResult<BailoutAuction?> = withContext(io) {
+        degradeToEmpty(null) { api.getPositionBailout(symbolId).toDomain() }
+    }
+
+    override suspend fun prefs(): ApiResult<BailoutPrefs> = withContext(io) {
+        // Degrade to the device-local copy on HTTP error (endpoint pending); mirror server reads locally.
+        when (val r = apiCall { api.getPrefs().toDomain() }) {
+            is ApiResult.Success -> { prefsStore.write(r.data); r }
+            is ApiResult.Failure -> ApiResult.Success(prefsStore.read())
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun openBailout(
+        symbolId: Int,
+        maxShareBps: Int,
+        closeTs: Long?,
+    ): ApiResult<BailoutAuction> = withContext(io) {
+        apiCall { api.openBailout(symbolId, OpenBailoutRequestDto(maxShareBps, closeTs)).toDomain() }
+    }
+
+    override suspend fun placeBid(
+        auctionId: String,
+        capitalCents: Long,
+        shareBps: Int,
+    ): ApiResult<BailoutAck> = withContext(io) {
+        apiCall { api.placeBid(auctionId, BailoutBidRequestDto(capitalCents, shareBps)).toDomain() }
+    }
+
+    override suspend fun clear(auctionId: String): ApiResult<BailoutAuction> = withContext(io) {
+        apiCall { api.clear(auctionId).toDomain(auctionId) }
+    }
+
+    override suspend fun putPrefs(
+        autoEnabled: Boolean,
+        defaultMaxShareBps: Int,
+    ): ApiResult<BailoutPrefs> = withContext(io) {
+        // Always persist locally so the toggle is durable even when the server endpoint 404s. If the PUT
+        // itself 404s we still report success from the local write (labelled device-local in the UI).
+        prefsStore.write(BailoutPrefs(autoEnabled, defaultMaxShareBps))
+        when (val r = apiCall { api.putPrefs(BailoutPrefsDto(autoEnabled, defaultMaxShareBps)).toDomain() }) {
+            is ApiResult.Success -> { prefsStore.write(r.data); r }
+            is ApiResult.Failure -> ApiResult.Success(prefsStore.read())
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    /**
+     * Read helper: run [block]; on an HTTP error (the endpoint doesn't exist yet -> 404) DEGRADE to
+     * [empty]; only a transport [ApiResult.NetworkError] is surfaced (so the UI can offer retry).
+     */
+    private suspend fun <T> degradeToEmpty(empty: T, block: suspend () -> T): ApiResult<T> =
+        when (val r = apiCall(block)) {
+            is ApiResult.Success -> r
+            is ApiResult.Failure -> ApiResult.Success(empty)
+            is ApiResult.NetworkError -> r
+        }
+
+    private suspend fun <T> apiCall(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutAuctionScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutAuctionScreen.kt
@@ -1,0 +1,327 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.bailout
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.bailout.BailoutAuction
+import com.testlogon.android.data.bailout.BailoutStatus
+import com.testlogon.android.data.bailout.HealthZone
+
+/**
+ * One pre-emptive bailout auction: capital-needed target, rescuer bid list, a "Bail out" rescue-bid
+ * form (capital -> position-share) behind a money-safety confirm, the indicative clearing share
+ * (pure [BailoutMath]), a live "if mark hits {liqPrice} first -> cancels -> liquidation" warning, and
+ * an owner Clear. Reads degrade on 404. The screen self-detects owner vs rescuer from ownerSub when
+ * available, else shows both affordances defensively (server enforces authority).
+ */
+@Composable
+fun BailoutAuctionRoute(
+    onBack: () -> Unit,
+    viewModel: BailoutAuctionViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbar = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.actionMessage) {
+        state.actionMessage?.let {
+            snackbar.showSnackbar(it)
+            viewModel.consumeActionMessage()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Bailout auction") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbar) },
+    ) { padding ->
+        when (state.phase) {
+            BailoutAuctionUiState.Phase.Loading -> LoadingState(message = "Loading auction")
+            BailoutAuctionUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Something went wrong.",
+                onRetry = viewModel::onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            BailoutAuctionUiState.Phase.Content -> AuctionContent(
+                state = state,
+                modifier = Modifier.padding(padding),
+                onBid = viewModel::placeBid,
+                onClear = viewModel::clear,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AuctionContent(
+    state: BailoutAuctionUiState,
+    modifier: Modifier = Modifier,
+    onBid: (capitalCents: Long, shareBps: Int) -> Unit,
+    onClear: () -> Unit,
+) {
+    val auction = state.auction
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        if (auction == null) {
+            BailoutSectionCard(title = "No auction") {
+                Text(
+                    "There is no open bailout auction for this position. If the margin-distress backend is still pending, this stays empty rather than guessing.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return
+        }
+
+        // Live liquidation warning (pre-emptive auctions auto-cancel if the mark reaches the liq price).
+        if (auction.status == BailoutStatus.OPEN) {
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = HealthZone.LIQUIDATION.color.copy(alpha = 0.12f),
+                ),
+            ) {
+                Column(Modifier.padding(14.dp)) {
+                    Text(
+                        "Pre-emptive only",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = HealthZone.LIQUIDATION.color,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "If the mark hits ${auction.liqPrice} first, the position breaches maintenance: this auction auto-cancels and normal liquidation proceeds. Mark now: ${auction.markPrice}.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+
+        BailoutSectionCard(title = "Target") {
+            BailoutKeyValueRow("Status", auction.status.label(), emphasize = true)
+            BailoutKeyValueRow("Position", "${auction.side.label()} ${auction.qty}")
+            BailoutKeyValueRow("Capital needed", BailoutMath.formatCents(auction.capitalNeededCents))
+            BailoutKeyValueRow("Max share offered", BailoutMath.formatBps(auction.maxShareBps))
+            auction.raisedCents?.let { BailoutKeyValueRow("Raised", BailoutMath.formatCents(it)) }
+            auction.clearingShareBps?.let {
+                BailoutKeyValueRow("Clearing share", BailoutMath.formatBps(it), emphasize = true)
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+
+        // Indicative single-clearing-share preview from the sealed rescuer bids (pure BailoutMath).
+        val bids = remember(auction.rescuers) {
+            auction.rescuers.map { BailoutMath.BailoutBid(it.capitalCents, it.shareBps) }
+        }
+        if (auction.status == BailoutStatus.OPEN && bids.isNotEmpty()) {
+            val summary = remember(bids, auction.capitalNeededCents) {
+                BailoutMath.clearingSummary(bids, auction.capitalNeededCents)
+            }
+            BailoutSectionCard(title = "Indicative clearing (from ${bids.size} rescuers)") {
+                BailoutKeyValueRow(
+                    "Would give up",
+                    summary.clearingShareBps?.let { BailoutMath.formatBps(it) } ?: "n/a",
+                )
+                BailoutKeyValueRow("Would raise", BailoutMath.formatCents(summary.raisedCents))
+                BailoutKeyValueRow(
+                    "Funded",
+                    if (summary.fullyFunded) "fully" else "partial (short of target)",
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+
+        if (auction.rescuers.isNotEmpty()) {
+            BailoutSectionCard(title = "Rescuers") {
+                auction.rescuers.forEach { r ->
+                    BailoutKeyValueRow(
+                        shortSub(r.sub),
+                        "${BailoutMath.formatCents(r.capitalCents)} -> ${BailoutMath.formatBps(r.shareBps)}",
+                    )
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+
+        when (auction.status) {
+            BailoutStatus.OPEN -> {
+                RescueBidForm(
+                    auction = auction,
+                    inFlight = state.actionInFlight,
+                    onBid = onBid,
+                )
+                Spacer(Modifier.height(12.dp))
+                OwnerClear(inFlight = state.actionInFlight, onClear = onClear)
+            }
+            else -> BailoutSectionCard(title = "Closed") {
+                Text(
+                    "Auction ${auction.status.label().lowercase()} - bidding closed.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RescueBidForm(
+    auction: BailoutAuction,
+    inFlight: Boolean,
+    onBid: (Long, Int) -> Unit,
+) {
+    var capitalText by remember { mutableStateOf("") }
+    var shareText by remember { mutableStateOf("") }
+    var showConfirm by remember { mutableStateOf(false) }
+
+    val capitalCents = capitalText.trim().toDoubleOrNull()?.let { (it * 100).toLong() }?.takeIf { it > 0 }
+    val shareBps = shareText.trim().toDoubleOrNull()?.let { (it * 100).toInt() }?.takeIf { it in 1..auction.maxShareBps }
+
+    BailoutSectionCard(title = "Bail out (inject rescue capital)") {
+        Text(
+            "Inject capital in return for a slice of the position (and its uPnL). You give up share only up to the single clearing rate if filled.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = capitalText,
+            onValueChange = { capitalText = it.filter { c -> c.isDigit() || c == '.' } },
+            label = { Text("Capital ($)") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+            modifier = Modifier.fillMaxWidth().testTag("rescue_capital"),
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = shareText,
+            onValueChange = { shareText = it.filter { c -> c.isDigit() || c == '.' } },
+            label = { Text("Share asked % (<= ${BailoutMath.formatBps(auction.maxShareBps)})") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+            modifier = Modifier.fillMaxWidth().testTag("rescue_share"),
+        )
+        Spacer(Modifier.height(10.dp))
+        OutlinedButton(
+            onClick = { showConfirm = true },
+            enabled = !inFlight && capitalCents != null && shareBps != null,
+            modifier = Modifier.fillMaxWidth().testTag("rescue_submit"),
+        ) { Text("Bail out") }
+    }
+
+    if (showConfirm && capitalCents != null && shareBps != null) {
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text("Confirm rescue bid") },
+            text = {
+                Column {
+                    BailoutKeyValueRow("Capital", BailoutMath.formatCents(capitalCents))
+                    BailoutKeyValueRow("Share asked", BailoutMath.formatBps(shareBps))
+                    HorizontalDivider(Modifier.padding(vertical = 6.dp))
+                    Text(
+                        "Sealed rescue bid - you pay this capital and receive up to the clearing position-share if filled. Auto-cancels (no fill) if the position liquidates first.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = { showConfirm = false; onBid(capitalCents, shareBps) },
+                    modifier = Modifier.testTag("rescue_confirm"),
+                ) { Text("Bail out") }
+            },
+            dismissButton = { TextButton(onClick = { showConfirm = false }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun OwnerClear(inFlight: Boolean, onClear: () -> Unit) {
+    var showConfirm by remember { mutableStateOf(false) }
+    BailoutSectionCard(title = "Owner: clear") {
+        Text(
+            "If you are the position owner, clear the auction at the single least-dilutive clearing share once enough rescue capital is bid.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(8.dp))
+        Button(
+            onClick = { showConfirm = true },
+            enabled = !inFlight,
+            modifier = Modifier.fillMaxWidth().testTag("owner_clear"),
+        ) { Text("Clear auction (single share)") }
+    }
+
+    if (showConfirm) {
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text("Clear the auction?") },
+            text = {
+                Text(
+                    "All accepted rescue bids fill at one clearing position-share (the least total share needed to raise the capital). This closes bidding.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = { showConfirm = false; onClear() },
+                    modifier = Modifier.testTag("owner_clear_confirm"),
+                ) { Text("Clear") }
+            },
+            dismissButton = { TextButton(onClick = { showConfirm = false }) { Text("Cancel") } },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutAuctionViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutAuctionViewModel.kt
@@ -1,0 +1,106 @@
+package com.testlogon.android.feature.bailout
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.bailout.BailoutAuction
+import com.testlogon.android.data.bailout.BailoutRepository
+import com.testlogon.android.navigation.BailoutAuctionDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class BailoutAuctionUiState(
+    val symbolId: Int,
+    val phase: Phase = Phase.Loading,
+    val auction: BailoutAuction? = null,
+    val errorMessage: String? = null,
+    val actionMessage: String? = null,
+    val actionInFlight: Boolean = false,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * Drives one PRE-EMPTIVE BAILOUT AUCTION (for a position addressed by symbolId): the capital-needed
+ * target, rescuer bids, a rescue-bid form behind a money-safety confirm, the indicative clearing share
+ * (pure [BailoutMath]), the live "if mark hits liqPrice first -> cancels -> liquidation" warning, and
+ * the owner Clear. Reads degrade on 404; mutations surface a clear result then refresh.
+ */
+@HiltViewModel
+class BailoutAuctionViewModel @Inject constructor(
+    private val repository: BailoutRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val symbolId: Int =
+        savedStateHandle.get<String>(BailoutAuctionDest.ARG_SYMBOL_ID)?.toIntOrNull() ?: 0
+
+    private val _uiState = MutableStateFlow(BailoutAuctionUiState(symbolId = symbolId))
+    val uiState: StateFlow<BailoutAuctionUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    fun consumeActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+
+    fun load() {
+        _uiState.update { it.copy(phase = BailoutAuctionUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.positionBailout(symbolId)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(phase = BailoutAuctionUiState.Phase.Content, auction = r.data, errorMessage = null)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = BailoutAuctionUiState.Phase.Content, auction = null)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = BailoutAuctionUiState.Phase.Error,
+                        errorMessage = "No connection. Check your network and retry.",
+                    )
+                }
+            }
+        }
+    }
+
+    /** Inject rescue capital for a position-share (a sealed rescue bid). */
+    fun placeBid(capitalCents: Long, shareBps: Int) = mutate {
+        val id = _uiState.value.auction?.auctionId.orEmpty()
+        if (id.isBlank()) return@mutate "No open auction to bid on."
+        when (val r = repository.placeBid(id, capitalCents, shareBps)) {
+            is ApiResult.Success -> if (r.data.accepted) "Rescue bid placed." else (r.data.message ?: "Bid not accepted.")
+            is ApiResult.Failure -> r.error.message.ifBlank { "Couldn't place a rescue bid (backend pending)." }
+            is ApiResult.NetworkError -> "No connection. Your rescue bid was not placed."
+        }
+    }
+
+    /** Owner-only: clear the auction at the single least-dilutive clearing share. */
+    fun clear() = mutate {
+        val id = _uiState.value.auction?.auctionId.orEmpty()
+        if (id.isBlank()) return@mutate "No open auction to clear."
+        when (val r = repository.clear(id)) {
+            is ApiResult.Success -> "Auction cleared at the single clearing share."
+            is ApiResult.Failure -> r.error.message.ifBlank { "Couldn't clear the auction (backend pending)." }
+            is ApiResult.NetworkError -> "No connection. The auction was not cleared."
+        }
+    }
+
+    private fun mutate(block: suspend () -> String) {
+        if (_uiState.value.actionInFlight) return
+        _uiState.update { it.copy(actionInFlight = true) }
+        viewModelScope.launch {
+            val msg = block()
+            _uiState.update { it.copy(actionInFlight = false, actionMessage = msg) }
+            load()
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutBoardScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutBoardScreen.kt
@@ -1,0 +1,131 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.bailout
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.bailout.BailoutAuction
+
+/**
+ * Bailouts discovery board: open pre-emptive bailout auctions a rescuer can inject capital into. Honest
+ * empty/pending state on 404 (never fabricates a distress opportunity). Tapping a row opens the auction
+ * (addressed by its symbolId).
+ */
+@Composable
+fun BailoutBoardRoute(
+    onBack: () -> Unit,
+    onOpenAuction: (symbolId: Int) -> Unit,
+    viewModel: BailoutBoardViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Open bailouts") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            BailoutBoardUiState.Phase.Loading -> LoadingState(message = "Loading bailouts")
+            BailoutBoardUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Something went wrong.",
+                onRetry = viewModel::onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            BailoutBoardUiState.Phase.Content -> LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                item {
+                    Text(
+                        "Inject rescue capital into a distressed-but-solvent position for a slice of it (and its uPnL). Bids clear at a single least-dilutive share.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (state.auctions.isEmpty()) {
+                    item { EmptyBoard() }
+                } else {
+                    items(state.auctions.size, key = { "b_" + state.auctions[it].auctionId }) { i ->
+                        BoardRow(state.auctions[i], onOpenAuction)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoardRow(auction: BailoutAuction, onOpenAuction: (Int) -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable { onOpenAuction(auction.symbolId) },
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    "${auction.side.label()} ${auction.qty} · symbol ${auction.symbolId}",
+                    fontWeight = FontWeight.SemiBold,
+                )
+                BailoutStatusPill(auction.status.label())
+            }
+            Spacer(Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(6.dp))
+            BailoutKeyValueRow("Capital needed", BailoutMath.formatCents(auction.capitalNeededCents))
+            auction.raisedCents?.let { BailoutKeyValueRow("Raised", BailoutMath.formatCents(it)) }
+            BailoutKeyValueRow("Max share offered", BailoutMath.formatBps(auction.maxShareBps))
+            BailoutKeyValueRow("Liq / mark", "${auction.liqPrice} / ${auction.markPrice}")
+            BailoutKeyValueRow("Rescuers", auction.rescuers.size.toString())
+        }
+    }
+}
+
+@Composable
+private fun EmptyBoard() {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(24.dp)) {
+            Text("No open bailouts", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "There are no open bailout auctions to rescue right now. (If the me/bailouts backend is still pending, this stays empty rather than inventing opportunities.)",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutBoardViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutBoardViewModel.kt
@@ -1,0 +1,62 @@
+package com.testlogon.android.feature.bailout
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.bailout.BailoutAuction
+import com.testlogon.android.data.bailout.BailoutRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class BailoutBoardUiState(
+    val phase: Phase = Phase.Loading,
+    val auctions: List<BailoutAuction> = emptyList(),
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * Drives the BAILOUTS DISCOVERY board — open pre-emptive bailout auctions a rescuer can inject capital
+ * into. Degrades to an honest empty/pending state on 404 (the me/bailouts backend is undeployed) rather
+ * than an error, so nothing distress-like is ever fabricated.
+ */
+@HiltViewModel
+class BailoutBoardViewModel @Inject constructor(
+    private val repository: BailoutRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BailoutBoardUiState())
+    val uiState: StateFlow<BailoutBoardUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    fun load() {
+        _uiState.update { it.copy(phase = BailoutBoardUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.bailouts()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(phase = BailoutBoardUiState.Phase.Content, auctions = r.data, errorMessage = null)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = BailoutBoardUiState.Phase.Content, auctions = emptyList())
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = BailoutBoardUiState.Phase.Error,
+                        errorMessage = "No connection. Check your network and retry.",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutMath.kt
@@ -1,0 +1,161 @@
+package com.testlogon.android.feature.bailout
+
+import com.testlogon.android.data.bailout.HealthZone
+
+/**
+ * Pure, side-effect-free math for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION surface. Extracted
+ * so the tricky bits (health-zone classification, single-clearing-price bailout clearing) are
+ * unit-testable off the Android runtime.
+ *
+ * All amounts are integer CENTS; `Bps` are basis points (10_000 bps == 100%). This math NEVER decides
+ * distress on its own account values — the server is authoritative and passes buffer/danger/solvency in;
+ * [healthZone] only classifies numbers the server already computed.
+ */
+object BailoutMath {
+
+    /** Basis points denominator: 10_000 bps == 100%. */
+    const val BPS_DENOM: Int = 10_000
+
+    /**
+     * Classify a position into a health zone from its volatility-scaled band read.
+     *
+     * - NOT [solvent] (equity <= maintenance) -> [HealthZone.LIQUIDATION] regardless of buffer: a
+     *   pre-emptive bailout is impossible once maintenance is breached.
+     * - solvent AND `bufferBps <= dangerBps` (inside the danger band) -> [HealthZone.DISTRESS]: a
+     *   pre-emptive bailout auction is possible here (distressed but still solvent).
+     * - solvent AND `bufferBps > dangerBps` -> [HealthZone.HEALTHY].
+     *
+     * [bufferBps] is `|mark - liqPrice| / mark` in bps (distance to liquidation); [dangerBps] is the
+     * clamped volatility-scaled danger line. Negative inputs are treated as zero.
+     */
+    fun healthZone(bufferBps: Int, dangerBps: Int, solvent: Boolean): HealthZone {
+        if (!solvent) return HealthZone.LIQUIDATION
+        val buffer = bufferBps.coerceAtLeast(0)
+        val danger = dangerBps.coerceAtLeast(0)
+        return if (buffer <= danger) HealthZone.DISTRESS else HealthZone.HEALTHY
+    }
+
+    /**
+     * The volatility-scaled danger line in bps: `clamp(k * volatilityBps, floor, ceil)`. Provided so the
+     * client can render/verify the danger line the server computed. [kNumerator]/[kDenominator] express
+     * the multiplier `k` as a fraction (default k = 1.5). Result is clamped to [floorBps]..[ceilBps].
+     */
+    fun dangerBps(
+        volatilityBps: Int,
+        kNumerator: Int = 3,
+        kDenominator: Int = 2,
+        floorBps: Int = 100,
+        ceilBps: Int = 3_000,
+    ): Int {
+        if (volatilityBps <= 0 || kDenominator <= 0) return floorBps.coerceAtLeast(0)
+        val scaled = (volatilityBps.toLong() * kNumerator / kDenominator).toInt()
+        val lo = floorBps.coerceAtLeast(0)
+        val hi = ceilBps.coerceAtLeast(lo)
+        return scaled.coerceIn(lo, hi)
+    }
+
+    /** Distance-to-liquidation buffer in bps from a mark + liq price (`|mark - liq| / mark`). */
+    fun bufferBps(markPrice: Long, liqPrice: Long): Int {
+        if (markPrice <= 0L) return 0
+        val dist = kotlin.math.abs(markPrice - liqPrice)
+        return ((dist * BPS_DENOM + markPrice / 2) / markPrice).toInt().coerceIn(0, BPS_DENOM)
+    }
+
+    /**
+     * Summary of a single-clearing-price bailout auction over sealed rescue [bids] to raise
+     * [capitalNeededCents].
+     *
+     * Each bid offers [BailoutBid.capitalCents] of rescue capital in return for up to
+     * [BailoutBid.shareBps] of the position-share. Cheaper (LESS share per dollar) capital is taken
+     * FIRST — bids are ordered by their share-rate `shareBps / capitalCents` ascending (least dilutive).
+     * The CLEARING SHARE-RATE is the marginal filled bid's rate, and EVERY filled dollar gives up share
+     * at that one rate (single clearing price). The marginal bid is PRO-RATED so exactly the needed
+     * capital is raised. [clearingShareBps] is the total position-share the owner gives up across all
+     * fills at that clearing rate; null when nothing can be raised.
+     *
+     * If total offered capital is below [capitalNeededCents] the whole book fills (partial raise) and
+     * the clearing rate is the worst (highest) accepted rate.
+     */
+    fun clearingSummary(
+        bids: List<BailoutBid>,
+        capitalNeededCents: Long,
+    ): BailoutClearing {
+        if (capitalNeededCents <= 0L) {
+            return BailoutClearing(clearingShareBps = 0, raisedCents = 0L, filledRescuers = 0, fullyFunded = true)
+        }
+        // Rate = share-bps per cent; scaled by BPS_DENOM to keep integer ordering stable and precise.
+        val eligible = bids
+            .filter { it.capitalCents > 0L && it.shareBps > 0 }
+            .sortedBy { rateScaled(it) }
+        if (eligible.isEmpty()) {
+            return BailoutClearing(clearingShareBps = null, raisedCents = 0L, filledRescuers = 0, fullyFunded = false)
+        }
+
+        var remaining = capitalNeededCents
+        var raised = 0L
+        var filled = 0
+        var totalShareBps = 0L
+        var worstRateScaled = 0L
+        for (bid in eligible) {
+            if (remaining <= 0L) break
+            val take = bid.capitalCents.coerceAtMost(remaining)
+            if (take <= 0L) break
+            // Share given up for this slice at THIS bid's rate: shareBps * take / capitalCents (round half-up).
+            val slice = (bid.shareBps.toLong() * take + bid.capitalCents / 2) / bid.capitalCents
+            totalShareBps += slice
+            raised += take
+            remaining -= take
+            filled += 1
+            worstRateScaled = rateScaled(bid)
+        }
+        val clearing = totalShareBps.coerceIn(0L, BPS_DENOM.toLong()).toInt()
+        return BailoutClearing(
+            clearingShareBps = clearing,
+            raisedCents = raised,
+            filledRescuers = filled,
+            fullyFunded = remaining <= 0L,
+            worstRateScaled = worstRateScaled,
+        )
+    }
+
+    /** Share-bps per cent, scaled by [BPS_DENOM] for stable integer ordering (lower == less dilutive). */
+    private fun rateScaled(bid: BailoutBid): Long =
+        if (bid.capitalCents <= 0L) Long.MAX_VALUE
+        else (bid.shareBps.toLong() * BPS_DENOM) / bid.capitalCents
+
+    /** The position-share (in bps) a rescuer receives for [capitalCents] at a clearing rate. */
+    fun shareForCapital(capitalCents: Long, clearingShareBps: Int, raisedCents: Long): Int {
+        if (capitalCents <= 0L || clearingShareBps <= 0 || raisedCents <= 0L) return 0
+        return ((clearingShareBps.toLong() * capitalCents + raisedCents / 2) / raisedCents)
+            .toInt().coerceIn(0, BPS_DENOM)
+    }
+
+    /** Human label for a basis-points value, e.g. 2500 -> "25.00%", 10000 -> "100.00%". */
+    fun formatBps(bps: Int): String = String.format("%.2f%%", bps.coerceAtLeast(0) / 100.0)
+
+    /** Format integer cents as a dollar string, e.g. 10000 -> "$100.00". */
+    fun formatCents(cents: Long): String {
+        val sign = if (cents < 0) "-" else ""
+        val abs = kotlin.math.abs(cents)
+        return "$sign$" + String.format("%,d.%02d", abs / 100, abs % 100)
+    }
+
+    /** One sealed rescue bid: [capitalCents] injected for up to [shareBps] of the position-share. */
+    data class BailoutBid(
+        val capitalCents: Long,
+        val shareBps: Int,
+    )
+
+    /**
+     * Result of [clearingSummary]: the single [clearingShareBps] the owner gives up in total across all
+     * fills (null when nothing clears), the [raisedCents] raised, how many [filledRescuers] were (fully
+     * or partially) filled, and whether the target was [fullyFunded].
+     */
+    data class BailoutClearing(
+        val clearingShareBps: Int?,
+        val raisedCents: Long,
+        val filledRescuers: Int,
+        val fullyFunded: Boolean,
+        val worstRateScaled: Long = 0L,
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutSettingsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutSettingsScreen.kt
@@ -1,0 +1,151 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.bailout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Auto-bailout protection setting: a toggle that, when on, auto-opens a pre-emptive bailout auction on
+ * distress-band entry (else the trader opens it manually), plus a default max position-share. Wired to
+ * `GET/PUT me/prefs/bailout`; degrades to a device-local copy (labelled "saved on this device") when the
+ * server endpoint is undeployed.
+ */
+@Composable
+fun BailoutSettingsRoute(
+    onBack: () -> Unit,
+    viewModel: BailoutSettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbar = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.actionMessage) {
+        state.actionMessage?.let {
+            snackbar.showSnackbar(it)
+            viewModel.consumeActionMessage()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Auto-bailout protection") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbar) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Card {
+                Column(Modifier.padding(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text("Auto-open on distress", fontWeight = FontWeight.SemiBold)
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                "When a margin position enters the volatility-scaled distress band, automatically open a pre-emptive bailout auction. Off = you open it manually.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        Switch(
+                            checked = state.autoEnabled,
+                            enabled = !state.saving && !state.loading,
+                            onCheckedChange = viewModel::setAutoEnabled,
+                            modifier = Modifier.testTag("auto_bailout_toggle"),
+                        )
+                    }
+                }
+            }
+
+            Card {
+                Column(Modifier.padding(16.dp)) {
+                    Text("Default max position-share", fontWeight = FontWeight.SemiBold)
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        "The most of the position an auto-opened auction offers rescuers. Currently ${BailoutMath.formatBps(state.defaultMaxShareBps)}.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(10.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        listOf(1_000, 2_000, 3_000, 5_000).forEach { bps ->
+                            val selected = state.defaultMaxShareBps == bps
+                            if (selected) {
+                                Button(
+                                    onClick = { viewModel.setDefaultMaxShareBps(bps) },
+                                    enabled = !state.saving,
+                                    modifier = Modifier.testTag("share_$bps"),
+                                ) { Text(BailoutMath.formatBps(bps)) }
+                            } else {
+                                OutlinedButton(
+                                    onClick = { viewModel.setDefaultMaxShareBps(bps) },
+                                    enabled = !state.saving,
+                                    modifier = Modifier.testTag("share_$bps"),
+                                ) { Text(BailoutMath.formatBps(bps)) }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (state.deviceLocal) {
+                Text(
+                    "Saved on this device - the server preference endpoint (me/prefs/bailout) is not available yet, so this is stored locally and will sync when the backend lands.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutSettingsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutSettingsViewModel.kt
@@ -1,0 +1,88 @@
+package com.testlogon.android.feature.bailout
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.bailout.BailoutRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class BailoutSettingsUiState(
+    val loading: Boolean = true,
+    val autoEnabled: Boolean = false,
+    val defaultMaxShareBps: Int = 2_000,
+    /** True when the value shown is the device-local fallback (the server endpoint 404'd). */
+    val deviceLocal: Boolean = false,
+    val actionMessage: String? = null,
+    val saving: Boolean = false,
+)
+
+/**
+ * Drives the AUTO-BAILOUT PROTECTION account setting: when enabled a bailout auction auto-opens on
+ * band-entry (else the trader must open it manually), offering up to a default max position-share.
+ * Wired to `GET/PUT me/prefs/bailout`; degrades to a device-local ([BailoutPrefsStore]) copy — labelled
+ * "saved on this device" — when the server endpoint 404s.
+ */
+@HiltViewModel
+class BailoutSettingsViewModel @Inject constructor(
+    private val repository: BailoutRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BailoutSettingsUiState())
+    val uiState: StateFlow<BailoutSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun consumeActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+
+    fun load() {
+        _uiState.update { it.copy(loading = true) }
+        viewModelScope.launch {
+            when (val r = repository.prefs()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        loading = false,
+                        autoEnabled = r.data.autoEnabled,
+                        defaultMaxShareBps = r.data.defaultMaxShareBps.takeIf { v -> v > 0 } ?: 2_000,
+                        // The repository degrades to the local copy on 404, so a Success may be local; we
+                        // can't distinguish here, so treat any non-network result as authoritative-enough
+                        // and label device-local only when the save path reports it.
+                        deviceLocal = it.deviceLocal,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(loading = false, deviceLocal = true) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(loading = false, deviceLocal = true) }
+            }
+        }
+    }
+
+    fun setAutoEnabled(enabled: Boolean) = save(enabled, _uiState.value.defaultMaxShareBps)
+
+    fun setDefaultMaxShareBps(bps: Int) =
+        save(_uiState.value.autoEnabled, bps.coerceIn(0, 10_000))
+
+    private fun save(autoEnabled: Boolean, defaultMaxShareBps: Int) {
+        if (_uiState.value.saving) return
+        _uiState.update { it.copy(saving = true, autoEnabled = autoEnabled, defaultMaxShareBps = defaultMaxShareBps) }
+        viewModelScope.launch {
+            val msg = when (val r = repository.putPrefs(autoEnabled, defaultMaxShareBps)) {
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(autoEnabled = r.data.autoEnabled, defaultMaxShareBps = r.data.defaultMaxShareBps.takeIf { v -> v > 0 } ?: defaultMaxShareBps)
+                    }
+                    "Auto-bailout preference saved."
+                }
+                is ApiResult.Failure -> "Saved on this device (backend pending)."
+                is ApiResult.NetworkError -> "No connection — saved on this device."
+            }
+            _uiState.update { it.copy(saving = false, actionMessage = msg) }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutUi.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutUi.kt
@@ -1,0 +1,171 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.bailout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.testlogon.android.data.bailout.BailoutStatus
+import com.testlogon.android.data.bailout.HealthZone
+import com.testlogon.android.data.bailout.PositionSide
+
+fun PositionSide.label(): String = when (this) {
+    PositionSide.LONG -> "LONG"
+    PositionSide.SHORT -> "SHORT"
+    PositionSide.UNKNOWN -> "—"
+}
+
+fun BailoutStatus.label(): String = when (this) {
+    BailoutStatus.OPEN -> "Open"
+    BailoutStatus.CLEARED -> "Cleared"
+    BailoutStatus.CANCELLED -> "Cancelled"
+    BailoutStatus.LIQUIDATED -> "Liquidated"
+    BailoutStatus.UNKNOWN -> "—"
+}
+
+fun HealthZone.label(): String = when (this) {
+    HealthZone.HEALTHY -> "Healthy"
+    HealthZone.DISTRESS -> "Distress"
+    HealthZone.LIQUIDATION -> "Liquidation"
+}
+
+/** Zone colour, independent of app theme (green safe / amber distress / red liquidation). */
+val HealthZone.color: Color
+    get() = when (this) {
+        HealthZone.HEALTHY -> Color(0xFF2E7D32)
+        HealthZone.DISTRESS -> Color(0xFFF9A825)
+        HealthZone.LIQUIDATION -> Color(0xFFC62828)
+    }
+
+/** A label/value row used across the bailout sections and confirm dialogs. */
+@Composable
+fun BailoutKeyValueRow(label: String, value: String, emphasize: Boolean = false) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal,
+            color = if (emphasize) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+fun BailoutSectionCard(title: String, content: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(10.dp))
+            content()
+        }
+    }
+}
+
+@Composable
+fun BailoutStatusPill(text: String, tint: Color = MaterialTheme.colorScheme.secondaryContainer) {
+    Surface(color = tint, shape = MaterialTheme.shapes.small) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+/**
+ * A 3-zone health meter: a horizontal bar with a HEALTHY / DISTRESS / LIQUIDATION gradient of fixed
+ * proportions, a marker at the current buffer, and the volatility-scaled danger line. [bufferBps] is
+ * the distance-to-liquidation (0 == at liq); [dangerBps] is where the distress band starts. The bar is
+ * drawn 0..capBps left-to-right where 0 == liquidation (right-most danger) and capBps == safe.
+ */
+@Composable
+fun HealthMeter(
+    zone: HealthZone,
+    bufferBps: Int,
+    dangerBps: Int,
+    capBps: Int = 5_000,
+) {
+    val cap = capBps.coerceAtLeast(1)
+    val bufferFrac = (bufferBps.coerceIn(0, cap)).toFloat() / cap
+    val dangerFrac = (dangerBps.coerceIn(0, cap)).toFloat() / cap
+
+    Column(Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            BailoutStatusPill(zone.label(), tint = zone.color)
+            Spacer(Modifier.width(8.dp))
+            Text(
+                "Buffer ${BailoutMath.formatBps(bufferBps)} · danger line ${BailoutMath.formatBps(dangerBps)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        // The bar: left (0) = liquidation edge, right = safe. Distress zone spans 0..dangerFrac.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(14.dp)
+                .background(HealthZone.HEALTHY.color.copy(alpha = 0.25f), RoundedCornerShape(7.dp)),
+        ) {
+            // Distress band (from the liquidation edge up to the danger line).
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(dangerFrac)
+                    .background(HealthZone.DISTRESS.color.copy(alpha = 0.5f), RoundedCornerShape(7.dp)),
+            )
+            // Current-buffer marker.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(bufferFrac)
+                    .fillMaxHeight(),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .width(3.dp)
+                        .fillMaxHeight()
+                        .background(zone.color),
+                )
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text("Liquidation", style = MaterialTheme.typography.labelSmall, color = HealthZone.LIQUIDATION.color)
+            Spacer(Modifier.weight(1f))
+            Text("Safe", style = MaterialTheme.typography.labelSmall, color = HealthZone.HEALTHY.color)
+        }
+    }
+}
+
+/** Compact holder id for rescuer / owner rows (keeps rows readable). */
+fun shortSub(sub: String): String =
+    if (sub.length <= 10) sub.ifBlank { "—" } else sub.take(6) + "…" + sub.takeLast(4)

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/DistressScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/DistressScreen.kt
@@ -1,0 +1,327 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.bailout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.bailout.DistressPosition
+import com.testlogon.android.data.bailout.HealthZone
+
+/**
+ * Margin distress overview: the caller's distressed-but-solvent positions, each with a 3-zone health
+ * meter + buffer readout and, when eligible, a distress banner with ordered actions (Add margin /
+ * Reduce position -> existing flows, then "Open bailout auction"). Server-authoritative; degrades to an
+ * honest empty state on 404. Tapping a position with an existing auction opens the auction screen.
+ */
+@Composable
+fun DistressRoute(
+    onBack: () -> Unit,
+    onOpenAuction: (symbolId: Int) -> Unit,
+    onBrowseBailouts: () -> Unit,
+    onAddMargin: () -> Unit,
+    onReducePosition: (symbolId: Int) -> Unit,
+    viewModel: DistressViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbar = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.actionMessage) {
+        state.actionMessage?.let {
+            snackbar.showSnackbar(it)
+            viewModel.consumeActionMessage()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Margin distress") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbar) },
+    ) { padding ->
+        when (state.phase) {
+            DistressUiState.Phase.Loading -> LoadingState(message = "Checking your positions")
+            DistressUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Something went wrong.",
+                onRetry = viewModel::onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            DistressUiState.Phase.Content -> DistressContent(
+                state = state,
+                modifier = Modifier.padding(padding),
+                onOpenAuction = onOpenAuction,
+                onBrowseBailouts = onBrowseBailouts,
+                onAddMargin = onAddMargin,
+                onReducePosition = onReducePosition,
+                onOpenBailout = viewModel::openBailout,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DistressContent(
+    state: DistressUiState,
+    modifier: Modifier = Modifier,
+    onOpenAuction: (Int) -> Unit,
+    onBrowseBailouts: () -> Unit,
+    onAddMargin: () -> Unit,
+    onReducePosition: (Int) -> Unit,
+    onOpenBailout: (symbolId: Int, maxShareBps: Int) -> Unit,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            ) {
+                Column(Modifier.padding(16.dp)) {
+                    Text(
+                        "A distressed but still-solvent margin position can raise rescue capital via a pre-emptive bailout auction - avoiding the forced-liquidation penalty. Once equity falls to maintenance it is too late (that is liquidation).",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = onBrowseBailouts,
+                        modifier = Modifier.fillMaxWidth().testTag("distress_browse_bailouts"),
+                    ) { Text("Browse open bailouts (rescue others)") }
+                }
+            }
+        }
+
+        if (state.positions.isEmpty()) {
+            item { EmptyDistress() }
+        } else {
+            items(state.positions.size, key = { "d_" + state.positions[it].symbolId + it }) { i ->
+                DistressPositionCard(
+                    pos = state.positions[i],
+                    inFlight = state.actionInFlight,
+                    onOpenAuction = onOpenAuction,
+                    onAddMargin = onAddMargin,
+                    onReducePosition = onReducePosition,
+                    onOpenBailout = onOpenBailout,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DistressPositionCard(
+    pos: DistressPosition,
+    inFlight: Boolean,
+    onOpenAuction: (Int) -> Unit,
+    onAddMargin: () -> Unit,
+    onReducePosition: (Int) -> Unit,
+    onOpenBailout: (Int, Int) -> Unit,
+) {
+    val solvent = pos.equityCents > pos.maintenanceCents
+    val zone = BailoutMath.healthZone(pos.bufferBps, pos.dangerBps, solvent)
+    var showOpen by remember { mutableStateOf(false) }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(pos.symbol.ifBlank { "Symbol ${pos.symbolId}" }, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "${pos.side.label()} ${pos.qty}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = zone.color,
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            HealthMeter(zone = zone, bufferBps = pos.bufferBps, dangerBps = pos.dangerBps)
+            Spacer(Modifier.height(10.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(6.dp))
+            BailoutKeyValueRow("Mark", pos.markPrice.toString())
+            BailoutKeyValueRow("Liq. price", if (pos.liqPrice > 0) pos.liqPrice.toString() else "--")
+            BailoutKeyValueRow("Equity", BailoutMath.formatCents(pos.equityCents))
+            BailoutKeyValueRow("Maintenance", BailoutMath.formatCents(pos.maintenanceCents))
+            BailoutKeyValueRow("Volatility", BailoutMath.formatBps(pos.volatilityBps))
+
+            if (zone == HealthZone.LIQUIDATION) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Equity is at/below maintenance - a pre-emptive bailout is no longer possible; this is liquidation territory.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = HealthZone.LIQUIDATION.color,
+                )
+                return@Column
+            }
+
+            if (pos.auctionId != null) {
+                Spacer(Modifier.height(10.dp))
+                Button(
+                    onClick = { onOpenAuction(pos.symbolId) },
+                    modifier = Modifier.fillMaxWidth().testTag("distress_view_auction"),
+                ) { Text("View bailout auction") }
+                return@Column
+            }
+
+            if (pos.eligible && pos.inBand) {
+                Spacer(Modifier.height(10.dp))
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = HealthZone.DISTRESS.color.copy(alpha = 0.15f),
+                    ),
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        Text(
+                            "This position is in the distress band. To avoid forced liquidation:",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        OutlinedButton(
+                            onClick = onAddMargin,
+                            modifier = Modifier.fillMaxWidth().testTag("distress_add_margin"),
+                        ) { Text("1 - Add margin") }
+                        Spacer(Modifier.height(6.dp))
+                        OutlinedButton(
+                            onClick = { onReducePosition(pos.symbolId) },
+                            modifier = Modifier.fillMaxWidth().testTag("distress_reduce"),
+                        ) { Text("2 - Reduce position") }
+                        Spacer(Modifier.height(6.dp))
+                        Button(
+                            onClick = { showOpen = true },
+                            enabled = !inFlight,
+                            modifier = Modifier.fillMaxWidth().testTag("distress_open_bailout"),
+                        ) { Text("3 - Open bailout auction") }
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            "A bailout raises rescue capital from others for a slice of this position - no forced-liquidation penalty.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "In the danger band but not currently eligible to open a bailout (server-gated).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+
+    if (showOpen) {
+        OpenBailoutDialog(
+            pos = pos,
+            onConfirm = { maxShareBps -> showOpen = false; onOpenBailout(pos.symbolId, maxShareBps) },
+            onDismiss = { showOpen = false },
+        )
+    }
+}
+
+@Composable
+private fun OpenBailoutDialog(
+    pos: DistressPosition,
+    onConfirm: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var pctText by remember { mutableStateOf("20") }
+    val maxShareBps = pctText.trim().toDoubleOrNull()?.let { (it * 100).toInt() }?.takeIf { it in 1..10_000 }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Open bailout auction") },
+        text = {
+            Column {
+                Text(
+                    "Offer up to this % of the position-share to rescuers. The auction clears at the single least-dilutive share needed to raise the rescue capital.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = pctText,
+                    onValueChange = { pctText = it.filter { c -> c.isDigit() || c == '.' } },
+                    label = { Text("Max position-share %") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.fillMaxWidth().testTag("open_max_share"),
+                )
+                Spacer(Modifier.height(8.dp))
+                BailoutKeyValueRow("Position", "${pos.side.label()} ${pos.qty} ${pos.symbol}")
+                BailoutKeyValueRow("If mark hits", "${pos.liqPrice} -> auto-cancel -> liquidation")
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { maxShareBps?.let(onConfirm) },
+                enabled = maxShareBps != null,
+                modifier = Modifier.testTag("open_bailout_confirm"),
+            ) { Text("Open auction") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun EmptyDistress() {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(24.dp)) {
+            Text("No positions in distress", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "None of your margin positions are in the volatility-scaled danger band right now. (If the margin-distress backend is still pending, this stays empty rather than guessing.)",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/DistressViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/DistressViewModel.kt
@@ -1,0 +1,84 @@
+package com.testlogon.android.feature.bailout
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.bailout.BailoutRepository
+import com.testlogon.android.data.bailout.DistressPosition
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class DistressUiState(
+    val phase: Phase = Phase.Loading,
+    val positions: List<DistressPosition> = emptyList(),
+    val errorMessage: String? = null,
+    val actionMessage: String? = null,
+    val actionInFlight: Boolean = false,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * Drives the MARGIN DISTRESS overview: the caller's distressed-but-solvent margin positions with their
+ * volatility-scaled health read + an "Open bailout auction" affordance for eligible ones. Every read is
+ * SERVER-AUTHORITATIVE and degrades to an honest empty/pending state on 404 — the client never
+ * fabricates distress. Opening an auction surfaces a clear result (never a silent success), then
+ * refreshes.
+ */
+@HiltViewModel
+class DistressViewModel @Inject constructor(
+    private val repository: BailoutRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DistressUiState())
+    val uiState: StateFlow<DistressUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    fun consumeActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+
+    fun load() {
+        _uiState.update { it.copy(phase = DistressUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.distress()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(phase = DistressUiState.Phase.Content, positions = r.data, errorMessage = null)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    // Repository already degrades 404s to empty; a Failure here is unexpected -> honest empty.
+                    it.copy(phase = DistressUiState.Phase.Content, positions = emptyList())
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = DistressUiState.Phase.Error,
+                        errorMessage = "No connection. Check your network and retry.",
+                    )
+                }
+            }
+        }
+    }
+
+    /** Open a pre-emptive bailout auction on an eligible position, offering up to [maxShareBps]. */
+    fun openBailout(symbolId: Int, maxShareBps: Int) {
+        if (_uiState.value.actionInFlight) return
+        _uiState.update { it.copy(actionInFlight = true) }
+        viewModelScope.launch {
+            val msg = when (val r = repository.openBailout(symbolId, maxShareBps, closeTs = null)) {
+                is ApiResult.Success -> "Bailout auction opened."
+                is ApiResult.Failure -> r.error.message.ifBlank { "Couldn't open a bailout auction (backend pending)." }
+                is ApiResult.NetworkError -> "No connection. No auction was opened."
+            }
+            _uiState.update { it.copy(actionInFlight = false, actionMessage = msg) }
+            load()
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1604,6 +1604,18 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),
+        // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: the rescuer opportunity board (BROWSE open
+        // bailouts to inject rescue capital for a position-share). The distress overview + per-position
+        // auction + auto-bailout setting are reached from here / the margin position surface. All reads
+        // degrade-on-404 (the me/margin/distress + me/bailouts backend is pending).
+        MoreEntry(
+            id = "bailouts",
+            labelRes = R.string.more_entry_bailouts,
+            icon = Icons.Outlined.Shield,
+            route = MoreRoutes.BAILOUTS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
         // Analysis workbench (VIEW-ONLY): historical market-data research — returns / volatility /
         // drawdown / correlation + a fast/slow MA-cross backtest over the md/ history (or recent window).
         MoreEntry(

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -307,6 +307,9 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // Creator revenue-share TOKENS: mint + browse market + per-token detail (cap table /
         // revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
         tokensDestinations(navController)
+        // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: distress overview + rescuer board + per-position
+        // auction + auto-bailout setting. Endpoints degrade-on-404 (backend pending); distress never fabricated.
+        bailoutDestinations(navController)
         // Global search (symbols + trading destinations quick-jump); reached from the Markets header + More hub.
         globalSearchDestination(navController)
         // B5 admin queues (moderation board + video review + DMCA claims).

--- a/android/app/src/main/java/com/testlogon/android/navigation/BailoutNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/BailoutNavigation.kt
@@ -1,0 +1,74 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.feature.bailout.BailoutAuctionRoute
+import com.testlogon.android.feature.bailout.BailoutBoardRoute
+import com.testlogon.android.feature.bailout.BailoutSettingsRoute
+import com.testlogon.android.feature.bailout.DistressRoute
+
+/**
+ * MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION destinations, registered in the AUTHENTICATED nav graph.
+ *
+ * [BailoutDistressDest] is the distress overview (the caller's distressed-but-solvent positions + a
+ * "browse open bailouts" jump); [BailoutBoardDest] is the rescuer opportunity board (the navigable hub
+ * entry); [BailoutAuctionDest] is one auction addressed by the position's symbolId; [BailoutSettingsDest]
+ * is the auto-bailout protection account setting. All reads degrade to honest empty/pending states when
+ * the (not-yet-built) margin-distress / bailouts backend 404s — distress is never fabricated.
+ */
+data object BailoutDistressDest {
+    const val ROUTE = "bailout/distress"
+}
+
+data object BailoutBoardDest {
+    const val ROUTE = "bailout/board"
+}
+
+data object BailoutAuctionDest {
+    const val ROUTE = "bailout/auction/{symbolId}"
+    const val ARG_SYMBOL_ID = "symbolId"
+
+    fun build(symbolId: Int): String = "bailout/auction/$symbolId"
+}
+
+data object BailoutSettingsDest {
+    const val ROUTE = "bailout/settings"
+}
+
+/** Registers the distress overview + auction + discovery board + settings destinations. */
+fun NavGraphBuilder.bailoutDestinations(navController: NavHostController) {
+    composable(BailoutDistressDest.ROUTE) {
+        DistressRoute(
+            onBack = { navController.popBackStack() },
+            onOpenAuction = { symbolId ->
+                navController.navigate(BailoutAuctionDest.build(symbolId)) { launchSingleTop = true }
+            },
+            onBrowseBailouts = {
+                navController.navigate(BailoutBoardDest.ROUTE) { launchSingleTop = true }
+            },
+            // Add margin / reduce position reuse the existing trade surface (Markets).
+            onAddMargin = { navController.navigate(MarketsDest.ROUTE) { launchSingleTop = true } },
+            onReducePosition = { navController.navigate(MarketsDest.ROUTE) { launchSingleTop = true } },
+        )
+    }
+    composable(BailoutBoardDest.ROUTE) {
+        BailoutBoardRoute(
+            onBack = { navController.popBackStack() },
+            onOpenAuction = { symbolId ->
+                navController.navigate(BailoutAuctionDest.build(symbolId)) { launchSingleTop = true }
+            },
+        )
+    }
+    composable(
+        route = BailoutAuctionDest.ROUTE,
+        arguments = listOf(navArgument(BailoutAuctionDest.ARG_SYMBOL_ID) { type = NavType.StringType }),
+    ) {
+        BailoutAuctionRoute(onBack = { navController.popBackStack() })
+    }
+    composable(BailoutSettingsDest.ROUTE) {
+        BailoutSettingsRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -381,6 +381,13 @@ object MoreRoutes {
     // (cap table / revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
     const val TOKENS = TokensMarketDest.ROUTE
 
+    // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: the rescuer opportunity board (the navigable hub
+    // BROWSE entry) + the distress overview + auto-bailout account setting. Per-position auction is a
+    // detail route reached from those. All reads degrade-on-404 (the margin-distress backend is pending).
+    const val BAILOUTS = BailoutBoardDest.ROUTE
+    const val MARGIN_DISTRESS = BailoutDistressDest.ROUTE
+    const val BAILOUT_SETTINGS = BailoutSettingsDest.ROUTE
+
     // Analysis workbench: historical market-data research (stats / correlation / MA-cross backtest).
     const val ANALYSIS = AnalysisDest.ROUTE
 
@@ -674,6 +681,9 @@ object MoreRoutes {
             ADMIN_DASHBOARD,
             MARKETS,
             TOKENS,
+            BAILOUTS,
+            MARGIN_DISTRESS,
+            BAILOUT_SETTINGS,
             ANALYSIS,
             GLOBAL_SEARCH,
             TRADING_ALERTS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4286,6 +4286,7 @@
     <string name="more_entry_markets">Markets</string>
     <string name="more_entry_analysis">Analysis</string>
     <string name="more_entry_tokens">Creator Tokens</string>
+    <string name="more_entry_bailouts">Bailout Auctions</string>
     <string name="more_entry_trading_alerts">Trading alerts</string>
     <string name="admin_dashboard_title">Admin alerts</string>
     <string name="admin_dashboard_back">Back</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/bailout/BailoutMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/bailout/BailoutMathTest.kt
@@ -1,0 +1,157 @@
+package com.testlogon.android.feature.bailout
+
+import com.testlogon.android.data.bailout.HealthZone
+import com.testlogon.android.feature.bailout.BailoutMath.BailoutBid
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BailoutMathTest {
+
+    // ---- healthZone ----
+
+    @Test
+    fun healthZone_insolvent_isLiquidation_regardlessOfBuffer() {
+        assertEquals(HealthZone.LIQUIDATION, BailoutMath.healthZone(bufferBps = 9000, dangerBps = 100, solvent = false))
+    }
+
+    @Test
+    fun healthZone_solventInsideBand_isDistress() {
+        // buffer <= danger and solvent -> distressed but still solvent (bailout possible).
+        assertEquals(HealthZone.DISTRESS, BailoutMath.healthZone(bufferBps = 120, dangerBps = 300, solvent = true))
+    }
+
+    @Test
+    fun healthZone_solventAtBandEdge_isDistress() {
+        assertEquals(HealthZone.DISTRESS, BailoutMath.healthZone(bufferBps = 300, dangerBps = 300, solvent = true))
+    }
+
+    @Test
+    fun healthZone_solventOutsideBand_isHealthy() {
+        assertEquals(HealthZone.HEALTHY, BailoutMath.healthZone(bufferBps = 5000, dangerBps = 300, solvent = true))
+    }
+
+    @Test
+    fun healthZone_negativeInputsClampToZero_distress() {
+        assertEquals(HealthZone.DISTRESS, BailoutMath.healthZone(bufferBps = -5, dangerBps = -5, solvent = true))
+    }
+
+    // ---- dangerBps ----
+
+    @Test
+    fun dangerBps_scalesWithVolatility_kIs1point5() {
+        // 1000 bps vol * 1.5 = 1500 bps.
+        assertEquals(1500, BailoutMath.dangerBps(volatilityBps = 1000))
+    }
+
+    @Test
+    fun dangerBps_clampsToFloor() {
+        assertEquals(100, BailoutMath.dangerBps(volatilityBps = 10)) // 15 -> floor 100
+    }
+
+    @Test
+    fun dangerBps_clampsToCeil() {
+        assertEquals(3000, BailoutMath.dangerBps(volatilityBps = 100000)) // huge -> ceil 3000
+    }
+
+    // ---- bufferBps ----
+
+    @Test
+    fun bufferBps_distanceToLiquidation() {
+        // mark 10000, liq 9500 -> 500/10000 = 500 bps.
+        assertEquals(500, BailoutMath.bufferBps(markPrice = 10000, liqPrice = 9500))
+    }
+
+    @Test
+    fun bufferBps_zeroMark_isZero() {
+        assertEquals(0, BailoutMath.bufferBps(markPrice = 0, liqPrice = 100))
+    }
+
+    // ---- clearingSummary ----
+
+    @Test
+    fun clearing_empty_nothingClears() {
+        val s = BailoutMath.clearingSummary(emptyList(), capitalNeededCents = 100_00)
+        assertNull(s.clearingShareBps)
+        assertEquals(0L, s.raisedCents)
+        assertTrue(!s.fullyFunded)
+    }
+
+    @Test
+    fun clearing_leastDilutiveFirst_singlePrice() {
+        // Need $200. Bid A: $100 for 500bps (5bps/$). Bid B: $100 for 1000bps (10bps/$).
+        // A is cheaper -> filled first fully (500bps), then B fully (1000bps). Total 1500bps, raised $200.
+        val bids = listOf(
+            BailoutBid(capitalCents = 100_00, shareBps = 1000), // pricier
+            BailoutBid(capitalCents = 100_00, shareBps = 500),  // cheaper
+        )
+        val s = BailoutMath.clearingSummary(bids, capitalNeededCents = 200_00)
+        assertEquals(200_00L, s.raisedCents)
+        assertEquals(2, s.filledRescuers)
+        assertTrue(s.fullyFunded)
+        assertEquals(1500, s.clearingShareBps)
+    }
+
+    @Test
+    fun clearing_marginalBidProRated() {
+        // Need $150. Cheap bid: $100 for 500bps. Pricier: $100 for 1000bps.
+        // Cheap fills fully (500bps, $100). Pricier fills $50 of $100 -> 500bps share. Total 1000bps.
+        val bids = listOf(
+            BailoutBid(capitalCents = 100_00, shareBps = 500),
+            BailoutBid(capitalCents = 100_00, shareBps = 1000),
+        )
+        val s = BailoutMath.clearingSummary(bids, capitalNeededCents = 150_00)
+        assertEquals(150_00L, s.raisedCents)
+        assertEquals(2, s.filledRescuers)
+        assertTrue(s.fullyFunded)
+        assertEquals(1000, s.clearingShareBps) // 500 + (1000 * 5000/10000)
+    }
+
+    @Test
+    fun clearing_underfunded_partialRaise_notFullyFunded() {
+        val bids = listOf(BailoutBid(capitalCents = 50_00, shareBps = 500))
+        val s = BailoutMath.clearingSummary(bids, capitalNeededCents = 200_00)
+        assertEquals(50_00L, s.raisedCents)
+        assertTrue(!s.fullyFunded)
+        assertEquals(500, s.clearingShareBps)
+    }
+
+    @Test
+    fun clearing_zeroNeeded_fullyFundedNoShare() {
+        val s = BailoutMath.clearingSummary(
+            listOf(BailoutBid(capitalCents = 100_00, shareBps = 500)),
+            capitalNeededCents = 0,
+        )
+        assertEquals(0, s.clearingShareBps)
+        assertTrue(s.fullyFunded)
+    }
+
+    @Test
+    fun clearing_ignoresInvalidBids() {
+        val bids = listOf(
+            BailoutBid(capitalCents = 0, shareBps = 500),      // no capital
+            BailoutBid(capitalCents = 100_00, shareBps = 0),   // no share offered
+            BailoutBid(capitalCents = 100_00, shareBps = 400), // valid
+        )
+        val s = BailoutMath.clearingSummary(bids, capitalNeededCents = 100_00)
+        assertEquals(100_00L, s.raisedCents)
+        assertEquals(1, s.filledRescuers)
+        assertEquals(400, s.clearingShareBps)
+    }
+
+    // ---- helpers ----
+
+    @Test
+    fun shareForCapital_proRataOfClearing() {
+        // Rescuer put in $100 of $200 raised at 1500bps clearing -> 750bps.
+        assertEquals(750, BailoutMath.shareForCapital(capitalCents = 100_00, clearingShareBps = 1500, raisedCents = 200_00))
+    }
+
+    @Test
+    fun formatHelpers() {
+        assertEquals("25.00%", BailoutMath.formatBps(2500))
+        assertEquals("$100.00", BailoutMath.formatCents(100_00))
+        assertEquals("-$1.50", BailoutMath.formatCents(-150))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ const TradingBlotterPage = lazy(() => import("@/pages/blotter/TradingBlotterPage
 const TradingWorkspacePage = lazy(() => import("@/pages/blotter/TradingWorkspacePage"));
 const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
 const PortfolioPage = lazy(() => import("@/pages/portfolio/PortfolioPage"));
+const BailoutsBoardPage = lazy(() => import("@/pages/bailouts/BailoutsBoardPage"));
 const PnLPage = lazy(() => import("@/pages/pnl/PnLPage"));
 const ReportsPage = lazy(() => import("@/pages/reports/ReportsPage"));
 const CatalogPage = lazy(() => import("@/pages/shop/CatalogPage"));
@@ -751,6 +752,7 @@ export default function App() {
           <Route path="tokens" element={<TokenMarketPage />} />
           <Route path="tokens/new" element={<MintTokenPage />} />
           <Route path="tokens/:id" element={<TokenDetailPage />} />
+          <Route path="bailouts" element={<BailoutsBoardPage />} />
           <Route path="analysis" element={<MarketAnalysisPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />
           <Route path="paper" element={<PaperTradingPage />} />

--- a/frontend/src/api/endpoints/bailouts.ts
+++ b/frontend/src/api/endpoints/bailouts.ts
@@ -1,0 +1,174 @@
+import { api } from "@/api/client";
+
+/**
+ * MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION surface (`/me/margin/distress`,
+ * `/me/bailouts/*`, `/me/positions/{symbolId}/bailout`, `/me/prefs/bailout`).
+ *
+ * A leveraged margin position approaching a margin call can open a BAILOUT
+ * AUCTION to raise rescue capital and avoid forced liquidation. It exists only
+ * in a narrow window: the position is in a volatility-scaled DISTRESS band but
+ * STILL SOLVENT (`equity > maintenance`). Rescuers inject capital in exchange
+ * for a position-SHARE (co-owning a slice of the position + its future uPnL) via
+ * a sealed single-clearing-price auction (least total share given up). Breaching
+ * maintenance mid-auction auto-cancels -> normal liquidation.
+ *
+ * SERVER-AUTHORITATIVE: distress (marks / volatility / equity) is computed on the
+ * server; the client only RENDERS the read and NEVER fabricates a distress
+ * signal. CONVENTIONS: every monetary amount is INTEGER CENTS; every `_bps`
+ * field is BASIS POINTS (100% = 10_000). NONE of these endpoints exist on the
+ * backend yet — every GET degrades on 404/absent to an honest "pending backend"
+ * state (callers use `retry:false`), and every mutation surfaces a clear error
+ * (never silently "succeeds").
+ */
+
+export type BailoutStatus = "open" | "cleared" | "cancelled" | "liquidated";
+
+/** One margin position with its SERVER-COMPUTED distress read. */
+export interface DistressPosition {
+  symbol_id: number;
+  symbol: string;
+  side: "long" | "short" | string;
+  /** Position size (whole/base units as the server reports). */
+  qty: number;
+  /** Entry price in cents. */
+  entry_price: number;
+  /** Current mark price in cents. */
+  mark_price: number;
+  /** Liquidation price in cents. */
+  liq_price: number;
+  /** Position equity in cents. */
+  equity_cents: number;
+  /** Maintenance-margin requirement in cents (solvent when equity > this). */
+  maintenance_cents: number;
+  /** Distance-to-liq as bps of the mark = |mark - liq| / mark. */
+  buffer_bps: number;
+  /** Volatility in bps used to scale the danger line. */
+  volatility_bps: number;
+  /** The volatility-scaled danger line in bps (in-band when buffer <= this). */
+  danger_bps: number;
+  /** Server verdict: buffer <= danger AND still solvent. */
+  in_band: boolean;
+  /** Server verdict: a bailout auction may be opened for this position. */
+  eligible: boolean;
+  /** The open auction id, when one already exists for this position. */
+  auction_id?: string;
+}
+
+export interface DistressResult {
+  positions: DistressPosition[];
+}
+
+/** One rescuer who injected capital for a position-share. */
+export interface BailoutRescuer {
+  sub: string;
+  /** Capital escrowed, in cents. */
+  capital_cents: number;
+  /** Position-share granted (or bid), in bps. */
+  share_bps: number;
+}
+
+/** A pre-emptive bailout auction on a distressed (still-solvent) position. */
+export interface BailoutAuction {
+  auction_id: string;
+  symbol_id: number;
+  owner_sub: string;
+  side: "long" | "short" | string;
+  qty: number;
+  /** Rescue capital target, in cents. */
+  capital_needed_cents: number;
+  /** Owner's ceiling on total position-share given up, in bps. */
+  max_share_bps: number;
+  status: BailoutStatus;
+  /** Single uniform clearing share given up, in bps (present once cleared). */
+  clearing_share_bps?: number;
+  /** Total capital raised, in cents (present once cleared). */
+  raised_cents?: number;
+  rescuers?: BailoutRescuer[];
+  /** Liquidation price in cents — if the mark hits this first the auction cancels. */
+  liq_price: number;
+  /** Current mark price in cents. */
+  mark_price: number;
+  /** Auction close timestamp (seconds). */
+  close_ts: number;
+}
+
+export interface BailoutsResult {
+  auctions: BailoutAuction[];
+}
+
+/** Account preference: auto-open a bailout on band-entry + a default ceiling. */
+export interface BailoutPrefs {
+  auto_enabled: boolean;
+  default_max_share_bps: number;
+}
+
+/** Generic mutation ack (rescue bid / clear). Carries a message on rejection. */
+export interface BailoutAck {
+  status?: string;
+  auction_id?: string;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+}
+
+// -- Requests ----------------------------------------------------------
+
+/** Owner opens a bailout auction on an eligible, in-band position. */
+export interface OpenBailoutRequest {
+  /** Ceiling on total position-share given up, in bps. */
+  max_share_bps: number;
+  /** Optional auction close timestamp (seconds). */
+  close_ts?: number;
+}
+
+/** Rescuer bid: escrow capital for a position-share. */
+export interface RescueBidRequest {
+  capital_cents: number;
+  share_bps: number;
+}
+
+// -- Calls (all 404 until the backend ships — callers degrade gracefully) --
+
+/** The caller's margin positions with their server-computed distress read. */
+export const getDistress = () => api.get<DistressResult>("/me/margin/distress");
+
+/** Open opportunity board — every open bailout auction to browse/rescue. */
+export const getBailouts = () => api.get<BailoutsResult>("/me/bailouts");
+
+/** The bailout auction for one of the caller's positions (by symbol id). */
+export const getPositionBailout = (symbolId: number) =>
+  api.get<BailoutAuction>(`/me/positions/${encodeURIComponent(String(symbolId))}/bailout`);
+
+/** Owner: open a bailout auction (server rejects if not eligible / in-band). */
+export const openBailout = (symbolId: number, body: OpenBailoutRequest) =>
+  api.post<BailoutAuction>(
+    `/me/positions/${encodeURIComponent(String(symbolId))}/bailout`,
+    body,
+  );
+
+/** Rescuer: escrow capital for a position-share in an auction. */
+export const placeRescueBid = (auctionId: string, body: RescueBidRequest) =>
+  api.post<BailoutAck>(`/me/bailouts/${encodeURIComponent(auctionId)}/bid`, body);
+
+/** Owner: trigger sealed clearing at the least-dilutive single price. */
+export const clearBailout = (auctionId: string) =>
+  api.post<BailoutAuction>(`/me/bailouts/${encodeURIComponent(auctionId)}/clear`, {});
+
+/** Read the auto-bailout account preference. */
+export const getBailoutPrefs = () => api.get<BailoutPrefs>("/me/prefs/bailout");
+
+/** Persist the auto-bailout account preference. */
+export const putBailoutPrefs = (body: BailoutPrefs) =>
+  api.put<BailoutPrefs>("/me/prefs/bailout", body);
+
+// -- Helpers -----------------------------------------------------------
+
+/** Best human message off any bailout ack (error / detail / reject reason). */
+export const bailoutAckMessage = (a: BailoutAck | null | undefined): string | undefined => {
+  if (!a) return undefined;
+  if (a.detail) return a.detail;
+  if (a.error) return a.error;
+  if (a.note) return a.note;
+  return a.reason != null ? `rejected (${a.reason})` : undefined;
+};

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -151,6 +151,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Paper Trading", i18nKey: "nav.paperTrading", path: "/paper", icon: <TrendingUp className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
+      { label: "Bailouts", i18nKey: "nav.bailouts", path: "/bailouts", icon: <LifeBuoy className="h-5 w-5" /> },
       { label: "PnL", i18nKey: "nav.pnl", path: "/pnl", icon: <LineChart className="h-5 w-5" /> },
       { label: "Reports", i18nKey: "nav.reports", path: "/reports", icon: <FileText className="h-5 w-5" /> },
       { label: "Activity", i18nKey: "nav.activity", path: "/activity", icon: <Activity className="h-5 w-5" /> },

--- a/frontend/src/hooks/useBailouts.ts
+++ b/frontend/src/hooks/useBailouts.ts
@@ -1,0 +1,140 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import * as bailouts from "@/api/endpoints/bailouts";
+import { ApiError } from "@/api/client";
+
+/**
+ * React-query hooks for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION
+ * surface. Mirrors the `useTokens` / `useTrading` conventions: reads use
+ * `retry:false` because EVERY route 404s until the backend ships (callers render
+ * an honest empty / "pending backend" state and NEVER fabricate distress);
+ * mutations surface a clear error toast on failure (never silent).
+ */
+
+export const bailoutKeys = {
+  all: ["me", "bailouts"] as const,
+  distress: ["me", "margin", "distress"] as const,
+  board: ["me", "bailouts", "board"] as const,
+  position: (symbolId: number) => ["me", "bailouts", "position", symbolId] as const,
+  auction: (auctionId: string) => ["me", "bailouts", "auction", auctionId] as const,
+  prefs: ["me", "prefs", "bailout"] as const,
+};
+
+/** Distress polls fast — the band can shift under the mark in seconds. */
+const DISTRESS_POLL_MS = 8_000;
+const AUCTION_POLL_MS = 8_000;
+const BOARD_POLL_MS = 12_000;
+
+// -- Reads (degrade on 404 — retry:false) -----------------------------
+
+/** The caller's margin positions + their server-computed distress read. */
+export function useDistress(enabled = true) {
+  return useQuery({
+    queryKey: bailoutKeys.distress,
+    queryFn: bailouts.getDistress,
+    enabled,
+    retry: false,
+    refetchInterval: DISTRESS_POLL_MS,
+  });
+}
+
+/** The open bailout opportunity board (rescuer view). */
+export function useBailoutBoard(enabled = true) {
+  return useQuery({
+    queryKey: bailoutKeys.board,
+    queryFn: bailouts.getBailouts,
+    enabled,
+    retry: false,
+    refetchInterval: BOARD_POLL_MS,
+  });
+}
+
+/** The bailout auction for one of the caller's positions (by symbol id). */
+export function usePositionBailout(symbolId: number | undefined, enabled = true) {
+  return useQuery({
+    queryKey: bailoutKeys.position(symbolId ?? -1),
+    queryFn: () => bailouts.getPositionBailout(symbolId!),
+    enabled: enabled && symbolId != null && Number.isFinite(symbolId),
+    retry: false,
+    refetchInterval: AUCTION_POLL_MS,
+  });
+}
+
+/** The auto-bailout account preference. */
+export function useBailoutPrefs(enabled = true) {
+  return useQuery({
+    queryKey: bailoutKeys.prefs,
+    queryFn: bailouts.getBailoutPrefs,
+    enabled,
+    retry: false,
+  });
+}
+
+/** True when a query error is the expected "backend not shipped yet" 404. */
+export function isPendingBackend(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+/** Human error message for a failed mutation (404 -> "not available yet"). */
+function mutationErrorText(err: unknown, action: string): string {
+  if (err instanceof ApiError) {
+    if (err.status === 404)
+      return `${action} is not available yet — the bailout-auction backend has not shipped.`;
+    return err.detail || `${action} failed.`;
+  }
+  return `${action} failed.`;
+}
+
+// -- Mutations (clear error toast on failure — never silent) -----------
+
+/** Owner: open a bailout auction on an eligible, in-band position. */
+export function useOpenBailout(symbolId: number | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: bailouts.OpenBailoutRequest) => bailouts.openBailout(symbolId!, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: bailoutKeys.distress });
+      if (symbolId != null) qc.invalidateQueries({ queryKey: bailoutKeys.position(symbolId) });
+      qc.invalidateQueries({ queryKey: bailoutKeys.board });
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Opening the bailout auction")),
+  });
+}
+
+/** Rescuer: escrow capital for a position-share in an auction. */
+export function usePlaceRescueBid(auctionId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: bailouts.RescueBidRequest) => bailouts.placeRescueBid(auctionId!, body),
+    onSuccess: () => {
+      if (auctionId) qc.invalidateQueries({ queryKey: bailoutKeys.auction(auctionId) });
+      qc.invalidateQueries({ queryKey: bailoutKeys.board });
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Placing the rescue bid")),
+  });
+}
+
+/** Owner: trigger clearing at the least-dilutive single price. */
+export function useClearBailout(auctionId: string | undefined, symbolId?: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => bailouts.clearBailout(auctionId!),
+    onSuccess: () => {
+      if (auctionId) qc.invalidateQueries({ queryKey: bailoutKeys.auction(auctionId) });
+      if (symbolId != null) qc.invalidateQueries({ queryKey: bailoutKeys.position(symbolId) });
+      qc.invalidateQueries({ queryKey: bailoutKeys.distress });
+      qc.invalidateQueries({ queryKey: bailoutKeys.board });
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Clearing the auction")),
+  });
+}
+
+/** Persist the auto-bailout account preference. */
+export function usePutBailoutPrefs() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: bailouts.BailoutPrefs) => bailouts.putBailoutPrefs(body),
+    onSuccess: (data) => qc.setQueryData(bailoutKeys.prefs, data),
+    onError: (err) => toast.error(mutationErrorText(err, "Saving the preference")),
+  });
+}

--- a/frontend/src/lib/bailout.test.ts
+++ b/frontend/src/lib/bailout.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bpsToFraction,
+  bpsToPct,
+  pctToBps,
+  formatBps,
+  formatCents,
+  healthZone,
+  dangerBps,
+  bufferBps,
+  distressFraction,
+  bailoutClearing,
+  indicativeShareBps,
+  BPS_DENOM,
+} from "./bailout";
+
+describe("bps <-> pct/fraction + formatters", () => {
+  it("converts bps to fraction/pct and pct to bps", () => {
+    expect(bpsToFraction(10_000)).toBe(1);
+    expect(bpsToFraction(250)).toBe(0.025);
+    expect(bpsToPct(250)).toBeCloseTo(2.5, 6);
+    expect(bpsToFraction(undefined)).toBe(0);
+    expect(bpsToFraction(NaN)).toBe(0);
+    expect(pctToBps(2.5)).toBe(250);
+    expect(pctToBps(150)).toBe(10_000); // clamp
+    expect(pctToBps(-5)).toBe(0);
+    expect(BPS_DENOM).toBe(10_000);
+  });
+
+  it("formats bps and cents", () => {
+    expect(formatBps(250)).toBe("2.5%");
+    expect(formatBps(10_000)).toBe("100%");
+    expect(formatCents(123_456)).toBe("$1,234.56");
+    expect(formatCents(undefined)).toBe("—");
+    expect(formatCents(NaN)).toBe("—");
+  });
+});
+
+describe("healthZone", () => {
+  it("insolvent is always liquidation, regardless of buffer", () => {
+    expect(healthZone(9999, 100, false)).toBe("liquidation");
+    expect(healthZone(0, 0, false)).toBe("liquidation");
+  });
+
+  it("solvent + buffer <= danger is distress (in-band)", () => {
+    expect(healthZone(100, 200, true)).toBe("distress");
+    expect(healthZone(200, 200, true)).toBe("distress"); // boundary is in-band
+  });
+
+  it("solvent + buffer > danger is healthy", () => {
+    expect(healthZone(500, 200, true)).toBe("healthy");
+  });
+
+  it("non-finite buffer while solvent reads healthy (never fabricate distress)", () => {
+    expect(healthZone(undefined, 200, true)).toBe("healthy");
+    expect(healthZone(NaN, 200, true)).toBe("healthy");
+  });
+});
+
+describe("dangerBps + bufferBps", () => {
+  it("scales danger by volatility and clamps to [floor, ceil]", () => {
+    // k*vol below floor -> floor
+    expect(dangerBps(100, 1, 300, 1000)).toBe(300);
+    // in range
+    expect(dangerBps(500, 1, 300, 1000)).toBe(500);
+    // above ceil -> ceil
+    expect(dangerBps(5000, 1, 300, 1000)).toBe(1000);
+    // k multiplier
+    expect(dangerBps(200, 2, 0, 10000)).toBe(400);
+    // guards
+    expect(dangerBps(NaN, 1, 300, 1000)).toBe(300);
+  });
+
+  it("computes buffer bps from mark and liq distance", () => {
+    // mark 100.00 ($10000c), liq 95.00 ($9500c) -> 5% -> 500 bps
+    expect(bufferBps(10000, 9500)).toBe(500);
+    // symmetric (short: liq above mark)
+    expect(bufferBps(10000, 10500)).toBe(500);
+    // non-positive mark -> 0
+    expect(bufferBps(0, 9500)).toBe(0);
+  });
+});
+
+describe("distressFraction", () => {
+  it("is 1 at/over the liq line (no buffer)", () => {
+    expect(distressFraction(0, 200)).toBe(1);
+  });
+  it("is 1 at the danger line and 0 at 2x danger of buffer", () => {
+    expect(distressFraction(200, 200)).toBe(1); // at danger line
+    expect(distressFraction(400, 200)).toBe(0); // 2x danger -> healthy
+    expect(distressFraction(300, 200)).toBeCloseTo(0.5, 6); // midway
+  });
+  it("clamps beyond 2x danger to 0 (fully healthy)", () => {
+    expect(distressFraction(5000, 200)).toBe(0);
+  });
+  it("no danger band -> reads 0 (healthy)", () => {
+    expect(distressFraction(500, 0)).toBe(0);
+  });
+});
+
+describe("bailoutClearing", () => {
+  it("guards non-positive need / empty bids", () => {
+    expect(bailoutClearing([], 100_00).cleared).toBe(false);
+    expect(bailoutClearing([{ capital: 100_00, share_bps: 100 }], 0).clearingShareBps).toBe(0);
+    expect(bailoutClearing([{ capital: 100_00, share_bps: 100 }], 0).clearingRateBpsPerCent).toBeNull();
+  });
+
+  it("fills fully at least dilution when capital covers the need", () => {
+    // need $200. Two bids: A gives $200 for 100bps (cheap), B gives $200 for 400bps (dear).
+    // A alone covers -> take only A, give up 100bps.
+    const s = bailoutClearing(
+      [
+        { capital: 200_00, share_bps: 400 }, // dear
+        { capital: 200_00, share_bps: 100 }, // cheap
+      ],
+      200_00,
+    );
+    expect(s.cleared).toBe(true);
+    expect(s.raised).toBe(200_00);
+    expect(s.clearingShareBps).toBe(100); // only the cheap bid was needed
+    expect(s.filled).toHaveLength(1);
+    expect(s.filled[0]!.share_bps).toBe(100);
+  });
+
+  it("accepts cheapest-dilution first, then the next, until the need is met", () => {
+    // need $300. cheap A $200/100bps, dearer B $200/300bps.
+    // Take A fully ($200,100bps), then $100 of B (pro-rated share = 150bps).
+    const s = bailoutClearing(
+      [
+        { capital: 200_00, share_bps: 300 }, // B
+        { capital: 200_00, share_bps: 100 }, // A cheaper
+      ],
+      300_00,
+    );
+    expect(s.cleared).toBe(true);
+    expect(s.raised).toBe(300_00);
+    // A full 100bps + half of B's 300 = 150 -> 250 total
+    expect(s.clearingShareBps).toBe(250);
+    expect(s.filled).toHaveLength(2);
+  });
+
+  it("pro-rates the marginal bid to take exactly the remaining capital", () => {
+    // need $150, single bid $300 for 200bps -> take half: $150 for 100bps.
+    const s = bailoutClearing([{ capital: 300_00, share_bps: 200 }], 150_00);
+    expect(s.cleared).toBe(true);
+    expect(s.raised).toBe(150_00);
+    expect(s.clearingShareBps).toBe(100);
+    expect(s.filled[0]!.capital).toBe(150_00);
+  });
+
+  it("reports a not-cleared partial when total capital is short", () => {
+    const s = bailoutClearing([{ capital: 50_00, share_bps: 100 }], 200_00);
+    expect(s.cleared).toBe(false);
+    expect(s.raised).toBe(50_00);
+    expect(s.clearingShareBps).toBe(100);
+  });
+
+  it("ignores zero/negative capital or share bids", () => {
+    const s = bailoutClearing(
+      [
+        { capital: 0, share_bps: 100 },
+        { capital: 100_00, share_bps: 0 },
+        { capital: 100_00, share_bps: 100 },
+      ],
+      100_00,
+    );
+    expect(s.cleared).toBe(true);
+    expect(s.filled).toHaveLength(1);
+    expect(s.clearingShareBps).toBe(100);
+  });
+});
+
+describe("indicativeShareBps", () => {
+  it("pro-rates share by capital fraction of the need", () => {
+    // inject $50 of a $100 need at 400bps max dilution -> 200bps.
+    expect(indicativeShareBps(50_00, 100_00, 400)).toBe(200);
+    // full need -> full max share
+    expect(indicativeShareBps(100_00, 100_00, 400)).toBe(400);
+    // over-funding clamps to full
+    expect(indicativeShareBps(500_00, 100_00, 400)).toBe(400);
+  });
+  it("guards non-positive inputs", () => {
+    expect(indicativeShareBps(0, 100_00, 400)).toBe(0);
+    expect(indicativeShareBps(50_00, 0, 400)).toBe(0);
+    expect(indicativeShareBps(50_00, 100_00, 0)).toBe(0);
+  });
+});

--- a/frontend/src/lib/bailout.ts
+++ b/frontend/src/lib/bailout.ts
@@ -1,0 +1,262 @@
+// Pure, dependency-free math for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT
+// AUCTION surface. Framework-free so it is unit-testable in isolation (see
+// bailout.test.ts). None of these functions perform I/O — they only compute the
+// numbers the screens render off a SERVER-AUTHORITATIVE distress read.
+//
+// CONCEPT: a leveraged margin position approaching a margin call can raise
+// rescue capital via a sealed single-clearing-price auction — rescuers inject
+// capital for a position-SHARE (co-owning a slice of the position + its future
+// uPnL). This is PRE-EMPTIVE: it only exists while the position is in a
+// volatility-scaled DISTRESS band but STILL SOLVENT (equity > maintenance).
+// Once equity <= maintenance the auction is impossible — that is a liquidation.
+//
+// CONVENTIONS (locked, mirrors tokens.ts): all monetary amounts are INTEGER
+// CENTS; every `_bps` value is BASIS POINTS (1% = 100 bps, 100% = 10_000 bps).
+
+/** Full basis-points denominator (100%). */
+export const BPS_DENOM = 10_000;
+
+/** Clamp a number into [lo, hi]; non-finite -> lo. */
+export function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Basis points -> fraction (0..1). 10_000 bps -> 1. Non-finite -> 0. */
+export function bpsToFraction(bps: number | undefined | null): number {
+  if (bps == null || !Number.isFinite(bps)) return 0;
+  return bps / BPS_DENOM;
+}
+
+/** Basis points -> a human percent number (e.g. 250 -> 2.5). */
+export function bpsToPct(bps: number | undefined | null): number {
+  return bpsToFraction(bps) * 100;
+}
+
+/** A human percent number -> basis points, floored to an int (2.5 -> 250). */
+export function pctToBps(pct: number | undefined | null): number {
+  if (pct == null || !Number.isFinite(pct)) return 0;
+  return Math.round(clamp(pct, 0, 100) * 100);
+}
+
+/** Format basis points as a percent string, e.g. 250 -> "2.5%". */
+export function formatBps(bps: number | undefined | null, maxFrac = 2): string {
+  const pct = bpsToPct(bps);
+  return `${pct.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: maxFrac })}%`;
+}
+
+/** Integer cents -> "$1,234.56". Non-finite -> "—". */
+export function formatCents(cents: number | undefined | null): string {
+  if (cents == null || !Number.isFinite(cents)) return "—";
+  return `$${(cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+// -- Distress health zone ----------------------------------------------
+
+/** The three-zone position health classification. */
+export type HealthZone = "healthy" | "distress" | "liquidation";
+
+/**
+ * Classify a position into one of three zones from its SERVER-COMPUTED buffer
+ * and danger line (both in bps) plus its solvency flag:
+ *   - `liquidation` when NOT solvent (equity <= maintenance) — the bailout
+ *     window is closed; this is a liquidation, not a rescue opportunity.
+ *   - `distress`    when solvent AND buffer_bps <= danger_bps (in-band).
+ *   - `healthy`     otherwise (solvent and comfortably away from the liq line).
+ * The client NEVER fabricates distress — it renders the server read. A
+ * non-finite buffer/danger is treated as the safe (`healthy`) side while solvent.
+ */
+export function healthZone(
+  bufferBps: number | undefined | null,
+  dangerBps: number | undefined | null,
+  solvent: boolean,
+): HealthZone {
+  if (!solvent) return "liquidation";
+  const buffer = Number.isFinite(bufferBps as number) ? (bufferBps as number) : Infinity;
+  const danger = Number.isFinite(dangerBps as number) ? (dangerBps as number) : 0;
+  return buffer <= danger ? "distress" : "healthy";
+}
+
+/**
+ * The volatility-scaled danger line in bps:
+ *   danger_bps = clamp(k * volatility_bps, floor, ceil)
+ * A convenience mirror of the server rule so the UI can show the same number if
+ * the read only carries volatility. The server value (`danger_bps`) is
+ * authoritative when present.
+ */
+export function dangerBps(
+  volatilityBps: number,
+  k: number,
+  floorBps: number,
+  ceilBps: number,
+): number {
+  const vol = Number.isFinite(volatilityBps) ? Math.max(0, volatilityBps) : 0;
+  const kk = Number.isFinite(k) ? Math.max(0, k) : 0;
+  const lo = Number.isFinite(floorBps) ? floorBps : 0;
+  const hi = Number.isFinite(ceilBps) ? ceilBps : lo;
+  return clamp(kk * vol, lo, Math.max(lo, hi));
+}
+
+/**
+ * Buffer bps = |mark - liq| / mark * 10_000 — distance-to-liquidation as bps of
+ * the mark. Mirrors the server rule so the UI can render distance-to-liq when a
+ * read carries only marks. Returns 0 for a non-positive mark (already at/over
+ * the line). The server `buffer_bps` is authoritative when present.
+ */
+export function bufferBps(markCents: number, liqCents: number): number {
+  if (!(markCents > 0) || !Number.isFinite(liqCents)) return 0;
+  return Math.round((Math.abs(markCents - liqCents) / markCents) * BPS_DENOM);
+}
+
+/**
+ * Fraction (0..1) of the way the buffer has been consumed toward the danger
+ * line, for a 3-zone health meter fill. 0 = full buffer (healthy edge), 1 = at
+ * the danger line (distress). Values <= danger clamp to 1 (fully in-band).
+ */
+export function distressFraction(
+  bufferBps: number | undefined | null,
+  dangerBps: number | undefined | null,
+): number {
+  const buffer = Number.isFinite(bufferBps as number) ? Math.max(0, bufferBps as number) : 0;
+  const danger = Number.isFinite(dangerBps as number) ? Math.max(0, dangerBps as number) : 0;
+  if (!(buffer > 0)) return 1; // at/over the line
+  if (!(danger > 0)) return 0; // no danger band -> render as healthy
+  // The meter spans [danger .. 2*danger] of buffer -> [1 .. 0] consumed. Beyond
+  // 2*danger of buffer the meter reads 0 (fully healthy).
+  const span = danger; // width of the "approaching" ramp
+  const consumed = clamp((2 * danger - buffer) / span, 0, 1);
+  return consumed;
+}
+
+// -- Bailout clearing summary ------------------------------------------
+
+/**
+ * One sealed rescue bid: `capital` cents offered in exchange for `share_bps` of
+ * the position (the price the rescuer is willing to pay is capital per bps).
+ */
+export interface RescueBid {
+  capital: number; // integer cents escrowed
+  share_bps: number; // position-share demanded for that capital
+}
+
+/** One filled rescuer in the cleared outcome. */
+export interface FilledRescuer {
+  /** Index of the bid in the input array (stable identity for the caller). */
+  index: number;
+  /** Capital actually taken from this rescuer, in cents. */
+  capital: number;
+  /** Position-share actually granted to this rescuer, in bps. */
+  share_bps: number;
+}
+
+/** The computed outcome of clearing a bailout auction at a single share price. */
+export interface BailoutClearing {
+  /**
+   * The single uniform clearing rate = share_bps granted per capital cent for
+   * the marginal (last-filled) bid. `null` when nothing clears.
+   */
+  clearingRateBpsPerCent: number | null;
+  /** Total capital raised, in cents (meets need when cleared). */
+  raised: number;
+  /** Total position-share given up, in bps (the dilution the owner accepts). */
+  clearingShareBps: number;
+  /** The filled rescuers (pro-rated at the marginal level). */
+  filled: FilledRescuer[];
+  /** True when the raised capital meets `capitalNeeded`. */
+  cleared: boolean;
+}
+
+/**
+ * Clear a sealed bailout auction at a SINGLE clearing price, choosing the
+ * outcome that raises `capitalNeeded` while giving up the LEAST total
+ * position-share (least-dilutive to the owner) — the mirror of the token IPO
+ * uniform-price clearing, but here we minimise share GIVEN UP rather than
+ * maximise proceeds.
+ *
+ * Each bid asks for `share_bps` in exchange for `capital` cents; its implied
+ * "cheapness" for the owner is capital/share_bps (cents raised per bps of
+ * dilution) — HIGHER is better for the owner. We greedily accept bids from the
+ * cheapest-dilution (highest capital-per-bps) down until the capital need is
+ * met, pro-rating the marginal bid so we take exactly the capital still needed
+ * (and a pro-rated slice of its share).
+ *
+ * Returns a not-cleared summary (best partial) when total offered capital
+ * cannot cover the need.
+ */
+export function bailoutClearing(
+  bids: RescueBid[],
+  capitalNeeded: number,
+): BailoutClearing {
+  const empty: BailoutClearing = {
+    clearingRateBpsPerCent: null,
+    raised: 0,
+    clearingShareBps: 0,
+    filled: [],
+    cleared: false,
+  };
+  if (!(capitalNeeded > 0)) return empty;
+
+  const valid = (bids ?? [])
+    .map((b, index) => ({ index, capital: b?.capital ?? 0, share_bps: b?.share_bps ?? 0 }))
+    .filter((b) => b.capital > 0 && b.share_bps > 0);
+  if (valid.length === 0) return empty;
+
+  // Owner-cheapest first: MOST capital per bps of dilution given up.
+  valid.sort((a, b) => b.capital / b.share_bps - a.capital / a.share_bps);
+
+  let raised = 0;
+  let shareBps = 0;
+  const filled: FilledRescuer[] = [];
+
+  for (const b of valid) {
+    if (raised >= capitalNeeded) break;
+    const remaining = capitalNeeded - raised;
+    if (b.capital <= remaining) {
+      // Take the whole bid.
+      raised += b.capital;
+      shareBps += b.share_bps;
+      filled.push({ index: b.index, capital: b.capital, share_bps: b.share_bps });
+    } else {
+      // Pro-rate the marginal bid: take exactly `remaining` capital and a
+      // pro-rated slice of its share.
+      const frac = remaining / b.capital;
+      const takenShare = Math.round(b.share_bps * frac);
+      raised += remaining;
+      shareBps += takenShare;
+      filled.push({ index: b.index, capital: remaining, share_bps: takenShare });
+    }
+  }
+
+  const cleared = raised >= capitalNeeded;
+  // Marginal implied rate = share/capital of the last filled bid (bps per cent).
+  const last = filled.length > 0 ? filled[filled.length - 1]! : undefined;
+  const clearingRateBpsPerCent =
+    last && last.capital > 0 ? last.share_bps / last.capital : null;
+
+  return {
+    clearingRateBpsPerCent,
+    raised,
+    clearingShareBps: shareBps,
+    filled,
+    cleared,
+  };
+}
+
+/**
+ * Indicative position-share (bps) a rescuer would receive for injecting
+ * `capitalCents` into an auction needing `capitalNeeded` cents at a target total
+ * dilution of `maxShareBps` — a simple pro-rata preview for the bid form
+ * (server clearing is authoritative). Guards non-positive need by returning 0.
+ */
+export function indicativeShareBps(
+  capitalCents: number,
+  capitalNeeded: number,
+  maxShareBps: number,
+): number {
+  if (!(capitalNeeded > 0) || !(capitalCents > 0) || !(maxShareBps > 0)) return 0;
+  const frac = clamp(capitalCents / capitalNeeded, 0, 1);
+  return Math.round(maxShareBps * frac);
+}

--- a/frontend/src/pages/bailouts/BailoutAuctionPanel.tsx
+++ b/frontend/src/pages/bailouts/BailoutAuctionPanel.tsx
@@ -1,0 +1,312 @@
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { AlertTriangle, LifeBuoy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { BailoutAuction } from "@/api/endpoints/bailouts";
+import { usePlaceRescueBid, useClearBailout } from "@/hooks/useBailouts";
+import {
+  formatBps,
+  formatCents,
+  bailoutClearing,
+  indicativeShareBps,
+  type RescueBid,
+} from "@/lib/bailout";
+
+/** Dollars string -> integer cents (rounded). */
+function dollarsToCents(v: string): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n * 100) : 0;
+}
+
+function shortSub(sub: string): string {
+  return sub.length > 12 ? `${sub.slice(0, 6)}...${sub.slice(-4)}` : sub;
+}
+
+const STATUS_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  open: "default",
+  cleared: "secondary",
+  cancelled: "outline",
+  liquidated: "destructive",
+};
+
+/**
+ * The bailout-auction panel: capital-needed target, the rescuer bid book, a
+ * rescue-bid form (capital -> position-share) behind a money-safety confirm, an
+ * indicative clearing share preview, a live "if the mark hits {liq_price} first
+ * this cancels -> liquidation" warning, and (owner) a Clear button. A variant of
+ * the token AuctionSection adapted to the position-share rescue mechanic.
+ */
+export function BailoutAuctionPanel({
+  auction,
+  isOwner,
+  symbolId,
+}: {
+  auction: BailoutAuction;
+  isOwner: boolean;
+  symbolId?: number;
+}) {
+  const bid = usePlaceRescueBid(auction.auction_id);
+  const clear = useClearBailout(auction.auction_id, symbolId);
+
+  const [capital, setCapital] = useState("");
+  const [sharePct, setSharePct] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const rescuers = auction.rescuers ?? [];
+  const isOpen = auction.status === "open";
+
+  const capitalCents = dollarsToCents(capital);
+  const shareBpsWanted = Math.round(Number(sharePct) * 100);
+
+  // Indicative pro-rata share the rescuer would receive (server clearing is
+  // authoritative). Uses the auction's max_share_bps ceiling.
+  const indicative = indicativeShareBps(
+    capitalCents,
+    auction.capital_needed_cents,
+    auction.max_share_bps,
+  );
+
+  // Clearing preview from the visible sealed bids (owner-facing dilution hint).
+  const preview = useMemo(() => {
+    const cb: RescueBid[] = rescuers.map((r) => ({
+      capital: r.capital_cents,
+      share_bps: r.share_bps,
+    }));
+    return bailoutClearing(cb, auction.capital_needed_cents);
+  }, [rescuers, auction.capital_needed_cents]);
+
+  const raised = rescuers.reduce((s, r) => s + (r.capital_cents ?? 0), 0);
+  const fundedPct = auction.capital_needed_cents > 0
+    ? Math.min(100, Math.round((raised / auction.capital_needed_cents) * 100))
+    : 0;
+
+  const errors: string[] = [];
+  if (!(capitalCents > 0)) errors.push("Capital must be greater than $0.");
+  if (!(shareBpsWanted > 0)) errors.push("Requested share must be greater than 0%.");
+  if (shareBpsWanted > auction.max_share_bps)
+    errors.push(`Requested share exceeds the owner's ${formatBps(auction.max_share_bps)} ceiling.`);
+
+  const doBid = async () => {
+    try {
+      await bid.mutateAsync({ capital_cents: capitalCents, share_bps: shareBpsWanted });
+      setConfirmOpen(false);
+      setCapital("");
+      setSharePct("");
+      toast.success("Rescue capital escrowed.");
+    } catch {
+      /* hook toasts on error */
+    }
+  };
+
+  const doClear = async () => {
+    try {
+      await clear.mutateAsync();
+      toast.success("Bailout auction cleared.");
+    } catch {
+      /* hook toasts on error */
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <LifeBuoy className="h-4 w-4 text-primary" /> Bailout auction
+          </CardTitle>
+          <Badge variant={STATUS_VARIANT[auction.status] ?? "outline"}>{auction.status}</Badge>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Metric label="Capital needed" value={formatCents(auction.capital_needed_cents)} />
+            <Metric label="Raised" value={`${formatCents(raised)} (${fundedPct}%)`} />
+            <Metric label="Max share (ceiling)" value={formatBps(auction.max_share_bps)} />
+            <Metric
+              label={auction.status === "cleared" ? "Clearing share" : "Implied share"}
+              value={
+                auction.clearing_share_bps != null
+                  ? formatBps(auction.clearing_share_bps)
+                  : preview.clearingShareBps > 0
+                    ? `~${formatBps(preview.clearingShareBps)}`
+                    : "—"
+              }
+            />
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${fundedPct}%` }} />
+          </div>
+          {isOpen && (
+            <p className="text-xs text-muted-foreground">
+              Implied from visible bids: {preview.cleared ? "fully funded" : "under-funded"} — would
+              raise {formatCents(preview.raised)} of {formatCents(auction.capital_needed_cents)} for
+              {preview.clearingShareBps > 0 ? ` ${formatBps(preview.clearingShareBps)} of the position` : " —"}.
+            </p>
+          )}
+          {/* Live cancel-on-liq warning. */}
+          <div className="flex items-start gap-2 rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/40 dark:text-amber-300">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              If the mark hits the {formatCents(auction.liq_price)} liquidation price first, this
+              auction auto-cancels and the position is liquidated normally. Current mark{" "}
+              {formatCents(auction.mark_price)}.
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Rescue-bid form (non-owner, while open) behind a money-safety confirm. */}
+      {!isOwner && isOpen && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Bail out this position</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Inject rescue capital in exchange for a position-share — you co-own that slice of the
+              position and its future unrealized PnL. Capital is escrowed until the auction clears or
+              cancels.
+            </p>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="rescue-capital">Capital ($)</Label>
+                <Input id="rescue-capital" type="number" min={0} step={0.01} value={capital} onChange={(e) => setCapital(e.target.value)} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="rescue-share">Position-share wanted (%)</Label>
+                <Input id="rescue-share" type="number" min={0} max={100} step={0.01} value={sharePct} onChange={(e) => setSharePct(e.target.value)} />
+              </div>
+            </div>
+            <div className="rounded-lg border bg-muted/30 p-3 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Indicative pro-rata share</span>
+                <span className="font-medium tabular-nums">
+                  {indicative > 0 ? `~${formatBps(indicative)}` : "—"}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Indicative only — the sealed auction clears at one uniform least-dilutive price.
+              </p>
+            </div>
+            {errors.length > 0 && (
+              <ul className="list-inside list-disc space-y-0.5 text-xs text-rose-600 dark:text-rose-400">
+                {errors.map((e) => (
+                  <li key={e}>{e}</li>
+                ))}
+              </ul>
+            )}
+            <Button
+              disabled={errors.length > 0 || bid.isPending}
+              onClick={() => setConfirmOpen(true)}
+              data-testid="rescue-bid"
+            >
+              Review &amp; bail out
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Bid book */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-base">Rescuer bids</CardTitle>
+          {isOwner && isOpen && (
+            <Button size="sm" onClick={doClear} disabled={clear.isPending} data-testid="clear-bailout">
+              {clear.isPending ? "Clearing..." : "Clear auction"}
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {rescuers.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No rescue bids yet.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Rescuer</TableHead>
+                  <TableHead className="text-right">Capital</TableHead>
+                  <TableHead className="text-right">Share (bps)</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rescuers.map((r, i) => (
+                  <TableRow key={`${r.sub}-${i}`}>
+                    <TableCell className="font-mono text-xs">{shortSub(r.sub)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatCents(r.capital_cents)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatBps(r.share_bps)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Money-safety confirm (arm -> confirm) */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm rescue bid</DialogTitle>
+            <DialogDescription>
+              This escrows real capital for a position-share. Capital is held until the auction
+              clears (you receive the share) or cancels (it is returned).
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-sm">
+            <Row label="Capital escrowed" value={formatCents(capitalCents)} />
+            <Row label="Position-share wanted" value={formatBps(shareBpsWanted)} />
+            <Row label="Indicative fill" value={indicative > 0 ? `~${formatBps(indicative)}` : "—"} />
+            <Row label="Auto-cancels if mark hits" value={formatCents(auction.liq_price)} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={bid.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={doBid} disabled={bid.isPending} data-testid="rescue-bid-confirm">
+              {bid.isPending ? "Escrowing..." : "Escrow capital"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border p-2.5">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-sm font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/pages/bailouts/BailoutShared.tsx
+++ b/frontend/src/pages/bailouts/BailoutShared.tsx
@@ -1,0 +1,123 @@
+import { Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatBps, type HealthZone } from "@/lib/bailout";
+
+/**
+ * Shared building blocks for the MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION
+ * surface: the honest "pending backend" note (every read 404s until the backend
+ * ships) and the 3-zone health meter. Kept framework-light and reused across the
+ * position surface, the auction panel, and the discovery board.
+ */
+
+/** Honest "pending backend" note shown when a `/me/margin/distress` or
+ * `/me/bailouts/*` read 404s (the surface is UI-complete; the backend has not
+ * shipped). It never fabricates a distress signal — it says so plainly. */
+export function BailoutPendingBackend({ label = "This data" }: { label?: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-dashed bg-muted/30 p-4 text-sm text-muted-foreground">
+      <Info className="mt-0.5 h-4 w-4 shrink-0" />
+      <div>
+        <p className="font-medium text-foreground">Pending backend</p>
+        <p>
+          {label} is not available yet — the margin-distress / bailout-auction endpoints have not
+          shipped on this environment. Distress is server-authoritative, so nothing is shown until
+          the backend reports it (the client never fabricates a distress signal). The surface is
+          wired and will populate automatically once the routes deploy.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const ZONE_META: Record<
+  HealthZone,
+  { label: string; badge: string; bar: string; text: string }
+> = {
+  healthy: {
+    label: "Healthy",
+    badge: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+    bar: "bg-emerald-500",
+    text: "Comfortably above the liquidation line.",
+  },
+  distress: {
+    label: "Distress",
+    badge: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+    bar: "bg-amber-500",
+    text: "Inside the volatility-scaled danger band — still solvent, but a bailout can be opened.",
+  },
+  liquidation: {
+    label: "Liquidation",
+    badge: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+    bar: "bg-rose-500",
+    text: "Equity is at/under maintenance — the bailout window is closed (this is a liquidation).",
+  },
+};
+
+/** A small zone badge. */
+export function ZoneBadge({ zone }: { zone: HealthZone }) {
+  const m = ZONE_META[zone];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold",
+        m.badge,
+      )}
+    >
+      {m.label}
+    </span>
+  );
+}
+
+/**
+ * The 3-zone Healthy -> Distress -> Liquidation health meter. `fraction` (0..1)
+ * is how far the buffer has been consumed toward the danger line (0 = healthy
+ * edge, 1 = at the danger line / in-band). The active zone tints the fill.
+ */
+export function HealthMeter({
+  zone,
+  fraction,
+  bufferBps,
+  dangerBps,
+}: {
+  zone: HealthZone;
+  fraction: number;
+  bufferBps: number;
+  dangerBps: number;
+}) {
+  const m = ZONE_META[zone];
+  // Liquidation pins the meter full; otherwise use the consumed fraction.
+  const pct = zone === "liquidation" ? 100 : Math.round(Math.max(0, Math.min(1, fraction)) * 100);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <ZoneBadge zone={zone} />
+          <span className="text-xs text-muted-foreground">{m.text}</span>
+        </div>
+      </div>
+      {/* Meter track with the three zone regions marked by gradient stops. */}
+      <div className="relative h-3 w-full overflow-hidden rounded-full bg-muted">
+        {/* zone regions: green (0-50%), amber (50-85%), rose (85-100%) */}
+        <div
+          className="absolute inset-y-0 left-0 right-0"
+          style={{
+            background:
+              "linear-gradient(90deg, rgba(16,185,129,0.25) 0%, rgba(16,185,129,0.25) 50%, rgba(245,158,11,0.25) 50%, rgba(245,158,11,0.25) 85%, rgba(244,63,94,0.25) 85%)",
+          }}
+        />
+        <div
+          className={cn("relative h-full rounded-full transition-all", m.bar)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex justify-between text-[11px] text-muted-foreground">
+        <span>
+          Buffer to liq: <span className="font-medium text-foreground">{formatBps(bufferBps)}</span>
+        </span>
+        <span>
+          Danger line: <span className="font-medium text-foreground">{formatBps(dangerBps)}</span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/bailouts/BailoutsBoardPage.tsx
+++ b/frontend/src/pages/bailouts/BailoutsBoardPage.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from "react";
+import { LifeBuoy, RefreshCw } from "lucide-react";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useAuthStore } from "@/stores/authStore";
+import { useBailoutBoard } from "@/hooks/useBailouts";
+import type { BailoutAuction } from "@/api/endpoints/bailouts";
+import { formatBps, formatCents, bufferBps } from "@/lib/bailout";
+import { BailoutPendingBackend } from "@/pages/bailouts/BailoutShared";
+import { BailoutAuctionPanel } from "@/pages/bailouts/BailoutAuctionPanel";
+
+/**
+ * BAILOUTS DISCOVERY BOARD (`/bailouts`) — the rescuer opportunity board,
+ * sibling to the liquidations feed. Lists every open pre-emptive bailout auction
+ * (symbol, capital needed, current implied share, buffer left, distance-to-liq)
+ * so a rescuer can inject capital for a position-share before the position is
+ * forced-liquidated. Degrades to an honest "pending backend" state on 404.
+ */
+export default function BailoutsBoardPage() {
+  const userId = useAuthStore((s) => s.userId);
+  const boardQ = useBailoutBoard();
+  const [active, setActive] = useState<BailoutAuction | null>(null);
+
+  const auctions = boardQ.data?.auctions ?? [];
+  const open = useMemo(() => auctions.filter((a) => a.status === "open"), [auctions]);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 sm:p-6">
+      <PageHeader
+        title="Bailouts"
+        description="Rescue distressed but still-solvent margin positions — inject capital for a position-share before a forced liquidation."
+        actions={
+          <Button variant="outline" size="sm" onClick={() => boardQ.refetch()} disabled={boardQ.isFetching}>
+            <RefreshCw className={boardQ.isFetching ? "mr-2 h-4 w-4 animate-spin" : "mr-2 h-4 w-4"} />
+            Refresh
+          </Button>
+        }
+      />
+
+      {boardQ.isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : boardQ.isError ? (
+        <BailoutPendingBackend label="The bailout opportunity board" />
+      ) : open.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 p-10 text-center">
+            <LifeBuoy className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm font-medium">No open bailout auctions</p>
+            <p className="max-w-md text-sm text-muted-foreground">
+              When a trader's position enters the distress band and they open a bailout, it appears
+              here for you to rescue. Nothing is fabricated — this reflects the server feed.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {open.map((a) => (
+            <BoardRow
+              key={a.auction_id}
+              a={a}
+              isOwner={!!userId && a.owner_sub === userId}
+              onOpen={() => setActive(a)}
+            />
+          ))}
+        </div>
+      )}
+
+      <Dialog open={!!active} onOpenChange={(o) => !o && setActive(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <LifeBuoy className="h-4 w-4 text-primary" /> Bailout auction
+            </DialogTitle>
+          </DialogHeader>
+          {active && (
+            <BailoutAuctionPanel
+              auction={active}
+              isOwner={!!userId && active.owner_sub === userId}
+              symbolId={active.symbol_id}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function BoardRow({
+  a,
+  isOwner,
+  onOpen,
+}: {
+  a: BailoutAuction;
+  isOwner: boolean;
+  onOpen: () => void;
+}) {
+  const raised = (a.rescuers ?? []).reduce((s, r) => s + (r.capital_cents ?? 0), 0);
+  const fundedPct = a.capital_needed_cents > 0
+    ? Math.min(100, Math.round((raised / a.capital_needed_cents) * 100))
+    : 0;
+  // Distance-to-liq from marks (server buffer authoritative; recompute for display).
+  const buffer = bufferBps(a.mark_price, a.liq_price);
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold">Symbol #{a.symbol_id}</span>
+            <Badge variant="outline" className="uppercase">{a.side}</Badge>
+            {isOwner && <Badge variant="secondary">Your position</Badge>}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs tabular-nums text-muted-foreground">
+            <span>Needed <span className="font-medium text-foreground">{formatCents(a.capital_needed_cents)}</span></span>
+            <span>Raised <span className="font-medium text-foreground">{formatCents(raised)} ({fundedPct}%)</span></span>
+            <span>Max share <span className="font-medium text-foreground">{formatBps(a.max_share_bps)}</span></span>
+            <span>Buffer to liq <span className="font-medium text-foreground">{formatBps(buffer)}</span></span>
+            <span>Mark {formatCents(a.mark_price)} · Liq {formatCents(a.liq_price)}</span>
+          </div>
+        </div>
+        <Button size="sm" onClick={onOpen} data-testid={`board-open-${a.auction_id}`}>
+          <LifeBuoy className="mr-1.5 h-3.5 w-3.5" /> {isOwner ? "Manage" : "Bail out"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/bailouts/MarginDistressSection.tsx
+++ b/frontend/src/pages/bailouts/MarginDistressSection.tsx
@@ -1,0 +1,233 @@
+import { useState } from "react";
+import { ShieldAlert, LifeBuoy, PlusCircle, Minus } from "lucide-react";
+import { toast } from "sonner";
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDistress, usePositionBailout, useOpenBailout, useBailoutPrefs } from "@/hooks/useBailouts";
+import type { DistressPosition } from "@/api/endpoints/bailouts";
+import { healthZone, distressFraction, formatBps, formatCents, pctToBps } from "@/lib/bailout";
+import { BailoutPendingBackend, HealthMeter } from "./BailoutShared";
+import { BailoutAuctionPanel } from "./BailoutAuctionPanel";
+
+/**
+ * The margin-distress block for the Portfolio / position surface. For each of
+ * the caller's margin positions it renders a 3-zone health meter + a live buffer
+ * readout (distance-to-liq % vs the volatility-scaled danger line). When a
+ * position is `eligible`, a distress banner offers the ordered escape options —
+ * Add margin / Reduce position (links to the existing flows) then "Open bailout
+ * auction" (which avoids the forced-liquidation penalty). Distress is
+ * server-authoritative; the client never fabricates a signal.
+ */
+export function MarginDistressSection() {
+  const distressQ = useDistress();
+  const prefsQ = useBailoutPrefs();
+
+  if (distressQ.isLoading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <ShieldAlert className="h-4 w-4 text-muted-foreground" /> Margin distress
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-24 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const positions = distressQ.data?.positions ?? [];
+  const autoEnabled = !!prefsQ.data?.auto_enabled;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <ShieldAlert className="h-4 w-4 text-muted-foreground" /> Margin distress
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {distressQ.isError ? (
+          <BailoutPendingBackend label="Margin distress" />
+        ) : positions.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">
+            No margin positions to monitor. Positions in the volatility-scaled distress band appear
+            here with a bailout option before they are liquidated.
+          </p>
+        ) : (
+          positions.map((p) => (
+            <DistressRow key={p.symbol_id} p={p} autoEnabled={autoEnabled} />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DistressRow({ p, autoEnabled }: { p: DistressPosition; autoEnabled: boolean }) {
+  const solvent = p.equity_cents > p.maintenance_cents;
+  const zone = healthZone(p.buffer_bps, p.danger_bps, solvent);
+  const frac = distressFraction(p.buffer_bps, p.danger_bps);
+
+  // If a bailout already exists for this position, show its panel inline.
+  const bailoutQ = usePositionBailout(p.symbol_id, !!p.auction_id);
+  const auction = bailoutQ.data;
+
+  return (
+    <div className="space-y-3 rounded-lg border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{p.symbol}</span>
+          <span className="text-xs uppercase text-muted-foreground">{p.side}</span>
+        </div>
+        <div className="flex gap-4 text-xs tabular-nums text-muted-foreground">
+          <span>Entry {formatCents(p.entry_price)}</span>
+          <span>Mark {formatCents(p.mark_price)}</span>
+          <span>Liq {formatCents(p.liq_price)}</span>
+        </div>
+      </div>
+
+      <HealthMeter zone={zone} fraction={frac} bufferBps={p.buffer_bps} dangerBps={p.danger_bps} />
+
+      <div className="flex flex-wrap gap-4 text-xs tabular-nums text-muted-foreground">
+        <span>
+          Equity <span className="font-medium text-foreground">{formatCents(p.equity_cents)}</span>
+        </span>
+        <span>
+          Maintenance{" "}
+          <span className="font-medium text-foreground">{formatCents(p.maintenance_cents)}</span>
+        </span>
+        <span>
+          Volatility <span className="font-medium text-foreground">{formatBps(p.volatility_bps)}</span>
+        </span>
+      </div>
+
+      {/* Distress banner with the ordered escape options (eligible only). */}
+      {p.eligible && !auction && (
+        <DistressBanner p={p} autoEnabled={autoEnabled} />
+      )}
+
+      {/* An already-open auction renders inline. */}
+      {auction && <BailoutAuctionPanel auction={auction} isOwner symbolId={p.symbol_id} />}
+    </div>
+  );
+}
+
+function DistressBanner({ p, autoEnabled }: { p: DistressPosition; autoEnabled: boolean }) {
+  return (
+    <div className="space-y-3 rounded-md border border-amber-300/60 bg-amber-50 p-3 dark:border-amber-500/40 dark:bg-amber-950/40">
+      <div className="flex items-start gap-2">
+        <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-400" />
+        <div className="text-sm text-amber-900 dark:text-amber-200">
+          <p className="font-semibold">This position is in the distress band.</p>
+          <p className="text-xs">
+            It is still solvent (equity above maintenance), so you can act before a forced
+            liquidation. Options, in order:
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button asChild size="sm" variant="outline">
+          <Link to={`/markets/${p.symbol_id}`}>
+            <PlusCircle className="mr-1.5 h-3.5 w-3.5" /> Add margin
+          </Link>
+        </Button>
+        <Button asChild size="sm" variant="outline">
+          <Link to={`/markets/${p.symbol_id}`}>
+            <Minus className="mr-1.5 h-3.5 w-3.5" /> Reduce position
+          </Link>
+        </Button>
+        <OpenBailoutButton p={p} autoEnabled={autoEnabled} />
+      </div>
+      <p className="text-[11px] text-amber-800/80 dark:text-amber-300/80">
+        A bailout auction raises rescue capital from other traders for a slice of this position —
+        avoiding the forced-liquidation penalty.{" "}
+        {autoEnabled
+          ? "Auto-bailout is ON: an auction opens automatically on band-entry."
+          : "Auto-bailout is off, so open one manually below."}
+      </p>
+    </div>
+  );
+}
+
+function OpenBailoutButton({ p, autoEnabled }: { p: DistressPosition; autoEnabled: boolean }) {
+  const open = useOpenBailout(p.symbol_id);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [maxSharePct, setMaxSharePct] = useState("20");
+
+  const maxShareBps = pctToBps(Number(maxSharePct));
+  const invalid = !(Number(maxSharePct) > 0) || Number(maxSharePct) > 100;
+
+  const doOpen = async () => {
+    try {
+      await open.mutateAsync({ max_share_bps: maxShareBps });
+      setDialogOpen(false);
+      toast.success("Bailout auction opened.");
+    } catch {
+      /* hook toasts on error */
+    }
+  };
+
+  return (
+    <>
+      <Button size="sm" onClick={() => setDialogOpen(true)} data-testid="open-bailout">
+        <LifeBuoy className="mr-1.5 h-3.5 w-3.5" /> Open bailout auction
+      </Button>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Open a bailout auction</DialogTitle>
+            <DialogDescription>
+              Raise rescue capital for {p.symbol} in a sealed single-clearing-price auction. Rescuers
+              inject capital for a position-share (co-owning a slice of the position and its future
+              uPnL). It clears at the least-dilutive uniform price. If the mark hits{" "}
+              {formatCents(p.liq_price)} first it auto-cancels into a normal liquidation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Label htmlFor="bailout-max-share">Max position-share to give up (%)</Label>
+            <Input
+              id="bailout-max-share"
+              type="number"
+              min={1}
+              max={100}
+              step={1}
+              value={maxSharePct}
+              onChange={(e) => setMaxSharePct(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Ceiling on total dilution ({formatBps(maxShareBps)}). The auction clears at or below
+              this.
+            </p>
+            {autoEnabled && (
+              <p className="text-xs text-muted-foreground">
+                Auto-bailout is enabled — the server may have opened one automatically already.
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)} disabled={open.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={doOpen} disabled={invalid || open.isPending} data-testid="open-bailout-confirm">
+              {open.isPending ? "Opening..." : "Open auction"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/pages/portfolio/PortfolioPage.tsx
+++ b/frontend/src/pages/portfolio/PortfolioPage.tsx
@@ -44,6 +44,7 @@ import { formatPrice, formatQty } from "@/pages/markets/format";
 import { usePaperMode } from "@/lib/paperMode";
 import { buildPnlSummaryFromPaper } from "@/lib/paperBlotter";
 import { usePaperAccount, usePaperMarks } from "@/hooks/usePaperMarks";
+import { MarginDistressSection } from "@/pages/bailouts/MarginDistressSection";
 
 // --- helpers ----------------------------------------------------
 
@@ -699,6 +700,9 @@ export default function PortfolioPage() {
           )}
         </VenueCard>
       </div>
+
+      {/* Margin distress / pre-emptive bailout */}
+      <MarginDistressSection />
 
       {/* Open positions (margin) */}
       <Card>

--- a/frontend/src/pages/settings/BailoutSettings.tsx
+++ b/frontend/src/pages/settings/BailoutSettings.tsx
@@ -1,0 +1,163 @@
+import * as React from "react";
+import { LifeBuoy, Save } from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useBailoutPrefs, usePutBailoutPrefs, isPendingBackend } from "@/hooks/useBailouts";
+import { formatBps, pctToBps, bpsToPct } from "@/lib/bailout";
+
+const LS_KEY = "tl:bailoutPrefs";
+
+interface LocalPrefs {
+  auto_enabled: boolean;
+  default_max_share_bps: number;
+}
+
+const DEFAULT_PREFS: LocalPrefs = { auto_enabled: false, default_max_share_bps: 2000 };
+
+function loadLocal(): LocalPrefs {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return DEFAULT_PREFS;
+    const p = JSON.parse(raw) as Partial<LocalPrefs>;
+    return {
+      auto_enabled: !!p.auto_enabled,
+      default_max_share_bps:
+        Number.isFinite(p.default_max_share_bps) && (p.default_max_share_bps as number) > 0
+          ? (p.default_max_share_bps as number)
+          : DEFAULT_PREFS.default_max_share_bps,
+    };
+  } catch {
+    return DEFAULT_PREFS;
+  }
+}
+
+function saveLocal(p: LocalPrefs) {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(p));
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
+/**
+ * Auto-bailout protection account setting. Reads `GET /me/prefs/bailout` and
+ * writes `PUT /me/prefs/bailout`. Degrades on 404: persists the preference
+ * CLIENT-SIDE (localStorage) as a clearly-labelled fallback until the backend
+ * ships. When auto is ON, an eligible position opens a bailout automatically on
+ * distress band-entry (server-side); when OFF, the trader opens one manually.
+ */
+export function BailoutSettings() {
+  const prefsQ = useBailoutPrefs();
+  const put = usePutBailoutPrefs();
+
+  const pendingBackend = prefsQ.isError && isPendingBackend(prefsQ.error);
+
+  const [auto, setAuto] = React.useState<boolean>(DEFAULT_PREFS.auto_enabled);
+  const [sharePct, setSharePct] = React.useState<string>(String(bpsToPct(DEFAULT_PREFS.default_max_share_bps)));
+  const [hydrated, setHydrated] = React.useState(false);
+
+  // Hydrate from the server read, else the local fallback.
+  React.useEffect(() => {
+    if (hydrated) return;
+    if (prefsQ.data) {
+      setAuto(!!prefsQ.data.auto_enabled);
+      setSharePct(String(bpsToPct(prefsQ.data.default_max_share_bps)));
+      setHydrated(true);
+    } else if (prefsQ.isError) {
+      const local = loadLocal();
+      setAuto(local.auto_enabled);
+      setSharePct(String(bpsToPct(local.default_max_share_bps)));
+      setHydrated(true);
+    }
+  }, [prefsQ.data, prefsQ.isError, hydrated]);
+
+  const maxShareBps = pctToBps(Number(sharePct));
+  const invalid = !(Number(sharePct) > 0) || Number(sharePct) > 100;
+
+  const onSave = async () => {
+    const body = { auto_enabled: auto, default_max_share_bps: maxShareBps };
+    try {
+      await put.mutateAsync(body);
+      toast.success("Auto-bailout preference saved.");
+    } catch (err) {
+      if (isPendingBackend(err)) {
+        // Backend not shipped — persist client-side as a clearly-labelled fallback.
+        saveLocal(body);
+        toast.success("Saved locally (backend pending) — will sync when the surface ships.");
+      }
+      /* other errors toast in the hook */
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <LifeBuoy className="h-4 w-4" /> Auto-bailout protection
+        </CardTitle>
+      </CardHeader>
+      <Separator />
+      <CardContent className="space-y-5 pt-4">
+        <p className="text-sm text-muted-foreground">
+          A bailout auction raises rescue capital from other traders in exchange for a slice of a
+          distressed (but still solvent) margin position — pre-empting a forced liquidation. When
+          this is on, an eligible position opens one automatically the moment it enters the
+          volatility-scaled distress band. Off means you open one manually after a prompt.
+        </p>
+
+        {pendingBackend && (
+          <p className="rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/40 dark:text-amber-300">
+            <span className="font-semibold">Backend pending:</span> the preference endpoint has not
+            shipped on this environment, so this setting is saved locally in this browser and will
+            sync automatically once the backend deploys.
+          </p>
+        )}
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium">Auto-open on band-entry</p>
+            <p className="text-xs text-muted-foreground">
+              Automatically open a bailout auction when a position enters distress.
+            </p>
+          </div>
+          <Switch
+            checked={auto}
+            onCheckedChange={setAuto}
+            aria-label="Toggle auto-bailout protection"
+            data-testid="bailout-auto-toggle"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="bailout-default-share" className="text-sm font-medium">
+            Default max position-share to give up (%)
+          </Label>
+          <Input
+            id="bailout-default-share"
+            type="number"
+            min={1}
+            max={100}
+            step={1}
+            value={sharePct}
+            onChange={(e) => setSharePct(e.target.value)}
+            className="w-full sm:w-48"
+            data-testid="bailout-default-share"
+          />
+          <p className="text-xs text-muted-foreground">
+            The dilution ceiling ({formatBps(maxShareBps)}) an auto-opened auction uses by default.
+          </p>
+        </div>
+
+        <Button onClick={onSave} disabled={invalid || put.isPending} data-testid="bailout-prefs-save">
+          <Save className="mr-2 h-4 w-4" />
+          {put.isPending ? "Saving..." : "Save preference"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { Appearance } from "./Appearance";
 import { AppearanceSection } from "./AppearanceSection";
 import { JiraIntegrationSettings } from "./JiraIntegrationSettings";
 import { TradingSettings } from "./TradingSettings";
+import { BailoutSettings } from "./BailoutSettings";
 import { openShortcutsHelp } from "@/components/layout/KeyboardShortcutsHost";
 
 export default function SettingsPage() {
@@ -114,6 +115,8 @@ export default function SettingsPage() {
       </Card>
 
       <TradingSettings />
+
+      <BailoutSettings />
 
       <Account />
 


### PR DESCRIPTION
## Pre-emptive margin distress / bailout auction (frontend, degrade-on-404)

A leveraged position **approaching** a margin call can raise rescue capital to avoid forced liquidation. **Pre-emptive by design:** the auction exists ONLY while the position is in a volatility-scaled distress band AND still solvent (`equity > maintenance`); once `equity ≤ maintenance` it's impossible and normal liquidation takes over.

### Locked decisions
1. **Distress band = volatility-scaled distance-to-liq** — `danger_bps = clamp(k·vol_bps, floor, ceil)`; in-band when `buffer_bps ≤ danger_bps`. Server-authoritative — the client renders the read and never fabricates distress.
2. **Position-share rescue** — rescuers inject capital and co-own a slice of the position + its uPnL.
3. **Sealed single-clearing-price auction** (least share given up), reusing the token IPO clearing.
4. **Auto-open on band-entry only if the trader enabled** the account setting, else manual with a strong prompt.
5. **Breach maintenance mid-auction → auto-cancel → normal liquidation.**

### API contract (none deployed yet; reads degrade-on-404, mutations error clearly)
`GET /me/margin/distress` · `GET /me/bailouts` · `GET|POST /me/positions/{symbolId}/bailout` · `POST /me/bailouts/{id}/{bid,clear}` · `GET|PUT /me/prefs/bailout`.

### Web (`/bailouts` route, "Bailouts" nav)
- `src/lib/bailout.ts` (+20 vitest) — pure `healthZone`, volatility band mirrors, single-clearing bailout clearing; `api/endpoints/bailouts.ts`; `hooks/useBailouts.ts`.
- `MarginDistressSection` on the Portfolio page (3-zone health meter + buffer/danger readout + eligible-only distress banner: Add margin / Reduce / Open bailout), `BailoutAuctionPanel` (capital-needed gauge, rescuer bid book, rescue-bid arm→confirm, "if mark hits liq first → cancels → liquidation"), `BailoutsBoardPage` discovery board, `BailoutSettings` on the Settings page.

### Android (`feature/bailout` + `data/bailout`, registered in `MoreRoutes`)
- `BailoutMath.kt` (+18 JVM tests) + typed `BailoutApi/Dtos/Domain/Mappers/Repository/DataModule` + `BailoutPrefsStore`.
- Distress / BailoutAuction / BailoutBoard / BailoutSettings Compose screens + Hilt ViewModels; `MoreCatalog` entry + `MoreRoutes.REGISTERED` + `AuthenticatedGraph`.

No new deps. Gates: web tsc 0 · vite build · vitest 20/20; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (BailoutMath 18/18, MoreCatalogTest passes).

### Backend (tracked in exchange_missing_features.md)
Volatility-scaled distress read, position co-ownership in the position ledger, single-clearing-price clearing tied to margin restoration, auto-trigger hook + `/me/prefs/bailout`. None of this moves real value until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
