### PR TITLE
feat(invest): unified Discover/Invest hub (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokenDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokenDtos.kt
@@ -89,6 +89,12 @@ data class TokenAuctionDto(
     @Json(name = "bids") val bids: List<TokenBidDto>? = null,
 )
 
+/** `GET me/tokens/auctions` -> the open IPO auctions feed. Optional endpoint (degrade-on-404). */
+@JsonClass(generateAdapter = true)
+data class TokenAuctionListDto(
+    @Json(name = "auctions") val auctions: List<TokenAuctionDto>? = null,
+)
+
 /** `POST me/tokens/{id}/auction/bid` body. */
 @JsonClass(generateAdapter = true)
 data class PlaceBidRequestDto(

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokenMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokenMappers.kt
@@ -78,6 +78,10 @@ fun TokenAuctionDto.toDomain(fallbackId: String): TokenAuction = TokenAuction(
     bids = bids.orEmpty().map { it.toDomain() },
 )
 
+/** Map the open-auctions feed; each row falls back to its own token_id when present, else blank. */
+fun TokenAuctionListDto.toDomain(): List<TokenAuction> =
+    auctions.orEmpty().map { it.toDomain(it.tokenId.orEmpty()) }
+
 fun TokenDistributionDto.toDomain(): TokenDistribution = TokenDistribution(
     ts = ts ?: 0L,
     totalAmount = totalAmount ?: 0L,

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokensApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokensApi.kt
@@ -29,6 +29,13 @@ interface TokensApi {
     @GET("me/tokens/market")
     suspend fun getMarket(): TokenListDto
 
+    /**
+     * OPEN IPO token auctions (the discovery feed of tokens currently raising via a sealed-bid IPO).
+     * OPTIONAL / not deployed on every backend: the [TokensRepository] degrades a 404 to an empty list.
+     */
+    @GET("me/tokens/auctions")
+    suspend fun getOpenAuctions(): TokenAuctionListDto
+
     @GET("me/tokens/{id}")
     suspend fun getToken(@Path("id") id: String): TokenDto
 

--- a/android/app/src/main/java/com/testlogon/android/data/tokens/TokensRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tokens/TokensRepository.kt
@@ -28,6 +28,9 @@ interface TokensRepository {
     /** Listed tokens to browse — the market (degrades to empty). */
     suspend fun market(): ApiResult<List<Token>>
 
+    /** Open IPO token auctions (the discovery feed; OPTIONAL endpoint, degrades to empty on 404). */
+    suspend fun openAuctions(): ApiResult<List<TokenAuction>>
+
     /** A single token by id (degrades to null when absent/undeployed). */
     suspend fun token(id: String): ApiResult<Token?>
 
@@ -66,6 +69,10 @@ class TokensRepositoryImpl @Inject constructor(
 
     override suspend fun market(): ApiResult<List<Token>> = withContext(io) {
         degradeToEmpty(emptyList()) { api.getMarket().toDomain() }
+    }
+
+    override suspend fun openAuctions(): ApiResult<List<TokenAuction>> = withContext(io) {
+        degradeToEmpty(emptyList()) { api.getOpenAuctions().toDomain() }
     }
 
     override suspend fun token(id: String): ApiResult<Token?> = withContext(io) {

--- a/android/app/src/main/java/com/testlogon/android/feature/invest/InvestMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/invest/InvestMath.kt
@@ -1,0 +1,125 @@
+package com.testlogon.android.feature.invest
+
+import kotlin.math.abs
+
+/**
+ * PURE, dependency-free logic for the unified INVEST hub. Everything here is deterministic over plain
+ * inputs (no Android, no coroutines, no repositories) so it is exhaustively unit-testable (see
+ * InvestMathTest). The ViewModel maps its heterogeneous repository domain models down to the
+ * normalized [InvestItem] shape, then leans on these functions for search + ranking.
+ *
+ * The hub aggregates five investable/tradeable product classes that each already live in their own
+ * screen: exchange markets, creator revenue-share tokens, strategy funds, staking, and open
+ * opportunities (IPO token auctions / bailout rescue auctions / peer stake+auction discovery). By
+ * collapsing them all to [InvestItem] the UI renders one uniform card and one search box filters
+ * across every section at once.
+ */
+
+/** The product class an [InvestItem] belongs to — drives its section + which detail route it opens. */
+enum class InvestKind {
+    MARKET,
+    TOKEN,
+    STRATEGY,
+    STAKING,
+    OPPORTUNITY,
+}
+
+/**
+ * A normalized, render-ready row for ANY investable product. Kept intentionally flat so a single card
+ * composable can present a market, a token, a strategy fund, a staking provider, or an opportunity
+ * without branching.
+ *
+ * @property kind which product class this is (also selects the section).
+ * @property id the stable per-kind identifier (symbolId as string, tokenId, strategyId, provider id, ...).
+ * @property title the primary label (ticker / name).
+ * @property subtitle the secondary label (full name / descriptor); may be blank.
+ * @property metric a short headline metric string already formatted for display (may be blank).
+ * @property route the in-app navigation route this item opens (blank = not navigable on its own).
+ * @property sortKey a numeric key the ranking helpers sort DESC by (e.g. |change|, return bps, AUM,
+ *   capacity-remaining fraction scaled). Higher = more prominent. Defaults to 0.
+ * @property searchText extra lowercase text folded into search matching beyond title/subtitle (e.g. a
+ *   ticker distinct from the title, a chain/asset name). Kept lowercase to avoid per-query work.
+ */
+data class InvestItem(
+    val kind: InvestKind,
+    val id: String,
+    val title: String,
+    val subtitle: String = "",
+    val metric: String = "",
+    val route: String = "",
+    val sortKey: Double = 0.0,
+    val searchText: String = "",
+)
+
+object InvestMath {
+
+    /** Normalize a query for matching: trimmed + lowercased. */
+    fun normalizeQuery(query: String): String = query.trim().lowercase()
+
+    /**
+     * Whether [item] matches [query] (heterogeneous search across symbol/token/strategy/etc). A blank
+     * query matches everything. Matching is a case-insensitive substring test over the title, subtitle,
+     * id, and the item's extra [InvestItem.searchText] (ticker/name/chain/asset). This is the single
+     * definition of "matches" the ViewModel uses so every section filters consistently.
+     */
+    fun matches(item: InvestItem, query: String): Boolean {
+        val q = normalizeQuery(query)
+        if (q.isEmpty()) return true
+        val hay = buildString {
+            append(item.title.lowercase()); append(' ')
+            append(item.subtitle.lowercase()); append(' ')
+            append(item.id.lowercase()); append(' ')
+            append(item.searchText)
+        }
+        return hay.contains(q)
+    }
+
+    /** Filter a list to the items matching [query] (order preserved). */
+    fun filter(items: List<InvestItem>, query: String): List<InvestItem> =
+        items.filter { matches(it, query) }
+
+    /**
+     * Rank DESC by [InvestItem.sortKey] (highest first), tie-broken by title then id for a STABLE,
+     * deterministic order. Used to surface top movers / best-returning strategies / largest funds /
+     * most-open-capacity first within a section.
+     */
+    fun rankBySortKey(items: List<InvestItem>): List<InvestItem> =
+        items.sortedWith(
+            compareByDescending<InvestItem> { it.sortKey }
+                .thenBy { it.title.lowercase() }
+                .thenBy { it.id },
+        )
+
+    /** Take the top [n] after ranking DESC by sort key (n <= 0 -> empty). */
+    fun topN(items: List<InvestItem>, n: Int): List<InvestItem> =
+        if (n <= 0) emptyList() else rankBySortKey(items).take(n)
+
+    // ---- Numeric sort-key helpers (one definition per ranking dimension) ----
+
+    /** Top-movers key: absolute value of a percent change (null change -> 0, never negative). */
+    fun moverKey(changePct: Double?): Double = abs(changePct ?: 0.0)
+
+    /** Strategy-by-return key: inception return in bps as a Double (null -> 0; negatives allowed). */
+    fun returnKey(inceptionReturnBps: Int?): Double = (inceptionReturnBps ?: 0).toDouble()
+
+    /** Size key: AUM in cents as a Double (null -> 0). Larger funds rank first. */
+    fun aumKey(aumCents: Long?): Double = (aumCents ?: 0L).toDouble()
+
+    /**
+     * Capacity-remaining FRACTION of a capped fund: remaining / max, clamped to [0,1]. Returns null
+     * when there is no cap (maxAumCents <= 0) so the caller can treat "uncapped" distinctly from
+     * "full". A higher fraction = more room to invest.
+     */
+    fun capacityRemainingFraction(maxAumCents: Long, aumCents: Long?): Double? {
+        if (maxAumCents <= 0L) return null
+        val used = (aumCents ?: 0L).coerceAtLeast(0L)
+        val remaining = (maxAumCents - used).coerceAtLeast(0L)
+        return (remaining.toDouble() / maxAumCents.toDouble()).coerceIn(0.0, 1.0)
+    }
+
+    /**
+     * The grand-total count across a set of section item-lists — powers the hub header ("N products")
+     * and the honest "nothing matches your search" empty state.
+     */
+    fun totalCount(sections: List<List<InvestItem>>): Int = sections.sumOf { it.size }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/invest/InvestScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/invest/InvestScreen.kt
@@ -1,0 +1,248 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.invest
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+
+/**
+ * The unified INVEST hub — one front door aggregating every investable/tradeable product (markets,
+ * creator tokens, strategy funds, staking, and open opportunities). A single search box filters ALL
+ * sections live; each section is a horizontally-scrollable card row with a "See all" into its existing
+ * screen. Sections degrade INDEPENDENTLY to an honest "pending backend" note on 404.
+ *
+ * [onOpenRoute] navigates to any resolved in-app route (detail screens + the per-section "see all").
+ */
+@Composable
+fun InvestRoute(
+    onBack: () -> Unit,
+    onOpenRoute: (route: String) -> Unit,
+    viewModel: InvestViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Invest") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            InvestUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            InvestUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Something went wrong.",
+                onRetry = viewModel::onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            InvestUiState.Phase.Content -> InvestContent(
+                state = state,
+                onQueryChange = viewModel::onQueryChange,
+                onOpenRoute = onOpenRoute,
+                contentPadding = padding,
+            )
+        }
+    }
+}
+
+@Composable
+private fun InvestContent(
+    state: InvestUiState,
+    onQueryChange: (String) -> Unit,
+    onOpenRoute: (String) -> Unit,
+    contentPadding: PaddingValues,
+) {
+    val sections = listOf(
+        "Markets" to state.markets,
+        "Creator Tokens" to state.tokens,
+        "Strategy Funds" to state.strategies,
+        "Staking" to state.staking,
+        "Opportunities" to state.opportunities,
+    )
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .testTag("invest_list"),
+        contentPadding = PaddingValues(vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        item {
+            OutlinedTextField(
+                value = state.query,
+                onValueChange = onQueryChange,
+                singleLine = true,
+                leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
+                placeholder = { Text("Search markets, tokens, funds…") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .testTag("invest_search"),
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "${state.totalCount} products",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+        }
+
+        if (state.noSearchResults) {
+            item {
+                Box(Modifier.fillMaxWidth().padding(24.dp), contentAlignment = Alignment.Center) {
+                    EmptyState(title = "No matches", body = "Nothing matches \"${state.query}\".")
+                }
+            }
+        } else {
+            sections.forEach { (title, section) ->
+                val visible = state.visibleItems(section)
+                // Hide a section entirely once a search filters it to nothing (keeps results tight),
+                // but with a blank query show every section (incl. its honest pending note).
+                if (state.query.isBlank() || visible.isNotEmpty()) {
+                    item(key = "section_${section.kind}") {
+                        InvestSection(
+                            title = title,
+                            items = visible,
+                            pending = section.pending,
+                            seeAllRoute = section.seeAllRoute,
+                            onOpenRoute = onOpenRoute,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InvestSection(
+    title: String,
+    items: List<InvestItem>,
+    pending: Boolean,
+    seeAllRoute: String,
+    onOpenRoute: (String) -> Unit,
+) {
+    Column(Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (seeAllRoute.isNotBlank()) {
+                TextButton(
+                    onClick = { onOpenRoute(seeAllRoute) },
+                    modifier = Modifier.testTag("invest_seeall_$title"),
+                ) { Text("See all") }
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        when {
+            items.isEmpty() && pending -> Text(
+                text = "Pending backend — not available yet.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            items.isEmpty() -> Text(
+                text = "Nothing here yet.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            else -> LazyRow(
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(items, key = { it.kind.name + ":" + it.id }) { di ->
+                    InvestCard(item = di, onOpenRoute = onOpenRoute)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InvestCard(item: InvestItem, onOpenRoute: (String) -> Unit) {
+    Card(
+        modifier = Modifier
+            .width(180.dp)
+            .then(if (item.route.isNotBlank()) Modifier.clickable { onOpenRoute(item.route) } else Modifier)
+            .testTag("invest_card_${item.id}"),
+    ) {
+        Column(Modifier.fillMaxWidth().padding(12.dp)) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (item.subtitle.isNotBlank()) {
+                Text(
+                    text = item.subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (item.metric.isNotBlank()) {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = item.metric,
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/invest/InvestViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/invest/InvestViewModel.kt
@@ -1,0 +1,313 @@
+package com.testlogon.android.feature.invest
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.bailout.BailoutRepository
+import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.navigation.BailoutBoardDest
+import com.testlogon.android.navigation.CustodyDest
+import com.testlogon.android.navigation.MarketsDest
+import com.testlogon.android.navigation.StrategyDetailDest
+import com.testlogon.android.navigation.StrategyMarketDest
+import com.testlogon.android.navigation.SymbolDetailDest
+import com.testlogon.android.navigation.TokenDetailDest
+import com.testlogon.android.navigation.TokensMarketDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * The state of ONE invest section. [items] is the FULL (unfiltered) ranked list; the ViewModel
+ * exposes the search-filtered view via [InvestUiState.visibleItems]. [pending] is the honest
+ * degrade-on-404 flag: the endpoint isn't wired yet (or empty), so the section shows a "pending
+ * backend" note rather than looking broken.
+ */
+data class InvestSectionState(
+    val kind: InvestKind,
+    val items: List<InvestItem> = emptyList(),
+    val pending: Boolean = false,
+    val seeAllRoute: String = "",
+)
+
+data class InvestUiState(
+    val phase: Phase = Phase.Loading,
+    val query: String = "",
+    val markets: InvestSectionState = InvestSectionState(InvestKind.MARKET, seeAllRoute = MarketsDest.ROUTE),
+    val tokens: InvestSectionState = InvestSectionState(InvestKind.TOKEN, seeAllRoute = TokensMarketDest.ROUTE),
+    val strategies: InvestSectionState = InvestSectionState(InvestKind.STRATEGY, seeAllRoute = StrategyMarketDest.ROUTE),
+    val staking: InvestSectionState = InvestSectionState(InvestKind.STAKING, seeAllRoute = CustodyDest.ROUTE),
+    val opportunities: InvestSectionState = InvestSectionState(InvestKind.OPPORTUNITY, seeAllRoute = BailoutBoardDest.ROUTE),
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+
+    private val allSections: List<InvestSectionState>
+        get() = listOf(markets, tokens, strategies, staking, opportunities)
+
+    /** The section's items filtered by the live [query] (ordering preserved from the ranked list). */
+    fun visibleItems(section: InvestSectionState): List<InvestItem> =
+        InvestMath.filter(section.items, query)
+
+    /** Total products across all sections (unfiltered) — hub header count. */
+    val totalCount: Int get() = InvestMath.totalCount(allSections.map { it.items })
+
+    /** Total products matching the live query across all sections. */
+    val matchCount: Int get() = allSections.sumOf { visibleItems(it).size }
+
+    /** True when a non-blank query matches nothing anywhere (honest "no results" state). */
+    val noSearchResults: Boolean
+        get() = query.isNotBlank() && matchCount == 0 && totalCount > 0
+}
+
+/**
+ * Drives the unified INVEST hub. Injects the EXISTING per-product repositories (markets, creator
+ * tokens, strategy funds, staking, and opportunities: IPO token auctions + bailout rescue auctions +
+ * peer stake/auction discovery) and aggregates them CLIENT-SIDE into one screen.
+ *
+ * Each section degrades INDEPENDENTLY: a 404 (endpoint not wired yet) folds to an honest "pending"
+ * empty state for THAT section only, so the hub works NOW for whatever is already live. Only a real
+ * transport failure surfaces as a retryable whole-screen error.
+ */
+@HiltViewModel
+class InvestViewModel @Inject constructor(
+    private val exchange: ExchangeRepository,
+    private val tokens: TokensRepository,
+    private val strategies: StrategiesRepository,
+    private val custody: CustodyRepository,
+    private val bailout: BailoutRepository,
+    private val trading: TradingRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(InvestUiState())
+    val uiState: StateFlow<InvestUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    fun onQueryChange(query: String) = _uiState.update { it.copy(query = query) }
+
+    fun load() {
+        _uiState.update { it.copy(phase = InvestUiState.Phase.Loading, errorMessage = null) }
+        viewModelScope.launch {
+            // Sequential reads (each is a cheap poll; sequential keeps the code + error handling simple).
+            val symbolsR = exchange.symbols()
+            val tokensR = tokens.market()
+            val strategiesR = strategies.market()
+            val stakingR = custody.getStaking()
+            val tokenAuctionsR = tokens.openAuctions()
+            val bailoutsR = bailout.bailouts()
+            val stakeReqR = trading.stakeRequestsBrowse()
+            val peerAuctionsR = trading.auctionsBrowse()
+
+            // A transport failure on ANY read fails the whole hub (retryable). Endpoint-404s do NOT
+            // reach here — the repositories already fold those into empty Success values.
+            val netError = listOf(
+                symbolsR, tokensR, strategiesR, stakingR, tokenAuctionsR, bailoutsR, stakeReqR, peerAuctionsR,
+            ).firstOrNull { it is ApiResult.NetworkError }
+            if (netError != null) {
+                _uiState.update {
+                    it.copy(
+                        phase = InvestUiState.Phase.Error,
+                        errorMessage = "No connection. Check your network and retry.",
+                    )
+                }
+                return@launch
+            }
+
+            // ---- Markets ----
+            val instruments = (symbolsR as? ApiResult.Success)?.data.orEmpty()
+            val marketItems = InvestMath.rankBySortKey(
+                instruments.map { i ->
+                    InvestItem(
+                        kind = InvestKind.MARKET,
+                        id = i.symbolId.toString(),
+                        title = i.symbol,
+                        subtitle = if (i.isPerpetual) "Perpetual" else "Spot",
+                        metric = "Ref ${i.display(i.referencePrice)}",
+                        route = SymbolDetailDest.build(i.symbolId),
+                        // No live change here (that needs per-symbol candle polls); rank spot/perp
+                        // deterministically by symbolId so the ordering is stable.
+                        sortKey = i.symbolId.toDouble(),
+                        searchText = (i.symbol + " " + if (i.isPerpetual) "perp perpetual" else "spot").lowercase(),
+                    )
+                },
+            )
+            // Markets are always available (the repo has a hardcoded fallback catalogue).
+            val marketsSection = InvestSectionState(
+                kind = InvestKind.MARKET,
+                items = marketItems,
+                pending = instruments.isEmpty(),
+                seeAllRoute = MarketsDest.ROUTE,
+            )
+
+            // ---- Creator tokens ----
+            val tokenList = (tokensR as? ApiResult.Success)?.data.orEmpty()
+            val tokenItems = InvestMath.rankBySortKey(
+                tokenList.map { t ->
+                    InvestItem(
+                        kind = InvestKind.TOKEN,
+                        id = t.tokenId,
+                        title = t.ticker.ifBlank { t.name },
+                        subtitle = t.name,
+                        metric = "${t.revenueShareBps / 100.0}% rev-share",
+                        route = TokenDetailDest.build(t.tokenId),
+                        sortKey = t.revenueShareBps.toDouble(),
+                        searchText = (t.ticker + " " + t.name).lowercase(),
+                    )
+                },
+            )
+            val tokensSection = InvestSectionState(
+                kind = InvestKind.TOKEN,
+                items = tokenItems,
+                pending = tokenList.isEmpty(),
+                seeAllRoute = TokensMarketDest.ROUTE,
+            )
+
+            // ---- Strategy funds (top by inception return, then AUM) ----
+            val strategyList = (strategiesR as? ApiResult.Success)?.data.orEmpty()
+            val strategyItems = InvestMath.rankBySortKey(
+                strategyList.map { s ->
+                    val cap = InvestMath.capacityRemainingFraction(s.maxAumCents, s.aumCents)
+                    val fees = "${s.mgmtFeeBps / 100.0}%/${s.perfFeeBps / 100.0}% fees"
+                    val capText = cap?.let { " · ${(it * 100).toInt()}% open" } ?: ""
+                    InvestItem(
+                        kind = InvestKind.STRATEGY,
+                        id = s.strategyId,
+                        title = s.name,
+                        subtitle = "${(s.inceptionReturnBps ?: 0) / 100.0}% since inception",
+                        metric = fees + capText,
+                        route = StrategyDetailDest.build(s.strategyId),
+                        // Primary rank = inception return; AUM as a tiny secondary nudge for ties.
+                        sortKey = InvestMath.returnKey(s.inceptionReturnBps) +
+                            (InvestMath.aumKey(s.aumCents) / 1_000_000_000.0),
+                        searchText = s.name.lowercase(),
+                    )
+                },
+            )
+            val strategiesSection = InvestSectionState(
+                kind = InvestKind.STRATEGY,
+                items = strategyItems,
+                pending = strategyList.isEmpty(),
+                seeAllRoute = StrategyMarketDest.ROUTE,
+            )
+
+            // ---- Staking (providers/yield) ----
+            val stakingDash = (stakingR as? ApiResult.Success)?.data
+            val stakingProviders = stakingDash?.providers.orEmpty()
+            val stakingItems = InvestMath.rankBySortKey(
+                stakingProviders.map { p ->
+                    InvestItem(
+                        kind = InvestKind.STAKING,
+                        id = p.displayId,
+                        title = p.asset.ifBlank { p.displayId },
+                        subtitle = p.chain.ifBlank { p.kind },
+                        metric = p.kind.ifBlank { "Staking" },
+                        route = CustodyDest.ROUTE,
+                        sortKey = 0.0,
+                        searchText = (p.asset + " " + p.chain + " " + p.kind).lowercase(),
+                    )
+                },
+            )
+            val stakingSection = InvestSectionState(
+                kind = InvestKind.STAKING,
+                items = stakingItems,
+                // Unavailable (404/403) or simply empty -> pending note.
+                pending = stakingProviders.isEmpty(),
+                seeAllRoute = CustodyDest.ROUTE,
+            )
+
+            // ---- Opportunities (open IPO token auctions + open bailouts + peer stake/auction discovery) ----
+            val openTokenAuctions = (tokenAuctionsR as? ApiResult.Success)?.data.orEmpty()
+            val openBailouts = (bailoutsR as? ApiResult.Success)?.data.orEmpty()
+            val stakeBrowse = (stakeReqR as? ApiResult.Success)?.data
+            val peerAuctions = (peerAuctionsR as? ApiResult.Success)?.data
+
+            val oppItems = buildList {
+                openTokenAuctions.forEach { a ->
+                    add(
+                        InvestItem(
+                            kind = InvestKind.OPPORTUNITY,
+                            id = "tokauction:${a.auctionId.ifBlank { a.tokenId }}",
+                            title = "Token IPO",
+                            subtitle = a.tokenId.ifBlank { a.auctionId },
+                            metric = "${a.offeredPctBps / 100.0}% offered",
+                            route = if (a.tokenId.isNotBlank()) TokenDetailDest.build(a.tokenId) else TokensMarketDest.ROUTE,
+                            sortKey = a.offeredPctBps.toDouble(),
+                            searchText = ("token ipo auction " + a.tokenId).lowercase(),
+                        ),
+                    )
+                }
+                openBailouts.forEach { b ->
+                    add(
+                        InvestItem(
+                            kind = InvestKind.OPPORTUNITY,
+                            id = "bailout:${b.auctionId}",
+                            title = "Bailout rescue",
+                            subtitle = "Symbol ${b.symbolId} · ${b.side}",
+                            metric = "up to ${b.maxShareBps / 100.0}% share",
+                            route = BailoutBoardDest.ROUTE,
+                            sortKey = b.maxShareBps.toDouble(),
+                            searchText = ("bailout rescue symbol " + b.symbolId).lowercase(),
+                        ),
+                    )
+                }
+                stakeBrowse?.items.orEmpty().forEach { r ->
+                    add(
+                        InvestItem(
+                            kind = InvestKind.OPPORTUNITY,
+                            id = "stakereq:${r.requestId ?: r.hashCode()}",
+                            title = "Stake request",
+                            subtitle = r.symbolLabel ?: r.idLabel,
+                            metric = r.maxStakePct?.let { "max $it%" }.orEmpty(),
+                            route = "",
+                            sortKey = 0.0,
+                            searchText = ("stake request " + (r.symbolLabel ?: "")).lowercase(),
+                        ),
+                    )
+                }
+                peerAuctions?.items.orEmpty().forEach { a ->
+                    add(
+                        InvestItem(
+                            kind = InvestKind.OPPORTUNITY,
+                            id = "peerauction:${a.auctionId ?: a.hashCode()}",
+                            title = "Position auction",
+                            subtitle = a.symbolLabel ?: a.idLabel,
+                            metric = a.qty?.let { "qty $it" }.orEmpty(),
+                            route = "",
+                            sortKey = 0.0,
+                            searchText = ("position auction " + (a.symbolLabel ?: "")).lowercase(),
+                        ),
+                    )
+                }
+            }
+            val opportunitiesSection = InvestSectionState(
+                kind = InvestKind.OPPORTUNITY,
+                items = InvestMath.rankBySortKey(oppItems),
+                pending = oppItems.isEmpty(),
+                seeAllRoute = BailoutBoardDest.ROUTE,
+            )
+
+            _uiState.update {
+                it.copy(
+                    phase = InvestUiState.Phase.Content,
+                    markets = marketsSection,
+                    tokens = tokensSection,
+                    strategies = strategiesSection,
+                    staking = stakingSection,
+                    opportunities = opportunitiesSection,
+                    errorMessage = null,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.outlined.Lightbulb
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.EditCalendar
 import androidx.compose.material.icons.outlined.EventNote
+import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Campaign
 import androidx.compose.material.icons.outlined.AddBusiness
@@ -1588,6 +1589,17 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_global_search,
             icon = Icons.Outlined.ManageSearch,
             route = MoreRoutes.GLOBAL_SEARCH,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
+        // Unified INVEST hub: one front door aggregating every investable/tradeable product (markets +
+        // creator tokens + strategy funds + staking + open opportunities) client-side. A live search
+        // filters all sections; each "see all" opens the existing screen. Degrades per-section on 404.
+        MoreEntry(
+            id = "invest",
+            labelRes = R.string.more_entry_invest,
+            icon = Icons.Outlined.Explore,
+            route = MoreRoutes.INVEST,
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -306,6 +306,10 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         adminDashboardDestination(navController)
         // Markets (exchange market-data, VIEW-ONLY): instrument list + per-symbol chart/book/tape.
         marketsDestinations(navController)
+        // Unified INVEST hub: aggregates markets + creator tokens + strategy funds + staking +
+        // open opportunities client-side into one front door. Owns no detail routes — each card /
+        // see-all navigates to the existing per-product destination in this same graph.
+        investDestinations(navController)
         // Creator revenue-share TOKENS: mint + browse market + per-token detail (cap table /
         // revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
         tokensDestinations(navController)

--- a/android/app/src/main/java/com/testlogon/android/navigation/InvestNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/InvestNavigation.kt
@@ -1,0 +1,33 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.invest.InvestRoute
+
+/**
+ * The unified INVEST hub destination, registered in the AUTHENTICATED nav graph.
+ *
+ * [InvestDest] is a single navigable screen that aggregates every investable/tradeable product
+ * (markets, creator tokens, strategy funds, staking, opportunities) client-side. It does NOT own any
+ * detail routes: each card + "See all" navigates to the EXISTING per-product destination already
+ * registered in this same graph (markets/tokens/strategies/custody/bailout), so the hub is a pure
+ * front door. A blank/absent route from an item is treated as non-navigable and ignored.
+ */
+data object InvestDest {
+    const val ROUTE = "invest"
+}
+
+/** Registers the Invest hub destination (Back pops the stack; items navigate to existing screens). */
+fun NavGraphBuilder.investDestinations(navController: NavHostController) {
+    composable(InvestDest.ROUTE) {
+        InvestRoute(
+            onBack = { navController.popBackStack() },
+            onOpenRoute = { route ->
+                if (route.isNotBlank()) {
+                    navController.navigate(route) { launchSingleTop = true }
+                }
+            },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -380,6 +380,10 @@ object MoreRoutes {
     // Markets (exchange market-data, VIEW-ONLY): instrument list -> per-symbol chart/book/tape.
     const val MARKETS = MarketsDest.ROUTE
 
+    // Unified INVEST hub: one front door aggregating markets + creator tokens + strategy funds +
+    // staking + open opportunities. Degrades per-section on 404; owns no detail routes.
+    const val INVEST = InvestDest.ROUTE
+
     // Creator revenue-share TOKENS: mint a token, browse the listed market, per-token detail
     // (cap table / revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).
     const val TOKENS = TokensMarketDest.ROUTE
@@ -689,6 +693,7 @@ object MoreRoutes {
             WEBHOOKS,
             ADMIN_DASHBOARD,
             MARKETS,
+            INVEST,
             TOKENS,
             STRATEGIES,
             BAILOUTS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4284,6 +4284,7 @@
     <!-- AND-403: Read-only admin alerts/dashboards. -->
     <string name="more_entry_admin_dashboard">Admin alerts</string>
     <string name="more_entry_global_search">Search</string>
+    <string name="more_entry_invest">Invest Hub</string>
     <string name="more_entry_markets">Markets</string>
     <string name="more_entry_analysis">Analysis</string>
     <string name="more_entry_tokens">Creator Tokens</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/invest/InvestMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/invest/InvestMathTest.kt
@@ -1,0 +1,135 @@
+package com.testlogon.android.feature.invest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure unit tests for [InvestMath] — no Android, no repositories. */
+class InvestMathTest {
+
+    private fun item(
+        id: String,
+        title: String,
+        subtitle: String = "",
+        kind: InvestKind = InvestKind.MARKET,
+        sortKey: Double = 0.0,
+        searchText: String = "",
+    ) = InvestItem(kind = kind, id = id, title = title, subtitle = subtitle, sortKey = sortKey, searchText = searchText)
+
+    @Test
+    fun normalizeQuery_trimsAndLowercases() {
+        assertEquals("btc", InvestMath.normalizeQuery("  BTC  "))
+        assertEquals("", InvestMath.normalizeQuery("   "))
+    }
+
+    @Test
+    fun matches_blankQueryMatchesEverything() {
+        assertTrue(InvestMath.matches(item("1", "BTCUSDC"), ""))
+        assertTrue(InvestMath.matches(item("1", "BTCUSDC"), "   "))
+    }
+
+    @Test
+    fun matches_byTitleCaseInsensitive() {
+        val it = item("1", "BTCUSDC", subtitle = "Bitcoin")
+        assertTrue(InvestMath.matches(it, "btc"))
+        assertTrue(InvestMath.matches(it, "USDC"))
+    }
+
+    @Test
+    fun matches_bySubtitleAndId() {
+        val it = item("tok_42", "MOON", subtitle = "Creator revenue token")
+        assertTrue(InvestMath.matches(it, "revenue"))
+        assertTrue(InvestMath.matches(it, "tok_42"))
+    }
+
+    @Test
+    fun matches_byExtraSearchText() {
+        // searchText is expected lowercase (chain/asset/ticker folded in by the ViewModel).
+        val it = item("p1", "Lido", kind = InvestKind.STAKING, searchText = "ethereum steth")
+        assertTrue(InvestMath.matches(it, "ethereum"))
+        assertTrue(InvestMath.matches(it, "STETH"))
+    }
+
+    @Test
+    fun matches_negativeWhenNoField() {
+        val it = item("1", "BTCUSDC", subtitle = "Bitcoin", searchText = "spot")
+        assertFalse(InvestMath.matches(it, "solana"))
+    }
+
+    @Test
+    fun filter_preservesOrderAndDropsNonMatches() {
+        val items = listOf(
+            item("1", "BTCUSDC"),
+            item("2", "ETHUSDC"),
+            item("3", "SOLUSDC"),
+        )
+        val out = InvestMath.filter(items, "eth")
+        assertEquals(1, out.size)
+        assertEquals("2", out.single().id)
+    }
+
+    @Test
+    fun rankBySortKey_descWithStableTieBreak() {
+        val items = listOf(
+            item("a", "Alpha", sortKey = 1.0),
+            item("c", "Charlie", sortKey = 3.0),
+            item("b", "Bravo", sortKey = 3.0),
+        )
+        val ranked = InvestMath.rankBySortKey(items)
+        // 3.0s first, tie broken by title (Bravo < Charlie), then the 1.0.
+        assertEquals(listOf("b", "c", "a"), ranked.map { it.id })
+    }
+
+    @Test
+    fun topN_takesHighestAndClampsAtZero() {
+        val items = listOf(
+            item("a", "A", sortKey = 1.0),
+            item("b", "B", sortKey = 5.0),
+            item("c", "C", sortKey = 3.0),
+        )
+        assertEquals(listOf("b", "c"), InvestMath.topN(items, 2).map { it.id })
+        assertTrue(InvestMath.topN(items, 0).isEmpty())
+        assertTrue(InvestMath.topN(items, -1).isEmpty())
+    }
+
+    @Test
+    fun moverKey_isAbsoluteAndNullSafe() {
+        assertEquals(5.0, InvestMath.moverKey(-5.0), 0.0)
+        assertEquals(2.5, InvestMath.moverKey(2.5), 0.0)
+        assertEquals(0.0, InvestMath.moverKey(null), 0.0)
+    }
+
+    @Test
+    fun returnKey_andAumKey_nullSafe() {
+        assertEquals(1200.0, InvestMath.returnKey(1200), 0.0)
+        assertEquals(-300.0, InvestMath.returnKey(-300), 0.0)
+        assertEquals(0.0, InvestMath.returnKey(null), 0.0)
+        assertEquals(999.0, InvestMath.aumKey(999L), 0.0)
+        assertEquals(0.0, InvestMath.aumKey(null), 0.0)
+    }
+
+    @Test
+    fun capacityRemainingFraction_bounds() {
+        // Half full -> 0.5 remaining.
+        assertEquals(0.5, InvestMath.capacityRemainingFraction(1000L, 500L)!!, 1e-9)
+        // Fully used -> 0.0 (clamped, never negative even if over-subscribed).
+        assertEquals(0.0, InvestMath.capacityRemainingFraction(1000L, 1500L)!!, 1e-9)
+        // Empty fund -> 1.0 remaining (null AUM treated as 0).
+        assertEquals(1.0, InvestMath.capacityRemainingFraction(1000L, null)!!, 1e-9)
+        // No cap -> null (uncapped is distinct from full).
+        assertNull(InvestMath.capacityRemainingFraction(0L, 100L))
+    }
+
+    @Test
+    fun totalCount_sumsSections() {
+        val sections = listOf(
+            listOf(item("1", "A"), item("2", "B")),
+            emptyList(),
+            listOf(item("3", "C")),
+        )
+        assertEquals(3, InvestMath.totalCount(sections))
+        assertEquals(0, InvestMath.totalCount(emptyList()))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,6 +130,7 @@ const QuestionnaireRespondentPage = lazy(() => import("@/pages/questionnaires/Qu
 const PublicUserProfilePage = lazy(() => import("@/pages/profile/PublicUserProfilePage"));
 const VideosPage = lazy(() => import("@/pages/videos/VideosPage"));
 const DiscoverPage = lazy(() => import("@/pages/discover/DiscoverPage"));
+const InvestHubPage = lazy(() => import("@/pages/invest/InvestHubPage"));
 const TagPage = lazy(() => import("@/pages/discover/TagPage"));
 const SearchPage = lazy(() => import("@/pages/search/SearchPage"));
 const VideoPlayerPage = lazy(() => import("@/pages/videos/VideoPlayerPage"));
@@ -764,6 +765,7 @@ export default function App() {
           <Route path="strategies/:id/edit" element={<StrategyBuilderPage />} />
           <Route path="strategies/:id/backtest" element={<StrategyBacktestPage />} />
           <Route path="bailouts" element={<BailoutsBoardPage />} />
+          <Route path="invest" element={<InvestHubPage />} />
           <Route path="analysis" element={<MarketAnalysisPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />
           <Route path="paper" element={<PaperTradingPage />} />

--- a/frontend/src/api/endpoints/tokens.ts
+++ b/frontend/src/api/endpoints/tokens.ts
@@ -169,6 +169,19 @@ export const getMyTokens = () => api.get<TokensResult>("/me/tokens");
 /** All listed creator tokens to browse. */
 export const getTokenMarket = () => api.get<TokensResult>("/me/tokens/market");
 
+/** Result of the open-IPO-auctions browse feed. */
+export interface TokenAuctionsResult {
+  auctions: TokenAuction[];
+}
+
+/**
+ * Browse OPEN creator-token IPO auctions to bid on. OPTIONAL/NEW route — 404s
+ * until the backend ships this listing; the Discover hub degrades to an honest
+ * empty state on 404 (retry:false).
+ */
+export const getOpenTokenAuctions = () =>
+  api.get<TokenAuctionsResult>("/me/tokens/auctions");
+
 export const getToken = (id: string) => api.get<Token>(`/me/tokens/${encodeURIComponent(id)}`);
 
 export const getCapTable = (id: string) =>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { NavLink, useLocation } from "react-router-dom";
 import {
+  Sparkles,
   LayoutDashboard,
   MessageSquare,
   Rss,
@@ -147,6 +148,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: <Rss className="h-5 w-5" /> },
       { label: "Trading Home", i18nKey: "nav.tradingHome", path: "/home", icon: <Gauge className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
+      { label: "Invest", i18nKey: "nav.invest", path: "/invest", icon: <Sparkles className="h-5 w-5" /> },
       { label: "Analysis", i18nKey: "nav.analysis", path: "/analysis", icon: <LineChart className="h-5 w-5" /> },
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Paper Trading", i18nKey: "nav.paperTrading", path: "/paper", icon: <TrendingUp className="h-5 w-5" /> },

--- a/frontend/src/lib/discover.test.ts
+++ b/frontend/src/lib/discover.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import type { Token } from "@/api/endpoints/tokens";
+import type { Strategy } from "@/api/endpoints/strategies";
+import {
+  normalizeQuery,
+  matchesText,
+  searchSymbols,
+  searchTokens,
+  searchStrategies,
+  topMovers,
+  changeBpsFromPrices,
+  sortStrategies,
+  sortTokens,
+  capacityRemainingFraction,
+  bpsToSignedPct,
+  centsToUsd,
+  marketItem,
+  tokenItem,
+  strategyItem,
+  type SymbolChange,
+} from "./discover";
+
+// -- Fixtures ---------------------------------------------------------
+
+function sym(partial: Partial<MarketSymbol> & { symbol: string; symbol_id: number }): MarketSymbol {
+  return {
+    instrument_id: partial.symbol_id,
+    price_scaler: 1,
+    lot_size: 1,
+    reference_price: 100,
+    matching_algo: "price_time",
+    is_perpetual: false,
+    funding_interval_s: 0,
+    ...partial,
+  };
+}
+
+function tok(partial: Partial<Token> & { token_id: string; name: string; ticker: string }): Token {
+  return {
+    creator_sub: "u1",
+    total_supply: 1000,
+    revenue_share_bps: 500,
+    status: "listed",
+    created_ts: 1000,
+    ...partial,
+  };
+}
+
+function strat(partial: Partial<Strategy> & { strategy_id: string; name: string }): Strategy {
+  return {
+    creator_sub: "u1",
+    description: "",
+    kind: "basket",
+    status: "published",
+    legs: [],
+    rebalance: "none",
+    min_investment_cents: 10000,
+    max_aum_cents: 0,
+    mgmt_fee_bps: 100,
+    perf_fee_bps: 1000,
+    high_water_mark: true,
+    redemption: { type: "instant" },
+    created_ts: 1000,
+    ...partial,
+  };
+}
+
+const BTC = sym({ symbol: "BTCUSDC", symbol_id: 1 });
+const ETH = sym({ symbol: "ETHUSDC", symbol_id: 2, is_perpetual: true });
+const SOL = sym({ symbol: "SOLUSDC", symbol_id: 3 });
+
+// -- normalizeQuery / matchesText -------------------------------------
+
+describe("normalizeQuery", () => {
+  it("lower-cases and trims", () => {
+    expect(normalizeQuery("  BtC ")).toBe("btc");
+  });
+  it("treats null/undefined as empty", () => {
+    expect(normalizeQuery(null)).toBe("");
+    expect(normalizeQuery(undefined)).toBe("");
+  });
+});
+
+describe("matchesText", () => {
+  it("empty query matches anything", () => {
+    expect(matchesText("", "whatever")).toBe(true);
+  });
+  it("case-insensitive substring", () => {
+    expect(matchesText("btc", "BTCUSDC")).toBe(true);
+  });
+  it("all tokens must be present (AND)", () => {
+    expect(matchesText("moon coin", "Moon Rocket Coin")).toBe(true);
+    expect(matchesText("moon zzz", "Moon Rocket Coin")).toBe(false);
+  });
+  it("no matchable fields -> false for a non-empty query", () => {
+    expect(matchesText("btc", null, undefined, "")).toBe(false);
+  });
+  it("searches across multiple fields", () => {
+    expect(matchesText("rocket", "MoonCoin", "The Rocket Fund")).toBe(true);
+  });
+});
+
+// -- heterogeneous search ---------------------------------------------
+
+describe("searchSymbols", () => {
+  it("empty query returns all", () => {
+    expect(searchSymbols([BTC, ETH, SOL], "")).toHaveLength(3);
+  });
+  it("filters by symbol text", () => {
+    const r = searchSymbols([BTC, ETH, SOL], "eth");
+    expect(r).toHaveLength(1);
+    expect(r[0]!.symbol).toBe("ETHUSDC");
+  });
+  it("tolerates null input", () => {
+    expect(searchSymbols(null as unknown as MarketSymbol[], "x")).toEqual([]);
+  });
+});
+
+describe("searchTokens", () => {
+  const tokens = [
+    tok({ token_id: "t1", name: "Moon Coin", ticker: "MOON" }),
+    tok({ token_id: "t2", name: "Rocket Fund", ticker: "RKT" }),
+  ];
+  it("matches by name", () => {
+    expect(searchTokens(tokens, "moon").map((t) => t.token_id)).toEqual(["t1"]);
+  });
+  it("matches by ticker", () => {
+    expect(searchTokens(tokens, "rkt").map((t) => t.token_id)).toEqual(["t2"]);
+  });
+  it("empty query returns all", () => {
+    expect(searchTokens(tokens, "")).toHaveLength(2);
+  });
+});
+
+describe("searchStrategies", () => {
+  const strategies = [
+    strat({ strategy_id: "s1", name: "Blue Chip", description: "large caps" }),
+    strat({ strategy_id: "s2", name: "DeFi Basket", description: "yield tokens" }),
+  ];
+  it("matches by name", () => {
+    expect(searchStrategies(strategies, "blue").map((s) => s.strategy_id)).toEqual(["s1"]);
+  });
+  it("matches by description", () => {
+    expect(searchStrategies(strategies, "yield").map((s) => s.strategy_id)).toEqual(["s2"]);
+  });
+});
+
+// -- ranking ----------------------------------------------------------
+
+describe("changeBpsFromPrices", () => {
+  it("computes a positive change", () => {
+    expect(changeBpsFromPrices(100, 110)).toBeCloseTo(1000, 6);
+  });
+  it("computes a negative change", () => {
+    expect(changeBpsFromPrices(100, 90)).toBeCloseTo(-1000, 6);
+  });
+  it("NaN on zero/undefined base", () => {
+    expect(changeBpsFromPrices(0, 10)).toBeNaN();
+    expect(changeBpsFromPrices(undefined, 10)).toBeNaN();
+    expect(changeBpsFromPrices(100, null)).toBeNaN();
+  });
+});
+
+describe("topMovers", () => {
+  const items: SymbolChange[] = [
+    { symbol: BTC, changeBps: 300 },
+    { symbol: ETH, changeBps: -900 },
+    { symbol: SOL, changeBps: 100 },
+  ];
+  it("orders by absolute change, biggest first", () => {
+    expect(topMovers(items).map((i) => i.symbol.symbol)).toEqual([
+      "ETHUSDC",
+      "BTCUSDC",
+      "SOLUSDC",
+    ]);
+  });
+  it("respects the limit", () => {
+    expect(topMovers(items, 2)).toHaveLength(2);
+  });
+  it("sinks non-finite changes to the bottom", () => {
+    const withNaN: SymbolChange[] = [
+      { symbol: BTC, changeBps: NaN },
+      { symbol: ETH, changeBps: 50 },
+    ];
+    expect(topMovers(withNaN)[0]!.symbol.symbol).toBe("ETHUSDC");
+  });
+  it("does not mutate the input", () => {
+    const copy = items.slice();
+    topMovers(items);
+    expect(items).toEqual(copy);
+  });
+});
+
+describe("sortStrategies", () => {
+  const strategies = [
+    strat({ strategy_id: "a", name: "A", inception_return_bps: 500, aum_cents: 100 }),
+    strat({ strategy_id: "b", name: "B", inception_return_bps: 1500, aum_cents: 50 }),
+    strat({ strategy_id: "c", name: "C", aum_cents: 9999 }),
+  ];
+  it("sorts by inception return desc, missing last", () => {
+    expect(sortStrategies(strategies, "inception").map((s) => s.strategy_id)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+  it("sorts by aum desc", () => {
+    expect(sortStrategies(strategies, "aum").map((s) => s.strategy_id)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+  it("respects the limit", () => {
+    expect(sortStrategies(strategies, "aum", 1).map((s) => s.strategy_id)).toEqual(["c"]);
+  });
+});
+
+describe("sortTokens", () => {
+  it("lists listed tokens before non-listed, then by created desc", () => {
+    const tokens = [
+      tok({ token_id: "draft", name: "D", ticker: "D", status: "draft", created_ts: 5000 }),
+      tok({ token_id: "old", name: "O", ticker: "O", status: "listed", created_ts: 1000 }),
+      tok({ token_id: "new", name: "N", ticker: "N", status: "listed", created_ts: 3000 }),
+    ];
+    expect(sortTokens(tokens).map((t) => t.token_id)).toEqual(["new", "old", "draft"]);
+  });
+});
+
+describe("capacityRemainingFraction", () => {
+  it("uncapped -> 1", () => {
+    expect(capacityRemainingFraction(500, 0)).toBe(1);
+    expect(capacityRemainingFraction(500, null)).toBe(1);
+  });
+  it("half full -> 0.5", () => {
+    expect(capacityRemainingFraction(500, 1000)).toBe(0.5);
+  });
+  it("over-full clamps to 0", () => {
+    expect(capacityRemainingFraction(2000, 1000)).toBe(0);
+  });
+  it("empty fund -> 1", () => {
+    expect(capacityRemainingFraction(0, 1000)).toBe(1);
+  });
+});
+
+// -- formatting -------------------------------------------------------
+
+describe("bpsToSignedPct", () => {
+  it("positive gets a plus sign", () => {
+    expect(bpsToSignedPct(250)).toBe("+2.5%");
+  });
+  it("negative keeps the minus", () => {
+    expect(bpsToSignedPct(-250)).toBe("-2.5%");
+  });
+});
+
+describe("centsToUsd", () => {
+  it("formats cents", () => {
+    expect(centsToUsd(123456)).toBe("$1,234.56");
+  });
+  it("undefined on non-finite", () => {
+    expect(centsToUsd(undefined)).toBeUndefined();
+    expect(centsToUsd(NaN)).toBeUndefined();
+  });
+});
+
+// -- mappers ----------------------------------------------------------
+
+describe("marketItem", () => {
+  it("maps a spot symbol with a change", () => {
+    const item = marketItem(BTC, 250);
+    expect(item).toMatchObject({
+      kind: "market",
+      id: "1",
+      title: "BTCUSDC",
+      subtitle: "Spot",
+      metric: "+2.5%",
+      changeBps: 250,
+      href: "/markets/1",
+    });
+  });
+  it("labels perps and omits metric on non-finite change", () => {
+    const item = marketItem(ETH, NaN);
+    expect(item.subtitle).toBe("Perpetual");
+    expect(item.metric).toBeUndefined();
+    expect(item.changeBps).toBeUndefined();
+  });
+});
+
+describe("tokenItem", () => {
+  it("uses ticker as title and links to the token", () => {
+    const item = tokenItem(tok({ token_id: "t1", name: "Moon Coin", ticker: "MOON", clearing_price: 5000 }));
+    expect(item).toMatchObject({
+      kind: "token",
+      id: "t1",
+      title: "MOON",
+      subtitle: "Moon Coin",
+      metric: "$50.00",
+      href: "/tokens/t1",
+    });
+  });
+  it("falls back to status when unpriced", () => {
+    const item = tokenItem(tok({ token_id: "t2", name: "X", ticker: "X", status: "draft" }));
+    expect(item.metric).toBe("draft");
+  });
+});
+
+describe("strategyItem", () => {
+  it("maps inception return as the metric", () => {
+    const item = strategyItem(strat({ strategy_id: "s1", name: "Blue Chip", inception_return_bps: 1200, aum_cents: 500000 }));
+    expect(item).toMatchObject({
+      kind: "strategy",
+      id: "s1",
+      title: "Blue Chip",
+      subtitle: "AUM $5,000.00",
+      metric: "+12%",
+      changeBps: 1200,
+      href: "/strategies/s1",
+    });
+  });
+  it("falls back to NAV when no inception return", () => {
+    const item = strategyItem(strat({ strategy_id: "s2", name: "New", nav_per_unit: 1000 }));
+    expect(item.metric).toBe("$10.00");
+    expect(item.changeBps).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/discover.ts
+++ b/frontend/src/lib/discover.ts
@@ -1,0 +1,245 @@
+/**
+ * Pure, framework-free helpers for the unified DISCOVER / INVEST HUB.
+ *
+ * The hub is a single front door over the several investable/tradeable product
+ * surfaces that each already live in their own route (Markets, Creator Tokens,
+ * Strategy Funds, Staking, and the peer/bailout/IPO "Opportunities"). This
+ * module holds the cross-surface logic that must NOT touch React, the network,
+ * or the DOM so it can be exhaustively unit-tested:
+ *
+ *   - a NORMALIZED {@link DiscoverItem} shape so every heterogeneous product
+ *     row renders through one card component (kind / id / title / subtitle /
+ *     metric / href);
+ *   - a heterogeneous SEARCH match (a single query filters across market
+ *     symbols, creator tokens, and strategy funds by name / ticker);
+ *   - RANKING helpers (top movers by |change|, strategies by inception return
+ *     or AUM, tokens, capacity-remaining fraction).
+ *
+ * CONVENTIONS (shared with the reused surfaces): monetary amounts are INTEGER
+ * CENTS; `_bps` fields are BASIS POINTS (100% = 10_000). Nothing here fetches --
+ * callers pass already-read data and render the result, degrading per-section
+ * on a 404 upstream.
+ */
+
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import type { Token } from "@/api/endpoints/tokens";
+import type { Strategy } from "@/api/endpoints/strategies";
+
+// -- Normalized item shape --------------------------------------------
+
+/** Which product surface a {@link DiscoverItem} came from. */
+export type DiscoverKind =
+  | "market"
+  | "token"
+  | "strategy"
+  | "staking"
+  | "opportunity";
+
+/**
+ * A single, surface-agnostic row for the hub. Every section maps its native
+ * records to this shape so one card component renders them all uniformly.
+ */
+export interface DiscoverItem {
+  kind: DiscoverKind;
+  /** Stable id within the kind (symbol id, token id, strategy id, ...). */
+  id: string;
+  title: string;
+  subtitle?: string;
+  /** Pre-formatted headline metric (price, NAV, APY, return, ...). */
+  metric?: string;
+  /** Signed change in bps when the metric trends (drives up/down colour). */
+  changeBps?: number;
+  /** Deep link into the existing route for this item. */
+  href: string;
+}
+
+// -- Text search (heterogeneous) --------------------------------------
+
+/** Lower-case + trim a query/term for case-insensitive substring matching. */
+export function normalizeQuery(q: string | null | undefined): string {
+  return (q ?? "").trim().toLowerCase();
+}
+
+/** True when every whitespace-separated token of `q` is a substring of some field. */
+export function matchesText(q: string, ...fields: Array<string | null | undefined>): boolean {
+  const query = normalizeQuery(q);
+  if (!query) return true;
+  const hay = fields
+    .filter((f): f is string => typeof f === "string" && f.length > 0)
+    .join(" ")
+    .toLowerCase();
+  if (!hay) return false;
+  return query.split(/\s+/).every((tok) => hay.includes(tok));
+}
+
+/** Filter market symbols by symbol/ticker text. Empty query -> all. */
+export function searchSymbols(symbols: MarketSymbol[], q: string): MarketSymbol[] {
+  const query = normalizeQuery(q);
+  if (!query) return symbols ?? [];
+  return (symbols ?? []).filter((s) => matchesText(query, s.symbol));
+}
+
+/** Filter creator tokens by name/ticker text. Empty query -> all. */
+export function searchTokens(tokens: Token[], q: string): Token[] {
+  const query = normalizeQuery(q);
+  if (!query) return tokens ?? [];
+  return (tokens ?? []).filter((t) => matchesText(query, t.name, t.ticker));
+}
+
+/** Filter strategy funds by name/description text. Empty query -> all. */
+export function searchStrategies(strategies: Strategy[], q: string): Strategy[] {
+  const query = normalizeQuery(q);
+  if (!query) return strategies ?? [];
+  return (strategies ?? []).filter((s) => matchesText(query, s.name, s.description));
+}
+
+// -- Ranking helpers --------------------------------------------------
+
+/** A symbol paired with its (client-computed) recent change, in bps. */
+export interface SymbolChange {
+  symbol: MarketSymbol;
+  /** Signed change over the sampled window, in bps (10_000 = +100%). */
+  changeBps: number;
+}
+
+/**
+ * Top movers: sort by ABSOLUTE change (biggest movers first, either direction),
+ * breaking ties by symbol name for a stable order. Non-finite changes sink to
+ * the bottom. Returns a new array (does not mutate the input).
+ */
+export function topMovers(items: SymbolChange[], limit = Infinity): SymbolChange[] {
+  const scored = (items ?? []).filter((i) => i && i.symbol);
+  const sorted = scored.slice().sort((a, b) => {
+    const aa = Number.isFinite(a.changeBps) ? Math.abs(a.changeBps) : -1;
+    const bb = Number.isFinite(b.changeBps) ? Math.abs(b.changeBps) : -1;
+    if (bb !== aa) return bb - aa;
+    return a.symbol.symbol.localeCompare(b.symbol.symbol);
+  });
+  return Number.isFinite(limit) ? sorted.slice(0, Math.max(0, limit)) : sorted;
+}
+
+/** Change in bps between a first and last price (10_000 = +100%). NaN if undefined/zero base. */
+export function changeBpsFromPrices(
+  first: number | undefined | null,
+  last: number | undefined | null,
+): number {
+  if (first == null || last == null || !Number.isFinite(first) || !Number.isFinite(last)) {
+    return NaN;
+  }
+  if (first === 0) return NaN;
+  return ((last - first) / first) * 10_000;
+}
+
+/**
+ * Sort strategies by a chosen metric, descending (best first). Missing values
+ * sink to the bottom. Returns a new array.
+ */
+export function sortStrategies(
+  strategies: Strategy[],
+  by: "inception" | "aum",
+  limit = Infinity,
+): Strategy[] {
+  const key = (s: Strategy): number => {
+    const v = by === "inception" ? s.inception_return_bps : s.aum_cents;
+    return v != null && Number.isFinite(v) ? v : Number.NEGATIVE_INFINITY;
+  };
+  const sorted = (strategies ?? []).slice().sort((a, b) => {
+    const d = key(b) - key(a);
+    if (d !== 0) return d;
+    return (a.name ?? "").localeCompare(b.name ?? "");
+  });
+  return Number.isFinite(limit) ? sorted.slice(0, Math.max(0, limit)) : sorted;
+}
+
+/**
+ * Sort creator tokens (listed first, then by most recently created). Returns a
+ * new array.
+ */
+export function sortTokens(tokens: Token[], limit = Infinity): Token[] {
+  const rank = (t: Token): number => (t.status === "listed" ? 1 : 0);
+  const sorted = (tokens ?? []).slice().sort((a, b) => {
+    const r = rank(b) - rank(a);
+    if (r !== 0) return r;
+    const d = (b.created_ts ?? 0) - (a.created_ts ?? 0);
+    if (d !== 0) return d;
+    return (a.name ?? "").localeCompare(b.name ?? "");
+  });
+  return Number.isFinite(limit) ? sorted.slice(0, Math.max(0, limit)) : sorted;
+}
+
+/**
+ * Fraction (0..1) of a strategy's AUM CAPACITY still AVAILABLE. Uncapped
+ * (max <= 0) returns 1 (fully open). Clamped to [0, 1].
+ */
+export function capacityRemainingFraction(
+  aumCents: number | undefined | null,
+  maxAumCents: number | undefined | null,
+): number {
+  if (maxAumCents == null || !(maxAumCents > 0)) return 1;
+  const aum = aumCents != null && aumCents > 0 ? aumCents : 0;
+  const frac = 1 - aum / maxAumCents;
+  if (!Number.isFinite(frac)) return 0;
+  return Math.min(1, Math.max(0, frac));
+}
+
+// -- Mappers to the normalized DiscoverItem ---------------------------
+
+/** Basis points -> a compact signed percent string, e.g. 250 -> "+2.5%". */
+export function bpsToSignedPct(bps: number, maxFrac = 2): string {
+  const pct = bps / 100;
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: maxFrac,
+  })}%`;
+}
+
+/** Integer cents -> "$1,234.56"; non-finite -> undefined. */
+export function centsToUsd(cents: number | undefined | null): string | undefined {
+  if (cents == null || !Number.isFinite(cents)) return undefined;
+  return `$${(cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/** Map a symbol + its recent change to a normalized market item. */
+export function marketItem(sym: MarketSymbol, changeBps: number): DiscoverItem {
+  const hasChange = Number.isFinite(changeBps);
+  return {
+    kind: "market",
+    id: String(sym.symbol_id),
+    title: sym.symbol,
+    subtitle: sym.is_perpetual ? "Perpetual" : "Spot",
+    metric: hasChange ? bpsToSignedPct(changeBps) : undefined,
+    changeBps: hasChange ? changeBps : undefined,
+    href: `/markets/${sym.symbol_id}`,
+  };
+}
+
+/** Map a creator token to a normalized item. */
+export function tokenItem(t: Token): DiscoverItem {
+  return {
+    kind: "token",
+    id: t.token_id,
+    title: t.ticker || t.name,
+    subtitle: t.name,
+    metric: t.clearing_price != null ? centsToUsd(t.clearing_price) : t.status,
+    href: `/tokens/${encodeURIComponent(t.token_id)}`,
+  };
+}
+
+/** Map a strategy fund to a normalized item (metric = since-inception return). */
+export function strategyItem(s: Strategy): DiscoverItem {
+  const hasReturn = s.inception_return_bps != null && Number.isFinite(s.inception_return_bps);
+  const aumUsd = centsToUsd(s.aum_cents);
+  return {
+    kind: "strategy",
+    id: s.strategy_id,
+    title: s.name,
+    subtitle: aumUsd ? `AUM ${aumUsd}` : s.kind === "rule" ? "Rule-based" : "Basket",
+    metric: hasReturn ? bpsToSignedPct(s.inception_return_bps!) : centsToUsd(s.nav_per_unit),
+    changeBps: hasReturn ? s.inception_return_bps! : undefined,
+    href: `/strategies/${encodeURIComponent(s.strategy_id)}`,
+  };
+}

--- a/frontend/src/pages/invest/InvestHubPage.tsx
+++ b/frontend/src/pages/invest/InvestHubPage.tsx
@@ -1,0 +1,611 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Sparkles,
+  TrendingUp,
+  Landmark,
+  Boxes,
+  Coins,
+  Rocket,
+  ChevronRight,
+  Search,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+import { useSymbols, useCandles } from "@/hooks/useMarketData";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { useTokenMarket } from "@/hooks/useTokens";
+import { useStrategyMarket } from "@/hooks/useStrategies";
+import { getOpenTokenAuctions } from "@/api/endpoints/tokens";
+import { getStakingProviders, type StakingProvider } from "@/api/endpoints/custody";
+import { getBailouts, type BailoutAuction } from "@/api/endpoints/bailouts";
+import { getStakeRequests, getOpenAuctions } from "@/api/endpoints/trading";
+import {
+  ALL_CLASS,
+  CLASS_TAB_ORDER,
+  CLASS_LABELS,
+  symbolInClass,
+  type ClassTab,
+} from "@/lib/instrumentClass";
+import {
+  searchSymbols,
+  searchTokens,
+  searchStrategies,
+  topMovers,
+  changeBpsFromPrices,
+  sortStrategies,
+  sortTokens,
+  capacityRemainingFraction,
+  bpsToSignedPct,
+  centsToUsd,
+  type DiscoverItem,
+  type SymbolChange,
+} from "@/lib/discover";
+
+/** How many cards to render per row. */
+const ROW_LIMIT = 12;
+
+// -- Shared row scaffolding -------------------------------------------
+
+function SectionHeader({
+  icon,
+  title,
+  description,
+  seeAllHref,
+  seeAllLabel,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  seeAllHref: string;
+  seeAllLabel?: string;
+}) {
+  return (
+    <div className="mb-3 flex items-end justify-between gap-3">
+      <div className="flex items-center gap-2">
+        <span className="text-primary">{icon}</span>
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+          {description && <p className="text-xs text-muted-foreground">{description}</p>}
+        </div>
+      </div>
+      <Link
+        to={seeAllHref}
+        className="flex shrink-0 items-center gap-0.5 text-sm font-medium text-primary hover:underline"
+      >
+        {seeAllLabel ?? "See all"} <ChevronRight className="h-4 w-4" />
+      </Link>
+    </div>
+  );
+}
+
+/** A horizontally-scrollable strip that holds the section's cards. */
+function CardRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-2">{children}</div>
+  );
+}
+
+function SectionShell({
+  header,
+  children,
+}: {
+  header: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      {header}
+      {children}
+    </section>
+  );
+}
+
+function RowSkeleton() {
+  return (
+    <CardRow>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Skeleton key={i} className="h-28 w-44 shrink-0 rounded-lg" />
+      ))}
+    </CardRow>
+  );
+}
+
+function EmptyRow({ note }: { note: string }) {
+  return (
+    <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+      {note}
+    </div>
+  );
+}
+
+/** A uniform card for any normalized {@link DiscoverItem}. */
+function ItemCard({ item }: { item: DiscoverItem }) {
+  const up = item.changeBps != null ? item.changeBps >= 0 : undefined;
+  return (
+    <Link
+      to={item.href}
+      data-testid={`discover-item-${item.kind}`}
+      className="flex w-44 shrink-0 flex-col justify-between rounded-lg border bg-card p-3 transition-colors hover:border-primary/50 hover:bg-accent/40"
+    >
+      <div className="min-w-0">
+        <div className="truncate font-semibold">{item.title}</div>
+        {item.subtitle && (
+          <div className="truncate text-xs text-muted-foreground">{item.subtitle}</div>
+        )}
+      </div>
+      {item.metric != null && (
+        <div
+          className={cn(
+            "mt-3 text-sm font-medium tabular-nums",
+            up == null
+              ? "text-foreground"
+              : up
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-rose-600 dark:text-rose-400",
+          )}
+        >
+          {item.metric}
+        </div>
+      )}
+    </Link>
+  );
+}
+
+// -- Markets (top movers + class tab) ---------------------------------
+
+/**
+ * Fetches recent candles for ONE symbol to compute its intraday change, then
+ * reports it up to the parent so the parent can rank the movers. Renders
+ * nothing itself.
+ */
+function SymbolChangeProbe({
+  sym,
+  onChange,
+}: {
+  sym: MarketSymbol;
+  onChange: (id: number, change: number) => void;
+}) {
+  const candles = useCandles(sym.symbol_id, 60, true, 60);
+  const bars = candles.data?.bars ?? [];
+  const first = bars.length ? bars[0]!.close : undefined;
+  const last = bars.length ? bars[bars.length - 1]!.close : undefined;
+  const change = changeBpsFromPrices(first, last);
+  // Report up whenever we have a finite value; react-query dedupes the fetch.
+  useEffect(() => {
+    if (Number.isFinite(change)) onChange(sym.symbol_id, change);
+  }, [change, sym.symbol_id, onChange]);
+  return null;
+}
+
+function MarketsSection({ query }: { query: string }) {
+  const symbols = useSymbols();
+  const [classTab, setClassTab] = useState<ClassTab>(ALL_CLASS);
+  const [changes, setChanges] = useState<Record<number, number>>({});
+
+  const all = symbols.data?.symbols ?? [];
+  const filtered = useMemo(() => {
+    const bySearch = searchSymbols(all, query);
+    return bySearch.filter((s) => symbolInClass(s, classTab));
+  }, [all, query, classTab]);
+
+  const onChange = useMemo(
+    () => (id: number, change: number) =>
+      setChanges((prev) => (prev[id] === change ? prev : { ...prev, [id]: change })),
+    [],
+  );
+
+  const ranked: SymbolChange[] = useMemo(() => {
+    const withChange = filtered.map((s) => ({
+      symbol: s,
+      changeBps: changes[s.symbol_id] ?? NaN,
+    }));
+    return topMovers(withChange, ROW_LIMIT);
+  }, [filtered, changes]);
+
+  const items: DiscoverItem[] = ranked.map(({ symbol, changeBps }) => ({
+    kind: "market",
+    id: String(symbol.symbol_id),
+    title: symbol.symbol,
+    subtitle: symbol.is_perpetual ? "Perpetual" : "Spot",
+    metric: Number.isFinite(changeBps) ? bpsToSignedPct(changeBps) : "—",
+    changeBps: Number.isFinite(changeBps) ? changeBps : undefined,
+    href: `/markets/${symbol.symbol_id}`,
+  }));
+
+  return (
+    <SectionShell
+      header={
+        <SectionHeader
+          icon={<TrendingUp className="h-5 w-5" />}
+          title="Markets"
+          description="Top movers across spot, perps, prediction & funding books."
+          seeAllHref="/markets"
+        />
+      }
+    >
+      {/* Probes: one lightweight candle read per filtered symbol. */}
+      {filtered.map((s) => (
+        <SymbolChangeProbe key={s.symbol_id} sym={s} onChange={onChange} />
+      ))}
+
+      <Tabs value={classTab} onValueChange={(v) => setClassTab(v as ClassTab)} className="mb-3">
+        <TabsList>
+          {CLASS_TAB_ORDER.map((t) => (
+            <TabsTrigger key={t} value={t}>
+              {CLASS_LABELS[t]}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {symbols.isLoading ? (
+        <RowSkeleton />
+      ) : items.length === 0 ? (
+        <EmptyRow note={query ? "No markets match your search." : "No markets listed yet."} />
+      ) : (
+        <CardRow>
+          {items.map((it) => (
+            <ItemCard key={it.id} item={it} />
+          ))}
+        </CardRow>
+      )}
+    </SectionShell>
+  );
+}
+
+// -- Creator tokens ---------------------------------------------------
+
+function TokensSection({ query }: { query: string }) {
+  const market = useTokenMarket();
+  const tokens = market.data?.tokens ?? [];
+  const items = useMemo(
+    () =>
+      sortTokens(searchTokens(tokens, query), ROW_LIMIT).map((t) => ({
+        kind: "token" as const,
+        id: t.token_id,
+        title: t.ticker || t.name,
+        subtitle: t.name,
+        metric: t.clearing_price != null ? centsToUsd(t.clearing_price) ?? t.status : t.status,
+        href: `/tokens/${encodeURIComponent(t.token_id)}`,
+      })),
+    [tokens, query],
+  );
+
+  return (
+    <SectionShell
+      header={
+        <SectionHeader
+          icon={<Landmark className="h-5 w-5" />}
+          title="Creator Tokens"
+          description="Tradeable creator revenue-share tokens."
+          seeAllHref="/tokens"
+        />
+      }
+    >
+      {market.isLoading ? (
+        <RowSkeleton />
+      ) : items.length === 0 ? (
+        <EmptyRow
+          note={
+            market.isError
+              ? "Creator tokens are pending backend — nothing to browse yet."
+              : query
+                ? "No tokens match your search."
+                : "No creator tokens listed yet."
+          }
+        />
+      ) : (
+        <CardRow>
+          {items.map((it) => (
+            <ItemCard key={it.id} item={it} />
+          ))}
+        </CardRow>
+      )}
+    </SectionShell>
+  );
+}
+
+// -- Strategy funds ---------------------------------------------------
+
+function StrategiesSection({ query }: { query: string }) {
+  const market = useStrategyMarket();
+  const strategies = market.data?.strategies ?? [];
+  const items = useMemo(
+    () =>
+      sortStrategies(searchStrategies(strategies, query), "inception", ROW_LIMIT).map((s) => {
+        const capFrac = capacityRemainingFraction(s.aum_cents, s.max_aum_cents);
+        const capLabel =
+          s.max_aum_cents > 0 ? `${Math.round(capFrac * 100)}% capacity left` : "Uncapped";
+        const fees = `${(s.mgmt_fee_bps / 100).toLocaleString()}% mgmt / ${(s.perf_fee_bps / 100).toLocaleString()}% perf`;
+        const hasReturn = s.inception_return_bps != null && Number.isFinite(s.inception_return_bps);
+        return {
+          kind: "strategy" as const,
+          id: s.strategy_id,
+          title: s.name,
+          subtitle: `${fees} · ${capLabel}`,
+          metric: hasReturn ? bpsToSignedPct(s.inception_return_bps!) : centsToUsd(s.nav_per_unit) ?? "—",
+          changeBps: hasReturn ? s.inception_return_bps! : undefined,
+          href: `/strategies/${encodeURIComponent(s.strategy_id)}`,
+        };
+      }),
+    [strategies, query],
+  );
+
+  return (
+    <SectionShell
+      header={
+        <SectionHeader
+          icon={<Boxes className="h-5 w-5" />}
+          title="Strategy Funds"
+          description="Pooled NAV funds — top by since-inception return, with fees & capacity."
+          seeAllHref="/strategies"
+        />
+      }
+    >
+      {market.isLoading ? (
+        <RowSkeleton />
+      ) : items.length === 0 ? (
+        <EmptyRow
+          note={
+            market.isError
+              ? "Strategy funds are pending backend — nothing to browse yet."
+              : query
+                ? "No strategies match your search."
+                : "No published strategy funds yet."
+          }
+        />
+      ) : (
+        <CardRow>
+          {items.map((it) => (
+            <Card key={it.id} className="w-56 shrink-0">
+              <CardContent className="p-0">
+                <ItemCard item={{ ...it, subtitle: undefined }} />
+                <div className="px-3 pb-3 text-xs text-muted-foreground">{it.subtitle}</div>
+              </CardContent>
+            </Card>
+          ))}
+        </CardRow>
+      )}
+    </SectionShell>
+  );
+}
+
+// -- Staking ----------------------------------------------------------
+
+function StakingSection({ query }: { query: string }) {
+  const providers = useQuery({
+    queryKey: ["me", "staking", "providers", "discover"],
+    queryFn: getStakingProviders,
+    retry: false,
+  });
+
+  const list: StakingProvider[] = providers.data?.providers ?? [];
+  const items = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return list
+      .filter((p) =>
+        !q ? true : `${p.asset} ${p.kind} ${p.chain} ${p.id}`.toLowerCase().includes(q),
+      )
+      .slice(0, ROW_LIMIT)
+      .map((p) => ({
+        kind: "staking" as const,
+        id: p.id,
+        title: p.asset,
+        subtitle: `${p.kind} · ${p.chain}`,
+        metric: undefined,
+        href: "/custody",
+      }));
+  }, [list, query]);
+
+  return (
+    <SectionShell
+      header={
+        <SectionHeader
+          icon={<Coins className="h-5 w-5" />}
+          title="Staking"
+          description="Gateway-backed yield vaults & validators."
+          seeAllHref="/custody"
+        />
+      }
+    >
+      {providers.isLoading ? (
+        <RowSkeleton />
+      ) : items.length === 0 ? (
+        <EmptyRow
+          note={
+            providers.isError
+              ? "Staking is not available on this account / pending backend."
+              : query
+                ? "No staking providers match your search."
+                : "No staking providers offered yet."
+          }
+        />
+      ) : (
+        <CardRow>
+          {items.map((it) => (
+            <ItemCard key={it.id} item={it} />
+          ))}
+        </CardRow>
+      )}
+    </SectionShell>
+  );
+}
+
+// -- Opportunities (IPO auctions + bailouts + peer discovery) ---------
+
+function OpportunitiesSection({ query }: { query: string }) {
+  const q = query.trim().toLowerCase();
+
+  const tokenAuctions = useQuery({
+    queryKey: ["me", "tokens", "auctions", "discover"],
+    queryFn: getOpenTokenAuctions,
+    retry: false,
+  });
+  const bailouts = useQuery({
+    queryKey: ["me", "bailouts", "discover"],
+    queryFn: getBailouts,
+    retry: false,
+  });
+  const stakeRequests = useQuery({
+    queryKey: ["me", "stake_requests", "discover"],
+    queryFn: getStakeRequests,
+    retry: false,
+  });
+  const peerAuctions = useQuery({
+    queryKey: ["me", "auctions", "discover"],
+    queryFn: getOpenAuctions,
+    retry: false,
+  });
+
+  const loading =
+    tokenAuctions.isLoading ||
+    bailouts.isLoading ||
+    stakeRequests.isLoading ||
+    peerAuctions.isLoading;
+
+  const items: DiscoverItem[] = useMemo(() => {
+    const out: DiscoverItem[] = [];
+
+    for (const a of tokenAuctions.data?.auctions ?? []) {
+      out.push({
+        kind: "opportunity",
+        id: `tokipo-${a.auction_id}`,
+        title: `IPO · ${a.token_id}`,
+        subtitle: `Reserve ${centsToUsd(a.reserve_price) ?? "—"} · ${(a.offered_pct_bps / 100).toLocaleString()}% offered`,
+        metric: "Bid",
+        href: `/tokens/${encodeURIComponent(a.token_id)}`,
+      });
+    }
+
+    for (const b of (bailouts.data?.auctions ?? []) as BailoutAuction[]) {
+      out.push({
+        kind: "opportunity",
+        id: `bailout-${b.auction_id}`,
+        title: `Bailout · ${b.side}`,
+        subtitle: `Needs ${centsToUsd(b.capital_needed_cents) ?? "—"} · up to ${(b.max_share_bps / 100).toLocaleString()}% share`,
+        metric: "Rescue",
+        href: "/bailouts",
+      });
+    }
+
+    for (const r of stakeRequests.data?.stake_requests ?? []) {
+      out.push({
+        kind: "opportunity",
+        id: `stakereq-${r.request_id ?? Math.random()}`,
+        title: `Stake request${r.symbolid != null ? ` · #${r.symbolid}` : ""}`,
+        subtitle:
+          r.max_stake_pct != null ? `up to ${r.max_stake_pct}% stake` : "peer collateral market",
+        metric: "Offer",
+        href: "/bailouts",
+      });
+    }
+
+    for (const a of peerAuctions.data?.auctions ?? []) {
+      out.push({
+        kind: "opportunity",
+        id: `peerauc-${a.auction_id ?? Math.random()}`,
+        title: `Position auction${a.symbolid != null ? ` · #${a.symbolid}` : ""}`,
+        subtitle: a.qty != null ? `qty ${a.qty}` : "peer position auction",
+        metric: "Bid",
+        href: "/bailouts",
+      });
+    }
+
+    return out
+      .filter((it) => (!q ? true : `${it.title} ${it.subtitle ?? ""}`.toLowerCase().includes(q)))
+      .slice(0, ROW_LIMIT);
+  }, [tokenAuctions.data, bailouts.data, stakeRequests.data, peerAuctions.data, q]);
+
+  // Honest note when every source degraded / returned nothing.
+  const allErrored =
+    tokenAuctions.isError && bailouts.isError && stakeRequests.isError && peerAuctions.isError;
+
+  return (
+    <SectionShell
+      header={
+        <SectionHeader
+          icon={<Rocket className="h-5 w-5" />}
+          title="Opportunities"
+          description="Open IPO auctions, position bailouts & peer staking/auction markets."
+          seeAllHref="/bailouts"
+          seeAllLabel="Bailouts board"
+        />
+      }
+    >
+      {loading ? (
+        <RowSkeleton />
+      ) : items.length === 0 ? (
+        <EmptyRow
+          note={
+            allErrored
+              ? "Opportunity feeds are pending backend — check back once they ship."
+              : query
+                ? "No open opportunities match your search."
+                : "No open opportunities right now."
+          }
+        />
+      ) : (
+        <CardRow>
+          {items.map((it) => (
+            <div key={it.id} className="w-56 shrink-0">
+              <ItemCard item={it} />
+            </div>
+          ))}
+        </CardRow>
+      )}
+    </SectionShell>
+  );
+}
+
+// -- Page -------------------------------------------------------------
+
+export default function InvestHubPage() {
+  const [query, setQuery] = useState("");
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-8 p-4 md:p-6">
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Invest</h1>
+            <p className="text-sm text-muted-foreground">
+              One front door to everything investable — markets, creator tokens, strategy funds,
+              staking & open opportunities.
+            </p>
+          </div>
+        </div>
+        <div className="relative max-w-md">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search markets, tokens & strategies…"
+            className="pl-9"
+            data-testid="discover-search"
+          />
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <Badge variant="secondary">Markets</Badge>
+          <Badge variant="secondary">Creator Tokens</Badge>
+          <Badge variant="secondary">Strategy Funds</Badge>
+          <Badge variant="secondary">Staking</Badge>
+          <Badge variant="secondary">Opportunities</Badge>
+        </div>
+      </div>
+
+      <MarketsSection query={query} />
+      <TokensSection query={query} />
+      <StrategiesSection query={query} />
+      <StakingSection query={query} />
+      <OpportunitiesSection query={query} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Unified Discover / Invest hub

One front door aggregating every investable/tradeable product that was each siloed in its own route: **markets** (by class + top movers), **creator tokens**, **strategy funds** (fees + capacity), **staking**, and an **Opportunities** row (open IPO token auctions, bailout auctions, peer stake/auction discovery). Aggregates existing reads client-side, degrading per section on 404 — works now for whatever the backend already serves.

Mounted at **/invest** ("Invest" nav) — `/discover` was already an existing social-discovery surface, left untouched (verified clean on both platforms).

### Web
`lib/discover.ts` (+40 vitest) — normalized DiscoverItem, heterogeneous search, ranking (top movers / by-return / by-AUM / capacity-remaining); `pages/invest/InvestHubPage` — live cross-product search + 5 card-row sections with per-section degrade + see-all deep-links; `getOpenTokenAuctions()`.

### Android
`feature/invest/InvestMath.kt` (+13 JVM tests) + `InvestScreen`/`ViewModel` combining the existing Exchange/Tokens/Strategies/Custody/Bailout repos; `MoreCatalog` + `MoreRoutes.REGISTERED` + `AuthenticatedGraph`; `openAuctions()`.

Only new endpoint (degrade-on-404): `GET /me/tokens/auctions`. No new deps. Gates: web tsc 0 · vite build · vitest 40/40; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (InvestMath 13/13, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
