### PR TITLE
feat(portfolio): allocation & risk analytics across all holdings (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1000,6 +1000,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "portfolio_analytics",
+            labelRes = R.string.more_entry_portfolio_analytics,
+            icon = Icons.Outlined.Assessment,
+            route = MoreRoutes.PORTFOLIO_ANALYTICS,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "paper_trading",
             labelRes = R.string.more_entry_paper_trading,
             icon = Icons.Outlined.Science,

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsMath.kt
@@ -1,0 +1,248 @@
+package com.testlogon.android.feature.portfolioanalytics
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.sqrt
+
+/**
+ * Pure, framework-free portfolio analytics math for the "how am I positioned / what is my risk"
+ * surface. No Android/Compose/coroutine imports so it is unit-testable on the JVM (see
+ * PortfolioAnalyticsMathTest). Every function guards its edge cases (empty / single / zero-equity /
+ * degenerate matrix) with a null or identity value rather than throwing.
+ *
+ * The ViewModel normalizes every holding (custody / spot / margin / creator tokens / strategy funds /
+ * staking) into a [NormalizedPosition] with an indicative USD [valueCents], then these helpers compute
+ * allocation, concentration, exposure, portfolio volatility, VaR and a diversification score. All
+ * monetary inputs/outputs are integer CENTS; all weights are BASIS POINTS (10_000 bps == 100%).
+ */
+
+/** Which side of the book a position sits on (drives gross/net/long/short exposure). */
+enum class PositionSide { LONG, SHORT }
+
+/** How to bucket holdings for the allocation breakdown. */
+enum class AllocationBy { ASSET, CLASS, PRODUCT }
+
+/**
+ * One normalized holding across every venue, reduced to the fields the analytics need.
+ *
+ * [key] is the stable dedupe/return-series key (usually an uppercase asset symbol, e.g. "BTC");
+ * [label] is the human row label; [group] is the PRODUCT bucket (venue/product family, e.g. "Spot");
+ * [assetClass] is the CLASS bucket (e.g. "Crypto", "Cash", "Fund"); [valueCents] is the indicative
+ * USD gross value (magnitude used); [side] is LONG/SHORT; [qty] is informational.
+ */
+data class NormalizedPosition(
+    val key: String,
+    val label: String,
+    val group: String,
+    val assetClass: String,
+    val valueCents: Long,
+    val side: PositionSide = PositionSide.LONG,
+    val qty: Double = 0.0,
+)
+
+/** One weighted breakdown slice: a bucket [key], its gross [valueCents], and its [weightBps]. */
+data class AllocationSlice(
+    val key: String,
+    val valueCents: Long,
+    val weightBps: Int,
+)
+
+/** Concentration read: Herfindahl-Hirschman Index over weights plus the topN cumulative weight. */
+data class Concentration(
+    val hhi: Int,
+    val topWeightBps: Int,
+    val topKey: String?,
+    val topNCumulativeBps: Int,
+    val n: Int,
+) {
+    /** Effective number of independent bets (1/normalized-HHI); 0 when there is nothing to hold. */
+    val effectiveBets: Double get() = if (hhi <= 0) 0.0 else 10_000.0 / hhi
+}
+
+/** Gross/net/long/short exposure (all cents) plus leverage vs net equity (bps; 10_000 == 1.0x). */
+data class Exposure(
+    val grossCents: Long,
+    val netCents: Long,
+    val longCents: Long,
+    val shortCents: Long,
+    val leverageBps: Int,
+)
+
+object PortfolioAnalyticsMath {
+
+    /** Total gross USD value across positions (sum of magnitudes), in cents. */
+    fun totalValueCents(positions: List<NormalizedPosition>): Long =
+        positions.sumOf { abs(it.valueCents) }
+
+    /**
+     * Weighted allocation breakdown bucketed [by] ASSET/CLASS/PRODUCT. Each slice carries its summed
+     * gross value and its weight in bps of the total gross. Empty input -> empty list; a zero-total
+     * (all positions worth 0) -> slices with 0 bps (no divide-by-zero). Sorted descending by value.
+     */
+    fun allocation(positions: List<NormalizedPosition>, by: AllocationBy): List<AllocationSlice> {
+        if (positions.isEmpty()) return emptyList()
+        val grouped = positions.groupBy {
+            when (by) {
+                AllocationBy.ASSET -> it.key
+                AllocationBy.CLASS -> it.assetClass
+                AllocationBy.PRODUCT -> it.group
+            }
+        }
+        val total = totalValueCents(positions)
+        return grouped.map { (k, ps) ->
+            val v = ps.sumOf { abs(it.valueCents) }
+            AllocationSlice(key = k, valueCents = v, weightBps = bpsOf(v, total))
+        }.sortedByDescending { it.valueCents }
+    }
+
+    /** The weight-in-bps vector implied by a set of allocation slices (order preserved). */
+    fun weightsBps(slices: List<AllocationSlice>): List<Int> = slices.map { it.weightBps }
+
+    /**
+     * Concentration over a set of allocation slices. HHI = sum(w_i^2) with w_i as a FRACTION, scaled
+     * back to a 0..10_000 index (10_000 == a single 100% holding; ~0 == perfectly diffuse). [topN]
+     * cumulative weight is the sum of the largest N weights. Empty -> a zeroed read.
+     */
+    fun concentration(slices: List<AllocationSlice>, topN: Int = 3): Concentration {
+        if (slices.isEmpty()) return Concentration(hhi = 0, topWeightBps = 0, topKey = null, topNCumulativeBps = 0, n = 0)
+        val sorted = slices.sortedByDescending { it.weightBps }
+        // HHI: sum of squared fractional weights, rescaled to the conventional 0..10_000 index.
+        val hhi = sorted.sumOf { s ->
+            val frac = s.weightBps / 10_000.0
+            frac * frac
+        } * 10_000.0
+        val top = sorted.first()
+        val cum = sorted.take(topN.coerceAtLeast(1)).sumOf { it.weightBps }
+        return Concentration(
+            hhi = hhi.toInt().coerceIn(0, 10_000),
+            topWeightBps = top.weightBps,
+            topKey = top.key,
+            topNCumulativeBps = cum.coerceAtMost(10_000),
+            n = slices.size,
+        )
+    }
+
+    /**
+     * Gross/net/long/short exposure (cents) + leverage. Long value is positive, short value negative in
+     * the NET sum; gross is the sum of magnitudes. Leverage = gross / |net| in bps (10_000 == 1.0x);
+     * when net is 0 (perfectly hedged) leverage is 0 to avoid a divide-by-zero blow-up.
+     */
+    fun exposure(positions: List<NormalizedPosition>): Exposure {
+        var longC = 0L
+        var shortC = 0L
+        for (p in positions) {
+            val v = abs(p.valueCents)
+            if (p.side == PositionSide.SHORT) shortC += v else longC += v
+        }
+        val gross = longC + shortC
+        val net = longC - shortC
+        val leverage = if (net == 0L) 0 else Math.round(gross.toDouble() / abs(net).toDouble() * 10_000.0).toInt()
+        return Exposure(grossCents = gross, netCents = net, longCents = longC, shortCents = shortC, leverageBps = leverage)
+    }
+
+    /**
+     * Portfolio volatility (bps) via the covariance combine sigma_p = sqrt(w^T C w), where C_ij =
+     * rho_ij * sigma_i * sigma_j. [weightsBps] and [perAssetVolBps] are aligned index-for-index;
+     * [correlationMatrix] is NxN (row-major) with 1.0 on the diagonal. A missing/short matrix falls
+     * back to the ASSUME-INDEPENDENT diagonal (rho=0 off-diagonal). Empty/degenerate input -> null.
+     * Weights are treated as fractions of the whole (bps/10_000); a single asset returns its own vol.
+     */
+    fun portfolioVolatilityBps(
+        weightsBps: List<Int>,
+        perAssetVolBps: List<Int>,
+        correlationMatrix: List<List<Double>>? = null,
+    ): Int? {
+        val n = minOf(weightsBps.size, perAssetVolBps.size)
+        if (n == 0) return null
+        val w = DoubleArray(n) { weightsBps[it] / 10_000.0 }
+        val s = DoubleArray(n) { perAssetVolBps[it] / 10_000.0 }
+        var variance = 0.0
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                val rho = when {
+                    i == j -> 1.0
+                    correlationMatrix != null && i < correlationMatrix.size && j < correlationMatrix[i].size ->
+                        correlationMatrix[i][j].coerceIn(-1.0, 1.0)
+                    else -> 0.0
+                }
+                variance += w[i] * w[j] * s[i] * s[j] * rho
+            }
+        }
+        if (variance <= 0.0) return 0
+        return (sqrt(variance) * 10_000.0).toInt().coerceAtLeast(0)
+    }
+
+    /**
+     * Parametric (variance-covariance) Value-at-Risk in CENTS: VaR = value * volFraction * z, where
+     * [volBps] is the horizon volatility in bps and [z] is the confidence z-score (1.645 == 95%,
+     * 2.326 == 99%). A non-positive value or vol -> 0. Returned as a positive cents figure (a loss).
+     */
+    fun parametricVarCents(valueCents: Long, volBps: Int, z: Double): Long {
+        if (valueCents <= 0L || volBps <= 0) return 0L
+        val vol = volBps / 10_000.0
+        return max(0.0, valueCents * vol * z).toLong()
+    }
+
+    /**
+     * Historical VaR in CENTS from a series of periodic portfolio [returns] (fractions, e.g. -0.03) at
+     * a [confidence] (0..1, e.g. 0.95). Takes the (1-confidence) worst-quantile loss and scales it by
+     * the current [valueCents]. Fewer than two returns -> 0 (nothing to rank). The result is a positive
+     * cents loss figure (0 when the quantile return is non-negative).
+     */
+    fun historicalVarCents(valueCents: Long, returns: List<Double>, confidence: Double): Long {
+        if (valueCents <= 0L || returns.size < 2) return 0L
+        val c = confidence.coerceIn(0.0, 0.999)
+        val sorted = returns.sorted() // ascending: worst (most negative) first
+        // Quantile index at the lower tail: floor((1 - c) * N), clamped into range.
+        val idx = ((1.0 - c) * sorted.size).toInt().coerceIn(0, sorted.size - 1)
+        val quantileReturn = sorted[idx]
+        if (quantileReturn >= 0.0) return 0L
+        return max(0.0, valueCents * -quantileReturn).toLong()
+    }
+
+    /**
+     * A 0..100 diversification score. Combines HOW SPREAD the weights are (1 - normalized HHI) with HOW
+     * UNCORRELATED the book is (1 - average absolute pairwise correlation, weight-weighted). A single
+     * holding scores 0; many equal, uncorrelated holdings approach 100. Empty -> 0. When no correlation
+     * matrix is supplied the correlation term is treated as fully diversifying (independent assumption).
+     */
+    fun diversificationScore(
+        weightsBps: List<Int>,
+        correlationMatrix: List<List<Double>>? = null,
+    ): Int {
+        val n = weightsBps.size
+        if (n == 0) return 0
+        if (n == 1) return 0
+        val w = weightsBps.map { it / 10_000.0 }
+        // Spread term: 1 - normalized HHI, where normalized HHI in [1/n, 1] maps to [0, 1].
+        val hhi = w.sumOf { it * it }
+        val minHhi = 1.0 / n
+        val spread = if (1.0 - minHhi <= 0.0) 0.0 else ((1.0 - hhi) / (1.0 - minHhi)).coerceIn(0.0, 1.0)
+        // Correlation term: 1 - weight-weighted average |rho| over distinct pairs.
+        val corrTerm: Double = if (correlationMatrix == null) {
+            1.0
+        } else {
+            var wsum = 0.0
+            var acc = 0.0
+            for (i in 0 until n) {
+                for (j in i + 1 until n) {
+                    val rho = if (i < correlationMatrix.size && j < correlationMatrix[i].size)
+                        abs(correlationMatrix[i][j].coerceIn(-1.0, 1.0)) else 0.0
+                    val pairW = w[i] * w[j]
+                    acc += pairW * rho
+                    wsum += pairW
+                }
+            }
+            if (wsum <= 0.0) 1.0 else (1.0 - (acc / wsum)).coerceIn(0.0, 1.0)
+        }
+        val score = 100.0 * (0.5 * spread + 0.5 * corrTerm)
+        return score.toInt().coerceIn(0, 100)
+    }
+
+    /** value/total as bps (0 when total <= 0), rounded to nearest, clamped to 0..10_000. */
+    private fun bpsOf(value: Long, total: Long): Int {
+        if (total <= 0L) return 0
+        val bps = Math.round(value.toDouble() / total.toDouble() * 10_000.0)
+        return bps.toInt().coerceIn(0, 10_000)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsScreen.kt
@@ -1,0 +1,383 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.portfolioanalytics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.util.Locale
+
+private val Warn = Color(0xFFDC2626)
+private val Ok = Color(0xFF16A34A)
+
+@Composable
+fun PortfolioAnalyticsRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PortfolioAnalyticsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PortfolioAnalyticsScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onSelectAllocationBy = viewModel::onSelectAllocationBy,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PortfolioAnalyticsScreen(
+    state: PortfolioAnalyticsUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onSelectAllocationBy: (AllocationBy) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Allocation & Risk") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { HeaderCard(state) }
+
+            when {
+                state.loading -> item { LoadingBlock() }
+                state.allEmpty -> item { EmptyBlock(state) }
+                else -> {
+                    if (state.sourceIssues.isNotEmpty()) item { SourceIssuesCard(state.sourceIssues) }
+                    item { AllocationCard(state, onSelectAllocationBy) }
+                    item { ConcentrationCard(state) }
+                    item { ExposureCard(state) }
+                    item { RiskCard(state) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderCard(state: PortfolioAnalyticsUiState) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Indicative portfolio value (USD)",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                usd(state.totalValueCents),
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                if (state.pricesStub) {
+                    "Cross-venue gross value — indicative (stub prices)."
+                } else {
+                    "Cross-venue gross value across custody / spot / margin / tokens / funds / staking."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SourceIssuesCard(issues: List<String>) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Some sources unavailable", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(6.dp))
+            issues.forEach { Text("• $it", style = MaterialTheme.typography.bodySmall) }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "These sources contribute nothing to the numbers below.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AllocationCard(state: PortfolioAnalyticsUiState, onSelect: (AllocationBy) -> Unit) {
+    SectionCard("Allocation") {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            AllocationBy.entries.forEach { by ->
+                FilterChip(
+                    selected = state.allocationBy == by,
+                    onClick = { onSelect(by) },
+                    label = { Text(by.name.lowercase().replaceFirstChar { it.uppercase() }) },
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        if (state.allocation.isEmpty()) {
+            EmptyLine("No priced holdings to break down.")
+        } else {
+            state.allocation.forEach { slice -> WeightBar(slice.key, slice.weightBps, slice.valueCents) }
+        }
+    }
+}
+
+@Composable
+private fun WeightBar(label: String, weightBps: Int, valueCents: Long) {
+    Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(label, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                pct(weightBps) + "  " + usd(valueCents),
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.height(2.dp))
+        LinearProgressIndicator(
+            progress = { (weightBps / 10_000f).coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth().height(6.dp),
+        )
+    }
+}
+
+@Composable
+private fun ConcentrationCard(state: PortfolioAnalyticsUiState) {
+    val c = state.concentration
+    SectionCard("Concentration") {
+        if (c == null || c.n == 0) {
+            EmptyLine("Nothing to measure yet.")
+            return@SectionCard
+        }
+        StatRow("Largest position", (c.topKey ?: "—") + "  " + pct(c.topWeightBps))
+        StatRow("Top-3 combined", pct(c.topNCumulativeBps))
+        StatRow("Effective bets", String.format(Locale.US, "%.1f", c.effectiveBets))
+        Spacer(Modifier.height(8.dp))
+        Text("HHI concentration", style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(2.dp))
+        LinearProgressIndicator(
+            progress = { (c.hhi / 10_000f).coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth().height(8.dp),
+            color = if (c.hhi >= 4_000) Warn else MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            hhiLabel(c.hhi) + " (" + c.hhi + " / 10000)",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ExposureCard(state: PortfolioAnalyticsUiState) {
+    val e = state.exposure
+    SectionCard("Exposure") {
+        if (e == null) {
+            EmptyLine("Nothing to measure yet.")
+            return@SectionCard
+        }
+        StatRow("Gross", usd(e.grossCents))
+        StatRow("Net", usd(e.netCents))
+        StatRow("Long", usd(e.longCents))
+        StatRow("Short", usd(e.shortCents))
+        StatRow("Leverage", leverage(e.leverageBps))
+    }
+}
+
+@Composable
+private fun RiskCard(state: PortfolioAnalyticsUiState) {
+    SectionCard("Risk") {
+        if (state.riskUnavailable) {
+            EmptyLine("Risk needs per-asset price history for your priced holdings — none available yet.")
+            return@SectionCard
+        }
+        if (state.limitedHistory) {
+            Surface(
+                color = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                shape = RoundedCornerShape(6.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    "Limited history: some series use the recent window only — figures are approximate.",
+                    modifier = Modifier.padding(8.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+        StatRow("Portfolio volatility (annualized)", state.portfolioVolBps?.let { pct(it) } ?: "—")
+        StatRow("Parametric VaR (95%, 1d)", usd(state.parametricVar95Cents))
+        StatRow("Parametric VaR (99%, 1d)", usd(state.parametricVar99Cents))
+        StatRow("Historical VaR (95%, 1d)", usd(state.historicalVar95Cents))
+        Spacer(Modifier.height(8.dp))
+        Text("Diversification score", style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(2.dp))
+        LinearProgressIndicator(
+            progress = { (state.diversificationScore / 100f).coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth().height(8.dp),
+            color = if (state.diversificationScore >= 60) Ok else Warn,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            state.diversificationScore.toString() + " / 100 · based on " + state.riskAssetsCovered + " priced asset(s)",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// ---------------- shared bits ----------------
+
+@Composable
+private fun SectionCard(title: String, content: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(8.dp))
+            content()
+        }
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+private fun EmptyLine(text: String) {
+    Text(text, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+}
+
+@Composable
+private fun LoadingBlock() {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(Modifier.height(12.dp))
+        Text("Analyzing your positions…", style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun EmptyBlock(state: PortfolioAnalyticsUiState) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("No priced holdings yet", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Fund custody, spot, or margin (with indicative prices available) to see allocation & risk.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (state.sourceIssues.isNotEmpty()) {
+            Spacer(Modifier.height(12.dp))
+            state.sourceIssues.forEach { Text("• $it", style = MaterialTheme.typography.labelSmall) }
+        }
+    }
+}
+
+// ---------------- formatting ----------------
+
+private fun usd(cents: Long): String {
+    val v = cents / 100.0
+    return "$" + String.format(Locale.US, "%,.2f", v)
+}
+
+private fun pct(bps: Int): String = String.format(Locale.US, "%.1f%%", bps / 100.0)
+
+private fun leverage(bps: Int): String =
+    if (bps <= 0) "—" else String.format(Locale.US, "%.2fx", bps / 10_000.0)
+
+private fun hhiLabel(hhi: Int): String = when {
+    hhi >= 5_000 -> "Highly concentrated"
+    hhi >= 2_500 -> "Moderately concentrated"
+    hhi >= 1_500 -> "Somewhat diversified"
+    else -> "Diversified"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsUiState.kt
@@ -1,0 +1,48 @@
+package com.testlogon.android.feature.portfolioanalytics
+
+/**
+ * Read-only Portfolio Analytics UI state ("how am I positioned / what is my risk").
+ *
+ * The ViewModel normalizes every holding across custody / spot / margin / creator tokens / strategy
+ * funds / staking into a [NormalizedPosition] list (indicative USD cents), then folds the pure
+ * [PortfolioAnalyticsMath] outputs into this snapshot. Each SOURCE degrades independently: a source
+ * that could not be read is recorded in [sourceIssues] and simply contributes nothing, while the
+ * sections that CAN be computed still render. Nothing here moves money.
+ */
+data class PortfolioAnalyticsUiState(
+    val loading: Boolean = true,
+    /** The normalized cross-venue positions the analytics are computed from. */
+    val positions: List<NormalizedPosition> = emptyList(),
+    /** Total indicative gross USD value (cents) across all normalized positions. */
+    val totalValueCents: Long = 0L,
+    /** The currently-selected allocation grouping. */
+    val allocationBy: AllocationBy = AllocationBy.ASSET,
+    /** The allocation breakdown for [allocationBy] (weighted slices, descending). */
+    val allocation: List<AllocationSlice> = emptyList(),
+    /** Concentration read over the ASSET-level weights (HHI + topN). */
+    val concentration: Concentration? = null,
+    /** Gross/net/long/short exposure + leverage. */
+    val exposure: Exposure? = null,
+    /** Portfolio volatility in bps (covariance combine), null when insufficient history. */
+    val portfolioVolBps: Int? = null,
+    /** Parametric VaR (95%) in cents. */
+    val parametricVar95Cents: Long = 0L,
+    /** Parametric VaR (99%) in cents. */
+    val parametricVar99Cents: Long = 0L,
+    /** Historical VaR (95%) in cents from the blended portfolio return series. */
+    val historicalVar95Cents: Long = 0L,
+    /** 0..100 diversification score. */
+    val diversificationScore: Int = 0,
+    /** How many priced assets had a usable return series backing the risk math. */
+    val riskAssetsCovered: Int = 0,
+    /** True when at least one asset's history was DEGRADED to the recent window (stub) — show banner. */
+    val limitedHistory: Boolean = false,
+    /** True when risk could not be computed at all (no usable per-asset return series yet). */
+    val riskUnavailable: Boolean = false,
+    /** Per-source read problems (e.g. "Margin: not available on this deployment"). */
+    val sourceIssues: List<String> = emptyList(),
+    /** True when the indicative USD marks are the edge STUB placeholders. */
+    val pricesStub: Boolean = false,
+    /** True when no priced holdings could be normalized at all (whole-screen empty state). */
+    val allEmpty: Boolean = false,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsViewModel.kt
@@ -1,0 +1,471 @@
+package com.testlogon.android.feature.portfolioanalytics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.PriceMap
+import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.feature.analysis.MarketStats
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.math.abs
+import kotlin.math.roundToLong
+
+/**
+ * Read-only Portfolio Analytics ViewModel. Fans out the SIX independent holding sources in parallel —
+ * custody balances + staking ([CustodyRepository]); spot + margin + indicative prices
+ * ([TradingRepository]); creator tokens ([TokensRepository]); strategy funds ([StrategiesRepository])
+ * — normalizes each into a [NormalizedPosition] in indicative USD cents, then folds everything through
+ * the pure [PortfolioAnalyticsMath]. Per-asset return series for the risk math come from the exchange
+ * [ExchangeRepository.getHistory] (degrade-on-404 handled inside the repo). Every source degrades
+ * independently: an unreadable source contributes nothing and is noted in
+ * [PortfolioAnalyticsUiState.sourceIssues] instead of blanking the screen. No writes.
+ */
+@HiltViewModel
+class PortfolioAnalyticsViewModel @Inject constructor(
+    private val custody: CustodyRepository,
+    private val trading: TradingRepository,
+    private val exchange: ExchangeRepository,
+    private val tokens: TokensRepository,
+    private val strategies: StrategiesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PortfolioAnalyticsUiState())
+    val uiState: StateFlow<PortfolioAnalyticsUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    /** Change the allocation grouping without re-fetching (recompute from the held positions). */
+    fun onSelectAllocationBy(by: AllocationBy) {
+        val cur = _uiState.value
+        if (cur.allocationBy == by) return
+        _uiState.value = cur.copy(
+            allocationBy = by,
+            allocation = PortfolioAnalyticsMath.allocation(cur.positions, by),
+        )
+    }
+
+    fun refresh() {
+        _uiState.value = PortfolioAnalyticsUiState(loading = true, allocationBy = _uiState.value.allocationBy)
+        viewModelScope.launch {
+            val built = coroutineScope {
+                val custodyDef = async { custody.getBalance() }
+                val stakingDef = async { custody.getStaking() }
+                val spotDef = async { trading.spotBalance() }
+                val marginDef = async { trading.marginAccount() }
+                val pricesDef = async { trading.getPrices() }
+                val instrumentsDef = async { exchange.symbols() }
+                val issuedDef = async { tokens.issued() }
+                val tokenMarketDef = async { tokens.market() }
+                val strategiesMineDef = async { strategies.mine() }
+
+                val prices = (pricesDef.await() as? ApiResult.Success)?.data ?: PriceMap.unavailable()
+                val instruments = (instrumentsDef.await() as? ApiResult.Success)?.data ?: emptyList()
+                val instrumentBySymbol = instruments.associateBy { it.symbol.uppercase() }
+
+                val positions = ArrayList<NormalizedPosition>()
+                val issues = ArrayList<String>()
+
+                normalizeCustody(custodyDef.await(), prices, positions, issues)
+                normalizeStaking(stakingDef.await(), prices, positions, issues)
+                normalizeSpot(spotDef.await(), instruments, prices, positions, issues)
+                normalizeMargin(marginDef.await(), prices, positions, issues)
+                normalizeTokens(issuedDef.await(), tokenMarketDef.await(), positions, issues)
+                normalizeStrategies(strategiesMineDef.await(), positions, issues)
+
+                // Risk math needs a per-asset return series for the priced EXCHANGE assets we hold.
+                val riskKeys = positions.map { it.key.uppercase() }.toSet()
+                    .mapNotNull { instrumentBySymbol[it] }
+                    .distinctBy { it.symbolId }
+                val risk = computeRisk(positions, riskKeys)
+
+                buildState(positions, prices, issues, risk)
+            }
+            _uiState.value = built
+        }
+    }
+
+    // ---------------- normalization per source ----------------
+
+    private fun normalizeCustody(
+        r: ApiResult<*>,
+        prices: PriceMap,
+        out: MutableList<NormalizedPosition>,
+        issues: MutableList<String>,
+    ) {
+        when (r) {
+            is ApiResult.Success -> {
+                val balances = r.data as? com.testlogon.android.data.custody.CustodyBalances ?: return
+                balances.rows.filter { it.amount > 0.0 }.forEach { row ->
+                    val usd = prices.priceFor(row.symbol)?.let { it * row.amount }
+                    if (usd != null) {
+                        out.add(
+                            NormalizedPosition(
+                                key = row.symbol.uppercase(),
+                                label = row.symbol,
+                                group = "Custody",
+                                assetClass = classOf(row.symbol),
+                                valueCents = toCents(usd),
+                                qty = row.amount,
+                            ),
+                        )
+                    }
+                }
+            }
+            is ApiResult.Failure -> issues.add("Custody: " + reason(r.error.status))
+            is ApiResult.NetworkError -> issues.add("Custody: network error")
+        }
+    }
+
+    private fun normalizeStaking(
+        r: ApiResult<*>,
+        prices: PriceMap,
+        out: MutableList<NormalizedPosition>,
+        issues: MutableList<String>,
+    ) {
+        when (r) {
+            is ApiResult.Success -> {
+                val dash = r.data as? com.testlogon.android.data.custody.StakingDashboard ?: return
+                if (dash.unavailable) return
+                dash.positions.forEach { p ->
+                    val amount = p.total.toDoubleOrNull()
+                    val usd = if (amount != null) prices.priceFor(p.asset)?.let { it * amount } else null
+                    if (usd != null && amount != null) {
+                        out.add(
+                            NormalizedPosition(
+                                key = p.asset.uppercase(),
+                                label = p.asset + " (staked)",
+                                group = "Staking",
+                                assetClass = "Staking",
+                                valueCents = toCents(usd),
+                                qty = amount,
+                            ),
+                        )
+                    }
+                }
+            }
+            is ApiResult.Failure -> issues.add("Staking: " + reason(r.error.status))
+            is ApiResult.NetworkError -> issues.add("Staking: network error")
+        }
+    }
+
+    private fun normalizeSpot(
+        r: ApiResult<*>,
+        instruments: List<Instrument>,
+        prices: PriceMap,
+        out: MutableList<NormalizedPosition>,
+        issues: MutableList<String>,
+    ) {
+        when (r) {
+            is ApiResult.Success -> {
+                val spot = r.data as? com.testlogon.android.data.exchange.SpotBalance ?: return
+                spot.assets.filter { it.balance > 0L }.forEach { a ->
+                    val sym = a.symbol.ifBlank {
+                        instruments.firstOrNull { it.symbolId == a.asset }?.symbol.orEmpty()
+                    }
+                    val usd = sym.takeIf { it.isNotBlank() }?.let { prices.priceFor(it) }?.let { it * a.balance.toDouble() }
+                    if (usd != null && sym.isNotBlank()) {
+                        out.add(
+                            NormalizedPosition(
+                                key = sym.uppercase(),
+                                label = sym,
+                                group = "Spot",
+                                assetClass = classOf(sym),
+                                valueCents = toCents(usd),
+                                qty = a.balance.toDouble(),
+                            ),
+                        )
+                    }
+                }
+            }
+            is ApiResult.Failure -> issues.add("Spot: " + reason(r.error.status))
+            is ApiResult.NetworkError -> issues.add("Spot: network error")
+        }
+    }
+
+    private fun normalizeMargin(
+        r: ApiResult<*>,
+        prices: PriceMap,
+        out: MutableList<NormalizedPosition>,
+        issues: MutableList<String>,
+    ) {
+        when (r) {
+            is ApiResult.Success -> {
+                val acct = r.data as? com.testlogon.android.data.exchange.MarginAccount ?: return
+                // Free margin cash (USDC-denominated), valued via the quote asset.
+                if (acct.balance > 0L) {
+                    val usd = (prices.priceFor("USDC") ?: prices.priceFor("USD"))?.let { it * acct.balance.toDouble() }
+                    if (usd != null) {
+                        out.add(
+                            NormalizedPosition(
+                                key = "USDC",
+                                label = "Margin cash",
+                                group = "Margin",
+                                assetClass = "Cash",
+                                valueCents = toCents(usd),
+                                qty = acct.balance.toDouble(),
+                            ),
+                        )
+                    }
+                }
+                // The open position, valued as an indicative USD notional via the underlying's price.
+                val pos = acct.position
+                if (pos != null && pos.qty != 0L) {
+                    val sym = marginSymbol(pos.symbolId)
+                    val unitPrice = prices.priceFor(sym)
+                    if (unitPrice != null && unitPrice > 0.0) {
+                        val notionalUsd = abs(pos.qty).toDouble() * unitPrice
+                        out.add(
+                            NormalizedPosition(
+                                key = sym.uppercase(),
+                                label = sym + " position",
+                                group = "Margin",
+                                assetClass = classOf(sym),
+                                valueCents = toCents(notionalUsd),
+                                side = if (pos.qty >= 0) PositionSide.LONG else PositionSide.SHORT,
+                                qty = pos.qty.toDouble(),
+                            ),
+                        )
+                    }
+                }
+            }
+            is ApiResult.Failure -> issues.add("Margin: " + reason(r.error.status))
+            is ApiResult.NetworkError -> issues.add("Margin: network error")
+        }
+    }
+
+    private fun normalizeTokens(
+        issued: ApiResult<*>,
+        market: ApiResult<*>,
+        out: MutableList<NormalizedPosition>,
+        issues: MutableList<String>,
+    ) {
+        val issuedFail = issued is ApiResult.Failure || issued is ApiResult.NetworkError
+        val marketFail = market is ApiResult.Failure || market is ApiResult.NetworkError
+        if (issuedFail && marketFail) {
+            issues.add("Creator tokens: unavailable")
+            return
+        }
+        @Suppress("UNCHECKED_CAST")
+        val issuedList = (issued as? ApiResult.Success)?.data as? List<com.testlogon.android.data.tokens.Token> ?: emptyList()
+        // Tokens I issued: I hold the un-sold supply; value it at the cleared IPO price when listed.
+        issuedList.forEach { t ->
+            val price = t.clearingPrice
+            if (price != null && price > 0L && t.totalSupply > 0L) {
+                // Indicative cents value of my creator holding (supply * price/token cents).
+                val valueCents = t.totalSupply * price
+                out.add(
+                    NormalizedPosition(
+                        key = "TOK:" + t.ticker.uppercase(),
+                        label = t.ticker + " (my token)",
+                        group = "Creator tokens",
+                        assetClass = "Creator token",
+                        valueCents = valueCents,
+                        qty = t.totalSupply.toDouble(),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun normalizeStrategies(
+        mine: ApiResult<*>,
+        out: MutableList<NormalizedPosition>,
+        issues: MutableList<String>,
+    ) {
+        when (mine) {
+            is ApiResult.Success -> {
+                @Suppress("UNCHECKED_CAST")
+                val list = mine.data as? List<com.testlogon.android.data.strategies.Strategy> ?: emptyList()
+                list.forEach { s ->
+                    val aum = s.aumCents
+                    if (aum != null && aum > 0L) {
+                        out.add(
+                            NormalizedPosition(
+                                key = "FUND:" + s.strategyId,
+                                label = s.name + " (fund)",
+                                group = "Strategy funds",
+                                assetClass = "Fund",
+                                valueCents = aum,
+                                qty = 0.0,
+                            ),
+                        )
+                    }
+                }
+            }
+            is ApiResult.Failure -> issues.add("Strategy funds: " + reason(mine.error.status))
+            is ApiResult.NetworkError -> issues.add("Strategy funds: network error")
+        }
+    }
+
+    // ---------------- risk math (per-asset return series -> vol/corr/VaR) ----------------
+
+    private data class RiskInputs(
+        val volBps: Int?,
+        val parametric95: Long,
+        val parametric99: Long,
+        val historical95: Long,
+        val diversification: Int,
+        val covered: Int,
+        val limitedHistory: Boolean,
+        val unavailable: Boolean,
+    )
+
+    private suspend fun computeRisk(
+        positions: List<NormalizedPosition>,
+        riskInstruments: List<Instrument>,
+    ): RiskInputs {
+        val totalValue = PortfolioAnalyticsMath.totalValueCents(positions)
+        if (riskInstruments.isEmpty() || totalValue <= 0L) {
+            return RiskInputs(null, 0, 0, 0, 0, 0, false, unavailable = true)
+        }
+        // Per-asset gross value (cents) for the priced exchange assets, keyed by uppercase symbol.
+        val valueByKey = HashMap<String, Long>()
+        positions.forEach { valueByKey[it.key.uppercase()] = (valueByKey[it.key.uppercase()] ?: 0L) + abs(it.valueCents) }
+
+        val seriesBySymbol = LinkedHashMap<String, List<Double>>()
+        var limited = false
+        for (inst in riskInstruments) {
+            val bars = when (val h = exchange.getHistory(inst.symbolId, "1d")) {
+                is ApiResult.Success -> {
+                    if (h.data.stub) limited = true
+                    h.data.bars.map { it.close.toDouble() }
+                }
+                else -> emptyList()
+            }
+            if (bars.size >= 2) seriesBySymbol[inst.symbol.uppercase()] = bars
+        }
+        if (seriesBySymbol.isEmpty()) {
+            return RiskInputs(null, 0, 0, 0, 0, 0, limited, unavailable = true)
+        }
+
+        val keys = seriesBySymbol.keys.toList()
+        // Sub-portfolio value covered by return series (only the priced exchange assets).
+        val coveredValue = keys.sumOf { valueByKey[it] ?: 0L }
+        if (coveredValue <= 0L) {
+            return RiskInputs(null, 0, 0, 0, 0, 0, limited, unavailable = true)
+        }
+        val weightsBps = keys.map { k ->
+            Math.round((valueByKey[k] ?: 0L).toDouble() / coveredValue.toDouble() * 10_000.0).toInt()
+        }
+        val volsBps = keys.map { k ->
+            val v = MarketStats.annualizedVolatility(seriesBySymbol[k].orEmpty())
+            ((v ?: 0.0) * 10_000.0).toInt().coerceAtLeast(0)
+        }
+        // Correlation matrix over aligned log-returns.
+        val logReturns = keys.map { MarketStats.logReturns(seriesBySymbol[it].orEmpty()) }
+        val corr = keys.indices.map { i ->
+            keys.indices.map { j ->
+                if (i == j) 1.0 else (MarketStats.correlation(logReturns[i], logReturns[j]) ?: 0.0)
+            }
+        }
+        val portVolBps = PortfolioAnalyticsMath.portfolioVolatilityBps(weightsBps, volsBps, corr)
+        val diversification = PortfolioAnalyticsMath.diversificationScore(weightsBps, corr)
+
+        // Parametric VaR uses the DAILY vol (de-annualize) on the covered sub-portfolio value.
+        val dailyVolBps = portVolBps?.let { (it / kotlin.math.sqrt(MarketStats.ANNUALIZATION_PERIODS)).toInt() } ?: 0
+        val param95 = PortfolioAnalyticsMath.parametricVarCents(coveredValue, dailyVolBps, Z_95)
+        val param99 = PortfolioAnalyticsMath.parametricVarCents(coveredValue, dailyVolBps, Z_99)
+
+        // Historical VaR: blend per-asset daily log-returns by weight into a portfolio return series.
+        val minLen = logReturns.filter { it.isNotEmpty() }.minOfOrNull { it.size } ?: 0
+        val blended = ArrayList<Double>(minLen)
+        for (t in 0 until minLen) {
+            var r = 0.0
+            for (i in keys.indices) {
+                val w = weightsBps[i] / 10_000.0
+                val series = logReturns[i]
+                r += w * series[series.size - minLen + t]
+            }
+            blended.add(r)
+        }
+        val hist95 = PortfolioAnalyticsMath.historicalVarCents(coveredValue, blended, 0.95)
+
+        return RiskInputs(
+            volBps = portVolBps,
+            parametric95 = param95,
+            parametric99 = param99,
+            historical95 = hist95,
+            diversification = diversification,
+            covered = keys.size,
+            limitedHistory = limited,
+            unavailable = false,
+        )
+    }
+
+    // ---------------- fold into UI state ----------------
+
+    private fun buildState(
+        positions: List<NormalizedPosition>,
+        prices: PriceMap,
+        issues: List<String>,
+        risk: RiskInputs,
+    ): PortfolioAnalyticsUiState {
+        val by = _uiState.value.allocationBy
+        val allocation = PortfolioAnalyticsMath.allocation(positions, by)
+        val assetSlices = PortfolioAnalyticsMath.allocation(positions, AllocationBy.ASSET)
+        val concentration = PortfolioAnalyticsMath.concentration(assetSlices)
+        val exposure = PortfolioAnalyticsMath.exposure(positions)
+        return PortfolioAnalyticsUiState(
+            loading = false,
+            positions = positions,
+            totalValueCents = PortfolioAnalyticsMath.totalValueCents(positions),
+            allocationBy = by,
+            allocation = allocation,
+            concentration = if (positions.isEmpty()) null else concentration,
+            exposure = if (positions.isEmpty()) null else exposure,
+            portfolioVolBps = risk.volBps,
+            parametricVar95Cents = risk.parametric95,
+            parametricVar99Cents = risk.parametric99,
+            historicalVar95Cents = risk.historical95,
+            diversificationScore = risk.diversification,
+            riskAssetsCovered = risk.covered,
+            limitedHistory = risk.limitedHistory,
+            riskUnavailable = risk.unavailable,
+            sourceIssues = issues,
+            pricesStub = !prices.unavailable && prices.stub && positions.isNotEmpty(),
+            allEmpty = positions.isEmpty(),
+        )
+    }
+
+    // ---------------- helpers ----------------
+
+    private fun toCents(usd: Double): Long = (usd * 100.0).roundToLong().coerceAtLeast(0L)
+
+    private fun reason(status: Int): String = when (status) {
+        403 -> "not available for this account"
+        404 -> "not available on this deployment"
+        else -> "unavailable right now"
+    }
+
+    /** Coarse asset-class bucketing for the CLASS allocation view. */
+    private fun classOf(symbol: String): String = when (symbol.trim().uppercase()) {
+        "USD", "USDC", "USDT", "DAI" -> "Cash"
+        else -> "Crypto"
+    }
+
+    private fun marginSymbol(symbolId: Int): String = when (symbolId) {
+        1 -> "BTC"
+        2 -> "ETH"
+        3 -> "SOL"
+        else -> "#$symbolId"
+    }
+
+    private companion object {
+        const val Z_95 = 1.645
+        const val Z_99 = 2.326
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -223,6 +223,9 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         portfolioDestination(navController)
         // PnL & performance: read-only realized/unrealized analytics, equity curve, per-symbol breakdown.
         pnlDestination(navController)
+        // Portfolio Allocation & Risk Analytics: read-only cross-venue allocation / concentration /
+        // exposure / risk (vol + VaR + diversification), client-computed from existing holding reads.
+        portfolioAnalyticsDestination(navController)
         // Paper Trading: self-contained client-side trading simulation (isolated paper account; no real orders).
         paperDestination(navController)
         // Export & reporting: read-only period-scoped CSV export (trade history / PnL / statement).

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -112,6 +112,10 @@ object MoreRoutes {
     // Portfolio: read-only cross-venue account overview (custody / spot / margin / staking snapshot).
     const val PORTFOLIO = PortfolioDest.ROUTE
 
+    // Portfolio Allocation & Risk Analytics: read-only cross-venue allocation / concentration /
+    // exposure / risk (vol + VaR + diversification), client-computed from existing holding reads.
+    const val PORTFOLIO_ANALYTICS = PortfolioAnalyticsDest.ROUTE
+
     // PnL & performance: read-only realized/unrealized analytics + equity curve (Wallet hub, near Portfolio).
     const val PNL = PnlDest.ROUTE
 
@@ -607,6 +611,7 @@ object MoreRoutes {
             CUSTODY,
             CUSTODY_PROVIDERS,
             PORTFOLIO,
+            PORTFOLIO_ANALYTICS,
             PNL,
             PAPER,
             REPORTS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/PortfolioAnalyticsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/PortfolioAnalyticsNavigation.kt
@@ -1,0 +1,25 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.portfolioanalytics.PortfolioAnalyticsRoute
+
+/**
+ * The read-only Portfolio Allocation & Risk Analytics surface, reached from the More -> Wallet hub.
+ * Client-computes allocation / concentration / exposure / risk (vol + VaR + diversification) from the
+ * existing cross-venue holding reads (custody / spot / margin / tokens / funds / staking); each source
+ * degrades independently. No order entry, no money movement.
+ */
+data object PortfolioAnalyticsDest {
+    const val ROUTE = "portfolio_analytics"
+}
+
+/** Registers the Portfolio Analytics screen in the authenticated graph. Up / Back pops the stack. */
+fun NavGraphBuilder.portfolioAnalyticsDestination(navController: NavHostController) {
+    composable(PortfolioAnalyticsDest.ROUTE) {
+        PortfolioAnalyticsRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1461,6 +1461,7 @@
     <string name="more_entry_custody_providers">Custody providers</string>
     <string name="more_entry_portfolio">Portfolio</string>
     <string name="more_entry_pnl">PnL &amp; performance</string>
+    <string name="more_entry_portfolio_analytics">Allocation &amp; risk</string>
     <string name="more_entry_paper_trading">Paper Trading</string>
     <string name="more_entry_reports">Export &amp; reporting</string>
     <string name="story_ring_unseen">Story from %1$s, unseen</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsMathTest.kt
@@ -1,0 +1,238 @@
+package com.testlogon.android.feature.portfolioanalytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-math coverage for [PortfolioAnalyticsMath]: allocation/concentration/exposure plus the risk
+ * combinators (portfolio vol, parametric + historical VaR, diversification). Every edge case
+ * (empty / single / zero-equity / hedged / degenerate matrix) is pinned so the ViewModel can lean on
+ * these without re-guarding.
+ */
+class PortfolioAnalyticsMathTest {
+
+    private fun pos(
+        key: String,
+        valueCents: Long,
+        group: String = "Spot",
+        assetClass: String = "Crypto",
+        side: PositionSide = PositionSide.LONG,
+    ) = NormalizedPosition(key = key, label = key, group = group, assetClass = assetClass, valueCents = valueCents, side = side)
+
+    // ---------------- allocation ----------------
+
+    @Test
+    fun allocation_byAsset_weightsSumTo10000() {
+        val positions = listOf(pos("BTC", 6_000), pos("ETH", 4_000))
+        val slices = PortfolioAnalyticsMath.allocation(positions, AllocationBy.ASSET)
+        assertEquals(2, slices.size)
+        assertEquals("BTC", slices.first().key)
+        assertEquals(6_000, slices.first().weightBps)
+        assertEquals(4_000, slices[1].weightBps)
+        assertEquals(10_000, slices.sumOf { it.weightBps })
+    }
+
+    @Test
+    fun allocation_byClass_bucketsAcrossKeys() {
+        val positions = listOf(
+            pos("BTC", 5_000, assetClass = "Crypto"),
+            pos("ETH", 3_000, assetClass = "Crypto"),
+            pos("USD", 2_000, assetClass = "Cash"),
+        )
+        val slices = PortfolioAnalyticsMath.allocation(positions, AllocationBy.CLASS)
+        assertEquals(2, slices.size)
+        val crypto = slices.single { it.key == "Crypto" }
+        assertEquals(8_000, crypto.valueCents)
+        assertEquals(8_000, crypto.weightBps)
+    }
+
+    @Test
+    fun allocation_byProduct_buckets() {
+        val positions = listOf(
+            pos("BTC", 5_000, group = "Spot"),
+            pos("BTC", 5_000, group = "Custody"),
+        )
+        val slices = PortfolioAnalyticsMath.allocation(positions, AllocationBy.PRODUCT)
+        assertEquals(2, slices.size)
+        assertEquals(5_000, slices.first().weightBps)
+    }
+
+    @Test
+    fun allocation_empty_isEmpty() {
+        assertTrue(PortfolioAnalyticsMath.allocation(emptyList(), AllocationBy.ASSET).isEmpty())
+    }
+
+    @Test
+    fun allocation_zeroTotal_noDivideByZero() {
+        val slices = PortfolioAnalyticsMath.allocation(listOf(pos("BTC", 0)), AllocationBy.ASSET)
+        assertEquals(1, slices.size)
+        assertEquals(0, slices.first().weightBps)
+    }
+
+    // ---------------- concentration ----------------
+
+    @Test
+    fun concentration_singleHolding_maxHhi() {
+        val slices = PortfolioAnalyticsMath.allocation(listOf(pos("BTC", 1_000)), AllocationBy.ASSET)
+        val c = PortfolioAnalyticsMath.concentration(slices)
+        assertEquals(10_000, c.hhi)
+        assertEquals(10_000, c.topWeightBps)
+        assertEquals("BTC", c.topKey)
+    }
+
+    @Test
+    fun concentration_equalHoldings_lowHhi() {
+        val positions = (1..10).map { pos("A$it", 1_000) }
+        val slices = PortfolioAnalyticsMath.allocation(positions, AllocationBy.ASSET)
+        val c = PortfolioAnalyticsMath.concentration(slices, topN = 3)
+        // 10 equal 1000-bps holdings -> HHI = 10 * 0.1^2 = 0.1 -> 1000 index.
+        assertEquals(1_000, c.hhi)
+        assertEquals(3_000, c.topNCumulativeBps)
+        assertTrue(c.effectiveBets > 9.0)
+    }
+
+    @Test
+    fun concentration_empty_zeroed() {
+        val c = PortfolioAnalyticsMath.concentration(emptyList())
+        assertEquals(0, c.hhi)
+        assertNull(c.topKey)
+        assertEquals(0.0, c.effectiveBets, 0.0)
+    }
+
+    // ---------------- exposure ----------------
+
+    @Test
+    fun exposure_longOnly() {
+        val e = PortfolioAnalyticsMath.exposure(listOf(pos("BTC", 6_000), pos("ETH", 4_000)))
+        assertEquals(10_000, e.grossCents)
+        assertEquals(10_000, e.netCents)
+        assertEquals(10_000, e.longCents)
+        assertEquals(0, e.shortCents)
+        assertEquals(10_000, e.leverageBps) // gross/|net| = 1.0x
+    }
+
+    @Test
+    fun exposure_longShort_netAndLeverage() {
+        val e = PortfolioAnalyticsMath.exposure(
+            listOf(pos("BTC", 8_000, side = PositionSide.LONG), pos("ETH", 2_000, side = PositionSide.SHORT)),
+        )
+        assertEquals(10_000, e.grossCents)
+        assertEquals(6_000, e.netCents)
+        assertEquals(8_000, e.longCents)
+        assertEquals(2_000, e.shortCents)
+        // gross 10000 / net 6000 = 1.6667x -> ~16667 bps
+        assertTrue(e.leverageBps in 16_600..16_700)
+    }
+
+    @Test
+    fun exposure_perfectlyHedged_zeroLeverage() {
+        val e = PortfolioAnalyticsMath.exposure(
+            listOf(pos("BTC", 5_000, side = PositionSide.LONG), pos("BTC", 5_000, side = PositionSide.SHORT)),
+        )
+        assertEquals(0, e.netCents)
+        assertEquals(0, e.leverageBps)
+    }
+
+    @Test
+    fun exposure_empty_allZero() {
+        val e = PortfolioAnalyticsMath.exposure(emptyList())
+        assertEquals(0, e.grossCents)
+        assertEquals(0, e.leverageBps)
+    }
+
+    // ---------------- portfolio volatility ----------------
+
+    @Test
+    fun portfolioVol_singleAsset_returnsOwnVol() {
+        val v = PortfolioAnalyticsMath.portfolioVolatilityBps(listOf(10_000), listOf(5_000))
+        assertEquals(5_000, v)
+    }
+
+    @Test
+    fun portfolioVol_independent_lessThanWeightedSum() {
+        // Two 50/50 assets, each 40% vol, uncorrelated (no matrix -> rho=0).
+        val v = PortfolioAnalyticsMath.portfolioVolatilityBps(listOf(5_000, 5_000), listOf(4_000, 4_000))
+        assertNotNull(v)
+        // sqrt(0.5^2*0.4^2 + 0.5^2*0.4^2) = 0.2828 -> ~2828 bps, well under 4000.
+        assertTrue(v!! in 2_700..2_900)
+    }
+
+    @Test
+    fun portfolioVol_perfectlyCorrelated_equalsWeightedSum() {
+        val corr = listOf(listOf(1.0, 1.0), listOf(1.0, 1.0))
+        val v = PortfolioAnalyticsMath.portfolioVolatilityBps(listOf(5_000, 5_000), listOf(4_000, 4_000), corr)
+        // rho=1 -> vol = 0.5*0.4 + 0.5*0.4 = 0.4 -> 4000 bps.
+        assertEquals(4_000, v)
+    }
+
+    @Test
+    fun portfolioVol_empty_null() {
+        assertNull(PortfolioAnalyticsMath.portfolioVolatilityBps(emptyList(), emptyList()))
+    }
+
+    // ---------------- VaR ----------------
+
+    @Test
+    fun parametricVar_computesLoss() {
+        // $10,000 (1_000_000 cents) at 20% vol, z=1.645 -> ~329,000 cents.
+        val v = PortfolioAnalyticsMath.parametricVarCents(1_000_000, 2_000, 1.645)
+        assertEquals(329_000, v)
+    }
+
+    @Test
+    fun parametricVar_zeroInputs_zero() {
+        assertEquals(0L, PortfolioAnalyticsMath.parametricVarCents(0, 2_000, 1.645))
+        assertEquals(0L, PortfolioAnalyticsMath.parametricVarCents(1_000_000, 0, 1.645))
+    }
+
+    @Test
+    fun historicalVar_quantileLoss() {
+        // 20 returns; worst is -0.10. At 95% the (1-.95)*20 = index 1 -> -0.08.
+        val returns = listOf(-0.10, -0.08) + List(18) { 0.01 }
+        val v = PortfolioAnalyticsMath.historicalVarCents(1_000_000, returns, 0.95)
+        assertEquals(80_000, v)
+    }
+
+    @Test
+    fun historicalVar_tooFewReturns_zero() {
+        assertEquals(0L, PortfolioAnalyticsMath.historicalVarCents(1_000_000, listOf(-0.05), 0.95))
+    }
+
+    @Test
+    fun historicalVar_allPositive_zero() {
+        val v = PortfolioAnalyticsMath.historicalVarCents(1_000_000, listOf(0.01, 0.02, 0.03, 0.04), 0.95)
+        assertEquals(0L, v)
+    }
+
+    // ---------------- diversification ----------------
+
+    @Test
+    fun diversification_singleHolding_zero() {
+        assertEquals(0, PortfolioAnalyticsMath.diversificationScore(listOf(10_000)))
+    }
+
+    @Test
+    fun diversification_manyEqualUncorrelated_high() {
+        val weights = List(5) { 2_000 }
+        val score = PortfolioAnalyticsMath.diversificationScore(weights)
+        assertTrue("expected high score, got $score", score >= 90)
+    }
+
+    @Test
+    fun diversification_correlatedPair_lowerThanUncorrelated() {
+        val weights = listOf(5_000, 5_000)
+        val uncorr = PortfolioAnalyticsMath.diversificationScore(weights)
+        val corr = PortfolioAnalyticsMath.diversificationScore(
+            weights, listOf(listOf(1.0, 0.95), listOf(0.95, 1.0)),
+        )
+        assertTrue("corr $corr should be < uncorr $uncorr", corr < uncorr)
+    }
+
+    @Test
+    fun diversification_empty_zero() {
+        assertEquals(0, PortfolioAnalyticsMath.diversificationScore(emptyList()))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ const TradingWorkspacePage = lazy(() => import("@/pages/blotter/TradingWorkspace
 const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
 const CustodyProvidersPage = lazy(() => import("@/pages/custody/CustodyProvidersPage"));
 const PortfolioPage = lazy(() => import("@/pages/portfolio/PortfolioPage"));
+const PortfolioAnalyticsPage = lazy(() => import("@/pages/portfolio/PortfolioAnalyticsPage"));
 const BailoutsBoardPage = lazy(() => import("@/pages/bailouts/BailoutsBoardPage"));
 const PnLPage = lazy(() => import("@/pages/pnl/PnLPage"));
 const ReportsPage = lazy(() => import("@/pages/reports/ReportsPage"));
@@ -739,6 +740,7 @@ export default function App() {
           <Route path="custody" element={<CustodyPage />} />
           <Route path="custody/providers" element={<CustodyProvidersPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
+          <Route path="portfolio/analytics" element={<PortfolioAnalyticsPage />} />
           <Route path="pnl" element={<PnLPage />} />
           <Route path="reports" element={<ReportsPage />} />
           <Route path="content-calendar" element={<ContentCalendarPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -153,6 +153,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Paper Trading", i18nKey: "nav.paperTrading", path: "/paper", icon: <TrendingUp className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
+      { label: "Portfolio Risk", i18nKey: "nav.portfolioRisk", path: "/portfolio/analytics", icon: <ShieldAlert className="h-5 w-5" /> },
       { label: "Bailouts", i18nKey: "nav.bailouts", path: "/bailouts", icon: <LifeBuoy className="h-5 w-5" /> },
       { label: "PnL", i18nKey: "nav.pnl", path: "/pnl", icon: <LineChart className="h-5 w-5" /> },
       { label: "Reports", i18nKey: "nav.reports", path: "/reports", icon: <FileText className="h-5 w-5" /> },

--- a/frontend/src/lib/portfolioAnalytics.test.ts
+++ b/frontend/src/lib/portfolioAnalytics.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type NormalizedPosition,
+  allocation,
+  concentration,
+  diversificationScore,
+  exposure,
+  historicalVarCents,
+  parametricVarCents,
+  portfolioVolatilityBps,
+  zForConfidence,
+} from "./portfolioAnalytics";
+
+function pos(over: Partial<NormalizedPosition> & { key: string; valueCents: number }): NormalizedPosition {
+  return {
+    label: over.key,
+    group: "Spot",
+    assetClass: "Crypto",
+    side: "long",
+    ...over,
+  };
+}
+
+describe("allocation", () => {
+  it("returns empty for an empty book", () => {
+    expect(allocation([], "asset")).toEqual([]);
+  });
+
+  it("weights sum to ~10000 bps and sorts by value desc", () => {
+    const book = [
+      pos({ key: "BTC", label: "BTC", valueCents: 6000 }),
+      pos({ key: "ETH", label: "ETH", valueCents: 3000 }),
+      pos({ key: "SOL", label: "SOL", valueCents: 1000 }),
+    ];
+    const a = allocation(book, "asset");
+    expect(a.map((s) => s.label)).toEqual(["BTC", "ETH", "SOL"]);
+    expect(a[0]!.weightBps).toBe(6000);
+    const sum = a.reduce((s, x) => s + x.weightBps, 0);
+    expect(sum).toBe(10000);
+  });
+
+  it("buckets by class and by product", () => {
+    const book = [
+      pos({ key: "a", label: "BTC", assetClass: "Crypto", group: "Spot", valueCents: 100 }),
+      pos({ key: "b", label: "USDC", assetClass: "Stablecoin", group: "Custody", valueCents: 100 }),
+      pos({ key: "c", label: "ETH", assetClass: "Crypto", group: "Custody", valueCents: 200 }),
+    ];
+    const byClass = allocation(book, "class");
+    expect(byClass.find((s) => s.label === "Crypto")!.valueCents).toBe(300);
+    const byProduct = allocation(book, "product");
+    expect(byProduct.find((s) => s.label === "Custody")!.valueCents).toBe(300);
+  });
+
+  it("uses absolute value for short legs", () => {
+    const book = [pos({ key: "s", label: "BTC", side: "short", valueCents: -500 })];
+    const a = allocation(book, "asset");
+    expect(a[0]!.valueCents).toBe(500);
+  });
+});
+
+describe("concentration", () => {
+  it("single position -> hhi 10000", () => {
+    const c = concentration([{ label: "BTC", weightBps: 10000 }]);
+    expect(c.hhi).toBe(10000);
+    expect(c.top).toHaveLength(1);
+  });
+
+  it("even 4-way -> hhi 2500", () => {
+    const c = concentration([
+      { label: "a", weightBps: 2500 },
+      { label: "b", weightBps: 2500 },
+      { label: "c", weightBps: 2500 },
+      { label: "d", weightBps: 2500 },
+    ]);
+    expect(c.hhi).toBe(2500);
+  });
+
+  it("empty -> hhi 0 and no top", () => {
+    const c = concentration([]);
+    expect(c).toEqual({ hhi: 0, top: [] });
+  });
+
+  it("topN limits and orders descending", () => {
+    const c = concentration(
+      [
+        { label: "a", weightBps: 1000 },
+        { label: "b", weightBps: 5000 },
+        { label: "c", weightBps: 4000 },
+      ],
+      2,
+    );
+    expect(c.top.map((t) => t.label)).toEqual(["b", "c"]);
+  });
+});
+
+describe("exposure", () => {
+  it("computes gross/net/long/short and leverage", () => {
+    const book = [
+      pos({ key: "l", side: "long", valueCents: 8000 }),
+      pos({ key: "s", side: "short", valueCents: 2000 }),
+    ];
+    const e = exposure(book, 5000);
+    expect(e.longCents).toBe(8000);
+    expect(e.shortCents).toBe(2000);
+    expect(e.grossCents).toBe(10000);
+    expect(e.netCents).toBe(6000);
+    expect(e.leverageBps).toBe(20000); // 10000 / 5000 = 2.0x
+  });
+
+  it("leverage is 0 when equity is non-positive", () => {
+    const e = exposure([pos({ key: "l", valueCents: 100 })], 0);
+    // equity <=0 falls back to gross so leverage is 1.0x, not divide-by-zero
+    expect(e.leverageBps).toBe(10000);
+  });
+
+  it("empty book -> all zeros", () => {
+    const e = exposure([]);
+    expect(e).toEqual({ grossCents: 0, netCents: 0, longCents: 0, shortCents: 0, leverageBps: 0 });
+  });
+});
+
+describe("portfolioVolatilityBps", () => {
+  it("single asset equals that asset's vol", () => {
+    expect(portfolioVolatilityBps([1], [4000], [[1]])).toBe(4000);
+  });
+
+  it("uncorrelated equal weights reduce vol below the naive average", () => {
+    const v = portfolioVolatilityBps(
+      [0.5, 0.5],
+      [4000, 4000],
+      [
+        [1, 0],
+        [0, 1],
+      ],
+    );
+    // sqrt(0.25*0.16 + 0.25*0.16) = sqrt(0.08) ~ 0.2828 -> 2828 bps
+    expect(v).toBe(2828);
+  });
+
+  it("perfectly correlated equal weights equals the average vol", () => {
+    const v = portfolioVolatilityBps(
+      [0.5, 0.5],
+      [4000, 4000],
+      [
+        [1, 1],
+        [1, 1],
+      ],
+    );
+    expect(v).toBe(4000);
+  });
+
+  it("empty / all-zero -> 0", () => {
+    expect(portfolioVolatilityBps([], [], [])).toBe(0);
+    expect(portfolioVolatilityBps([0, 0], [0, 0], [[1, 0], [0, 1]])).toBe(0);
+  });
+});
+
+describe("parametricVarCents", () => {
+  it("value * vol * z", () => {
+    // 1,000,000c * 0.20 * 1.645 = 329,000c
+    expect(parametricVarCents(1_000_000, 2000, 1.645)).toBe(329000);
+  });
+
+  it("guards non-positive inputs", () => {
+    expect(parametricVarCents(0, 2000, 1.645)).toBe(0);
+    expect(parametricVarCents(1000, 0, 1.645)).toBe(0);
+    expect(parametricVarCents(1000, 2000, 0)).toBe(0);
+  });
+});
+
+describe("historicalVarCents", () => {
+  it("returns the loss at the lower tail as positive cents", () => {
+    const rets = [-0.10, -0.05, -0.02, 0.01, 0.03, 0.04, 0.02, -0.01, 0.00, -0.03];
+    const v = historicalVarCents(1_000_000, rets, 0.9);
+    expect(v).toBeGreaterThan(0);
+  });
+
+  it("0 when no losses at the quantile or empty series", () => {
+    expect(historicalVarCents(1_000_000, [0.01, 0.02, 0.03], 0.95)).toBe(0);
+    expect(historicalVarCents(1_000_000, [], 0.95)).toBe(0);
+    expect(historicalVarCents(0, [-0.5], 0.95)).toBe(0);
+  });
+});
+
+describe("zForConfidence", () => {
+  it("maps common confidences", () => {
+    expect(zForConfidence(0.95)).toBeCloseTo(1.645, 3);
+    expect(zForConfidence(0.99)).toBeCloseTo(2.326, 3);
+    expect(zForConfidence(0.5)).toBeCloseTo(1.645, 3);
+  });
+});
+
+describe("diversificationScore", () => {
+  it("single position -> 0", () => {
+    expect(diversificationScore([{ label: "BTC", weightBps: 10000 }], [[1]])).toBe(0);
+  });
+
+  it("even + uncorrelated scores higher than concentrated + correlated", () => {
+    const good = diversificationScore(
+      [
+        { label: "a", weightBps: 5000 },
+        { label: "b", weightBps: 5000 },
+      ],
+      [
+        [1, 0],
+        [0, 1],
+      ],
+    );
+    const bad = diversificationScore(
+      [
+        { label: "a", weightBps: 9500 },
+        { label: "b", weightBps: 500 },
+      ],
+      [
+        [1, 0.98],
+        [0.98, 1],
+      ],
+    );
+    expect(good).toBeGreaterThan(bad);
+    expect(good).toBeGreaterThanOrEqual(0);
+    expect(good).toBeLessThanOrEqual(100);
+  });
+
+  it("empty -> 0", () => {
+    expect(diversificationScore([], [])).toBe(0);
+  });
+});

--- a/frontend/src/lib/portfolioAnalytics.ts
+++ b/frontend/src/lib/portfolioAnalytics.ts
@@ -1,0 +1,309 @@
+/**
+ * Pure, framework-free PORTFOLIO ANALYTICS — allocation, concentration,
+ * exposure & risk math over a normalized cross-venue position list.
+ *
+ * Nothing here touches React, the network, or the DOM. All monetary inputs are
+ * INTEGER CENTS; all weight outputs are BASIS POINTS (100% = 10_000). Everything
+ * is deterministic and unit-tested in `portfolioAnalytics.test.ts`.
+ *
+ * Every function guards the degenerate edges the analytics page actually hits at
+ * runtime: an empty book, a single position, and zero equity.
+ */
+
+/** A LONG position adds to gross+net; a SHORT adds to gross but subtracts net. */
+export type PositionSide = "long" | "short";
+
+/** How allocation buckets a normalized position. */
+export type AllocationBy = "asset" | "class" | "product";
+
+/**
+ * One normalized holding, valued in USD cents (indicative). `valueCents` is the
+ * ABSOLUTE market value of the leg (always >= 0); `side` carries direction.
+ */
+export interface NormalizedPosition {
+  /** Stable de-dupe key (venue+asset). */
+  key: string;
+  /** Human label shown in the UI. */
+  label: string;
+  /** Product/venue bucket, e.g. "Custody", "Spot", "Margin", "Tokens". */
+  group: string;
+  /** Asset-class bucket, e.g. "Crypto", "Stablecoin", "Fund", "Token". */
+  assetClass: string;
+  /** Absolute USD value of the leg, in integer cents (>= 0). */
+  valueCents: number;
+  /** Direction; defaults to "long" when omitted by the caller. */
+  side?: PositionSide;
+  /** Optional underlying quantity (informational; not used by the math). */
+  qty?: number;
+}
+
+/** One allocation slice: a bucket, its summed value, and its weight in bps. */
+export interface AllocationSlice {
+  label: string;
+  valueCents: number;
+  /** Share of total ABSOLUTE value, in basis points (sums to ~10_000). */
+  weightBps: number;
+}
+
+/** Concentration summary: Herfindahl index + the heaviest slices. */
+export interface Concentration {
+  /**
+   * Herfindahl-Hirschman index on fractional weights, scaled to 0..10_000.
+   * 10_000 = a single position; -> 0 as holdings become many & even.
+   */
+  hhi: number;
+  /** The top-N slices by weight (descending). */
+  top: { label: string; weightBps: number }[];
+}
+
+/** Directional exposure across the book. */
+export interface Exposure {
+  /** Sum of ALL leg values (long + short), in cents. */
+  grossCents: number;
+  /** Long minus short, in cents (signed). */
+  netCents: number;
+  longCents: number;
+  shortCents: number;
+  /** gross / equity, in basis points (10_000 = 1.0x). 0 when equity <= 0. */
+  leverageBps: number;
+}
+
+const BPS = 10_000;
+
+function isNum(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n);
+}
+
+/** Absolute, finite cents value of a leg (defensive; clamps junk to 0). */
+function legValue(p: NormalizedPosition): number {
+  return isNum(p.valueCents) ? Math.abs(p.valueCents) : 0;
+}
+
+/**
+ * Allocation by asset / class / product. Buckets the book, sums absolute value
+ * per bucket, and assigns each a weight in bps of the total absolute value.
+ * Empty in -> empty out. Sorted by value descending.
+ */
+export function allocation(
+  positions: NormalizedPosition[],
+  by: AllocationBy,
+): AllocationSlice[] {
+  const keyOf = (p: NormalizedPosition): string =>
+    by === "asset" ? p.label : by === "class" ? p.assetClass : p.group;
+
+  const sums = new Map<string, number>();
+  let total = 0;
+  for (const p of positions) {
+    const v = legValue(p);
+    if (v <= 0) continue;
+    const k = keyOf(p) || "—";
+    sums.set(k, (sums.get(k) ?? 0) + v);
+    total += v;
+  }
+
+  const slices: AllocationSlice[] = [];
+  for (const [label, valueCents] of sums) {
+    slices.push({
+      label,
+      valueCents,
+      weightBps: total > 0 ? Math.round((valueCents / total) * BPS) : 0,
+    });
+  }
+  slices.sort((a, b) => b.valueCents - a.valueCents);
+  return slices;
+}
+
+/**
+ * Concentration from a set of weights (bps). HHI = sum(fraction^2) scaled to
+ * 0..10_000; `top` is the heaviest `topN` slices. Empty in -> hhi 0, top [].
+ */
+export function concentration(
+  weights: { label: string; weightBps: number }[],
+  topN = 5,
+): Concentration {
+  if (weights.length === 0) return { hhi: 0, top: [] };
+  let hhi = 0;
+  for (const w of weights) {
+    const frac = (isNum(w.weightBps) ? w.weightBps : 0) / BPS;
+    hhi += frac * frac;
+  }
+  const top = [...weights]
+    .sort((a, b) => b.weightBps - a.weightBps)
+    .slice(0, Math.max(0, topN))
+    .map((w) => ({ label: w.label, weightBps: w.weightBps }));
+  return { hhi: Math.round(hhi * BPS), top };
+}
+
+/**
+ * Directional exposure. Gross = sum |value|; long/short split by side; net =
+ * long - short; leverage = gross / equity in bps. `equityCents` is the account
+ * equity to lever against (typically total value); leverage is 0 when it's <= 0.
+ */
+export function exposure(
+  positions: NormalizedPosition[],
+  equityCents?: number,
+): Exposure {
+  let longCents = 0;
+  let shortCents = 0;
+  for (const p of positions) {
+    const v = legValue(p);
+    if (v <= 0) continue;
+    if (p.side === "short") shortCents += v;
+    else longCents += v;
+  }
+  const grossCents = longCents + shortCents;
+  const netCents = longCents - shortCents;
+  const equity = isNum(equityCents) && equityCents > 0 ? equityCents : grossCents;
+  const leverageBps = equity > 0 ? Math.round((grossCents / equity) * BPS) : 0;
+  return { grossCents, netCents, longCents, shortCents, leverageBps };
+}
+
+/**
+ * Portfolio volatility (bps) from per-asset vols (bps) + a correlation matrix,
+ * combined via the standard quadratic form sqrt(w' * Sigma * w) where
+ * Sigma_ij = corr_ij * vol_i * vol_j. `weights` are fractional or bps — they are
+ * NORMALIZED internally so only their relative sizes matter. Missing correlation
+ * entries default to 0 (diagonal to 1). Returns 0 for an empty / all-zero book.
+ */
+export function portfolioVolatilityBps(
+  weights: number[],
+  perAssetVolBps: number[],
+  correlationMatrix: number[][],
+): number {
+  const n = Math.min(weights.length, perAssetVolBps.length);
+  if (n === 0) return 0;
+
+  // Normalize weights to sum 1 (by absolute magnitude; tolerate junk).
+  let wSum = 0;
+  const w: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const x = isNum(weights[i]) ? Math.abs(weights[i]!) : 0;
+    w.push(x);
+    wSum += x;
+  }
+  if (wSum <= 0) return 0;
+  for (let i = 0; i < n; i++) w[i]! /= wSum;
+
+  const vol = (i: number): number =>
+    isNum(perAssetVolBps[i]) && perAssetVolBps[i]! > 0 ? perAssetVolBps[i]! : 0;
+
+  const corr = (i: number, j: number): number => {
+    if (i === j) return 1;
+    const row = correlationMatrix[i];
+    const c = row ? row[j] : undefined;
+    if (!isNum(c)) return 0;
+    return Math.max(-1, Math.min(1, c));
+  };
+
+  let variance = 0;
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      variance += w[i]! * w[j]! * vol(i) * vol(j) * corr(i, j);
+    }
+  }
+  if (variance <= 0) return 0;
+  return Math.round(Math.sqrt(variance));
+}
+
+/** Standard-normal z for a common confidence (fallback 1.645 = 95%). */
+export function zForConfidence(confidence: number): number {
+  if (confidence >= 0.99) return 2.326;
+  if (confidence >= 0.975) return 1.96;
+  if (confidence >= 0.95) return 1.645;
+  if (confidence >= 0.9) return 1.282;
+  return 1.645;
+}
+
+/**
+ * Parametric (variance-covariance) Value-at-Risk in cents:
+ * VaR = portfolioValue * (volBps/10_000) * z. Guards non-positive inputs to 0.
+ */
+export function parametricVarCents(
+  portfolioValueCents: number,
+  volBps: number,
+  z: number,
+): number {
+  if (!isNum(portfolioValueCents) || portfolioValueCents <= 0) return 0;
+  if (!isNum(volBps) || volBps <= 0) return 0;
+  if (!isNum(z) || z <= 0) return 0;
+  return Math.round(portfolioValueCents * (volBps / BPS) * z);
+}
+
+/**
+ * Historical VaR in cents: the loss at the (1 - confidence) percentile of a
+ * per-period portfolio-return distribution, applied to the portfolio value.
+ * `portfolioReturns` are fractional per-period returns (e.g. -0.03 = -3%).
+ * Returned as a POSITIVE cents loss (0 when there is no loss at that quantile or
+ * the series is empty). Uses linear interpolation between order statistics.
+ */
+export function historicalVarCents(
+  portfolioValueCents: number,
+  portfolioReturns: number[],
+  confidence: number,
+): number {
+  if (!isNum(portfolioValueCents) || portfolioValueCents <= 0) return 0;
+  const rs = portfolioReturns.filter((r) => isNum(r));
+  if (rs.length === 0) return 0;
+
+  const sorted = [...rs].sort((a, b) => a - b);
+  const conf = isNum(confidence) ? Math.min(0.9999, Math.max(0.5, confidence)) : 0.95;
+  const alpha = 1 - conf; // lower-tail probability
+
+  // Linear-interpolated quantile at probability alpha.
+  const idx = alpha * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  const frac = idx - lo;
+  const q = sorted[lo]! + (sorted[hi]! - sorted[lo]!) * frac;
+
+  // A loss is a negative return; VaR is the magnitude of that loss in cents.
+  if (q >= 0) return 0;
+  return Math.round(portfolioValueCents * -q);
+}
+
+/**
+ * Diversification score 0..100. Higher = better diversified: rewards LOW average
+ * pairwise correlation and EVEN weights (low concentration). Combines two 0..1
+ * sub-scores equally:
+ *   - corrScore  = (1 - avgAbsPairwiseCorr), clamped
+ *   - evenScore  = 1 - (HHI - 1/n) / (1 - 1/n)   [1 = perfectly even, 0 = all in one]
+ * Single position -> 0 (undiversifiable). Empty -> 0.
+ */
+export function diversificationScore(
+  weights: { label: string; weightBps: number }[],
+  correlationMatrix: number[][],
+): number {
+  const n = weights.length;
+  if (n <= 1) return 0;
+
+  // Even-ness from HHI on fractional weights.
+  let hhi = 0;
+  let wSum = 0;
+  const fr: number[] = [];
+  for (const w of weights) {
+    const x = (isNum(w.weightBps) ? Math.max(0, w.weightBps) : 0) / BPS;
+    fr.push(x);
+    wSum += x;
+  }
+  if (wSum > 0) for (let i = 0; i < n; i++) fr[i]! /= wSum;
+  for (const f of fr) hhi += f * f;
+  const minHhi = 1 / n;
+  const evenScore = 1 - Math.max(0, (hhi - minHhi) / (1 - minHhi));
+
+  // Average absolute pairwise correlation over the upper triangle.
+  let cSum = 0;
+  let cCount = 0;
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const row = correlationMatrix[i];
+      const c = row ? row[j] : undefined;
+      cSum += isNum(c) ? Math.abs(Math.max(-1, Math.min(1, c))) : 0;
+      cCount++;
+    }
+  }
+  const avgCorr = cCount > 0 ? cSum / cCount : 0;
+  const corrScore = Math.max(0, Math.min(1, 1 - avgCorr));
+
+  const score = 0.5 * corrScore + 0.5 * evenScore;
+  return Math.round(Math.max(0, Math.min(1, score)) * 100);
+}

--- a/frontend/src/pages/portfolio/PortfolioAnalyticsPage.tsx
+++ b/frontend/src/pages/portfolio/PortfolioAnalyticsPage.tsx
@@ -1,0 +1,686 @@
+// Portfolio Risk — a client-computed "how am I positioned / what's my risk"
+// view spanning EVERY venue the account touches: custody vault, trading spot,
+// margin (incl. its open position), creator revenue-share tokens, strategy /
+// basket funds, and staking. It builds a single NORMALIZED position list from
+// the SAME reads the consolidated Portfolio page uses, values every leg in
+// indicative USD cents (via /me/prices marks, degrade-labelled), and runs the
+// pure `portfolioAnalytics` math over it: allocation, concentration (HHI),
+// exposure/leverage, and risk (portfolio volatility + parametric & historical
+// VaR from per-asset getHistory returns + a diversification score).
+//
+// EVERYTHING degrades independently: any source that 404s/403s is excluded and
+// its contribution simply drops out; thin/absent history flips the risk section
+// to a "recent window only / limited history" banner. All reads, no mutations.
+import { useMemo, useState } from "react";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import {
+  PieChart,
+  ShieldAlert,
+  RefreshCw,
+  Layers,
+  Scale,
+  Activity,
+  Info,
+  Loader2,
+  TrendingUp,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+
+import { getBalance, getStakingPositions, mergeBalances } from "@/api/endpoints/custody";
+import { getSpotBalance, getMarginAccount, getPrices } from "@/api/endpoints/trading";
+import { getSymbols, type MarketSymbol } from "@/api/endpoints/marketData";
+import { getMyTokens, getCapTable } from "@/api/endpoints/tokens";
+import { getMyStrategies, getStrategyPosition } from "@/api/endpoints/strategies";
+import { getHistory } from "@/api/endpoints/marketHistory";
+import { logReturns, stdev, seriesCorrelation, barsPerYear, type Bar } from "@/lib/marketStats";
+import {
+  allocation,
+  concentration,
+  exposure,
+  portfolioVolatilityBps,
+  parametricVarCents,
+  historicalVarCents,
+  diversificationScore,
+  zForConfidence,
+  type NormalizedPosition,
+  type AllocationBy,
+} from "@/lib/portfolioAnalytics";
+
+// ── small helpers ────────────────────────────────────────────────────
+
+function num(v: string | number | undefined | null): number {
+  if (v == null) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Format integer cents as a USD string. */
+function usdCents(cents: number): string {
+  return `$${(cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+/** bps -> "12.34%". */
+function bpsPct(bps: number, digits = 2): string {
+  return `${(bps / 100).toFixed(digits)}%`;
+}
+
+/** bps leverage -> "2.00x". */
+function bpsX(bps: number): string {
+  return `${(bps / 10_000).toFixed(2)}x`;
+}
+
+const HISTORY_INTERVAL = "1h";
+const HISTORY_SECS = 3600;
+
+/** Fetch + de-scale up to a recent window of bars for one market symbol. */
+async function fetchBars(symbolId: number, scaler: number): Promise<{ bars: Bar[]; stub: boolean }> {
+  const res = await getHistory(symbolId, { interval: HISTORY_INTERVAL });
+  const s = scaler || 1;
+  const bars: Bar[] = (res.bars ?? []).map((b) => ({
+    ts: b.ts,
+    o: b.o / s,
+    h: b.h / s,
+    l: b.l / s,
+    c: b.c / s,
+    v: b.v,
+  }));
+  bars.sort((a, b) => a.ts - b.ts);
+  return { bars, stub: !!res.stub };
+}
+
+// ── presentational bits ──────────────────────────────────────────────
+
+function SectionCard({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          {icon}
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function WeightBar({ label, valueCents, weightBps }: { label: string; valueCents: number; weightBps: number }) {
+  return (
+    <div className="space-y-1 py-1.5">
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span className="truncate">{label}</span>
+        <span className="tabular-nums text-muted-foreground">
+          {bpsPct(weightBps)} · {usdCents(valueCents)}
+        </span>
+      </div>
+      <Progress value={weightBps} max={10_000} />
+    </div>
+  );
+}
+
+function Stat({ label, value, tone, sub }: { label: string; value: string; tone?: string; sub?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</span>
+      <span className="num text-lg font-semibold tabular-nums" style={tone ? { color: tone } : undefined}>
+        {value}
+      </span>
+      {sub && <span className="text-[11px] text-muted-foreground">{sub}</span>}
+    </div>
+  );
+}
+
+const RED = "rgb(239 68 68)";
+const GREEN = "rgb(16 185 129)";
+
+// ── page ─────────────────────────────────────────────────────────────
+
+export default function PortfolioAnalyticsPage() {
+  // Cross-venue reads (mirror the Portfolio page; each degrades independently).
+  const custodyQ = useQuery({ queryKey: ["pa", "custody"], queryFn: getBalance, retry: false });
+  const stakingQ = useQuery({ queryKey: ["pa", "staking"], queryFn: getStakingPositions, retry: false });
+  const spotQ = useQuery({ queryKey: ["pa", "spot"], queryFn: getSpotBalance, retry: false });
+  const marginQ = useQuery({ queryKey: ["pa", "margin"], queryFn: getMarginAccount, retry: false });
+  const symbolsQ = useQuery({ queryKey: ["pa", "symbols"], queryFn: getSymbols, retry: false });
+  const pricesQ = useQuery({ queryKey: ["pa", "prices"], queryFn: getPrices, retry: false });
+  const tokensQ = useQuery({ queryKey: ["pa", "tokens"], queryFn: getMyTokens, retry: false });
+  const strategiesQ = useQuery({ queryKey: ["pa", "strategies"], queryFn: getMyStrategies, retry: false });
+
+  const myTokens = tokensQ.data?.tokens ?? [];
+  const myStrategies = strategiesQ.data?.strategies ?? [];
+
+  // Per-token cap table (my qty) and per-strategy investor position.
+  const capTableQs = useQueries({
+    queries: myTokens.map((t) => ({
+      queryKey: ["pa", "captable", t.token_id],
+      queryFn: () => getCapTable(t.token_id),
+      retry: false,
+    })),
+  });
+  const strategyPosQs = useQueries({
+    queries: myStrategies.map((s) => ({
+      queryKey: ["pa", "stratpos", s.strategy_id],
+      queryFn: () => getStrategyPosition(s.strategy_id),
+      retry: false,
+    })),
+  });
+
+  const refetchAll = () => {
+    [custodyQ, stakingQ, spotQ, marginQ, symbolsQ, pricesQ, tokensQ, strategiesQ].forEach((q) => q.refetch());
+    capTableQs.forEach((q) => q.refetch());
+    strategyPosQs.forEach((q) => q.refetch());
+  };
+
+  const anyFetching =
+    custodyQ.isFetching ||
+    stakingQ.isFetching ||
+    spotQ.isFetching ||
+    marginQ.isFetching ||
+    symbolsQ.isFetching ||
+    pricesQ.isFetching ||
+    tokensQ.isFetching ||
+    strategiesQ.isFetching;
+
+  const pricesStub = pricesQ.isSuccess && (pricesQ.data?.stub === true || pricesQ.data?.source === "stub");
+  const pricesUnavailable = pricesQ.isError;
+
+  // asset-symbol (upper) -> USD price (number). Empty when /me/prices 404s.
+  const priceOf = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const [sym, px] of Object.entries(pricesQ.data?.prices ?? {})) {
+      const n = num(px);
+      if (n > 0) map.set(sym.toUpperCase(), n);
+    }
+    return (symbol: string | undefined | null): number | undefined =>
+      symbol ? map.get(String(symbol).toUpperCase()) : undefined;
+  }, [pricesQ.data]);
+
+  // Map an asset ticker to a tradeable market symbol (for history/vol/corr).
+  const symLookup = useMemo(() => {
+    const byId = new Map<number, MarketSymbol>();
+    const list = symbolsQ.data?.symbols ?? [];
+    for (const s of list) byId.set(s.symbol_id, s);
+    const findByAsset = (asset: string | undefined | null): MarketSymbol | undefined => {
+      if (!asset) return undefined;
+      const up = String(asset).toUpperCase();
+      // Prefer an exact base match ("BTC" -> "BTC-USD"/"BTCUSD"/"BTC"), else contains.
+      return (
+        list.find((s) => s.symbol.toUpperCase() === up) ||
+        list.find((s) => s.symbol.toUpperCase().startsWith(up + "-") || s.symbol.toUpperCase().startsWith(up + "/")) ||
+        list.find((s) => s.symbol.toUpperCase().startsWith(up)) ||
+        list.find((s) => s.symbol.toUpperCase().includes(up))
+      );
+    };
+    return { byId, findByAsset };
+  }, [symbolsQ.data]);
+
+  const marginSymName = (id: number | undefined): string => {
+    const s = id != null ? symLookup.byId.get(id) : undefined;
+    return s?.symbol ?? (id != null ? `#${id}` : "Margin position");
+  };
+
+  // ── build the normalized position list (USD cents, indicative) ──────
+  // Only assets with a USD mark are valued; unpriced balances are counted so we
+  // can honestly report how much of the book we could not value.
+  const { positions, valuedCount, unpricedCount, sourcesOk } = useMemo(() => {
+    const out: NormalizedPosition[] = [];
+    let valued = 0;
+    let unpriced = 0;
+    let sources = 0;
+
+    const push = (
+      key: string,
+      label: string,
+      group: string,
+      assetClass: string,
+      amount: number,
+      symbol: string | undefined,
+      side: "long" | "short" = "long",
+      qty?: number,
+    ) => {
+      if (amount === 0) return;
+      const px = priceOf(symbol);
+      if (px == null) {
+        unpriced++;
+        return;
+      }
+      const valueCents = Math.round(Math.abs(amount) * px * 100);
+      if (valueCents <= 0) return;
+      out.push({ key, label, group, assetClass, valueCents, side, qty });
+      valued++;
+    };
+
+    const classOf = (sym: string | undefined): string => {
+      const up = (sym ?? "").toUpperCase();
+      if (up === "USDC" || up === "USDT" || up === "DAI" || up === "USD") return "Stablecoin";
+      return "Crypto";
+    };
+
+    if (custodyQ.isSuccess) {
+      sources++;
+      for (const r of mergeBalances(custodyQ.data?.balances)) {
+        const bal = num(r.balance);
+        if (bal !== 0) push(`custody:${r.symbol}`, r.symbol, "Custody", classOf(r.symbol), bal, r.symbol, "long", bal);
+      }
+    }
+    if (spotQ.isSuccess) {
+      sources++;
+      for (const b of spotQ.data?.balances ?? []) {
+        const bal = num(b.balance);
+        const sym = b.symbol;
+        if (bal !== 0 && sym) push(`spot:${sym}`, sym, "Spot", classOf(sym), bal, sym, "long", bal);
+      }
+    }
+    if (marginQ.isSuccess) {
+      sources++;
+      const m = marginQ.data;
+      // Margin collateral balance is USD-denominated (quote currency).
+      const bal = num(m?.balance);
+      if (bal !== 0) {
+        out.push({ key: "margin:cash", label: "Margin cash", group: "Margin", assetClass: "Cash", valueCents: Math.round(Math.abs(bal) * 100), side: "long" });
+        valued++;
+      }
+      // The open leveraged position (valued via its notional at entry).
+      const hasPos = num(m?.num_positions) > 0 && num(m?.pos_qty) !== 0;
+      if (hasPos) {
+        const symId = m?.pos_symbol_idx;
+        const sym = symId != null ? symLookup.byId.get(symId) : undefined;
+        const scaler = sym?.price_scaler || 1;
+        const qtyRaw = num(m?.pos_qty);
+        const entryRaw = num(m?.pos_entry_price);
+        const notional = Math.abs((qtyRaw / scaler) * (entryRaw / scaler));
+        if (notional > 0) {
+          out.push({
+            key: "margin:pos",
+            label: marginSymName(symId),
+            group: "Margin",
+            assetClass: "Derivative",
+            valueCents: Math.round(notional * 100),
+            side: qtyRaw < 0 ? "short" : "long",
+            qty: qtyRaw / scaler,
+          });
+          valued++;
+        }
+      }
+    }
+    if (stakingQ.isSuccess) {
+      sources++;
+      for (const p of stakingQ.data?.positions ?? []) {
+        const tot = num(p.total);
+        if (tot !== 0) push(`stake:${p.position_id}`, `${p.asset} (staked)`, "Staking", classOf(p.asset), tot, p.asset, "long", tot);
+      }
+    }
+    // Creator tokens — value my holding at the token's clearing price (cents).
+    if (tokensQ.isSuccess && myTokens.length > 0) {
+      sources++;
+      myTokens.forEach((t, i) => {
+        const cap = capTableQs[i]?.data;
+        const priceCents = num(t.clearing_price);
+        // my qty: creator retains its slice; find my row by pct if present.
+        const holders = cap?.holders ?? [];
+        const myQty = holders.reduce((a, h) => a + num(h.qty), 0); // best-effort: sum (single-holder self view)
+        const qty = myQty > 0 ? myQty : t.total_supply; // pre-IPO: hold full supply
+        if (priceCents > 0 && qty > 0) {
+          out.push({ key: `token:${t.token_id}`, label: `${t.ticker}`, group: "Tokens", assetClass: "Token", valueCents: Math.round(qty * priceCents), side: "long", qty });
+          valued++;
+        }
+      });
+    }
+    // Strategy funds — value at my investor current_value.
+    if (strategiesQ.isSuccess && myStrategies.length > 0) {
+      sources++;
+      myStrategies.forEach((s, i) => {
+        const posn = strategyPosQs[i]?.data;
+        const cv = num(posn?.current_value_cents);
+        if (cv > 0) {
+          out.push({ key: `strat:${s.strategy_id}`, label: s.name, group: "Strategies", assetClass: "Fund", valueCents: cv, side: "long", qty: num(posn?.units) });
+          valued++;
+        }
+      });
+    }
+
+    return { positions: out, valuedCount: valued, unpricedCount: unpriced, sourcesOk: sources };
+  }, [
+    custodyQ.isSuccess, custodyQ.data, spotQ.isSuccess, spotQ.data, marginQ.isSuccess, marginQ.data,
+    stakingQ.isSuccess, stakingQ.data, tokensQ.isSuccess, strategiesQ.isSuccess,
+    myTokens, myStrategies, capTableQs, strategyPosQs, priceOf, symLookup,
+  ]);
+
+  const totalCents = useMemo(() => positions.reduce((a, p) => a + p.valueCents, 0), [positions]);
+  const marginEquityCents = useMemo(() => {
+    // Prefer the margin cash balance as the equity to lever gross exposure by;
+    // fall back to total portfolio value when no margin balance is readable.
+    const cash = positions.find((p) => p.key === "margin:cash");
+    return cash ? cash.valueCents : totalCents;
+  }, [positions, totalCents]);
+
+  // ── derived analytics ──────────────────────────────────────────────
+  const [allocBy, setAllocBy] = useState<AllocationBy>("asset");
+
+  const byAsset = useMemo(() => allocation(positions, "asset"), [positions]);
+  const alloc = useMemo(() => allocation(positions, allocBy), [positions, allocBy]);
+  const conc = useMemo(() => concentration(byAsset, 5), [byAsset]);
+  const expo = useMemo(() => exposure(positions, marginEquityCents), [positions, marginEquityCents]);
+
+  // Per-asset return series for the RISK section — one history fetch per priced
+  // asset that maps to a tradeable market symbol. Degrades on 404 to the recent
+  // window (getHistory) and to an "empty" contribution when a symbol is missing.
+  const riskAssets = useMemo(() => {
+    // De-dupe by market symbol id; carry each asset's weight (bps) from byAsset.
+    const seen = new Map<number, { symbolId: number; scaler: number; label: string; weightBps: number }>();
+    for (const slice of byAsset) {
+      const sym = symLookup.findByAsset(slice.label);
+      if (!sym) continue;
+      if (!seen.has(sym.symbol_id)) {
+        seen.set(sym.symbol_id, { symbolId: sym.symbol_id, scaler: sym.price_scaler || 1, label: slice.label, weightBps: slice.weightBps });
+      }
+    }
+    return [...seen.values()];
+  }, [byAsset, symLookup]);
+
+  const historyQs = useQueries({
+    queries: riskAssets.map((a) => ({
+      queryKey: ["pa", "hist", a.symbolId],
+      queryFn: () => fetchBars(a.symbolId, a.scaler),
+      retry: false,
+      staleTime: 60_000,
+      enabled: symbolsQ.isSuccess,
+    })),
+  });
+
+  const risk = useMemo(() => {
+    const n = riskAssets.length;
+    const returnsByAsset: number[][] = [];
+    const volsBps: number[] = [];
+    const weights: number[] = [];
+    const labels: string[] = [];
+    let anyStub = false;
+    let loadedCount = 0;
+    let thin = false;
+
+    const annFactor = Math.sqrt(barsPerYear(HISTORY_SECS));
+
+    for (let i = 0; i < n; i++) {
+      const q = historyQs[i];
+      const bars = q?.data?.bars ?? [];
+      anyStub = anyStub || !!q?.data?.stub;
+      if (bars.length >= 2) loadedCount++;
+      if (bars.length < 10) thin = true;
+      const rets = logReturns(bars);
+      const perBarVol = stdev(rets);
+      const annVolBps = Math.round(perBarVol * annFactor * 10_000);
+      returnsByAsset.push(rets);
+      volsBps.push(annVolBps);
+      weights.push(riskAssets[i]!.weightBps);
+      labels.push(riskAssets[i]!.label);
+    }
+
+    // Correlation matrix over aligned bar series.
+    const corr: number[][] = Array.from({ length: n }, () => new Array(n).fill(0));
+    for (let i = 0; i < n; i++) {
+      corr[i]![i] = 1;
+      for (let j = i + 1; j < n; j++) {
+        const bi = historyQs[i]?.data?.bars ?? [];
+        const bj = historyQs[j]?.data?.bars ?? [];
+        const c = seriesCorrelation(bi, bj);
+        corr[i]![j] = c;
+        corr[j]![i] = c;
+      }
+    }
+
+    const portVolBps = portfolioVolatilityBps(weights, volsBps, corr);
+
+    // Historical portfolio return series: weighted sum of per-asset returns over
+    // the shortest common length (equal weights fallback handled by normalize).
+    let minLen = Infinity;
+    for (const r of returnsByAsset) minLen = Math.min(minLen, r.length);
+    const portReturns: number[] = [];
+    if (Number.isFinite(minLen) && minLen > 0 && n > 0) {
+      const wSum = weights.reduce((a, w) => a + Math.max(0, w), 0) || 1;
+      for (let t = 0; t < minLen; t++) {
+        let r = 0;
+        for (let i = 0; i < n; i++) r += (Math.max(0, weights[i]!) / wSum) * (returnsByAsset[i]![t] ?? 0);
+        portReturns.push(r);
+      }
+    }
+
+    const z = zForConfidence(0.95);
+    const paramVar = parametricVarCents(totalCents, portVolBps, z);
+    const histVar = historicalVarCents(totalCents, portReturns, 0.95);
+    const divScore = diversificationScore(byAsset, corr);
+
+    const loading = historyQs.some((q) => q.isLoading);
+    return { n, portVolBps, paramVar, histVar, divScore, anyStub, thin, loadedCount, portReturnsLen: portReturns.length, loading };
+  }, [riskAssets, historyQs, totalCents, byAsset]);
+
+  // ── render ─────────────────────────────────────────────────────────
+  const anyLoading =
+    custodyQ.isLoading || spotQ.isLoading || marginQ.isLoading || stakingQ.isLoading ||
+    tokensQ.isLoading || strategiesQ.isLoading || symbolsQ.isLoading;
+
+  const bookEmpty = !anyLoading && positions.length === 0;
+  const concentratedLabel = conc.hhi >= 2500 ? "Concentrated" : conc.hhi >= 1500 ? "Moderately concentrated" : "Diversified";
+  const concentratedTone = conc.hhi >= 2500 ? "destructive" : conc.hhi >= 1500 ? "warning" : "success";
+  const leverageBps = expo.leverageBps;
+  const levTone = leverageBps > 30_000 ? "destructive" : leverageBps > 15_000 ? "warning" : "secondary";
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold leading-tight">Portfolio Risk</h1>
+            <p className="text-xs text-muted-foreground">
+              Client-computed allocation, concentration, exposure & risk across custody, spot, margin, tokens, funds & staking.
+            </p>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" className="gap-2 self-start sm:self-auto" onClick={refetchAll}>
+          <RefreshCw className={cn("h-4 w-4", anyFetching && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Valuation banner */}
+      <Card>
+        <CardContent className="flex flex-col gap-1 py-5">
+          <span className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+            Total valued (indicative USD)
+            {pricesStub && (
+              <Badge variant="outline" className="gap-1 text-[10px] font-normal normal-case">
+                <Info className="h-3 w-3" /> indicative (stub prices)
+              </Badge>
+            )}
+          </span>
+          {anyLoading ? (
+            <Skeleton className="h-9 w-48" />
+          ) : (
+            <div className="flex items-baseline gap-2">
+              <span className="num text-3xl font-bold tabular-nums">{usdCents(totalCents)}</span>
+              {anyFetching && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+            </div>
+          )}
+          <span className="text-[11px] text-muted-foreground">
+            {pricesUnavailable
+              ? "USD valuation marks unavailable on this backend — risk analytics cannot value the book here."
+              : `Valued ${valuedCount} position${valuedCount === 1 ? "" : "s"} across ${sourcesOk} source${sourcesOk === 1 ? "" : "s"}`}
+            {unpricedCount > 0 ? `, ${unpricedCount} unpriced balance${unpricedCount === 1 ? "" : "s"} excluded` : ""}
+            {pricesStub ? " — indicative marks, not a live valuation." : "."}
+          </span>
+        </CardContent>
+      </Card>
+
+      {bookEmpty ? (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            No valuable positions to analyze. Once custody / spot / margin / token / fund / staking
+            holdings with a USD price mark are readable, allocation and risk analytics appear here.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {/* Allocation */}
+          <SectionCard title="Allocation" icon={<PieChart className="h-4 w-4 text-muted-foreground" />}>
+            <Tabs value={allocBy} onValueChange={(v) => setAllocBy(v as AllocationBy)}>
+              <TabsList className="mb-3">
+                <TabsTrigger value="asset">By asset</TabsTrigger>
+                <TabsTrigger value="class">By class</TabsTrigger>
+                <TabsTrigger value="product">By product</TabsTrigger>
+              </TabsList>
+              <TabsContent value={allocBy} className="mt-0">
+                {anyLoading ? (
+                  <div className="space-y-3 py-2">
+                    {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-6 w-full" />)}
+                  </div>
+                ) : alloc.length === 0 ? (
+                  <p className="py-4 text-sm text-muted-foreground">Nothing to allocate.</p>
+                ) : (
+                  <div className="divide-y divide-border/40">
+                    {alloc.map((s) => (
+                      <WeightBar key={s.label} label={s.label} valueCents={s.valueCents} weightBps={s.weightBps} />
+                    ))}
+                    <div className="flex items-center justify-between pt-3 text-sm font-medium">
+                      <span>Total</span>
+                      <span className="tabular-nums">{usdCents(totalCents)}</span>
+                    </div>
+                  </div>
+                )}
+              </TabsContent>
+            </Tabs>
+          </SectionCard>
+
+          {/* Concentration */}
+          <SectionCard title="Concentration" icon={<Layers className="h-4 w-4 text-muted-foreground" />}>
+            {anyLoading ? (
+              <Skeleton className="h-24 w-full" />
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Herfindahl (HHI)</span>
+                    <span className="num text-2xl font-semibold tabular-nums">{conc.hhi.toLocaleString()}</span>
+                    <span className="text-[11px] text-muted-foreground">0 = perfectly even · 10,000 = single position</span>
+                  </div>
+                  <Badge variant={concentratedTone as never}>{concentratedLabel}</Badge>
+                </div>
+                <Progress value={conc.hhi} max={10_000} />
+                <Separator />
+                <div>
+                  <p className="mb-2 text-xs font-medium text-muted-foreground">Top positions</p>
+                  <div className="divide-y divide-border/40">
+                    {conc.top.map((t) => (
+                      <div key={t.label} className="flex items-center justify-between py-1.5 text-sm">
+                        <span className="truncate">{t.label}</span>
+                        <span className="tabular-nums text-muted-foreground">{bpsPct(t.weightBps)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </SectionCard>
+
+          {/* Exposure */}
+          <SectionCard title="Exposure" icon={<Scale className="h-4 w-4 text-muted-foreground" />}>
+            {anyLoading ? (
+              <Skeleton className="h-24 w-full" />
+            ) : (
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                  <Stat label="Gross" value={usdCents(expo.grossCents)} />
+                  <Stat label="Net" value={usdCents(expo.netCents)} tone={expo.netCents < 0 ? RED : GREEN} />
+                  <Stat label="Long" value={usdCents(expo.longCents)} tone={GREEN} />
+                  <Stat label="Short" value={usdCents(expo.shortCents)} tone={expo.shortCents > 0 ? RED : undefined} />
+                </div>
+                <Separator />
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Leverage (gross / margin equity)</span>
+                    <span className="num text-2xl font-semibold tabular-nums">{bpsX(leverageBps)}</span>
+                  </div>
+                  <Badge variant={levTone as never}>
+                    {leverageBps > 30_000 ? "High leverage" : leverageBps > 15_000 ? "Elevated" : leverageBps > 10_000 ? "Levered" : "Unlevered"}
+                  </Badge>
+                </div>
+                {expo.shortCents === 0 && (
+                  <p className="text-[11px] text-muted-foreground">
+                    No short exposure detected — gross equals net. Margin shorts surface here when the open position is a short.
+                  </p>
+                )}
+              </div>
+            )}
+          </SectionCard>
+
+          {/* Risk */}
+          <SectionCard title="Risk" icon={<Activity className="h-4 w-4 text-muted-foreground" />}>
+            {pricesUnavailable ? (
+              <div className="flex flex-col items-start gap-2 py-4">
+                <p className="text-sm text-muted-foreground">Cannot value the book — risk analytics are unavailable on this backend.</p>
+                <Badge variant="outline" className="gap-1.5"><Info className="h-3 w-3" /> Valuation marks unavailable</Badge>
+              </div>
+            ) : risk.loading ? (
+              <Skeleton className="h-28 w-full" />
+            ) : risk.n === 0 ? (
+              <p className="py-4 text-sm text-muted-foreground">
+                No priced asset maps to a tradeable market symbol, so volatility & VaR cannot be computed. Cash / fund / token
+                legs still count toward allocation and exposure above.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {(risk.anyStub || risk.thin) && (
+                  <Badge variant="outline" className="gap-1.5 text-[11px] font-normal">
+                    <Info className="h-3 w-3" />
+                    {risk.anyStub ? "Recent window only — real history endpoint not deployed" : "Limited history — estimates use a thin window"}
+                  </Badge>
+                )}
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                  <Stat label="Ann. volatility" value={bpsPct(risk.portVolBps, 1)} sub={`${risk.n} priced asset${risk.n === 1 ? "" : "s"}`} />
+                  <Stat label="Parametric VaR (95%)" value={usdCents(risk.paramVar)} tone={RED} sub="1-period, z=1.645" />
+                  <Stat
+                    label="Historical VaR (95%)"
+                    value={risk.portReturnsLen > 0 ? usdCents(risk.histVar) : "—"}
+                    tone={risk.histVar > 0 ? RED : undefined}
+                    sub={risk.portReturnsLen > 0 ? `${risk.portReturnsLen} periods` : "no return series"}
+                  />
+                </div>
+                <Separator />
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-1.5 text-muted-foreground">
+                      <TrendingUp className="h-3.5 w-3.5" /> Diversification score
+                    </span>
+                    <span className="num font-semibold tabular-nums">{risk.divScore} / 100</span>
+                  </div>
+                  <Progress value={risk.divScore} max={100} />
+                  <p className="text-[11px] text-muted-foreground">
+                    Higher = lower average pairwise correlation and more even weights. VaR is the indicative 1-period loss not
+                    expected to be exceeded at 95% confidence, on indicative marks.
+                  </p>
+                </div>
+              </div>
+            )}
+          </SectionCard>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Portfolio allocation & risk analytics (frontend, client-computed)

A cross-holdings "how am I positioned / what is my risk" view spanning custody + spot + margin + creator tokens + strategy funds + staking. Computed client-side from the existing portfolio reads + the shipped `marketStats`/`getHistory`; each source degrades independently; values are indicative USD cents (labelled). Works now.

**Sections:** Allocation (by asset/class/product), Concentration (HHI gauge + top positions), Exposure (gross/net/long/short + leverage), Risk (portfolio volatility + parametric & historical VaR + diversification score, with a limited-history banner).

### Web (`/portfolio/analytics`, "Portfolio Risk" nav)
`lib/portfolioAnalytics.ts` (+23 vitest) — allocation, concentration/HHI, exposure/leverage, covariance portfolio vol, parametric+historical VaR, diversification score; `PortfolioAnalyticsPage` normalizes all holdings into the four sections.

### Android (new `feature/portfolioanalytics`, registered in `MoreRoutes`)
`PortfolioAnalyticsMath.kt` (+25 JVM tests) + Screen/ViewModel/UiState fanning out the existing repos in parallel + risk from `getHistory`. Also **fixed a real leverage bug** (was bps-clamped to 1.0x → now true `gross/|net|`).

No new deps. Gates: web tsc 0 · vite build · vitest 23/23; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (25/25, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
