### PR TITLE
feat(activity): consolidated Activity Center (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/activity/ActivityLastSeenStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/activity/ActivityLastSeenStore.kt
@@ -1,0 +1,45 @@
+package com.testlogon.android.data.activity
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.activityLastSeenDataStore by preferencesDataStore(name = "activity_center_last_seen")
+
+/**
+ * Persists the Activity Center "last seen" high-water mark (epoch millis of the newest event the user
+ * has acknowledged) so unread markers survive re-entry / process death. Only a single Long is stored -
+ * never any event payload. Reads degrade to 0 (everything unread) on an IO error.
+ */
+@Singleton
+class ActivityLastSeenStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val dataStore = context.activityLastSeenDataStore
+
+    /** Hot stream of the persisted last-seen millis (0 when never set). */
+    val lastSeen: Flow<Long> = dataStore.data
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .map { it[KEY_LAST_SEEN] ?: 0L }
+
+    /** Advance the mark to [ts] (never moves it backwards). */
+    suspend fun setLastSeen(ts: Long) {
+        dataStore.edit { prefs ->
+            val current = prefs[KEY_LAST_SEEN] ?: 0L
+            if (ts > current) prefs[KEY_LAST_SEEN] = ts
+        }
+    }
+
+    private companion object {
+        val KEY_LAST_SEEN = longPreferencesKey("activity_last_seen_ms")
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityCenterScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityCenterScreen.kt
@@ -1,0 +1,258 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.activity
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.feature.markets.ui.MarketColors
+import com.testlogon.android.feature.markets.ui.MarketSurface
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * The consolidated ACTIVITY CENTER: a durable, filterable, day-grouped timeline of account events
+ * (trades / funding / liquidations / risk / money / system), aggregated client-side from the shipped
+ * exchange feeds. Distinct from transient toasts; degrades per-source on 404 with an honest empty
+ * state. [onOpenRoute] deep-links a tapped event to the relevant screen.
+ */
+@Composable
+fun ActivityCenterRoute(
+    onBack: () -> Unit,
+    onOpenRoute: (String) -> Unit = {},
+    viewModel: ActivityCenterViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val unread by viewModel.unreadCount.collectAsStateWithLifecycle()
+    MarketSurface {
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            ActivityHeader(
+                unread = unread,
+                onBack = onBack,
+                onMarkAllRead = viewModel::markAllRead,
+                onRefresh = viewModel::refresh,
+            )
+            CategoryChips(selected = state.selected, onSelect = viewModel::selectCategory)
+            if (state.degradedSources.isNotEmpty()) {
+                Text(
+                    "Some feeds unavailable: " + state.degradedSources.joinToString(", "),
+                    color = MarketColors.TextSecondary,
+                    fontSize = 11.sp,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
+            Box(modifier = Modifier.fillMaxSize()) {
+                when {
+                    state.days.isEmpty() && state.loading -> EmptyState("Loading activity...", "")
+                    state.days.isEmpty() && state.total == 0 -> EmptyState(
+                        "No activity yet",
+                        "Your fills, funding, liquidations, risk and market events will appear here.",
+                    )
+                    state.days.isEmpty() -> EmptyState("Nothing in this filter", "Try a different category.")
+                    else -> LazyColumn(
+                        modifier = Modifier.fillMaxSize().testTag("activity_center_list"),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        state.days.forEach { day ->
+                            item(key = "day-" + day.dayKey) { DayHeader(day.dayKey) }
+                            items(count = day.events.size, key = { day.events[it].id }) { i ->
+                                val e = day.events[i]
+                                ActivityCard(
+                                    event = e,
+                                    lastSeen = false,
+                                    onClick = { e.route?.let(onOpenRoute) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActivityHeader(
+    unread: Int,
+    onBack: () -> Unit,
+    onMarkAllRead: () -> Unit,
+    onRefresh: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(start = 4.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = MarketColors.TextPrimary)
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text("Activity", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 22.sp)
+            Text(
+                if (unread > 0) "$unread new" else "up to date",
+                color = if (unread > 0) MarketColors.Accent else MarketColors.TextSecondary,
+                fontSize = 12.sp,
+            )
+        }
+        IconButton(onClick = onRefresh, modifier = Modifier.testTag("activity_refresh")) {
+            Icon(Icons.Filled.Refresh, contentDescription = "Refresh", tint = MarketColors.TextSecondary)
+        }
+        IconButton(onClick = onMarkAllRead, modifier = Modifier.testTag("activity_mark_read")) {
+            Icon(Icons.Filled.DoneAll, contentDescription = "Mark all read", tint = MarketColors.TextSecondary)
+        }
+    }
+}
+
+private data class ChipSpec(val label: String, val category: ActivityCategory?)
+
+private val CHIPS = listOf(
+    ChipSpec("All", null),
+    ChipSpec("Trades", ActivityCategory.TRADE),
+    ChipSpec("Funding", ActivityCategory.FUNDING),
+    ChipSpec("Liquidations", ActivityCategory.LIQUIDATION),
+    ChipSpec("Risk", ActivityCategory.RISK),
+    ChipSpec("Money", ActivityCategory.MONEY),
+    ChipSpec("System", ActivityCategory.SYSTEM),
+)
+
+@Composable
+private fun CategoryChips(selected: ActivityCategory?, onSelect: (ActivityCategory?) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CHIPS.forEach { chip ->
+            val active = chip.category == selected
+            Text(
+                chip.label,
+                color = if (active) MarketColors.Bg else MarketColors.TextSecondary,
+                fontSize = 12.sp,
+                fontWeight = if (active) FontWeight.Bold else FontWeight.Normal,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(if (active) MarketColors.Accent else MarketColors.Surface)
+                    .border(1.dp, MarketColors.Border, RoundedCornerShape(16.dp))
+                    .clickable { onSelect(chip.category) }
+                    .testTag("chip_" + (chip.category?.name ?: "ALL"))
+                    .padding(horizontal = 14.dp, vertical = 7.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DayHeader(dayKey: Long) {
+    Text(
+        DAY_FMT.format(Date(dayKey)),
+        color = MarketColors.TextSecondary,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Bold,
+        fontFamily = FontFamily.Monospace,
+        modifier = Modifier.padding(start = 4.dp, top = 6.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+private fun ActivityCard(event: ActivityEvent, lastSeen: Boolean, onClick: () -> Unit) {
+    val accent = severityColor(event.severity)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MarketColors.Surface)
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(accent))
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    event.kind,
+                    color = accent,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 11.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    event.title,
+                    color = MarketColors.TextPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                )
+            }
+            event.subtitle?.let {
+                Spacer(Modifier.size(3.dp))
+                Text(it, color = MarketColors.TextSecondary, fontSize = 13.sp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(title: String, body: String) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(title, color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+        if (body.isNotEmpty()) {
+            Spacer(Modifier.size(6.dp))
+            Text(body, color = MarketColors.TextSecondary, fontSize = 13.sp)
+        }
+    }
+}
+
+private fun severityColor(severity: ActivitySeverity): Color = when (severity) {
+    ActivitySeverity.SUCCESS -> MarketColors.Up
+    ActivitySeverity.WARNING -> MarketColors.Accent
+    ActivitySeverity.CRITICAL -> MarketColors.Down
+    ActivitySeverity.INFO -> MarketColors.TextSecondary
+}
+
+private val DAY_FMT = SimpleDateFormat("EEE, MMM d yyyy", Locale.US)

--- a/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityCenterViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityCenterViewModel.kt
@@ -1,0 +1,115 @@
+package com.testlogon.android.feature.activity
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.activity.ActivityLastSeenStore
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.TradingRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * UI state for the Activity Center. [days] is the day-grouped, category-filtered timeline; [total] is
+ * the unfiltered event count (so the empty state can distinguish "no events at all" from "none in this
+ * filter"); [degradedSources] names any feed that failed this load (surfaced as an honest banner).
+ */
+data class ActivityUiState(
+    val loading: Boolean = true,
+    val days: List<ActivityDay> = emptyList(),
+    val total: Int = 0,
+    val selected: ActivityCategory? = null,
+    val degradedSources: List<String> = emptyList(),
+)
+
+/**
+ * Drives the consolidated Activity Center. Aggregates the existing exchange feed reads CLIENT-SIDE
+ * (fills / funding / liquidations / margin-distress / PM-resolutions), each degrading independently to
+ * empty on 404 / error, normalizes them through the pure [ActivityModel], and exposes a filterable,
+ * day-grouped timeline plus a DataStore-persisted unread count.
+ *
+ * No new backend route: this works today off the shipped trader feeds and simply shows less when a
+ * source is unavailable.
+ */
+@HiltViewModel
+class ActivityCenterViewModel @Inject constructor(
+    private val trading: TradingRepository,
+    private val lastSeenStore: ActivityLastSeenStore,
+) : ViewModel() {
+
+    private val allEvents = MutableStateFlow<List<ActivityEvent>>(emptyList())
+    private val selectedCategory = MutableStateFlow<ActivityCategory?>(null)
+    private val degraded = MutableStateFlow<List<String>>(emptyList())
+    private val loading = MutableStateFlow(true)
+
+    val state: StateFlow<ActivityUiState> =
+        combine(allEvents, selectedCategory, degraded, loading) { events, cat, deg, isLoading ->
+            val filtered = ActivityModel.filterByCategory(events, cat)
+            ActivityUiState(
+                loading = isLoading,
+                days = ActivityModel.groupByDay(filtered),
+                total = events.size,
+                selected = cat,
+                degradedSources = deg,
+            )
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ActivityUiState())
+
+    /** Unread count (events strictly newer than the persisted last-seen mark). */
+    val unreadCount: StateFlow<Int> =
+        combine(allEvents, lastSeenStore.lastSeen) { events, seen ->
+            ActivityModel.unreadCount(events, seen)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
+
+    init {
+        refresh()
+    }
+
+    fun selectCategory(category: ActivityCategory?) {
+        selectedCategory.value = category
+    }
+
+    /** Advance the last-seen mark to the newest event so the unread badge clears. */
+    fun markAllRead() {
+        viewModelScope.launch {
+            lastSeenStore.setLastSeen(ActivityModel.newestTs(allEvents.value))
+        }
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            loading.value = true
+            val nowMs = System.currentTimeMillis()
+            val failed = ArrayList<String>()
+
+            val fillsData = (trading.fillsFees() as? ApiResult.Success)?.data
+            if (fillsData == null) failed += "Trades"
+            val fundingData = (trading.fundingPayments() as? ApiResult.Success)?.data
+            if (fundingData == null) failed += "Funding"
+            val liqData = (trading.liquidations() as? ApiResult.Success)?.data
+            if (liqData == null) failed += "Liquidations"
+            // Margin is 403 for a non-trading account -> null (no risk signal), not a degraded source.
+            val margin = (trading.marginAccount() as? ApiResult.Success)?.data
+            val pmData = (trading.pmResolutions() as? ApiResult.Success)?.data
+            if (pmData == null) failed += "System"
+
+            allEvents.value = ActivityModel.mergeEvents(
+                ActivityModel.fromFills(fillsData ?: FillsFees(emptyList(), 0), nowMs),
+                ActivityModel.fromFunding(fundingData ?: FundingPayments(emptyList(), 0), nowMs),
+                ActivityModel.fromLiquidations(liqData ?: Liquidations(emptyList(), 0), nowMs),
+                ActivityModel.fromMargin(margin, nowMs),
+                ActivityModel.fromPmResolutions(pmData ?: emptyList(), nowMs),
+            )
+            degraded.value = failed
+            loading.value = false
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityModel.kt
@@ -1,0 +1,217 @@
+package com.testlogon.android.feature.activity
+
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.PmResolution
+
+/**
+ * The consolidated ACTIVITY CENTER model. A durable, filterable, day-grouped timeline of account
+ * events - distinct from transient toasts / notifications. Everything here is PURE (no Android / no
+ * coroutines / no I/O): the ViewModel assembles the already-degraded feed reads into [ActivityEvent]s
+ * via the per-feed normalizers, then merges / groups / filters through these functions.
+ *
+ * Money is integer minor units ([amountCents]-style Long), shown verbatim; the model does no monetary
+ * math. Timestamps are epoch MILLISECONDS ([ts]) so day-grouping is trivial and the mixed feeds (some
+ * carry nanosecond event stamps, some do not) share one comparable axis.
+ */
+
+/** Top-level grouping for a filter chip + section colour. */
+enum class ActivityCategory { TRADE, FUNDING, LIQUIDATION, RISK, MONEY, SYSTEM }
+
+/** Visual weight of an event (drives icon tint / accent). */
+enum class ActivitySeverity { INFO, SUCCESS, WARNING, CRITICAL }
+
+/**
+ * One normalized, render-ready account event.
+ *
+ * [id]        stable de-dupe key (feed-kind + event identity) so one underlying event never appears twice.
+ * [ts]        epoch millis used for sort + day-grouping + unread comparison.
+ * [kind]      a short machine tag ("FILL" / "FUNDING" / ...) surfaced as a mono badge.
+ * [category]  the filter bucket.
+ * [title]     one-line headline.
+ * [subtitle]  optional detail line.
+ * [amountCents] optional signed integer minor-unit amount (verbatim; null when not money-shaped).
+ * [route]     optional deep-link target (a MoreRoutes / Dest route string) for tap-through.
+ * [severity]  visual weight.
+ */
+data class ActivityEvent(
+    val id: String,
+    val ts: Long,
+    val kind: String,
+    val category: ActivityCategory,
+    val title: String,
+    val subtitle: String? = null,
+    val amountCents: Long? = null,
+    val route: String? = null,
+    val severity: ActivitySeverity = ActivitySeverity.INFO,
+)
+
+/** A day bucket of events (newest day first; events within a day are newest-first). */
+data class ActivityDay(
+    val dayKey: Long,
+    val events: List<ActivityEvent>,
+)
+
+/**
+ * Pure normalizers + timeline algebra. Kept object-scoped so the whole surface is unit-testable
+ * without Hilt / Compose. Deep-link routes are plain strings the caller maps to nav destinations.
+ */
+object ActivityModel {
+
+    /** Deep-link route strings (kept as literals so this stays Android-free for the JVM test). */
+    const val ROUTE_MARKETS = "markets"
+    const val ROUTE_TRADING_ALERTS = "markets/alerts"
+    const val ROUTE_PORTFOLIO = "portfolio"
+    const val ROUTE_WALLET = "wallet"
+
+    private const val MS_PER_DAY = 86_400_000L
+
+    // ---- per-feed normalizers (each already degraded-to-empty on 404 by the repo) ----
+
+    /** Fills feed (me/fills/fees) -> TRADE events. [nowMs] backstops rows the feed left at ts 0. */
+    fun fromFills(feed: FillsFees, nowMs: Long): List<ActivityEvent> =
+        feed.fills.map { f ->
+            val side = f.side?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "Filled"
+            ActivityEvent(
+                id = "fill:" + f.symbolId + ":" + f.tsNs + ":" + f.price + ":" + f.qty,
+                ts = nsToMs(f.tsNs, nowMs),
+                kind = "FILL",
+                category = ActivityCategory.TRADE,
+                title = "Order filled",
+                subtitle = side + " " + f.qty + " @ " + f.price + " on #" + f.symbolId + " (fee " + f.fee + ")",
+                amountCents = f.fee,
+                route = ROUTE_MARKETS,
+                severity = if (f.side == OrderSide.SELL) ActivitySeverity.INFO else ActivitySeverity.SUCCESS,
+            )
+        }
+
+    /** Funding feed (me/funding/payments) -> FUNDING events (signed money). */
+    fun fromFunding(feed: FundingPayments, nowMs: Long): List<ActivityEvent> =
+        feed.payments.map { p ->
+            val verb = if (p.received) "Received" else "Paid"
+            val amt = kotlin.math.abs(p.payment)
+            ActivityEvent(
+                id = "fund:" + p.symbolId + ":" + p.tsNs + ":" + p.payment,
+                ts = nsToMs(p.tsNs, nowMs),
+                kind = "FUNDING",
+                category = ActivityCategory.FUNDING,
+                title = "Funding " + (if (p.received) "received" else "paid"),
+                subtitle = verb + " " + amt + " on #" + p.symbolId + " (" + p.fundingRateBps + " bps)",
+                amountCents = p.payment,
+                route = ROUTE_PORTFOLIO,
+                severity = if (p.received) ActivitySeverity.SUCCESS else ActivitySeverity.WARNING,
+            )
+        }
+
+    /** Liquidations feed (me/liquidations) -> LIQUIDATION events (always CRITICAL). */
+    fun fromLiquidations(feed: Liquidations, nowMs: Long): List<ActivityEvent> =
+        feed.events.map { e ->
+            ActivityEvent(
+                id = "liq:" + e.symbolId + ":" + e.tsNs + ":" + e.qty,
+                ts = nsToMs(e.tsNs, nowMs),
+                kind = "LIQUIDATION",
+                category = ActivityCategory.LIQUIDATION,
+                title = "Position liquidated",
+                subtitle = "Force-liquidated " + e.qty + " on #" + e.symbolId + " @ " + e.markPrice + " (PnL " + e.realizedPnl + ")",
+                amountCents = e.realizedPnl,
+                route = ROUTE_PORTFOLIO,
+                severity = ActivitySeverity.CRITICAL,
+            )
+        }
+
+    /**
+     * Margin account (me/margin) -> at most ONE current RISK event when the account is in distress /
+     * being liquidated. Level-triggered snapshot (not a feed), so it is keyed by the current level/flag
+     * and stamped [nowMs]; a healthy account (null margin or level 0) contributes nothing.
+     */
+    fun fromMargin(margin: MarginAccount?, nowMs: Long): List<ActivityEvent> {
+        if (margin == null) return emptyList()
+        val level = margin.distressLevel
+        val liquidating = margin.isLiquidating
+        if (level <= 0 && !liquidating) return emptyList()
+        val subtitle = if (liquidating) {
+            "Your account is being liquidated (distress level " + level + ")"
+        } else {
+            "Margin distress at level " + level + " - top up collateral to avoid liquidation"
+        }
+        return listOf(
+            ActivityEvent(
+                id = "margin:" + level + ":" + liquidating,
+                ts = nowMs,
+                kind = "RISK",
+                category = ActivityCategory.RISK,
+                title = if (liquidating) "Liquidation in progress" else "Margin distress",
+                subtitle = subtitle,
+                route = ROUTE_PORTFOLIO,
+                severity = ActivitySeverity.CRITICAL,
+            ),
+        )
+    }
+
+    /** PM resolutions (admin/pm resolutions log) -> SYSTEM events. [ts] is seconds on the wire. */
+    fun fromPmResolutions(resolutions: List<PmResolution>, nowMs: Long): List<ActivityEvent> =
+        resolutions.map { r ->
+            ActivityEvent(
+                id = "pm:" + r.marketLabel + ":" + r.outcomeLabel + ":" + r.ts,
+                ts = if (r.ts > 0L) r.ts * 1000L else nowMs,
+                kind = "RESOLVED",
+                category = ActivityCategory.SYSTEM,
+                title = "Market resolved",
+                subtitle = r.marketLabel + " resolved " + r.outcomeLabel,
+                route = ROUTE_MARKETS,
+                severity = ActivitySeverity.INFO,
+            )
+        }
+
+    // ---- timeline algebra ----
+
+    /**
+     * Merge any number of already-normalized event lists into one timeline: de-duped by [ActivityEvent.id]
+     * (first occurrence wins) and sorted newest-first ([ts] desc, id desc as a stable tiebreak). Pure.
+     */
+    fun mergeEvents(vararg sources: List<ActivityEvent>): List<ActivityEvent> =
+        mergeEvents(sources.asList())
+
+    fun mergeEvents(sources: List<List<ActivityEvent>>): List<ActivityEvent> {
+        val seen = HashSet<String>()
+        val merged = ArrayList<ActivityEvent>()
+        sources.forEach { list ->
+            list.forEach { e -> if (seen.add(e.id)) merged += e }
+        }
+        merged.sortWith(compareByDescending<ActivityEvent> { it.ts }.thenByDescending { it.id })
+        return merged
+    }
+
+    /** Filter to a single category, or return the input unchanged when [category] is null (== All). */
+    fun filterByCategory(events: List<ActivityEvent>, category: ActivityCategory?): List<ActivityEvent> =
+        if (category == null) events else events.filter { it.category == category }
+
+    /**
+     * Group a (typically already newest-first) event list into day buckets. Each bucket carries the
+     * day-start epoch-millis [ActivityDay.dayKey] (UTC-day, derived by integer division so the model
+     * stays timezone-free / deterministic). Days are newest-first; within a day, newest-first.
+     */
+    fun groupByDay(events: List<ActivityEvent>): List<ActivityDay> =
+        events
+            .groupBy { dayKeyOf(it.ts) }
+            .map { (day, evs) -> ActivityDay(day, evs.sortedWith(compareByDescending<ActivityEvent> { it.ts }.thenByDescending { it.id })) }
+            .sortedByDescending { it.dayKey }
+
+    /** UTC-day-start epoch millis for [ts] (deterministic; used as a group key). */
+    fun dayKeyOf(ts: Long): Long = (ts / MS_PER_DAY) * MS_PER_DAY
+
+    /** How many events are strictly newer than [lastSeenTs] (the unread badge count). */
+    fun unreadCount(events: List<ActivityEvent>, lastSeenTs: Long): Int =
+        events.count { it.ts > lastSeenTs }
+
+    /** The newest event timestamp (what "mark all read" persists), or 0 when empty. */
+    fun newestTs(events: List<ActivityEvent>): Long = events.maxOfOrNull { it.ts } ?: 0L
+
+    // ---- helpers ----
+
+    /** Nanosecond event stamp -> millis; falls back to [nowMs] when the feed left it at 0. */
+    private fun nsToMs(tsNs: Long, nowMs: Long): Long = if (tsNs > 0L) tsNs / 1_000_000L else nowMs
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1683,6 +1683,17 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),
+        // Activity Center: the consolidated, filterable, day-grouped account-event timeline (trades /
+        // funding / liquidations / risk / system), aggregated client-side from the shipped exchange feeds.
+        // Durable history, distinct from the transient Trading Alerts bell. Degrades per-source on 404.
+        MoreEntry(
+            id = "activity_center",
+            labelRes = R.string.more_entry_activity_center,
+            icon = Icons.Outlined.History,
+            route = MoreRoutes.ACTIVITY_CENTER,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
         // AND-404: READ-ONLY admin EMAIL delivery dashboard (per-channel stats + recent activity). Self-gates
         // via the backend 403 -> the screen's Forbidden state; a non-admin sees no admin data.
         MoreEntry(

--- a/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
@@ -10,6 +10,7 @@ import com.testlogon.android.feature.markets.SymbolDetailRoute
 import com.testlogon.android.feature.markets.alerts.TradingAlertsRoute
 import com.testlogon.android.feature.markets.alerts.pricealerts.PriceAlertsRoute
 import com.testlogon.android.feature.analysis.MarketAnalysisRoute
+import com.testlogon.android.feature.activity.ActivityCenterRoute
 
 /**
  * Markets (exchange market-data, VIEW-ONLY) destinations, registered in the AUTHENTICATED nav graph.
@@ -43,6 +44,11 @@ data object AnalysisDest {
     const val ROUTE = "markets/analysis"
 }
 
+/** Consolidated Activity Center (durable, day-grouped account-event timeline). New navigable destination. */
+data object ActivityCenterDest {
+    const val ROUTE = "activity/center"
+}
+
 /** Registers the Markets list + per-symbol detail destinations (Back pops the back stack). */
 fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
     composable(MarketsDest.ROUTE) {
@@ -72,6 +78,12 @@ fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
     }
     composable(AnalysisDest.ROUTE) {
         MarketAnalysisRoute(onBack = { navController.popBackStack() })
+    }
+    composable(ActivityCenterDest.ROUTE) {
+        ActivityCenterRoute(
+            onBack = { navController.popBackStack() },
+            onOpenRoute = { route -> navController.navigate(route) { launchSingleTop = true } },
+        )
     }
     composable(
         route = SymbolDetailDest.ROUTE,

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -416,6 +416,10 @@ object MoreRoutes {
     // Trading Alerts (derived notifications: fills / liquidations / funding / margin-distress / PM-resolved).
     const val TRADING_ALERTS = TradingAlertsDest.ROUTE
 
+    // Activity Center: consolidated, filterable, day-grouped account-event timeline (client-aggregated
+    // from the shipped exchange feeds; degrades per-source on 404). Distinct from transient notifications.
+    const val ACTIVITY_CENTER = ActivityCenterDest.ROUTE
+
     // AND-404: READ-ONLY admin email/SMS delivery dashboards (per-channel stats + recent activity). Self-gate
     // via the backend 403 -> the screen's Forbidden state (cf. the AND-403 admin-dashboard pattern); a non-admin
     // sees no admin data. Two concrete entry routes off the shared `{channel}` destination template.
@@ -711,6 +715,7 @@ object MoreRoutes {
             ANALYSIS,
             GLOBAL_SEARCH,
             TRADING_ALERTS,
+            ACTIVITY_CENTER,
             ADMIN_EMAIL_DASHBOARD,
             ADMIN_SMS_DASHBOARD,
             ADMIN_MODERATION,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4293,6 +4293,7 @@
     <string name="more_entry_strategies">Strategies &amp; Baskets</string>
     <string name="more_entry_bailouts">Bailout Auctions</string>
     <string name="more_entry_trading_alerts">Trading alerts</string>
+    <string name="more_entry_activity_center">Activity Center</string>
     <string name="admin_dashboard_title">Admin alerts</string>
     <string name="admin_dashboard_back">Back</string>
     <string name="admin_dashboard_refresh">Refresh</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/activity/ActivityModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/activity/ActivityModelTest.kt
@@ -1,0 +1,180 @@
+package com.testlogon.android.feature.activity
+
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayment
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.Liquidation
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.Liquidity
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.PmResolution
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure unit tests for the Activity Center model (normalizers + timeline algebra). */
+class ActivityModelTest {
+
+    private val nowMs = 1_700_000_000_000L
+
+    // Nanoseconds for a couple of distinct days.
+    private val day1Ns = 1_699_900_000_000_000_000L
+    private val day2Ns = 1_699_990_000_000_000_000L
+
+    private fun fill(sym: Int, ns: Long, side: OrderSide?, fee: Long = 5L) = FillFee(
+        symbolId = sym, price = 100L, qty = 2L, side = side,
+        liquidity = Liquidity.MAKER, fee = fee, feeAsset = 0, tsNs = ns,
+    )
+
+    private fun funding(sym: Int, ns: Long, payment: Long, received: Boolean) = FundingPayment(
+        symbolId = sym, fundingRateBps = 3, markPrice = 100L, positionQty = 10L,
+        payment = payment, received = received, tsNs = ns,
+    )
+
+    private fun liq(sym: Int, ns: Long) = Liquidation(
+        symbolId = sym, qty = 4L, markPrice = 90L, realizedPnl = -50L, fee = 2L, tsNs = ns,
+    )
+
+    private fun margin(level: Int, liquidating: Boolean) = MarginAccount(
+        // minimal — only distressLevel / isLiquidating drive the normalizer; the rest are safe defaults.
+        balance = 0L, availableBalance = 0L, reservedMargin = 0L, numPositions = 0,
+        position = null, distressLevel = level, isLiquidating = liquidating, mpid = "",
+    )
+
+    private fun pm(sym: Int, outcome: String, ts: Long) = PmResolution(
+        symbolId = sym, groupId = null, winningSymbolId = null, outcome = outcome,
+        resolverId = "r", ts = ts, source = "admin",
+    )
+
+    @Test fun fromFills_mapsCategoryAndSeverity() {
+        val evs = ActivityModel.fromFills(FillsFees(listOf(fill(1, day1Ns, OrderSide.BUY)), 1), nowMs)
+        assertEquals(1, evs.size)
+        assertEquals(ActivityCategory.TRADE, evs[0].category)
+        assertEquals("FILL", evs[0].kind)
+        assertEquals(ActivitySeverity.SUCCESS, evs[0].severity)
+        assertEquals(5L, evs[0].amountCents)
+    }
+
+    @Test fun fromFills_sellIsInfo() {
+        val evs = ActivityModel.fromFills(FillsFees(listOf(fill(1, day1Ns, OrderSide.SELL)), 1), nowMs)
+        assertEquals(ActivitySeverity.INFO, evs[0].severity)
+    }
+
+    @Test fun fromFills_zeroTsFallsBackToNow() {
+        val evs = ActivityModel.fromFills(FillsFees(listOf(fill(1, 0L, OrderSide.BUY)), 1), nowMs)
+        assertEquals(nowMs, evs[0].ts)
+    }
+
+    @Test fun fromFunding_receivedIsSuccess_paidIsWarning() {
+        val recv = ActivityModel.fromFunding(FundingPayments(listOf(funding(1, day1Ns, 20L, true)), 1), nowMs)
+        val paid = ActivityModel.fromFunding(FundingPayments(listOf(funding(1, day1Ns, -20L, false)), 1), nowMs)
+        assertEquals(ActivitySeverity.SUCCESS, recv[0].severity)
+        assertEquals(ActivityCategory.FUNDING, recv[0].category)
+        assertEquals(ActivitySeverity.WARNING, paid[0].severity)
+        assertEquals(-20L, paid[0].amountCents)
+    }
+
+    @Test fun fromLiquidations_isCritical() {
+        val evs = ActivityModel.fromLiquidations(Liquidations(listOf(liq(1, day1Ns)), 1), nowMs)
+        assertEquals(ActivityCategory.LIQUIDATION, evs[0].category)
+        assertEquals(ActivitySeverity.CRITICAL, evs[0].severity)
+    }
+
+    @Test fun fromMargin_healthyProducesNothing() {
+        assertTrue(ActivityModel.fromMargin(margin(0, false), nowMs).isEmpty())
+        assertTrue(ActivityModel.fromMargin(null, nowMs).isEmpty())
+    }
+
+    @Test fun fromMargin_distressProducesOneCriticalRiskEvent() {
+        val evs = ActivityModel.fromMargin(margin(2, false), nowMs)
+        assertEquals(1, evs.size)
+        assertEquals(ActivityCategory.RISK, evs[0].category)
+        assertEquals(ActivitySeverity.CRITICAL, evs[0].severity)
+        assertEquals(nowMs, evs[0].ts)
+    }
+
+    @Test fun fromMargin_liquidatingTitle() {
+        val evs = ActivityModel.fromMargin(margin(3, true), nowMs)
+        assertEquals("Liquidation in progress", evs[0].title)
+    }
+
+    @Test fun fromPmResolutions_secondsScaledToMillis() {
+        val evs = ActivityModel.fromPmResolutions(listOf(pm(1, "yes", 1_699_000_000L)), nowMs)
+        assertEquals(ActivityCategory.SYSTEM, evs[0].category)
+        assertEquals(1_699_000_000L * 1000L, evs[0].ts)
+    }
+
+    @Test fun mergeEvents_sortsDescAndDedupesById() {
+        val a = ActivityModel.fromFills(FillsFees(listOf(fill(1, day1Ns, OrderSide.BUY)), 1), nowMs)
+        val b = ActivityModel.fromFunding(FundingPayments(listOf(funding(1, day2Ns, 10L, true)), 1), nowMs)
+        // include a duplicate of 'a' to exercise de-dupe
+        val merged = ActivityModel.mergeEvents(a, b, a)
+        assertEquals(2, merged.size)
+        // day2 funding is newer than day1 fill -> first
+        assertTrue(merged[0].ts >= merged[1].ts)
+        assertEquals("FUNDING", merged[0].kind)
+    }
+
+    @Test fun filterByCategory_nullReturnsAll_andFilters() {
+        val fills = ActivityModel.fromFills(FillsFees(listOf(fill(1, day1Ns, OrderSide.BUY)), 1), nowMs)
+        val funds = ActivityModel.fromFunding(FundingPayments(listOf(funding(1, day2Ns, 10L, true)), 1), nowMs)
+        val all = ActivityModel.mergeEvents(fills, funds)
+        assertEquals(2, ActivityModel.filterByCategory(all, null).size)
+        assertEquals(1, ActivityModel.filterByCategory(all, ActivityCategory.TRADE).size)
+        assertTrue(ActivityModel.filterByCategory(all, ActivityCategory.MONEY).isEmpty())
+    }
+
+    @Test fun groupByDay_bucketsByUtcDay_newestFirst() {
+        val d1 = ActivityModel.fromFills(FillsFees(listOf(fill(1, day1Ns, OrderSide.BUY)), 1), nowMs)
+        val d2 = ActivityModel.fromFunding(FundingPayments(listOf(funding(1, day2Ns, 10L, true)), 1), nowMs)
+        val merged = ActivityModel.mergeEvents(d1, d2)
+        val days = ActivityModel.groupByDay(merged)
+        assertEquals(2, days.size)
+        assertTrue("newest day first", days[0].dayKey > days[1].dayKey)
+        assertEquals(1, days[0].events.size)
+    }
+
+    @Test fun groupByDay_sameDayEventsGrouped() {
+        val ns2 = day1Ns + 60_000_000_000L // +60s, same UTC day
+        val evs = ActivityModel.fromFills(
+            FillsFees(listOf(fill(1, day1Ns, OrderSide.BUY), fill(2, ns2, OrderSide.SELL)), 2), nowMs,
+        )
+        val days = ActivityModel.groupByDay(evs)
+        assertEquals(1, days.size)
+        assertEquals(2, days[0].events.size)
+    }
+
+    @Test fun unreadCount_countsStrictlyNewer() {
+        val evs = ActivityModel.mergeEvents(
+            ActivityModel.fromFills(FillsFees(listOf(fill(1, day1Ns, OrderSide.BUY)), 1), nowMs),
+            ActivityModel.fromFunding(FundingPayments(listOf(funding(1, day2Ns, 10L, true)), 1), nowMs),
+        )
+        // last-seen at the day1 fill's ts -> only the day2 funding is unread.
+        val day1Ms = day1Ns / 1_000_000L
+        assertEquals(1, ActivityModel.unreadCount(evs, day1Ms))
+        assertEquals(2, ActivityModel.unreadCount(evs, 0L))
+        assertEquals(0, ActivityModel.unreadCount(evs, Long.MAX_VALUE))
+    }
+
+    @Test fun newestTs_emptyIsZero_elseMax() {
+        assertEquals(0L, ActivityModel.newestTs(emptyList()))
+        val evs = ActivityModel.fromFunding(FundingPayments(listOf(funding(1, day2Ns, 10L, true)), 1), nowMs)
+        assertEquals(day2Ns / 1_000_000L, ActivityModel.newestTs(evs))
+    }
+
+    @Test fun emptyFeeds_produceNoEvents() {
+        val merged = ActivityModel.mergeEvents(
+            ActivityModel.fromFills(FillsFees(emptyList(), 0), nowMs),
+            ActivityModel.fromFunding(FundingPayments(emptyList(), 0), nowMs),
+            ActivityModel.fromLiquidations(Liquidations(emptyList(), 0), nowMs),
+            ActivityModel.fromMargin(null, nowMs),
+            ActivityModel.fromPmResolutions(emptyList(), nowMs),
+        )
+        assertTrue(merged.isEmpty())
+        assertTrue(ActivityModel.groupByDay(merged).isEmpty())
+        assertNull(merged.firstOrNull()?.route)
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,6 +84,7 @@ const DelegationApiKeysPage = lazy(
 );
 const AlertsPage = lazy(() => import("@/pages/alerts/AlertsPage"));
 const ActivityFeedPage = lazy(() => import("@/pages/activity/ActivityFeedPage"));
+const ActivityCenterPage = lazy(() => import("@/pages/activity-center/ActivityCenterPage"));
 const NotificationsPage = lazy(() => import("@/pages/notifications/NotificationsPage"));
 const SecurityPage = lazy(() => import("@/pages/security/SecurityPage"));
 const ProfilePage = lazy(() => import("@/pages/settings/ProfilePage"));
@@ -788,6 +789,7 @@ export default function App() {
           <Route path="delegation-api" element={<DelegationApiKeysPage />} />
           <Route path="alerts" element={<AlertsPage />} />
           <Route path="activity" element={<ActivityFeedPage />} />
+          <Route path="activity-center" element={<ActivityCenterPage />} />
           <Route path="notifications" element={<NotificationsPage />} />
           <Route path="appeals" element={<AppealsPage />} />
           <Route path="tickets" element={<TicketsPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink, useLocation } from "react-router-dom";
+import { useActivityUnread } from "@/hooks/useActivity";
 import {
   Sparkles,
   LayoutDashboard,
@@ -159,6 +160,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Reports", i18nKey: "nav.reports", path: "/reports", icon: <FileText className="h-5 w-5" /> },
       { label: "Tax & Gains", i18nKey: "nav.taxGains", path: "/reports/tax", icon: <Receipt className="h-5 w-5" /> },
       { label: "Activity", i18nKey: "nav.activity", path: "/activity", icon: <Activity className="h-5 w-5" /> },
+      { label: "Activity Center", i18nKey: "nav.activityCenter", path: "/activity-center", icon: <Bell className="h-5 w-5" /> },
       { label: "Discover", i18nKey: "nav.discover", path: "/discover", icon: <Compass className="h-5 w-5" /> },
       { label: "Saved", i18nKey: "nav.saved", path: "/saved", icon: <Bookmark className="h-5 w-5" /> },
       { label: "Achievements", i18nKey: "nav.achievements", path: "/achievements", icon: <Trophy className="h-5 w-5" /> },
@@ -450,6 +452,7 @@ export default function Sidebar() {
     (sum, c) => sum + (c.unread_count ?? 0),
     0,
   );
+  const activityUnread = useActivityUnread(!!accessToken);
 
   const isActive = (path: string) => {
     if (path === "/") return location.pathname === "/";
@@ -517,7 +520,7 @@ export default function Sidebar() {
             <ul className="space-y-0.5">
               {items.map((item) => {
                 const active = isActive(item.path);
-                const badge = item.path === "/messages" ? totalUnread : (item.badge ?? 0);
+                const badge = item.path === "/messages" ? totalUnread : item.path === "/activity-center" ? activityUnread : (item.badge ?? 0);
                 const link = (
                   <NavLink
                     key={item.path}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,115 @@
+import * as React from "react";
+import {
+  useFillsFees,
+  useLiquidations,
+  useFundingPayments,
+} from "@/hooks/useTrading";
+import { useSymbols } from "@/hooks/useMarketData";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import {
+  normalizeFills,
+  normalizeFunding,
+  normalizeLiquidations,
+  mergeEvents,
+  unreadCount as computeUnread,
+  type ActivityEvent,
+  type NormalizeContext,
+} from "@/lib/activity";
+
+/** localStorage key for the Activity Center last-seen high-water mark (epoch ms). */
+export const ACTIVITY_LAST_SEEN_KEY = "activity.lastSeen.v1";
+
+export function loadLastSeen(): number {
+  try {
+    const raw = localStorage.getItem(ACTIVITY_LAST_SEEN_KEY);
+    if (!raw) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function saveLastSeen(ts: number): void {
+  try {
+    localStorage.setItem(ACTIVITY_LAST_SEEN_KEY, String(ts));
+  } catch {
+    /* quota / private-mode — degrades to in-memory only */
+  }
+}
+
+/** Custom event so a mark-all-read in the page updates the bell badge live. */
+export const ACTIVITY_SEEN_EVENT = "tl:activitySeen";
+
+/**
+ * Aggregate the account-level `/me/*` trader feeds into ONE normalized,
+ * newest-first Activity timeline. Each source degrades independently: a 404
+ * (route not deployed) leaves that feed empty rather than failing the whole
+ * page. This is the durable-history counterpart to `useTradingAlerts`.
+ */
+export function useActivityEvents(enabled = true): {
+  events: ActivityEvent[];
+  sources: { fills: boolean; funding: boolean; liquidations: boolean };
+  isLoading: boolean;
+} {
+  const fills = useFillsFees(enabled);
+  const funding = useFundingPayments(enabled);
+  const liquidations = useLiquidations(enabled);
+  const { data: symbolsData } = useSymbols();
+
+  const ctx = React.useMemo<NormalizeContext>(() => {
+    const byId = new Map<number, MarketSymbol>();
+    for (const s of symbolsData?.symbols ?? []) byId.set(s.symbol_id, s);
+    return {
+      symbolName: (id) =>
+        (id != null && byId.get(id)?.symbol) || (id != null ? `#${id}` : "?"),
+      scalerFor: (id) => (id != null && byId.get(id)?.price_scaler) || 1,
+    };
+  }, [symbolsData]);
+
+  const events = React.useMemo(
+    () =>
+      mergeEvents(
+        normalizeFills(fills.data?.fills, ctx),
+        normalizeFunding(funding.data?.funding, ctx),
+        normalizeLiquidations(liquidations.data?.liquidations, ctx),
+      ),
+    [fills.data, funding.data, liquidations.data, ctx],
+  );
+
+  return {
+    events,
+    sources: {
+      // A source is "available" unless it errored (typically a 404).
+      fills: !fills.isError,
+      funding: !funding.isError,
+      liquidations: !liquidations.isError,
+    },
+    isLoading: fills.isLoading || funding.isLoading || liquidations.isLoading,
+  };
+}
+
+/**
+ * Lightweight unread badge for the header/nav: derives the count from the same
+ * aggregated feeds vs the persisted last-seen marker. Re-reads the marker when
+ * the page fires ACTIVITY_SEEN_EVENT (or another tab writes it).
+ */
+export function useActivityUnread(enabled = true): number {
+  const { events } = useActivityEvents(enabled);
+  const [lastSeen, setLastSeen] = React.useState<number>(() => loadLastSeen());
+
+  React.useEffect(() => {
+    const reload = () => setLastSeen(loadLastSeen());
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === ACTIVITY_LAST_SEEN_KEY || e.key === null) reload();
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(ACTIVITY_SEEN_EVENT, reload);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(ACTIVITY_SEEN_EVENT, reload);
+    };
+  }, []);
+
+  return React.useMemo(() => computeUnread(events, lastSeen), [events, lastSeen]);
+}

--- a/frontend/src/lib/activity.test.ts
+++ b/frontend/src/lib/activity.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  toMs,
+  tickToCents,
+  normalizeFills,
+  normalizeFunding,
+  normalizeLiquidations,
+  mergeEvents,
+  groupByDay,
+  dayKey,
+  filterByCategory,
+  isUnread,
+  unreadCount,
+  type ActivityEvent,
+  type NormalizeContext,
+} from "./activity";
+
+const ctx: NormalizeContext = {
+  symbolName: (id) => (id === 1 ? "BTC" : id === 2 ? "ETH" : `#${id}`),
+  scalerFor: () => 100, // 100 ticks == 1 unit -> amountCents = tick
+};
+
+describe("toMs", () => {
+  it("passes ms through and scales seconds to ms", () => {
+    expect(toMs(1_700_000_000_000)).toBe(1_700_000_000_000);
+    expect(toMs(1_700_000_000)).toBe(1_700_000_000_000);
+  });
+  it("returns 0 for missing / non-finite", () => {
+    expect(toMs(undefined)).toBe(0);
+    expect(toMs(NaN)).toBe(0);
+  });
+});
+
+describe("tickToCents", () => {
+  it("converts an int tick to integer cents via the scaler", () => {
+    // 100 ticks / scaler 100 = 1 unit = 100 cents
+    expect(tickToCents(100, ctx, 1)).toBe(100);
+    expect(tickToCents(250, ctx, 1)).toBe(250);
+  });
+  it("defaults scaler to 1 when no context", () => {
+    expect(tickToCents(5, undefined, 1)).toBe(500);
+  });
+  it("keeps sign and returns undefined for missing", () => {
+    expect(tickToCents(-100, ctx, 1)).toBe(-100);
+    expect(tickToCents(undefined, ctx, 1)).toBeUndefined();
+  });
+});
+
+describe("normalizeFills", () => {
+  it("maps a fill to a trade event with deep-link + severity", () => {
+    const ev = normalizeFills(
+      [{ symbolid: 1, price: 500, qty: 3, side: "buy", fee: 100, ts: 1_700_000_000 }],
+      ctx,
+    )[0]!;
+    expect(ev.category).toBe("trade");
+    expect(ev.kind).toBe("fill");
+    expect(ev.title).toBe("Filled BTC");
+    expect(ev.severity).toBe("success");
+    expect(ev.href).toBe("/markets/1");
+    expect(ev.ts).toBe(1_700_000_000_000);
+    expect(ev.id).toContain("fill:1:");
+  });
+  it("handles empty / undefined", () => {
+    expect(normalizeFills(undefined)).toEqual([]);
+    expect(normalizeFills([])).toEqual([]);
+  });
+});
+
+describe("normalizeFunding", () => {
+  it("marks received funding as success with signed cents", () => {
+    const ev = normalizeFunding(
+      [{ symbolid: 2, payment: 100, received: true, funding_rate_bps: 12, ts: 1_700_000_100 }],
+      ctx,
+    )[0]!;
+    expect(ev.category).toBe("funding");
+    expect(ev.severity).toBe("success");
+    expect(ev.amountCents).toBe(100);
+    expect(ev.title).toBe("Funding received");
+    expect(ev.href).toBe("/markets/2");
+  });
+  it("marks paid funding as info", () => {
+    const ev = normalizeFunding([{ symbolid: 2, payment: -50, received: false, ts: 1 }], ctx)[0]!;
+    expect(ev.severity).toBe("info");
+    expect(ev.amountCents).toBe(-50);
+    expect(ev.title).toBe("Funding paid");
+  });
+});
+
+describe("normalizeLiquidations", () => {
+  it("maps a liquidation to a critical event", () => {
+    const ev = normalizeLiquidations(
+      [{ symbolid: 1, qty: 5, mark_price: 400, realized_pnl: -300, ts: 1_700_000_200 }],
+      ctx,
+    )[0]!;
+    expect(ev.category).toBe("liquidation");
+    expect(ev.severity).toBe("critical");
+    expect(ev.amountCents).toBe(-300);
+    expect(ev.href).toBe("/portfolio/analytics");
+  });
+});
+
+describe("mergeEvents", () => {
+  const a: ActivityEvent = { id: "a", ts: 100, kind: "x", category: "trade", title: "A", severity: "info" };
+  const b: ActivityEvent = { id: "b", ts: 300, kind: "x", category: "trade", title: "B", severity: "info" };
+  const c: ActivityEvent = { id: "c", ts: 200, kind: "x", category: "trade", title: "C", severity: "info" };
+
+  it("merges + sorts descending by ts", () => {
+    const out = mergeEvents([a], [b, c]);
+    expect(out.map((e) => e.id)).toEqual(["b", "c", "a"]);
+  });
+  it("dedupes by id (first occurrence wins)", () => {
+    const dup: ActivityEvent = { ...a, title: "DUP" };
+    const out = mergeEvents([a], [dup, b]);
+    expect(out.filter((e) => e.id === "a")).toHaveLength(1);
+    expect(out.find((e) => e.id === "a")!.title).toBe("A");
+  });
+  it("is a stable sort for equal ts (insertion order preserved)", () => {
+    const t1: ActivityEvent = { ...a, id: "t1", ts: 500 };
+    const t2: ActivityEvent = { ...a, id: "t2", ts: 500 };
+    const out = mergeEvents([t1, t2]);
+    expect(out.map((e) => e.id)).toEqual(["t1", "t2"]);
+  });
+});
+
+describe("dayKey + groupByDay", () => {
+  it("groups consecutive same-day events into one bucket", () => {
+    const d1 = new Date(2024, 0, 2, 10, 0, 0).getTime();
+    const d1b = new Date(2024, 0, 2, 12, 0, 0).getTime();
+    const d0 = new Date(2024, 0, 1, 9, 0, 0).getTime();
+    const events: ActivityEvent[] = [
+      { id: "1", ts: d1b, kind: "x", category: "trade", title: "", severity: "info" },
+      { id: "2", ts: d1, kind: "x", category: "trade", title: "", severity: "info" },
+      { id: "3", ts: d0, kind: "x", category: "trade", title: "", severity: "info" },
+    ];
+    const groups = groupByDay(events);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.day).toBe(dayKey(d1b));
+    expect(groups[0]!.events.map((e) => e.id)).toEqual(["1", "2"]);
+    expect(groups[1]!.events.map((e) => e.id)).toEqual(["3"]);
+  });
+  it("dayKey is zero-padded YYYY-MM-DD", () => {
+    expect(dayKey(new Date(2024, 2, 5, 0, 0, 0).getTime())).toBe("2024-03-05");
+  });
+});
+
+describe("filterByCategory", () => {
+  const events: ActivityEvent[] = [
+    { id: "1", ts: 1, kind: "fill", category: "trade", title: "", severity: "info" },
+    { id: "2", ts: 2, kind: "funding", category: "funding", title: "", severity: "info" },
+  ];
+  it("passes through for all / undefined", () => {
+    expect(filterByCategory(events, "all")).toHaveLength(2);
+    expect(filterByCategory(events, undefined)).toHaveLength(2);
+  });
+  it("filters to the requested category", () => {
+    expect(filterByCategory(events, "funding").map((e) => e.id)).toEqual(["2"]);
+  });
+});
+
+describe("unread markers", () => {
+  const events: ActivityEvent[] = [
+    { id: "1", ts: 100, kind: "x", category: "trade", title: "", severity: "info" },
+    { id: "2", ts: 200, kind: "x", category: "trade", title: "", severity: "info" },
+    { id: "3", ts: 300, kind: "x", category: "trade", title: "", severity: "info" },
+  ];
+  it("isUnread compares against lastSeen", () => {
+    expect(isUnread(events[2]!, 200)).toBe(true);
+    expect(isUnread(events[1]!, 200)).toBe(false); // equal is not newer
+    expect(isUnread(events[0]!, undefined)).toBe(true); // never seen -> all unread
+  });
+  it("unreadCount counts events strictly newer than lastSeen", () => {
+    expect(unreadCount(events, 200)).toBe(1);
+    expect(unreadCount(events, 0)).toBe(3);
+    expect(unreadCount(events, undefined)).toBe(3);
+    expect(unreadCount(events, 300)).toBe(0);
+  });
+});

--- a/frontend/src/lib/activity.ts
+++ b/frontend/src/lib/activity.ts
@@ -1,0 +1,264 @@
+/**
+ * Activity Center — pure, framework-free normalization + aggregation of the
+ * account-level `/me/*` trader feeds into a single durable, day-grouped
+ * timeline. This is the history-view counterpart to the transient
+ * `useTradingAlerts` bell (same source feeds; different lifetime).
+ *
+ * Everything here is deterministic and side-effect free so it is trivially
+ * unit-testable. Monetary values are carried as INTEGER CENTS (`amountCents`)
+ * — never floats — matching the ledger convention elsewhere in the app.
+ *
+ * Timestamps (`ts`) are normalized to epoch MILLISECONDS. Feed rows may carry
+ * seconds OR ms; `toMs` detects and normalizes (parity with useTradingAlerts).
+ */
+
+export type ActivityCategory =
+  | "trade"
+  | "funding"
+  | "liquidation"
+  | "risk"
+  | "money"
+  | "system";
+
+export type ActivitySeverity = "info" | "success" | "warning" | "critical";
+
+/** A normalized, source-agnostic account event. */
+export interface ActivityEvent {
+  /** Stable de-dupe id (source + event key). */
+  id: string;
+  /** Epoch MILLISECONDS. */
+  ts: number;
+  /** Fine-grained event kind (e.g. "fill", "funding", "liquidation"). */
+  kind: string;
+  category: ActivityCategory;
+  title: string;
+  subtitle?: string;
+  /** Signed integer cents when the event carries a monetary amount. */
+  amountCents?: number;
+  /** In-app deep link to the most relevant surface. */
+  href?: string;
+  severity: ActivitySeverity;
+}
+
+// -- Time helpers -----------------------------------------------------
+
+/** Feed timestamps may be seconds OR ms — normalize to ms. */
+export function toMs(ts: number | undefined): number {
+  if (ts == null || !Number.isFinite(ts)) return 0;
+  return ts < 1e12 ? Math.floor(ts * 1000) : Math.floor(ts);
+}
+
+// -- Minimal structural feed shapes -----------------------------------
+// Structural (not imported) so this lib stays framework/endpoint free and
+// unit-testable in isolation. Fields mirror the `/me/*` feed rows.
+
+export interface FillRow {
+  symbolid?: number;
+  price?: number;
+  qty?: number;
+  side?: string;
+  fee?: number;
+  ts?: number;
+}
+
+export interface FundingRow {
+  symbolid?: number;
+  funding_rate_bps?: number;
+  payment?: number;
+  received?: boolean;
+  ts?: number;
+}
+
+export interface LiquidationRow {
+  symbolid?: number;
+  qty?: number;
+  mark_price?: number;
+  realized_pnl?: number;
+  fee?: number;
+  ts?: number;
+}
+
+/** Optional per-symbol context (display name + tick-to-cents scaler). */
+export interface NormalizeContext {
+  /** Map a symbol id to a display name. Defaults to `#<id>`. */
+  symbolName?: (id: number | undefined) => string;
+  /**
+   * Divisor turning an int64 engine tick into whole currency units.
+   * `amountCents` is then `Math.round(tick / scaler * 100)`. Defaults to 1
+   * (i.e. one tick == one cent) which keeps values integer + stable.
+   */
+  scalerFor?: (id: number | undefined) => number;
+}
+
+function nameOf(ctx: NormalizeContext | undefined, id: number | undefined): string {
+  if (ctx?.symbolName) return ctx.symbolName(id);
+  return id != null ? `#${id}` : "?";
+}
+
+/** Convert an int64 engine tick to signed integer cents. */
+export function tickToCents(
+  tick: number | undefined,
+  ctx: NormalizeContext | undefined,
+  id: number | undefined,
+): number | undefined {
+  if (tick == null || !Number.isFinite(tick)) return undefined;
+  const scaler = (ctx?.scalerFor && ctx.scalerFor(id)) || 1;
+  return Math.round((tick / scaler) * 100);
+}
+
+// -- Normalizers ------------------------------------------------------
+
+export function normalizeFills(
+  rows: FillRow[] | undefined,
+  ctx?: NormalizeContext,
+): ActivityEvent[] {
+  if (!rows) return [];
+  return rows.map((r) => {
+    const sym = nameOf(ctx, r.symbolid);
+    const side = (r.side ?? "").toString().toUpperCase();
+    const feeCents = tickToCents(r.fee, ctx, r.symbolid);
+    return {
+      id: `fill:${r.symbolid}:${r.ts}:${r.price}:${r.qty}:${r.side}`,
+      ts: toMs(r.ts),
+      kind: "fill",
+      category: "trade",
+      title: `Filled ${sym}`,
+      subtitle:
+        `${side} ${r.qty ?? "?"} @ ${r.price ?? "?"}` +
+        (feeCents != null ? ` · fee ${(feeCents / 100).toFixed(2)}` : ""),
+      href: r.symbolid != null ? `/markets/${r.symbolid}` : "/blotter",
+      severity: "success",
+    };
+  });
+}
+
+export function normalizeFunding(
+  rows: FundingRow[] | undefined,
+  ctx?: NormalizeContext,
+): ActivityEvent[] {
+  if (!rows) return [];
+  return rows.map((r) => {
+    const sym = nameOf(ctx, r.symbolid);
+    const received = !!r.received;
+    const amountCents = tickToCents(r.payment, ctx, r.symbolid);
+    const dir = received ? "received" : "paid";
+    return {
+      id: `funding:${r.symbolid}:${r.ts}:${r.payment}`,
+      ts: toMs(r.ts),
+      kind: "funding",
+      category: "funding",
+      title: `Funding ${dir}`,
+      subtitle: `${sym} · ${r.funding_rate_bps ?? 0} bps`,
+      amountCents,
+      href: r.symbolid != null ? `/markets/${r.symbolid}` : "/portfolio",
+      severity: received ? "success" : "info",
+    };
+  });
+}
+
+export function normalizeLiquidations(
+  rows: LiquidationRow[] | undefined,
+  ctx?: NormalizeContext,
+): ActivityEvent[] {
+  if (!rows) return [];
+  return rows.map((r) => {
+    const sym = nameOf(ctx, r.symbolid);
+    const pnlCents = tickToCents(r.realized_pnl, ctx, r.symbolid);
+    return {
+      id: `liq:${r.symbolid}:${r.ts}:${r.qty}`,
+      ts: toMs(r.ts),
+      kind: "liquidation",
+      category: "liquidation",
+      title: `Liquidated ${sym}`,
+      subtitle:
+        `${r.qty ?? "?"} closed @ ${r.mark_price ?? "?"}` +
+        (pnlCents != null ? ` · PnL ${(pnlCents / 100).toFixed(2)}` : ""),
+      amountCents: pnlCents,
+      href: "/portfolio/analytics",
+      severity: "critical",
+    };
+  });
+}
+
+// -- Aggregation ------------------------------------------------------
+
+/**
+ * Merge any number of event lists into ONE list sorted newest-first, with a
+ * stable de-dupe by `id` (delta-dedupe: the first occurrence of an id wins so
+ * re-polled feeds never double-count). Ties on `ts` keep insertion order.
+ */
+export function mergeEvents(...lists: ActivityEvent[][]): ActivityEvent[] {
+  const seen = new Set<string>();
+  const out: ActivityEvent[] = [];
+  for (const list of lists) {
+    for (const ev of list) {
+      if (!ev || seen.has(ev.id)) continue;
+      seen.add(ev.id);
+      out.push(ev);
+    }
+  }
+  // Stable descending sort by ts (later ts first; equal ts keeps order).
+  return out
+    .map((ev, i) => ({ ev, i }))
+    .sort((a, b) => (b.ev.ts - a.ev.ts) || (a.i - b.i))
+    .map((x) => x.ev);
+}
+
+export interface ActivityDayGroup {
+  /** ISO date key `YYYY-MM-DD` (local time). */
+  day: string;
+  events: ActivityEvent[];
+}
+
+/** Local `YYYY-MM-DD` for an epoch-ms timestamp. */
+export function dayKey(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Group an already-sorted (desc) event list into day buckets, preserving the
+ * incoming order both across and within groups. Does NOT re-sort — pass the
+ * output of `mergeEvents`.
+ */
+export function groupByDay(events: ActivityEvent[]): ActivityDayGroup[] {
+  const groups: ActivityDayGroup[] = [];
+  let current: ActivityDayGroup | null = null;
+  for (const ev of events) {
+    const key = dayKey(ev.ts);
+    if (!current || current.day !== key) {
+      current = { day: key, events: [] };
+      groups.push(current);
+    }
+    current.events.push(ev);
+  }
+  return groups;
+}
+
+/** Filter by category; `"all"` (or undefined) is a pass-through. */
+export function filterByCategory(
+  events: ActivityEvent[],
+  category: ActivityCategory | "all" | undefined,
+): ActivityEvent[] {
+  if (!category || category === "all") return events;
+  return events.filter((e) => e.category === category);
+}
+
+/** True when the event is newer than the last-seen marker. */
+export function isUnread(ev: ActivityEvent, lastSeenTs: number | undefined): boolean {
+  if (lastSeenTs == null) return true;
+  return ev.ts > lastSeenTs;
+}
+
+/** Count events newer than the last-seen marker. */
+export function unreadCount(
+  events: ActivityEvent[],
+  lastSeenTs: number | undefined,
+): number {
+  let n = 0;
+  for (const ev of events) if (isUnread(ev, lastSeenTs)) n++;
+  return n;
+}

--- a/frontend/src/pages/activity-center/ActivityCenterPage.tsx
+++ b/frontend/src/pages/activity-center/ActivityCenterPage.tsx
@@ -1,0 +1,277 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+import {
+  Activity,
+  TrendingUp,
+  Coins,
+  AlertTriangle,
+  ShieldAlert,
+  Wallet,
+  Bell,
+  CheckCheck,
+  Loader2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { relativeTime } from "@/hooks/useTradingAlerts";
+import {
+  filterByCategory,
+  groupByDay,
+  isUnread,
+  type ActivityCategory,
+  type ActivityEvent,
+  type ActivitySeverity,
+} from "@/lib/activity";
+import {
+  useActivityEvents,
+  loadLastSeen,
+  saveLastSeen,
+  ACTIVITY_SEEN_EVENT,
+} from "@/hooks/useActivity";
+
+// ── Category filter chips ────────────────────────────────────────────
+const CHIPS: { key: ActivityCategory | "all"; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "trade", label: "Trades" },
+  { key: "funding", label: "Funding" },
+  { key: "liquidation", label: "Liquidations" },
+  { key: "risk", label: "Risk" },
+  { key: "money", label: "Money" },
+  { key: "system", label: "System" },
+];
+
+function CategoryIcon({
+  category,
+  severity,
+}: {
+  category: ActivityCategory;
+  severity: ActivitySeverity;
+}) {
+  const cls = cn(
+    "h-4 w-4 shrink-0",
+    severity === "success" && "text-emerald-500",
+    severity === "warning" && "text-amber-500",
+    severity === "critical" && "text-destructive",
+    severity === "info" && "text-sky-500",
+  );
+  switch (category) {
+    case "trade":
+      return <TrendingUp className={cls} />;
+    case "funding":
+      return <Coins className={cls} />;
+    case "liquidation":
+      return <AlertTriangle className={cls} />;
+    case "risk":
+      return <ShieldAlert className={cls} />;
+    case "money":
+      return <Wallet className={cls} />;
+    default:
+      return <Activity className={cls} />;
+  }
+}
+
+function EventRow({
+  ev,
+  unread,
+  now,
+}: {
+  ev: ActivityEvent;
+  unread: boolean;
+  now: number;
+}) {
+  const body = (
+    <div
+      className={cn(
+        "flex items-start gap-3 rounded-lg border px-4 py-3 transition-colors",
+        ev.href && "hover:bg-accent",
+        unread && "border-primary/40 bg-accent/40",
+      )}
+    >
+      <CategoryIcon category={ev.category} severity={ev.severity} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">{ev.title}</span>
+          {unread && (
+            <span className="ml-auto h-2 w-2 shrink-0 rounded-full bg-primary" aria-label="unread" />
+          )}
+        </div>
+        {ev.subtitle && (
+          <p className="truncate text-xs text-muted-foreground">{ev.subtitle}</p>
+        )}
+        <p className="mt-0.5 text-[10px] text-muted-foreground">{relativeTime(ev.ts, now)}</p>
+      </div>
+    </div>
+  );
+  return ev.href ? (
+    <Link to={ev.href} className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg">
+      {body}
+    </Link>
+  ) : (
+    body
+  );
+}
+
+/** Human day heading — "Today" / "Yesterday" / a full date. */
+function dayLabel(dayKey: string, now: number): string {
+  const today = new Date(now);
+  const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  const yest = new Date(now - 86_400_000);
+  const yestKey = `${yest.getFullYear()}-${String(yest.getMonth() + 1).padStart(2, "0")}-${String(yest.getDate()).padStart(2, "0")}`;
+  if (dayKey === todayKey) return "Today";
+  if (dayKey === yestKey) return "Yesterday";
+  const [y = 1970, m = 1, d = 1] = dayKey.split("-").map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/**
+ * Activity Center — a durable, filterable, day-grouped timeline of every
+ * account event, aggregated client-side from the same `/me/*` feeds that power
+ * the transient alerts bell. Unread is tracked against a persisted last-seen
+ * marker; "Mark all read" advances it to the newest event.
+ */
+export default function ActivityCenterPage() {
+  const { events, sources, isLoading } = useActivityEvents(true);
+  const [category, setCategory] = React.useState<ActivityCategory | "all">("all");
+  const [lastSeen, setLastSeen] = React.useState<number>(() => loadLastSeen());
+
+  // Refresh relative times periodically.
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const newestTs = events.length > 0 ? events[0]!.ts : 0;
+  const unread = React.useMemo(
+    () => events.reduce((n, e) => (isUnread(e, lastSeen) ? n + 1 : n), 0),
+    [events, lastSeen],
+  );
+
+  const markAllRead = React.useCallback(() => {
+    const ts = newestTs || Date.now();
+    saveLastSeen(ts);
+    setLastSeen(ts);
+    try {
+      window.dispatchEvent(new CustomEvent(ACTIVITY_SEEN_EVENT));
+    } catch {
+      /* SSR / no window */
+    }
+  }, [newestTs]);
+
+  const filtered = React.useMemo(
+    () => filterByCategory(events, category),
+    [events, category],
+  );
+  const groups = React.useMemo(() => groupByDay(filtered), [filtered]);
+
+  const anySourceDown = !sources.fills || !sources.funding || !sources.liquidations;
+  const downList = [
+    !sources.fills ? "fills" : null,
+    !sources.funding ? "funding" : null,
+    !sources.liquidations ? "liquidations" : null,
+  ].filter(Boolean);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Activity className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-semibold">Activity Center</h1>
+          {unread > 0 && (
+            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-bold text-destructive-foreground">
+              {unread > 99 ? "99+" : unread}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm" className="gap-2">
+            <Link to="/markets/price-alerts">
+              <Bell className="h-4 w-4" />
+              Price alerts
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={markAllRead}
+            disabled={unread === 0}
+          >
+            <CheckCheck className="h-4 w-4" />
+            Mark all read
+          </Button>
+        </div>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        A durable history of your fills, funding, liquidations and risk events — the
+        permanent record behind the transient alerts bell.
+      </p>
+
+      {/* Category filter chips */}
+      <div className="flex flex-wrap gap-2">
+        {CHIPS.map((c) => (
+          <Button
+            key={c.key}
+            variant={category === c.key ? "default" : "outline"}
+            size="sm"
+            className="h-7 rounded-full px-3 text-xs"
+            onClick={() => setCategory(c.key)}
+          >
+            {c.label}
+          </Button>
+        ))}
+      </div>
+
+      {anySourceDown && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            Some activity sources are unavailable ({downList.join(", ")}). Showing what
+            is available.
+          </span>
+        </div>
+      )}
+
+      {isLoading && events.length === 0 ? (
+        <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          Loading activity…
+        </div>
+      ) : groups.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+            <Activity className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm font-medium">No activity yet</p>
+            <p className="max-w-sm text-xs text-muted-foreground">
+              {category === "all"
+                ? "Your fills, funding payments, liquidations and risk events will appear here as they happen."
+                : "No events in this category yet. Try a different filter."}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {groups.map((g) => (
+            <div key={g.day} className="space-y-2">
+              <h2 className="sticky top-0 z-10 bg-background/80 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground backdrop-blur">
+                {dayLabel(g.day, now)}
+              </h2>
+              <div className="space-y-2">
+                {g.events.map((ev) => (
+                  <EventRow key={ev.id} ev={ev} unread={isUnread(ev, lastSeen)} now={now} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Consolidated Activity Center — durable account-event timeline (frontend)

A durable, filterable, day-grouped timeline of all account events, **distinct from the transient alerts bell** (extends that infra, doesn't duplicate). Aggregates the existing exchange feeds client-side (fills / funding / liquidations / margin-distress / PM-resolutions), degrading per-source on 404 — works now.

Normalized `ActivityEvent` (trade/funding/liquidation/risk/money/system + severity), merge+dedupe-by-id, group-by-day, category filter, unread tracking vs a persisted last-seen mark.

Mounted at **`/activity-center`** (web) + **`activity/center`** (Android) — `/activity` was already the existing social activity feed, left untouched.

### Web (`/activity-center`, "Activity Center" nav)
`lib/activity.ts` (+19 vitest) + `hooks/useActivity.ts` (aggregates the existing fills/funding/liquidations hooks + symbols; `activity.lastSeen.v1` + live badge event); `ActivityCenterPage` (filter chips, day timeline, unread, mark-all-read, deep-links, per-source degrade banner); Sidebar unread badge.

### Android (new `feature/activity` + `data/activity`, registered in `MoreRoutes`)
`ActivityModel.kt` (+16 JVM tests) + `ActivityLastSeenStore` (DataStore) + `ActivityCenterScreen`/`ViewModel`; `MoreCatalog` + `MoreRoutes.REGISTERED` + `MarketsNavigation` destination.

No new deps; existing social `/activity` untouched. Gates: web tsc 0 · vite build · vitest 19/19; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (ActivityModel 16/16, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
