### PR TITLE
feat(strategies): user-created strategy/basket funds (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/strategies/StrategiesApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/strategies/StrategiesApi.kt
@@ -1,0 +1,59 @@
+package com.testlogon.android.data.strategies
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+/**
+ * Retrofit interface for the USER-CREATED STRATEGIES / BASKETS surface (`me/strategies/(all)`).
+ *
+ * Paths are relative (no leading slash) so they resolve against the shared Retrofit base URL; the
+ * core-network interceptor chain attaches the cookie session. All methods are `suspend` and return the
+ * typed DTO body; a non-2xx surfaces as `retrofit2.HttpException`.
+ *
+ * NONE of these endpoints exist on the backend yet. The [StrategiesRepository] degrades every GET to
+ * an empty-but-honest state on 404/absence and surfaces a clear error on every failed mutation (never
+ * a silent success), so this contract is a forward declaration wired for graceful "pending backend" UX.
+ */
+interface StrategiesApi {
+
+    @POST("me/strategies")
+    suspend fun create(@Body body: UpsertStrategyRequestDto): StrategyDto
+
+    /** Strategies AUTHORED by the caller. */
+    @GET("me/strategies")
+    suspend fun getMine(): StrategyListDto
+
+    @GET("me/strategies/{id}")
+    suspend fun getStrategy(@Path("id") id: String): StrategyDto
+
+    @PUT("me/strategies/{id}")
+    suspend fun update(@Path("id") id: String, @Body body: UpsertStrategyRequestDto): StrategyDto
+
+    @POST("me/strategies/{id}/publish")
+    suspend fun publish(@Path("id") id: String): StrategyDto
+
+    /** PUBLISHED strategies to browse (the marketplace). */
+    @GET("me/strategies/market")
+    suspend fun getMarket(): StrategyListDto
+
+    @GET("me/strategies/{id}/nav")
+    suspend fun getNav(@Path("id") id: String): StrategyNavDto
+
+    @GET("me/strategies/{id}/holdings")
+    suspend fun getHoldings(@Path("id") id: String): StrategyHoldingsDto
+
+    @POST("me/strategies/{id}/invest")
+    suspend fun invest(@Path("id") id: String, @Body body: InvestRequestDto): StrategyAckDto
+
+    @POST("me/strategies/{id}/redeem")
+    suspend fun redeem(@Path("id") id: String, @Body body: RedeemRequestDto): StrategyAckDto
+
+    @GET("me/strategies/{id}/position")
+    suspend fun getPosition(@Path("id") id: String): InvestorPositionDto
+
+    @GET("me/strategies/{id}/fees")
+    suspend fun getFees(@Path("id") id: String): StrategyFeesDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/strategies/StrategiesDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/strategies/StrategiesDataModule.kt
@@ -1,0 +1,37 @@
+package com.testlogon.android.data.strategies
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * Provides the [StrategiesApi] and binds [StrategiesRepository] to its impl for the USER-CREATED
+ * STRATEGIES / BASKETS surface. Mirrors the tokens/exchange data modules: the API is built off the
+ * shared Retrofit but pinned to HTTP/1.1 on its own pool (the cpp h2 edge refuses concurrent streams
+ * under polling load).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class StrategiesDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindStrategiesRepository(impl: StrategiesRepositoryImpl): StrategiesRepository
+
+    companion object {
+        private fun http1(baseClient: okhttp3.OkHttpClient): okhttp3.OkHttpClient =
+            baseClient.newBuilder()
+                .protocols(listOf(okhttp3.Protocol.HTTP_1_1))
+                .connectionPool(okhttp3.ConnectionPool())
+                .build()
+
+        @Provides
+        @Singleton
+        fun provideStrategiesApi(retrofit: Retrofit, baseClient: okhttp3.OkHttpClient): StrategiesApi =
+            retrofit.newBuilder().client(http1(baseClient)).build().create(StrategiesApi::class.java)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/strategies/StrategiesRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/strategies/StrategiesRepository.kt
@@ -1,0 +1,125 @@
+package com.testlogon.android.data.strategies
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer over [StrategiesApi] for the USER-CREATED STRATEGIES / BASKETS surface.
+ *
+ * The `me/strategies/(all)` endpoints do NOT exist on the backend yet, so every READ DEGRADES to an
+ * empty-but-honest value on 404/HTTP-error (the UI shows an honest "pending backend" / empty state),
+ * while a real transport failure ([ApiResult.NetworkError]) is surfaced so the UI can offer retry.
+ * Every MUTATION passes failures through as [ApiResult.Failure]/[ApiResult.NetworkError] so a 404
+ * (undeployed) surfaces as a clear error and never a silent success.
+ */
+interface StrategiesRepository {
+    /** Strategies authored by the caller (degrades to empty). */
+    suspend fun mine(): ApiResult<List<Strategy>>
+
+    /** Published strategies to browse — the marketplace (degrades to empty). */
+    suspend fun market(): ApiResult<List<Strategy>>
+
+    /** A single strategy by id (degrades to null when absent/undeployed). */
+    suspend fun strategy(id: String): ApiResult<Strategy?>
+
+    /** Current NAV read (degrades to null when none / undeployed). */
+    suspend fun nav(id: String): ApiResult<StrategyNav?>
+
+    /** Holdings breakdown (degrades to empty). */
+    suspend fun holdings(id: String): ApiResult<List<StrategyHolding>>
+
+    /** The caller's investor position (degrades to null when none / undeployed). */
+    suspend fun position(id: String): ApiResult<InvestorPosition?>
+
+    /** Creator-view fee schedule (degrades to a zeroed, empty read). */
+    suspend fun fees(id: String): ApiResult<StrategyFees>
+
+    // ---- Mutations (errors surface; never silent success) ----
+    suspend fun create(body: UpsertStrategyRequestDto): ApiResult<Strategy>
+    suspend fun update(id: String, body: UpsertStrategyRequestDto): ApiResult<Strategy>
+    suspend fun publish(id: String): ApiResult<Strategy>
+    suspend fun invest(id: String, amountCents: Long): ApiResult<StrategyAck>
+    suspend fun redeem(id: String, units: Long): ApiResult<StrategyAck>
+}
+
+@Singleton
+class StrategiesRepositoryImpl @Inject constructor(
+    private val api: StrategiesApi,
+    private val errorParser: ApiErrorParser,
+) : StrategiesRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun mine(): ApiResult<List<Strategy>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getMine().toDomain() }
+    }
+
+    override suspend fun market(): ApiResult<List<Strategy>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getMarket().toDomain() }
+    }
+
+    override suspend fun strategy(id: String): ApiResult<Strategy?> = withContext(io) {
+        degradeToEmpty(null) { api.getStrategy(id).toDomain() }
+    }
+
+    override suspend fun nav(id: String): ApiResult<StrategyNav?> = withContext(io) {
+        degradeToEmpty(null) { api.getNav(id).toDomain(id) }
+    }
+
+    override suspend fun holdings(id: String): ApiResult<List<StrategyHolding>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getHoldings(id).toDomain() }
+    }
+
+    override suspend fun position(id: String): ApiResult<InvestorPosition?> = withContext(io) {
+        degradeToEmpty(null) { api.getPosition(id).toDomain(id) }
+    }
+
+    override suspend fun fees(id: String): ApiResult<StrategyFees> = withContext(io) {
+        degradeToEmpty(StrategyFees(id, 0L, 0L, 0L, emptyList())) { api.getFees(id).toDomain(id) }
+    }
+
+    override suspend fun create(body: UpsertStrategyRequestDto): ApiResult<Strategy> =
+        withContext(io) { apiCall { api.create(body).toDomain() } }
+
+    override suspend fun update(id: String, body: UpsertStrategyRequestDto): ApiResult<Strategy> =
+        withContext(io) { apiCall { api.update(id, body).toDomain() } }
+
+    override suspend fun publish(id: String): ApiResult<Strategy> =
+        withContext(io) { apiCall { api.publish(id).toDomain() } }
+
+    override suspend fun invest(id: String, amountCents: Long): ApiResult<StrategyAck> =
+        withContext(io) { apiCall { api.invest(id, InvestRequestDto(amountCents)).toDomain() } }
+
+    override suspend fun redeem(id: String, units: Long): ApiResult<StrategyAck> =
+        withContext(io) { apiCall { api.redeem(id, RedeemRequestDto(units)).toDomain() } }
+
+    /**
+     * Read helper: run [block]; on an HTTP error (the endpoint doesn't exist yet -> 404) DEGRADE to
+     * [empty]; only a transport [ApiResult.NetworkError] is surfaced (so the UI can offer retry).
+     */
+    private suspend fun <T> degradeToEmpty(empty: T, block: suspend () -> T): ApiResult<T> =
+        when (val r = apiCall(block)) {
+            is ApiResult.Success -> r
+            is ApiResult.Failure -> ApiResult.Success(empty)
+            is ApiResult.NetworkError -> r
+        }
+
+    private suspend fun <T> apiCall(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/strategies/StrategyDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/strategies/StrategyDomain.kt
@@ -1,0 +1,117 @@
+package com.testlogon.android.data.strategies
+
+/**
+ * USER-CREATED STRATEGIES / BASKETS domain models — render-ready shapes the feature layer consumes.
+ *
+ * A creator defines a STRATEGY: a basket of legs following a simple rule set. Others paper-trade it,
+ * view its backtest, then invest real capital. It is a POOLED fund with NAV units (an ASSUMPTION
+ * labelled in-UI and flippable): investors subscribe/redeem at NAV and own units — not copy/replication.
+ * Amounts are integer CENTS; weights/fees are basis points (10_000 bps == 100%).
+ */
+enum class StrategyKind { BASKET, RULE, UNKNOWN }
+
+enum class StrategyStatus { DRAFT, PAPER, PUBLISHED, CLOSED, UNKNOWN }
+
+/** Rebalance cadence for the basket back to its target weights. */
+enum class RebalanceRule { NONE, DAILY, WEEKLY, MONTHLY, THRESHOLD, UNKNOWN }
+
+enum class RedemptionType { INSTANT, NOTICE, UNKNOWN }
+
+/** Redemption / profit-taking policy. Notice + lockup only meaningful for a NOTICE policy. */
+data class Redemption(
+    val type: RedemptionType,
+    val noticeDays: Int? = null,
+    val lockupDays: Int? = null,
+)
+
+/** One basket leg: a [symbolId] with a target [weightBps] (all legs sum to 10_000). */
+data class StrategyLeg(
+    val symbolId: Int,
+    val weightBps: Int,
+)
+
+data class Strategy(
+    val strategyId: String,
+    val creatorSub: String? = null,
+    val name: String,
+    val description: String = "",
+    val kind: StrategyKind = StrategyKind.BASKET,
+    val status: StrategyStatus = StrategyStatus.DRAFT,
+    val legs: List<StrategyLeg> = emptyList(),
+    val rebalance: RebalanceRule = RebalanceRule.NONE,
+    val thresholdBps: Int? = null,
+    val minInvestmentCents: Long = 0,
+    val maxAumCents: Long = 0,
+    val mgmtFeeBps: Int = 0,
+    val perfFeeBps: Int = 0,
+    val highWaterMark: Boolean = true,
+    val redemption: Redemption = Redemption(RedemptionType.INSTANT),
+    val createdTs: Long = 0,
+    /** Current NAV per unit in cents (present once the strategy has a running fund). */
+    val navPerUnit: Long? = null,
+    val aumCents: Long? = null,
+    val investorCount: Int? = null,
+    /** Cumulative return since inception, in basis points (may be negative). */
+    val inceptionReturnBps: Int? = null,
+) {
+    /** Remaining capacity = max AUM - current AUM (>= 0), or null when capacity/AUM is unknown. */
+    val capacityRemainingCents: Long?
+        get() = if (maxAumCents <= 0) null else (maxAumCents - (aumCents ?: 0L)).coerceAtLeast(0L)
+}
+
+/** Current NAV read for a strategy fund. */
+data class StrategyNav(
+    val strategyId: String,
+    val navPerUnit: Long,
+    val aumCents: Long,
+    val unitsOutstanding: Long,
+    val inceptionReturnBps: Int,
+)
+
+/** One holding row: target vs actual weight drift + current value. */
+data class StrategyHolding(
+    val symbolId: Int,
+    val targetWeightBps: Int,
+    val actualWeightBps: Int,
+    val valueCents: Long,
+)
+
+/**
+ * An investor's pooled position: [units] held at the current [navPerUnit], the cost basis
+ * [investedCents], the mark-to-market [currentValueCents] + [unrealizedPnlCents], fees paid, and the
+ * per-unit [highWaterMark] the performance fee is measured above.
+ */
+data class InvestorPosition(
+    val strategyId: String,
+    val units: Long,
+    val navPerUnit: Long,
+    val investedCents: Long,
+    val currentValueCents: Long,
+    val unrealizedPnlCents: Long,
+    val feesPaidCents: Long,
+    val highWaterMark: Long,
+)
+
+enum class FeeType { MANAGEMENT, PERFORMANCE, UNKNOWN }
+
+/** One fee accrual line (management on AUM or performance above the high-water mark). */
+data class FeeAccrual(
+    val ts: Long,
+    val type: FeeType,
+    val amountCents: Long,
+)
+
+/** Creator-view fee schedule: accrued management + performance fees and the running high-water mark. */
+data class StrategyFees(
+    val strategyId: String,
+    val mgmtFeesAccruedCents: Long,
+    val perfFeesAccruedCents: Long,
+    val highWaterMark: Long,
+    val accruals: List<FeeAccrual>,
+)
+
+/** A simple mutation acknowledgement — [accepted] is false when the server didn't confirm. */
+data class StrategyAck(
+    val accepted: Boolean,
+    val message: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/strategies/StrategyDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/strategies/StrategyDtos.kt
@@ -1,0 +1,154 @@
+package com.testlogon.android.data.strategies
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.network.json.LenientInt
+import com.testlogon.android.core.network.json.LenientLong
+
+/**
+ * Wire DTOs for the USER-CREATED STRATEGIES / BASKETS (investable funds) surface (`me/strategies/(all)`).
+ *
+ * NONE of these endpoints exist on the backend yet — the repository degrades every GET to an
+ * empty-but-honest state on 404/absence and surfaces a clear error on every failed mutation. All
+ * numeric fields are lenient (the edge may stringify ids / cents / bps) and every field is defaulted
+ * so a partial / drifted payload still parses. Amounts are integer CENTS; `Bps` are basis points.
+ *
+ * The model (mirrored EXACTLY from the web contract): a creator defines a STRATEGY = a basket of legs
+ * (target weights in bps summing to 10000) following a simple rebalance rule, with a dual fee
+ * (management fee on AUM + performance fee on profit above a high-water mark), a min investment, a
+ * max AUM (capacity) and a redemption policy. It is a POOLED fund with NAV units: investors
+ * subscribe/redeem at NAV and own units.
+ */
+@JsonClass(generateAdapter = true)
+data class StrategyLegDto(
+    @LenientInt @Json(name = "symbol_id") val symbolId: Int? = null,
+    @LenientInt @Json(name = "weight_bps") val weightBps: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class RedemptionDto(
+    @Json(name = "type") val type: String? = null,
+    @LenientInt @Json(name = "notice_days") val noticeDays: Int? = null,
+    @LenientInt @Json(name = "lockup_days") val lockupDays: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class StrategyDto(
+    @Json(name = "strategy_id") val strategyId: String? = null,
+    @Json(name = "creator_sub") val creatorSub: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "kind") val kind: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "legs") val legs: List<StrategyLegDto>? = null,
+    @Json(name = "rebalance") val rebalance: String? = null,
+    @LenientInt @Json(name = "threshold_bps") val thresholdBps: Int? = null,
+    @LenientLong @Json(name = "min_investment_cents") val minInvestmentCents: Long? = null,
+    @LenientLong @Json(name = "max_aum_cents") val maxAumCents: Long? = null,
+    @LenientInt @Json(name = "mgmt_fee_bps") val mgmtFeeBps: Int? = null,
+    @LenientInt @Json(name = "perf_fee_bps") val perfFeeBps: Int? = null,
+    @Json(name = "high_water_mark") val highWaterMark: Boolean? = null,
+    @Json(name = "redemption") val redemption: RedemptionDto? = null,
+    @LenientLong @Json(name = "created_ts") val createdTs: Long? = null,
+    @LenientLong @Json(name = "nav_per_unit") val navPerUnit: Long? = null,
+    @LenientLong @Json(name = "aum_cents") val aumCents: Long? = null,
+    @LenientInt @Json(name = "investor_count") val investorCount: Int? = null,
+    @LenientInt @Json(name = "inception_return_bps") val inceptionReturnBps: Int? = null,
+)
+
+/** `GET me/strategies` (mine) / `GET me/strategies/market` (browse published) -> {strategies:[Strategy]}. */
+@JsonClass(generateAdapter = true)
+data class StrategyListDto(
+    @Json(name = "strategies") val strategies: List<StrategyDto>? = null,
+)
+
+/** `POST me/strategies` / `PUT me/strategies/{id}` body. */
+@JsonClass(generateAdapter = true)
+data class UpsertStrategyRequestDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String,
+    @Json(name = "kind") val kind: String,
+    @Json(name = "legs") val legs: List<StrategyLegDto>,
+    @Json(name = "rebalance") val rebalance: String,
+    @Json(name = "threshold_bps") val thresholdBps: Int?,
+    @Json(name = "min_investment_cents") val minInvestmentCents: Long,
+    @Json(name = "max_aum_cents") val maxAumCents: Long,
+    @Json(name = "mgmt_fee_bps") val mgmtFeeBps: Int,
+    @Json(name = "perf_fee_bps") val perfFeeBps: Int,
+    @Json(name = "high_water_mark") val highWaterMark: Boolean,
+    @Json(name = "redemption") val redemption: RedemptionDto,
+)
+
+/** `GET me/strategies/{id}/nav` -> current NAV/unit + AUM + units outstanding. */
+@JsonClass(generateAdapter = true)
+data class StrategyNavDto(
+    @Json(name = "strategy_id") val strategyId: String? = null,
+    @LenientLong @Json(name = "nav_per_unit") val navPerUnit: Long? = null,
+    @LenientLong @Json(name = "aum_cents") val aumCents: Long? = null,
+    @LenientLong @Json(name = "units_outstanding") val unitsOutstanding: Long? = null,
+    @LenientInt @Json(name = "inception_return_bps") val inceptionReturnBps: Int? = null,
+)
+
+/** One holding row on `GET me/strategies/{id}/holdings`. */
+@JsonClass(generateAdapter = true)
+data class StrategyHoldingDto(
+    @LenientInt @Json(name = "symbol_id") val symbolId: Int? = null,
+    @LenientInt @Json(name = "target_weight_bps") val targetWeightBps: Int? = null,
+    @LenientInt @Json(name = "actual_weight_bps") val actualWeightBps: Int? = null,
+    @LenientLong @Json(name = "value_cents") val valueCents: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class StrategyHoldingsDto(
+    @Json(name = "strategy_id") val strategyId: String? = null,
+    @Json(name = "holdings") val holdings: List<StrategyHoldingDto>? = null,
+)
+
+/** `POST me/strategies/{id}/invest` body — amount in integer cents. */
+@JsonClass(generateAdapter = true)
+data class InvestRequestDto(
+    @Json(name = "amount_cents") val amountCents: Long,
+)
+
+/** `POST me/strategies/{id}/redeem` body — units to redeem. */
+@JsonClass(generateAdapter = true)
+data class RedeemRequestDto(
+    @Json(name = "units") val units: Long,
+)
+
+/** `GET me/strategies/{id}/position` -> the caller's investor position (defaults zeroed). */
+@JsonClass(generateAdapter = true)
+data class InvestorPositionDto(
+    @Json(name = "strategy_id") val strategyId: String? = null,
+    @LenientLong @Json(name = "units") val units: Long? = null,
+    @LenientLong @Json(name = "nav_per_unit") val navPerUnit: Long? = null,
+    @LenientLong @Json(name = "invested_cents") val investedCents: Long? = null,
+    @LenientLong @Json(name = "current_value_cents") val currentValueCents: Long? = null,
+    @LenientLong @Json(name = "unrealized_pnl_cents") val unrealizedPnlCents: Long? = null,
+    @LenientLong @Json(name = "fees_paid_cents") val feesPaidCents: Long? = null,
+    @LenientLong @Json(name = "high_water_mark") val highWaterMark: Long? = null,
+)
+
+/** One fee accrual row on `GET me/strategies/{id}/fees`. */
+@JsonClass(generateAdapter = true)
+data class FeeAccrualDto(
+    @LenientLong @Json(name = "ts") val ts: Long? = null,
+    @Json(name = "type") val type: String? = null,
+    @LenientLong @Json(name = "amount_cents") val amountCents: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class StrategyFeesDto(
+    @Json(name = "strategy_id") val strategyId: String? = null,
+    @LenientLong @Json(name = "mgmt_fees_accrued_cents") val mgmtFeesAccruedCents: Long? = null,
+    @LenientLong @Json(name = "perf_fees_accrued_cents") val perfFeesAccruedCents: Long? = null,
+    @LenientLong @Json(name = "high_water_mark") val highWaterMark: Long? = null,
+    @Json(name = "accruals") val accruals: List<FeeAccrualDto>? = null,
+)
+
+/** Generic mutation ack ({status:"ok"|"ack", ...}); parsed defensively. */
+@JsonClass(generateAdapter = true)
+data class StrategyAckDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "message") val message: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/strategies/StrategyMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/strategies/StrategyMappers.kt
@@ -1,0 +1,131 @@
+package com.testlogon.android.data.strategies
+
+/**
+ * DTO -> domain mappers for the USER-CREATED STRATEGIES / BASKETS surface. Every field is defensively
+ * defaulted (the endpoints don't exist yet + the edge may drift), so a partial payload maps to a
+ * sane, honest domain object rather than throwing.
+ */
+
+private fun String?.toStrategyKind(): StrategyKind = when (this?.trim()?.lowercase()) {
+    "basket" -> StrategyKind.BASKET
+    "rule" -> StrategyKind.RULE
+    else -> StrategyKind.UNKNOWN
+}
+
+private fun String?.toStrategyStatus(): StrategyStatus = when (this?.trim()?.lowercase()) {
+    "draft" -> StrategyStatus.DRAFT
+    "paper" -> StrategyStatus.PAPER
+    "published" -> StrategyStatus.PUBLISHED
+    "closed" -> StrategyStatus.CLOSED
+    else -> StrategyStatus.UNKNOWN
+}
+
+private fun String?.toRebalanceRule(): RebalanceRule = when (this?.trim()?.lowercase()) {
+    "none" -> RebalanceRule.NONE
+    "daily" -> RebalanceRule.DAILY
+    "weekly" -> RebalanceRule.WEEKLY
+    "monthly" -> RebalanceRule.MONTHLY
+    "threshold" -> RebalanceRule.THRESHOLD
+    else -> RebalanceRule.UNKNOWN
+}
+
+private fun String?.toRedemptionType(): RedemptionType = when (this?.trim()?.lowercase()) {
+    "instant" -> RedemptionType.INSTANT
+    "notice" -> RedemptionType.NOTICE
+    else -> RedemptionType.UNKNOWN
+}
+
+private fun String?.toFeeType(): FeeType = when (this?.trim()?.lowercase()) {
+    "management", "mgmt" -> FeeType.MANAGEMENT
+    "performance", "perf" -> FeeType.PERFORMANCE
+    else -> FeeType.UNKNOWN
+}
+
+fun StrategyLegDto.toDomain(): StrategyLeg = StrategyLeg(
+    symbolId = symbolId ?: 0,
+    weightBps = weightBps ?: 0,
+)
+
+fun RedemptionDto?.toDomain(): Redemption = Redemption(
+    type = this?.type.toRedemptionType(),
+    noticeDays = this?.noticeDays,
+    lockupDays = this?.lockupDays,
+)
+
+fun StrategyDto.toDomain(): Strategy = Strategy(
+    strategyId = strategyId.orEmpty(),
+    creatorSub = creatorSub,
+    name = name.orEmpty(),
+    description = description.orEmpty(),
+    kind = kind.toStrategyKind(),
+    status = status.toStrategyStatus(),
+    legs = legs.orEmpty().map { it.toDomain() }.filter { it.symbolId > 0 },
+    rebalance = rebalance.toRebalanceRule(),
+    thresholdBps = thresholdBps,
+    minInvestmentCents = minInvestmentCents ?: 0L,
+    maxAumCents = maxAumCents ?: 0L,
+    mgmtFeeBps = mgmtFeeBps ?: 0,
+    perfFeeBps = perfFeeBps ?: 0,
+    highWaterMark = highWaterMark ?: true,
+    redemption = redemption.toDomain(),
+    createdTs = createdTs ?: 0L,
+    navPerUnit = navPerUnit,
+    aumCents = aumCents,
+    investorCount = investorCount,
+    inceptionReturnBps = inceptionReturnBps,
+)
+
+fun StrategyListDto.toDomain(): List<Strategy> =
+    strategies.orEmpty().map { it.toDomain() }.filter { it.strategyId.isNotBlank() }
+
+fun StrategyNavDto.toDomain(fallbackId: String): StrategyNav = StrategyNav(
+    strategyId = strategyId ?: fallbackId,
+    navPerUnit = navPerUnit ?: 0L,
+    aumCents = aumCents ?: 0L,
+    unitsOutstanding = unitsOutstanding ?: 0L,
+    inceptionReturnBps = inceptionReturnBps ?: 0,
+)
+
+fun StrategyHoldingDto.toDomain(): StrategyHolding = StrategyHolding(
+    symbolId = symbolId ?: 0,
+    targetWeightBps = targetWeightBps ?: 0,
+    actualWeightBps = actualWeightBps ?: 0,
+    valueCents = valueCents ?: 0L,
+)
+
+fun StrategyHoldingsDto.toDomain(): List<StrategyHolding> =
+    holdings.orEmpty().map { it.toDomain() }.filter { it.symbolId > 0 }
+
+fun InvestorPositionDto.toDomain(fallbackId: String): InvestorPosition = InvestorPosition(
+    strategyId = strategyId ?: fallbackId,
+    units = units ?: 0L,
+    navPerUnit = navPerUnit ?: 0L,
+    investedCents = investedCents ?: 0L,
+    currentValueCents = currentValueCents ?: 0L,
+    unrealizedPnlCents = unrealizedPnlCents ?: 0L,
+    feesPaidCents = feesPaidCents ?: 0L,
+    highWaterMark = highWaterMark ?: 0L,
+)
+
+fun FeeAccrualDto.toDomain(): FeeAccrual = FeeAccrual(
+    ts = ts ?: 0L,
+    type = type.toFeeType(),
+    amountCents = amountCents ?: 0L,
+)
+
+fun StrategyFeesDto.toDomain(fallbackId: String): StrategyFees = StrategyFees(
+    strategyId = strategyId ?: fallbackId,
+    mgmtFeesAccruedCents = mgmtFeesAccruedCents ?: 0L,
+    perfFeesAccruedCents = perfFeesAccruedCents ?: 0L,
+    highWaterMark = highWaterMark ?: 0L,
+    accruals = accruals.orEmpty().map { it.toDomain() },
+)
+
+/** An ack is accepted when the server returns a positive status token. */
+fun StrategyAckDto.toDomain(): StrategyAck {
+    val accepted = when (status?.trim()?.lowercase()) {
+        "ok", "ack", "accepted", "success", "queued", "published" -> true
+        else -> false
+    }
+    return StrategyAck(accepted = accepted, message = message)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1612,6 +1612,17 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),
+        // USER-CREATED STRATEGIES / BASKETS (investable funds): define a basket following a simple rule
+        // set, paper-trade + backtest it, then invest real capital at NAV (pooled fund with NAV units).
+        // Dual fee (mgmt on AUM + perf above a high-water mark). All reads degrade-on-404 (backend pending).
+        MoreEntry(
+            id = "strategies",
+            labelRes = R.string.more_entry_strategies,
+            icon = Icons.Outlined.PieChart,
+            route = MoreRoutes.STRATEGIES,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
         // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: the rescuer opportunity board (BROWSE open
         // bailouts to inject rescue capital for a position-share). The distress overview + per-position
         // auction + auto-bailout setting are reached from here / the margin position surface. All reads

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyBuilderScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyBuilderScreen.kt
@@ -1,0 +1,359 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class, androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.strategies
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.strategies.RebalanceRule
+import com.testlogon.android.data.strategies.RedemptionType
+import com.testlogon.android.data.strategies.StrategyKind
+
+/**
+ * The STRATEGY BUILDER form. Define name/description/kind, a basket leg editor (add symbols + set
+ * weights with a live 100% check), the rebalance cadence, and the fund params (min investment, max
+ * AUM, management + performance fee with a high-water-mark toggle, redemption policy). "Save draft"
+ * persists a draft; "Publish" is gated behind a money-safety confirm and only enabled for a valid
+ * 100% basket.
+ */
+@Composable
+fun StrategyBuilderRoute(
+    onBack: () -> Unit,
+    onSaved: (strategyId: String) -> Unit,
+    viewModel: StrategyBuilderViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var showPublishConfirm by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.savedStrategyId) {
+        state.savedStrategyId?.let { id ->
+            viewModel.consumeSaved()
+            onSaved(id)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(if (state.editingId != null) "Edit strategy" else "Create strategy") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(
+                "Define a basket following a simple rule set. Others can paper-trade and backtest it, then invest at NAV.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = viewModel::onName,
+                label = { Text("Strategy name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().testTag("builder_name"),
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = state.description,
+                onValueChange = viewModel::onDescription,
+                label = { Text("Description") },
+                modifier = Modifier.fillMaxWidth().testTag("builder_desc"),
+            )
+            Spacer(Modifier.height(12.dp))
+
+            SectionLabel("Kind")
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                StrategyKind.entries.filter { it != StrategyKind.UNKNOWN }.forEach { k ->
+                    FilterChip(
+                        selected = state.kind == k,
+                        onClick = { viewModel.onKind(k) },
+                        label = { Text(k.label()) },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+            LegEditor(state = state, viewModel = viewModel)
+
+            Spacer(Modifier.height(16.dp))
+            SectionLabel("Rebalance cadence")
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                RebalanceRule.entries.filter { it != RebalanceRule.UNKNOWN }.forEach { r ->
+                    FilterChip(
+                        selected = state.rebalance == r,
+                        onClick = { viewModel.onRebalance(r) },
+                        label = { Text(r.label()) },
+                    )
+                }
+            }
+            if (state.rebalance == RebalanceRule.THRESHOLD) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = state.thresholdPctText,
+                    onValueChange = viewModel::onThreshold,
+                    label = { Text("Drift threshold %") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.fillMaxWidth().testTag("builder_threshold"),
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+            SectionLabel("Fund parameters")
+            OutlinedTextField(
+                value = state.minInvestmentText,
+                onValueChange = viewModel::onMinInvestment,
+                label = { Text("Min investment ($)") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth().testTag("builder_min"),
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = state.maxAumText,
+                onValueChange = viewModel::onMaxAum,
+                label = { Text("Max total AUM / capacity ($)") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth().testTag("builder_maxaum"),
+            )
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = state.mgmtFeePctText,
+                    onValueChange = viewModel::onMgmtFee,
+                    label = { Text("Mgmt fee % (AUM/yr)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f).testTag("builder_mgmtfee"),
+                )
+                OutlinedTextField(
+                    value = state.perfFeePctText,
+                    onValueChange = viewModel::onPerfFee,
+                    label = { Text("Perf fee % (profit)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f).testTag("builder_perffee"),
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("High-water mark", style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        "Performance fee only on new profit above the prior peak NAV.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(checked = state.highWaterMark, onCheckedChange = viewModel::onHighWaterMark, modifier = Modifier.testTag("builder_hwm"))
+            }
+
+            Spacer(Modifier.height(16.dp))
+            SectionLabel("Redemption / profit-taking policy")
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                RedemptionType.entries.filter { it != RedemptionType.UNKNOWN }.forEach { t ->
+                    FilterChip(
+                        selected = state.redemptionType == t,
+                        onClick = { viewModel.onRedemptionType(t) },
+                        label = { Text(t.label()) },
+                    )
+                }
+            }
+            if (state.redemptionType == RedemptionType.NOTICE) {
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    OutlinedTextField(
+                        value = state.noticeDaysText,
+                        onValueChange = viewModel::onNoticeDays,
+                        label = { Text("Notice days") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.weight(1f),
+                    )
+                    OutlinedTextField(
+                        value = state.lockupDaysText,
+                        onValueChange = viewModel::onLockupDays,
+                        label = { Text("Lockup days") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            state.errorMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("builder_error"))
+            }
+
+            Spacer(Modifier.height(20.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(
+                    onClick = { viewModel.save(thenPublish = false) },
+                    enabled = state.canSave,
+                    modifier = Modifier.weight(1f).testTag("builder_save_draft"),
+                ) { Text("Save draft") }
+                Button(
+                    onClick = { showPublishConfirm = true },
+                    enabled = state.canSave,
+                    modifier = Modifier.weight(1f).testTag("builder_publish"),
+                ) {
+                    if (state.submitting) CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
+                    else Text("Publish")
+                }
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+
+    if (showPublishConfirm) {
+        AlertDialog(
+            onDismissRequest = { showPublishConfirm = false },
+            title = { Text("Confirm publish") },
+            text = {
+                Column {
+                    StrategyKeyValueRow("Action", "Publish investable strategy")
+                    StrategyKeyValueRow("Name", state.name)
+                    StrategyKeyValueRow("Legs", "${state.legs.size}")
+                    StrategyKeyValueRow("Min investment", "$" + state.minInvestmentText.ifBlank { "0" })
+                    StrategyKeyValueRow("Max AUM", "$" + state.maxAumText.ifBlank { "0" })
+                    StrategyKeyValueRow("Mgmt fee", state.mgmtFeePctText + "% / yr")
+                    StrategyKeyValueRow("Perf fee", state.perfFeePctText + "%", emphasize = true)
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "Publishing makes this a live, investable POOLED fund. Others can subscribe real capital at NAV. You are responsible for its management.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showPublishConfirm = false
+                        viewModel.save(thenPublish = true)
+                    },
+                    modifier = Modifier.testTag("builder_publish_confirm"),
+                ) { Text("Publish now") }
+            },
+            dismissButton = { TextButton(onClick = { showPublishConfirm = false }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun LegEditor(state: StrategyBuilderUiState, viewModel: StrategyBuilderViewModel) {
+    SectionLabel("Basket legs")
+    val chosen = state.legs.map { it.symbolId }.toSet()
+    val addable = state.availableSymbols.filter { it.symbolId !in chosen }
+    if (addable.isNotEmpty()) {
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            addable.forEach { inst ->
+                AssistChip(
+                    onClick = { viewModel.addLeg(inst.symbolId) },
+                    label = { Text("+ ${inst.symbol}") },
+                    modifier = Modifier.testTag("builder_addleg_${inst.symbolId}"),
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+    }
+    if (state.legs.isEmpty()) {
+        Text(
+            "Add at least one symbol and set target weights that total 100%.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    } else {
+        state.legs.forEach { leg ->
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                Text(symbolName(leg.symbolId), style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium, modifier = Modifier.width(96.dp))
+                OutlinedTextField(
+                    value = leg.weightPctText,
+                    onValueChange = { viewModel.onLegWeight(leg.symbolId, it) },
+                    label = { Text("Weight %") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f).testTag("builder_legweight_${leg.symbolId}"),
+                )
+                IconButton(onClick = { viewModel.removeLeg(leg.symbolId) }) {
+                    Icon(Icons.Filled.Close, contentDescription = "Remove leg")
+                }
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        val total = state.totalWeightBps
+        val valid = state.weightsValid
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text(
+                "Total weight: ${StrategyMath.formatBps(total)}" + if (valid) " ✓" else " (must be 100%)",
+                color = if (valid) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f).testTag("builder_weight_total"),
+            )
+            TextButton(onClick = { viewModel.equalizeWeights() }) { Text("Equalize") }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(text, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(bottom = 6.dp))
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyBuilderViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyBuilderViewModel.kt
@@ -1,0 +1,264 @@
+package com.testlogon.android.feature.strategies
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.strategies.RebalanceRule
+import com.testlogon.android.data.strategies.Redemption
+import com.testlogon.android.data.strategies.RedemptionDto
+import com.testlogon.android.data.strategies.RedemptionType
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.strategies.StrategyKind
+import com.testlogon.android.data.strategies.StrategyLeg
+import com.testlogon.android.data.strategies.StrategyLegDto
+import com.testlogon.android.data.strategies.UpsertStrategyRequestDto
+import com.testlogon.android.navigation.StrategyBuilderDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** One editable leg row in the builder: a chosen symbol + a weight-percent text field. */
+data class LegDraft(
+    val symbolId: Int,
+    val weightPctText: String = "",
+) {
+    /** Weight in bps parsed from the percent field (e.g. "40" -> 4000). Null when invalid. */
+    val weightBps: Int?
+        get() {
+            val pct = weightPctText.trim().toDoubleOrNull() ?: return null
+            if (pct < 0.0 || pct > 100.0) return null
+            return (pct * 100.0).toInt()
+        }
+}
+
+data class StrategyBuilderUiState(
+    val editingId: String? = null,
+    val loading: Boolean = false,
+    val name: String = "",
+    val description: String = "",
+    val kind: StrategyKind = StrategyKind.BASKET,
+    val availableSymbols: List<Instrument> = emptyList(),
+    val legs: List<LegDraft> = emptyList(),
+    val rebalance: RebalanceRule = RebalanceRule.NONE,
+    val thresholdPctText: String = "5",
+    val minInvestmentText: String = "100",
+    val maxAumText: String = "1000000",
+    val mgmtFeePctText: String = "2",
+    val perfFeePctText: String = "20",
+    val highWaterMark: Boolean = true,
+    val redemptionType: RedemptionType = RedemptionType.INSTANT,
+    val noticeDaysText: String = "7",
+    val lockupDaysText: String = "0",
+    val submitting: Boolean = false,
+    val errorMessage: String? = null,
+    val savedStrategyId: String? = null,
+    val didPublish: Boolean = false,
+) {
+    val legModels: List<StrategyLeg>
+        get() = legs.mapNotNull { d -> d.weightBps?.let { StrategyLeg(d.symbolId, it) } }
+
+    val totalWeightBps: Int get() = StrategyMath.totalWeightBps(legModels)
+
+    val weightsValid: Boolean get() = StrategyMath.weightsValid(legModels) && legModels.size == legs.size
+
+    val minInvestmentCents: Long? get() = dollarsToCents(minInvestmentText)
+    val maxAumCents: Long? get() = dollarsToCents(maxAumText)
+    val mgmtFeeBps: Int? get() = pctToBps(mgmtFeePctText)
+    val perfFeeBps: Int? get() = pctToBps(perfFeePctText)
+    val thresholdBps: Int? get() = if (rebalance == RebalanceRule.THRESHOLD) pctToBps(thresholdPctText) else null
+
+    val canSave: Boolean
+        get() = name.isNotBlank() &&
+            weightsValid &&
+            minInvestmentCents != null &&
+            maxAumCents != null &&
+            mgmtFeeBps != null &&
+            perfFeeBps != null &&
+            (rebalance != RebalanceRule.THRESHOLD || thresholdBps != null) &&
+            !submitting
+}
+
+private fun dollarsToCents(text: String): Long? {
+    val v = text.trim().toDoubleOrNull() ?: return null
+    if (v < 0.0) return null
+    return Math.round(v * 100.0)
+}
+
+private fun pctToBps(text: String): Int? {
+    val v = text.trim().toDoubleOrNull() ?: return null
+    if (v < 0.0 || v > 100.0) return null
+    return (v * 100.0).toInt()
+}
+
+/**
+ * Drives the STRATEGY BUILDER: name/description/kind, the basket leg editor (symbol picker + weight,
+ * with live 100% validation), rebalance cadence, and the fund params (min investment, max AUM, dual
+ * fee + HWM toggle, redemption policy). Save persists a DRAFT; publishing is gated behind a
+ * money-safety confirm and only offered once weights are a valid 100% basket. Loads the instrument
+ * catalogue from [ExchangeRepository] for the leg picker (degrades to the known symbols on 404).
+ *
+ * When opened with a strategy id it loads that strategy for EDITING (creator-owned drafts).
+ */
+@HiltViewModel
+class StrategyBuilderViewModel @Inject constructor(
+    private val repository: StrategiesRepository,
+    private val exchange: ExchangeRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val editId: String? = savedStateHandle.get<String>(StrategyBuilderDest.ARG_STRATEGY_ID)
+        ?.takeIf { it.isNotBlank() && it != StrategyBuilderDest.NEW }
+
+    private val _uiState = MutableStateFlow(StrategyBuilderUiState(editingId = editId, loading = true))
+    val uiState: StateFlow<StrategyBuilderUiState> = _uiState.asStateFlow()
+
+    init { bootstrap() }
+
+    private fun bootstrap() {
+        viewModelScope.launch {
+            val symbols = (exchange.symbols() as? ApiResult.Success)?.data.orEmpty()
+            _uiState.update { it.copy(availableSymbols = symbols, loading = editId != null) }
+            if (editId != null) loadForEdit(editId, symbols)
+        }
+    }
+
+    private suspend fun loadForEdit(id: String, symbols: List<Instrument>) {
+        when (val r = repository.strategy(id)) {
+            is ApiResult.Success -> {
+                val s = r.data
+                if (s == null) {
+                    _uiState.update { it.copy(loading = false, errorMessage = "That strategy isn't available (backend pending).") }
+                    return
+                }
+                _uiState.update {
+                    it.copy(
+                        loading = false,
+                        name = s.name,
+                        description = s.description,
+                        kind = s.kind.takeIf { k -> k != StrategyKind.UNKNOWN } ?: StrategyKind.BASKET,
+                        legs = s.legs.map { leg -> LegDraft(leg.symbolId, (leg.weightBps / 100.0).toString().trimEnd('0').trimEnd('.')) },
+                        rebalance = s.rebalance.takeIf { rb -> rb != RebalanceRule.UNKNOWN } ?: RebalanceRule.NONE,
+                        thresholdPctText = s.thresholdBps?.let { b -> (b / 100.0).toString() } ?: it.thresholdPctText,
+                        minInvestmentText = (s.minInvestmentCents / 100.0).toString(),
+                        maxAumText = (s.maxAumCents / 100.0).toString(),
+                        mgmtFeePctText = (s.mgmtFeeBps / 100.0).toString(),
+                        perfFeePctText = (s.perfFeeBps / 100.0).toString(),
+                        highWaterMark = s.highWaterMark,
+                        redemptionType = s.redemption.type.takeIf { t -> t != RedemptionType.UNKNOWN } ?: RedemptionType.INSTANT,
+                        noticeDaysText = s.redemption.noticeDays?.toString() ?: it.noticeDaysText,
+                        lockupDaysText = s.redemption.lockupDays?.toString() ?: it.lockupDaysText,
+                    )
+                }
+            }
+            is ApiResult.Failure -> _uiState.update { it.copy(loading = false, errorMessage = r.error.message) }
+            is ApiResult.NetworkError -> _uiState.update { it.copy(loading = false, errorMessage = "No connection.") }
+        }
+    }
+
+    // ---- field events ----
+    fun onName(v: String) = _uiState.update { it.copy(name = v, errorMessage = null) }
+    fun onDescription(v: String) = _uiState.update { it.copy(description = v, errorMessage = null) }
+    fun onKind(k: StrategyKind) = _uiState.update { it.copy(kind = k, errorMessage = null) }
+    fun onRebalance(r: RebalanceRule) = _uiState.update { it.copy(rebalance = r, errorMessage = null) }
+    fun onThreshold(v: String) = _uiState.update { it.copy(thresholdPctText = v.numeric(), errorMessage = null) }
+    fun onMinInvestment(v: String) = _uiState.update { it.copy(minInvestmentText = v.numeric(), errorMessage = null) }
+    fun onMaxAum(v: String) = _uiState.update { it.copy(maxAumText = v.numeric(), errorMessage = null) }
+    fun onMgmtFee(v: String) = _uiState.update { it.copy(mgmtFeePctText = v.numeric(), errorMessage = null) }
+    fun onPerfFee(v: String) = _uiState.update { it.copy(perfFeePctText = v.numeric(), errorMessage = null) }
+    fun onHighWaterMark(v: Boolean) = _uiState.update { it.copy(highWaterMark = v) }
+    fun onRedemptionType(t: RedemptionType) = _uiState.update { it.copy(redemptionType = t) }
+    fun onNoticeDays(v: String) = _uiState.update { it.copy(noticeDaysText = v.filter { c -> c.isDigit() }) }
+    fun onLockupDays(v: String) = _uiState.update { it.copy(lockupDaysText = v.filter { c -> c.isDigit() }) }
+
+    fun addLeg(symbolId: Int) = _uiState.update {
+        if (it.legs.any { l -> l.symbolId == symbolId }) it
+        else it.copy(legs = it.legs + LegDraft(symbolId), errorMessage = null)
+    }
+
+    fun removeLeg(symbolId: Int) = _uiState.update {
+        it.copy(legs = it.legs.filterNot { l -> l.symbolId == symbolId }, errorMessage = null)
+    }
+
+    fun onLegWeight(symbolId: Int, v: String) = _uiState.update { st ->
+        st.copy(legs = st.legs.map { if (it.symbolId == symbolId) it.copy(weightPctText = v.numeric()) else it }, errorMessage = null)
+    }
+
+    /** Evenly split 100% across the current legs (helper for the builder). */
+    fun equalizeWeights() = _uiState.update { st ->
+        val n = st.legs.size
+        if (n == 0) return@update st
+        val each = 10_000 / n
+        val remainder = 10_000 - each * n
+        st.copy(
+            legs = st.legs.mapIndexed { i, l ->
+                val bps = each + if (i == 0) remainder else 0
+                l.copy(weightPctText = (bps / 100.0).toString().trimEnd('0').trimEnd('.'))
+            },
+            errorMessage = null,
+        )
+    }
+
+    fun consumeSaved() = _uiState.update { it.copy(savedStrategyId = null, didPublish = false) }
+
+    /** Save (create or update) the DRAFT. On success, optionally publish (money-safety confirmed). */
+    fun save(thenPublish: Boolean) {
+        val s = _uiState.value
+        if (!s.canSave) {
+            _uiState.update { it.copy(errorMessage = "Fix the fields: weights must total 100% and every value must be valid.") }
+            return
+        }
+        val body = UpsertStrategyRequestDto(
+            name = s.name.trim(),
+            description = s.description.trim(),
+            kind = when (s.kind) { StrategyKind.RULE -> "rule"; else -> "basket" },
+            legs = s.legModels.map { StrategyLegDto(it.symbolId, it.weightBps) },
+            rebalance = s.rebalance.name.lowercase(),
+            thresholdBps = s.thresholdBps,
+            minInvestmentCents = s.minInvestmentCents ?: 0L,
+            maxAumCents = s.maxAumCents ?: 0L,
+            mgmtFeeBps = s.mgmtFeeBps ?: 0,
+            perfFeeBps = s.perfFeeBps ?: 0,
+            highWaterMark = s.highWaterMark,
+            redemption = RedemptionDto(
+                type = s.redemptionType.name.lowercase(),
+                noticeDays = if (s.redemptionType == RedemptionType.NOTICE) s.noticeDaysText.toIntOrNull() else null,
+                lockupDays = s.lockupDaysText.toIntOrNull(),
+            ),
+        )
+        _uiState.update { it.copy(submitting = true, errorMessage = null) }
+        viewModelScope.launch {
+            val saveResult = if (s.editingId != null) repository.update(s.editingId, body) else repository.create(body)
+            when (saveResult) {
+                is ApiResult.Success -> {
+                    val id = saveResult.data.strategyId.ifBlank { s.editingId.orEmpty() }
+                    if (thenPublish && id.isNotBlank()) {
+                        when (val pub = repository.publish(id)) {
+                            is ApiResult.Success -> _uiState.update { it.copy(submitting = false, savedStrategyId = id, didPublish = true) }
+                            is ApiResult.Failure -> _uiState.update { it.copy(submitting = false, errorMessage = publishError(pub.error.message)) }
+                            is ApiResult.NetworkError -> _uiState.update { it.copy(submitting = false, errorMessage = "No connection. Publish did not go through.") }
+                        }
+                    } else {
+                        _uiState.update { it.copy(submitting = false, savedStrategyId = id.ifBlank { null }, didPublish = false) }
+                    }
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(submitting = false, errorMessage = saveError(saveResult.error.message)) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(submitting = false, errorMessage = "No connection. Your strategy was not saved.") }
+            }
+        }
+    }
+
+    private fun saveError(msg: String): String =
+        msg.ifBlank { "Saving isn't available yet (backend pending). Your strategy was not saved." }
+
+    private fun publishError(msg: String): String =
+        msg.ifBlank { "Publishing isn't available yet (backend pending). The draft was saved but not published." }
+
+    private fun String.numeric(): String = filter { it.isDigit() || it == '.' }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailScreen.kt
@@ -1,0 +1,359 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.strategies
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.strategies.Strategy
+
+/**
+ * STRATEGY DETAIL + invest/redeem. Shows the NAV, holdings, dual-fee schedule + the pooled-NAV
+ * assumption note, the caller's investor position, and (for the creator) the accrued-fee view. Invest
+ * validates min-size + capacity and is gated behind a money-safety confirm; Redeem respects the
+ * position held and the strategy's redemption policy. Every read degrades to an honest empty/pending
+ * state on 404.
+ */
+@Composable
+fun StrategyDetailRoute(
+    onBack: () -> Unit,
+    onEdit: (strategyId: String) -> Unit,
+    onPaperRun: (strategyId: String) -> Unit,
+    viewModel: StrategyDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbar = remember { SnackbarHostState() }
+    var showInvest by remember { mutableStateOf(false) }
+    var showRedeem by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.actionMessage) {
+        state.actionMessage?.let {
+            snackbar.showSnackbar(it)
+            viewModel.consumeActionMessage()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Strategy") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbar) },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (state.phase) {
+                StrategyDetailUiState.Phase.Loading -> LoadingState(message = "Loading strategy")
+                StrategyDetailUiState.Phase.Error -> ErrorState(
+                    message = state.errorMessage ?: "Something went wrong.",
+                    onRetry = viewModel::onRetry,
+                )
+                StrategyDetailUiState.Phase.Content ->
+                    if (state.strategy == null) {
+                        EmptyState(
+                            title = "Strategy unavailable",
+                            body = "This strategy isn't available yet (the backend is pending). Check back once strategies are live.",
+                        )
+                    } else {
+                        DetailContent(
+                            state = state,
+                            onInvest = { showInvest = true },
+                            onRedeem = { showRedeem = true },
+                            onEdit = { onEdit(state.strategyId) },
+                            onPaperRun = { onPaperRun(state.strategyId) },
+                        )
+                    }
+            }
+        }
+    }
+
+    val s = state.strategy
+    if (showInvest && s != null) {
+        InvestDialog(state = state, strategy = s, onDismiss = { showInvest = false }, onConfirm = { cents ->
+            showInvest = false
+            viewModel.confirmInvest(cents)
+        }, viewModel = viewModel)
+    }
+    if (showRedeem && s != null) {
+        RedeemDialog(state = state, strategy = s, onDismiss = { showRedeem = false }, onConfirm = { units ->
+            showRedeem = false
+            viewModel.confirmRedeem(units)
+        })
+    }
+}
+
+@Composable
+private fun DetailContent(
+    state: StrategyDetailUiState,
+    onInvest: () -> Unit,
+    onRedeem: () -> Unit,
+    onEdit: () -> Unit,
+    onPaperRun: () -> Unit,
+) {
+    val s = state.strategy ?: return
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+    ) {
+        Row {
+            Text(s.name.ifBlank { "(unnamed)" }, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+            StrategyStatusPill(s.status.label())
+        }
+        if (s.description.isNotBlank()) {
+            Spacer(Modifier.height(4.dp))
+            Text(s.description, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+
+        Spacer(Modifier.height(16.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text("Fund", style = MaterialTheme.typography.labelLarge)
+                Spacer(Modifier.height(6.dp))
+                StrategyKeyValueRow("NAV / unit", StrategyMath.formatNav(state.navPerUnitCents), emphasize = true)
+                StrategyKeyValueRow("AUM", (state.nav?.aumCents ?: s.aumCents)?.let { StrategyMath.formatCents(it) } ?: "—")
+                StrategyKeyValueRow("Investors", (s.investorCount ?: 0).toString())
+                StrategyKeyValueRow("Inception return", (state.nav?.inceptionReturnBps ?: s.inceptionReturnBps)?.let { StrategyMath.formatBps(it) } ?: "—")
+                StrategyKeyValueRow("Capacity remaining", s.capacityRemainingCents?.let { StrategyMath.formatCents(it) } ?: "Uncapped")
+                StrategyKeyValueRow("Kind / rebalance", "${s.kind.label()} · ${s.rebalance.label()}")
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text("Basket", style = MaterialTheme.typography.labelLarge)
+                Spacer(Modifier.height(6.dp))
+                if (state.holdings.isNotEmpty()) {
+                    state.holdings.forEach { h ->
+                        StrategyKeyValueRow(
+                            symbolName(h.symbolId),
+                            "target ${StrategyMath.formatBps(h.targetWeightBps)} · actual ${StrategyMath.formatBps(h.actualWeightBps)}",
+                        )
+                    }
+                } else if (s.legs.isNotEmpty()) {
+                    s.legs.forEach { leg ->
+                        StrategyKeyValueRow(symbolName(leg.symbolId), StrategyMath.formatBps(leg.weightBps))
+                    }
+                } else {
+                    Text("No legs defined.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text("Fees & policy", style = MaterialTheme.typography.labelLarge)
+                Spacer(Modifier.height(6.dp))
+                StrategyKeyValueRow("Management fee", "${StrategyMath.formatBps(s.mgmtFeeBps)} / yr on AUM")
+                StrategyKeyValueRow("Performance fee", "${StrategyMath.formatBps(s.perfFeeBps)} on profit" + if (s.highWaterMark) " (high-water mark)" else "")
+                StrategyKeyValueRow("Min investment", StrategyMath.formatCents(s.minInvestmentCents))
+                StrategyKeyValueRow("Redemption", s.redemption.type.label() + (s.redemption.noticeDays?.let { " · $it-day notice" } ?: ""))
+            }
+        }
+
+        // Pooled-NAV assumption note (flippable label).
+        Spacer(Modifier.height(12.dp))
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            shape = MaterialTheme.shapes.small,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                "Assumption: this is a POOLED fund with NAV units — you subscribe/redeem at NAV and own units (not copy/replication).",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(10.dp),
+            )
+        }
+
+        // Investor position (only when the caller holds units).
+        state.position?.takeIf { it.units > 0 }?.let { pos ->
+            Spacer(Modifier.height(12.dp))
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(14.dp)) {
+                    Text("Your position", style = MaterialTheme.typography.labelLarge)
+                    Spacer(Modifier.height(6.dp))
+                    StrategyKeyValueRow("Units", String.format("%.4f", pos.units / 1_000_000.0))
+                    StrategyKeyValueRow("NAV / unit", StrategyMath.formatNav(pos.navPerUnit))
+                    StrategyKeyValueRow("Invested", StrategyMath.formatCents(pos.investedCents))
+                    StrategyKeyValueRow("Current value", StrategyMath.formatCents(pos.currentValueCents), emphasize = true)
+                    StrategyKeyValueRow("Unrealized P&L", StrategyMath.formatCents(pos.unrealizedPnlCents))
+                    StrategyKeyValueRow("Fees paid", StrategyMath.formatCents(pos.feesPaidCents))
+                }
+            }
+        }
+
+        // Creator-view fee accrual.
+        state.fees?.let { fees ->
+            Spacer(Modifier.height(12.dp))
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(14.dp)) {
+                    Text("Fee accrual (creator view)", style = MaterialTheme.typography.labelLarge)
+                    Spacer(Modifier.height(6.dp))
+                    StrategyKeyValueRow("Mgmt fees accrued", StrategyMath.formatCents(fees.mgmtFeesAccruedCents))
+                    StrategyKeyValueRow("Perf fees accrued", StrategyMath.formatCents(fees.perfFeesAccruedCents))
+                    StrategyKeyValueRow("High-water mark", StrategyMath.formatNav(fees.highWaterMark))
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = onInvest, enabled = !state.actionInFlight, modifier = Modifier.weight(1f).testTag("detail_invest")) { Text("Invest") }
+            OutlinedButton(
+                onClick = onRedeem,
+                enabled = !state.actionInFlight && (state.position?.units ?: 0L) > 0L,
+                modifier = Modifier.weight(1f).testTag("detail_redeem"),
+            ) { Text("Redeem") }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(onClick = onPaperRun, modifier = Modifier.weight(1f).testTag("detail_paperrun")) { Text("Paper-run / backtest") }
+            OutlinedButton(onClick = onEdit, modifier = Modifier.weight(1f).testTag("detail_edit")) { Text("Edit") }
+        }
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun InvestDialog(
+    state: StrategyDetailUiState,
+    strategy: Strategy,
+    onDismiss: () -> Unit,
+    onConfirm: (amountCents: Long) -> Unit,
+    viewModel: StrategyDetailViewModel,
+) {
+    var amountText by remember { mutableStateOf((strategy.minInvestmentCents / 100.0).let { if (it <= 0) "" else it.toString() }) }
+    val cents = amountText.trim().toDoubleOrNull()?.let { Math.round(it * 100.0) } ?: 0L
+    val validationError = if (cents > 0L) viewModel.investValidationError(cents) else "Enter an amount."
+    val units = if (cents > 0L) viewModel.estimatedUnits(cents) else 0.0
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Invest in ${strategy.name}") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = amountText,
+                    onValueChange = { amountText = it.filter { c -> c.isDigit() || c == '.' } },
+                    label = { Text("Amount ($)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.fillMaxWidth().testTag("invest_amount"),
+                )
+                Spacer(Modifier.height(8.dp))
+                StrategyKeyValueRow("NAV / unit", StrategyMath.formatNav(state.navPerUnitCents))
+                StrategyKeyValueRow("Est. units", String.format("%.4f", units))
+                StrategyKeyValueRow("Min investment", StrategyMath.formatCents(strategy.minInvestmentCents))
+                StrategyKeyValueRow("Capacity remaining", strategy.capacityRemainingCents?.let { StrategyMath.formatCents(it) } ?: "Uncapped")
+                if (validationError != null) {
+                    Spacer(Modifier.height(6.dp))
+                    Text(validationError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall, modifier = Modifier.testTag("invest_error"))
+                } else {
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "This charges your account ${StrategyMath.formatCents(cents)} now and issues units at NAV.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(cents) },
+                enabled = validationError == null,
+                modifier = Modifier.testTag("invest_confirm"),
+            ) { Text("Confirm & invest") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun RedeemDialog(
+    state: StrategyDetailUiState,
+    strategy: Strategy,
+    onDismiss: () -> Unit,
+    onConfirm: (units: Long) -> Unit,
+) {
+    val heldUnits = (state.position?.units ?: 0L) / 1_000_000.0
+    var unitsText by remember { mutableStateOf("") }
+    val units = unitsText.trim().toLongOrNull() ?: 0L
+    val proceeds = StrategyMath.proceedsForUnits(units * 1_000_000L, state.navPerUnitCents)
+    val valid = units > 0L && units <= heldUnits.toLong()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Redeem units") },
+        text = {
+            Column {
+                Text("You hold ${String.format("%.4f", heldUnits)} units.", style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = unitsText,
+                    onValueChange = { unitsText = it.filter { c -> c.isDigit() } },
+                    label = { Text("Units to redeem (whole)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth().testTag("redeem_units"),
+                )
+                Spacer(Modifier.height(8.dp))
+                StrategyKeyValueRow("Est. proceeds", StrategyMath.formatCents(proceeds), emphasize = true)
+                StrategyKeyValueRow("Redemption policy", strategy.redemption.type.label())
+                strategy.redemption.noticeDays?.let { StrategyKeyValueRow("Notice", "$it days") }
+                strategy.redemption.lockupDays?.takeIf { it > 0 }?.let { StrategyKeyValueRow("Lockup", "$it days") }
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onConfirm(units) }, enabled = valid, modifier = Modifier.testTag("redeem_confirm")) { Text("Redeem") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailViewModel.kt
@@ -1,0 +1,182 @@
+package com.testlogon.android.feature.strategies
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.strategies.InvestorPosition
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.strategies.Strategy
+import com.testlogon.android.data.strategies.StrategyFees
+import com.testlogon.android.data.strategies.StrategyHolding
+import com.testlogon.android.data.strategies.StrategyNav
+import com.testlogon.android.navigation.StrategyDetailDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class StrategyDetailUiState(
+    val strategyId: String,
+    val phase: Phase = Phase.Loading,
+    val strategy: Strategy? = null,
+    val nav: StrategyNav? = null,
+    val holdings: List<StrategyHolding> = emptyList(),
+    val position: InvestorPosition? = null,
+    val fees: StrategyFees? = null,
+    /** True when the caller authored this strategy (drives creator-view fee accrual + edit/publish). */
+    val isCreator: Boolean = false,
+    val errorMessage: String? = null,
+    val actionMessage: String? = null,
+    val actionInFlight: Boolean = false,
+) {
+    enum class Phase { Loading, Content, Error }
+
+    /** The NAV per unit to price a subscription/redemption at (cents); falls back to par. */
+    val navPerUnitCents: Long
+        get() = nav?.navPerUnit?.takeIf { it > 0 } ?: strategy?.navPerUnit?.takeIf { it > 0 } ?: StrategyMath.PAR_NAV_CENTS
+}
+
+/**
+ * Drives the STRATEGY DETAIL surface: NAV, holdings, fee schedule + the pooled-NAV assumption note,
+ * Invest (min-size + capacity validated + money-safety confirmed), the investor position, Redeem
+ * (respecting the policy), and the creator-view fee accrual + edit/publish affordances. Every read
+ * degrades to an honest empty/pending state on 404; every mutation surfaces a clear result message
+ * (never a silent success), then refreshes the affected reads.
+ */
+@HiltViewModel
+class StrategyDetailViewModel @Inject constructor(
+    private val repository: StrategiesRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val strategyId: String = savedStateHandle.get<String>(StrategyDetailDest.ARG_STRATEGY_ID).orEmpty()
+
+    private val _uiState = MutableStateFlow(StrategyDetailUiState(strategyId = strategyId))
+    val uiState: StateFlow<StrategyDetailUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    fun consumeActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+
+    private fun load() {
+        _uiState.update { it.copy(phase = StrategyDetailUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.strategy(strategyId)) {
+                is ApiResult.Success -> {
+                    val s = r.data
+                    if (s == null) {
+                        _uiState.update {
+                            it.copy(
+                                phase = StrategyDetailUiState.Phase.Content,
+                                strategy = null,
+                                errorMessage = null,
+                            )
+                        }
+                    } else {
+                        _uiState.update { it.copy(phase = StrategyDetailUiState.Phase.Content, strategy = s) }
+                    }
+                    refreshReads()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = StrategyDetailUiState.Phase.Error, errorMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(phase = StrategyDetailUiState.Phase.Error, errorMessage = "No connection. Check your network and retry.")
+                }
+            }
+        }
+    }
+
+    private suspend fun refreshReads() {
+        val nav = (repository.nav(strategyId) as? ApiResult.Success)?.data
+        val holdings = (repository.holdings(strategyId) as? ApiResult.Success)?.data.orEmpty()
+        val position = (repository.position(strategyId) as? ApiResult.Success)?.data
+        val fees = (repository.fees(strategyId) as? ApiResult.Success)?.data
+        _uiState.update {
+            it.copy(nav = nav, holdings = holdings, position = position, fees = fees)
+        }
+    }
+
+    /** Whether an [amountCents] subscription is valid against the min-size + remaining-capacity checks. */
+    fun investValidationError(amountCents: Long): String? {
+        val s = _uiState.value.strategy ?: return "Strategy unavailable."
+        if (!StrategyMath.meetsMinInvestment(amountCents, s.minInvestmentCents)) {
+            return "Below the minimum investment of ${StrategyMath.formatCents(s.minInvestmentCents)}."
+        }
+        val currentAum = _uiState.value.nav?.aumCents ?: s.aumCents ?: 0L
+        if (!StrategyMath.withinCapacity(amountCents, s.maxAumCents, currentAum)) {
+            val remaining = StrategyMath.capacityRemaining(s.maxAumCents, currentAum)
+            return "Exceeds remaining capacity" + (remaining?.let { " of ${StrategyMath.formatCents(it)}." } ?: ".")
+        }
+        return null
+    }
+
+    /** Estimated units issued for [amountCents] at the current NAV (for the confirm preview). */
+    fun estimatedUnits(amountCents: Long): Double =
+        StrategyMath.unitsForInvestment(amountCents, _uiState.value.navPerUnitCents) / 1_000_000.0
+
+    /** Called AFTER the invest money-safety confirm is accepted. */
+    fun confirmInvest(amountCents: Long) {
+        val err = investValidationError(amountCents)
+        if (err != null) {
+            _uiState.update { it.copy(actionMessage = err) }
+            return
+        }
+        _uiState.update { it.copy(actionInFlight = true) }
+        viewModelScope.launch {
+            when (val r = repository.invest(strategyId, amountCents)) {
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            actionInFlight = false,
+                            actionMessage = if (r.data.accepted) "Invested ${StrategyMath.formatCents(amountCents)}." else (r.data.message ?: "The server did not confirm the investment."),
+                        )
+                    }
+                    refreshReads()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(actionInFlight = false, actionMessage = r.error.message.ifBlank { "Investing isn't available yet (backend pending). Nothing was charged." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(actionInFlight = false, actionMessage = "No connection. Nothing was charged.")
+                }
+            }
+        }
+    }
+
+    /** Called AFTER the redeem confirm is accepted. [units] is whole units; converted to micro-units. */
+    fun confirmRedeem(units: Long) {
+        val microUnits = units * 1_000_000L
+        val held = _uiState.value.position?.units ?: 0L
+        if (microUnits <= 0L || microUnits > held) {
+            _uiState.update { it.copy(actionMessage = "You can't redeem more units than you hold.") }
+            return
+        }
+        _uiState.update { it.copy(actionInFlight = true) }
+        viewModelScope.launch {
+            when (val r = repository.redeem(strategyId, microUnits)) {
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            actionInFlight = false,
+                            actionMessage = if (r.data.accepted) "Redemption submitted." else (r.data.message ?: "The server did not confirm the redemption."),
+                        )
+                    }
+                    refreshReads()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(actionInFlight = false, actionMessage = r.error.message.ifBlank { "Redemption isn't available yet (backend pending)." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(actionInFlight = false, actionMessage = "No connection. Your redemption was not submitted.")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMarketScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMarketScreen.kt
@@ -1,0 +1,188 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.strategies
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.strategies.Strategy
+
+/**
+ * The USER-CREATED STRATEGY MARKETPLACE. Two tabs: the PUBLISHED marketplace (browse) and the caller's
+ * AUTHORED strategies. A row taps through to detail; a FAB opens the builder. Every read degrades to an
+ * honest empty state when the (not-yet-built) `me/strategies/(all)` backend 404s.
+ */
+@Composable
+fun StrategyMarketRoute(
+    onBack: () -> Unit,
+    onOpenStrategy: (strategyId: String) -> Unit,
+    onCreate: () -> Unit,
+    viewModel: StrategyMarketViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Strategies") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = onCreate,
+                icon = { Icon(Icons.Filled.Add, contentDescription = null) },
+                text = { Text("Create") },
+                modifier = Modifier.testTag("strategies_create_fab"),
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TabRow(selectedTabIndex = if (state.tab == StrategyListTab.MARKET) 0 else 1) {
+                Tab(
+                    selected = state.tab == StrategyListTab.MARKET,
+                    onClick = { viewModel.selectTab(StrategyListTab.MARKET) },
+                    text = { Text("Marketplace (${state.market.size})") },
+                    modifier = Modifier.testTag("strategies_tab_market"),
+                )
+                Tab(
+                    selected = state.tab == StrategyListTab.MINE,
+                    onClick = { viewModel.selectTab(StrategyListTab.MINE) },
+                    text = { Text("Mine (${state.mine.size})") },
+                    modifier = Modifier.testTag("strategies_tab_mine"),
+                )
+            }
+            Box(modifier = Modifier.fillMaxSize()) {
+                when (state.phase) {
+                    StrategyMarketUiState.Phase.Loading -> LoadingState(message = "Loading strategies")
+                    StrategyMarketUiState.Phase.Error -> ErrorState(
+                        message = state.errorMessage ?: "Something went wrong.",
+                        onRetry = viewModel::onRetry,
+                    )
+                    StrategyMarketUiState.Phase.Content ->
+                        if (state.rows.isEmpty()) {
+                            EmptyState(
+                                title = if (state.tab == StrategyListTab.MARKET) "No published strategies" else "No strategies yet",
+                                body = if (state.tab == StrategyListTab.MARKET) {
+                                    "No investable strategies are published yet. Check back once creators publish their baskets."
+                                } else {
+                                    "You haven't created a strategy yet. Tap Create to define a basket, backtest it, then publish."
+                                },
+                            )
+                        } else {
+                            StrategyList(rows = state.rows, isMarket = state.tab == StrategyListTab.MARKET, onOpen = onOpenStrategy)
+                        }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StrategyList(rows: List<Strategy>, isMarket: Boolean, onOpen: (String) -> Unit) {
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        items(rows, key = { it.strategyId }) { s ->
+            StrategyRow(s = s, isMarket = isMarket, onOpen = onOpen)
+        }
+    }
+}
+
+@Composable
+private fun StrategyRow(s: Strategy, isMarket: Boolean, onOpen: (String) -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onOpen(s.strategyId) }
+            .testTag("strategy_row_${s.strategyId}"),
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    s.name.ifBlank { "(unnamed)" },
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                StrategyStatusPill(s.status.label())
+            }
+            if (s.description.isNotBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    s.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Stat("NAV", s.navPerUnit?.let { StrategyMath.formatNav(it) } ?: "—")
+                Stat("AUM", s.aumCents?.let { StrategyMath.formatCents(it) } ?: "—")
+                Stat(
+                    "Return",
+                    s.inceptionReturnBps?.let { StrategyMath.formatBps(it) } ?: "—",
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Stat("Mgmt fee", StrategyMath.formatBps(s.mgmtFeeBps))
+                Stat("Perf fee", StrategyMath.formatBps(s.perfFeeBps))
+                Stat(
+                    "Capacity left",
+                    s.capacityRemainingCents?.let { StrategyMath.formatCents(it) } ?: "Uncapped",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Stat(label: String, value: String) {
+    Column {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Medium)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMarketViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMarketViewModel.kt
@@ -1,0 +1,76 @@
+package com.testlogon.android.feature.strategies
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.strategies.Strategy
+import com.testlogon.android.data.strategies.StrategiesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** Which slice of the strategy list is shown. */
+enum class StrategyListTab { MARKET, MINE }
+
+data class StrategyMarketUiState(
+    val phase: Phase = Phase.Loading,
+    val tab: StrategyListTab = StrategyListTab.MARKET,
+    val market: List<Strategy> = emptyList(),
+    val mine: List<Strategy> = emptyList(),
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+
+    val rows: List<Strategy> get() = if (tab == StrategyListTab.MARKET) market else mine
+}
+
+/**
+ * Drives the strategy MARKETPLACE + "My strategies" list. Loads both the PUBLISHED marketplace and the
+ * caller's AUTHORED strategies; both degrade to empty on 404 so the screen shows an honest "pending
+ * backend" empty state rather than an error when the endpoints are undeployed. A transport failure
+ * (offline) on either read surfaces as a retryable error.
+ */
+@HiltViewModel
+class StrategyMarketViewModel @Inject constructor(
+    private val repository: StrategiesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StrategyMarketUiState())
+    val uiState: StateFlow<StrategyMarketUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    fun selectTab(tab: StrategyListTab) = _uiState.update { it.copy(tab = tab) }
+
+    fun load() {
+        _uiState.update { it.copy(phase = StrategyMarketUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            val market = repository.market()
+            val mine = repository.mine()
+            val netError = (market as? ApiResult.NetworkError) ?: (mine as? ApiResult.NetworkError)
+            if (netError != null) {
+                _uiState.update {
+                    it.copy(
+                        phase = StrategyMarketUiState.Phase.Error,
+                        errorMessage = "No connection. Check your network and retry.",
+                    )
+                }
+                return@launch
+            }
+            _uiState.update {
+                it.copy(
+                    phase = StrategyMarketUiState.Phase.Content,
+                    market = (market as? ApiResult.Success)?.data.orEmpty(),
+                    mine = (mine as? ApiResult.Success)?.data.orEmpty(),
+                    errorMessage = null,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMath.kt
@@ -1,0 +1,201 @@
+package com.testlogon.android.feature.strategies
+
+import com.testlogon.android.data.strategies.StrategyLeg
+
+/**
+ * Pure, side-effect-free math for the USER-CREATED STRATEGIES / BASKETS surface. Extracted so the
+ * tricky bits (NAV unit issuance/redemption, dual-fee accrual with a high-water mark, weight
+ * validation, min-size + capacity checks, and the client-side basket backtest) are unit-testable off
+ * the Android runtime (see StrategyMathTest). All amounts are integer CENTS; `Bps` are basis points
+ * (10_000 bps == 100%). NAV per unit is carried in cents.
+ *
+ * The fund is a POOLED fund with NAV units — an ASSUMPTION surfaced in the UI (see the pooled-NAV note
+ * on the detail screen) so it can be flipped to copy/replication later without touching the rest of
+ * the surface.
+ */
+object StrategyMath {
+
+    /** Basis-points denominator: 10_000 bps == 100%. */
+    const val BPS_DENOM: Int = 10_000
+
+    /** The par NAV per unit at inception, in cents ($1.00 per unit). */
+    const val PAR_NAV_CENTS: Long = 100L
+
+    /** Approximate calendar days per year used to annualize the management-fee accrual. */
+    const val DAYS_PER_YEAR: Double = 365.0
+
+    // ---- Weight validation -------------------------------------------------
+
+    /** Sum of every leg weight in bps (may exceed / fall short of 10_000). */
+    fun totalWeightBps(legs: List<StrategyLeg>): Int = legs.sumOf { it.weightBps.coerceAtLeast(0) }
+
+    /**
+     * True when the basket is a valid target: at least one leg, no non-positive weight, and the
+     * weights sum to EXACTLY 10_000 bps (100%).
+     */
+    fun weightsValid(legs: List<StrategyLeg>): Boolean =
+        legs.isNotEmpty() &&
+            legs.all { it.weightBps > 0 && it.symbolId > 0 } &&
+            totalWeightBps(legs) == BPS_DENOM
+
+    // ---- NAV unit math -----------------------------------------------------
+
+    /**
+     * Units issued for an [amountCents] subscription at [navPerUnitCents]. Units are carried at
+     * 1e-6-unit granularity (micro-units) so small NAV moves don't round a subscription to zero:
+     * `floor(amount * 1_000_000 / nav)`. A non-positive NAV or amount yields 0.
+     */
+    fun unitsForInvestment(amountCents: Long, navPerUnitCents: Long): Long {
+        if (amountCents <= 0L || navPerUnitCents <= 0L) return 0L
+        return (amountCents * UNIT_SCALE) / navPerUnitCents
+    }
+
+    /**
+     * Cash proceeds (cents, floored) for redeeming [units] micro-units at [navPerUnitCents]:
+     * `floor(units * nav / 1_000_000)`. Non-positive inputs yield 0.
+     */
+    fun proceedsForUnits(units: Long, navPerUnitCents: Long): Long {
+        if (units <= 0L || navPerUnitCents <= 0L) return 0L
+        return (units * navPerUnitCents) / UNIT_SCALE
+    }
+
+    /**
+     * NAV per unit (cents) for a fund holding [aumCents] across [unitsOutstanding] micro-units:
+     * `aum * 1_000_000 / units`. Falls back to [PAR_NAV_CENTS] when there are no units outstanding
+     * (a fresh fund prices its first subscription at par).
+     */
+    fun navPerUnit(aumCents: Long, unitsOutstanding: Long): Long {
+        if (unitsOutstanding <= 0L) return PAR_NAV_CENTS
+        return (aumCents.coerceAtLeast(0L) * UNIT_SCALE) / unitsOutstanding
+    }
+
+    // ---- Fee accrual -------------------------------------------------------
+
+    /**
+     * Management fee accrued over [days] on an [aumCents] base at [mgmtFeeBps] ANNUAL:
+     * `aum * mgmtFeeBps/10_000 * days/365`, rounded half-up to the nearest cent. Never negative.
+     */
+    fun mgmtFeeAccrual(aumCents: Long, mgmtFeeBps: Int, days: Double): Long {
+        if (aumCents <= 0L || mgmtFeeBps <= 0 || days <= 0.0) return 0L
+        val annual = aumCents.toDouble() * mgmtFeeBps / BPS_DENOM
+        val accrued = annual * (days / DAYS_PER_YEAR)
+        return Math.round(accrued).coerceAtLeast(0L)
+    }
+
+    /**
+     * Performance fee on profit ABOVE a high-water mark. Charged only on the gain of the current NAV
+     * ([navPerUnitCents]) over the prior [highWaterMarkCents], applied to [units] micro-units:
+     * `perfFeeBps/10_000 * (nav - hwm) * units/1_000_000`. Zero when NAV is at/below the HWM (no fee
+     * on a recovery back to the mark) or when there is no profit. Rounded half-up; never negative.
+     */
+    fun perfFee(
+        navPerUnitCents: Long,
+        highWaterMarkCents: Long,
+        units: Long,
+        perfFeeBps: Int,
+    ): Long {
+        if (perfFeeBps <= 0 || units <= 0L) return 0L
+        val gainPerUnit = navPerUnitCents - highWaterMarkCents
+        if (gainPerUnit <= 0L) return 0L
+        val profitCents = gainPerUnit.toDouble() * units / UNIT_SCALE
+        val fee = profitCents * perfFeeBps / BPS_DENOM
+        return Math.round(fee).coerceAtLeast(0L)
+    }
+
+    /**
+     * The new high-water mark after observing [navPerUnitCents]: the mark only ratchets UP (a
+     * performance fee is never charged twice on the same peak). Equal to `max(prior, nav)`.
+     */
+    fun updatedHighWaterMark(priorHwmCents: Long, navPerUnitCents: Long): Long =
+        maxOf(priorHwmCents, navPerUnitCents)
+
+    // ---- Size + capacity checks -------------------------------------------
+
+    /** True when [amountCents] meets the [minInvestmentCents] floor (a 0/absent floor always passes). */
+    fun meetsMinInvestment(amountCents: Long, minInvestmentCents: Long): Boolean =
+        amountCents > 0L && amountCents >= minInvestmentCents.coerceAtLeast(0L)
+
+    /** Remaining capacity in cents = `max(0, maxAum - currentAum)`; a 0/absent max means uncapped (null). */
+    fun capacityRemaining(maxAumCents: Long, currentAumCents: Long): Long? {
+        if (maxAumCents <= 0L) return null
+        return (maxAumCents - currentAumCents.coerceAtLeast(0L)).coerceAtLeast(0L)
+    }
+
+    /**
+     * True when an [amountCents] subscription fits the remaining capacity. An uncapped fund
+     * (max AUM <= 0) always fits; otherwise the subscription must not push AUM past the cap.
+     */
+    fun withinCapacity(amountCents: Long, maxAumCents: Long, currentAumCents: Long): Boolean {
+        val remaining = capacityRemaining(maxAumCents, currentAumCents) ?: return true
+        return amountCents in 1L..remaining
+    }
+
+    // ---- Basket backtest ---------------------------------------------------
+
+    /**
+     * Client-side basket backtest: given per-leg close series (chronological, oldest-first) each with
+     * its target weight in bps, build the portfolio EQUITY CURVE (base 1.0) of a weight-target basket.
+     *
+     * Each leg is normalized to base 1.0 at its first observation; the portfolio value at each step is
+     * the weight-weighted sum of the legs' normalized levels (a periodically-rebalanced-to-target
+     * approximation). Series are truncated to their common leading length so a short leg never
+     * fabricates data. Returns a single-point [1.0] curve when there is nothing to compute.
+     *
+     * Weights are normalized by their own sum, so an off-100% draft still produces a sensible preview.
+     */
+    fun basketEquityCurve(legs: List<BacktestLeg>): List<Double> {
+        val usable = legs.filter { it.closes.size >= 2 && it.weightBps > 0 }
+        if (usable.isEmpty()) return listOf(1.0)
+        val n = usable.minOf { it.closes.size }
+        if (n < 2) return listOf(1.0)
+        val weightSum = usable.sumOf { it.weightBps.toDouble() }
+        if (weightSum <= 0.0) return listOf(1.0)
+
+        // Per-leg normalized level series (base 1.0 at its first common point).
+        val normalized = usable.map { leg ->
+            val base = leg.closes[0]
+            val w = leg.weightBps / weightSum
+            Pair(w, DoubleArray(n) { i -> if (base != 0.0) leg.closes[i] / base else 1.0 })
+        }
+
+        val curve = ArrayList<Double>(n)
+        for (i in 0 until n) {
+            var v = 0.0
+            for ((w, series) in normalized) v += w * series[i]
+            curve.add(v)
+        }
+        return curve
+    }
+
+    /** Total return fraction of an equity [curve] (last/first - 1). 0.0 for a degenerate curve. */
+    fun totalReturn(curve: List<Double>): Double {
+        if (curve.size < 2) return 0.0
+        val first = curve.first()
+        if (first == 0.0) return 0.0
+        return curve.last() / first - 1.0
+    }
+
+    // ---- Formatting --------------------------------------------------------
+
+    /** Human label for a basis-points value, e.g. 250 -> "2.50%", 10000 -> "100.00%". */
+    fun formatBps(bps: Int): String = String.format("%.2f%%", bps / 100.0)
+
+    /** Format integer cents as a dollar string, e.g. 10000 -> "$100.00", -50 -> "-$0.50". */
+    fun formatCents(cents: Long): String {
+        val sign = if (cents < 0) "-" else ""
+        val abs = kotlin.math.abs(cents)
+        return "$sign$" + String.format("%,d.%02d", abs / 100, abs % 100)
+    }
+
+    /** Format a NAV-per-unit (cents) at 4 decimals of a dollar, e.g. 100 -> "$1.0000". */
+    fun formatNav(navCents: Long): String = String.format("$%,.4f", navCents / 100.0)
+
+    /** Micro-unit scale: units are carried at 1e-6-unit granularity. */
+    private const val UNIT_SCALE: Long = 1_000_000L
+
+    /** One backtest leg: its target [weightBps] and its close series (oldest-first). */
+    data class BacktestLeg(
+        val weightBps: Int,
+        val closes: List<Double>,
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyPaperScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyPaperScreen.kt
@@ -1,0 +1,150 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.strategies
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+
+/**
+ * The PAPER-RUN + BACKTEST screen. Shows a client-side weighted-basket equity curve (built from the
+ * strategy's legs' historical closes) plus summary stats (return / annualized vol / max drawdown) and
+ * a $10,000 paper account marked along the same curve. When any leg's history was degraded from the
+ * recent-window candles read (md/history 404), a banner makes that honest.
+ */
+@Composable
+fun StrategyPaperRoute(
+    onBack: () -> Unit,
+    viewModel: StrategyPaperViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Paper-run & backtest") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (state.phase) {
+                StrategyPaperUiState.Phase.Loading -> LoadingState(message = "Running backtest")
+                StrategyPaperUiState.Phase.Error -> ErrorState(
+                    message = state.errorMessage ?: "Something went wrong.",
+                    onRetry = viewModel::onRetry,
+                )
+                StrategyPaperUiState.Phase.Empty -> EmptyState(
+                    title = "Nothing to backtest",
+                    body = "This strategy has no basket legs yet. Add legs in the builder to paper-trade and backtest it.",
+                )
+                StrategyPaperUiState.Phase.Content -> PaperContent(state)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PaperContent(state: StrategyPaperUiState) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        Text(
+            state.strategy?.name.orEmpty(),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            "Weighted-basket backtest over historical closes. The paper account follows the target weights.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (state.degraded) {
+            Spacer(Modifier.height(8.dp))
+            Surface(
+                color = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                shape = MaterialTheme.shapes.small,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    "Recent window only — long-range history is unavailable, so this backtest uses the recent candle window.",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(10.dp),
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text("Equity curve (base 1.0)", style = MaterialTheme.typography.labelLarge)
+                EquitySparkline(curve = state.equityCurve)
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text("Backtest stats", style = MaterialTheme.typography.labelLarge)
+                Spacer(Modifier.height(6.dp))
+                StrategyKeyValueRow("Total return", pct(state.totalReturnPct), emphasize = true)
+                StrategyKeyValueRow("Annualized volatility", pct(state.annualizedVolPct))
+                StrategyKeyValueRow("Max drawdown", state.maxDrawdownPct?.let { "-" + pct(it) } ?: "—")
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text("Paper account (following weights)", style = MaterialTheme.typography.labelLarge)
+                Spacer(Modifier.height(6.dp))
+                StrategyKeyValueRow("Starting notional", StrategyMath.formatCents(state.paperStartCents))
+                StrategyKeyValueRow(
+                    "Ending value",
+                    state.paperEndCents?.let { StrategyMath.formatCents(it) } ?: "—",
+                    emphasize = true,
+                )
+                val pnl = state.paperEndCents?.let { it - state.paperStartCents }
+                StrategyKeyValueRow("Paper P&L", pnl?.let { StrategyMath.formatCents(it) } ?: "—")
+            }
+        }
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+private fun pct(v: Double?): String = v?.let { String.format("%.2f%%", it) } ?: "—"

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyPaperViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyPaperViewModel.kt
@@ -1,0 +1,132 @@
+package com.testlogon.android.feature.strategies
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.strategies.Strategy
+import com.testlogon.android.data.strategies.StrategyLeg
+import com.testlogon.android.feature.analysis.MarketStats
+import com.testlogon.android.navigation.StrategyPaperDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** The interval label used for the client-side basket backtest history reads. */
+private const val BACKTEST_INTERVAL = "1d"
+
+/** The paper account's starting notional in cents ($10,000). */
+private const val PAPER_START_CENTS = 1_000_000L
+
+data class StrategyPaperUiState(
+    val strategyId: String,
+    val phase: Phase = Phase.Loading,
+    val strategy: Strategy? = null,
+    /** True when ANY leg's history was degraded from the recent-window candles read (md/history 404). */
+    val degraded: Boolean = false,
+    val equityCurve: List<Double> = emptyList(),
+    val totalReturnPct: Double? = null,
+    val annualizedVolPct: Double? = null,
+    val maxDrawdownPct: Double? = null,
+    /** The paper account NAV/value following the basket weights over the backtest window (cents). */
+    val paperStartCents: Long = PAPER_START_CENTS,
+    val paperEndCents: Long? = null,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error, Empty }
+}
+
+/**
+ * Drives the PAPER-RUN + BACKTEST screen for a strategy. Loads the strategy, then for each basket leg
+ * pulls historical closes (reusing [ExchangeRepository.getHistory], which degrades to the recent
+ * candles window on a 404 — surfaced via [StrategyPaperUiState.degraded]) and builds a client-side
+ * weighted-basket EQUITY CURVE via the pure [StrategyMath.basketEquityCurve]. Stats come from
+ * [MarketStats]. The "paper account" is a NAV-tracking simulation: it follows the basket weights and
+ * marks a $10,000 notional along the same equity curve (no separate order simulation needed — the
+ * basket IS the paper position).
+ */
+@HiltViewModel
+class StrategyPaperViewModel @Inject constructor(
+    private val repository: StrategiesRepository,
+    private val exchange: ExchangeRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val strategyId: String = savedStateHandle.get<String>(StrategyPaperDest.ARG_STRATEGY_ID).orEmpty()
+
+    private val _uiState = MutableStateFlow(StrategyPaperUiState(strategyId = strategyId))
+    val uiState: StateFlow<StrategyPaperUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update { it.copy(phase = StrategyPaperUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.strategy(strategyId)) {
+                is ApiResult.Success -> {
+                    val s = r.data
+                    if (s == null || s.legs.isEmpty()) {
+                        _uiState.update { it.copy(phase = StrategyPaperUiState.Phase.Empty, strategy = s) }
+                        return@launch
+                    }
+                    _uiState.update { it.copy(strategy = s) }
+                    runBacktest(s)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = StrategyPaperUiState.Phase.Error, errorMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(phase = StrategyPaperUiState.Phase.Error, errorMessage = "No connection. Check your network and retry.")
+                }
+            }
+        }
+    }
+
+    private suspend fun runBacktest(strategy: Strategy) {
+        var anyDegraded = false
+        val backtestLegs = ArrayList<StrategyMath.BacktestLeg>()
+        for (leg: StrategyLeg in strategy.legs) {
+            when (val h = exchange.getHistory(leg.symbolId, BACKTEST_INTERVAL)) {
+                is ApiResult.Success -> {
+                    if (h.data.stub) anyDegraded = true
+                    val closes = h.data.bars.map { it.close.toDouble() }
+                    if (closes.size >= 2) backtestLegs.add(StrategyMath.BacktestLeg(leg.weightBps, closes))
+                }
+                is ApiResult.Failure -> anyDegraded = true
+                is ApiResult.NetworkError -> {
+                    _uiState.update {
+                        it.copy(phase = StrategyPaperUiState.Phase.Error, errorMessage = "No connection. Check your network and retry.")
+                    }
+                    return
+                }
+            }
+        }
+
+        val curve = StrategyMath.basketEquityCurve(backtestLegs)
+        val totalRet = StrategyMath.totalReturn(curve)
+        val vol = MarketStats.annualizedVolatility(curve)
+        val mdd = MarketStats.maxDrawdown(curve)
+        val paperEnd = Math.round(PAPER_START_CENTS * (curve.lastOrNull() ?: 1.0))
+
+        _uiState.update {
+            it.copy(
+                phase = StrategyPaperUiState.Phase.Content,
+                degraded = anyDegraded,
+                equityCurve = curve,
+                totalReturnPct = totalRet * 100.0,
+                annualizedVolPct = vol?.let { v -> v * 100.0 },
+                maxDrawdownPct = mdd?.let { d -> d * 100.0 },
+                paperEndCents = paperEnd,
+                errorMessage = null,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyUi.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyUi.kt
@@ -1,0 +1,141 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.strategies
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.testlogon.android.data.strategies.RebalanceRule
+import com.testlogon.android.data.strategies.RedemptionType
+import com.testlogon.android.data.strategies.StrategyKind
+import com.testlogon.android.data.strategies.StrategyStatus
+
+/** Human label for a strategy lifecycle status. */
+fun StrategyStatus.label(): String = when (this) {
+    StrategyStatus.DRAFT -> "Draft"
+    StrategyStatus.PAPER -> "Paper"
+    StrategyStatus.PUBLISHED -> "Published"
+    StrategyStatus.CLOSED -> "Closed"
+    StrategyStatus.UNKNOWN -> "—"
+}
+
+fun StrategyKind.label(): String = when (this) {
+    StrategyKind.BASKET -> "Basket"
+    StrategyKind.RULE -> "Rule"
+    StrategyKind.UNKNOWN -> "—"
+}
+
+fun RebalanceRule.label(): String = when (this) {
+    RebalanceRule.NONE -> "No rebalance"
+    RebalanceRule.DAILY -> "Daily"
+    RebalanceRule.WEEKLY -> "Weekly"
+    RebalanceRule.MONTHLY -> "Monthly"
+    RebalanceRule.THRESHOLD -> "On threshold"
+    RebalanceRule.UNKNOWN -> "—"
+}
+
+fun RedemptionType.label(): String = when (this) {
+    RedemptionType.INSTANT -> "Instant (at NAV)"
+    RedemptionType.NOTICE -> "Notice period"
+    RedemptionType.UNKNOWN -> "—"
+}
+
+/**
+ * A short human name for a symbol id, using the same catalogue the markets surface seeds
+ * (1=BTCUSDC, 2=ETHUSDC, 3=SOLUSDC). Falls back to "#id" for anything else so a drifted/extra symbol
+ * still renders honestly.
+ */
+fun symbolName(symbolId: Int): String = when (symbolId) {
+    1 -> "BTCUSDC"
+    2 -> "ETHUSDC"
+    3 -> "SOLUSDC"
+    else -> "#$symbolId"
+}
+
+/** A label/value row used across the strategy detail sections and confirm dialogs. */
+@Composable
+fun StrategyKeyValueRow(label: String, value: String, emphasize: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal,
+            color = if (emphasize) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+/** A small pill that renders a status string. */
+@Composable
+fun StrategyStatusPill(text: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+/**
+ * A minimal equity-curve sparkline drawn from a [curve] of levels (base ~1.0). Line-only, no axes;
+ * used for the backtest / paper-run preview. Renders nothing meaningful for a <2-point curve.
+ */
+@Composable
+fun EquitySparkline(
+    curve: List<Double>,
+    modifier: Modifier = Modifier,
+    lineColor: Color = MaterialTheme.colorScheme.primary,
+) {
+    Canvas(modifier = modifier.fillMaxWidth().height(120.dp).padding(vertical = 8.dp)) {
+        if (curve.size < 2) return@Canvas
+        val min = curve.min()
+        val max = curve.max()
+        val range = (max - min).takeIf { it > 0.0 } ?: 1.0
+        val w = size.width
+        val h = size.height
+        val dx = w / (curve.size - 1)
+        val path = Path()
+        curve.forEachIndexed { i, v ->
+            val x = dx * i
+            val y = h - ((v - min) / range).toFloat() * h
+            if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        drawPath(path = path, color = lineColor, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 4f))
+        // Baseline marker at the first level.
+        val baseY = h - ((curve.first() - min) / range).toFloat() * h
+        drawLine(
+            color = lineColor.copy(alpha = 0.25f),
+            start = Offset(0f, baseY),
+            end = Offset(w, baseY),
+            strokeWidth = 2f,
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -309,6 +309,9 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // Creator revenue-share TOKENS: mint + browse market + per-token detail (cap table /
         // revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
         tokensDestinations(navController)
+        // USER-CREATED STRATEGIES / BASKETS (investable funds): marketplace + builder + detail
+        // (invest/redeem at NAV) + paper-run/backtest. Endpoints degrade-on-404 (backend pending).
+        strategiesDestinations(navController)
         // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: distress overview + rescuer board + per-position
         // auction + auto-bailout setting. Endpoints degrade-on-404 (backend pending); distress never fabricated.
         bailoutDestinations(navController)

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -384,6 +384,11 @@ object MoreRoutes {
     // (cap table / revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
     const val TOKENS = TokensMarketDest.ROUTE
 
+    // USER-CREATED STRATEGIES / BASKETS (investable funds): the marketplace + "my strategies" list
+    // (the navigable hub BROWSE entry). Builder / detail+invest/redeem / paper-run+backtest are
+    // detail routes reached from there. All reads degrade-on-404 (the me/strategies backend is pending).
+    const val STRATEGIES = StrategyMarketDest.ROUTE
+
     // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: the rescuer opportunity board (the navigable hub
     // BROWSE entry) + the distress overview + auto-bailout account setting. Per-position auction is a
     // detail route reached from those. All reads degrade-on-404 (the margin-distress backend is pending).
@@ -685,6 +690,7 @@ object MoreRoutes {
             ADMIN_DASHBOARD,
             MARKETS,
             TOKENS,
+            STRATEGIES,
             BAILOUTS,
             MARGIN_DISTRESS,
             BAILOUT_SETTINGS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/StrategiesNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/StrategiesNavigation.kt
@@ -1,0 +1,93 @@
+package com.testlogon.android.navigation
+
+import android.net.Uri
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.feature.strategies.StrategyBuilderRoute
+import com.testlogon.android.feature.strategies.StrategyDetailRoute
+import com.testlogon.android.feature.strategies.StrategyMarketRoute
+import com.testlogon.android.feature.strategies.StrategyPaperRoute
+
+/**
+ * USER-CREATED STRATEGIES / BASKETS (investable funds) destinations, registered in the AUTHENTICATED
+ * nav graph.
+ *
+ * [StrategyMarketDest] is the marketplace + "my strategies" list (the navigable hub entry);
+ * [StrategyBuilderDest] is the create/edit form (id = "new" for a fresh draft); [StrategyDetailDest]
+ * is the per-strategy detail + invest/redeem; [StrategyPaperDest] is the paper-run + backtest screen.
+ * All read surfaces degrade to honest empty/pending states when the (not-yet-built) `me/strategies/(all)`
+ * backend 404s.
+ */
+data object StrategyMarketDest {
+    const val ROUTE = "strategies"
+}
+
+data object StrategyBuilderDest {
+    const val ROUTE = "strategies/builder/{strategyId}"
+    const val ARG_STRATEGY_ID = "strategyId"
+
+    /** Sentinel id for a brand-new draft (no strategy loaded for edit). */
+    const val NEW = "new"
+
+    fun build(strategyId: String): String = "strategies/builder/${Uri.encode(strategyId)}"
+    fun buildNew(): String = build(NEW)
+}
+
+data object StrategyDetailDest {
+    const val ROUTE = "strategies/detail/{strategyId}"
+    const val ARG_STRATEGY_ID = "strategyId"
+
+    fun build(strategyId: String): String = "strategies/detail/${Uri.encode(strategyId)}"
+}
+
+data object StrategyPaperDest {
+    const val ROUTE = "strategies/paper/{strategyId}"
+    const val ARG_STRATEGY_ID = "strategyId"
+
+    fun build(strategyId: String): String = "strategies/paper/${Uri.encode(strategyId)}"
+}
+
+/** Registers the strategy marketplace + builder + detail + paper-run destinations (Back pops the stack). */
+fun NavGraphBuilder.strategiesDestinations(navController: NavHostController) {
+    composable(StrategyMarketDest.ROUTE) {
+        StrategyMarketRoute(
+            onBack = { navController.popBackStack() },
+            onOpenStrategy = { id -> navController.navigate(StrategyDetailDest.build(id)) { launchSingleTop = true } },
+            onCreate = { navController.navigate(StrategyBuilderDest.buildNew()) { launchSingleTop = true } },
+        )
+    }
+    composable(
+        route = StrategyBuilderDest.ROUTE,
+        arguments = listOf(navArgument(StrategyBuilderDest.ARG_STRATEGY_ID) { type = NavType.StringType }),
+    ) {
+        StrategyBuilderRoute(
+            onBack = { navController.popBackStack() },
+            onSaved = { id ->
+                // Replace the builder with the saved strategy's detail so Back returns to the list.
+                navController.navigate(StrategyDetailDest.build(id)) {
+                    launchSingleTop = true
+                    popUpTo(StrategyBuilderDest.ROUTE) { inclusive = true }
+                }
+            },
+        )
+    }
+    composable(
+        route = StrategyDetailDest.ROUTE,
+        arguments = listOf(navArgument(StrategyDetailDest.ARG_STRATEGY_ID) { type = NavType.StringType }),
+    ) {
+        StrategyDetailRoute(
+            onBack = { navController.popBackStack() },
+            onEdit = { id -> navController.navigate(StrategyBuilderDest.build(id)) { launchSingleTop = true } },
+            onPaperRun = { id -> navController.navigate(StrategyPaperDest.build(id)) { launchSingleTop = true } },
+        )
+    }
+    composable(
+        route = StrategyPaperDest.ROUTE,
+        arguments = listOf(navArgument(StrategyPaperDest.ARG_STRATEGY_ID) { type = NavType.StringType }),
+    ) {
+        StrategyPaperRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4287,6 +4287,7 @@
     <string name="more_entry_markets">Markets</string>
     <string name="more_entry_analysis">Analysis</string>
     <string name="more_entry_tokens">Creator Tokens</string>
+    <string name="more_entry_strategies">Strategies &amp; Baskets</string>
     <string name="more_entry_bailouts">Bailout Auctions</string>
     <string name="more_entry_trading_alerts">Trading alerts</string>
     <string name="admin_dashboard_title">Admin alerts</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/strategies/StrategyMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/strategies/StrategyMathTest.kt
@@ -1,0 +1,147 @@
+package com.testlogon.android.feature.strategies
+
+import com.testlogon.android.data.strategies.StrategyLeg
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure JVM tests for [StrategyMath] — NAV unit math, dual-fee accrual with a high-water mark, weight
+ * validation, min-size + capacity checks, and the basket backtest helper. No Android runtime.
+ */
+class StrategyMathTest {
+
+    private fun legs(vararg pairs: Pair<Int, Int>): List<StrategyLeg> =
+        pairs.map { StrategyLeg(symbolId = it.first, weightBps = it.second) }
+
+    // ---- weight validation ----
+
+    @Test
+    fun weightsValid_true_whenLegsSumTo10000() {
+        assertTrue(StrategyMath.weightsValid(legs(1 to 6000, 2 to 4000)))
+        assertEquals(10000, StrategyMath.totalWeightBps(legs(1 to 6000, 2 to 4000)))
+    }
+
+    @Test
+    fun weightsValid_false_whenSumOff_orEmpty_orBadLeg() {
+        assertFalse(StrategyMath.weightsValid(legs(1 to 6000, 2 to 3000))) // 90%
+        assertFalse(StrategyMath.weightsValid(legs(1 to 6000, 2 to 5000))) // 110%
+        assertFalse(StrategyMath.weightsValid(emptyList()))
+        assertFalse(StrategyMath.weightsValid(legs(1 to 10000, 0 to 0))) // bad symbol/weight
+    }
+
+    // ---- NAV unit math ----
+
+    @Test
+    fun unitsForInvestment_atPar_issuesProportionalMicroUnits() {
+        // $100.00 at par NAV $1.00 -> 100 units == 100_000_000 micro-units.
+        assertEquals(100_000_000L, StrategyMath.unitsForInvestment(10_000L, StrategyMath.PAR_NAV_CENTS))
+    }
+
+    @Test
+    fun unitsForInvestment_guardsNonPositive() {
+        assertEquals(0L, StrategyMath.unitsForInvestment(0L, 100L))
+        assertEquals(0L, StrategyMath.unitsForInvestment(10_000L, 0L))
+    }
+
+    @Test
+    fun proceedsForUnits_roundTripsAtPar() {
+        val units = StrategyMath.unitsForInvestment(50_000L, StrategyMath.PAR_NAV_CENTS)
+        assertEquals(50_000L, StrategyMath.proceedsForUnits(units, StrategyMath.PAR_NAV_CENTS))
+    }
+
+    @Test
+    fun proceedsForUnits_appreciatedNav_returnsMore() {
+        val units = StrategyMath.unitsForInvestment(10_000L, 100L) // 100 units
+        // NAV doubled to $2.00 -> redeeming the same units yields ~$200.
+        assertEquals(20_000L, StrategyMath.proceedsForUnits(units, 200L))
+    }
+
+    @Test
+    fun navPerUnit_freshFundPricesAtPar_thenTracksAum() {
+        assertEquals(StrategyMath.PAR_NAV_CENTS, StrategyMath.navPerUnit(0L, 0L))
+        val units = StrategyMath.unitsForInvestment(10_000L, StrategyMath.PAR_NAV_CENTS)
+        // AUM grows to $150 on the same units -> NAV $1.50.
+        assertEquals(150L, StrategyMath.navPerUnit(15_000L, units))
+    }
+
+    // ---- fee accrual ----
+
+    @Test
+    fun mgmtFeeAccrual_annualBps_proRataByDays() {
+        // 2% (200 bps) annual on $10,000 AUM for a full year == $200.00 (20000 cents).
+        assertEquals(20_000L, StrategyMath.mgmtFeeAccrual(1_000_000L, 200, 365.0))
+        // Half a year -> ~half.
+        assertEquals(10_000L, StrategyMath.mgmtFeeAccrual(1_000_000L, 200, 182.5))
+        assertEquals(0L, StrategyMath.mgmtFeeAccrual(1_000_000L, 0, 365.0))
+    }
+
+    @Test
+    fun perfFee_onlyAboveHighWaterMark() {
+        val units = StrategyMath.unitsForInvestment(10_000L, 100L) // 100 units of $100 at par
+        // NAV $1.20, HWM $1.00, 20% (2000 bps) perf fee -> profit $20 -> fee $4.00 (400 cents).
+        assertEquals(400L, StrategyMath.perfFee(120L, 100L, units, 2000))
+        // NAV below the HWM -> no fee.
+        assertEquals(0L, StrategyMath.perfFee(90L, 100L, units, 2000))
+        // NAV equal to the HWM -> no fee.
+        assertEquals(0L, StrategyMath.perfFee(100L, 100L, units, 2000))
+    }
+
+    @Test
+    fun highWaterMark_onlyRatchetsUp() {
+        assertEquals(120L, StrategyMath.updatedHighWaterMark(100L, 120L))
+        assertEquals(120L, StrategyMath.updatedHighWaterMark(120L, 110L))
+    }
+
+    // ---- size + capacity ----
+
+    @Test
+    fun meetsMinInvestment_enforcesFloor() {
+        assertTrue(StrategyMath.meetsMinInvestment(10_000L, 10_000L))
+        assertFalse(StrategyMath.meetsMinInvestment(9_999L, 10_000L))
+        assertTrue(StrategyMath.meetsMinInvestment(500L, 0L)) // uncapped floor
+        assertFalse(StrategyMath.meetsMinInvestment(0L, 0L))
+    }
+
+    @Test
+    fun capacityAndWithinCapacity() {
+        assertEquals(null, StrategyMath.capacityRemaining(0L, 5_000L)) // uncapped
+        assertEquals(4_000L, StrategyMath.capacityRemaining(10_000L, 6_000L))
+        assertEquals(0L, StrategyMath.capacityRemaining(10_000L, 12_000L)) // over cap clamps to 0
+        assertTrue(StrategyMath.withinCapacity(4_000L, 10_000L, 6_000L))
+        assertFalse(StrategyMath.withinCapacity(4_001L, 10_000L, 6_000L))
+        assertTrue(StrategyMath.withinCapacity(1_000_000L, 0L, 0L)) // uncapped always fits
+    }
+
+    // ---- basket backtest ----
+
+    @Test
+    fun basketEquityCurve_singleLeg_tracksItsReturn() {
+        val leg = StrategyMath.BacktestLeg(weightBps = 10000, closes = listOf(100.0, 110.0, 121.0))
+        val curve = StrategyMath.basketEquityCurve(listOf(leg))
+        assertEquals(3, curve.size)
+        assertEquals(1.0, curve.first(), 1e-9)
+        assertEquals(1.21, curve.last(), 1e-9)
+        assertEquals(0.21, StrategyMath.totalReturn(curve), 1e-9)
+    }
+
+    @Test
+    fun basketEquityCurve_twoLegs_blendsByWeight_andTruncatesToCommonLength() {
+        val a = StrategyMath.BacktestLeg(weightBps = 5000, closes = listOf(100.0, 200.0, 300.0)) // +100% then +200%
+        val b = StrategyMath.BacktestLeg(weightBps = 5000, closes = listOf(100.0, 100.0))        // flat, shorter
+        val curve = StrategyMath.basketEquityCurve(listOf(a, b))
+        // Common length is 2. Step 2: 0.5*2.0 + 0.5*1.0 = 1.5.
+        assertEquals(2, curve.size)
+        assertEquals(1.0, curve.first(), 1e-9)
+        assertEquals(1.5, curve.last(), 1e-9)
+    }
+
+    @Test
+    fun basketEquityCurve_degenerateInputs_returnsFlatCurve() {
+        assertEquals(listOf(1.0), StrategyMath.basketEquityCurve(emptyList()))
+        val tooShort = StrategyMath.BacktestLeg(weightBps = 10000, closes = listOf(100.0))
+        assertEquals(listOf(1.0), StrategyMath.basketEquityCurve(listOf(tooShort)))
+        assertEquals(0.0, StrategyMath.totalReturn(listOf(1.0)), 1e-9)
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,10 @@ const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
 const TokenMarketPage = lazy(() => import("@/pages/tokens/TokenMarketPage"));
 const MintTokenPage = lazy(() => import("@/pages/tokens/MintTokenPage"));
 const TokenDetailPage = lazy(() => import("@/pages/tokens/TokenDetailPage"));
+const StrategyMarketPage = lazy(() => import("@/pages/strategies/StrategyMarketPage"));
+const StrategyBuilderPage = lazy(() => import("@/pages/strategies/StrategyBuilderPage"));
+const StrategyDetailPage = lazy(() => import("@/pages/strategies/StrategyDetailPage"));
+const StrategyBacktestPage = lazy(() => import("@/pages/strategies/StrategyBacktestPage"));
 const MarketAnalysisPage = lazy(() => import("@/pages/analysis/MarketAnalysisPage"));
 const PaperTradingPage = lazy(() => import("@/pages/paper/PaperTradingPage"));
 const PriceAlertsPage = lazy(() => import("@/pages/alerts/PriceAlertsPage"));
@@ -754,6 +758,11 @@ export default function App() {
           <Route path="tokens" element={<TokenMarketPage />} />
           <Route path="tokens/new" element={<MintTokenPage />} />
           <Route path="tokens/:id" element={<TokenDetailPage />} />
+          <Route path="strategies" element={<StrategyMarketPage />} />
+          <Route path="strategies/new" element={<StrategyBuilderPage />} />
+          <Route path="strategies/:id" element={<StrategyDetailPage />} />
+          <Route path="strategies/:id/edit" element={<StrategyBuilderPage />} />
+          <Route path="strategies/:id/backtest" element={<StrategyBacktestPage />} />
           <Route path="bailouts" element={<BailoutsBoardPage />} />
           <Route path="analysis" element={<MarketAnalysisPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />

--- a/frontend/src/api/endpoints/strategies.ts
+++ b/frontend/src/api/endpoints/strategies.ts
@@ -1,0 +1,216 @@
+import { api } from "@/api/client";
+
+/**
+ * USER-CREATED STRATEGIES / BASKETS surface (`/me/strategies/*`).
+ *
+ * A creator defines a STRATEGY: a basket of target weights (from a static
+ * ETF-like allocation through a simple rule set) that others can PAPER-TRADE,
+ * BACKTEST, then INVEST real capital into. The creator sets a minimum
+ * investment, a maximum total AUM (capacity cap), a redemption / profit-taking
+ * policy, and a DUAL FEE — a management fee on AUM (`mgmt_fee_bps`, annual) AND
+ * a performance fee on profit (`perf_fee_bps`, gated by a high-water mark).
+ *
+ * ASSUMPTION (labelled in-UI so it can be flipped): the fund is a POOLED FUND
+ * WITH NAV UNITS — investors subscribe/redeem at NAV and own units; it is NOT
+ * copy / replication trading.
+ *
+ * CONVENTIONS (locked): every monetary amount is INTEGER CENTS; every `_bps`
+ * field is BASIS POINTS (100% = 10_000). NONE of these endpoints exist on the
+ * backend yet — every GET degrades on 404/absent to an empty-but-honest state
+ * (callers use `retry:false` + render a "pending backend" note), and every
+ * mutation surfaces a clear error toast on 404 (never silently "succeeds").
+ */
+
+export type StrategyKind = "basket" | "rule";
+export type StrategyStatus = "draft" | "paper" | "published" | "closed";
+export type RebalanceCadence = "none" | "daily" | "weekly" | "monthly" | "threshold";
+export type RedemptionType = "instant" | "notice";
+
+/** One basket leg: a symbol and its target weight in basis points. */
+export interface StrategyLeg {
+  symbol_id: number;
+  weight_bps: number;
+}
+
+/** The redemption / profit-taking policy the creator sets. */
+export interface RedemptionPolicy {
+  type: RedemptionType;
+  /** Notice period before a redemption settles (notice type). */
+  notice_days?: number;
+  /** Initial lock-up before any redemption is allowed. */
+  lockup_days?: number;
+}
+
+/** A user-created investable strategy / basket fund. */
+export interface Strategy {
+  strategy_id: string;
+  creator_sub: string;
+  name: string;
+  description: string;
+  kind: StrategyKind;
+  status: StrategyStatus;
+  legs: StrategyLeg[];
+  rebalance: RebalanceCadence;
+  /** Rebalance trigger drift (threshold cadence), in bps. */
+  threshold_bps?: number;
+  min_investment_cents: number;
+  /** Capacity cap; 0 (or absent) = uncapped. */
+  max_aum_cents: number;
+  mgmt_fee_bps: number;
+  perf_fee_bps: number;
+  high_water_mark: boolean;
+  redemption: RedemptionPolicy;
+  created_ts: number;
+  /** NAV per unit in cents (present once the fund is live). */
+  nav_per_unit?: number;
+  /** Assets under management in cents. */
+  aum_cents?: number;
+  investor_count?: number;
+  /** Return since inception, in bps. */
+  inception_return_bps?: number;
+}
+
+export interface StrategiesResult {
+  strategies: Strategy[];
+}
+
+/** Live NAV snapshot for a published fund. */
+export interface StrategyNav {
+  nav_per_unit: number;
+  aum_cents: number;
+  units_outstanding: number;
+  /** Snapshot timestamp (seconds). */
+  as_of: number;
+}
+
+/** One holding row in the fund's current composition. */
+export interface HoldingLeg {
+  symbol_id: number;
+  weight_bps: number;
+  value_cents: number;
+}
+
+export interface StrategyHoldings {
+  legs: HoldingLeg[];
+}
+
+/** An investor's position in a strategy. */
+export interface InvestorPosition {
+  strategy_id: string;
+  units: number;
+  nav_per_unit: number;
+  invested_cents: number;
+  current_value_cents: number;
+  unrealized_pnl_cents: number;
+  fees_paid_cents: number;
+  high_water_mark: number;
+}
+
+/** The creator's fee-accrual snapshot for the fund. */
+export interface StrategyFees {
+  mgmt_accrued_cents: number;
+  perf_accrued_cents: number;
+  high_water_mark: number;
+}
+
+/** Result of an invest (subscribe) action. */
+export interface InvestResult {
+  units: number;
+  nav_per_unit: number;
+}
+
+/** Result of a redeem action. */
+export interface RedeemResult {
+  proceeds_cents: number;
+}
+
+// -- Requests ---------------------------------------------------------
+
+export interface CreateStrategyRequest {
+  name: string;
+  description: string;
+  kind: StrategyKind;
+  legs: StrategyLeg[];
+  rebalance: RebalanceCadence;
+  threshold_bps?: number;
+  min_investment_cents: number;
+  max_aum_cents: number;
+  mgmt_fee_bps: number;
+  perf_fee_bps: number;
+  high_water_mark: boolean;
+  redemption: RedemptionPolicy;
+}
+
+export type UpdateStrategyRequest = CreateStrategyRequest;
+
+export interface InvestRequest {
+  amount_cents: number;
+}
+
+export interface RedeemRequest {
+  units: number;
+}
+
+/** Generic mutation ack; carries a message on the failure paths. */
+export interface StrategyAck {
+  status?: string;
+  strategy_id?: string;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+}
+
+// -- Calls (all 404 until the backend ships — callers degrade) --------
+
+/** Create a draft strategy. */
+export const createStrategy = (body: CreateStrategyRequest) =>
+  api.post<Strategy>("/me/strategies", body);
+
+/** Strategies I created. */
+export const getMyStrategies = () => api.get<StrategiesResult>("/me/strategies");
+
+/** Published strategies to browse. */
+export const getStrategyMarket = () => api.get<StrategiesResult>("/me/strategies/market");
+
+export const getStrategy = (id: string) =>
+  api.get<Strategy>(`/me/strategies/${encodeURIComponent(id)}`);
+
+/** Edit a draft strategy (creator only). */
+export const updateStrategy = (id: string, body: UpdateStrategyRequest) =>
+  api.put<Strategy>(`/me/strategies/${encodeURIComponent(id)}`, body);
+
+/** Publish a strategy (opens it for investment). */
+export const publishStrategy = (id: string) =>
+  api.post<Strategy>(`/me/strategies/${encodeURIComponent(id)}/publish`, {});
+
+export const getStrategyNav = (id: string) =>
+  api.get<StrategyNav>(`/me/strategies/${encodeURIComponent(id)}/nav`);
+
+export const getStrategyHoldings = (id: string) =>
+  api.get<StrategyHoldings>(`/me/strategies/${encodeURIComponent(id)}/holdings`);
+
+/** Subscribe real capital at NAV. */
+export const investStrategy = (id: string, body: InvestRequest) =>
+  api.post<InvestResult>(`/me/strategies/${encodeURIComponent(id)}/invest`, body);
+
+/** Redeem units at NAV (respecting the redemption policy). */
+export const redeemStrategy = (id: string, body: RedeemRequest) =>
+  api.post<RedeemResult>(`/me/strategies/${encodeURIComponent(id)}/redeem`, body);
+
+export const getStrategyPosition = (id: string) =>
+  api.get<InvestorPosition>(`/me/strategies/${encodeURIComponent(id)}/position`);
+
+export const getStrategyFees = (id: string) =>
+  api.get<StrategyFees>(`/me/strategies/${encodeURIComponent(id)}/fees`);
+
+// -- Helpers ----------------------------------------------------------
+
+/** Best human message off any strategy ack (error / detail / reject reason). */
+export const strategyAckMessage = (a: StrategyAck | null | undefined): string | undefined => {
+  if (!a) return undefined;
+  if (a.detail) return a.detail;
+  if (a.error) return a.error;
+  if (a.note) return a.note;
+  return a.reason != null ? `rejected (${a.reason})` : undefined;
+};

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -182,6 +182,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Custody", i18nKey: "nav.custody", path: "/custody", icon: <Coins className="h-5 w-5" /> },
       { label: "Custody Providers", i18nKey: "nav.custodyProviders", path: "/custody/providers", icon: <Building2 className="h-5 w-5" /> },
       { label: "Creator Tokens", i18nKey: "nav.creatorTokens", path: "/tokens", icon: <Landmark className="h-5 w-5" /> },
+      { label: "Strategies", i18nKey: "nav.strategies", path: "/strategies", icon: <Boxes className="h-5 w-5" /> },
       { label: "Referrals", i18nKey: "nav.referrals", path: "/referrals", icon: <Share2 className="h-5 w-5" /> },
       { label: "Promo Codes", i18nKey: "nav.promoCodes", path: "/promo", icon: <Tag className="h-5 w-5" /> },
       { label: "Affiliates", i18nKey: "nav.affiliates", path: "/affiliates", icon: <Link2 className="h-5 w-5" /> },

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,0 +1,172 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import * as strategies from "@/api/endpoints/strategies";
+import { ApiError } from "@/api/client";
+
+/**
+ * React-query hooks for the USER-CREATED STRATEGIES / BASKETS surface. Mirrors
+ * the `useTokens` conventions: reads use `retry:false` because EVERY route 404s
+ * until the backend ships (callers render an honest empty / "pending backend"
+ * state); mutations surface a clear error toast on failure (never silent).
+ */
+
+export const strategyKeys = {
+  all: ["me", "strategies"] as const,
+  mine: ["me", "strategies", "mine"] as const,
+  market: ["me", "strategies", "market"] as const,
+  detail: (id: string) => ["me", "strategies", "detail", id] as const,
+  nav: (id: string) => ["me", "strategies", "nav", id] as const,
+  holdings: (id: string) => ["me", "strategies", "holdings", id] as const,
+  position: (id: string) => ["me", "strategies", "position", id] as const,
+  fees: (id: string) => ["me", "strategies", "fees", id] as const,
+};
+
+const POLL_MS = 15_000;
+
+// -- Reads (degrade on 404 — retry:false) -----------------------------
+
+export function useMyStrategies(enabled = true) {
+  return useQuery({
+    queryKey: strategyKeys.mine,
+    queryFn: strategies.getMyStrategies,
+    enabled,
+    retry: false,
+  });
+}
+
+export function useStrategyMarket(enabled = true) {
+  return useQuery({
+    queryKey: strategyKeys.market,
+    queryFn: strategies.getStrategyMarket,
+    enabled,
+    retry: false,
+  });
+}
+
+export function useStrategy(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: strategyKeys.detail(id ?? ""),
+    queryFn: () => strategies.getStrategy(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+export function useStrategyNav(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: strategyKeys.nav(id ?? ""),
+    queryFn: () => strategies.getStrategyNav(id!),
+    enabled: enabled && !!id,
+    retry: false,
+    refetchInterval: POLL_MS,
+  });
+}
+
+export function useStrategyHoldings(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: strategyKeys.holdings(id ?? ""),
+    queryFn: () => strategies.getStrategyHoldings(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+export function useStrategyPosition(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: strategyKeys.position(id ?? ""),
+    queryFn: () => strategies.getStrategyPosition(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+export function useStrategyFees(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: strategyKeys.fees(id ?? ""),
+    queryFn: () => strategies.getStrategyFees(id!),
+    enabled: enabled && !!id,
+    retry: false,
+  });
+}
+
+/** True when a query error is the expected "backend not shipped yet" 404. */
+export function isPendingBackend(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+/** Human error message for a failed mutation (404 -> "not available yet"). */
+function mutationErrorText(err: unknown, action: string): string {
+  if (err instanceof ApiError) {
+    if (err.status === 404) {
+      return `${action} is not available yet — the strategies backend has not shipped.`;
+    }
+    return err.detail || `${action} failed.`;
+  }
+  return `${action} failed.`;
+}
+
+// -- Mutations (clear error toast on failure — never silent) ----------
+
+export function useCreateStrategy() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: strategies.CreateStrategyRequest) => strategies.createStrategy(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: strategyKeys.mine }),
+    onError: (err) => toast.error(mutationErrorText(err, "Creating the strategy")),
+  });
+}
+
+export function useUpdateStrategy(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: strategies.UpdateStrategyRequest) => strategies.updateStrategy(id!, body),
+    onSuccess: () => {
+      if (id) qc.invalidateQueries({ queryKey: strategyKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: strategyKeys.mine });
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Saving the strategy")),
+  });
+}
+
+export function usePublishStrategy(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => strategies.publishStrategy(id!),
+    onSuccess: () => {
+      if (id) qc.invalidateQueries({ queryKey: strategyKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: strategyKeys.mine });
+      qc.invalidateQueries({ queryKey: strategyKeys.market });
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Publishing the strategy")),
+  });
+}
+
+export function useInvestStrategy(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: strategies.InvestRequest) => strategies.investStrategy(id!, body),
+    onSuccess: () => {
+      if (id) {
+        qc.invalidateQueries({ queryKey: strategyKeys.position(id) });
+        qc.invalidateQueries({ queryKey: strategyKeys.nav(id) });
+        qc.invalidateQueries({ queryKey: strategyKeys.detail(id) });
+      }
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Investing")),
+  });
+}
+
+export function useRedeemStrategy(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: strategies.RedeemRequest) => strategies.redeemStrategy(id!, body),
+    onSuccess: () => {
+      if (id) {
+        qc.invalidateQueries({ queryKey: strategyKeys.position(id) });
+        qc.invalidateQueries({ queryKey: strategyKeys.nav(id) });
+        qc.invalidateQueries({ queryKey: strategyKeys.detail(id) });
+      }
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Redeeming")),
+  });
+}

--- a/frontend/src/lib/strategies.test.ts
+++ b/frontend/src/lib/strategies.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import type { Bar } from "./marketStats";
+import {
+  bpsToFraction,
+  bpsToPct,
+  pctToBps,
+  formatBps,
+  formatCents,
+  unitsForInvestment,
+  proceedsForUnits,
+  mgmtFeeAccrual,
+  perfFee,
+  totalWeightBps,
+  validateWeights,
+  canInvest,
+  capacityFilledFraction,
+  basketBacktest,
+  BPS_DENOM,
+  type StrategyLeg,
+  type LegSeries,
+} from "./strategies";
+
+describe("bps <-> pct/fraction", () => {
+  it("converts and formats bps", () => {
+    expect(bpsToFraction(10_000)).toBe(1);
+    expect(bpsToFraction(250)).toBe(0.025);
+    expect(bpsToFraction(undefined)).toBe(0);
+    expect(bpsToPct(250)).toBeCloseTo(2.5, 6);
+    expect(pctToBps(2.5)).toBe(250);
+    expect(pctToBps(150)).toBe(10_000); // clamp default 100
+    expect(pctToBps(150, 5000)).toBe(15_000); // custom max raises the clamp ceiling
+    expect(formatBps(250)).toBe("2.5%");
+    expect(formatCents(123456)).toBe("$1,234.56");
+    expect(formatCents(undefined)).toBe("—");
+  });
+});
+
+describe("NAV / units math", () => {
+  it("mints units for an investment at NAV", () => {
+    // $100.00 at a $12.34 NAV -> 8.103... units
+    expect(unitsForInvestment(10000, 1234)).toBeCloseTo(8.1037, 3);
+    expect(unitsForInvestment(0, 1234)).toBe(0);
+    expect(unitsForInvestment(10000, 0)).toBe(0);
+  });
+  it("redeems proceeds for units at NAV, rounded to cents", () => {
+    expect(proceedsForUnits(8.1037, 1234)).toBe(10000); // round-trips ~$100
+    expect(proceedsForUnits(10, 1500)).toBe(15000);
+    expect(proceedsForUnits(0, 1500)).toBe(0);
+  });
+  it("round-trips invest -> redeem at a flat NAV", () => {
+    const nav = 2000;
+    const units = unitsForInvestment(50000, nav);
+    expect(proceedsForUnits(units, nav)).toBe(50000);
+  });
+});
+
+describe("fee accrual", () => {
+  it("accrues a management fee by day-count on AUM", () => {
+    // 2% (200 bps) annual on $1,000,000 for a full year = $20,000
+    expect(mgmtFeeAccrual(100_000_00, 200, 365)).toBe(2_000_00 * 100 / 100); // = 2_000_000 cents
+    // half a year -> half the fee
+    expect(mgmtFeeAccrual(100_000_00, 200, 182.5)).toBe(100_000);
+    expect(mgmtFeeAccrual(0, 200, 365)).toBe(0);
+    expect(mgmtFeeAccrual(100_000_00, 0, 365)).toBe(0);
+    expect(mgmtFeeAccrual(100_000_00, 200, 0)).toBe(0);
+  });
+  it("charges a performance fee only on gains above the high-water mark", () => {
+    // 20% (2000 bps) of a $10,000 gain above HWM = $2,000
+    expect(perfFee(110_000_00, 100_000_00, 2000)).toBe(2_000_00);
+    // at/below the mark -> no fee
+    expect(perfFee(100_000_00, 100_000_00, 2000)).toBe(0);
+    expect(perfFee(90_000_00, 100_000_00, 2000)).toBe(0);
+    expect(perfFee(110_000_00, 100_000_00, 0)).toBe(0);
+  });
+});
+
+describe("weight validation", () => {
+  const legs = (arr: [number, number][]): StrategyLeg[] =>
+    arr.map(([symbol_id, weight_bps]) => ({ symbol_id, weight_bps }));
+
+  it("sums leg weights ignoring junk", () => {
+    expect(totalWeightBps(legs([[1, 5000], [2, 5000]]))).toBe(10_000);
+    expect(totalWeightBps(legs([[1, 5000], [2, -100]]))).toBe(5000);
+  });
+  it("passes only when legs sum to exactly 100% with unique symbols", () => {
+    const ok = validateWeights(legs([[1, 6000], [2, 4000]]));
+    expect(ok.valid).toBe(true);
+    expect(ok.driftBps).toBe(0);
+    expect(ok.hasDuplicateSymbol).toBe(false);
+  });
+  it("fails when under/over 100%", () => {
+    expect(validateWeights(legs([[1, 6000], [2, 3000]])).valid).toBe(false);
+    expect(validateWeights(legs([[1, 6000], [2, 3000]])).driftBps).toBe(-1000);
+    expect(validateWeights(legs([[1, 6000], [2, 5000]])).driftBps).toBe(1000);
+  });
+  it("flags duplicate symbols and empty baskets", () => {
+    expect(validateWeights(legs([[1, 5000], [1, 5000]])).hasDuplicateSymbol).toBe(true);
+    expect(validateWeights(legs([[1, 5000], [1, 5000]])).valid).toBe(false);
+    expect(validateWeights([]).hasLegs).toBe(false);
+    expect(validateWeights([]).valid).toBe(false);
+  });
+  it("honors a rounding tolerance", () => {
+    expect(validateWeights(legs([[1, 3333], [2, 3333], [3, 3333]]), 5).valid).toBe(true);
+    expect(validateWeights(legs([[1, 3333], [2, 3333], [3, 3333]]), 0).valid).toBe(false);
+  });
+});
+
+describe("min-size + capacity checks", () => {
+  it("blocks non-positive amounts", () => {
+    expect(canInvest(0, 10000, 0, 0).ok).toBe(false);
+    expect(canInvest(0, 10000, 0, 0).reason).toBe("amount_non_positive");
+  });
+  it("blocks below the minimum investment", () => {
+    const r = canInvest(5000, 10000, 0, 0);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("below_min");
+  });
+  it("blocks over the AUM capacity cap", () => {
+    // cap $100k, already $95k in -> only $5k room
+    const r = canInvest(10_000_00, 0, 95_000_00, 100_000_00);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("over_capacity");
+    expect(r.capacityRemainingCents).toBe(5_000_00);
+  });
+  it("allows a valid investment and reports uncapped remaining as Infinity", () => {
+    const r = canInvest(50_000_00, 10000, 0, 0);
+    expect(r.ok).toBe(true);
+    expect(r.capacityRemainingCents).toBe(Number.POSITIVE_INFINITY);
+  });
+  it("computes capacity-filled fraction", () => {
+    expect(capacityFilledFraction(50_000_00, 100_000_00)).toBeCloseTo(0.5, 6);
+    expect(capacityFilledFraction(50_000_00, 0)).toBe(0); // uncapped
+    expect(capacityFilledFraction(200_000_00, 100_000_00)).toBe(1); // clamped
+  });
+});
+
+describe("basket backtest", () => {
+  const bars = (closes: number[], startTs = 1_000): Bar[] =>
+    closes.map((c, i) => ({ ts: startTs + i * 60, o: c, h: c, l: c, c, v: 0 }));
+
+  it("returns an empty result for no legs", () => {
+    const r = basketBacktest([], 60);
+    expect(r.steps).toBe(0);
+    expect(r.equity).toEqual([]);
+    expect(r.aligned).toBe(false);
+  });
+
+  it("tracks a single leg's return exactly", () => {
+    const legs: LegSeries[] = [
+      { symbol_id: 1, weight_bps: 10_000, bars: bars([100, 110, 121]) },
+    ];
+    const r = basketBacktest(legs, 60);
+    expect(r.steps).toBe(3);
+    expect(r.equity[0]).toBeCloseTo(1, 9);
+    expect(r.equity[2]).toBeCloseTo(1.21, 9); // +10% then +10%
+    expect(r.stats.cumulativeReturn).toBeCloseTo(0.21, 6);
+  });
+
+  it("blends two legs by weight over shared timestamps", () => {
+    // Leg A doubles (100->200, +100%); leg B flat. 50/50 -> +50% total.
+    const legs: LegSeries[] = [
+      { symbol_id: 1, weight_bps: 5000, bars: bars([100, 200]) },
+      { symbol_id: 2, weight_bps: 5000, bars: bars([100, 100]) },
+    ];
+    const r = basketBacktest(legs, 60);
+    expect(r.aligned).toBe(true);
+    expect(r.equity[1]).toBeCloseTo(1.5, 9);
+  });
+
+  it("aligns on shared timestamps only", () => {
+    const legs: LegSeries[] = [
+      { symbol_id: 1, weight_bps: 5000, bars: bars([100, 110, 120], 1000) },
+      { symbol_id: 2, weight_bps: 5000, bars: bars([100, 105], 1060) }, // ts 1060,1120
+    ];
+    const r = basketBacktest(legs, 60);
+    // Shared ts = 1060, 1120 -> 2 aligned steps.
+    expect(r.steps).toBe(2);
+  });
+
+  it("normalizes weights that do not total 100%", () => {
+    // Both legs weight 2500 bps (sum 5000). A +10%, B flat -> normalized 50/50 -> +5%.
+    const legs: LegSeries[] = [
+      { symbol_id: 1, weight_bps: 2500, bars: bars([100, 110]) },
+      { symbol_id: 2, weight_bps: 2500, bars: bars([100, 100]) },
+    ];
+    const r = basketBacktest(legs, 60);
+    expect(r.equity[1]).toBeCloseTo(1.05, 9);
+  });
+});
+
+describe("constants", () => {
+  it("uses 10_000 bps as the 100% denominator", () => {
+    expect(BPS_DENOM).toBe(10_000);
+  });
+});

--- a/frontend/src/lib/strategies.ts
+++ b/frontend/src/lib/strategies.ts
@@ -1,0 +1,311 @@
+/**
+ * Pure, framework-free math for the USER-CREATED STRATEGIES / BASKETS surface.
+ *
+ * A "strategy" is an investable fund: a basket of target weights (optionally
+ * following a simple rule set) that investors subscribe to at NAV. We model it
+ * (LABELLED assumption, flippable) as a POOLED NAV FUND — investors own units,
+ * subscribe/redeem at the current net-asset-value-per-unit; this is NOT copy /
+ * replication trading.
+ *
+ * CONVENTIONS (locked): every monetary amount is INTEGER CENTS; every `_bps`
+ * field is BASIS POINTS (1% = 100 bps, 100% = 10_000 bps). Nothing here touches
+ * React, the network, or the DOM — deterministic and unit-tested in
+ * `strategies.test.ts`. NAV-per-unit is carried in cents (a $12.34 unit = 1234).
+ */
+
+import { computeStats, type Bar, type SeriesStats } from "./marketStats";
+
+/** Full basis-points denominator (100%). */
+export const BPS_DENOM = 10_000;
+
+/** Days in a year used for the management-fee day-count accrual. */
+export const DAYS_PER_YEAR = 365;
+
+/** Clamp a number into [lo, hi]; non-finite -> lo. */
+export function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Basis points -> fraction (0..1). 10_000 -> 1. Non-finite -> 0. */
+export function bpsToFraction(bps: number | undefined | null): number {
+  if (bps == null || !Number.isFinite(bps)) return 0;
+  return bps / BPS_DENOM;
+}
+
+/** Basis points -> a human percent number (e.g. 250 -> 2.5). */
+export function bpsToPct(bps: number | undefined | null): number {
+  return bpsToFraction(bps) * 100;
+}
+
+/** A human percent number -> basis points, floored to an int (2.5 -> 250). */
+export function pctToBps(pct: number | undefined | null, maxPct = 100): number {
+  if (pct == null || !Number.isFinite(pct)) return 0;
+  return Math.round(clamp(pct, 0, maxPct) * 100);
+}
+
+/** Format basis points as a percent string, e.g. 250 -> "2.5%". */
+export function formatBps(bps: number | undefined | null, maxFrac = 2): string {
+  const pct = bpsToPct(bps);
+  return `${pct.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: maxFrac })}%`;
+}
+
+/** Integer cents -> "$1,234.56". Non-finite -> "—". */
+export function formatCents(cents: number | undefined | null): string {
+  if (cents == null || !Number.isFinite(cents)) return "—";
+  return `$${(cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+// -- NAV / units math --------------------------------------------------
+
+/**
+ * Units minted for an investment. `amountCents` invested at `navPerUnitCents`
+ * yields amount / nav units (NOT floored — pooled funds mint fractional units).
+ * Guards non-positive NAV / amount by returning 0.
+ */
+export function unitsForInvestment(amountCents: number, navPerUnitCents: number): number {
+  if (!(amountCents > 0) || !(navPerUnitCents > 0)) return 0;
+  return amountCents / navPerUnitCents;
+}
+
+/**
+ * Redemption proceeds (cents) for redeeming `units` at `navPerUnitCents`,
+ * rounded to a whole cent. Guards non-positive inputs by returning 0.
+ */
+export function proceedsForUnits(units: number, navPerUnitCents: number): number {
+  if (!(units > 0) || !(navPerUnitCents > 0)) return 0;
+  return Math.round(units * navPerUnitCents);
+}
+
+// -- Fee accrual -------------------------------------------------------
+
+/**
+ * Management-fee accrual (cents) over `days` on `aumCents` at an ANNUAL rate of
+ * `mgmtFeeBps`. accrual = aum * (bps/10_000) * (days/365), rounded to a whole
+ * cent. Guards non-positive inputs by returning 0.
+ */
+export function mgmtFeeAccrual(aumCents: number, mgmtFeeBps: number, days: number): number {
+  if (!(aumCents > 0) || !(mgmtFeeBps > 0) || !(days > 0)) return 0;
+  return Math.round(aumCents * bpsToFraction(mgmtFeeBps) * (days / DAYS_PER_YEAR));
+}
+
+/**
+ * Performance fee (cents) on PROFIT ABOVE the high-water mark. `currentValueCents`
+ * is the position value now; `highWaterMarkCents` is the prior peak value the fee
+ * was last taken at (or the invested cost basis when no HWM is enforced). Fee =
+ * max(0, current - hwm) * (perfFeeBps/10_000), rounded. Only charges on gains;
+ * returns 0 when at/below the mark.
+ */
+export function perfFee(
+  currentValueCents: number,
+  highWaterMarkCents: number,
+  perfFeeBps: number,
+): number {
+  if (!(perfFeeBps > 0)) return 0;
+  const profit = currentValueCents - highWaterMarkCents;
+  if (!(profit > 0)) return 0;
+  return Math.round(profit * bpsToFraction(perfFeeBps));
+}
+
+// -- Weight validation -------------------------------------------------
+
+/** One basket leg: a symbol and its target weight in bps. */
+export interface StrategyLeg {
+  symbol_id: number;
+  weight_bps: number;
+}
+
+/** Sum of leg weights in bps (ignores non-finite / non-positive). */
+export function totalWeightBps(legs: StrategyLeg[]): number {
+  return (legs ?? []).reduce(
+    (sum, l) => sum + (Number.isFinite(l?.weight_bps) && l.weight_bps > 0 ? l.weight_bps : 0),
+    0,
+  );
+}
+
+export interface WeightValidation {
+  totalBps: number;
+  /** Signed distance from 100% (10_000 bps): +over / -under. */
+  driftBps: number;
+  valid: boolean;
+  /** True when there is at least one leg with a positive weight. */
+  hasLegs: boolean;
+  /** True when any two legs reference the same symbol. */
+  hasDuplicateSymbol: boolean;
+}
+
+/**
+ * Validate that basket legs sum to exactly 100% (10_000 bps) with no duplicate
+ * symbols and at least one leg. `toleranceBps` allows small rounding slack.
+ */
+export function validateWeights(legs: StrategyLeg[], toleranceBps = 0): WeightValidation {
+  const total = totalWeightBps(legs);
+  const seen = new Set<number>();
+  let dup = false;
+  let count = 0;
+  for (const l of legs ?? []) {
+    if (l && l.weight_bps > 0) {
+      count += 1;
+      if (seen.has(l.symbol_id)) dup = true;
+      seen.add(l.symbol_id);
+    }
+  }
+  const drift = total - BPS_DENOM;
+  return {
+    totalBps: total,
+    driftBps: drift,
+    hasLegs: count > 0,
+    hasDuplicateSymbol: dup,
+    valid: count > 0 && !dup && Math.abs(drift) <= toleranceBps,
+  };
+}
+
+// -- Min-size + capacity checks ----------------------------------------
+
+export type InvestBlockReason = "amount_non_positive" | "below_min" | "over_capacity";
+
+export interface InvestCheck {
+  ok: boolean;
+  reason?: InvestBlockReason;
+  /** Remaining room under the AUM cap, in cents (Infinity when uncapped). */
+  capacityRemainingCents: number;
+}
+
+/**
+ * Can `amountCents` be invested given a `minInvestmentCents` floor and a
+ * `maxAumCents` capacity cap against the fund's current `currentAumCents`?
+ * A `maxAumCents` <= 0 means UNCAPPED. Returns the first blocking reason.
+ */
+export function canInvest(
+  amountCents: number,
+  minInvestmentCents: number,
+  currentAumCents: number,
+  maxAumCents: number,
+): InvestCheck {
+  const capped = maxAumCents > 0;
+  const capacityRemaining = capped
+    ? Math.max(0, maxAumCents - Math.max(0, currentAumCents))
+    : Number.POSITIVE_INFINITY;
+
+  if (!(amountCents > 0)) {
+    return { ok: false, reason: "amount_non_positive", capacityRemainingCents: capacityRemaining };
+  }
+  if (minInvestmentCents > 0 && amountCents < minInvestmentCents) {
+    return { ok: false, reason: "below_min", capacityRemainingCents: capacityRemaining };
+  }
+  if (capped && amountCents > capacityRemaining) {
+    return { ok: false, reason: "over_capacity", capacityRemainingCents: capacityRemaining };
+  }
+  return { ok: true, capacityRemainingCents: capacityRemaining };
+}
+
+/** Fraction (0..1) of the AUM cap already filled, for a capacity gauge. */
+export function capacityFilledFraction(currentAumCents: number, maxAumCents: number): number {
+  if (!(maxAumCents > 0)) return 0;
+  return clamp(Math.max(0, currentAumCents) / maxAumCents, 0, 1);
+}
+
+// -- Basket backtest ---------------------------------------------------
+
+/** A per-leg historical return series aligned to weights, for the backtest. */
+export interface LegSeries {
+  symbol_id: number;
+  weight_bps: number;
+  /** Bars for this leg, de-scaled closes, ascending by ts. */
+  bars: Bar[];
+}
+
+export interface BasketBacktestResult {
+  /** Equity curve of the weighted basket, base 1.0, one point per aligned step. */
+  equity: number[];
+  /** Timestamps aligned to the equity points. */
+  ts: number[];
+  /** Portfolio-level stats over the synthesized equity bar series. */
+  stats: SeriesStats;
+  /** Number of aligned time steps used (equity.length). */
+  steps: number;
+  /** True when at least two legs had overlapping timestamps. */
+  aligned: boolean;
+}
+
+/**
+ * Client-side basket backtest: given each leg's historical bar series and its
+ * weight, synthesize the pooled fund's equity curve as a fixed-weight
+ * combination of the legs' PER-STEP simple returns, aligned on the timestamps
+ * ALL legs share. The portfolio return each step is the weight-normalized sum
+ * of the legs' returns; equity compounds from 1.0.
+ *
+ * Weights are normalized by their own sum, so the backtest is meaningful even
+ * if the draft's weights do not yet total exactly 100%.
+ *
+ * Reuses {@link computeStats} to derive returns/vol/drawdown over the resulting
+ * synthetic equity series (treated as closes on a flat OHLCV bar).
+ */
+export function basketBacktest(legs: LegSeries[], intervalSec: number): BasketBacktestResult {
+  const active = (legs ?? []).filter((l) => l && l.weight_bps > 0 && l.bars && l.bars.length > 1);
+  const weightSum = active.reduce((s, l) => s + l.weight_bps, 0);
+
+  const emptyStats = computeStats([], intervalSec);
+  if (active.length === 0 || weightSum <= 0) {
+    return { equity: [], ts: [], stats: emptyStats, steps: 0, aligned: false };
+  }
+
+  // Timestamps common to EVERY active leg.
+  const tsSets = active.map((l) => new Set(l.bars.map((b) => b.ts)));
+  let common = active[0]!.bars.map((b) => b.ts);
+  for (let i = 1; i < tsSets.length; i++) {
+    common = common.filter((t) => tsSets[i]!.has(t));
+  }
+  common.sort((a, b) => a - b);
+  const aligned = active.length >= 2;
+  if (common.length < 2) {
+    return {
+      equity: common.length ? [1] : [],
+      ts: common.slice(),
+      stats: emptyStats,
+      steps: common.length,
+      aligned,
+    };
+  }
+
+  // Close lookup per leg for O(1) access at each common timestamp.
+  const closeMaps = active.map((l) => {
+    const m = new Map<number, number>();
+    for (const b of l.bars) m.set(b.ts, b.c);
+    return m;
+  });
+  const weights = active.map((l) => l.weight_bps / weightSum);
+
+  const equity: number[] = [1];
+  let eq = 1;
+  for (let i = 1; i < common.length; i++) {
+    const tPrev = common[i - 1]!;
+    const tCur = common[i]!;
+    let portRet = 0;
+    for (let j = 0; j < active.length; j++) {
+      const prev = closeMaps[j]!.get(tPrev)!;
+      const cur = closeMaps[j]!.get(tCur)!;
+      const legRet = prev !== 0 ? cur / prev - 1 : 0;
+      portRet += weights[j]! * legRet;
+    }
+    eq *= 1 + portRet;
+    equity.push(eq);
+  }
+
+  // Build a synthetic bar series (equity as closes) to reuse the stat pack.
+  const equityBars: Bar[] = common.map((t, i) => {
+    const c = equity[i]!;
+    return { ts: t, o: c, h: c, l: c, c, v: 0 };
+  });
+
+  return {
+    equity,
+    ts: common.slice(),
+    stats: computeStats(equityBars, intervalSec),
+    steps: common.length,
+    aligned,
+  };
+}

--- a/frontend/src/pages/strategies/PendingBackend.tsx
+++ b/frontend/src/pages/strategies/PendingBackend.tsx
@@ -1,0 +1,39 @@
+import { Info, Layers } from "lucide-react";
+
+/**
+ * Honest "pending backend" note shown when a `/me/strategies/*` read 404s (the
+ * surface is UI-complete but the backend has not shipped yet). Reused across
+ * every strategy screen so the empty state reads the same everywhere.
+ */
+export function PendingBackend({ label = "This data" }: { label?: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-dashed bg-muted/30 p-4 text-sm text-muted-foreground">
+      <Info className="mt-0.5 h-4 w-4 shrink-0" />
+      <div>
+        <p className="font-medium text-foreground">Pending backend</p>
+        <p>
+          {label} is not available yet — the strategy / basket-fund endpoints have not shipped on
+          this environment. The surface is wired and will populate automatically once they do.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Small labelled note flagging the flippable fund-structure assumption: the
+ * fund is modelled as a POOLED NAV FUND (investors own units, subscribe/redeem
+ * at NAV) rather than copy / replication trading.
+ */
+export function PooledNavNote() {
+  return (
+    <p className="flex items-start gap-2 rounded-md border border-sky-300/50 bg-sky-50 px-3 py-2 text-xs text-sky-800 dark:border-sky-500/30 dark:bg-sky-950/40 dark:text-sky-300">
+      <Layers className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>
+        <span className="font-semibold">Assumption (flippable):</span> this is a{" "}
+        <span className="font-semibold">pooled NAV fund</span> — you subscribe and redeem at the
+        fund&rsquo;s net-asset-value per unit and own units. It is not copy / replication trading.
+      </span>
+    </p>
+  );
+}

--- a/frontend/src/pages/strategies/StrategyBacktestPage.tsx
+++ b/frontend/src/pages/strategies/StrategyBacktestPage.tsx
@@ -1,0 +1,296 @@
+import { useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useQueries } from "@tanstack/react-query";
+import { ArrowLeft, FlaskConical, Play, TrendingUp, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useStrategy } from "@/hooks/useStrategies";
+import { useSymbols } from "@/hooks/useMarketData";
+import { getHistory, intervalToSeconds } from "@/api/endpoints/marketHistory";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { basketBacktest, formatBps, type LegSeries } from "@/lib/strategies";
+import type { Bar } from "@/lib/marketStats";
+import { newAccount, placeOrder, equity as paperEquity, type PaperAccount } from "@/lib/paperEngine";
+import { PendingBackend, PooledNavNote } from "./PendingBackend";
+
+const INTERVAL = "1d";
+const PAPER_SEED_CENTS = 100_000_00; // $100k paper capital
+
+/** Sparkline-style SVG equity curve (base 1.0). */
+function EquityCurve({ equity }: { equity: number[] }) {
+  if (equity.length < 2) return null;
+  const w = 640;
+  const h = 160;
+  const min = Math.min(...equity);
+  const max = Math.max(...equity);
+  const span = max - min || 1;
+  const pts = equity
+    .map((v, i) => {
+      const x = (i / (equity.length - 1)) * w;
+      const y = h - ((v - min) / span) * h;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  const up = equity[equity.length - 1]! >= equity[0]!;
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} className="h-40 w-full" preserveAspectRatio="none" role="img" aria-label="Backtest equity curve">
+      <polyline
+        fill="none"
+        stroke={up ? "hsl(142 71% 45%)" : "hsl(0 72% 51%)"}
+        strokeWidth={2}
+        points={pts}
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "pos" | "neg" }) {
+  const cls =
+    tone === "pos"
+      ? "text-emerald-600 dark:text-emerald-400"
+      : tone === "neg"
+        ? "text-rose-600 dark:text-rose-400"
+        : "";
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={`mt-0.5 font-semibold tabular-nums ${cls}`}>{value}</p>
+    </div>
+  );
+}
+
+export default function StrategyBacktestPage() {
+  const { id } = useParams<{ id: string }>();
+  const strategyQ = useStrategy(id);
+  const symbolsQ = useSymbols();
+  const strategy = strategyQ.data;
+
+  const legs = strategy?.legs ?? [];
+  const symById = useMemo(() => {
+    const m = new Map<number, MarketSymbol>();
+    for (const s of symbolsQ.data?.symbols ?? []) m.set(s.symbol_id, s);
+    return m;
+  }, [symbolsQ.data]);
+
+  // Fetch each leg's history (degrades to the recent candle window on 404).
+  const historyQueries = useQueries({
+    queries: legs.map((leg) => ({
+      queryKey: ["strategy-backtest-history", leg.symbol_id, INTERVAL],
+      queryFn: () => getHistory(leg.symbol_id, { interval: INTERVAL }),
+      enabled: !!strategy && leg.symbol_id > 0,
+      retry: false,
+      staleTime: 60_000,
+    })),
+  });
+
+  const anyLoading = historyQueries.some((q) => q.isLoading);
+  const anyStub = historyQueries.some((q) => q.data?.stub);
+  const anyError = historyQueries.some((q) => q.isError);
+
+  // De-scale each leg's bars by its symbol price_scaler into Bar[].
+  const legSeries: LegSeries[] = useMemo(() => {
+    return legs.map((leg, i) => {
+      const res = historyQueries[i]?.data;
+      const sym = symById.get(leg.symbol_id);
+      const scaler = sym?.price_scaler && sym.price_scaler > 0 ? sym.price_scaler : 1;
+      const bars: Bar[] = (res?.bars ?? []).map((b) => ({
+        ts: b.ts,
+        o: b.o / scaler,
+        h: b.h / scaler,
+        l: b.l / scaler,
+        c: b.c / scaler,
+        v: b.v,
+      }));
+      return { symbol_id: leg.symbol_id, weight_bps: leg.weight_bps, bars };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [legs, symById, historyQueries.map((q) => q.dataUpdatedAt).join(",")]);
+
+  const backtest = useMemo(
+    () => basketBacktest(legSeries, intervalToSeconds(INTERVAL)),
+    [legSeries],
+  );
+
+  // -- Paper run -------------------------------------------------------
+  const [paper, setPaper] = useState<PaperAccount | null>(null);
+
+  const runPaper = () => {
+    if (!strategy) return;
+    // Seed a paper account and place a market buy per leg sized by its target
+    // weight against the latest de-scaled close (the fund following the basket).
+    let acct = newAccount(PAPER_SEED_CENTS);
+    const marks: Record<number, number> = {};
+    let placed = 0;
+    for (const ls of legSeries) {
+      const last = ls.bars[ls.bars.length - 1]?.c;
+      if (!(last && last > 0) || !(ls.weight_bps > 0)) continue;
+      const allocCents = PAPER_SEED_CENTS * (ls.weight_bps / 10_000);
+      // Paper engine works in ticks/quote units; use cents as the quote unit and
+      // price in cents so cash accounting stays integer-cents consistent.
+      const priceCents = Math.max(1, Math.round(last * 100));
+      const qty = Math.floor(allocCents / priceCents);
+      if (qty <= 0) continue;
+      marks[ls.symbol_id] = priceCents;
+      const res = placeOrder(acct, { symbolId: ls.symbol_id, side: "buy", type: "market", qty }, priceCents);
+      acct = res.account;
+      placed += 1;
+    }
+    setPaper(acct);
+    if (placed === 0) {
+      toast.error("No leg had a usable price to paper-trade yet.");
+    } else {
+      toast.success(`Paper account seeded — bought ${placed} leg${placed === 1 ? "" : "s"} by weight.`);
+    }
+  };
+
+  const paperEquityCents = useMemo(() => {
+    if (!paper) return 0;
+    const marks: Record<number, number> = {};
+    for (const ls of legSeries) {
+      const last = ls.bars[ls.bars.length - 1]?.c;
+      if (last && last > 0) marks[ls.symbol_id] = Math.max(1, Math.round(last * 100));
+    }
+    return paperEquity(paper, marks);
+  }, [paper, legSeries]);
+
+  if (strategyQ.isError) {
+    return (
+      <Shell id={id}>
+        <PendingBackend label="This strategy" />
+      </Shell>
+    );
+  }
+
+  const s = backtest.stats;
+
+  return (
+    <Shell id={id} name={strategy?.name}>
+      <PooledNavNote />
+
+      {(anyStub || anyError) && (
+        <p className="flex items-start gap-2 rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/40 dark:text-amber-300">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Long-range history is unavailable — the backtest uses the most recent candle window
+            for {anyError ? "some legs" : "one or more legs"}. Results are indicative only.
+          </span>
+        </p>
+      )}
+
+      {/* Backtest */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <FlaskConical className="h-4 w-4" /> Basket backtest ({INTERVAL})
+          </CardTitle>
+          {backtest.aligned ? (
+            <Badge variant="secondary">{backtest.steps} bars</Badge>
+          ) : (
+            <Badge variant="outline">single-leg</Badge>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {strategyQ.isLoading || anyLoading ? (
+            <Skeleton className="h-40 w-full" />
+          ) : backtest.equity.length < 2 ? (
+            <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+              Not enough overlapping history across the legs to backtest yet.
+            </div>
+          ) : (
+            <>
+              <EquityCurve equity={backtest.equity} />
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                <Stat
+                  label="Total return"
+                  value={`${s.cumulativeReturn >= 0 ? "+" : ""}${(s.cumulativeReturn * 100).toFixed(2)}%`}
+                  tone={s.cumulativeReturn >= 0 ? "pos" : "neg"}
+                />
+                <Stat label="Ann. volatility" value={`${(s.annualizedVolatility * 100).toFixed(1)}%`} />
+                <Stat label="Max drawdown" value={`${(s.maxDrawdown * 100).toFixed(1)}%`} tone="neg" />
+                <Stat label="Bars" value={String(s.bars)} />
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Composition */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Composition</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {legs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">This strategy has no legs.</p>
+          ) : (
+            <div className="space-y-2">
+              {legSeries.map((ls) => (
+                <div key={ls.symbol_id} className="flex items-center justify-between text-sm">
+                  <span className="font-medium">{symById.get(ls.symbol_id)?.symbol ?? `#${ls.symbol_id}`}</span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {formatBps(ls.weight_bps)} · {ls.bars.length} bars
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Paper run */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <TrendingUp className="h-4 w-4" /> Paper-trade the basket
+          </CardTitle>
+          <Button size="sm" onClick={runPaper} disabled={!strategy || anyLoading} data-testid="run-paper">
+            <Play className="mr-1 h-4 w-4" /> {paper ? "Re-run" : "Run paper"}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-3 text-xs text-muted-foreground">
+            Seeds a paper account with $100,000 and buys each leg by its target weight at the
+            latest price — no real capital. This is the &ldquo;paper-trade before you invest&rdquo; step.
+          </p>
+          {!paper ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Run the paper account to preview how the basket would hold.
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <Stat label="Seed" value={`$${(PAPER_SEED_CENTS / 100).toLocaleString()}`} />
+              <Stat label="Cash left" value={`$${(paper.cash / 100).toLocaleString(undefined, { maximumFractionDigits: 0 })}`} />
+              <Stat label="Positions" value={String(Object.values(paper.positions).filter((p) => p.qty !== 0).length)} />
+              <Stat label="Mark value" value={`$${(paperEquityCents / 100).toLocaleString(undefined, { maximumFractionDigits: 0 })}`} />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </Shell>
+  );
+}
+
+function Shell({ id, name, children }: { id?: string; name?: string; children: React.ReactNode }) {
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4 md:p-6">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="ghost" size="icon">
+          <Link to={id ? `/strategies/${encodeURIComponent(id)}` : "/strategies"} aria-label="Back">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <FlaskConical className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold tracking-tight">
+            Paper-run &amp; backtest{name ? <span className="text-muted-foreground"> — {name}</span> : null}
+          </h1>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/pages/strategies/StrategyBuilderPage.tsx
+++ b/frontend/src/pages/strategies/StrategyBuilderPage.tsx
@@ -1,0 +1,606 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams, Link } from "react-router-dom";
+import { ArrowLeft, Boxes, Plus, Trash2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Progress } from "@/components/ui/progress";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useSymbols } from "@/hooks/useMarketData";
+import {
+  useCreateStrategy,
+  useUpdateStrategy,
+  usePublishStrategy,
+  useStrategy,
+} from "@/hooks/useStrategies";
+import type {
+  RebalanceCadence,
+  RedemptionType,
+  StrategyKind,
+  CreateStrategyRequest,
+} from "@/api/endpoints/strategies";
+import { strategyAckMessage } from "@/api/endpoints/strategies";
+import {
+  validateWeights,
+  formatBps,
+  pctToBps,
+  bpsToPct,
+  type StrategyLeg,
+} from "@/lib/strategies";
+import { PooledNavNote } from "./PendingBackend";
+
+/** A leg row in the editor: symbol + weight-percent string (bps derived). */
+interface LegRow {
+  symbol_id: number | null;
+  weightPct: string;
+}
+
+const REBALANCE_OPTIONS: { value: RebalanceCadence; label: string }[] = [
+  { value: "none", label: "No rebalance (buy & hold)" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "threshold", label: "On drift threshold" },
+];
+
+function dollarsToCents(s: string): number {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? Math.round(n * 100) : 0;
+}
+function centsToDollars(cents: number | undefined): string {
+  return cents && cents > 0 ? String(cents / 100) : "";
+}
+
+export default function StrategyBuilderPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const isEdit = !!id;
+
+  const symbolsQ = useSymbols();
+  const symbols = symbolsQ.data?.symbols ?? [];
+  const symbolName = (sid: number | null) =>
+    sid == null ? "Select symbol" : symbols.find((s) => s.symbol_id === sid)?.symbol ?? `#${sid}`;
+
+  const existing = useStrategy(id);
+  const create = useCreateStrategy();
+  const update = useUpdateStrategy(id);
+  const publish = usePublishStrategy(id);
+
+  // -- Form state ------------------------------------------------------
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [kind, setKind] = useState<StrategyKind>("basket");
+  const [legs, setLegs] = useState<LegRow[]>([{ symbol_id: null, weightPct: "" }]);
+  const [rebalance, setRebalance] = useState<RebalanceCadence>("none");
+  const [thresholdPct, setThresholdPct] = useState("5");
+  const [minInvest, setMinInvest] = useState("100");
+  const [maxAum, setMaxAum] = useState("");
+  const [mgmtFeePct, setMgmtFeePct] = useState("2");
+  const [perfFeePct, setPerfFeePct] = useState("20");
+  const [highWaterMark, setHighWaterMark] = useState(true);
+  const [redemptionType, setRedemptionType] = useState<RedemptionType>("instant");
+  const [noticeDays, setNoticeDays] = useState("7");
+  const [lockupDays, setLockupDays] = useState("0");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate the form once when editing an existing draft.
+  useEffect(() => {
+    if (!isEdit || hydrated || !existing.data) return;
+    const s = existing.data;
+    setName(s.name);
+    setDescription(s.description ?? "");
+    setKind(s.kind);
+    setLegs(
+      s.legs?.length
+        ? s.legs.map((l) => ({ symbol_id: l.symbol_id, weightPct: String(bpsToPct(l.weight_bps)) }))
+        : [{ symbol_id: null, weightPct: "" }],
+    );
+    setRebalance(s.rebalance);
+    setThresholdPct(s.threshold_bps != null ? String(bpsToPct(s.threshold_bps)) : "5");
+    setMinInvest(centsToDollars(s.min_investment_cents));
+    setMaxAum(centsToDollars(s.max_aum_cents));
+    setMgmtFeePct(String(bpsToPct(s.mgmt_fee_bps)));
+    setPerfFeePct(String(bpsToPct(s.perf_fee_bps)));
+    setHighWaterMark(s.high_water_mark);
+    setRedemptionType(s.redemption?.type ?? "instant");
+    setNoticeDays(String(s.redemption?.notice_days ?? 7));
+    setLockupDays(String(s.redemption?.lockup_days ?? 0));
+    setHydrated(true);
+  }, [isEdit, hydrated, existing.data]);
+
+  // -- Derived ---------------------------------------------------------
+  const modelLegs: StrategyLeg[] = useMemo(
+    () =>
+      legs
+        .filter((l) => l.symbol_id != null && Number(l.weightPct) > 0)
+        .map((l) => ({ symbol_id: l.symbol_id as number, weight_bps: pctToBps(Number(l.weightPct)) })),
+    [legs],
+  );
+  const weightCheck = useMemo(() => validateWeights(modelLegs, 1), [modelLegs]);
+
+  const mgmtFeeBps = pctToBps(Number(mgmtFeePct), 100);
+  const perfFeeBps = pctToBps(Number(perfFeePct), 100);
+  const minInvestCents = dollarsToCents(minInvest);
+  const maxAumCents = dollarsToCents(maxAum);
+
+  const errors = useMemo(() => {
+    const e: string[] = [];
+    if (!name.trim()) e.push("Name is required.");
+    if (!weightCheck.hasLegs) e.push("Add at least one basket leg.");
+    if (weightCheck.hasDuplicateSymbol) e.push("Each symbol can appear only once.");
+    if (weightCheck.hasLegs && !weightCheck.valid && !weightCheck.hasDuplicateSymbol) {
+      e.push("Leg weights must total exactly 100%.");
+    }
+    if (!(minInvestCents > 0)) e.push("Minimum investment must be greater than $0.");
+    if (Number(mgmtFeePct) < 0 || Number(mgmtFeePct) > 100) e.push("Management fee must be 0–100%.");
+    if (Number(perfFeePct) < 0 || Number(perfFeePct) > 100) e.push("Performance fee must be 0–100%.");
+    if (redemptionType === "notice" && !(Number(noticeDays) > 0)) {
+      e.push("Notice period must be at least 1 day.");
+    }
+    return e;
+  }, [name, weightCheck, minInvestCents, mgmtFeePct, perfFeePct, redemptionType, noticeDays]);
+
+  const busy = create.isPending || update.isPending || publish.isPending;
+  const canSubmit = errors.length === 0 && !busy;
+
+  // -- Leg editor helpers ---------------------------------------------
+  const setLeg = (i: number, patch: Partial<LegRow>) =>
+    setLegs((prev) => prev.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
+  const addLeg = () => setLegs((prev) => [...prev, { symbol_id: null, weightPct: "" }]);
+  const removeLeg = (i: number) =>
+    setLegs((prev) => (prev.length > 1 ? prev.filter((_, idx) => idx !== i) : prev));
+  const equalWeight = () => {
+    const active = legs.filter((l) => l.symbol_id != null);
+    if (active.length === 0) return;
+    const per = Math.floor(10000 / active.length) / 100; // percent, 2dp
+    let assigned = 0;
+    setLegs((prev) =>
+      prev.map((l) => {
+        if (l.symbol_id == null) return l;
+        assigned += 1;
+        // Give the last active leg the remainder so it totals ~100.
+        const isLast = assigned === active.length;
+        const pct = isLast ? Math.round((100 - per * (active.length - 1)) * 100) / 100 : per;
+        return { ...l, weightPct: String(pct) };
+      }),
+    );
+  };
+
+  // -- Build the request body -----------------------------------------
+  const buildBody = (): CreateStrategyRequest => ({
+    name: name.trim(),
+    description: description.trim(),
+    kind,
+    legs: modelLegs,
+    rebalance,
+    threshold_bps: rebalance === "threshold" ? pctToBps(Number(thresholdPct), 100) : undefined,
+    min_investment_cents: minInvestCents,
+    max_aum_cents: maxAumCents,
+    mgmt_fee_bps: mgmtFeeBps,
+    perf_fee_bps: perfFeeBps,
+    high_water_mark: highWaterMark,
+    redemption: {
+      type: redemptionType,
+      notice_days: redemptionType === "notice" ? Number(noticeDays) : undefined,
+      lockup_days: Number(lockupDays) > 0 ? Number(lockupDays) : undefined,
+    },
+  });
+
+  const saveDraft = async () => {
+    try {
+      const body = buildBody();
+      const saved = isEdit ? await update.mutateAsync(body) : await create.mutateAsync(body);
+      toast.success(isEdit ? "Draft saved." : "Draft created.");
+      navigate(`/strategies/${encodeURIComponent(saved.strategy_id)}`);
+    } catch (err) {
+      const msg = strategyAckMessage((err as { body?: never })?.body as never);
+      if (msg) toast.error(msg);
+    }
+  };
+
+  const doPublish = async () => {
+    try {
+      // Persist any edits first, then publish. On create-then-publish, use the
+      // returned id for the publish call by routing through the saved strategy.
+      const body = buildBody();
+      const saved = isEdit ? await update.mutateAsync(body) : await create.mutateAsync(body);
+      if (isEdit) {
+        await publish.mutateAsync();
+      }
+      setConfirmOpen(false);
+      toast.success(isEdit ? "Strategy published." : "Draft created — open it to publish.");
+      navigate(`/strategies/${encodeURIComponent(saved.strategy_id)}`);
+    } catch (err) {
+      const msg = strategyAckMessage((err as { body?: never })?.body as never);
+      if (msg) toast.error(msg);
+    }
+  };
+
+  const totalPct = bpsToPct(weightCheck.totalBps);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4 md:p-6">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="ghost" size="icon">
+          <Link to="/strategies" aria-label="Back to strategies">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <Boxes className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold tracking-tight">
+            {isEdit ? "Edit strategy" : "Create a strategy"}
+          </h1>
+        </div>
+      </div>
+
+      <PooledNavNote />
+
+      {/* Identity */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Basics</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="s-name">Name</Label>
+            <Input
+              id="s-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Blue-chip crypto basket"
+              maxLength={80}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="s-desc">Description</Label>
+            <Textarea
+              id="s-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="A market-cap-weighted basket of the top three majors, rebalanced monthly."
+              maxLength={500}
+              rows={3}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Kind</Label>
+            <Select value={kind} onValueChange={(v) => setKind(v as StrategyKind)}>
+              <SelectTrigger data-testid="kind-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="basket">Static basket (fixed target weights)</SelectItem>
+                <SelectItem value="rule">Rule-based (weights + a simple rule set)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Basket legs */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-base">Basket legs</CardTitle>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={equalWeight}>
+              Equal-weight
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={addLeg} data-testid="add-leg">
+              <Plus className="mr-1 h-4 w-4" /> Add leg
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {legs.map((leg, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <div className="flex-1">
+                <Select
+                  value={leg.symbol_id != null ? String(leg.symbol_id) : undefined}
+                  onValueChange={(v) => setLeg(i, { symbol_id: Number(v) })}
+                >
+                  <SelectTrigger data-testid="leg-symbol">
+                    <SelectValue placeholder="Select symbol">{symbolName(leg.symbol_id)}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {symbols.map((s) => (
+                      <SelectItem key={s.symbol_id} value={String(s.symbol_id)}>
+                        {s.symbol}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="relative w-28">
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.5}
+                  value={leg.weightPct}
+                  onChange={(e) => setLeg(i, { weightPct: e.target.value })}
+                  placeholder="Weight"
+                  className="pr-6 text-right"
+                  data-testid="leg-weight"
+                />
+                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
+                  %
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeLeg(i)}
+                disabled={legs.length <= 1}
+                aria-label="Remove leg"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+
+          <Separator />
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">Total weight</span>
+              <span
+                className={
+                  weightCheck.valid
+                    ? "font-semibold tabular-nums text-emerald-600 dark:text-emerald-400"
+                    : "font-semibold tabular-nums text-amber-600 dark:text-amber-400"
+                }
+                data-testid="weight-total"
+              >
+                {totalPct.toLocaleString(undefined, { maximumFractionDigits: 2 })}% / 100%
+              </span>
+            </div>
+            <Progress value={Math.min(100, totalPct)} />
+            {weightCheck.hasDuplicateSymbol && (
+              <p className="flex items-center gap-1 text-xs text-rose-600 dark:text-rose-400">
+                <AlertTriangle className="h-3 w-3" /> A symbol is used more than once.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Rebalance */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Rebalance</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Cadence</Label>
+              <Select value={rebalance} onValueChange={(v) => setRebalance(v as RebalanceCadence)}>
+                <SelectTrigger data-testid="rebalance-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {REBALANCE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {rebalance === "threshold" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="s-threshold">Drift threshold %</Label>
+                <Input
+                  id="s-threshold"
+                  type="number"
+                  min={0.5}
+                  max={100}
+                  step={0.5}
+                  value={thresholdPct}
+                  onChange={(e) => setThresholdPct(e.target.value)}
+                />
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Terms + fees */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Terms &amp; fees</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="s-min">Minimum investment ($)</Label>
+              <Input
+                id="s-min"
+                type="number"
+                min={1}
+                step={1}
+                value={minInvest}
+                onChange={(e) => setMinInvest(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="s-cap">Max total AUM ($, blank = uncapped)</Label>
+              <Input
+                id="s-cap"
+                type="number"
+                min={0}
+                step={1000}
+                value={maxAum}
+                onChange={(e) => setMaxAum(e.target.value)}
+                placeholder="Uncapped"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="s-mgmt">Management fee (% of AUM / yr)</Label>
+              <Input
+                id="s-mgmt"
+                type="number"
+                min={0}
+                max={100}
+                step={0.25}
+                value={mgmtFeePct}
+                onChange={(e) => setMgmtFeePct(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">{formatBps(mgmtFeeBps)} annual on AUM.</p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="s-perf">Performance fee (% of profit)</Label>
+              <Input
+                id="s-perf"
+                type="number"
+                min={0}
+                max={100}
+                step={1}
+                value={perfFeePct}
+                onChange={(e) => setPerfFeePct(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">{formatBps(perfFeeBps)} of gains.</p>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border bg-muted/30 p-3">
+            <div>
+              <p className="text-sm font-medium">High-water mark</p>
+              <p className="text-xs text-muted-foreground">
+                Performance fee only on new profit above the prior peak.
+              </p>
+            </div>
+            <Switch checked={highWaterMark} onCheckedChange={setHighWaterMark} aria-label="High-water mark" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Redemption */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Redemption policy</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Redemptions</Label>
+            <Select value={redemptionType} onValueChange={(v) => setRedemptionType(v as RedemptionType)}>
+              <SelectTrigger data-testid="redemption-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="instant">Instant (redeem at NAV any time)</SelectItem>
+                <SelectItem value="notice">Notice period required</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {redemptionType === "notice" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="s-notice">Notice period (days)</Label>
+                <Input
+                  id="s-notice"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={noticeDays}
+                  onChange={(e) => setNoticeDays(e.target.value)}
+                />
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <Label htmlFor="s-lockup">Initial lock-up (days, 0 = none)</Label>
+              <Input
+                id="s-lockup"
+                type="number"
+                min={0}
+                step={1}
+                value={lockupDays}
+                onChange={(e) => setLockupDays(e.target.value)}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {errors.length > 0 && (
+        <ul className="list-inside list-disc space-y-0.5 rounded-lg border border-rose-300/50 bg-rose-50 p-3 text-xs text-rose-700 dark:border-rose-500/30 dark:bg-rose-950/40 dark:text-rose-300">
+          {errors.map((e) => (
+            <li key={e}>{e}</li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap gap-3">
+        <Button variant="outline" onClick={saveDraft} disabled={busy} data-testid="save-draft">
+          {busy ? "Saving…" : isEdit ? "Save draft" : "Create draft"}
+        </Button>
+        <Button onClick={() => setConfirmOpen(true)} disabled={!canSubmit} data-testid="publish-open">
+          Publish…
+        </Button>
+      </div>
+
+      {/* Money-safety publish confirm. */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Publish this strategy?</DialogTitle>
+            <DialogDescription>
+              Publishing opens the fund for real investment at NAV. Investors will subscribe under
+              these terms — review them carefully.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-sm">
+            <Row label="Name" value={name || "—"} />
+            <Row label="Legs" value={`${modelLegs.length} (weights ${totalPct.toFixed(0)}%)`} />
+            <Row label="Minimum investment" value={`$${(minInvestCents / 100).toLocaleString()}`} />
+            <Row label="Max AUM" value={maxAumCents > 0 ? `$${(maxAumCents / 100).toLocaleString()}` : "Uncapped"} />
+            <Row label="Management fee" value={`${formatBps(mgmtFeeBps)} / yr`} />
+            <Row label="Performance fee" value={`${formatBps(perfFeeBps)}${highWaterMark ? " (HWM)" : ""}`} />
+            <Row
+              label="Redemptions"
+              value={redemptionType === "notice" ? `${noticeDays}-day notice` : "Instant"}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={busy}>
+              Cancel
+            </Button>
+            <Button onClick={doPublish} disabled={busy} data-testid="publish-confirm">
+              {busy ? "Publishing…" : "Publish"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/pages/strategies/StrategyDetailPage.tsx
+++ b/frontend/src/pages/strategies/StrategyDetailPage.tsx
@@ -1,0 +1,601 @@
+import { useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { ArrowLeft, Boxes, FlaskConical, Pencil, Rocket, Lock } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Progress } from "@/components/ui/progress";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useAuthStore } from "@/stores/authStore";
+import { useSymbols } from "@/hooks/useMarketData";
+import {
+  useStrategy,
+  useStrategyNav,
+  useStrategyHoldings,
+  useStrategyPosition,
+  useStrategyFees,
+  useInvestStrategy,
+  useRedeemStrategy,
+  usePublishStrategy,
+} from "@/hooks/useStrategies";
+import type { Strategy, StrategyStatus } from "@/api/endpoints/strategies";
+import {
+  formatBps,
+  formatCents,
+  canInvest,
+  capacityFilledFraction,
+  unitsForInvestment,
+  proceedsForUnits,
+  type InvestBlockReason,
+} from "@/lib/strategies";
+import { PendingBackend, PooledNavNote } from "./PendingBackend";
+
+const STATUS_VARIANT: Record<StrategyStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "outline",
+  paper: "secondary",
+  published: "default",
+  closed: "destructive",
+};
+
+function shortSub(sub: string | undefined): string {
+  if (!sub) return "—";
+  return sub.length > 12 ? `${sub.slice(0, 6)}…${sub.slice(-4)}` : sub;
+}
+
+const BLOCK_COPY: Record<InvestBlockReason, string> = {
+  amount_non_positive: "Enter an amount to invest.",
+  below_min: "Amount is below the fund's minimum investment.",
+  over_capacity: "Amount exceeds the fund's remaining capacity.",
+};
+
+export default function StrategyDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const userId = useAuthStore((s) => s.userId);
+
+  const strategyQ = useStrategy(id);
+  const navQ = useStrategyNav(id);
+  const holdingsQ = useStrategyHoldings(id);
+  const positionQ = useStrategyPosition(id);
+  const feesQ = useStrategyFees(id);
+  const symbolsQ = useSymbols();
+
+  const invest = useInvestStrategy(id);
+  const redeem = useRedeemStrategy(id);
+  const publish = usePublishStrategy(id);
+
+  const strategy: Strategy | undefined = strategyQ.data;
+  const isCreator = !!strategy && !!userId && strategy.creator_sub === userId;
+  const isDraft = strategy?.status === "draft";
+  const isPublished = strategy?.status === "published";
+
+  const symName = (sid: number) =>
+    symbolsQ.data?.symbols.find((s) => s.symbol_id === sid)?.symbol ?? `#${sid}`;
+
+  const [tab, setTab] = useState("overview");
+  const [investAmt, setInvestAmt] = useState("");
+  const [investConfirm, setInvestConfirm] = useState(false);
+  const [redeemUnits, setRedeemUnits] = useState("");
+  const [redeemConfirm, setRedeemConfirm] = useState(false);
+  const [publishConfirm, setPublishConfirm] = useState(false);
+
+  // -- NAV / capacity --------------------------------------------------
+  const navCents = navQ.data?.nav_per_unit ?? strategy?.nav_per_unit ?? 0;
+  const aumCents = navQ.data?.aum_cents ?? strategy?.aum_cents ?? 0;
+  const capCents = strategy?.max_aum_cents ?? 0;
+  const capFilled = capacityFilledFraction(aumCents, capCents);
+
+  // -- Invest math + validation ---------------------------------------
+  const investCents = useMemo(() => {
+    const n = Number(investAmt);
+    return Number.isFinite(n) && n > 0 ? Math.round(n * 100) : 0;
+  }, [investAmt]);
+  const investCheck = useMemo(
+    () => canInvest(investCents, strategy?.min_investment_cents ?? 0, aumCents, capCents),
+    [investCents, strategy?.min_investment_cents, aumCents, capCents],
+  );
+  const estUnits = useMemo(() => unitsForInvestment(investCents, navCents), [investCents, navCents]);
+
+  // -- Redeem math -----------------------------------------------------
+  const position = positionQ.data;
+  const redeemUnitsN = Number(redeemUnits);
+  const redeemProceeds = useMemo(
+    () => proceedsForUnits(redeemUnitsN > 0 ? redeemUnitsN : 0, position?.nav_per_unit ?? navCents),
+    [redeemUnitsN, position?.nav_per_unit, navCents],
+  );
+  const redeemTooMany = position != null && redeemUnitsN > position.units;
+
+  const doInvest = async () => {
+    try {
+      const res = await invest.mutateAsync({ amount_cents: investCents });
+      setInvestConfirm(false);
+      setInvestAmt("");
+      toast.success(`Invested — received ${res.units.toLocaleString(undefined, { maximumFractionDigits: 4 })} units at ${formatCents(res.nav_per_unit)}.`);
+    } catch {
+      /* hook toasts */
+    }
+  };
+
+  const doRedeem = async () => {
+    try {
+      const res = await redeem.mutateAsync({ units: redeemUnitsN });
+      setRedeemConfirm(false);
+      setRedeemUnits("");
+      toast.success(`Redemption submitted — proceeds ${formatCents(res.proceeds_cents)}.`);
+    } catch {
+      /* hook toasts */
+    }
+  };
+
+  const doPublish = async () => {
+    try {
+      await publish.mutateAsync();
+      setPublishConfirm(false);
+      toast.success("Strategy published.");
+    } catch {
+      /* hook toasts */
+    }
+  };
+
+  const header = useMemo(() => {
+    if (strategyQ.isLoading) return <Skeleton className="h-9 w-64" />;
+    if (!strategy) return <h1 className="text-2xl font-bold tracking-tight">Strategy</h1>;
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <Boxes className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold tracking-tight">{strategy.name}</h1>
+        <Badge variant={STATUS_VARIANT[strategy.status] ?? "outline"}>{strategy.status}</Badge>
+        {isCreator && <Badge variant="outline">Creator view</Badge>}
+      </div>
+    );
+  }, [strategyQ.isLoading, strategy, isCreator]);
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-6 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="icon">
+            <Link to="/strategies" aria-label="Back to strategies">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          {header}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to={`/strategies/${encodeURIComponent(id ?? "")}/backtest`}>
+              <FlaskConical className="mr-1 h-4 w-4" /> Paper &amp; backtest
+            </Link>
+          </Button>
+          {isCreator && isDraft && (
+            <>
+              <Button asChild variant="outline" size="sm">
+                <Link to={`/strategies/${encodeURIComponent(id ?? "")}/edit`}>
+                  <Pencil className="mr-1 h-4 w-4" /> Edit
+                </Link>
+              </Button>
+              <Button size="sm" onClick={() => setPublishConfirm(true)} data-testid="detail-publish">
+                <Rocket className="mr-1 h-4 w-4" /> Publish
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {strategyQ.isError ? (
+        <PendingBackend label="This strategy" />
+      ) : (
+        <>
+          <PooledNavNote />
+
+          {strategy && (
+            <Card>
+              <CardContent className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-4">
+                <Stat label="NAV / unit" value={navCents > 0 ? formatCents(navCents) : "—"} />
+                <Stat label="AUM" value={aumCents > 0 ? formatCents(aumCents) : "—"} />
+                <Stat label="Investors" value={strategy.investor_count != null ? String(strategy.investor_count) : "—"} />
+                <Stat
+                  label="Since inception"
+                  value={
+                    strategy.inception_return_bps != null
+                      ? `${strategy.inception_return_bps >= 0 ? "+" : ""}${formatBps(strategy.inception_return_bps)}`
+                      : "—"
+                  }
+                />
+              </CardContent>
+            </Card>
+          )}
+
+          {strategy?.description && (
+            <p className="text-sm text-muted-foreground">{strategy.description}</p>
+          )}
+
+          <Tabs value={tab} onValueChange={setTab}>
+            <TabsList>
+              <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="invest">Invest</TabsTrigger>
+              <TabsTrigger value="position">My position</TabsTrigger>
+              {isCreator && <TabsTrigger value="fees">Fee accrual</TabsTrigger>}
+            </TabsList>
+
+            {/* Overview: holdings + fee schedule */}
+            <TabsContent value="overview" className="space-y-4 pt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Holdings / composition</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {holdingsQ.isLoading ? (
+                    <Skeleton className="h-24 w-full" />
+                  ) : holdingsQ.isError ? (
+                    strategy && strategy.legs?.length ? (
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Symbol</TableHead>
+                            <TableHead className="text-right">Target weight</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {strategy.legs.map((l) => (
+                            <TableRow key={l.symbol_id}>
+                              <TableCell className="font-medium">{symName(l.symbol_id)}</TableCell>
+                              <TableCell className="text-right tabular-nums">{formatBps(l.weight_bps)}</TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    ) : (
+                      <PendingBackend label="Live holdings" />
+                    )
+                  ) : (
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Symbol</TableHead>
+                          <TableHead className="text-right">Weight</TableHead>
+                          <TableHead className="text-right">Value</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {(holdingsQ.data?.legs ?? []).map((l) => (
+                          <TableRow key={l.symbol_id}>
+                            <TableCell className="font-medium">{symName(l.symbol_id)}</TableCell>
+                            <TableCell className="text-right tabular-nums">{formatBps(l.weight_bps)}</TableCell>
+                            <TableCell className="text-right tabular-nums">{formatCents(l.value_cents)}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Fee schedule &amp; terms</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm">
+                  {strategy && (
+                    <>
+                      <Row label="Management fee (annual, on AUM)" value={formatBps(strategy.mgmt_fee_bps)} />
+                      <Row
+                        label="Performance fee (on profit)"
+                        value={`${formatBps(strategy.perf_fee_bps)}${strategy.high_water_mark ? " · high-water mark" : ""}`}
+                      />
+                      <Row label="Minimum investment" value={formatCents(strategy.min_investment_cents)} />
+                      <Row
+                        label="Maximum AUM (capacity)"
+                        value={strategy.max_aum_cents > 0 ? formatCents(strategy.max_aum_cents) : "Uncapped"}
+                      />
+                      <Row
+                        label="Redemptions"
+                        value={
+                          strategy.redemption?.type === "notice"
+                            ? `${strategy.redemption.notice_days ?? 0}-day notice`
+                            : "Instant (at NAV)"
+                        }
+                      />
+                      {(strategy.redemption?.lockup_days ?? 0) > 0 && (
+                        <Row label="Initial lock-up" value={`${strategy.redemption.lockup_days} days`} />
+                      )}
+                      <Row label="Rebalance" value={strategy.rebalance} />
+                      <Row label="Creator" value={shortSub(strategy.creator_sub)} />
+                    </>
+                  )}
+                  {capCents > 0 && (
+                    <div className="pt-2">
+                      <div className="mb-1 flex justify-between text-xs text-muted-foreground">
+                        <span>Capacity used</span>
+                        <span className="tabular-nums">{Math.round(capFilled * 100)}%</span>
+                      </div>
+                      <Progress value={capFilled * 100} />
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            {/* Invest */}
+            <TabsContent value="invest" className="pt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Invest at NAV</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {!isPublished && (
+                    <p className="flex items-center gap-2 rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/40 dark:text-amber-300">
+                      <Lock className="h-3.5 w-3.5" /> This fund is not open for investment yet (status: {strategy?.status}).
+                    </p>
+                  )}
+                  <div className="space-y-1.5">
+                    <Label htmlFor="invest-amt">Amount to invest ($)</Label>
+                    <Input
+                      id="invest-amt"
+                      type="number"
+                      min={0}
+                      step={10}
+                      value={investAmt}
+                      onChange={(e) => setInvestAmt(e.target.value)}
+                      placeholder={strategy ? String((strategy.min_investment_cents ?? 0) / 100) : "0"}
+                      disabled={!isPublished}
+                      data-testid="invest-amount"
+                    />
+                    <div className="flex flex-wrap justify-between gap-2 text-xs text-muted-foreground">
+                      <span>Minimum {formatCents(strategy?.min_investment_cents ?? 0)}</span>
+                      <span>
+                        Capacity left{" "}
+                        {Number.isFinite(investCheck.capacityRemainingCents)
+                          ? formatCents(investCheck.capacityRemainingCents)
+                          : "uncapped"}
+                      </span>
+                    </div>
+                  </div>
+
+                  {investCents > 0 && (
+                    <div className="rounded-lg border bg-muted/30 p-3 text-sm">
+                      <Row label="NAV / unit" value={navCents > 0 ? formatCents(navCents) : "—"} />
+                      <Row
+                        label="Estimated units"
+                        value={navCents > 0 ? estUnits.toLocaleString(undefined, { maximumFractionDigits: 4 }) : "—"}
+                      />
+                    </div>
+                  )}
+
+                  {investCents > 0 && !investCheck.ok && investCheck.reason && (
+                    <p className="text-xs text-rose-600 dark:text-rose-400">{BLOCK_COPY[investCheck.reason]}</p>
+                  )}
+
+                  <Button
+                    className="w-full"
+                    disabled={!isPublished || !investCheck.ok || invest.isPending}
+                    onClick={() => setInvestConfirm(true)}
+                    data-testid="invest-review"
+                  >
+                    Review &amp; invest
+                  </Button>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            {/* My position + redeem */}
+            <TabsContent value="position" className="pt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">My position</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {positionQ.isLoading ? (
+                    <Skeleton className="h-24 w-full" />
+                  ) : positionQ.isError ? (
+                    <PendingBackend label="Your position" />
+                  ) : !position || position.units <= 0 ? (
+                    <p className="text-sm text-muted-foreground">You have no position in this fund yet.</p>
+                  ) : (
+                    <>
+                      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                        <Stat label="Units" value={position.units.toLocaleString(undefined, { maximumFractionDigits: 4 })} />
+                        <Stat label="NAV / unit" value={formatCents(position.nav_per_unit)} />
+                        <Stat label="Invested" value={formatCents(position.invested_cents)} />
+                        <Stat label="Current value" value={formatCents(position.current_value_cents)} />
+                        <Stat
+                          label="Unrealized P&L"
+                          value={`${position.unrealized_pnl_cents >= 0 ? "+" : ""}${formatCents(position.unrealized_pnl_cents)}`}
+                          tone={position.unrealized_pnl_cents >= 0 ? "pos" : "neg"}
+                        />
+                        <Stat label="Fees paid" value={formatCents(position.fees_paid_cents)} />
+                      </div>
+
+                      <Separator />
+
+                      <div className="space-y-1.5">
+                        <Label htmlFor="redeem-units">Redeem units</Label>
+                        <Input
+                          id="redeem-units"
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={redeemUnits}
+                          onChange={(e) => setRedeemUnits(e.target.value)}
+                          placeholder={String(position.units)}
+                          data-testid="redeem-units"
+                        />
+                        <div className="flex justify-between text-xs text-muted-foreground">
+                          <span>
+                            {strategy?.redemption?.type === "notice"
+                              ? `Redemptions require ${strategy.redemption.notice_days ?? 0} days' notice.`
+                              : "Instant redemption at NAV."}
+                          </span>
+                          <span className="tabular-nums">Est. {formatCents(redeemProceeds)}</span>
+                        </div>
+                        {redeemTooMany && (
+                          <p className="text-xs text-rose-600 dark:text-rose-400">
+                            You only hold {position.units.toLocaleString(undefined, { maximumFractionDigits: 4 })} units.
+                          </p>
+                        )}
+                      </div>
+                      <Button
+                        variant="outline"
+                        disabled={!(redeemUnitsN > 0) || redeemTooMany || redeem.isPending}
+                        onClick={() => setRedeemConfirm(true)}
+                        data-testid="redeem-review"
+                      >
+                        Review redemption
+                      </Button>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            {/* Creator fee accrual */}
+            {isCreator && (
+              <TabsContent value="fees" className="pt-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Fee accrual (creator)</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {feesQ.isLoading ? (
+                      <Skeleton className="h-20 w-full" />
+                    ) : feesQ.isError ? (
+                      <PendingBackend label="Fee accrual" />
+                    ) : feesQ.data ? (
+                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                        <Stat label="Management accrued" value={formatCents(feesQ.data.mgmt_accrued_cents)} />
+                        <Stat label="Performance accrued" value={formatCents(feesQ.data.perf_accrued_cents)} />
+                        <Stat label="High-water mark" value={formatCents(feesQ.data.high_water_mark)} />
+                      </div>
+                    ) : (
+                      <PendingBackend label="Fee accrual" />
+                    )}
+                  </CardContent>
+                </Card>
+              </TabsContent>
+            )}
+          </Tabs>
+        </>
+      )}
+
+      {/* Invest money-safety confirm */}
+      <Dialog open={investConfirm} onOpenChange={setInvestConfirm}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm investment</DialogTitle>
+            <DialogDescription>
+              You are subscribing real capital to a pooled NAV fund. Units are issued at the current NAV.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-sm">
+            <Row label="Amount" value={formatCents(investCents)} />
+            <Row label="NAV / unit" value={navCents > 0 ? formatCents(navCents) : "—"} />
+            <Row label="Estimated units" value={estUnits.toLocaleString(undefined, { maximumFractionDigits: 4 })} />
+            <Separator />
+            <Row label="Management fee" value={`${formatBps(strategy?.mgmt_fee_bps ?? 0)} / yr`} />
+            <Row label="Performance fee" value={formatBps(strategy?.perf_fee_bps ?? 0)} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setInvestConfirm(false)} disabled={invest.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={doInvest} disabled={invest.isPending} data-testid="invest-confirm">
+              {invest.isPending ? "Investing…" : `Invest ${formatCents(investCents)}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Redeem confirm */}
+      <Dialog open={redeemConfirm} onOpenChange={setRedeemConfirm}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm redemption</DialogTitle>
+            <DialogDescription>
+              {strategy?.redemption?.type === "notice"
+                ? `This fund settles redemptions after a ${strategy.redemption.notice_days ?? 0}-day notice period.`
+                : "Units are redeemed at the current NAV."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-sm">
+            <Row label="Units" value={redeemUnitsN.toLocaleString(undefined, { maximumFractionDigits: 4 })} />
+            <Row label="NAV / unit" value={formatCents(position?.nav_per_unit ?? navCents)} />
+            <Separator />
+            <Row label="Estimated proceeds" value={formatCents(redeemProceeds)} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRedeemConfirm(false)} disabled={redeem.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={doRedeem} disabled={redeem.isPending} data-testid="redeem-confirm">
+              {redeem.isPending ? "Redeeming…" : "Redeem"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Publish confirm (creator) */}
+      <Dialog open={publishConfirm} onOpenChange={setPublishConfirm}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Publish this strategy?</DialogTitle>
+            <DialogDescription>
+              Publishing opens the fund for real investment at NAV under its current terms.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPublishConfirm(false)} disabled={publish.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={doPublish} disabled={publish.isPending} data-testid="publish-confirm-detail">
+              {publish.isPending ? "Publishing…" : "Publish"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "pos" | "neg" }) {
+  const cls =
+    tone === "pos"
+      ? "text-emerald-600 dark:text-emerald-400"
+      : tone === "neg"
+        ? "text-rose-600 dark:text-rose-400"
+        : "";
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={`mt-0.5 font-semibold tabular-nums ${cls}`}>{value}</p>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/pages/strategies/StrategyMarketPage.tsx
+++ b/frontend/src/pages/strategies/StrategyMarketPage.tsx
@@ -1,0 +1,208 @@
+import { Link } from "react-router-dom";
+import { Boxes, Plus, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useStrategyMarket, useMyStrategies } from "@/hooks/useStrategies";
+import type { Strategy, StrategyStatus } from "@/api/endpoints/strategies";
+import { formatBps, formatCents, capacityFilledFraction } from "@/lib/strategies";
+import { PendingBackend, PooledNavNote } from "./PendingBackend";
+
+const STATUS_VARIANT: Record<StrategyStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "outline",
+  paper: "secondary",
+  published: "default",
+  closed: "destructive",
+};
+
+function StatusBadge({ status }: { status: StrategyStatus }) {
+  return <Badge variant={STATUS_VARIANT[status] ?? "outline"}>{status}</Badge>;
+}
+
+function capacityRemaining(s: Strategy): string {
+  if (!(s.max_aum_cents > 0)) return "Uncapped";
+  const filled = capacityFilledFraction(s.aum_cents ?? 0, s.max_aum_cents);
+  const remaining = Math.max(0, s.max_aum_cents - (s.aum_cents ?? 0));
+  return `${formatCents(remaining)} (${Math.round((1 - filled) * 100)}%)`;
+}
+
+function MarketTable({ strategies }: { strategies: Strategy[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead className="text-right">NAV / unit</TableHead>
+          <TableHead className="text-right">AUM</TableHead>
+          <TableHead className="text-right">Fees (mgmt / perf)</TableHead>
+          <TableHead className="text-right">Capacity left</TableHead>
+          <TableHead className="text-right">Since inception</TableHead>
+          <TableHead className="w-16" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {strategies.map((s) => (
+          <TableRow key={s.strategy_id} data-testid="strategy-row">
+            <TableCell className="max-w-[16rem]">
+              <div className="truncate font-medium">{s.name}</div>
+              <div className="text-xs text-muted-foreground">{s.kind === "rule" ? "Rule-based" : "Basket"}</div>
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {s.nav_per_unit != null ? formatCents(s.nav_per_unit) : "—"}
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {s.aum_cents != null ? formatCents(s.aum_cents) : "—"}
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {formatBps(s.mgmt_fee_bps)} / {formatBps(s.perf_fee_bps)}
+            </TableCell>
+            <TableCell className="text-right tabular-nums">{capacityRemaining(s)}</TableCell>
+            <TableCell className="text-right tabular-nums">
+              {s.inception_return_bps != null ? (
+                <span
+                  className={
+                    s.inception_return_bps >= 0
+                      ? "text-emerald-600 dark:text-emerald-400"
+                      : "text-rose-600 dark:text-rose-400"
+                  }
+                >
+                  {s.inception_return_bps >= 0 ? "+" : ""}
+                  {formatBps(s.inception_return_bps)}
+                </span>
+              ) : (
+                "—"
+              )}
+            </TableCell>
+            <TableCell>
+              <Button asChild variant="ghost" size="sm">
+                <Link to={`/strategies/${encodeURIComponent(s.strategy_id)}`}>View</Link>
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function MineTable({ strategies }: { strategies: Strategy[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Legs</TableHead>
+          <TableHead className="text-right">Min invest</TableHead>
+          <TableHead className="w-16" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {strategies.map((s) => (
+          <TableRow key={s.strategy_id} data-testid="my-strategy-row">
+            <TableCell className="max-w-[16rem] truncate font-medium">{s.name}</TableCell>
+            <TableCell>
+              <StatusBadge status={s.status} />
+            </TableCell>
+            <TableCell className="text-right tabular-nums">{s.legs?.length ?? 0}</TableCell>
+            <TableCell className="text-right tabular-nums">{formatCents(s.min_investment_cents)}</TableCell>
+            <TableCell>
+              <Button asChild variant="ghost" size="sm">
+                <Link to={`/strategies/${encodeURIComponent(s.strategy_id)}`}>Open</Link>
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export default function StrategyMarketPage() {
+  const market = useStrategyMarket();
+  const mine = useMyStrategies();
+
+  const marketStrategies = market.data?.strategies ?? [];
+  const myStrategies = mine.data?.strategies ?? [];
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Boxes className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Strategies &amp; Baskets</h1>
+            <p className="text-sm text-muted-foreground">
+              Investable funds — a basket of target weights you can paper-trade, backtest, then
+              invest in at NAV.
+            </p>
+          </div>
+        </div>
+        <Button asChild data-testid="new-strategy-cta">
+          <Link to="/strategies/new">
+            <Plus className="mr-1.5 h-4 w-4" /> Create a strategy
+          </Link>
+        </Button>
+      </div>
+
+      <PooledNavNote />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Marketplace — published funds</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {market.isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ) : market.isError ? (
+            <PendingBackend label="The strategy marketplace" />
+          ) : marketStrategies.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+              No strategies are published yet. Be the first to{" "}
+              <Link to="/strategies/new" className="font-medium text-primary underline-offset-4 hover:underline">
+                create one
+              </Link>
+              .
+            </div>
+          ) : (
+            <MarketTable strategies={marketStrategies} />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <FileText className="h-4 w-4" /> My strategies
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {mine.isLoading ? (
+            <Skeleton className="h-8 w-full" />
+          ) : mine.isError ? (
+            <PendingBackend label="Your strategies" />
+          ) : myStrategies.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              You haven&rsquo;t created any strategies yet.
+            </div>
+          ) : (
+            <MineTable strategies={myStrategies} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## User-created strategies / baskets — investable funds (frontend, degrade-on-404)

A marketplace of user-authored strategies: a creator defines a **basket** (target weights + rule set); others **paper-trade** it, view its **backtest**, then **invest**. Creator sets **min investment**, **max AUM** (capacity), **redemption/profit-taking policy**, and a **dual fee** — management fee on AUM + performance fee on profit with a **high-water mark**.

**Model (locked, labelled in-UI, flippable):** pooled fund with **NAV units** — investors subscribe/redeem at NAV, own units (not copy/replication).

**Reuses shipped code:** the **paper engine** (#222/#223/#225) for the paper-run, and the **`/analysis` stats + market history** (#227) for a client-side basket backtest.

### API contract (none deployed; reads degrade-on-404, mutations error clearly)
`POST/GET/PUT /me/strategies[/{id}[/publish|nav|holdings|invest|redeem|position|fees]]` · `GET /me/strategies/market`.

### Web (`/strategies` route tree, "Strategies" nav)
`lib/strategies.ts` (+22 vitest) — NAV unit math, dual-fee accrual w/ HWM, weight validation, min-size/capacity, basket backtest via `marketStats`; `api/endpoints/strategies.ts` + `hooks/useStrategies.ts`; pages: Market, Builder (leg editor + 100% validation + params + dual fee + HWM + redemption; publish confirm), Backtest (client-side basket backtest + paper-run), Detail (NAV/holdings/fees + pooled-NAV note, invest w/ min-size+capacity validation, investor position, redeem, creator fee panel).

### Android (new `feature/strategies` + `data/strategies`, registered in `MoreRoutes`)
`StrategyMath.kt` (+15 JVM tests) + typed `StrategiesApi/Dtos/Domain/Mappers/Repository/DataModule`; Market / Builder / Paper(backtest) / Detail Compose screens + Hilt ViewModels; `MoreCatalog` + `MoreRoutes.REGISTERED` + `AuthenticatedGraph`.

No new deps. Gates: web tsc 0 · vite build · vitest 22/22; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (StrategyMath 15/15, MoreCatalog 6/6).

### Backend (tracked in exchange_missing_features.md)
Strategy rules engine, pooled execution + rebalance, per-investor NAV/unit accounting (subscribe/redeem at NAV, HWM), fee accrual + crystallization (AUM daily + performance carry), capacity + min-size enforcement, paper-vs-live mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
