### PR TITLE
feat(custody): external custody provider surface (Fireblocks/BitGo) (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyApi.kt
@@ -4,6 +4,8 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 /**
@@ -92,4 +94,49 @@ interface CustodyApi {
     @Headers("Content-Type: application/json")
     @POST("me/staking/stake")
     suspend fun stake(@Body body: StakeRequestBodyDto): StakeAckDto
+
+
+    // ==== External custody providers (Fireblocks / BitGo / internal gateway) ====
+    // Provider creds are SERVER-SIDE only; these routes initiate a connection + report status. NOT
+    // deployed on every backend -> reads 404 -> repository degrades to a "pending backend" state.
+
+    /** List the custody providers this account can back vaults with (internal|fireblocks|bitgo). */
+    @GET("me/custody/providers")
+    suspend fun getProviders(): CustodyProvidersDto
+
+    /** Initiate a connection to a provider (creds resolved server-side). Optional human label. */
+    @Headers("Content-Type: application/json")
+    @POST("me/custody/providers/{id}/connect")
+    suspend fun connectProvider(
+        @Path("id") id: String,
+        @Body body: ProviderConnectRequestDto,
+    ): ProviderConnectResultDto
+
+    /** Disconnect a provider (server-side teardown; no secret client-side). */
+    @POST("me/custody/providers/{id}/disconnect")
+    suspend fun disconnectProvider(@Path("id") id: String): ProviderConnectResultDto
+
+    /** Live status probe for a provider (health, attestation, reconciliation, pending approvals). */
+    @GET("me/custody/providers/{id}/status")
+    suspend fun getProviderStatus(@Path("id") id: String): ProviderStatusDto
+
+    // ==== Provider-backed vaults ====
+
+    /** List the caller's vaults with their backing provider (extends the sub-accounts read). */
+    @GET("me/custody/vaults")
+    suspend fun getVaults(): VaultsDto
+
+    /** Set the backing provider for one vault. */
+    @Headers("Content-Type: application/json")
+    @PUT("me/custody/vaults/{vault}/provider")
+    suspend fun setVaultProvider(
+        @Path("vault") vault: String,
+        @Body body: SetVaultProviderRequestDto,
+    ): SetVaultProviderResultDto
+
+    // ==== Provider-backed withdrawal approval (multi-sig quorum) ====
+
+    /** Poll the approval state of a provider-backed withdrawal (status + quorum + approvers). */
+    @GET("me/custody/withdrawals/{id}/approval")
+    suspend fun getWithdrawalApproval(@Path("id") id: String): WithdrawalApprovalDto
 }

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDomain.kt
@@ -338,3 +338,116 @@ data class StakeResult(
     val status: String?,
     val reason: String?,
 )
+
+// ---------------- External custody providers ----------------
+
+/**
+ * One custody provider, display-ready. [kind] resolves to internal|fireblocks|bitgo; [status] is the
+ * raw wire status (the pure [com.testlogon.android.feature.custody.CustodyProviderFormat] turns it into
+ * a badge). Provider secrets are SERVER-SIDE only -- nothing here carries a credential.
+ */
+data class CustodyProvider(
+    val id: String,
+    val name: String,
+    val kind: String,
+    val connected: Boolean,
+    val status: String,
+    val features: List<String>,
+) {
+    val displayName: String get() = name.ifBlank { id.ifBlank { "Provider" } }
+}
+
+/**
+ * The providers list, plus an [unavailable] flag for when the backend does not expose the provider
+ * routes (404) -- a soft, honest "provider integration pending" empty state.
+ */
+data class CustodyProviders(
+    val providers: List<CustodyProvider>,
+    val unavailable: Boolean = false,
+) {
+    val isEmpty: Boolean get() = providers.isEmpty()
+
+    companion object {
+        fun unavailable(): CustodyProviders = CustodyProviders(providers = emptyList(), unavailable = true)
+    }
+}
+
+/**
+ * A provider's live status probe (GET providers/{id}/status): connection health, whether balances are
+ * attested, the last reconciliation marker, and any pending approvals count.
+ */
+data class ProviderStatusDetail(
+    val status: String,
+    val balancesAttested: Boolean?,
+    val lastReconciledTs: String?,
+    val pendingApprovals: Int?,
+)
+
+/** The immediate result of a connect/disconnect action. [reason] carries any gateway message. */
+data class ProviderActionResult(
+    val ok: Boolean,
+    val status: String?,
+    val reason: String?,
+)
+
+// ---------------- Vaults (provider-backed) ----------------
+
+/**
+ * One vault, display-ready. [provider] defaults to "internal" when the backend omits it (older vaults
+ * predate external custody). This reuses/extends the sub-accounts read with a backing provider.
+ */
+data class CustodyVault(
+    val vault: String,
+    val label: String,
+    val provider: String,
+) {
+    val displayLabel: String get() = label.ifBlank { "Vault" }
+    val vaultShort: String get() = if (vault.length <= 14) vault else "${vault.take(8)}…${vault.takeLast(4)}"
+}
+
+/** The vaults list, plus an [unavailable] flag for a 404 soft empty state. */
+data class CustodyVaults(
+    val vaults: List<CustodyVault>,
+    val unavailable: Boolean = false,
+) {
+    val isEmpty: Boolean get() = vaults.isEmpty()
+
+    companion object {
+        fun unavailable(): CustodyVaults = CustodyVaults(vaults = emptyList(), unavailable = true)
+    }
+}
+
+/** Result of setting a vault's backing provider (PUT vaults/{vault}/provider). */
+data class SetVaultProviderResult(
+    val ok: Boolean,
+    val vault: String?,
+    val provider: String?,
+    val reason: String?,
+)
+
+// ---------------- Withdrawal approval (provider-backed, multi-sig) ----------------
+
+/** One approver who signed off on a withdrawal. */
+data class WithdrawalApprover(
+    val approver: String,
+    val at: String,
+)
+
+/**
+ * A provider-backed withdrawal's approval state (GET withdrawals/{id}/approval): the current status,
+ * the required quorum, and the approvers collected so far. [unavailable] is true when the backend does
+ * not expose the approval route (404) -- a soft empty state.
+ */
+data class WithdrawalApproval(
+    val status: String,
+    val quorum: Int,
+    val approvals: List<WithdrawalApprover>,
+    val unavailable: Boolean = false,
+) {
+    val collected: Int get() = approvals.size
+
+    companion object {
+        fun unavailable(): WithdrawalApproval =
+            WithdrawalApproval(status = "", quorum = 0, approvals = emptyList(), unavailable = true)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyDtos.kt
@@ -2,6 +2,7 @@ package com.testlogon.android.data.custody
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.network.json.LenientInt
 
 /*
  * Wire DTOs for the PRODUCTION custody surface (the /me/custody endpoints), repointed to the REAL
@@ -263,4 +264,111 @@ data class StakeAckDto(
     @Json(name = "detail") val detail: String? = null,
     @Json(name = "error") val error: String? = null,
     @Json(name = "reason") val reason: String? = null,
+)
+
+// ==== External custody providers (Fireblocks / BitGo / internal gateway) ====
+// Provider creds are SERVER-SIDE only: these routes only initiate a connection + report status; no
+// provider secret is ever sent from or returned to the client. NONE are deployed on every backend --
+// a 404 folds to a soft "provider integration pending" state in the repository (reads only). All
+// fields nullable/defaulted so a partial shape parses. Integer/count fields use @LenientInt so a JSON
+// number OR numeric string both decode.
+
+/** One custody provider (GET me/custody/providers). kind in internal|fireblocks|bitgo. */
+@JsonClass(generateAdapter = true)
+data class CustodyProviderDto(
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "kind") val kind: String? = null,
+    @Json(name = "connected") val connected: Boolean? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "features") val features: List<String>? = null,
+)
+
+/** GET me/custody/providers envelope. */
+@JsonClass(generateAdapter = true)
+data class CustodyProvidersDto(
+    @Json(name = "providers") val providers: List<CustodyProviderDto>? = null,
+)
+
+/**
+ * POST me/custody/providers/{id}/connect (body {label?}) and .../disconnect response. connect returns
+ * {ok,status}; disconnect returns an ack ({ok} and/or {disconnected}). All fields nullable so both
+ * shapes parse. detail/error carry a rejection message.
+ */
+@JsonClass(generateAdapter = true)
+data class ProviderConnectResultDto(
+    @Json(name = "ok") val ok: Boolean? = null,
+    @Json(name = "disconnected") val disconnected: Boolean? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)
+
+/** Body for POST me/custody/providers/{id}/connect -- an optional human label for the connection. */
+@JsonClass(generateAdapter = true)
+data class ProviderConnectRequestDto(
+    @Json(name = "label") val label: String? = null,
+)
+
+/**
+ * GET me/custody/providers/{id}/status. balances_attested is a tri-state (true/false/absent);
+ * pending_approvals is an integer count (lenient). last_reconciled_ts is left as a raw string
+ * (epoch or ISO -- displayed verbatim).
+ */
+@JsonClass(generateAdapter = true)
+data class ProviderStatusDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "balances_attested") val balancesAttested: Boolean? = null,
+    @Json(name = "last_reconciled_ts") val lastReconciledTs: String? = null,
+    @LenientInt @Json(name = "pending_approvals") val pendingApprovals: Int? = null,
+)
+
+/** One vault row (GET me/custody/vaults). provider optional -> defaults to "internal" at the edge. */
+@JsonClass(generateAdapter = true)
+data class VaultDto(
+    @Json(name = "vault") val vault: String? = null,
+    @Json(name = "label") val label: String? = null,
+    @Json(name = "provider") val provider: String? = null,
+    @Json(name = "balances") val balances: Map<String, Any?>? = null,
+)
+
+/** GET me/custody/vaults envelope. */
+@JsonClass(generateAdapter = true)
+data class VaultsDto(
+    @Json(name = "vaults") val vaults: List<VaultDto>? = null,
+)
+
+/** Body for PUT me/custody/vaults/{vault}/provider -- the provider to back the vault with. */
+@JsonClass(generateAdapter = true)
+data class SetVaultProviderRequestDto(
+    @Json(name = "provider") val provider: String,
+)
+
+/** PUT me/custody/vaults/{vault}/provider ack ({ok, provider}). */
+@JsonClass(generateAdapter = true)
+data class SetVaultProviderResultDto(
+    @Json(name = "ok") val ok: Boolean? = null,
+    @Json(name = "vault") val vault: String? = null,
+    @Json(name = "provider") val provider: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)
+
+/** One approver who has signed off on a withdrawal (GET me/custody/withdrawals/{id}/approval). */
+@JsonClass(generateAdapter = true)
+data class WithdrawalApproverDto(
+    @Json(name = "approver") val approver: String? = null,
+    @Json(name = "at") val at: String? = null,
+)
+
+/**
+ * GET me/custody/withdrawals/{id}/approval. status in
+ * pending_approval|approved|signed|broadcast|rejected. quorum is the required approvals (lenient int);
+ * approvals lists who has signed so far.
+ */
+@JsonClass(generateAdapter = true)
+data class WithdrawalApprovalDto(
+    @Json(name = "status") val status: String? = null,
+    @LenientInt @Json(name = "quorum") val quorum: Int? = null,
+    @Json(name = "approvals") val approvals: List<WithdrawalApproverDto>? = null,
 )

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
@@ -165,6 +165,100 @@ class CustodyRepository @Inject constructor(
         ).toDomain()
     }
 
+
+    // ==== External custody providers (Fireblocks / BitGo / internal gateway) ====
+
+    /**
+     * List custody providers. Provider routes are NOT deployed on every backend: a 404 (or any HTTP
+     * error) folds into a soft "unavailable" success so the Providers screen can degrade to an honest
+     * "provider integration pending backend" empty state instead of erroring. Network errors still
+     * surface. No provider secret is ever transported -- these are status-only reads.
+     */
+    suspend fun getProviders(): ApiResult<CustodyProviders> = withContext(io) {
+        try {
+            ApiResult.Success(api.getProviders().toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(CustodyProviders.unavailable())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    /**
+     * Fetch a provider's live status probe. Also soft-degrades on HTTP error (returns null) so a single
+     * provider whose status route is missing doesn't error the whole screen; network errors surface.
+     */
+    suspend fun getProviderStatus(id: String): ApiResult<ProviderStatusDetail?> = withContext(io) {
+        try {
+            ApiResult.Success(api.getProviderStatus(id.trim()).toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(null)
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    /** Initiate a provider connection (creds server-side). A gateway rejection surfaces as a Failure. */
+    suspend fun connectProvider(id: String, label: String?): ApiResult<ProviderActionResult> = call {
+        api.connectProvider(
+            id.trim(),
+            ProviderConnectRequestDto(label = label?.trim()?.takeIf { it.isNotBlank() }),
+        ).toDomain()
+    }
+
+    /** Disconnect a provider. A gateway rejection surfaces as a Failure. */
+    suspend fun disconnectProvider(id: String): ApiResult<ProviderActionResult> = call {
+        api.disconnectProvider(id.trim()).toDomain()
+    }
+
+    // ==== Provider-backed vaults ====
+
+    /**
+     * List the caller's vaults with their backing provider. Soft-degrades on HTTP error to an
+     * "unavailable" empty state (route not deployed); network errors surface.
+     */
+    suspend fun getVaults(): ApiResult<CustodyVaults> = withContext(io) {
+        try {
+            ApiResult.Success(api.getVaults().toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(CustodyVaults.unavailable())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    /** Set a vault's backing provider. A gateway rejection surfaces as a Failure. */
+    suspend fun setVaultProvider(vault: String, provider: String): ApiResult<SetVaultProviderResult> = call {
+        api.setVaultProvider(
+            vault.trim(),
+            SetVaultProviderRequestDto(provider = provider.trim().lowercase()),
+        ).toDomain()
+    }
+
+    // ==== Provider-backed withdrawal approval ====
+
+    /**
+     * Poll a provider-backed withdrawal's approval state. Soft-degrades on HTTP error to an
+     * "unavailable" state (route not deployed / not a governed withdrawal); network errors surface.
+     */
+    suspend fun getWithdrawalApproval(id: String): ApiResult<WithdrawalApproval> = withContext(io) {
+        try {
+            ApiResult.Success(api.getWithdrawalApproval(id.trim()).toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(WithdrawalApproval.unavailable())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = withContext(io) {
         try {
             ApiResult.Success(block())
@@ -319,6 +413,65 @@ private fun StakeAckDto.toDomain(): StakeResult = StakeResult(
     amount = amount?.trim()?.takeIf { it.isNotBlank() },
     status = status?.trim()?.takeIf { it.isNotBlank() },
     reason = listOfNotNull(detail, error, reason).firstOrNull { it.isNotBlank() },
+)
+
+// ---- provider / vault / approval DTO -> domain mappers ----
+
+private fun CustodyProvidersDto.toDomain(): CustodyProviders = CustodyProviders(
+    providers = providers.orEmpty().map { it.toDomain() },
+    unavailable = false,
+)
+
+private fun CustodyProviderDto.toDomain(): CustodyProvider = CustodyProvider(
+    id = id?.trim().orEmpty(),
+    name = name?.trim().orEmpty(),
+    kind = kind?.trim().orEmpty().ifBlank { "internal" },
+    connected = connected == true,
+    status = status?.trim().orEmpty(),
+    features = features.orEmpty().mapNotNull { it?.trim()?.takeIf(String::isNotBlank) },
+)
+
+private fun ProviderStatusDto.toDomain(): ProviderStatusDetail = ProviderStatusDetail(
+    status = status?.trim().orEmpty(),
+    balancesAttested = balancesAttested,
+    lastReconciledTs = lastReconciledTs?.trim()?.takeIf { it.isNotBlank() },
+    pendingApprovals = pendingApprovals,
+)
+
+private fun ProviderConnectResultDto.toDomain(): ProviderActionResult = ProviderActionResult(
+    ok = (ok == true) || (disconnected == true),
+    status = status?.trim()?.takeIf { it.isNotBlank() },
+    reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
+)
+
+private fun VaultsDto.toDomain(): CustodyVaults = CustodyVaults(
+    vaults = vaults.orEmpty().map { it.toDomain() },
+    unavailable = false,
+)
+
+private fun VaultDto.toDomain(): CustodyVault = CustodyVault(
+    vault = vault?.trim().orEmpty(),
+    label = label?.trim().orEmpty(),
+    provider = provider?.trim().orEmpty().ifBlank { "internal" },
+)
+
+private fun SetVaultProviderResultDto.toDomain(): SetVaultProviderResult = SetVaultProviderResult(
+    ok = ok == true,
+    vault = vault?.trim()?.takeIf { it.isNotBlank() },
+    provider = provider?.trim()?.takeIf { it.isNotBlank() },
+    reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
+)
+
+private fun WithdrawalApprovalDto.toDomain(): WithdrawalApproval = WithdrawalApproval(
+    status = status?.trim().orEmpty(),
+    quorum = quorum ?: 0,
+    approvals = approvals.orEmpty().map { it.toDomain() },
+    unavailable = false,
+)
+
+private fun WithdrawalApproverDto.toDomain(): WithdrawalApprover = WithdrawalApprover(
+    approver = approver?.trim().orEmpty().ifBlank { "Approver" },
+    at = at?.trim().orEmpty(),
 )
 
 /** Provides the custody Retrofit API (mirrors the auth data module's provider style). */

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyProviderFormat.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyProviderFormat.kt
@@ -1,0 +1,185 @@
+package com.testlogon.android.feature.custody
+
+/**
+ * Pure, Android-free formatting + decision logic for the EXTERNAL custody provider surface
+ * (internal gateway vs. a qualified custodian like Fireblocks / BitGo). Kept free of Compose,
+ * Hilt and repositories so every rule -- the provider-status badge, the kind label, the
+ * balances-attested label, and the withdrawal-approval stepper model -- can be unit-tested from
+ * the JVM. The provider/vault/approval domain models live in data/custody/CustodyDomain.kt;
+ * this object only turns those value types into display-ready primitives.
+ */
+object CustodyProviderFormat {
+
+    /** Severity of a provider-status badge, ordered worst-last so a UI can pick a colour. */
+    enum class Severity { NEUTRAL, GOOD, WARN, BAD }
+
+    /** A resolved badge: the text to show plus its [severity]. */
+    data class Badge(val label: String, val severity: Severity)
+
+    // ---- provider connection status ----
+
+    /**
+     * Normalized provider connection status. wire matches the backend string; [NOT_CONNECTED] is
+     * also the fallback for an unknown / blank status so the UI never shows a raw wire token.
+     */
+    enum class ProviderStatus(val wire: String) {
+        HEALTHY("healthy"),
+        DEGRADED("degraded"),
+        DOWN("down"),
+        NOT_CONNECTED("not_connected"),
+        UNKNOWN("");
+
+        companion object {
+            fun from(wire: String?): ProviderStatus {
+                val w = wire?.trim()?.lowercase().orEmpty()
+                return entries.firstOrNull { it.wire == w } ?: UNKNOWN
+            }
+        }
+    }
+
+    /** Map a provider status to its badge (label + severity). */
+    fun statusBadge(status: ProviderStatus): Badge = when (status) {
+        ProviderStatus.HEALTHY -> Badge("Healthy", Severity.GOOD)
+        ProviderStatus.DEGRADED -> Badge("Degraded", Severity.WARN)
+        ProviderStatus.DOWN -> Badge("Down", Severity.BAD)
+        ProviderStatus.NOT_CONNECTED -> Badge("Not connected", Severity.NEUTRAL)
+        ProviderStatus.UNKNOWN -> Badge("Unknown", Severity.NEUTRAL)
+    }
+
+    /** Convenience: badge straight from a wire status string. */
+    fun statusBadge(wire: String?): Badge = statusBadge(ProviderStatus.from(wire))
+
+    // ---- provider kind ----
+
+    /** The backing custodian kind: the internal MPC gateway, or an external qualified custodian. */
+    enum class ProviderKind(val wire: String) {
+        INTERNAL("internal"),
+        FIREBLOCKS("fireblocks"),
+        BITGO("bitgo"),
+        UNKNOWN("");
+
+        companion object {
+            fun from(wire: String?): ProviderKind {
+                val w = wire?.trim()?.lowercase().orEmpty()
+                return entries.firstOrNull { it.wire == w } ?: UNKNOWN
+            }
+        }
+    }
+
+    /** Human label for a provider kind (used when the backend does not send a display name). */
+    fun kindLabel(kind: ProviderKind): String = when (kind) {
+        ProviderKind.INTERNAL -> "Internal gateway"
+        ProviderKind.FIREBLOCKS -> "Fireblocks"
+        ProviderKind.BITGO -> "BitGo"
+        ProviderKind.UNKNOWN -> "External custodian"
+    }
+
+    fun kindLabel(wire: String?): String = kindLabel(ProviderKind.from(wire))
+
+    /** True for the external qualified custodians (everything that is not the internal gateway). */
+    fun isExternal(kind: ProviderKind): Boolean =
+        kind == ProviderKind.FIREBLOCKS || kind == ProviderKind.BITGO
+
+    // ---- attestation ----
+
+    /**
+     * Label for the balances-attestation signal returned by a provider status probe. true means the
+     * custodian cryptographically attested the on-chain balances; null means the backend did not say.
+     */
+    fun attestationLabel(attested: Boolean?): String = when (attested) {
+        true -> "Balances attested"
+        false -> "Not attested"
+        null -> "Attestation unknown"
+    }
+
+    fun attestationSeverity(attested: Boolean?): Severity = when (attested) {
+        true -> Severity.GOOD
+        false -> Severity.WARN
+        null -> Severity.NEUTRAL
+    }
+
+    // ---- withdrawal approval stepper ----
+
+    /**
+     * Normalized withdrawal-approval state. The happy path advances
+     * pending_approval -> approved -> signed -> broadcast; [REJECTED] is a terminal off-path state.
+     */
+    enum class ApprovalStatus(val wire: String, val order: Int) {
+        PENDING_APPROVAL("pending_approval", 0),
+        APPROVED("approved", 1),
+        SIGNED("signed", 2),
+        BROADCAST("broadcast", 3),
+        REJECTED("rejected", -1),
+        UNKNOWN("", -2);
+
+        companion object {
+            fun from(wire: String?): ApprovalStatus {
+                val w = wire?.trim()?.lowercase().orEmpty()
+                return entries.firstOrNull { it.wire == w } ?: UNKNOWN
+            }
+        }
+    }
+
+    /** The ordered happy-path steps a provider-backed withdrawal advances through. */
+    val APPROVAL_STEPS: List<ApprovalStatus> = listOf(
+        ApprovalStatus.PENDING_APPROVAL,
+        ApprovalStatus.APPROVED,
+        ApprovalStatus.SIGNED,
+        ApprovalStatus.BROADCAST,
+    )
+
+    /** Human label for one approval step / status. */
+    fun approvalLabel(status: ApprovalStatus): String = when (status) {
+        ApprovalStatus.PENDING_APPROVAL -> "Pending approval"
+        ApprovalStatus.APPROVED -> "Approved"
+        ApprovalStatus.SIGNED -> "Signed"
+        ApprovalStatus.BROADCAST -> "Broadcast"
+        ApprovalStatus.REJECTED -> "Rejected"
+        ApprovalStatus.UNKNOWN -> "Unknown"
+    }
+
+    /** Where one step stands relative to the current [ApprovalStatus]. */
+    enum class StepState { DONE, CURRENT, UPCOMING, REJECTED }
+
+    /** One rendered stepper row: the step, its label, and its state relative to current. */
+    data class Step(val status: ApprovalStatus, val label: String, val state: StepState)
+
+    /**
+     * Build the ordered stepper model for a withdrawal whose current status is [current].
+     *
+     * On the happy path each step is DONE (index < current), CURRENT (== current) or UPCOMING
+     * (> current). On a REJECTED withdrawal the whole stepper is marked REJECTED so the UI can show
+     * the flow was aborted. An UNKNOWN status renders every step UPCOMING (nothing has happened yet).
+     */
+    fun stepper(current: ApprovalStatus): List<Step> {
+        if (current == ApprovalStatus.REJECTED) {
+            return APPROVAL_STEPS.map { Step(it, approvalLabel(it), StepState.REJECTED) }
+        }
+        val curIdx = APPROVAL_STEPS.indexOfFirst { it == current }
+        return APPROVAL_STEPS.mapIndexed { idx, step ->
+            val state = when {
+                curIdx < 0 -> StepState.UPCOMING
+                idx < curIdx -> StepState.DONE
+                idx == curIdx -> StepState.CURRENT
+                else -> StepState.UPCOMING
+            }
+            Step(step, approvalLabel(step), state)
+        }
+    }
+
+    fun stepper(wire: String?): List<Step> = stepper(ApprovalStatus.from(wire))
+
+    /** True once the withdrawal has reached a terminal state (broadcast or rejected). */
+    fun isTerminal(status: ApprovalStatus): Boolean =
+        status == ApprovalStatus.BROADCAST || status == ApprovalStatus.REJECTED
+
+    /**
+     * Compact quorum label like "2 of 3" from the approvals collected so far vs. the required quorum.
+     * Clamps negatives to 0.
+     */
+    fun quorumLabel(collected: Int, quorum: Int): String {
+        val c = collected.coerceAtLeast(0)
+        val q = quorum.coerceAtLeast(0)
+        return "$c of $q"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyProvidersScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyProvidersScreen.kt
@@ -1,0 +1,454 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.custody
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.custody.CustodyProvider
+import com.testlogon.android.data.custody.CustodyVault
+import com.testlogon.android.data.custody.ProviderStatusDetail
+import com.testlogon.android.data.custody.WithdrawalApproval
+import com.testlogon.android.feature.custody.CustodyProviderFormat.ProviderKind
+import com.testlogon.android.feature.custody.CustodyProviderFormat.Severity
+import com.testlogon.android.feature.custody.CustodyProviderFormat.StepState
+
+/** Route-level entry for the external custody-provider surface (reached from Custody / More). */
+@Composable
+fun CustodyProvidersRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CustodyProvidersViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CustodyProvidersScreen(state = state, onBack = onBack, viewModel = viewModel, modifier = modifier)
+}
+
+@Composable
+fun CustodyProvidersScreen(
+    state: ProvidersUiState,
+    onBack: () -> Unit,
+    viewModel: CustodyProvidersViewModel,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Custody providers") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Text(
+                "Back your custody with a qualified custodian (Fireblocks, BitGo) or the internal MPC gateway. " +
+                    "Provider credentials are held server-side; this screen only initiates the connection and shows status.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            ProvidersSection(state, viewModel)
+            HorizontalDivider()
+            VaultsSection(state, viewModel)
+            HorizontalDivider()
+            ApprovalSection(state, viewModel)
+        }
+    }
+}
+
+// ---------------- Providers ----------------
+
+@Composable
+private fun ProvidersSection(state: ProvidersUiState, viewModel: CustodyProvidersViewModel) {
+    Text("Providers", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+    val p = state.providers
+    when {
+        p.loading && p.data == null -> ProvLoading()
+        p.error != null && p.data == null -> ProvError(p.error) { viewModel.loadProviders() }
+        p.data == null || p.data.unavailable || p.data.isEmpty ->
+            PendingBackendCard("Provider integration pending backend. When the custody edge exposes the provider routes, Internal / Fireblocks / BitGo will appear here to connect.")
+        else -> Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            state.providerList.forEach { prov ->
+                ProviderCard(
+                    provider = prov,
+                    status = state.statuses[prov.id],
+                    inFlight = prov.id in state.actionInFlight,
+                    error = state.actionErrors[prov.id],
+                    onConnect = { viewModel.connect(prov.id, prov.name.ifBlank { null }) },
+                    onDisconnect = { viewModel.disconnect(prov.id) },
+                    onLoadStatus = { viewModel.loadProviderStatus(prov.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProviderCard(
+    provider: CustodyProvider,
+    status: ProviderStatusUi?,
+    inFlight: Boolean,
+    error: String?,
+    onConnect: () -> Unit,
+    onDisconnect: () -> Unit,
+    onLoadStatus: () -> Unit,
+) {
+    val kind = ProviderKind.from(provider.kind)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        provider.displayName.ifBlank { CustodyProviderFormat.kindLabel(kind) },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        CustodyProviderFormat.kindLabel(kind) + if (CustodyProviderFormat.isExternal(kind)) " · Qualified custodian" else "",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                SeverityBadge(CustodyProviderFormat.statusBadge(provider.status))
+            }
+
+            if (provider.features.isNotEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    provider.features.forEach { f ->
+                        AssistChip(onClick = {}, label = { Text(f, style = MaterialTheme.typography.labelSmall) })
+                    }
+                }
+            }
+
+            // Live status probe (attestation / reconciliation / pending approvals).
+            when {
+                status?.loading == true -> Text("Checking status…", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                status?.error != null -> Text(status.error, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                status?.data != null -> ProviderStatusDetailView(status.data)
+            }
+
+            if (error != null) {
+                Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onLoadStatus, modifier = Modifier.weight(1f)) { Text("Status") }
+                if (provider.connected) {
+                    Button(onClick = onDisconnect, enabled = !inFlight, modifier = Modifier.weight(1f)) {
+                        if (inFlight) SmallSpinnerOnPrimary()
+                        Text("Disconnect")
+                    }
+                } else {
+                    Button(onClick = onConnect, enabled = !inFlight, modifier = Modifier.weight(1f)) {
+                        if (inFlight) SmallSpinnerOnPrimary()
+                        Text("Connect")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProviderStatusDetailView(d: ProviderStatusDetail) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SeverityDot(CustodyProviderFormat.attestationSeverity(d.balancesAttested))
+            Spacer(Modifier.width(6.dp))
+            Text(CustodyProviderFormat.attestationLabel(d.balancesAttested), style = MaterialTheme.typography.bodySmall)
+        }
+        d.lastReconciledTs?.let {
+            Text("Last reconciled: $it", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
+        }
+        d.pendingApprovals?.let {
+            Text("Pending approvals: $it", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+// ---------------- Vaults (per-vault provider) ----------------
+
+@Composable
+private fun VaultsSection(state: ProvidersUiState, viewModel: CustodyProvidersViewModel) {
+    Text("Vaults", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+    Text(
+        "Choose which custodian backs each vault.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    val v = state.vaults
+    when {
+        v.loading && v.data == null -> ProvLoading()
+        v.error != null && v.data == null -> ProvError(v.error) { viewModel.loadVaults() }
+        v.data == null || v.data.unavailable || v.data.isEmpty ->
+            PendingBackendCard("Vault provider selection pending backend. Your vaults and their backing custodian will appear here once the route is deployed.")
+        else -> Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            v.data.vaults.forEach { vault ->
+                VaultCard(
+                    vault = vault,
+                    inFlight = vault.vault in state.vaultChangeInFlight,
+                    error = state.vaultChangeErrors[vault.vault],
+                    onSelectProvider = { viewModel.setVaultProvider(vault.vault, it) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VaultCard(
+    vault: CustodyVault,
+    inFlight: Boolean,
+    error: String?,
+    onSelectProvider: (String) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(vault.displayLabel, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(vault.vaultShort, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
+                }
+                val kind = ProviderKind.from(vault.provider)
+                SeverityBadge(
+                    CustodyProviderFormat.Badge(
+                        CustodyProviderFormat.kindLabel(kind),
+                        if (CustodyProviderFormat.isExternal(kind)) Severity.GOOD else Severity.NEUTRAL,
+                    ),
+                )
+            }
+            Text("Backing provider", style = MaterialTheme.typography.labelMedium)
+            Row(
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                PROVIDER_KIND_CHOICES.forEach { (wire, label) ->
+                    FilterChip(
+                        selected = vault.provider.equals(wire, ignoreCase = true),
+                        enabled = !inFlight,
+                        onClick = { if (!vault.provider.equals(wire, ignoreCase = true)) onSelectProvider(wire) },
+                        label = { Text(label) },
+                    )
+                }
+            }
+            if (inFlight) {
+                Text("Updating…", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (error != null) {
+                Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+private val PROVIDER_KIND_CHOICES: List<Pair<String, String>> = listOf(
+    "internal" to "Internal",
+    "fireblocks" to "Fireblocks",
+    "bitgo" to "BitGo",
+)
+
+// ---------------- Withdrawal approval stepper ----------------
+
+@Composable
+private fun ApprovalSection(state: ProvidersUiState, viewModel: CustodyProvidersViewModel) {
+    Text("Withdrawal approval", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+    Text(
+        "Look up the multi-sig approval progress of a provider-backed withdrawal.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    val a = state.approval
+    OutlinedTextField(
+        value = a.withdrawalId,
+        onValueChange = viewModel::onApprovalIdChanged,
+        label = { Text("Withdrawal id") },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    if (a.error != null) {
+        Text(a.error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+    }
+    Button(onClick = { viewModel.lookupApproval() }, enabled = !a.loading, modifier = Modifier.fillMaxWidth()) {
+        if (a.loading) SmallSpinnerOnPrimary()
+        Text("Check approval")
+    }
+    a.data?.let { ApprovalCard(it) }
+}
+
+@Composable
+private fun ApprovalCard(approval: WithdrawalApproval) {
+    if (approval.unavailable) {
+        PendingBackendCard("Approval tracking isn't available for this withdrawal on this backend.")
+        return
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            val status = CustodyProviderFormat.ApprovalStatus.from(approval.status)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Quorum", modifier = Modifier.weight(1f), style = MaterialTheme.typography.labelLarge)
+                Text(
+                    CustodyProviderFormat.quorumLabel(approval.collected, approval.quorum),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            // Stepper.
+            CustodyProviderFormat.stepper(status).forEach { step ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    StepDot(step.state)
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        step.label,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = if (step.state == StepState.CURRENT) FontWeight.SemiBold else FontWeight.Normal,
+                        color = when (step.state) {
+                            StepState.REJECTED -> MaterialTheme.colorScheme.error
+                            StepState.UPCOMING -> MaterialTheme.colorScheme.onSurfaceVariant
+                            else -> MaterialTheme.colorScheme.onSurface
+                        },
+                    )
+                }
+            }
+            if (approval.approvals.isNotEmpty()) {
+                HorizontalDivider()
+                Text("Approvers", style = MaterialTheme.typography.labelLarge)
+                approval.approvals.forEach { ap ->
+                    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Text(ap.approver, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodySmall)
+                        if (ap.at.isNotBlank()) {
+                            Text(ap.at, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, fontFamily = FontFamily.Monospace)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------- shared bits ----------------
+
+@Composable
+private fun SeverityBadge(badge: CustodyProviderFormat.Badge) {
+    val color = severityColor(badge.severity)
+    Box(
+        modifier = Modifier
+            .background(color.copy(alpha = 0.15f), RoundedCornerShape(50))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(badge.label, style = MaterialTheme.typography.labelSmall, color = color, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+private fun SeverityDot(severity: Severity) {
+    Box(modifier = Modifier.size(10.dp).background(severityColor(severity), CircleShape))
+}
+
+@Composable
+private fun StepDot(state: StepState) {
+    val color = when (state) {
+        StepState.DONE -> severityColor(Severity.GOOD)
+        StepState.CURRENT -> MaterialTheme.colorScheme.primary
+        StepState.REJECTED -> MaterialTheme.colorScheme.error
+        StepState.UPCOMING -> MaterialTheme.colorScheme.outline
+    }
+    Box(modifier = Modifier.size(12.dp).background(color, CircleShape))
+}
+
+@Composable
+private fun severityColor(severity: Severity): Color = when (severity) {
+    Severity.GOOD -> Color(0xFF2E7D32)
+    Severity.WARN -> Color(0xFFED6C02)
+    Severity.BAD -> MaterialTheme.colorScheme.error
+    Severity.NEUTRAL -> MaterialTheme.colorScheme.onSurfaceVariant
+}
+
+@Composable
+private fun SmallSpinnerOnPrimary() {
+    CircularProgressIndicator(modifier = Modifier.size(16.dp).padding(end = 0.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+    Spacer(Modifier.width(8.dp))
+}
+
+@Composable
+private fun PendingBackendCard(text: String) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant), modifier = Modifier.fillMaxWidth()) {
+        Row(modifier = Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Filled.Info, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.width(10.dp))
+            Text(text, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun ProvLoading() {
+    Box(modifier = Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ProvError(message: String, onRetry: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth().padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(message, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium)
+        Button(onClick = onRetry) { Text("Retry") }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyProvidersViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyProvidersViewModel.kt
@@ -1,0 +1,216 @@
+package com.testlogon.android.feature.custody
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.custody.CustodyProvider
+import com.testlogon.android.data.custody.CustodyProviders
+import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.custody.CustodyVaults
+import com.testlogon.android.data.custody.ProviderStatusDetail
+import com.testlogon.android.data.custody.WithdrawalApproval
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Per-provider live status slice (lazily probed when a card is expanded). Keyed by provider id in
+ * [ProvidersUiState.statuses].
+ */
+data class ProviderStatusUi(
+    val loading: Boolean = false,
+    val error: String? = null,
+    val data: ProviderStatusDetail? = null,
+)
+
+/** The withdrawal-approval lookup form + polled result on the Providers screen. */
+data class ApprovalLookupUiState(
+    val withdrawalId: String = "",
+    val loading: Boolean = false,
+    val error: String? = null,
+    val data: WithdrawalApproval? = null,
+)
+
+data class ProvidersUiState(
+    val providers: Async<CustodyProviders> = Async(loading = true),
+    val vaults: Async<CustodyVaults> = Async(loading = true),
+    /** Per-provider expanded status probes, keyed by provider id. */
+    val statuses: Map<String, ProviderStatusUi> = emptyMap(),
+    /** In-flight connect/disconnect action, keyed by provider id. */
+    val actionInFlight: Set<String> = emptySet(),
+    /** Last action error, keyed by provider id. */
+    val actionErrors: Map<String, String> = emptyMap(),
+    /** In-flight per-vault provider change, keyed by vault id. */
+    val vaultChangeInFlight: Set<String> = emptySet(),
+    val vaultChangeErrors: Map<String, String> = emptyMap(),
+    val approval: ApprovalLookupUiState = ApprovalLookupUiState(),
+) {
+    val providerList: List<CustodyProvider> get() = providers.data?.providers.orEmpty()
+}
+
+/**
+ * ViewModel for the EXTERNAL custody provider screen (Fireblocks / BitGo / internal gateway). Reads
+ * degrade to a soft "pending backend" state on 404; connect/disconnect + per-vault provider change are
+ * mutations whose failures surface a clear message. Provider secrets are never handled here -- the
+ * screen only initiates the server-side connection and shows status.
+ */
+@HiltViewModel
+class CustodyProvidersViewModel @Inject constructor(
+    private val repo: CustodyRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ProvidersUiState())
+    val uiState: StateFlow<ProvidersUiState> = _uiState.asStateFlow()
+
+    init {
+        loadProviders()
+        loadVaults()
+    }
+
+    fun loadProviders() {
+        _uiState.update { it.copy(providers = it.providers.copy(loading = true, error = null)) }
+        viewModelScope.launch {
+            _uiState.update { st -> st.copy(providers = repo.getProviders().toAsync()) }
+        }
+    }
+
+    fun loadVaults() {
+        _uiState.update { it.copy(vaults = it.vaults.copy(loading = true, error = null)) }
+        viewModelScope.launch {
+            _uiState.update { st -> st.copy(vaults = repo.getVaults().toAsync()) }
+        }
+    }
+
+    /** Lazily probe a provider's live status (health/attestation/reconciliation/pending approvals). */
+    fun loadProviderStatus(id: String) {
+        if (id.isBlank()) return
+        _uiState.update { st ->
+            st.copy(statuses = st.statuses + (id to (st.statuses[id] ?: ProviderStatusUi()).copy(loading = true, error = null)))
+        }
+        viewModelScope.launch {
+            val ui = when (val r = repo.getProviderStatus(id)) {
+                is ApiResult.Success -> ProviderStatusUi(loading = false, data = r.data)
+                is ApiResult.Failure -> ProviderStatusUi(loading = false, error = r.error.messageFor())
+                is ApiResult.NetworkError -> ProviderStatusUi(loading = false, error = "Network error. Check your connection and try again.")
+            }
+            _uiState.update { st -> st.copy(statuses = st.statuses + (id to ui)) }
+        }
+    }
+
+    fun connect(id: String, label: String?) {
+        if (id.isBlank() || id in _uiState.value.actionInFlight) return
+        setActionInFlight(id, true)
+        viewModelScope.launch {
+            when (val r = repo.connectProvider(id, label)) {
+                is ApiResult.Success -> {
+                    setActionInFlight(id, false)
+                    loadProviders()
+                    loadProviderStatus(id)
+                }
+                is ApiResult.Failure -> finishActionWithError(id, r.error.messageFor())
+                is ApiResult.NetworkError -> finishActionWithError(id, "Network error. Check your connection and try again.")
+            }
+        }
+    }
+
+    fun disconnect(id: String) {
+        if (id.isBlank() || id in _uiState.value.actionInFlight) return
+        setActionInFlight(id, true)
+        viewModelScope.launch {
+            when (val r = repo.disconnectProvider(id)) {
+                is ApiResult.Success -> {
+                    setActionInFlight(id, false)
+                    loadProviders()
+                }
+                is ApiResult.Failure -> finishActionWithError(id, r.error.messageFor())
+                is ApiResult.NetworkError -> finishActionWithError(id, "Network error. Check your connection and try again.")
+            }
+        }
+    }
+
+    private fun setActionInFlight(id: String, inFlight: Boolean) {
+        _uiState.update { st ->
+            st.copy(
+                actionInFlight = if (inFlight) st.actionInFlight + id else st.actionInFlight - id,
+                actionErrors = st.actionErrors - id,
+            )
+        }
+    }
+
+    private fun finishActionWithError(id: String, msg: String) {
+        _uiState.update { st ->
+            st.copy(
+                actionInFlight = st.actionInFlight - id,
+                actionErrors = st.actionErrors + (id to msg),
+            )
+        }
+    }
+
+    /** Set a vault's backing provider (PUT). Refreshes the vaults list on success. */
+    fun setVaultProvider(vault: String, provider: String) {
+        if (vault.isBlank() || vault in _uiState.value.vaultChangeInFlight) return
+        _uiState.update { st ->
+            st.copy(
+                vaultChangeInFlight = st.vaultChangeInFlight + vault,
+                vaultChangeErrors = st.vaultChangeErrors - vault,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repo.setVaultProvider(vault, provider)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(vaultChangeInFlight = it.vaultChangeInFlight - vault) }
+                    loadVaults()
+                }
+                is ApiResult.Failure -> finishVaultChangeWithError(vault, r.error.messageFor())
+                is ApiResult.NetworkError -> finishVaultChangeWithError(vault, "Network error. Check your connection and try again.")
+            }
+        }
+    }
+
+    private fun finishVaultChangeWithError(vault: String, msg: String) {
+        _uiState.update { st ->
+            st.copy(
+                vaultChangeInFlight = st.vaultChangeInFlight - vault,
+                vaultChangeErrors = st.vaultChangeErrors + (vault to msg),
+            )
+        }
+    }
+
+    // ---- withdrawal approval lookup ----
+
+    fun onApprovalIdChanged(v: String) {
+        _uiState.update { it.copy(approval = it.approval.copy(withdrawalId = v.trim(), error = null)) }
+    }
+
+    fun lookupApproval() {
+        val id = _uiState.value.approval.withdrawalId.trim()
+        if (id.isEmpty()) {
+            _uiState.update { it.copy(approval = it.approval.copy(error = "Enter a withdrawal id.")) }
+            return
+        }
+        _uiState.update { it.copy(approval = it.approval.copy(loading = true, error = null)) }
+        viewModelScope.launch {
+            when (val r = repo.getWithdrawalApproval(id)) {
+                is ApiResult.Success -> _uiState.update { it.copy(approval = it.approval.copy(loading = false, data = r.data)) }
+                is ApiResult.Failure -> _uiState.update { it.copy(approval = it.approval.copy(loading = false, error = r.error.messageFor())) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(approval = it.approval.copy(loading = false, error = "Network error. Check your connection and try again.")) }
+            }
+        }
+    }
+}
+
+private fun <T> ApiResult<T>.toAsync(): Async<T> = when (this) {
+    is ApiResult.Success -> Async(loading = false, error = null, data = data)
+    is ApiResult.Failure -> Async(loading = false, error = error.messageFor())
+    is ApiResult.NetworkError -> Async(loading = false, error = "Network error. Check your connection and try again.")
+}
+
+private fun ApiError.messageFor(): String = when (status) {
+    403 -> "You do not have access to this."
+    else -> message
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/custody/CustodyScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -79,6 +80,7 @@ import com.testlogon.android.data.custody.WithdrawStatus
 @Composable
 fun CustodyRoute(
     onBack: () -> Unit,
+    onOpenProviders: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: CustodyViewModel = hiltViewModel(),
 ) {
@@ -86,6 +88,7 @@ fun CustodyRoute(
     CustodyScreen(
         state = state,
         onBack = onBack,
+        onOpenProviders = onOpenProviders,
         viewModel = viewModel,
         modifier = modifier,
     )
@@ -95,6 +98,7 @@ fun CustodyRoute(
 fun CustodyScreen(
     state: CustodyUiState,
     onBack: () -> Unit,
+    onOpenProviders: () -> Unit,
     viewModel: CustodyViewModel,
     modifier: Modifier = Modifier,
 ) {
@@ -120,6 +124,11 @@ fun CustodyScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onOpenProviders) {
+                        Icon(Icons.Filled.Shield, contentDescription = "Custody providers")
                     }
                 },
             )

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -975,6 +975,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "custody_providers",
+            labelRes = R.string.more_entry_custody_providers,
+            icon = Icons.Outlined.Shield,
+            route = MoreRoutes.CUSTODY_PROVIDERS,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "portfolio",
             labelRes = R.string.more_entry_portfolio,
             icon = Icons.Outlined.PieChart,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -216,6 +216,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         blotterDestination(navController)
         // Custody: native crypto custody surface wired to /me/custody/* (officer approvals self-gate on the admin signal).
         custodyDestination(navController)
+        // External custody providers (Fireblocks / BitGo / internal gateway): connect + per-vault provider + withdrawal approval.
+        custodyProvidersDestination(navController)
         // Trading Home / Dashboard: read-only launch surface (reached from More -> Wallet hub top).
         homeDestination(navController)
         portfolioDestination(navController)

--- a/android/app/src/main/java/com/testlogon/android/navigation/CustodyNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CustodyNavigation.kt
@@ -4,10 +4,16 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.testlogon.android.feature.custody.CustodyRoute
+import com.testlogon.android.feature.custody.CustodyProvidersRoute
 
 /** The native Custody surface (balances / deposit / withdraw / activity / officer approvals), reached from the More -> Wallet hub. */
 data object CustodyDest {
     const val ROUTE = "custody"
+}
+
+/** The external custody-provider surface (Fireblocks / BitGo / internal gateway), reached from Custody. */
+data object CustodyProvidersDest {
+    const val ROUTE = "custody/providers"
 }
 
 /**
@@ -18,6 +24,20 @@ data object CustodyDest {
 fun NavGraphBuilder.custodyDestination(navController: NavHostController) {
     composable(CustodyDest.ROUTE) {
         CustodyRoute(
+            onBack = { navController.popBackStack() },
+            onOpenProviders = { navController.navigate(CustodyProvidersDest.ROUTE) },
+        )
+    }
+}
+
+/**
+ * Registers the external custody-provider screen (provider connect/status + per-vault provider +
+ * withdrawal approval). Wired to the me/custody/providers|vaults|withdrawals endpoints; reads degrade
+ * on 404 to an honest "provider integration pending backend" state.
+ */
+fun NavGraphBuilder.custodyProvidersDestination(navController: NavHostController) {
+    composable(CustodyProvidersDest.ROUTE) {
+        CustodyProvidersRoute(
             onBack = { navController.popBackStack() },
         )
     }

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -106,6 +106,9 @@ object MoreRoutes {
     // Custody: native crypto custody surface (balances / deposit / withdraw / activity / officer approvals), wired to /me/custody/*.
     const val CUSTODY = CustodyDest.ROUTE
 
+    // External custody providers (Fireblocks / BitGo / internal gateway): connect + per-vault provider + withdrawal approval.
+    const val CUSTODY_PROVIDERS = CustodyProvidersDest.ROUTE
+
     // Portfolio: read-only cross-venue account overview (custody / spot / margin / staking snapshot).
     const val PORTFOLIO = PortfolioDest.ROUTE
 
@@ -593,6 +596,7 @@ object MoreRoutes {
             TRADING_BLOTTER,
             HOME,
             CUSTODY,
+            CUSTODY_PROVIDERS,
             PORTFOLIO,
             PNL,
             PAPER,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1458,6 +1458,7 @@
     <string name="more_entry_trading_blotter">Trading Blotter</string>
     <string name="more_entry_home">Home</string>
     <string name="more_entry_custody">Custody</string>
+    <string name="more_entry_custody_providers">Custody providers</string>
     <string name="more_entry_portfolio">Portfolio</string>
     <string name="more_entry_pnl">PnL &amp; performance</string>
     <string name="more_entry_paper_trading">Paper Trading</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/custody/CustodyProviderFormatTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/custody/CustodyProviderFormatTest.kt
@@ -1,0 +1,146 @@
+package com.testlogon.android.feature.custody
+
+import com.testlogon.android.feature.custody.CustodyProviderFormat.ApprovalStatus
+import com.testlogon.android.feature.custody.CustodyProviderFormat.ProviderKind
+import com.testlogon.android.feature.custody.CustodyProviderFormat.ProviderStatus
+import com.testlogon.android.feature.custody.CustodyProviderFormat.Severity
+import com.testlogon.android.feature.custody.CustodyProviderFormat.StepState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [CustodyProviderFormat] -- the pure display/decision logic behind the external
+ * custody-provider surface (status badge, kind label, attestation label, and the withdrawal-approval
+ * stepper). No Android, Hilt or network types are touched.
+ */
+class CustodyProviderFormatTest {
+
+    // ---- status badge ----
+
+    @Test
+    fun statusBadge_mapsEachKnownStatus() {
+        assertEquals(Severity.GOOD, CustodyProviderFormat.statusBadge(ProviderStatus.HEALTHY).severity)
+        assertEquals(Severity.WARN, CustodyProviderFormat.statusBadge(ProviderStatus.DEGRADED).severity)
+        assertEquals(Severity.BAD, CustodyProviderFormat.statusBadge(ProviderStatus.DOWN).severity)
+        assertEquals(Severity.NEUTRAL, CustodyProviderFormat.statusBadge(ProviderStatus.NOT_CONNECTED).severity)
+        assertEquals("Healthy", CustodyProviderFormat.statusBadge(ProviderStatus.HEALTHY).label)
+    }
+
+    @Test
+    fun statusFrom_isCaseInsensitive_andFallsBackToUnknown() {
+        assertEquals(ProviderStatus.HEALTHY, ProviderStatus.from("HEALTHY"))
+        assertEquals(ProviderStatus.DEGRADED, ProviderStatus.from(" degraded "))
+        assertEquals(ProviderStatus.UNKNOWN, ProviderStatus.from("gibberish"))
+        assertEquals(ProviderStatus.UNKNOWN, ProviderStatus.from(null))
+    }
+
+    @Test
+    fun statusBadge_fromWireString_resolvesAndDefaults() {
+        assertEquals("Down", CustodyProviderFormat.statusBadge("down").label)
+        assertEquals(Severity.NEUTRAL, CustodyProviderFormat.statusBadge("???").severity)
+    }
+
+    // ---- kind ----
+
+    @Test
+    fun kindLabel_mapsKnownKinds() {
+        assertEquals("Internal gateway", CustodyProviderFormat.kindLabel(ProviderKind.INTERNAL))
+        assertEquals("Fireblocks", CustodyProviderFormat.kindLabel(ProviderKind.FIREBLOCKS))
+        assertEquals("BitGo", CustodyProviderFormat.kindLabel(ProviderKind.BITGO))
+        assertEquals("External custodian", CustodyProviderFormat.kindLabel(ProviderKind.UNKNOWN))
+    }
+
+    @Test
+    fun kindFrom_andIsExternal() {
+        assertEquals(ProviderKind.FIREBLOCKS, ProviderKind.from("Fireblocks"))
+        assertTrue(CustodyProviderFormat.isExternal(ProviderKind.FIREBLOCKS))
+        assertTrue(CustodyProviderFormat.isExternal(ProviderKind.BITGO))
+        assertFalse(CustodyProviderFormat.isExternal(ProviderKind.INTERNAL))
+        assertFalse(CustodyProviderFormat.isExternal(ProviderKind.UNKNOWN))
+    }
+
+    // ---- attestation ----
+
+    @Test
+    fun attestationLabel_andSeverity() {
+        assertEquals("Balances attested", CustodyProviderFormat.attestationLabel(true))
+        assertEquals("Not attested", CustodyProviderFormat.attestationLabel(false))
+        assertEquals("Attestation unknown", CustodyProviderFormat.attestationLabel(null))
+        assertEquals(Severity.GOOD, CustodyProviderFormat.attestationSeverity(true))
+        assertEquals(Severity.WARN, CustodyProviderFormat.attestationSeverity(false))
+        assertEquals(Severity.NEUTRAL, CustodyProviderFormat.attestationSeverity(null))
+    }
+
+    // ---- approval stepper ----
+
+    @Test
+    fun approvalFrom_isCaseInsensitive_andDefaults() {
+        assertEquals(ApprovalStatus.SIGNED, ApprovalStatus.from("SIGNED"))
+        assertEquals(ApprovalStatus.PENDING_APPROVAL, ApprovalStatus.from("pending_approval"))
+        assertEquals(ApprovalStatus.UNKNOWN, ApprovalStatus.from("nope"))
+    }
+
+    @Test
+    fun stepper_pendingApproval_firstIsCurrent_restUpcoming() {
+        val steps = CustodyProviderFormat.stepper(ApprovalStatus.PENDING_APPROVAL)
+        assertEquals(4, steps.size)
+        assertEquals(StepState.CURRENT, steps[0].state)
+        assertEquals(StepState.UPCOMING, steps[1].state)
+        assertEquals(StepState.UPCOMING, steps[3].state)
+        assertEquals(ApprovalStatus.PENDING_APPROVAL, steps[0].status)
+        assertEquals("Broadcast", steps[3].label)
+    }
+
+    @Test
+    fun stepper_signed_marksEarlierDone_currentSigned_broadcastUpcoming() {
+        val steps = CustodyProviderFormat.stepper(ApprovalStatus.SIGNED)
+        assertEquals(StepState.DONE, steps[0].state)
+        assertEquals(StepState.DONE, steps[1].state)
+        assertEquals(StepState.CURRENT, steps[2].state)
+        assertEquals(StepState.UPCOMING, steps[3].state)
+    }
+
+    @Test
+    fun stepper_broadcast_allDone() {
+        val steps = CustodyProviderFormat.stepper(ApprovalStatus.BROADCAST)
+        assertTrue(steps.dropLast(1).all { it.state == StepState.DONE })
+        assertEquals(StepState.CURRENT, steps.last().state)
+    }
+
+    @Test
+    fun stepper_rejected_marksAllRejected() {
+        val steps = CustodyProviderFormat.stepper(ApprovalStatus.REJECTED)
+        assertEquals(4, steps.size)
+        assertTrue(steps.all { it.state == StepState.REJECTED })
+    }
+
+    @Test
+    fun stepper_unknown_allUpcoming() {
+        val steps = CustodyProviderFormat.stepper(ApprovalStatus.UNKNOWN)
+        assertTrue(steps.all { it.state == StepState.UPCOMING })
+    }
+
+    @Test
+    fun stepper_fromWireString_resolves() {
+        val steps = CustodyProviderFormat.stepper("approved")
+        assertEquals(StepState.DONE, steps[0].state)
+        assertEquals(StepState.CURRENT, steps[1].state)
+    }
+
+    @Test
+    fun isTerminal_onlyBroadcastAndRejected() {
+        assertTrue(CustodyProviderFormat.isTerminal(ApprovalStatus.BROADCAST))
+        assertTrue(CustodyProviderFormat.isTerminal(ApprovalStatus.REJECTED))
+        assertFalse(CustodyProviderFormat.isTerminal(ApprovalStatus.PENDING_APPROVAL))
+        assertFalse(CustodyProviderFormat.isTerminal(ApprovalStatus.SIGNED))
+    }
+
+    @Test
+    fun quorumLabel_formatsAndClampsNegatives() {
+        assertEquals("2 of 3", CustodyProviderFormat.quorumLabel(2, 3))
+        assertEquals("0 of 0", CustodyProviderFormat.quorumLabel(-1, -5))
+        assertEquals("0 of 2", CustodyProviderFormat.quorumLabel(0, 2))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ const CalendarPage = lazy(() => import("@/pages/calendar/CalendarPage"));
 const TradingBlotterPage = lazy(() => import("@/pages/blotter/TradingBlotterPage"));
 const TradingWorkspacePage = lazy(() => import("@/pages/blotter/TradingWorkspacePage"));
 const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
+const CustodyProvidersPage = lazy(() => import("@/pages/custody/CustodyProvidersPage"));
 const PortfolioPage = lazy(() => import("@/pages/portfolio/PortfolioPage"));
 const BailoutsBoardPage = lazy(() => import("@/pages/bailouts/BailoutsBoardPage"));
 const PnLPage = lazy(() => import("@/pages/pnl/PnLPage"));
@@ -731,6 +732,7 @@ export default function App() {
           <Route path="blotter" element={<TradingWorkspacePage />} />
           <Route path="blotter/single" element={<TradingBlotterPage />} />
           <Route path="custody" element={<CustodyPage />} />
+          <Route path="custody/providers" element={<CustodyProvidersPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
           <Route path="pnl" element={<PnLPage />} />
           <Route path="reports" element={<ReportsPage />} />

--- a/frontend/src/api/endpoints/custodyProviders.ts
+++ b/frontend/src/api/endpoints/custodyProviders.ts
@@ -1,0 +1,119 @@
+import { api } from "@/api/client";
+
+// ─── External custody-provider surface ───────────────────────────
+// Back a custody vault with an EXTERNAL qualified custodian (Fireblocks,
+// BitGo, …) in addition to the internal gateway. Provider API creds live
+// SERVER-SIDE only — the UI merely INITIATES a connection and SHOWS status;
+// no provider secret ever touches the client.
+//
+// EVERY route below is NEW and MAY 404 on backends where the provider
+// integration isn't deployed yet. All callers must degrade gracefully
+// (react-query retry:false + an honest "provider integration pending backend"
+// empty state). The existing internal-custody behaviour is unchanged.
+
+export type ProviderKind = "internal" | "fireblocks" | "bitgo";
+
+export type ProviderStatus =
+  | "healthy"
+  | "degraded"
+  | "down"
+  | "not_connected";
+
+export interface CustodyProvider {
+  id: string;
+  name: string;
+  kind: ProviderKind;
+  connected: boolean;
+  status: ProviderStatus;
+  features: string[];
+}
+
+export interface ProvidersResult {
+  providers: CustodyProvider[];
+}
+
+export interface ConnectResult {
+  ok: boolean;
+  status: ProviderStatus | string;
+}
+
+export interface ProviderStatusResult {
+  status: ProviderStatus | string;
+  balances_attested: boolean;
+  last_reconciled_ts?: number | string | null;
+  pending_approvals: number;
+}
+
+/** List the custody providers available to the caller (internal + external). */
+export const getProviders = () =>
+  api.get<ProvidersResult>("/me/custody/providers");
+
+/** Initiate a server-side connection to a provider (creds stay server-side). */
+export const connectProvider = (id: string, label?: string) =>
+  api.post<ConnectResult>(`/me/custody/providers/${encodeURIComponent(id)}/connect`, {
+    ...(label ? { label } : {}),
+  });
+
+/** Tear down a provider connection. */
+export const disconnectProvider = (id: string) =>
+  api.post<{ ok?: boolean; status?: string; [k: string]: unknown }>(
+    `/me/custody/providers/${encodeURIComponent(id)}/disconnect`,
+  );
+
+/** Live provider status: attestation, last-reconciled, pending approvals. */
+export const getProviderStatus = (id: string) =>
+  api.get<ProviderStatusResult>(
+    `/me/custody/providers/${encodeURIComponent(id)}/status`,
+  );
+
+// ─── Vaults (provider-aware) ─────────────────────────────────────
+// A richer vault read than /me/custody/subaccounts: each vault carries the
+// provider that custodies it. `provider` is OPTIONAL and defaults to
+// "internal" when a backend omits it.
+
+export interface ProviderVault {
+  vault: string;
+  label?: string;
+  provider?: ProviderKind | string;
+  balances?: Record<string, number | string>;
+}
+
+export interface VaultsResult {
+  vaults: ProviderVault[];
+}
+
+/** List the caller's vaults with their custodying provider. */
+export const getVaults = () => api.get<VaultsResult>("/me/custody/vaults");
+
+/** Re-point a vault at a different custody provider. */
+export const setVaultProvider = (vault: string, provider: ProviderKind | string) =>
+  api.put<{ ok?: boolean; vault?: string; provider?: string; [k: string]: unknown }>(
+    `/me/custody/vaults/${encodeURIComponent(vault)}/provider`,
+    { provider },
+  );
+
+// ─── Provider-routed withdrawal approval ─────────────────────────
+
+export type ApprovalStatus =
+  | "pending_approval"
+  | "approved"
+  | "signed"
+  | "broadcast"
+  | "rejected";
+
+export interface ApprovalRecord {
+  approver: string;
+  at: number | string;
+}
+
+export interface WithdrawalApprovalResult {
+  status: ApprovalStatus | string;
+  quorum: number;
+  approvals: ApprovalRecord[];
+}
+
+/** Poll the approval state of a provider-backed withdrawal. */
+export const getWithdrawalApproval = (id: string) =>
+  api.get<WithdrawalApprovalResult>(
+    `/me/custody/withdrawals/${encodeURIComponent(id)}/approval`,
+  );

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -180,6 +180,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Content Revenue", i18nKey: "nav.contentRevenue", path: "/analytics/content-revenue", icon: <BarChart3 className="h-5 w-5" /> },
       { label: "Payouts", i18nKey: "nav.payouts", path: "/payouts", icon: <Wallet className="h-5 w-5" /> },
       { label: "Custody", i18nKey: "nav.custody", path: "/custody", icon: <Coins className="h-5 w-5" /> },
+      { label: "Custody Providers", i18nKey: "nav.custodyProviders", path: "/custody/providers", icon: <Building2 className="h-5 w-5" /> },
       { label: "Creator Tokens", i18nKey: "nav.creatorTokens", path: "/tokens", icon: <Landmark className="h-5 w-5" /> },
       { label: "Referrals", i18nKey: "nav.referrals", path: "/referrals", icon: <Share2 className="h-5 w-5" /> },
       { label: "Promo Codes", i18nKey: "nav.promoCodes", path: "/promo", icon: <Tag className="h-5 w-5" /> },

--- a/frontend/src/lib/custodyProviders.test.ts
+++ b/frontend/src/lib/custodyProviders.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  providerStatusBadge,
+  providerKindDisplay,
+  providerAttestationLabel,
+  approvalStepper,
+  approvalStatusLabel,
+  APPROVAL_STEP_ORDER,
+} from "@/lib/custodyProviders";
+
+describe("providerStatusBadge", () => {
+  it("maps each known status to a label + severity", () => {
+    expect(providerStatusBadge("healthy")).toEqual({ label: "Healthy", severity: "success" });
+    expect(providerStatusBadge("degraded")).toEqual({ label: "Degraded", severity: "warning" });
+    expect(providerStatusBadge("down")).toEqual({ label: "Down", severity: "danger" });
+    expect(providerStatusBadge("not_connected")).toEqual({
+      label: "Not connected",
+      severity: "neutral",
+    });
+  });
+
+  it("degrades unknown / nullish statuses to neutral Unknown", () => {
+    expect(providerStatusBadge("weird")).toEqual({ label: "Unknown", severity: "neutral" });
+    expect(providerStatusBadge(undefined)).toEqual({ label: "Unknown", severity: "neutral" });
+    expect(providerStatusBadge(null)).toEqual({ label: "Unknown", severity: "neutral" });
+  });
+});
+
+describe("providerKindDisplay", () => {
+  it("maps internal (non-external)", () => {
+    expect(providerKindDisplay("internal")).toEqual({
+      label: "Internal gateway",
+      iconKey: "internal",
+      external: false,
+    });
+  });
+
+  it("maps external custodians", () => {
+    expect(providerKindDisplay("fireblocks")).toEqual({
+      label: "Fireblocks",
+      iconKey: "fireblocks",
+      external: true,
+    });
+    expect(providerKindDisplay("bitgo")).toEqual({
+      label: "BitGo",
+      iconKey: "bitgo",
+      external: true,
+    });
+  });
+
+  it("degrades unknown kinds to an external label with the raw name", () => {
+    expect(providerKindDisplay("copper")).toEqual({
+      label: "copper",
+      iconKey: "external",
+      external: true,
+    });
+    expect(providerKindDisplay(undefined)).toEqual({
+      label: "Unknown",
+      iconKey: "external",
+      external: true,
+    });
+  });
+});
+
+describe("providerAttestationLabel", () => {
+  it("self-custodied for internal", () => {
+    expect(providerAttestationLabel("internal")).toBe("Self-custodied (internal gateway)");
+  });
+  it("names the external custodian", () => {
+    expect(providerAttestationLabel("fireblocks")).toBe("Custodied by Fireblocks");
+    expect(providerAttestationLabel("bitgo")).toBe("Custodied by BitGo");
+  });
+  it("degrades unknown to Custodied by <raw>", () => {
+    expect(providerAttestationLabel("copper")).toBe("Custodied by copper");
+  });
+});
+
+describe("approvalStepper", () => {
+  it("exposes the ordered ladder", () => {
+    expect(APPROVAL_STEP_ORDER).toEqual([
+      "pending_approval",
+      "approved",
+      "signed",
+      "broadcast",
+    ]);
+  });
+
+  it("pending_approval → first step current, rest upcoming", () => {
+    const m = approvalStepper("pending_approval");
+    expect(m.rejected).toBe(false);
+    expect(m.complete).toBe(false);
+    expect(m.currentIndex).toBe(0);
+    expect(m.steps.map((s) => s.state)).toEqual([
+      "current",
+      "upcoming",
+      "upcoming",
+      "upcoming",
+    ]);
+  });
+
+  it("approved → prior done, current on approved", () => {
+    const m = approvalStepper("approved");
+    expect(m.currentIndex).toBe(1);
+    expect(m.steps.map((s) => s.state)).toEqual([
+      "done",
+      "current",
+      "upcoming",
+      "upcoming",
+    ]);
+  });
+
+  it("signed → two done, current on signed", () => {
+    const m = approvalStepper("signed");
+    expect(m.steps.map((s) => s.state)).toEqual([
+      "done",
+      "done",
+      "current",
+      "upcoming",
+    ]);
+  });
+
+  it("broadcast → all done + complete", () => {
+    const m = approvalStepper("broadcast");
+    expect(m.complete).toBe(true);
+    expect(m.rejected).toBe(false);
+    expect(m.steps.map((s) => s.state)).toEqual(["done", "done", "done", "done"]);
+  });
+
+  it("rejected → terminal off-ladder", () => {
+    const m = approvalStepper("rejected");
+    expect(m.rejected).toBe(true);
+    expect(m.complete).toBe(false);
+    expect(m.currentIndex).toBe(-1);
+    expect(m.steps[0]?.state).toBe("rejected");
+    expect(m.steps.slice(1).every((s) => s.state === "upcoming")).toBe(true);
+  });
+
+  it("unknown status degrades to first-step current", () => {
+    const m = approvalStepper("mystery");
+    expect(m.rejected).toBe(false);
+    expect(m.currentIndex).toBe(-1);
+    expect(m.steps[0]?.state).toBe("current");
+  });
+
+  it("labels every step", () => {
+    const m = approvalStepper("pending_approval");
+    expect(m.steps.map((s) => s.label)).toEqual([
+      "Pending approval",
+      "Approved",
+      "Signed",
+      "Broadcast",
+    ]);
+  });
+});
+
+describe("approvalStatusLabel", () => {
+  it("labels each status incl. rejected", () => {
+    expect(approvalStatusLabel("pending_approval")).toBe("Pending approval");
+    expect(approvalStatusLabel("approved")).toBe("Approved");
+    expect(approvalStatusLabel("signed")).toBe("Signed");
+    expect(approvalStatusLabel("broadcast")).toBe("Broadcast");
+    expect(approvalStatusLabel("rejected")).toBe("Rejected");
+    expect(approvalStatusLabel("nope")).toBe("Unknown");
+  });
+});

--- a/frontend/src/lib/custodyProviders.ts
+++ b/frontend/src/lib/custodyProviders.ts
@@ -1,0 +1,172 @@
+// Pure, framework-free helpers for the external custody-provider surface.
+// No React / no network — safe to unit-test in isolation (vitest).
+//
+// Covers: provider status → badge label + severity; withdrawal approval
+// status → an ordered stepper model; provider kind → display label + icon
+// key; and a human "who custodies" attestation label.
+
+export type ProviderKind = "internal" | "fireblocks" | "bitgo";
+export type ProviderStatus = "healthy" | "degraded" | "down" | "not_connected";
+export type ApprovalStatus =
+  | "pending_approval"
+  | "approved"
+  | "signed"
+  | "broadcast"
+  | "rejected";
+
+export type BadgeSeverity = "success" | "warning" | "danger" | "neutral";
+
+export interface StatusBadge {
+  label: string;
+  severity: BadgeSeverity;
+}
+
+/** Map a provider status → a display badge (label + severity). */
+export function providerStatusBadge(
+  status: ProviderStatus | string | null | undefined,
+): StatusBadge {
+  switch (status) {
+    case "healthy":
+      return { label: "Healthy", severity: "success" };
+    case "degraded":
+      return { label: "Degraded", severity: "warning" };
+    case "down":
+      return { label: "Down", severity: "danger" };
+    case "not_connected":
+      return { label: "Not connected", severity: "neutral" };
+    default:
+      return { label: "Unknown", severity: "neutral" };
+  }
+}
+
+export interface ProviderDisplay {
+  /** Human provider name. */
+  label: string;
+  /** A stable icon key the UI maps to a concrete icon (no icon dep here). */
+  iconKey: "internal" | "fireblocks" | "bitgo" | "external";
+  /** True when the vault is custodied by a third-party qualified custodian. */
+  external: boolean;
+}
+
+/** Map a provider kind → display label + icon key. */
+export function providerKindDisplay(
+  kind: ProviderKind | string | null | undefined,
+): ProviderDisplay {
+  switch (kind) {
+    case "internal":
+      return { label: "Internal gateway", iconKey: "internal", external: false };
+    case "fireblocks":
+      return { label: "Fireblocks", iconKey: "fireblocks", external: true };
+    case "bitgo":
+      return { label: "BitGo", iconKey: "bitgo", external: true };
+    default:
+      return {
+        label: kind ? String(kind) : "Unknown",
+        iconKey: "external",
+        external: true,
+      };
+  }
+}
+
+/**
+ * A human "who custodies your assets" attestation label, e.g.
+ *   "Custodied by Fireblocks" / "Self-custodied (internal gateway)".
+ */
+export function providerAttestationLabel(
+  kind: ProviderKind | string | null | undefined,
+): string {
+  const d = providerKindDisplay(kind);
+  if (!d.external) return "Self-custodied (internal gateway)";
+  return `Custodied by ${d.label}`;
+}
+
+// ─── Withdrawal approval stepper ─────────────────────────────────
+// The happy path is an ORDERED progression:
+//   pending_approval → approved → signed → broadcast
+// "rejected" is a terminal off-path state (not a step in the ladder).
+
+export const APPROVAL_STEP_ORDER: readonly ApprovalStatus[] = [
+  "pending_approval",
+  "approved",
+  "signed",
+  "broadcast",
+] as const;
+
+const APPROVAL_STEP_LABELS: Record<
+  Exclude<ApprovalStatus, "rejected">,
+  string
+> = {
+  pending_approval: "Pending approval",
+  approved: "Approved",
+  signed: "Signed",
+  broadcast: "Broadcast",
+};
+
+export type StepState = "done" | "current" | "upcoming" | "rejected";
+
+export interface ApprovalStep {
+  key: ApprovalStatus;
+  label: string;
+  state: StepState;
+}
+
+export interface ApprovalStepperModel {
+  steps: ApprovalStep[];
+  /** True when the withdrawal was rejected (terminal, off the ladder). */
+  rejected: boolean;
+  /** True when broadcast (fully complete). */
+  complete: boolean;
+  /** Index of the current step in APPROVAL_STEP_ORDER (-1 if rejected/unknown). */
+  currentIndex: number;
+}
+
+/**
+ * Build an ordered stepper model from a withdrawal-approval status.
+ * Unknown statuses degrade to "everything upcoming" (index 0 pending).
+ */
+export function approvalStepper(
+  status: ApprovalStatus | string | null | undefined,
+): ApprovalStepperModel {
+  const rejected = status === "rejected";
+  const idx = APPROVAL_STEP_ORDER.indexOf(status as ApprovalStatus);
+  const currentIndex = rejected ? -1 : idx;
+
+  const steps: ApprovalStep[] = APPROVAL_STEP_ORDER.map((key, i) => {
+    let state: StepState;
+    if (rejected) {
+      // On rejection, the first step is marked rejected, the rest upcoming.
+      state = i === 0 ? "rejected" : "upcoming";
+    } else if (currentIndex < 0) {
+      // Unknown status → nothing reached yet.
+      state = i === 0 ? "current" : "upcoming";
+    } else if (i < currentIndex) {
+      state = "done";
+    } else if (i === currentIndex) {
+      // The final step "broadcast" is a completion, render it as done.
+      state = key === "broadcast" ? "done" : "current";
+    } else {
+      state = "upcoming";
+    }
+    return {
+      key,
+      label: APPROVAL_STEP_LABELS[key as Exclude<ApprovalStatus, "rejected">],
+      state,
+    };
+  });
+
+  return {
+    steps,
+    rejected,
+    complete: !rejected && status === "broadcast",
+    currentIndex,
+  };
+}
+
+/** A short human label for an approval status (incl. rejected). */
+export function approvalStatusLabel(
+  status: ApprovalStatus | string | null | undefined,
+): string {
+  if (status === "rejected") return "Rejected";
+  const key = status as Exclude<ApprovalStatus, "rejected">;
+  return APPROVAL_STEP_LABELS[key] ?? "Unknown";
+}

--- a/frontend/src/pages/custody/CustodyPage.tsx
+++ b/frontend/src/pages/custody/CustodyPage.tsx
@@ -26,7 +26,9 @@ import {
   Info,
   History,
   Sprout,
+  Building2,
 } from "lucide-react";
+import { Link } from "react-router-dom";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import { cn } from "@/lib/utils";
@@ -973,6 +975,14 @@ export default function CustodyPage() {
           <p className="text-sm text-muted-foreground">
             Hold, receive and send crypto from your custodial vault.
           </p>
+        </div>
+        <div className="ml-auto">
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link to="/custody/providers">
+              <Building2 className="h-4 w-4" />
+              Custody providers
+            </Link>
+          </Button>
         </div>
       </div>
 

--- a/frontend/src/pages/custody/CustodyProvidersPage.tsx
+++ b/frontend/src/pages/custody/CustodyProvidersPage.tsx
@@ -1,0 +1,714 @@
+// External custody-provider surface — a provider-aware companion to the
+// internal /me/custody hub. Providers (Internal gateway / Fireblocks / BitGo)
+// can be connected/disconnected here (creds stay SERVER-SIDE — the UI only
+// initiates + shows status), each vault can be re-pointed at a provider, and
+// provider-backed withdrawals surface a live approval stepper.
+//
+// Every read degrades on 404 (retry:false) to an honest "provider integration
+// pending backend" state. The existing internal-custody behaviour is untouched.
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  ShieldCheck,
+  Building2,
+  Server,
+  KeyRound,
+  Link2,
+  Unlink,
+  RefreshCw,
+  Loader2,
+  CheckCircle2,
+  Clock,
+  XCircle,
+  AlertTriangle,
+  Info,
+  Layers,
+  Wallet,
+  Search,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { ApiError } from "@/api/client";
+import { cn } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import {
+  getProviders,
+  connectProvider,
+  disconnectProvider,
+  getProviderStatus,
+  getVaults,
+  setVaultProvider,
+  getWithdrawalApproval,
+  type CustodyProvider,
+  type ProviderKind,
+  type ProviderVault,
+} from "@/api/endpoints/custodyProviders";
+import {
+  providerStatusBadge,
+  providerKindDisplay,
+  providerAttestationLabel,
+  approvalStepper,
+  type BadgeSeverity,
+} from "@/lib/custodyProviders";
+
+// ─── shared helpers ─────────────────────────────────────────────
+
+function isUnavailable(err: unknown): boolean {
+  return err instanceof ApiError && (err.status === 404 || err.status === 501);
+}
+
+function severityToVariant(
+  sev: BadgeSeverity,
+): "success" | "warning" | "destructive" | "secondary" {
+  switch (sev) {
+    case "success":
+      return "success";
+    case "warning":
+      return "warning";
+    case "danger":
+      return "destructive";
+    default:
+      return "secondary";
+  }
+}
+
+const KIND_ICON: Record<string, JSX.Element> = {
+  internal: <Server className="h-5 w-5" />,
+  fireblocks: <Building2 className="h-5 w-5" />,
+  bitgo: <Building2 className="h-5 w-5" />,
+  external: <Building2 className="h-5 w-5" />,
+};
+
+function kindIcon(kind: ProviderKind | string): JSX.Element {
+  const key = providerKindDisplay(kind).iconKey;
+  return KIND_ICON[key] ?? <Building2 className="h-5 w-5" />;
+}
+
+function fmtTs(ts: number | string | null | undefined): string {
+  if (ts == null || ts === "") return "never";
+  const n = typeof ts === "number" ? ts : Number(ts);
+  const ms = Number.isFinite(n) ? (n > 1e12 ? n : n * 1000) : Date.parse(String(ts));
+  if (!Number.isFinite(ms)) return String(ts);
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return String(ts);
+  }
+}
+
+function ProviderPendingCard({ line }: { line: string }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-3 py-16 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Building2 className="h-6 w-6" />
+        </div>
+        <div className="space-y-1">
+          <p className="font-medium">Provider integration pending backend</p>
+          <p className="mx-auto max-w-md text-sm text-muted-foreground">{line}</p>
+        </div>
+        <Badge variant="outline" className="gap-1.5">
+          <Info className="h-3 w-3" /> Not available on this backend yet
+        </Badge>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Attestation badge ──────────────────────────────────────────
+
+function AttestationBadge({ kind }: { kind: ProviderKind | string }) {
+  const d = providerKindDisplay(kind);
+  return (
+    <Badge variant={d.external ? "default" : "secondary"} className="gap-1.5">
+      <ShieldCheck className="h-3 w-3" />
+      {providerAttestationLabel(kind)}
+    </Badge>
+  );
+}
+
+// ─── Provider status detail (per-card) ──────────────────────────
+
+function ProviderStatusDetail({ id, connected }: { id: string; connected: boolean }) {
+  const q = useQuery({
+    queryKey: ["custody", "provider-status", id],
+    queryFn: () => getProviderStatus(id),
+    retry: false,
+    enabled: connected,
+    staleTime: 15_000,
+  });
+
+  if (!connected) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Connect this provider to see attestation &amp; approvals.
+      </p>
+    );
+  }
+  if (q.isLoading) {
+    return <Skeleton className="h-12 w-full rounded-md" />;
+  }
+  if (q.isError) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Status unavailable on this backend yet.
+      </p>
+    );
+  }
+  const s = q.data;
+  if (!s) return null;
+  return (
+    <div className="grid grid-cols-3 gap-2 text-center text-xs">
+      <div className="rounded-md border bg-muted/30 p-2">
+        <div className="flex items-center justify-center gap-1 text-muted-foreground">
+          <ShieldCheck className="h-3 w-3" /> Attested
+        </div>
+        <div className="mt-0.5 font-medium">
+          {s.balances_attested ? "Yes" : "No"}
+        </div>
+      </div>
+      <div className="rounded-md border bg-muted/30 p-2">
+        <div className="flex items-center justify-center gap-1 text-muted-foreground">
+          <Clock className="h-3 w-3" /> Reconciled
+        </div>
+        <div className="mt-0.5 font-medium">{fmtTs(s.last_reconciled_ts)}</div>
+      </div>
+      <div className="rounded-md border bg-muted/30 p-2">
+        <div className="flex items-center justify-center gap-1 text-muted-foreground">
+          <KeyRound className="h-3 w-3" /> Approvals
+        </div>
+        <div className="mt-0.5 font-medium">{s.pending_approvals ?? 0}</div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Provider card ──────────────────────────────────────────────
+
+function ProviderCard({ provider }: { provider: CustodyProvider }) {
+  const qc = useQueryClient();
+  const [label, setLabel] = useState("");
+  const badge = providerStatusBadge(provider.status);
+  const disp = providerKindDisplay(provider.kind);
+
+  const connect = useMutation({
+    mutationFn: () => connectProvider(provider.id, label.trim() || undefined),
+    onSuccess: () => {
+      toast.success(`Connection to ${disp.label} initiated`);
+      setLabel("");
+      qc.invalidateQueries({ queryKey: ["custody", "providers"] });
+      qc.invalidateQueries({ queryKey: ["custody", "provider-status", provider.id] });
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError ? err.detail : `Could not connect ${disp.label}`,
+      );
+    },
+  });
+
+  const disconnect = useMutation({
+    mutationFn: () => disconnectProvider(provider.id),
+    onSuccess: () => {
+      toast.success(`${disp.label} disconnected`);
+      qc.invalidateQueries({ queryKey: ["custody", "providers"] });
+      qc.invalidateQueries({ queryKey: ["custody", "provider-status", provider.id] });
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError ? err.detail : `Could not disconnect ${disp.label}`,
+      );
+    },
+  });
+
+  const busy = connect.isPending || disconnect.isPending;
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              {kindIcon(provider.kind)}
+            </div>
+            <div>
+              <CardTitle className="text-base">{provider.name || disp.label}</CardTitle>
+              <p className="text-xs text-muted-foreground">
+                {disp.external ? "External qualified custodian" : "Internal gateway"}
+              </p>
+            </div>
+          </div>
+          <Badge variant={severityToVariant(badge.severity)}>{badge.label}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-3">
+        <AttestationBadge kind={provider.kind} />
+
+        {provider.features?.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {provider.features.map((f) => (
+              <Badge key={f} variant="outline" className="text-[10px]">
+                {f}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        <ProviderStatusDetail id={provider.id} connected={provider.connected} />
+
+        <div className="mt-auto space-y-2 pt-1">
+          {!provider.connected && disp.external && (
+            <div className="space-y-1.5">
+              <Label htmlFor={`label-${provider.id}`} className="text-xs">
+                Connection label (optional)
+              </Label>
+              <Input
+                id={`label-${provider.id}`}
+                placeholder="e.g. treasury-desk"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                maxLength={48}
+                disabled={busy}
+              />
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            {provider.connected ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+                disabled={busy || provider.kind === "internal"}
+                onClick={() => disconnect.mutate()}
+                title={
+                  provider.kind === "internal"
+                    ? "The internal gateway can't be disconnected"
+                    : undefined
+                }
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Unlink className="h-4 w-4" />
+                )}
+                Disconnect
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                className="gap-1.5"
+                disabled={busy}
+                onClick={() => connect.mutate()}
+              >
+                {connect.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Link2 className="h-4 w-4" />
+                )}
+                Connect
+              </Button>
+            )}
+            <span className="text-[11px] text-muted-foreground">
+              Provider API keys stay server-side.
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Providers grid ─────────────────────────────────────────────
+
+function ProvidersSection() {
+  const q = useQuery({
+    queryKey: ["custody", "providers"],
+    queryFn: getProviders,
+    retry: false,
+    staleTime: 15_000,
+  });
+
+  if (q.isLoading) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-64 w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+  if (q.isError && isUnavailable(q.error)) {
+    return (
+      <ProviderPendingCard line="External custody providers (Fireblocks, BitGo, …) aren't served by this backend yet. Once the provider integration is deployed, you'll connect a qualified custodian and manage attestation here. Your internal-gateway custody keeps working in the meantime." />
+    );
+  }
+  if (q.isError) {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 py-10 text-sm text-muted-foreground">
+          <AlertTriangle className="h-4 w-4" /> Could not load custody providers. Please try again.
+        </CardContent>
+      </Card>
+    );
+  }
+  const providers = q.data?.providers ?? [];
+  if (providers.length === 0) {
+    return (
+      <ProviderPendingCard line="No custody providers are configured for your account yet." />
+    );
+  }
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {providers.map((p) => (
+        <ProviderCard key={p.id} provider={p} />
+      ))}
+    </div>
+  );
+}
+
+// ─── Per-vault provider selector ────────────────────────────────
+
+const PROVIDER_OPTIONS: { value: ProviderKind; label: string }[] = [
+  { value: "internal", label: "Internal gateway" },
+  { value: "fireblocks", label: "Fireblocks" },
+  { value: "bitgo", label: "BitGo" },
+];
+
+function VaultRow({ vault }: { vault: ProviderVault }) {
+  const qc = useQueryClient();
+  const current = (vault.provider as ProviderKind) || "internal";
+
+  const mutate = useMutation({
+    mutationFn: (provider: ProviderKind) => setVaultProvider(vault.vault, provider),
+    onSuccess: (_data, provider) => {
+      toast.success(
+        `Vault re-pointed to ${providerKindDisplay(provider).label}`,
+      );
+      qc.invalidateQueries({ queryKey: ["custody", "vaults"] });
+    },
+    onError: (err) => {
+      toast.error(err instanceof ApiError ? err.detail : "Could not change provider");
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-3 md:flex-row md:items-center md:justify-between">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          {vault.label ? (
+            <Layers className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <Wallet className="h-4 w-4 text-primary" />
+          )}
+          <span className="text-sm font-medium">
+            {vault.label || "Base vault"}
+          </span>
+          <AttestationBadge kind={current} />
+        </div>
+        <span className="mt-0.5 block break-all font-mono text-xs text-muted-foreground">
+          {vault.vault}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <Select
+          value={current}
+          onValueChange={(v) => mutate.mutate(v as ProviderKind)}
+          disabled={mutate.isPending}
+        >
+          <SelectTrigger className="w-[190px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PROVIDER_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {mutate.isPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+      </div>
+    </div>
+  );
+}
+
+function VaultProvidersSection() {
+  const q = useQuery({
+    queryKey: ["custody", "vaults"],
+    queryFn: getVaults,
+    retry: false,
+    staleTime: 15_000,
+  });
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Layers className="h-5 w-5 text-primary" /> Vault custody provider
+          </CardTitle>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => q.refetch()}
+            disabled={q.isFetching}
+          >
+            <RefreshCw className={cn("h-4 w-4", q.isFetching && "animate-spin")} />
+            Refresh
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {q.isLoading && (
+          <div className="space-y-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        )}
+        {!q.isLoading && q.isError && isUnavailable(q.error) && (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Per-vault provider assignment isn't served by this backend yet — your
+            vaults remain on the internal gateway.
+          </p>
+        )}
+        {!q.isLoading && q.isError && !isUnavailable(q.error) && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <AlertTriangle className="h-4 w-4" /> Could not load vaults.
+          </div>
+        )}
+        {!q.isLoading && !q.isError && (q.data?.vaults?.length ?? 0) === 0 && (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No vaults yet.
+          </p>
+        )}
+        {!q.isLoading &&
+          !q.isError &&
+          (q.data?.vaults ?? []).map((v) => <VaultRow key={v.vault} vault={v} />)}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Provider-routed withdrawal approval stepper ────────────────
+
+function ApprovalStepperView({ withdrawalId }: { withdrawalId: string }) {
+  const q = useQuery({
+    queryKey: ["custody", "withdrawal-approval", withdrawalId],
+    queryFn: () => getWithdrawalApproval(withdrawalId),
+    retry: false,
+    enabled: withdrawalId.trim() !== "",
+    // Poll while the approval is in flight (stops once broadcast/rejected).
+    refetchInterval: (query) => {
+      const st = query.state.data?.status;
+      if (st === "broadcast" || st === "rejected") return false;
+      return 5_000;
+    },
+  });
+
+  if (withdrawalId.trim() === "") {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        Enter a provider-backed withdrawal id to track its approval.
+      </p>
+    );
+  }
+  if (q.isLoading) {
+    return <Skeleton className="h-24 w-full rounded-md" />;
+  }
+  if (q.isError && isUnavailable(q.error)) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        Withdrawal approval routing isn't served by this backend yet.
+      </p>
+    );
+  }
+  if (q.isError) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <AlertTriangle className="h-4 w-4" /> Could not load approval status.
+      </div>
+    );
+  }
+  const data = q.data;
+  if (!data) return null;
+  const model = approvalStepper(data.status);
+
+  return (
+    <div className="space-y-4">
+      <ol className="flex flex-col gap-0 sm:flex-row sm:items-start sm:justify-between">
+        {model.steps.map((step, i) => {
+          const isRejected = step.state === "rejected";
+          const done = step.state === "done";
+          const current = step.state === "current";
+          return (
+            <li
+              key={step.key}
+              className="flex flex-1 items-center gap-2 sm:flex-col sm:text-center"
+            >
+              <div
+                className={cn(
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border",
+                  done && "border-success bg-success text-success-foreground",
+                  current && "border-primary bg-primary/10 text-primary",
+                  isRejected && "border-destructive bg-destructive text-destructive-foreground",
+                  step.state === "upcoming" && "border-muted text-muted-foreground",
+                )}
+              >
+                {done ? (
+                  <CheckCircle2 className="h-4 w-4" />
+                ) : isRejected ? (
+                  <XCircle className="h-4 w-4" />
+                ) : current ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <span className="text-xs">{i + 1}</span>
+                )}
+              </div>
+              <span
+                className={cn(
+                  "text-xs",
+                  (done || current) && "font-medium text-foreground",
+                  isRejected && "font-medium text-destructive",
+                  step.state === "upcoming" && "text-muted-foreground",
+                )}
+              >
+                {step.label}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+
+      <Separator />
+
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        <span className="flex items-center gap-1.5">
+          <KeyRound className="h-4 w-4 text-muted-foreground" /> Quorum:{" "}
+          <span className="font-medium">
+            {data.approvals?.length ?? 0} / {data.quorum ?? 0}
+          </span>
+        </span>
+        {model.complete && (
+          <Badge variant="success" className="gap-1">
+            <CheckCircle2 className="h-3 w-3" /> Broadcast
+          </Badge>
+        )}
+        {model.rejected && (
+          <Badge variant="destructive" className="gap-1">
+            <XCircle className="h-3 w-3" /> Rejected
+          </Badge>
+        )}
+      </div>
+
+      {(data.approvals?.length ?? 0) > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-muted-foreground">Approvers</p>
+          <ul className="space-y-1">
+            {data.approvals.map((a, i) => (
+              <li
+                key={`${a.approver}-${i}`}
+                className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-1.5 text-xs"
+              >
+                <span className="font-medium">{a.approver}</span>
+                <span className="text-muted-foreground">{fmtTs(a.at)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WithdrawalApprovalSection() {
+  const [input, setInput] = useState("");
+  const [tracked, setTracked] = useState("");
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ShieldCheck className="h-5 w-5 text-primary" /> Withdrawal approval
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Track a provider-routed withdrawal through its approval quorum:
+          pending → approved → signed → broadcast.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form
+          className="flex items-end gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setTracked(input.trim());
+          }}
+        >
+          <div className="flex-1 space-y-1.5">
+            <Label htmlFor="withdrawal-id" className="text-xs">
+              Withdrawal id
+            </Label>
+            <Input
+              id="withdrawal-id"
+              placeholder="e.g. wd_01H…"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+            />
+          </div>
+          <Button type="submit" className="gap-1.5" disabled={input.trim() === ""}>
+            <Search className="h-4 w-4" /> Track
+          </Button>
+        </form>
+        <ApprovalStepperView withdrawalId={tracked} />
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Page ───────────────────────────────────────────────────────
+
+export default function CustodyProvidersPage() {
+  const header = useMemo(
+    () => (
+      <div className="mb-4 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          <Building2 className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold tracking-tight md:text-2xl">
+            Custody providers
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Back your vaults with an external qualified custodian (Fireblocks,
+            BitGo) or the internal gateway. Keys stay server-side.
+          </p>
+        </div>
+      </div>
+    ),
+    [],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-6xl p-4 md:p-6">
+      {header}
+      <div className="space-y-6">
+        <ProvidersSection />
+        <VaultProvidersSection />
+        <WithdrawalApprovalSection />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## External custody providers (Fireblocks / BitGo) — frontend, degrade-on-404

Backs the custody layer with an external qualified custodian instead of only the internal gateway. A vault can be backed by `internal | fireblocks | bitgo`; provider API creds stay **server-side** (the UI only initiates a connection + shows status). Existing internal-custody behavior is unchanged (additive).

### API contract (none deployed yet; reads fold 404 → "provider integration pending backend", mutations error clearly)
`GET /me/custody/providers` · `POST /me/custody/providers/{id}/{connect,disconnect}` · `GET /me/custody/providers/{id}/status` · `GET /me/custody/vaults` · `PUT /me/custody/vaults/{vault}/provider` · `GET /me/custody/withdrawals/{id}/approval`.

### Web (`/custody/providers`, "Custody Providers" nav + custody-hub link)
`lib/custodyProviders.ts` (+17 vitest) — provider status→badge, kind→label, attestation label, withdrawal approval stepper (pending→approved→signed→broadcast +rejected); `CustodyProvidersPage` — provider cards (Internal/Fireblocks/BitGo) connect/disconnect + status/attestation + reconciled/pending-approvals, per-vault provider selector, withdrawal-approval stepper (quorum + approvers, 5s poll).

### Android (new `custody/providers` screen, registered in `MoreRoutes`)
`CustodyProviderFormat.kt` (+15 JVM tests) + `CustodyProvidersScreen`/`ViewModel`; custody `Dtos/Domain/Api/Repository` extended with the 6 endpoints (soft-degrade on 404); `MoreCatalog` + `MoreRoutes.REGISTERED` + `AuthenticatedGraph` + custody top-bar action.

No new deps. Gates: web tsc 0 · vite build · vitest 17/17; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (15/15, MoreCatalog 6/6).

### Backend (tracked in exchange_missing_features.md)
Per-custodian provider adapters, external address derivation, deposit webhook ingestion, policy-engine/MPC withdrawal signing, balance reconciliation, server-side provider creds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
