### PR TITLE
feat(trade): order-ticket depth — risk calculators, bracket helper, TWAP/Iceberg algos (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/ActiveAlgosScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/ActiveAlgosScreen.kt
@@ -1,0 +1,239 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.markets.trade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.markets.ui.MarketColors
+
+/** Route wrapper: the Active-Algos monitor (reached from More -> Studio). Up/Back pops the back stack. */
+@Composable
+fun ActiveAlgosRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ActiveAlgosViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    ActiveAlgosScreen(
+        state = state,
+        onBack = onBack,
+        onPause = viewModel::pause,
+        onResume = viewModel::resume,
+        onCancel = viewModel::cancel,
+        onClearFinished = viewModel::clearFinished,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ActiveAlgosScreen(
+    state: ActiveAlgosUiState,
+    onBack: () -> Unit,
+    onPause: (String) -> Unit,
+    onResume: (String) -> Unit,
+    onCancel: (String) -> Unit,
+    onClearFinished: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag("active_algos_screen"),
+        containerColor = MarketColors.Bg,
+        topBar = {
+            TopAppBar(
+                title = { Text("Active Algos", color = MarketColors.TextPrimary) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = MarketColors.TextPrimary)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MarketColors.Surface),
+            )
+        },
+    ) { pad ->
+        Column(Modifier.fillMaxSize().padding(pad).padding(horizontal = 12.dp)) {
+            Spacer(Modifier.height(8.dp))
+            Box(
+                Modifier.fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0x1FF0B90B))
+                    .border(1.dp, Color(0xFFF0B90B), RoundedCornerShape(8.dp))
+                    .padding(10.dp),
+            ) {
+                Text(
+                    "Client-side algos run only while the app is open. If the app is closed, running algos pause and can be resumed or cancelled here.",
+                    color = Color(0xFFF0B90B),
+                    fontSize = 11.sp,
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+
+            if (state.hasFinished) {
+                Text(
+                    "Clear finished",
+                    color = MarketColors.Accent,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 12.sp,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .clickable(onClick = onClearFinished)
+                        .testTag("algos_clear_finished")
+                        .padding(vertical = 4.dp),
+                )
+                Spacer(Modifier.height(6.dp))
+            }
+
+            if (state.algos.isEmpty()) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No algos yet. Start a TWAP or Iceberg from the trade ticket.", color = MarketColors.TextFaint, fontSize = 13.sp)
+                }
+            } else {
+                LazyColumn(contentPadding = PaddingValues(vertical = 4.dp)) {
+                    items(state.algos, key = { it.id }) { algo ->
+                        AlgoCard(algo, state.nowMs, onPause, onResume, onCancel)
+                        Spacer(Modifier.height(10.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlgoCard(
+    algo: AlgoOrder,
+    nowMs: Long,
+    onPause: (String) -> Unit,
+    onResume: (String) -> Unit,
+    onCancel: (String) -> Unit,
+) {
+    val sideColor = if (algo.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down
+    Column(
+        Modifier.fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(MarketColors.Surface)
+            .border(1.dp, MarketColors.Border, RoundedCornerShape(10.dp))
+            .padding(12.dp)
+            .testTag("algo_card"),
+    ) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "${algo.kind.name} · ${if (algo.side == OrderSide.BUY) "Buy" else "Sell"} ${algo.symbolLabel}",
+                color = sideColor, fontWeight = FontWeight.Bold, fontSize = 14.sp,
+            )
+            StatusPill(algo)
+        }
+        if (algo.paperMode) {
+            Spacer(Modifier.height(2.dp))
+            Text("PAPER", color = Color(0xFFF0B90B), fontSize = 10.sp, fontWeight = FontWeight.Bold)
+        }
+        Spacer(Modifier.height(8.dp))
+        LinearProgressIndicator(
+            progress = { algo.progress },
+            modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
+            color = MarketColors.Accent,
+            trackColor = MarketColors.SurfaceAlt,
+        )
+        Spacer(Modifier.height(6.dp))
+        InfoRow("Placed", "${algo.placedQty} / ${algo.totalQty}")
+        InfoRow("Children", "${algo.childrenDone} / ${algo.childrenTotal}")
+        when (algo.kind) {
+            AlgoKind.TWAP -> InfoRow("Interval", "${algo.sliceIntervalMs / 1000}s")
+            AlgoKind.ICEBERG -> InfoRow("Visible clip", algo.visibleQty.toString())
+        }
+        InfoRow("Price", algo.limitPrice?.toString() ?: "Market")
+        if (algo.status == AlgoStatus.RUNNING) {
+            val remaining = algo.nextFireAtMs?.let { ((it - nowMs).coerceAtLeast(0L) / 1000L) }
+            InfoRow("Next child in", remaining?.let { "${it}s" } ?: "--")
+        }
+        algo.message?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(it, color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+        }
+        if (!algo.isTerminal) {
+            Spacer(Modifier.height(10.dp))
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (algo.status == AlgoStatus.RUNNING) {
+                    ActionButton("Pause", MarketColors.Border, "algo_pause", Modifier.weight(1f)) { onPause(algo.id) }
+                } else {
+                    ActionButton("Resume", MarketColors.Accent, "algo_resume", Modifier.weight(1f)) { onResume(algo.id) }
+                }
+                ActionButton("Cancel", MarketColors.Down, "algo_cancel", Modifier.weight(1f)) { onCancel(algo.id) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusPill(algo: AlgoOrder) {
+    val (label, color) = when (algo.status) {
+        AlgoStatus.RUNNING -> "Running" to MarketColors.Up
+        AlgoStatus.PAUSED -> "Paused" to Color(0xFFF0B90B)
+        AlgoStatus.DONE -> "Done" to MarketColors.TextSecondary
+        AlgoStatus.CANCELLED -> "Cancelled" to MarketColors.Down
+    }
+    Text(
+        label, color = color, fontSize = 11.sp, fontWeight = FontWeight.Bold,
+        modifier = Modifier.clip(RoundedCornerShape(6.dp)).border(1.dp, color, RoundedCornerShape(6.dp)).padding(horizontal = 8.dp, vertical = 3.dp),
+    )
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(Modifier.fillMaxWidth().padding(vertical = 1.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label, color = MarketColors.TextSecondary, fontSize = 12.sp)
+        Text(value, color = MarketColors.TextPrimary, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.SemiBold, fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun ActionButton(text: String, color: Color, tag: String, modifier: Modifier, onClick: () -> Unit) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .border(1.dp, color, RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .testTag(tag)
+            .padding(vertical = 9.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text, color = color, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/ActiveAlgosViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/ActiveAlgosViewModel.kt
@@ -1,0 +1,54 @@
+package com.testlogon.android.feature.markets.trade
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** UI state for the Active-Algos monitor: the algo list + a wall-clock tick driving the countdowns. */
+data class ActiveAlgosUiState(
+    val algos: List<AlgoOrder> = emptyList(),
+    val nowMs: Long = System.currentTimeMillis(),
+) {
+    val hasFinished: Boolean get() = algos.any { it.isTerminal }
+}
+
+/**
+ * Drives the Active-Algos monitor screen. Observes the process-wide [AlgoManager] (algos survive this
+ * ViewModel), restores persisted algos once, and runs a 1s ticker so slice/clip countdowns recompute.
+ * Pause / resume / cancel / clear delegate straight to the manager (no orphaned timers).
+ */
+@HiltViewModel
+class ActiveAlgosViewModel @Inject constructor(
+    private val algoManager: AlgoManager,
+) : ViewModel() {
+
+    private val tick = MutableStateFlow(System.currentTimeMillis())
+
+    val uiState: StateFlow<ActiveAlgosUiState> =
+        combine(algoManager.algos, tick) { algos, now -> ActiveAlgosUiState(algos = algos, nowMs = now) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), ActiveAlgosUiState())
+
+    init {
+        algoManager.restore()
+        viewModelScope.launch {
+            while (isActive) {
+                delay(1_000L)
+                tick.value = System.currentTimeMillis()
+            }
+        }
+    }
+
+    fun pause(id: String) = algoManager.pause(id)
+    fun resume(id: String) = algoManager.resume(id)
+    fun cancel(id: String) = algoManager.cancel(id)
+    fun clearFinished() = algoManager.clearFinished()
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoManager.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoManager.kt
@@ -1,0 +1,290 @@
+package com.testlogon.android.feature.markets.trade
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.feature.paper.PaperAccountStore
+import com.testlogon.android.feature.paper.PaperEngine
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrder
+import com.testlogon.android.feature.paper.PaperEngine.PaperOrderType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Client-side algo-order scheduler (TWAP + Iceberg). A process-wide [Singleton] that owns the live
+ * coroutine timers, exposes the active-algos list as a [StateFlow], and persists every state change via
+ * [AlgoOrderStore]. Children are placed through the SAME submit path the ticket uses — the real
+ * [TradingRepository] for live orders, or the shared [PaperEngine] account in paper-mode — so an algo
+ * never diverges from a hand-placed order.
+ *
+ * IMPORTANT — the timers live ONLY in this in-memory scope, so algos progress ONLY while the app process
+ * is alive. On a cold start [restore] reloads the persisted snapshot but marks any still-RUNNING algo as
+ * PAUSED (its timer is gone); the user can cancel it from the monitor. The monitor surfaces the
+ * "client-side algos run only while the app is open" caveat.
+ *
+ * No WorkManager / no orphaned timers: cancel/pause cancel the per-algo [Job]; the scope is a
+ * SupervisorJob so one failing child never tears down the others.
+ */
+@Singleton
+class AlgoManager @Inject constructor(
+    private val repository: TradingRepository,
+    private val paperAccountStore: PaperAccountStore,
+    private val algoOrderStore: AlgoOrderStore,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val jobs = ConcurrentHashMap<String, Job>()
+    private val paperLock = Mutex()   // serialize paper-account read-modify-write across concurrent algos
+    private var restored = false
+    private var seq = 0
+
+    private val _algos = MutableStateFlow<List<AlgoOrder>>(emptyList())
+    val algos: StateFlow<List<AlgoOrder>> = _algos.asStateFlow()
+
+    /** Reload persisted algos once; still-RUNNING ones become PAUSED (their timers didn't survive). */
+    fun restore() {
+        if (restored) return
+        restored = true
+        scope.launch {
+            val persisted = algoOrderStore.load()
+            val healed = persisted.map { if (it.status == AlgoStatus.RUNNING) it.copy(status = AlgoStatus.PAUSED, nextFireAtMs = null, message = "Paused (app restarted)") else it }
+            _algos.value = healed
+            persist()
+        }
+    }
+
+    // ---- start ----
+
+    /**
+     * Start a TWAP algo: [totalQty] over [slices] children spaced across [durationMs]. [refPrice] is used
+     * to fill paper children (captured now, since the manager has no live book). Returns the new algo id,
+     * or null when the inputs are degenerate.
+     */
+    fun startTwap(
+        symbolId: Int,
+        symbolLabel: String,
+        side: OrderSide,
+        totalQty: Long,
+        slices: Int,
+        durationMs: Long,
+        limitPrice: Long?,
+        paperMode: Boolean,
+        refPrice: Long?,
+    ): String? {
+        val schedule = OrderCalc.twapSchedule(totalQty, slices, durationMs)
+        if (schedule.isEmpty()) return null
+        val id = newId("twap")
+        val interval = if (slices > 0) (durationMs.coerceAtLeast(0L) / slices) else 0L
+        val algo = AlgoOrder(
+            id = id, kind = AlgoKind.TWAP, symbolId = symbolId, symbolLabel = symbolLabel, side = side,
+            totalQty = totalQty, limitPrice = limitPrice, paperMode = paperMode,
+            slices = slices, durationMs = durationMs, sliceIntervalMs = interval,
+            childrenTotal = schedule.size, createdTsMs = now(),
+            nextFireAtMs = now(), status = AlgoStatus.RUNNING, message = "Started",
+        )
+        upsert(algo)
+        launchTwap(algo, schedule, refPrice)
+        return id
+    }
+
+    /**
+     * Start an Iceberg algo: place one [visibleQty] clip at a time (last clip = remainder), replenishing
+     * the next after [clipIntervalMs] (a client-side stand-in for "prior clip filled" — the manager has no
+     * live fill feed). Returns the new algo id, or null when inputs are degenerate.
+     */
+    fun startIceberg(
+        symbolId: Int,
+        symbolLabel: String,
+        side: OrderSide,
+        totalQty: Long,
+        visibleQty: Long,
+        clipIntervalMs: Long,
+        limitPrice: Long?,
+        paperMode: Boolean,
+        refPrice: Long?,
+    ): String? {
+        val clips = OrderCalc.icebergClips(totalQty, visibleQty)
+        if (clips.isEmpty()) return null
+        val id = newId("ice")
+        val algo = AlgoOrder(
+            id = id, kind = AlgoKind.ICEBERG, symbolId = symbolId, symbolLabel = symbolLabel, side = side,
+            totalQty = totalQty, limitPrice = limitPrice, paperMode = paperMode,
+            visibleQty = visibleQty, sliceIntervalMs = clipIntervalMs,
+            childrenTotal = clips.size, createdTsMs = now(),
+            nextFireAtMs = now(), status = AlgoStatus.RUNNING, message = "Started",
+        )
+        upsert(algo)
+        launchIceberg(algo, clips, clipIntervalMs, refPrice)
+        return id
+    }
+
+    // ---- controls ----
+
+    /** Pause a RUNNING algo (cancels its timer; keeps progress). No-op if terminal. */
+    fun pause(id: String) {
+        val a = _algos.value.firstOrNull { it.id == id } ?: return
+        if (a.isTerminal || a.status == AlgoStatus.PAUSED) return
+        jobs.remove(id)?.cancel()
+        upsert(a.copy(status = AlgoStatus.PAUSED, nextFireAtMs = null, message = "Paused"))
+    }
+
+    /** Resume a PAUSED algo from where it left off (fires the remaining children on the same cadence). */
+    fun resume(id: String, refPrice: Long? = null) {
+        val a = _algos.value.firstOrNull { it.id == id } ?: return
+        if (a.status != AlgoStatus.PAUSED) return
+        when (a.kind) {
+            AlgoKind.TWAP -> {
+                val remainingSchedule = OrderCalc.twapSchedule(a.remainingQty, (a.childrenTotal - a.childrenDone).coerceAtLeast(1), a.durationMs)
+                if (remainingSchedule.isEmpty()) { complete(a); return }
+                upsert(a.copy(status = AlgoStatus.RUNNING, nextFireAtMs = now(), message = "Resumed"))
+                launchTwap(a.copy(status = AlgoStatus.RUNNING), remainingSchedule, refPrice, resuming = true)
+            }
+            AlgoKind.ICEBERG -> {
+                val clips = OrderCalc.icebergClips(a.remainingQty, a.visibleQty)
+                if (clips.isEmpty()) { complete(a); return }
+                upsert(a.copy(status = AlgoStatus.RUNNING, nextFireAtMs = now(), message = "Resumed"))
+                launchIceberg(a.copy(status = AlgoStatus.RUNNING), clips, a.sliceIntervalMs, refPrice, resuming = true)
+            }
+        }
+    }
+
+    /** Cancel an algo (cancels its timer; marks CANCELLED). Children already placed are NOT recalled. */
+    fun cancel(id: String) {
+        val a = _algos.value.firstOrNull { it.id == id } ?: return
+        jobs.remove(id)?.cancel()
+        if (a.isTerminal) return
+        upsert(a.copy(status = AlgoStatus.CANCELLED, nextFireAtMs = null, message = "Cancelled (${a.placedQty}/${a.totalQty} placed)"))
+    }
+
+    /** Drop all terminal algos from the list + persistence (monitor "clear finished"). */
+    fun clearFinished() {
+        _algos.update { list -> list.filterNot { it.isTerminal } }
+        persist()
+    }
+
+    // ---- timers ----
+
+    private fun launchTwap(algo: AlgoOrder, schedule: List<OrderCalc.TwapSlice>, refPrice: Long?, resuming: Boolean = false) {
+        jobs.remove(algo.id)?.cancel()
+        val job = scope.launch {
+            var prevOffset = 0L
+            for (slice in schedule) {
+                val wait = (slice.offsetMs - prevOffset).coerceAtLeast(0L)
+                prevOffset = slice.offsetMs
+                // publish the next-fire time for the countdown
+                mutate(algo.id) { it.copy(nextFireAtMs = now() + wait) }
+                if (wait > 0L) delay(wait)
+                if (!isActive) return@launch
+                val ok = placeChild(algo.id, slice.qty, refPrice)
+                mutate(algo.id) { it.copy(childrenDone = it.childrenDone + 1, placedQty = it.placedQty + if (ok) slice.qty else 0L, message = if (ok) "Slice ${it.childrenDone + 1}/${it.childrenTotal} placed (${slice.qty})" else "Slice rejected") }
+            }
+            finalizeIfDone(algo.id)
+        }
+        jobs[algo.id] = job
+    }
+
+    private fun launchIceberg(algo: AlgoOrder, clips: List<Long>, clipIntervalMs: Long, refPrice: Long?, resuming: Boolean = false) {
+        jobs.remove(algo.id)?.cancel()
+        val job = scope.launch {
+            for ((i, clip) in clips.withIndex()) {
+                if (!isActive) return@launch
+                val ok = placeChild(algo.id, clip, refPrice)
+                mutate(algo.id) { it.copy(childrenDone = it.childrenDone + 1, placedQty = it.placedQty + if (ok) clip else 0L, message = if (ok) "Clip ${it.childrenDone + 1}/${it.childrenTotal} placed ($clip)" else "Clip rejected") }
+                // replenish the next clip after the interval (stand-in for "prior clip filled")
+                if (i < clips.lastIndex) {
+                    val wait = clipIntervalMs.coerceAtLeast(0L)
+                    mutate(algo.id) { it.copy(nextFireAtMs = now() + wait) }
+                    if (wait > 0L) delay(wait)
+                }
+            }
+            finalizeIfDone(algo.id)
+        }
+        jobs[algo.id] = job
+    }
+
+    private suspend fun finalizeIfDone(id: String) {
+        val a = _algos.value.firstOrNull { it.id == id } ?: return
+        if (a.status == AlgoStatus.RUNNING) complete(a)
+        jobs.remove(id)
+    }
+
+    private fun complete(a: AlgoOrder) =
+        upsert(a.copy(status = AlgoStatus.DONE, nextFireAtMs = null, message = "Done (${a.placedQty}/${a.totalQty} placed)"))
+
+    // ---- child placement (shared submit path) ----
+
+    /** Place one child of [qty] for algo [id]. Returns true when accepted. Respects paper-mode. */
+    private suspend fun placeChild(id: String, qty: Long, refPrice: Long?): Boolean {
+        val a = _algos.value.firstOrNull { it.id == id } ?: return false
+        if (qty <= 0L) return false
+        return if (a.paperMode) placePaperChild(a, qty, refPrice) else placeRealChild(a, qty)
+    }
+
+    private suspend fun placeRealChild(a: AlgoOrder, qty: Long): Boolean {
+        val isMarket = a.limitPrice == null
+        val price = a.limitPrice ?: 0L
+        val clordid = "a${System.currentTimeMillis()}${seq++ % 100}"
+        return when (val r = repository.placeOrder(a.symbolId, a.side, price, qty, clordid, market = if (isMarket) true else null)) {
+            is ApiResult.Success -> r.data.accepted
+            else -> false
+        }
+    }
+
+    private suspend fun placePaperChild(a: AlgoOrder, qty: Long, refPrice: Long?): Boolean = paperLock.withLock {
+        val fillPrice = a.limitPrice ?: refPrice ?: return false
+        if (fillPrice <= 0L) return false
+        val acct = paperAccountStore.load() ?: PaperEngine.newAccount(PAPER_STARTING_CASH)
+        val order = PaperOrder(
+            id = "algo-${a.id}-${System.currentTimeMillis()}",
+            symbolId = a.symbolId,
+            side = a.side,
+            type = if (a.limitPrice == null) PaperOrderType.MARKET else PaperOrderType.LIMIT,
+            qty = qty,
+            limitPrice = a.limitPrice,
+            createdTsMs = System.currentTimeMillis(),
+        )
+        val after = PaperEngine.placeOrder(acct, order, fillPrice)
+        paperAccountStore.save(after)
+        after !== acct
+    }
+
+    // ---- state plumbing ----
+
+    private fun upsert(algo: AlgoOrder) {
+        _algos.update { list ->
+            val idx = list.indexOfFirst { it.id == algo.id }
+            if (idx >= 0) list.toMutableList().also { it[idx] = algo } else list + algo
+        }
+        persist()
+    }
+
+    private fun mutate(id: String, block: (AlgoOrder) -> AlgoOrder) {
+        _algos.update { list -> list.map { if (it.id == id) block(it) else it } }
+        persist()
+    }
+
+    private fun persist() {
+        val snapshot = _algos.value
+        scope.launch { algoOrderStore.save(snapshot) }
+    }
+
+    private fun newId(prefix: String) = "$prefix-${System.currentTimeMillis()}-${seq++}"
+    private fun now() = System.currentTimeMillis()
+
+    private companion object {
+        const val PAPER_STARTING_CASH = 100_000L
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoModels.kt
@@ -1,0 +1,51 @@
+package com.testlogon.android.feature.markets.trade
+
+import com.testlogon.android.data.exchange.OrderSide
+
+/** The two client-side execution algorithms. */
+enum class AlgoKind { TWAP, ICEBERG }
+
+/** Lifecycle of a client-side algo. Terminal states: DONE, CANCELLED. */
+enum class AlgoStatus { RUNNING, PAUSED, DONE, CANCELLED }
+
+/**
+ * A durable, framework-free snapshot of one client-side algo order. The scheduler ([AlgoManager]) owns
+ * live timers; this value graph is what persists (via [AlgoOrderStore]) and what the Active-Algos monitor
+ * renders. All prices/quantities are raw int64 ticks (scaler = 1).
+ *
+ * TWAP fires one child per slice on a fixed cadence; ICEBERG places one visible clip and replenishes the
+ * next when the prior is (assumed) filled. Both place children through the SAME submit path as the ticket
+ * and respect paper-mode ([paperMode]).
+ *
+ * [placedQty] is the running total of child quantity actually submitted; [nextFireAtMs] is the wall-clock
+ * time the next child is due (for the monitor countdown); [message] carries the last child result.
+ */
+data class AlgoOrder(
+    val id: String,
+    val kind: AlgoKind,
+    val symbolId: Int,
+    val symbolLabel: String,
+    val side: OrderSide,
+    val totalQty: Long,
+    val limitPrice: Long?,          // null = market children (TWAP) / market clips (iceberg)
+    val paperMode: Boolean,
+    // TWAP params
+    val slices: Int = 0,
+    val durationMs: Long = 0L,
+    val sliceIntervalMs: Long = 0L,
+    // ICEBERG params
+    val visibleQty: Long = 0L,
+    // progress
+    val childrenDone: Int = 0,      // slices fired (TWAP) / clips placed (iceberg)
+    val childrenTotal: Int = 0,     // total slices (TWAP) / total clips (iceberg)
+    val placedQty: Long = 0L,
+    val status: AlgoStatus = AlgoStatus.RUNNING,
+    val createdTsMs: Long = 0L,
+    val nextFireAtMs: Long? = null, // wall-clock due time for the next child (RUNNING only)
+    val message: String? = null,
+) {
+    val isTerminal: Boolean get() = status == AlgoStatus.DONE || status == AlgoStatus.CANCELLED
+    val remainingQty: Long get() = (totalQty - placedQty).coerceAtLeast(0L)
+    /** 0..1 progress by quantity placed. */
+    val progress: Float get() = if (totalQty <= 0L) 0f else (placedQty.toFloat() / totalQty.toFloat()).coerceIn(0f, 1f)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoModule.kt
@@ -1,0 +1,17 @@
+package com.testlogon.android.feature.markets.trade
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Binds the durable client-side algo-order store (DataStore + Moshi) for injection into [AlgoManager]. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AlgoModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAlgoOrderStore(impl: DataStoreAlgoOrderStore): AlgoOrderStore
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoOrderStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/AlgoOrderStore.kt
@@ -1,0 +1,140 @@
+package com.testlogon.android.feature.markets.trade
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapter
+import com.testlogon.android.data.exchange.OrderSide
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.algoOrdersDataStore by preferencesDataStore(name = "algo_orders")
+
+/**
+ * Durable snapshot store for the client-side algo orders ([AlgoOrder]) — persisted as one Moshi JSON blob
+ * (a list) in DataStore, mirroring [com.testlogon.android.feature.paper.PaperAccountStore]. The whole list
+ * is serialized on every save (cheap for the handful of algos a user runs). Interface seam so the manager
+ * can inject an in-memory fake on the JVM. Every read/write is failure-safe (a store error degrades to
+ * "no data" / no-op, never throws).
+ */
+interface AlgoOrderStore {
+    suspend fun load(): List<AlgoOrder>
+    suspend fun save(algos: List<AlgoOrder>)
+    suspend fun clear()
+}
+
+@Singleton
+class DataStoreAlgoOrderStore @Inject constructor(
+    @ApplicationContext context: Context,
+    moshi: Moshi,
+) : AlgoOrderStore {
+
+    private val dataStore = context.algoOrdersDataStore
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private val adapter = moshi.adapter<AlgoOrdersJson>()
+
+    override suspend fun load(): List<AlgoOrder> = runCatching {
+        val prefs = dataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .first()
+        prefs[Keys.ALGOS]?.let { adapter.fromJson(it) }?.algos?.map { it.toDomain() }.orEmpty()
+    }.getOrDefault(emptyList())
+
+    override suspend fun save(algos: List<AlgoOrder>) {
+        runCatching {
+            dataStore.edit { it[Keys.ALGOS] = adapter.toJson(AlgoOrdersJson(algos.map { a -> a.toJson() })) }
+        }
+    }
+
+    override suspend fun clear() {
+        runCatching { dataStore.edit { it.remove(Keys.ALGOS) } }
+    }
+
+    private object Keys {
+        val ALGOS = stringPreferencesKey("algo_orders_json")
+    }
+}
+
+// ---- JSON wire model (KSP codegen adapters; unit-test-safe with a plain Moshi.Builder) ----
+
+@JsonClass(generateAdapter = true)
+internal data class AlgoOrdersJson(val algos: List<AlgoOrderJson> = emptyList())
+
+@JsonClass(generateAdapter = true)
+internal data class AlgoOrderJson(
+    val id: String,
+    val kind: String,
+    val symbolId: Int,
+    val symbolLabel: String,
+    val side: String,
+    val totalQty: Long,
+    val limitPrice: Long? = null,
+    val paperMode: Boolean = false,
+    val slices: Int = 0,
+    val durationMs: Long = 0L,
+    val sliceIntervalMs: Long = 0L,
+    val visibleQty: Long = 0L,
+    val childrenDone: Int = 0,
+    val childrenTotal: Int = 0,
+    val placedQty: Long = 0L,
+    val status: String = "RUNNING",
+    val createdTsMs: Long = 0L,
+    val nextFireAtMs: Long? = null,
+    val message: String? = null,
+)
+
+private fun sideOf(s: String): OrderSide =
+    runCatching { OrderSide.valueOf(s) }.getOrDefault(OrderSide.BUY)
+
+internal fun AlgoOrderJson.toDomain() = AlgoOrder(
+    id = id,
+    kind = runCatching { AlgoKind.valueOf(kind) }.getOrDefault(AlgoKind.TWAP),
+    symbolId = symbolId,
+    symbolLabel = symbolLabel,
+    side = sideOf(side),
+    totalQty = totalQty,
+    limitPrice = limitPrice,
+    paperMode = paperMode,
+    slices = slices,
+    durationMs = durationMs,
+    sliceIntervalMs = sliceIntervalMs,
+    visibleQty = visibleQty,
+    childrenDone = childrenDone,
+    childrenTotal = childrenTotal,
+    placedQty = placedQty,
+    status = runCatching { AlgoStatus.valueOf(status) }.getOrDefault(AlgoStatus.RUNNING),
+    createdTsMs = createdTsMs,
+    nextFireAtMs = nextFireAtMs,
+    message = message,
+)
+
+internal fun AlgoOrder.toJson() = AlgoOrderJson(
+    id = id,
+    kind = kind.name,
+    symbolId = symbolId,
+    symbolLabel = symbolLabel,
+    side = side.name,
+    totalQty = totalQty,
+    limitPrice = limitPrice,
+    paperMode = paperMode,
+    slices = slices,
+    durationMs = durationMs,
+    sliceIntervalMs = sliceIntervalMs,
+    visibleQty = visibleQty,
+    childrenDone = childrenDone,
+    childrenTotal = childrenTotal,
+    placedQty = placedQty,
+    status = status.name,
+    createdTsMs = createdTsMs,
+    nextFireAtMs = nextFireAtMs,
+    message = message,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/OrderCalc.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/OrderCalc.kt
@@ -1,0 +1,116 @@
+package com.testlogon.android.feature.markets.trade
+
+import com.testlogon.android.data.exchange.OrderSide
+
+/**
+ * Extended pure order-entry math for the trade ticket depth features: position sizing, risk:reward,
+ * bracket break-even, an estimated liquidation preview, and the client-side TWAP / Iceberg algo splits.
+ *
+ * Sits alongside [OrderMath] (which owns notional / buying-power / basic risk sizing + est. liquidation).
+ * [OrderCalc] adds the bracket + algo-scheduling math. Everything is side-effect free and guards
+ * degenerate inputs (nulls, non-positive prices/qty, zero distances, zero slices) so it can be called
+ * freely from Compose recomposition and unit-tested on the JVM. All prices/quantities are raw int64
+ * ticks (scaler = 1), matching the rest of the trading stack.
+ */
+object OrderCalc {
+
+    /**
+     * Position size from a risk budget expressed as a PERCENT of account equity: risk = equity * pct/100,
+     * then qty = floor(risk / |entry - stop|). Mirrors [OrderMath.riskSizedQty] but takes the risk % +
+     * equity rather than a pre-computed risk amount. Returns 0 for any degenerate input (null equity,
+     * pct <= 0, entry == stop, missing prices).
+     */
+    fun positionSizeQty(equity: Long?, riskPct: Int, entry: Long?, stop: Long?): Long {
+        if (equity == null || entry == null || stop == null) return 0L
+        if (equity <= 0L || riskPct <= 0) return 0L
+        val dist = kotlin.math.abs(entry - stop)
+        if (dist <= 0L) return 0L
+        val riskAmount = equity * riskPct.toLong() / 100L
+        if (riskAmount <= 0L) return 0L
+        return riskAmount / dist
+    }
+
+    /**
+     * Risk:reward for a bracket. Risk = |entry - stop|, Reward = |takeProfit - entry|; the ratio is
+     * reward/risk. Null when any leg is missing or the risk distance is zero (undefined ratio). The
+     * ratio is returned as a Double for display (e.g. 2.5 == "2.5:1"); the raw distances are exposed so
+     * the UI can show them without recomputing.
+     */
+    data class RiskReward(val risk: Long, val reward: Long, val ratio: Double)
+
+    fun riskReward(entry: Long?, stop: Long?, takeProfit: Long?): RiskReward? {
+        if (entry == null || stop == null || takeProfit == null) return null
+        val risk = kotlin.math.abs(entry - stop)
+        val reward = kotlin.math.abs(takeProfit - entry)
+        if (risk <= 0L) return null
+        return RiskReward(risk = risk, reward = reward, ratio = reward.toDouble() / risk.toDouble())
+    }
+
+    /**
+     * Estimated liquidation price for a fresh position — a thin, [side]-aware wrapper over
+     * [OrderMath.estLiquidationPrice] so the depth UI has a single call site. First-order estimate
+     * (ignores fees / funding / cross-margin); surface as "(est.)". Null when entry/bps are non-positive.
+     */
+    fun liquidationPreview(entry: Long?, side: OrderSide, maintenanceMarginBps: Long): Long? =
+        OrderMath.estLiquidationPrice(entry, side, maintenanceMarginBps)
+
+    /**
+     * Break-even price for a position after round-trip taker fees, in ticks. A BUY must exit high enough
+     * to cover the entry + exit fee; a SELL low enough. feeBps applies to notional on each side, so the
+     * combined drag is ~2 * feeBps; break-even = entry * (1 +/- 2*feeBps/10000). feeBps <= 0 -> break-even
+     * is just the entry. Null when entry is non-positive.
+     */
+    fun breakevenPrice(entry: Long?, side: OrderSide, feeBps: Long): Long? {
+        if (entry == null || entry <= 0L) return null
+        if (feeBps <= 0L) return entry
+        val drag = 2.0 * feeBps.toDouble() / 10_000.0
+        val factor = if (side == OrderSide.BUY) (1.0 + drag) else (1.0 - drag)
+        return Math.round(entry.toDouble() * factor).coerceAtLeast(0L)
+    }
+
+    /**
+     * A single TWAP child slice: which slice (1-based), the qty for it, and the offset (ms from start)
+     * at which it should fire.
+     */
+    data class TwapSlice(val index: Int, val qty: Long, val offsetMs: Long)
+
+    /**
+     * Even TWAP schedule for [totalQty] over [slices] evenly spaced across [durationMs]. The base per-slice
+     * qty is floor(total/slices); the remainder is spread one-unit-each onto the EARLIEST slices so the sum
+     * of the schedule always equals [totalQty] exactly. Slice i fires at offset i * durationMs/slices
+     * (slice 1 at t=0). Returns an empty list for degenerate inputs (qty <= 0, slices <= 0, or slices >
+     * totalQty which would create zero-qty children). Duration < 0 is clamped to 0 (all fire immediately).
+     */
+    fun twapSchedule(totalQty: Long, slices: Int, durationMs: Long): List<TwapSlice> {
+        if (totalQty <= 0L || slices <= 0) return emptyList()
+        if (slices.toLong() > totalQty) return emptyList()   // would create zero-qty children
+        val dur = durationMs.coerceAtLeast(0L)
+        val base = totalQty / slices
+        var remainder = totalQty - base * slices              // 0 .. slices-1
+        val step = dur / slices                               // even spacing; slice 1 at t=0
+        val out = ArrayList<TwapSlice>(slices)
+        for (i in 0 until slices) {
+            val extra = if (remainder > 0L) 1L else 0L
+            if (remainder > 0L) remainder--
+            out.add(TwapSlice(index = i + 1, qty = base + extra, offsetMs = i.toLong() * step))
+        }
+        return out
+    }
+
+    /**
+     * Split [totalQty] into visible-sized iceberg clips of [visibleQty] each, the last clip holding the
+     * remainder. E.g. total 100, visible 30 -> [30, 30, 30, 10]. Returns an empty list for degenerate
+     * inputs (total <= 0, visible <= 0). A visible >= total yields a single clip == total.
+     */
+    fun icebergClips(totalQty: Long, visibleQty: Long): List<Long> {
+        if (totalQty <= 0L || visibleQty <= 0L) return emptyList()
+        val out = ArrayList<Long>()
+        var remaining = totalQty
+        while (remaining > 0L) {
+            val clip = kotlin.math.min(visibleQty, remaining)
+            out.add(clip)
+            remaining -= clip
+        }
+        return out
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -166,6 +166,16 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?
     }
     Spacer(Modifier.height(10.dp))
 
+    // Algo mode: swap the entry panel for a client-side TWAP / Iceberg builder.
+    if (state.pm == null) {
+        AlgoModeToggle(state.algoMode, viewModel::toggleAlgoMode)
+        Spacer(Modifier.height(10.dp))
+    }
+    if (state.algoMode && state.pm == null) {
+        AlgoBuilder(state, lastPrice, bestBid, bestAsk, viewModel)
+        return
+    }
+
     if (state.orderType != OrderType.QUOTE && state.orderType != OrderType.FUNDING) {
         val buyLabel = if (state.pm != null) "YES" else "Buy"
         val sellLabel = if (state.pm != null) "NO" else "Sell"
@@ -206,6 +216,7 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?
             Spacer(Modifier.height(8.dp))
             OrderPreview(state, refPrice, viewModel)
             RiskCalculator(state, refPrice, viewModel)
+            BracketHelper(state, refPrice, viewModel)
             AdvancedSection(state, viewModel)
         }
         OrderType.MARKET -> {
@@ -216,6 +227,7 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?
             Spacer(Modifier.height(8.dp))
             OrderPreview(state, refPrice, viewModel)
             RiskCalculator(state, refPrice, viewModel)
+            BracketHelper(state, refPrice, viewModel)
             AdvancedSection(state, viewModel)
         }
         OrderType.STOP -> {
@@ -1232,6 +1244,30 @@ private fun RiskCalculator(state: TradingUiState, refPrice: Long?, viewModel: Tr
         ) {
             Text("Apply to ticket", color = if (sizedQty > 0L) Color.Black else MarketColors.TextFaint, fontWeight = FontWeight.Bold, fontSize = 11.sp)
         }
+    }
+    Spacer(Modifier.height(10.dp))
+    Text("Or size by risk % of buying power", color = MarketColors.TextSecondary, fontSize = 11.sp)
+    Spacer(Modifier.height(4.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+        Box(Modifier.weight(1f)) { NumberField("Risk %", state.riskPctText, viewModel::setRiskPct) }
+        val pctQty = state.riskPctSizedQty(refPrice)
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .clip(RoundedCornerShape(6.dp))
+                .background(if (pctQty > 0L) MarketColors.Accent else MarketColors.SurfaceAlt)
+                .clickable(enabled = pctQty > 0L) { viewModel.applyRiskPctSize(refPrice) }
+                .testTag("risk_pct_apply")
+                .padding(vertical = 12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(if (pctQty > 0L) "Apply $pctQty" else "Apply %", color = if (pctQty > 0L) Color.Black else MarketColors.TextFaint, fontWeight = FontWeight.Bold, fontSize = 11.sp)
+        }
+    }
+    val be = state.breakevenPrice(refPrice)
+    if (be != null) {
+        Spacer(Modifier.height(6.dp))
+        PreviewLine("Break-even (est., after fees)", fmt(be.toDouble()), MarketColors.TextPrimary)
     }
     Spacer(Modifier.height(6.dp))
     Text("Or size by buying power", color = MarketColors.TextSecondary, fontSize = 11.sp)
@@ -2343,5 +2379,154 @@ private fun AuctionBidPanel(form: AuctionBidForm, viewModel: TradingViewModel) {
             onSubmit = viewModel::submitAuctionBid,
             onDismiss = viewModel::clearAuctionBidResult,
         )
+    }
+}
+
+
+// ======================= Order-entry depth: bracket + algo =======================
+
+@Composable
+private fun BracketHelper(state: TradingUiState, refPrice: Long?, viewModel: TradingViewModel) {
+    Spacer(Modifier.height(8.dp))
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = if (state.bracketEnabled) "Bracket (TP + SL) ▲" else "Bracket (TP + SL) ▼",
+            color = MarketColors.Accent,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.clickable { viewModel.toggleBracket() }.testTag("bracket_toggle").padding(vertical = 4.dp),
+        )
+    }
+    if (!state.bracketEnabled) return
+    if (state.paperMode) {
+        Spacer(Modifier.height(4.dp))
+        Text("Brackets place server-side TP/SL orders — not simulated in paper mode.", color = PaperAmber, fontSize = 11.sp)
+        return
+    }
+    Spacer(Modifier.height(6.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(Modifier.weight(1f)) { NumberField("Take-profit", state.bracketTpText, viewModel::setBracketTp) }
+        Box(Modifier.weight(1f)) { NumberField("Stop-loss", state.bracketSlText, viewModel::setBracketSl) }
+    }
+    val rr = state.bracketRiskReward(refPrice)
+    Spacer(Modifier.height(4.dp))
+    Text(
+        text = when {
+            refPrice == null -> "Enter an entry price first."
+            state.bracketTpLong == null && state.bracketSlLong == null -> "Enter a take-profit and/or stop-loss."
+            rr == null -> "Set a stop-loss that differs from the entry for R:R."
+            else -> "R:R ${String.format(Locale.US, "%.2f", rr.ratio)} : 1  (risk ${fmt(rr.risk.toDouble())}, reward ${fmt(rr.reward.toDouble())})"
+        },
+        color = if (rr != null) MarketColors.TextPrimary else MarketColors.TextFaint,
+        fontFamily = FontFamily.Monospace,
+        fontSize = 11.sp,
+    )
+    Spacer(Modifier.height(4.dp))
+    Text(
+        "On submit: entry places first, then the opposite-side TP/SL are attached. If a leg is rejected it's reported (entry is unaffected).",
+        color = MarketColors.TextFaint,
+        fontSize = 10.sp,
+    )
+}
+
+@Composable
+private fun AlgoModeToggle(algoMode: Boolean, onToggle: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (algoMode) MarketColors.UpFill else MarketColors.Surface)
+            .border(1.dp, if (algoMode) MarketColors.Accent else MarketColors.Border, RoundedCornerShape(8.dp))
+            .clickable(onClick = onToggle)
+            .testTag("algo_mode_toggle")
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text("Algo order (TWAP / Iceberg)", color = if (algoMode) MarketColors.Accent else MarketColors.TextSecondary, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+        Text(if (algoMode) "ON" else "OFF", color = if (algoMode) MarketColors.Accent else MarketColors.TextFaint, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun AlgoBuilder(state: TradingUiState, lastPrice: Long?, bestBid: Long?, bestAsk: Long?, viewModel: TradingViewModel) {
+    val sideColor = if (state.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down
+    // Side selector (reused).
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        SideButton("Buy", state.side == OrderSide.BUY, MarketColors.Up, Modifier.weight(1f)) { viewModel.setSide(OrderSide.BUY) }
+        SideButton("Sell", state.side == OrderSide.SELL, MarketColors.Down, Modifier.weight(1f)) { viewModel.setSide(OrderSide.SELL) }
+    }
+    Spacer(Modifier.height(10.dp))
+    // Kind selector.
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        SideButton("TWAP", state.algoKind == AlgoKind.TWAP, MarketColors.Accent, Modifier.weight(1f)) { viewModel.setAlgoKind(AlgoKind.TWAP) }
+        SideButton("Iceberg", state.algoKind == AlgoKind.ICEBERG, MarketColors.Accent, Modifier.weight(1f)) { viewModel.setAlgoKind(AlgoKind.ICEBERG) }
+    }
+    Spacer(Modifier.height(10.dp))
+    NumberField("Total quantity", state.algoTotalQtyText, viewModel::setAlgoTotalQty)
+    Spacer(Modifier.height(8.dp))
+    when (state.algoKind) {
+        AlgoKind.TWAP -> {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { NumberField("Slices", state.algoSlicesText, viewModel::setAlgoSlices) }
+                Box(Modifier.weight(1f)) { NumberField("Duration (sec)", state.algoDurationSecText, viewModel::setAlgoDurationSec) }
+            }
+        }
+        AlgoKind.ICEBERG -> {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.weight(1f)) { NumberField("Visible clip", state.algoVisibleText, viewModel::setAlgoVisible) }
+                Box(Modifier.weight(1f)) { NumberField("Replenish (sec)", state.algoIntervalSecText, viewModel::setAlgoIntervalSec) }
+            }
+        }
+    }
+    Spacer(Modifier.height(8.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        SideButton("Market children", !state.algoUseLimit, MarketColors.Accent, Modifier.weight(1f)) { viewModel.setAlgoUseLimit(false) }
+        SideButton("Limit children", state.algoUseLimit, MarketColors.Accent, Modifier.weight(1f)) { viewModel.setAlgoUseLimit(true) }
+    }
+    if (state.algoUseLimit) {
+        Spacer(Modifier.height(8.dp))
+        NumberField("Child limit price", state.algoLimitText, viewModel::setAlgoLimit)
+    }
+    // Preview the split.
+    Spacer(Modifier.height(8.dp))
+    val previewText = when (state.algoKind) {
+        AlgoKind.TWAP -> {
+            val sched = OrderCalc.twapSchedule(state.algoTotalQtyLong ?: 0L, state.algoSlicesInt ?: 0, (state.algoDurationSecLong ?: 0L) * 1000L)
+            if (sched.isEmpty()) "Enter total qty, slices (≤ total) and duration." else "${sched.size} slices, ${sched.first().qty}–${sched.last().qty} each, every ${((state.algoDurationSecLong ?: 0L) / (state.algoSlicesInt ?: 1))}s"
+        }
+        AlgoKind.ICEBERG -> {
+            val clips = OrderCalc.icebergClips(state.algoTotalQtyLong ?: 0L, state.algoVisibleLong ?: 0L)
+            if (clips.isEmpty()) "Enter total qty, visible clip and replenish interval." else "${clips.size} clips of ≤${state.algoVisibleLong}, last ${clips.last()}"
+        }
+    }
+    Text(previewText, color = MarketColors.TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+    Spacer(Modifier.height(4.dp))
+    Text(
+        "Client-side algos run only while the app is open. Track progress in More → Active Algos.",
+        color = PaperAmber,
+        fontSize = 10.sp,
+    )
+    Spacer(Modifier.height(12.dp))
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (state.canStartAlgo) sideColor else MarketColors.SurfaceAlt)
+            .clickable(enabled = state.canStartAlgo) { viewModel.startAlgo(bestBid, bestAsk, lastPrice) }
+            .testTag("algo_start")
+            .padding(vertical = 14.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "Start ${state.algoKind.name} ${if (state.side == OrderSide.BUY) "Buy" else "Sell"}",
+            color = if (state.canStartAlgo) Color.Black else MarketColors.TextFaint,
+            fontWeight = FontWeight.Bold,
+            fontSize = 15.sp,
+        )
+    }
+    state.message?.let {
+        Spacer(Modifier.height(8.dp))
+        Text(it, color = if (state.messageIsError) MarketColors.Down else MarketColors.Up, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -112,6 +112,22 @@ data class TradingUiState(
     val riskCalcOpen: Boolean = false,
     val riskAmountText: String = "",
     val riskStopText: String = "",
+    // Risk-% sizer (equity * pct / stop distance -> qty via OrderCalc.positionSizeQty).
+    val riskPctText: String = "",
+    // Bracket helper: optional attached take-profit + stop-loss placed after the entry fills.
+    val bracketEnabled: Boolean = false,
+    val bracketTpText: String = "",
+    val bracketSlText: String = "",
+    // Client-side algo orders (TWAP / Iceberg). algoMode swaps the entry panel for the algo builder.
+    val algoMode: Boolean = false,
+    val algoKind: AlgoKind = AlgoKind.TWAP,
+    val algoTotalQtyText: String = "",
+    val algoSlicesText: String = "",
+    val algoDurationSecText: String = "",
+    val algoVisibleText: String = "",
+    val algoIntervalSecText: String = "",
+    val algoUseLimit: Boolean = false,
+    val algoLimitText: String = "",
     val pm: com.testlogon.android.data.exchange.PmState? = null,   // set when this symbol is a binary prediction market
     val isAdmin: Boolean = false,   // resolved from CurrentUserRepository; gates the margin-config panel
     val marginConfig: MarginConfigForm = MarginConfigForm(),
@@ -244,6 +260,42 @@ data class TradingUiState(
     /** Estimated liquidation price of the current order, using [maintenanceMarginBps]. */
     fun previewLiquidationPrice(maintenanceMarginBps: Long): Long? =
         OrderMath.estLiquidationPrice(entryRefPrice, side, maintenanceMarginBps)
+
+    // ---- Risk-% sizer + bracket + algo (order-entry depth) ----
+
+    val riskPctInt: Int? get() = riskPctText.toIntOrNull()
+
+    /** Qty from equity * riskPct / |entry - stop| (0 when inputs are incomplete). */
+    fun riskPctSizedQty(refPrice: Long?): Long =
+        OrderCalc.positionSizeQty(effectiveBuyingPower, riskPctInt ?: 0, refPrice ?: entryRefPrice, riskStopLong)
+
+    val bracketTpLong: Long? get() = bracketTpText.toLongOrNull()
+    val bracketSlLong: Long? get() = bracketSlText.toLongOrNull()
+
+    /** Risk:reward for the bracket (entry + SL + TP). Null until all three are set with non-zero risk. */
+    fun bracketRiskReward(refPrice: Long?): OrderCalc.RiskReward? =
+        OrderCalc.riskReward(refPrice ?: entryRefPrice, bracketSlLong, bracketTpLong)
+
+    /** Break-even price after round-trip taker fees (est.), using the fee schedule when present. */
+    fun breakevenPrice(refPrice: Long?): Long? =
+        OrderCalc.breakevenPrice(refPrice ?: entryRefPrice, side, feeSchedule?.takerFeeBps?.toLong() ?: 0L)
+
+    // Algo builder parse accessors.
+    val algoTotalQtyLong: Long? get() = algoTotalQtyText.toLongOrNull()
+    val algoSlicesInt: Int? get() = algoSlicesText.toIntOrNull()
+    val algoDurationSecLong: Long? get() = algoDurationSecText.toLongOrNull()
+    val algoVisibleLong: Long? get() = algoVisibleText.toLongOrNull()
+    val algoIntervalSecLong: Long? get() = algoIntervalSecText.toLongOrNull()
+    val algoLimitLong: Long? get() = algoLimitText.toLongOrNull()
+
+    /** Whether the algo builder has the fields it needs to start. */
+    val canStartAlgo: Boolean get() = when (algoKind) {
+        AlgoKind.TWAP -> (algoTotalQtyLong ?: 0L) > 0L && (algoSlicesInt ?: 0) > 0 &&
+            (algoSlicesInt ?: 0).toLong() <= (algoTotalQtyLong ?: 0L) && (algoDurationSecLong ?: 0L) > 0L &&
+            (!algoUseLimit || (algoLimitLong ?: 0L) > 0L)
+        AlgoKind.ICEBERG -> (algoTotalQtyLong ?: 0L) > 0L && (algoVisibleLong ?: 0L) > 0L &&
+            (algoIntervalSecLong ?: 0L) > 0L && (!algoUseLimit || (algoLimitLong ?: 0L) > 0L)
+    }
 }
 
 

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -40,6 +40,7 @@ class TradingViewModel @Inject constructor(
     private val currentUserRepository: CurrentUserRepository,
     private val paperModeStore: PaperModeStore,
     private val paperAccountStore: PaperAccountStore,
+    private val algoManager: AlgoManager,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -399,6 +400,108 @@ class TradingViewModel @Inject constructor(
         _uiState.update { it.copy(qtyText = q.toString(), armed = null) }
     }
 
+    // ---- Risk-% sizer ----
+    fun setRiskPct(text: String) = _uiState.update { it.copy(riskPctText = digits(text, 3)) }
+
+    /** Apply the risk-% sized qty (equity * pct / stop distance) to the ticket. No-op when it's 0. */
+    fun applyRiskPctSize(refPrice: Long?) {
+        val q = _uiState.value.riskPctSizedQty(refPrice)
+        if (q <= 0L) return
+        notifier.tick()
+        _uiState.update { it.copy(qtyText = q.toString(), armed = null) }
+    }
+
+    // ---- Bracket helper (attached TP + SL) ----
+    fun toggleBracket() = _uiState.update { it.copy(bracketEnabled = !it.bracketEnabled) }
+    fun setBracketTp(text: String) = _uiState.update { it.copy(bracketTpText = digits(text, 12)) }
+    fun setBracketSl(text: String) = _uiState.update { it.copy(bracketSlText = digits(text, 12)) }
+
+    // ---- Algo mode (client-side TWAP / Iceberg) ----
+    fun toggleAlgoMode() { notifier.tick(); _uiState.update { it.copy(algoMode = !it.algoMode, armed = null, message = null) } }
+    fun setAlgoKind(k: AlgoKind) { notifier.tick(); _uiState.update { it.copy(algoKind = k) } }
+    fun setAlgoTotalQty(text: String) = _uiState.update { it.copy(algoTotalQtyText = digits(text, 9)) }
+    fun setAlgoSlices(text: String) = _uiState.update { it.copy(algoSlicesText = digits(text, 4)) }
+    fun setAlgoDurationSec(text: String) = _uiState.update { it.copy(algoDurationSecText = digits(text, 6)) }
+    fun setAlgoVisible(text: String) = _uiState.update { it.copy(algoVisibleText = digits(text, 9)) }
+    fun setAlgoIntervalSec(text: String) = _uiState.update { it.copy(algoIntervalSecText = digits(text, 6)) }
+    fun setAlgoUseLimit(use: Boolean) = _uiState.update { it.copy(algoUseLimit = use) }
+    fun setAlgoLimit(text: String) = _uiState.update { it.copy(algoLimitText = digits(text, 12)) }
+
+    /**
+     * Start a client-side algo (TWAP / Iceberg) via [AlgoManager]. Children are placed through the same
+     * submit path as the ticket (paper-aware). [bestBid]/[bestAsk]/[last] give a reference fill price for
+     * paper-mode children when the algo is a market algo. No-op unless [TradingUiState.canStartAlgo].
+     */
+    fun startAlgo(bestBid: Long? = null, bestAsk: Long? = null, last: Long? = null) {
+        val s = _uiState.value
+        if (!s.canStartAlgo) return
+        val label = s.symbolLabel(symbolId)
+        val limit = if (s.algoUseLimit) s.algoLimitLong else null
+        val refPrice = com.testlogon.android.feature.paper.PaperTicketSupport.marketPriceFor(s.side, bestBid, bestAsk, last)
+        val id = when (s.algoKind) {
+            AlgoKind.TWAP -> algoManager.startTwap(
+                symbolId = symbolId, symbolLabel = label, side = s.side,
+                totalQty = s.algoTotalQtyLong ?: return, slices = s.algoSlicesInt ?: return,
+                durationMs = (s.algoDurationSecLong ?: return) * 1_000L,
+                limitPrice = limit, paperMode = s.paperMode, refPrice = refPrice,
+            )
+            AlgoKind.ICEBERG -> algoManager.startIceberg(
+                symbolId = symbolId, symbolLabel = label, side = s.side,
+                totalQty = s.algoTotalQtyLong ?: return, visibleQty = s.algoVisibleLong ?: return,
+                clipIntervalMs = (s.algoIntervalSecLong ?: return) * 1_000L,
+                limitPrice = limit, paperMode = s.paperMode, refPrice = refPrice,
+            )
+        }
+        if (id != null) {
+            notifier.success()
+            _uiState.update { it.copy(message = "${s.algoKind.name} algo started - track it in Active Algos", messageIsError = false) }
+        } else {
+            notifier.error()
+            _uiState.update { it.copy(message = "Algo inputs invalid", messageIsError = true) }
+        }
+    }
+
+    /**
+     * Place the attached bracket legs (take-profit + stop-loss) on the OPPOSITE side of the entry, after
+     * a successful entry placement. Uses the existing take_profit / stop_market algo endpoints (paper mode
+     * has no server algos, so this is skipped there). Failures are surfaced but never unwind the entry.
+     */
+    private fun placeBracketLegs(entrySide: OrderSide, qty: Long) {
+        val s = _uiState.value
+        if (!s.bracketEnabled || s.paperMode) return
+        val exitSide = if (entrySide == OrderSide.BUY) OrderSide.SELL else OrderSide.BUY
+        val tp = s.bracketTpLong
+        val sl = s.bracketSlLong
+        if (tp == null && sl == null) return
+        viewModelScope.launch {
+            var placed = 0
+            var failed = 0
+            if (tp != null && tp > 0L) {
+                when (val r = repository.placeAlgo("take_profit", symbolId, exitSide, qty, tp, null)) {
+                    is ApiResult.Success -> if (r.data.accepted) placed++ else failed++
+                    else -> failed++
+                }
+            }
+            if (sl != null && sl > 0L) {
+                when (val r = repository.placeAlgo("stop_market", symbolId, exitSide, qty, sl, null)) {
+                    is ApiResult.Success -> if (r.data.accepted) placed++ else failed++
+                    else -> failed++
+                }
+            }
+            _uiState.update {
+                it.copy(
+                    message = when {
+                        failed == 0 && placed > 0 -> "Entry placed + bracket ($placed leg(s)) armed"
+                        placed > 0 -> "Entry placed; bracket partially armed ($placed ok, $failed rejected)"
+                        else -> "Entry placed; bracket legs rejected (place TP/SL manually)"
+                    },
+                    messageIsError = failed > 0 && placed == 0,
+                )
+            }
+            if (placed > 0) refreshOrdersLive()
+        }
+    }
+
     // ---- One-click bid/ask / market prefills (the user still submits via the normal flow) ----
 
     /** Prefill a Buy limit at the best bid. */
@@ -725,6 +828,7 @@ class TradingViewModel @Inject constructor(
                         }
                         refreshAccount()
                         refreshOrdersLive()
+                        if (s.bracketEnabled) placeBracketLegs(s.side, qty)
                         if (filled > 0) notifier.notifyFill("Order filled", "Filled $filled @ ${ack.fills.firstOrNull()?.price ?: price}") else notifier.success()
                     } else {
                         _uiState.update { it.copy(placing = false, message = ack.message ?: "Order rejected", messageIsError = true) }

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -960,6 +960,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "active_algos",
+            labelRes = R.string.more_entry_active_algos,
+            icon = Icons.Outlined.Schedule,
+            route = MoreRoutes.ACTIVE_ALGOS,
+            hub = MoreHub.STUDIO,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "home",
             labelRes = R.string.more_entry_home,
             icon = Icons.Outlined.Dashboard,

--- a/android/app/src/main/java/com/testlogon/android/navigation/ActiveAlgosNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/ActiveAlgosNavigation.kt
@@ -1,0 +1,22 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.markets.trade.ActiveAlgosRoute
+
+/**
+ * The Active-Algos monitor surface (client-side TWAP / Iceberg progress + pause/cancel), reached from
+ * More -> Studio. Self-contained: observes the process-wide AlgoManager. Up / Back pops the back stack.
+ */
+data object ActiveAlgosDest {
+    const val ROUTE = "trading/algos"
+}
+
+fun NavGraphBuilder.activeAlgosDestination(navController: NavHostController) {
+    composable(ActiveAlgosDest.ROUTE) {
+        ActiveAlgosRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -214,6 +214,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         filesDestination(navController)
         // Trading Blotter: native orders/fills/positions blotter (web parity; sample data + ticker).
         blotterDestination(navController)
+        // Active Algos monitor: client-side TWAP / Iceberg algo progress + pause/cancel.
+        activeAlgosDestination(navController)
         // Custody: native crypto custody surface wired to /me/custody/* (officer approvals self-gate on the admin signal).
         custodyDestination(navController)
         // External custody providers (Fireblocks / BitGo / internal gateway): connect + per-vault provider + withdrawal approval.

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -100,6 +100,9 @@ object MoreRoutes {
     // Trading Blotter: native orders/fills/positions blotter (web parity). Sample data only.
     const val TRADING_BLOTTER = BlotterDest.ROUTE
 
+    // Active Algos: client-side TWAP / Iceberg algo-order monitor (progress + pause/cancel).
+    const val ACTIVE_ALGOS = ActiveAlgosDest.ROUTE
+
     // Home / Dashboard: read-only trading launch surface (portfolio + watchlist + activity + onboarding).
     const val HOME = HomeDest.ROUTE
 
@@ -614,6 +617,7 @@ object MoreRoutes {
             SELLER_SALES,
             FILES,
             TRADING_BLOTTER,
+            ACTIVE_ALGOS,
             HOME,
             CUSTODY,
             CUSTODY_PROVIDERS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1456,6 +1456,7 @@
     <string name="more_entry_gallery">Gallery</string>
     <string name="more_entry_files">Files</string>
     <string name="more_entry_trading_blotter">Trading Blotter</string>
+    <string name="more_entry_active_algos">Active Algos</string>
     <string name="more_entry_home">Home</string>
     <string name="more_entry_custody">Custody</string>
     <string name="more_entry_custody_providers">Custody providers</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/markets/trade/OrderCalcTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/markets/trade/OrderCalcTest.kt
@@ -1,0 +1,172 @@
+package com.testlogon.android.feature.markets.trade
+
+import com.testlogon.android.data.exchange.OrderSide
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [OrderCalc] — the pure order-entry depth math (position sizing, risk:reward, break-even,
+ * est. liquidation, TWAP schedule + Iceberg clips). All values are raw int64 ticks (scaler = 1).
+ */
+class OrderCalcTest {
+
+    // ---- positionSizeQty ----
+
+    @Test fun positionSize_basic() {
+        // equity 100_000, risk 2% = 2_000; stop distance 100 -> 20 units
+        assertEquals(20L, OrderCalc.positionSizeQty(100_000L, 2, 1_000L, 900L))
+    }
+
+    @Test fun positionSize_floorsToWhole() {
+        // risk 2_000 / distance 150 = 13.33 -> 13
+        assertEquals(13L, OrderCalc.positionSizeQty(100_000L, 2, 1_000L, 850L))
+    }
+
+    @Test fun positionSize_zeroWhenEntryEqualsStop() =
+        assertEquals(0L, OrderCalc.positionSizeQty(100_000L, 2, 1_000L, 1_000L))
+
+    @Test fun positionSize_guardsNullsAndNonPositive() {
+        assertEquals(0L, OrderCalc.positionSizeQty(null, 2, 1_000L, 900L))
+        assertEquals(0L, OrderCalc.positionSizeQty(100_000L, 2, null, 900L))
+        assertEquals(0L, OrderCalc.positionSizeQty(100_000L, 2, 1_000L, null))
+        assertEquals(0L, OrderCalc.positionSizeQty(0L, 2, 1_000L, 900L))
+        assertEquals(0L, OrderCalc.positionSizeQty(100_000L, 0, 1_000L, 900L))
+        assertEquals(0L, OrderCalc.positionSizeQty(100_000L, -5, 1_000L, 900L))
+    }
+
+    @Test fun positionSize_tinyRiskRoundsToZero() =
+        // equity 100, 1% = 1; distance 100 -> 0 units (floors)
+        assertEquals(0L, OrderCalc.positionSizeQty(100L, 1, 1_000L, 900L))
+
+    // ---- riskReward ----
+
+    @Test fun riskReward_twoToOne() {
+        val rr = OrderCalc.riskReward(entry = 1_000L, stop = 900L, takeProfit = 1_200L)!!
+        assertEquals(100L, rr.risk)
+        assertEquals(200L, rr.reward)
+        assertEquals(2.0, rr.ratio, 1e-9)
+    }
+
+    @Test fun riskReward_shortSide() {
+        // short: entry 1000, stop 1100 (risk 100), tp 800 (reward 200)
+        val rr = OrderCalc.riskReward(entry = 1_000L, stop = 1_100L, takeProfit = 800L)!!
+        assertEquals(100L, rr.risk)
+        assertEquals(200L, rr.reward)
+        assertEquals(2.0, rr.ratio, 1e-9)
+    }
+
+    @Test fun riskReward_nullWhenLegMissing() {
+        assertNull(OrderCalc.riskReward(null, 900L, 1_200L))
+        assertNull(OrderCalc.riskReward(1_000L, null, 1_200L))
+        assertNull(OrderCalc.riskReward(1_000L, 900L, null))
+    }
+
+    @Test fun riskReward_nullWhenRiskZero() =
+        assertNull(OrderCalc.riskReward(1_000L, 1_000L, 1_200L))
+
+    // ---- liquidationPreview ----
+
+    @Test fun liquidation_longBelowEntry() {
+        // 5% mmr -> long liquidates at 1000 * 0.95 = 950
+        assertEquals(950L, OrderCalc.liquidationPreview(1_000L, OrderSide.BUY, 500L))
+    }
+
+    @Test fun liquidation_shortAboveEntry() {
+        // 5% mmr -> short liquidates at 1000 * 1.05 = 1050
+        assertEquals(1_050L, OrderCalc.liquidationPreview(1_000L, OrderSide.SELL, 500L))
+    }
+
+    @Test fun liquidation_nullWhenEntryNonPositive() {
+        assertNull(OrderCalc.liquidationPreview(0L, OrderSide.BUY, 500L))
+        assertNull(OrderCalc.liquidationPreview(null, OrderSide.BUY, 500L))
+    }
+
+    // ---- breakevenPrice ----
+
+    @Test fun breakeven_longAboveEntry() {
+        // 10 bps -> drag 2*10/10000 = 0.002 ; 1000 * 1.002 = 1002
+        assertEquals(1_002L, OrderCalc.breakevenPrice(1_000L, OrderSide.BUY, 10L))
+    }
+
+    @Test fun breakeven_shortBelowEntry() {
+        // 1000 * 0.998 = 998
+        assertEquals(998L, OrderCalc.breakevenPrice(1_000L, OrderSide.SELL, 10L))
+    }
+
+    @Test fun breakeven_zeroFeeIsEntry() =
+        assertEquals(1_000L, OrderCalc.breakevenPrice(1_000L, OrderSide.BUY, 0L))
+
+    @Test fun breakeven_nullWhenEntryNonPositive() {
+        assertNull(OrderCalc.breakevenPrice(0L, OrderSide.BUY, 10L))
+        assertNull(OrderCalc.breakevenPrice(null, OrderSide.SELL, 10L))
+    }
+
+    // ---- twapSchedule ----
+
+    @Test fun twap_evenSplitSumsToTotal() {
+        val s = OrderCalc.twapSchedule(100L, 4, 60_000L)
+        assertEquals(4, s.size)
+        assertEquals(100L, s.sumOf { it.qty })
+        s.forEach { assertEquals(25L, it.qty) }
+    }
+
+    @Test fun twap_remainderOnEarliestSlices() {
+        // 10 over 3 -> base 3, remainder 1 -> [4,3,3]
+        val s = OrderCalc.twapSchedule(10L, 3, 30_000L)
+        assertEquals(listOf(4L, 3L, 3L), s.map { it.qty })
+        assertEquals(10L, s.sumOf { it.qty })
+    }
+
+    @Test fun twap_offsetsAreEvenlySpacedFromZero() {
+        val s = OrderCalc.twapSchedule(4L, 4, 40_000L)
+        assertEquals(listOf(0L, 10_000L, 20_000L, 30_000L), s.map { it.offsetMs })
+    }
+
+    @Test fun twap_emptyForDegenerate() {
+        assertTrue(OrderCalc.twapSchedule(0L, 4, 1000L).isEmpty())
+        assertTrue(OrderCalc.twapSchedule(100L, 0, 1000L).isEmpty())
+        assertTrue(OrderCalc.twapSchedule(-5L, 4, 1000L).isEmpty())
+        // more slices than qty would create zero-qty children -> empty
+        assertTrue(OrderCalc.twapSchedule(3L, 4, 1000L).isEmpty())
+    }
+
+    @Test fun twap_negativeDurationClampsToImmediate() {
+        val s = OrderCalc.twapSchedule(4L, 2, -100L)
+        assertEquals(2, s.size)
+        s.forEach { assertEquals(0L, it.offsetMs) }
+        assertEquals(4L, s.sumOf { it.qty })
+    }
+
+    @Test fun twap_singleSliceIsWholeQty() {
+        val s = OrderCalc.twapSchedule(50L, 1, 10_000L)
+        assertEquals(1, s.size)
+        assertEquals(50L, s.single().qty)
+        assertEquals(0L, s.single().offsetMs)
+    }
+
+    // ---- icebergClips ----
+
+    @Test fun iceberg_splitsWithRemainderLast() {
+        assertEquals(listOf(30L, 30L, 30L, 10L), OrderCalc.icebergClips(100L, 30L))
+    }
+
+    @Test fun iceberg_exactMultiple() {
+        assertEquals(listOf(25L, 25L, 25L, 25L), OrderCalc.icebergClips(100L, 25L))
+    }
+
+    @Test fun iceberg_visibleExceedsTotalIsSingleClip() =
+        assertEquals(listOf(50L), OrderCalc.icebergClips(50L, 200L))
+
+    @Test fun iceberg_emptyForDegenerate() {
+        assertTrue(OrderCalc.icebergClips(0L, 30L).isEmpty())
+        assertTrue(OrderCalc.icebergClips(100L, 0L).isEmpty())
+        assertTrue(OrderCalc.icebergClips(-5L, 30L).isEmpty())
+    }
+
+    @Test fun iceberg_sumEqualsTotal() {
+        val clips = OrderCalc.icebergClips(97L, 20L)
+        assertEquals(97L, clips.sum())
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,6 +61,7 @@ const PostDetailPage = lazy(() => import("@/pages/feed/PostDetailPage"));
 const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
 const HomePage = lazy(() => import("@/pages/home/HomePage"));
 const MarketsPage = lazy(() => import("@/pages/markets/MarketsPage"));
+const ActiveAlgosPage = lazy(() => import("@/pages/algos/ActiveAlgosPage"));
 const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
 const TokenMarketPage = lazy(() => import("@/pages/tokens/TokenMarketPage"));
 const MintTokenPage = lazy(() => import("@/pages/tokens/MintTokenPage"));
@@ -773,6 +774,7 @@ export default function App() {
           <Route path="invest" element={<InvestHubPage />} />
           <Route path="analysis" element={<MarketAnalysisPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />
+          <Route path="algos" element={<ActiveAlgosPage />} />
           <Route path="paper" element={<PaperTradingPage />} />
           <Route path="discover" element={<DiscoverPage />} />
           <Route path="discover/tags/:tag" element={<TagPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -107,6 +107,7 @@ import {
   CandlestickChart,
   PieChart,
   TrendingUp,
+  Timer,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -153,6 +154,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Analysis", i18nKey: "nav.analysis", path: "/analysis", icon: <LineChart className="h-5 w-5" /> },
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },
       { label: "Paper Trading", i18nKey: "nav.paperTrading", path: "/paper", icon: <TrendingUp className="h-5 w-5" /> },
+      { label: "Active Algos", i18nKey: "nav.activeAlgos", path: "/algos", icon: <Timer className="h-5 w-5" /> },
       { label: "Portfolio", i18nKey: "nav.portfolio", path: "/portfolio", icon: <PieChart className="h-5 w-5" /> },
       { label: "Portfolio Risk", i18nKey: "nav.portfolioRisk", path: "/portfolio/analytics", icon: <ShieldAlert className="h-5 w-5" /> },
       { label: "Bailouts", i18nKey: "nav.bailouts", path: "/bailouts", icon: <LifeBuoy className="h-5 w-5" /> },

--- a/frontend/src/lib/algoRunner.ts
+++ b/frontend/src/lib/algoRunner.ts
@@ -1,0 +1,190 @@
+// Client-side ALGO RUNNER hook. Mounted once by the trade ticket for the current
+// symbol; it drives every RUNNING TWAP / Iceberg algo for that symbol by placing
+// child orders on a timer (TWAP) or on-fill (Iceberg) through the SAME submit
+// primitives the ticket uses. Paper-mode algos route children to the local paper
+// engine; live algos go through the real place-order mutation.
+//
+// Algos run ONLY while this hook is mounted (i.e. the tab/ticket is open). On
+// unmount every timer is torn down — no orphaned timers. Pausing/cancelling an
+// algo (via the store) stops it scheduling further children on the next tick.
+
+import { useEffect, useRef } from "react";
+import {
+  loadAlgos,
+  saveAlgos,
+  filledQty,
+  isComplete,
+  nextPending,
+  type AlgoOrder,
+  type AlgoChild,
+} from "./algoStore";
+import {
+  placeOrder as placePaperOrder,
+  type PaperAccount,
+} from "./paperEngine";
+import { selectMarketPrice } from "./paperMode";
+
+export interface AlgoRunnerQuotes {
+  bestBid?: number;
+  bestAsk?: number;
+  lastPrice?: number;
+}
+
+export interface AlgoRunnerDeps {
+  symbolId: number;
+  quotes: AlgoRunnerQuotes;
+  /** Route a LIVE child order; resolves true when the child is considered filled. */
+  placeLiveChild: (args: {
+    side: "buy" | "sell";
+    type: "market" | "limit";
+    price?: number;
+    qty: number;
+  }) => Promise<{ filled: boolean; fillPrice?: number }>;
+  /** Latest paper account (source of truth for paper children). */
+  paperAccount: PaperAccount;
+  /** Commit a mutated paper account (persist + local state). */
+  commitPaper: (acct: PaperAccount) => void;
+  /** Called after any algo state mutation so the UI can refresh a status line. */
+  onProgress?: () => void;
+}
+
+/**
+ * Persist a single algo mutation back to the store (re-reading first so we never
+ * clobber concurrent changes from another algo / the monitor page).
+ */
+function commitAlgo(next: AlgoOrder): void {
+  const list = loadAlgos().map((a) => (a.id === next.id ? { ...next, updatedAt: Date.now() } : a));
+  saveAlgos(list);
+}
+
+export function useAlgoRunner(deps: AlgoRunnerDeps): void {
+  // Keep the latest deps in a ref so the single interval always sees fresh
+  // quotes / account without re-subscribing (which would churn timers).
+  const ref = useRef(deps);
+  ref.current = deps;
+  // Guards so we never double-fire a child while a placement is in flight.
+  const inFlight = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function tick() {
+      const { symbolId, quotes, paperAccount, commitPaper, placeLiveChild, onProgress } =
+        ref.current;
+      const now = Date.now();
+      const running = loadAlgos().filter(
+        (a) => a.status === "running" && a.symbolId === symbolId,
+      );
+      for (const algo of running) {
+        const key = algo.id;
+        if (inFlight.current.has(key)) continue;
+
+        // Complete → mark done.
+        if (isComplete(algo)) {
+          commitAlgo({ ...algo, status: "done" });
+          onProgress?.();
+          continue;
+        }
+
+        const child = nextPending(algo);
+        if (!child) {
+          // No pending child but not complete (all placed, awaiting fill) — skip.
+          continue;
+        }
+
+        if (algo.kind === "twap") {
+          // Fire only when the slice's scheduled time has arrived.
+          if (child.atMs != null && child.atMs > now) continue;
+        } else {
+          // Iceberg: only place the next clip once the prior placed clip filled.
+          const anyPlacedUnfilled = algo.children.some((c) => c.status === "placed");
+          if (anyPlacedUnfilled) continue;
+        }
+
+        inFlight.current.add(key);
+        try {
+          if (algo.paper) {
+            const marketPrice = selectMarketPrice(algo.side, {
+              bestBid: quotes.bestBid,
+              bestAsk: quotes.bestAsk,
+              lastPrice: quotes.lastPrice,
+              refPrice: algo.limitPrice,
+            });
+            const { account, fill } = placePaperOrder(
+              paperAccount,
+              {
+                symbolId: algo.symbolId,
+                side: algo.side,
+                type: algo.childType,
+                price: algo.childType === "limit" ? algo.limitPrice : undefined,
+                qty: child.qty,
+              },
+              marketPrice,
+            );
+            commitPaper(account);
+            // Paper children that don't immediately fill (resting limit) are
+            // still marked placed; onTick elsewhere would fill them, but for the
+            // algo's accounting we advance on the immediate fill only.
+            const updatedChild: AlgoChild = fill
+              ? { ...child, status: "filled", fillPrice: fill.price, placedAt: now, filledAt: now }
+              : { ...child, status: "placed", placedAt: now };
+            const fresh = loadAlgos().find((a) => a.id === algo.id);
+            if (fresh) {
+              const children = fresh.children.map((c) =>
+                c.seq === child.seq ? updatedChild : c,
+              );
+              const withChildren: AlgoOrder = { ...fresh, children };
+              commitAlgo(
+                isComplete(withChildren) ? { ...withChildren, status: "done" } : withChildren,
+              );
+            }
+          } else {
+            const res = await placeLiveChild({
+              side: algo.side,
+              type: algo.childType,
+              price: algo.childType === "limit" ? algo.limitPrice : undefined,
+              qty: child.qty,
+            });
+            if (cancelled) return;
+            const updatedChild: AlgoChild = res.filled
+              ? { ...child, status: "filled", fillPrice: res.fillPrice, placedAt: now, filledAt: Date.now() }
+              : { ...child, status: "placed", placedAt: now };
+            const fresh = loadAlgos().find((a) => a.id === algo.id);
+            if (fresh) {
+              const children = fresh.children.map((c) =>
+                c.seq === child.seq ? updatedChild : c,
+              );
+              const withChildren: AlgoOrder = { ...fresh, children };
+              commitAlgo(
+                isComplete(withChildren) ? { ...withChildren, status: "done" } : withChildren,
+              );
+            }
+          }
+          onProgress?.();
+        } catch {
+          // Placement failed — leave the child pending; it retries next tick.
+        } finally {
+          inFlight.current.delete(key);
+        }
+      }
+    }
+
+    // Poll on a short cadence; TWAP timing is enforced per-slice via atMs so a
+    // 1s tick is plenty and keeps the countdown display live.
+    const id = window.setInterval(() => {
+      void tick();
+    }, 1000);
+    // Fire once immediately so a just-created algo places its first slice.
+    void tick();
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+    // Re-mount the loop only when the symbol changes; deps ride the ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deps.symbolId]);
+}
+
+/** Total filled ticks for a live algo (re-export convenience). */
+export { filledQty };

--- a/frontend/src/lib/algoStore.ts
+++ b/frontend/src/lib/algoStore.ts
@@ -1,0 +1,190 @@
+// Persisted store + React hook for CLIENT-SIDE algo orders (TWAP + Iceberg) and
+// their Active-Algos monitor. Mirrors the paper-mode / price-alerts store pattern:
+// writes persist to localStorage under `algo.orders.v1` and dispatch a same-tab
+// event so every mounted `useAlgoOrders()` re-reads; cross-tab sync rides the
+// native `storage` event.
+//
+// IMPORTANT: these algos run ONLY while a tab is open — the actual scheduling /
+// child-order placement lives in a runner the ticket mounts (algoRunner.tsx). This
+// module is pure state: shape, persistence, and pure reducers (unit-tested-able).
+
+import { useCallback, useEffect, useState } from "react";
+
+export const ALGO_ORDERS_KEY = "algo.orders.v1";
+
+/** Fired (same-tab) whenever the algo store changes. */
+export const ALGO_ORDERS_EVENT = "tl:algoOrdersChanged";
+
+export type AlgoKind = "twap" | "iceberg";
+export type AlgoStatus = "running" | "paused" | "done" | "cancelled";
+export type AlgoSide = "buy" | "sell";
+
+/** A placed child order + its fill state. */
+export interface AlgoChild {
+  seq: number;
+  qty: number;
+  /** Scheduled fire time (ms epoch) — TWAP only; iceberg replenishes on fill. */
+  atMs?: number;
+  status: "pending" | "placed" | "filled";
+  /** Fill price (ticks) once known. */
+  fillPrice?: number;
+  placedAt?: number;
+  filledAt?: number;
+}
+
+export interface AlgoOrder {
+  id: string;
+  kind: AlgoKind;
+  symbolId: number;
+  symbolLabel?: string;
+  side: AlgoSide;
+  /** Order type each child is placed as. */
+  childType: "market" | "limit";
+  /** Limit price in ticks (limit children only). */
+  limitPrice?: number;
+  totalQty: number;
+  /** TWAP config. */
+  slices?: number;
+  durationMs?: number;
+  /** Iceberg config. */
+  visibleQty?: number;
+  /** Whether this algo routes children through the PAPER engine. */
+  paper: boolean;
+  status: AlgoStatus;
+  children: AlgoChild[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Read the persisted algo list (defaults to []). Corrupt values fall back to []. */
+export function loadAlgos(): AlgoOrder[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(ALGO_ORDERS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (a): a is AlgoOrder =>
+        a &&
+        typeof a.id === "string" &&
+        (a.kind === "twap" || a.kind === "iceberg") &&
+        Array.isArray(a.children),
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Persist the list and notify same-tab listeners. */
+export function saveAlgos(list: AlgoOrder[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ALGO_ORDERS_KEY, JSON.stringify(list));
+  } catch {
+    /* quota / private-mode — degrade to no-op */
+  }
+  try {
+    window.dispatchEvent(new Event(ALGO_ORDERS_EVENT));
+  } catch {
+    /* SSR — no-op */
+  }
+}
+
+let algoIdCounter = 0;
+export function nextAlgoId(): string {
+  algoIdCounter += 1;
+  return `algo_${Date.now().toString(36)}_${algoIdCounter.toString(36)}`;
+}
+
+// ── Pure derived helpers ─────────────────────────────────────────────
+
+/** Ticks filled so far across an algo's children. */
+export function filledQty(a: AlgoOrder): number {
+  return a.children.reduce((s, c) => s + (c.status === "filled" ? c.qty : 0), 0);
+}
+
+/** Count of children fully filled. */
+export function slicesDone(a: AlgoOrder): number {
+  return a.children.filter((c) => c.status === "filled").length;
+}
+
+/** Filled fraction in [0, 1]. */
+export function progressFrac(a: AlgoOrder): number {
+  if (!(a.totalQty > 0)) return 0;
+  return Math.min(1, filledQty(a) / a.totalQty);
+}
+
+/** True when every child has filled (TWAP) or the total qty is covered. */
+export function isComplete(a: AlgoOrder): boolean {
+  return filledQty(a) >= a.totalQty;
+}
+
+/** The next child still pending (lowest seq), or undefined. */
+export function nextPending(a: AlgoOrder): AlgoChild | undefined {
+  return a.children
+    .filter((c) => c.status === "pending")
+    .sort((x, y) => x.seq - y.seq)[0];
+}
+
+// ── React hook ───────────────────────────────────────────────────────
+
+/**
+ * React hook exposing the shared algo list plus mutators. Every mutator persists
+ * and fans the change out to every other `useAlgoOrders()` consumer + tab.
+ */
+export function useAlgoOrders() {
+  const [algos, setAlgos] = useState<AlgoOrder[]>(() => loadAlgos());
+
+  useEffect(() => {
+    const reload = (e?: StorageEvent) => {
+      if (e && e.key && e.key !== ALGO_ORDERS_KEY) return;
+      setAlgos(loadAlgos());
+    };
+    window.addEventListener("storage", reload as EventListener);
+    window.addEventListener(ALGO_ORDERS_EVENT, reload as EventListener);
+    return () => {
+      window.removeEventListener("storage", reload as EventListener);
+      window.removeEventListener(ALGO_ORDERS_EVENT, reload as EventListener);
+    };
+  }, []);
+
+  const persist = useCallback((next: AlgoOrder[]) => {
+    setAlgos(next);
+    saveAlgos(next);
+  }, []);
+
+  const add = useCallback(
+    (a: AlgoOrder) => persist([a, ...loadAlgos()]),
+    [persist],
+  );
+
+  const update = useCallback(
+    (id: string, patch: Partial<AlgoOrder> | ((a: AlgoOrder) => AlgoOrder)) =>
+      persist(
+        loadAlgos().map((a) =>
+          a.id === id
+            ? { ...(typeof patch === "function" ? patch(a) : { ...a, ...patch }), updatedAt: Date.now() }
+            : a,
+        ),
+      ),
+    [persist],
+  );
+
+  const remove = useCallback(
+    (id: string) => persist(loadAlgos().filter((a) => a.id !== id)),
+    [persist],
+  );
+
+  const setStatus = useCallback(
+    (id: string, status: AlgoStatus) => update(id, { status }),
+    [update],
+  );
+
+  const clearTerminal = useCallback(
+    () => persist(loadAlgos().filter((a) => a.status === "running" || a.status === "paused")),
+    [persist],
+  );
+
+  return { algos, add, update, remove, setStatus, clearTerminal };
+}

--- a/frontend/src/lib/orderCalc.test.ts
+++ b/frontend/src/lib/orderCalc.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  positionSizeQty,
+  riskReward,
+  liquidationPreview,
+  breakevenPrice,
+  twapSchedule,
+  icebergClips,
+} from "./orderCalc";
+
+describe("positionSizeQty", () => {
+  it("sizes qty from a risk budget and stop distance", () => {
+    // risk budget = 100000 * 1% = 1000; distance = 50 -> 20 lots
+    expect(
+      positionSizeQty({ equityCents: 100000, riskPct: 1, entryPrice: 1000, stopPrice: 950 }),
+    ).toBe(20);
+  });
+  it("floors to a whole lot", () => {
+    // budget = 100000 * 2% = 2000; distance = 300 -> 6.66 -> 6
+    expect(
+      positionSizeQty({ equityCents: 100000, riskPct: 2, entryPrice: 1000, stopPrice: 700 }),
+    ).toBe(6);
+  });
+  it("clamps riskPct above 100", () => {
+    expect(
+      positionSizeQty({ equityCents: 1000, riskPct: 999, entryPrice: 100, stopPrice: 90 }),
+    ).toBe(100); // budget 1000, dist 10
+  });
+  it("returns 0 for equal entry and stop (no distance)", () => {
+    expect(
+      positionSizeQty({ equityCents: 100000, riskPct: 1, entryPrice: 1000, stopPrice: 1000 }),
+    ).toBe(0);
+  });
+  it("returns 0 for non-positive equity or riskPct", () => {
+    expect(positionSizeQty({ equityCents: 0, riskPct: 1, entryPrice: 1000, stopPrice: 900 })).toBe(0);
+    expect(positionSizeQty({ equityCents: 100000, riskPct: 0, entryPrice: 1000, stopPrice: 900 })).toBe(0);
+    expect(positionSizeQty({ equityCents: -5, riskPct: 1, entryPrice: 1000, stopPrice: 900 })).toBe(0);
+  });
+});
+
+describe("riskReward", () => {
+  it("computes risk/reward for a long", () => {
+    const r = riskReward({ side: "buy", entry: 1000, stop: 900, target: 1300, qty: 5 });
+    expect(r.riskCents).toBe(500); // (1000-900)*5
+    expect(r.rewardCents).toBe(1500); // (1300-1000)*5
+    expect(r.rr).toBe(3);
+  });
+  it("computes risk/reward for a short (inverted)", () => {
+    const r = riskReward({ side: "sell", entry: 1000, stop: 1100, target: 800, qty: 2 });
+    expect(r.riskCents).toBe(200); // (1100-1000)*2
+    expect(r.rewardCents).toBe(400); // (1000-800)*2
+    expect(r.rr).toBe(2);
+  });
+  it("zeroes reward when target is on the wrong side", () => {
+    const r = riskReward({ side: "buy", entry: 1000, stop: 900, target: 950, qty: 1 });
+    expect(r.rewardCents).toBe(0);
+    expect(r.rr).toBe(0);
+  });
+  it("returns zeros for non-positive entry or qty", () => {
+    expect(riskReward({ side: "buy", entry: 0, stop: 1, target: 2, qty: 1 })).toEqual({
+      riskCents: 0,
+      rewardCents: 0,
+      rr: 0,
+    });
+    expect(riskReward({ side: "buy", entry: 100, stop: 90, target: 120, qty: 0 })).toEqual({
+      riskCents: 0,
+      rewardCents: 0,
+      rr: 0,
+    });
+  });
+  it("treats missing (zero) stop/target as no leg", () => {
+    const r = riskReward({ side: "buy", entry: 1000, stop: 0, target: 1200, qty: 3 });
+    expect(r.riskCents).toBe(0);
+    expect(r.rewardCents).toBe(600);
+    expect(r.rr).toBe(0); // no risk leg -> rr undefined -> 0
+  });
+});
+
+describe("liquidationPreview", () => {
+  it("computes margin from leverage", () => {
+    const r = liquidationPreview({
+      side: "buy",
+      entry: 1000,
+      qty: 10,
+      leverage: 5,
+      maintenanceMarginBps: 500,
+    });
+    expect(r.marginRequiredCents).toBe(2000); // 1000*10/5
+  });
+  it("long liq sits below entry, short liq above", () => {
+    const long = liquidationPreview({ side: "buy", entry: 1000, qty: 1, leverage: 10, maintenanceMarginBps: 0 });
+    const short = liquidationPreview({ side: "sell", entry: 1000, qty: 1, leverage: 10, maintenanceMarginBps: 0 });
+    expect(long.liqPrice).toBeCloseTo(900); // 1000*(1-0.1)
+    expect(short.liqPrice).toBeCloseTo(1100); // 1000*(1+0.1)
+  });
+  it("maintenance margin pulls the long liq up", () => {
+    const r = liquidationPreview({ side: "buy", entry: 1000, qty: 1, leverage: 10, maintenanceMarginBps: 200 });
+    expect(r.liqPrice).toBeCloseTo(920); // 1000*(1-0.1+0.02)
+  });
+  it("returns null liq / 0 margin for unusable inputs", () => {
+    expect(liquidationPreview({ side: "buy", entry: 0, qty: 1, leverage: 5, maintenanceMarginBps: 100 })).toEqual({
+      liqPrice: null,
+      marginRequiredCents: 0,
+    });
+    expect(liquidationPreview({ side: "buy", entry: 1000, qty: 1, leverage: 0, maintenanceMarginBps: 100 })).toEqual({
+      liqPrice: null,
+      marginRequiredCents: 0,
+    });
+  });
+});
+
+describe("breakevenPrice", () => {
+  it("buy breakeven sits above entry by round-trip fees", () => {
+    expect(breakevenPrice({ side: "buy", entry: 10000, feeBps: 10 })).toBe(10020); // 2*0.001
+  });
+  it("sell breakeven sits below entry", () => {
+    expect(breakevenPrice({ side: "sell", entry: 10000, feeBps: 10 })).toBe(9980);
+  });
+  it("zero fee returns entry", () => {
+    expect(breakevenPrice({ side: "buy", entry: 5000, feeBps: 0 })).toBe(5000);
+  });
+  it("returns 0 for non-positive entry", () => {
+    expect(breakevenPrice({ side: "buy", entry: 0, feeBps: 10 })).toBe(0);
+  });
+});
+
+describe("twapSchedule", () => {
+  it("splits evenly and puts the remainder on the last slice", () => {
+    const s = twapSchedule({ totalQty: 10, slices: 4, durationMs: 3000, startMs: 0 });
+    expect(s.map((x) => x.qty)).toEqual([2, 2, 2, 4]);
+    expect(s.reduce((a, b) => a + b.qty, 0)).toBe(10);
+  });
+  it("evenly spaces the fire times from the start", () => {
+    const s = twapSchedule({ totalQty: 4, slices: 4, durationMs: 4000, startMs: 1000 });
+    expect(s.map((x) => x.atMs)).toEqual([1000, 2000, 3000, 4000]);
+  });
+  it("guards <1 slice to a single slice", () => {
+    const s = twapSchedule({ totalQty: 7, slices: 0, durationMs: 1000, startMs: 0 });
+    expect(s).toHaveLength(1);
+    expect(s[0]!.qty).toBe(7);
+  });
+  it("caps slices at total qty so no slice is empty", () => {
+    const s = twapSchedule({ totalQty: 3, slices: 10, durationMs: 1000, startMs: 0 });
+    expect(s).toHaveLength(3);
+    expect(s.every((x) => x.qty >= 1)).toBe(true);
+  });
+  it("returns [] for non-positive total or duration", () => {
+    expect(twapSchedule({ totalQty: 0, slices: 3, durationMs: 1000, startMs: 0 })).toEqual([]);
+    expect(twapSchedule({ totalQty: 10, slices: 3, durationMs: 0, startMs: 0 })).toEqual([]);
+  });
+});
+
+describe("icebergClips", () => {
+  it("breaks total into visible clips with a smaller last clip", () => {
+    const r = icebergClips({ totalQty: 10, visibleQty: 3 });
+    expect(r).toEqual({ clips: 4, clipQty: 3, lastClipQty: 1 });
+  });
+  it("even division gives a full last clip", () => {
+    const r = icebergClips({ totalQty: 9, visibleQty: 3 });
+    expect(r).toEqual({ clips: 3, clipQty: 3, lastClipQty: 3 });
+  });
+  it("visible >= total is one whole clip", () => {
+    expect(icebergClips({ totalQty: 5, visibleQty: 5 })).toEqual({ clips: 1, clipQty: 5, lastClipQty: 5 });
+    expect(icebergClips({ totalQty: 5, visibleQty: 20 })).toEqual({ clips: 1, clipQty: 5, lastClipQty: 5 });
+  });
+  it("returns zero-clip for non-positive inputs", () => {
+    expect(icebergClips({ totalQty: 0, visibleQty: 3 })).toEqual({ clips: 0, clipQty: 0, lastClipQty: 0 });
+    expect(icebergClips({ totalQty: 10, visibleQty: 0 })).toEqual({ clips: 0, clipQty: 0, lastClipQty: 0 });
+  });
+  it("clip quantities sum back to the total", () => {
+    const r = icebergClips({ totalQty: 17, visibleQty: 5 });
+    const sum = r.clipQty * (r.clips - 1) + r.lastClipQty;
+    expect(sum).toBe(17);
+  });
+});

--- a/frontend/src/lib/orderCalc.ts
+++ b/frontend/src/lib/orderCalc.ts
@@ -1,0 +1,201 @@
+// Pure, framework-free ORDER-ENTRY DEPTH math for the markets trade ticket:
+// risk-based position sizing, risk/reward, a rough (clearly-labelled) liquidation
+// preview, breakeven, and the client-side TWAP / Iceberg algo schedulers.
+//
+// Everything stays in the engine's int64 "tick" space (prices/qtys/money are
+// integer ticks; the UI scales for display via the markets format helpers). None
+// of these place orders — they only compute numbers/schedules the ticket then
+// drives through the SAME submit path. Kept pure so it is unit-testable in
+// isolation (see orderCalc.test.ts). Every function guards zero / negative /
+// degenerate inputs.
+
+export type Side = "buy" | "sell";
+
+/**
+ * Risk-based position size:
+ *   qty = (equity * riskPct/100) / |entry - stop|
+ * floored to a whole lot. `equityCents` is account equity in ticks, `riskPct` is
+ * the percent of equity to risk (clamped to [0, 100]). Guards divide-by-zero
+ * (equal entry/stop) and non-positive inputs by returning 0.
+ */
+export function positionSizeQty({
+  equityCents,
+  riskPct,
+  entryPrice,
+  stopPrice,
+}: {
+  equityCents: number;
+  riskPct: number;
+  entryPrice: number;
+  stopPrice: number;
+}): number {
+  if (!(equityCents > 0)) return 0;
+  const pct = Math.min(100, Math.max(0, riskPct));
+  if (!(pct > 0)) return 0;
+  const dist = Math.abs(entryPrice - stopPrice);
+  if (!(dist > 0)) return 0;
+  const riskBudget = (equityCents * pct) / 100;
+  const qty = Math.floor(riskBudget / dist);
+  return qty > 0 ? qty : 0;
+}
+
+/**
+ * Risk / reward for a bracket: risk is the loss to the stop, reward the gain to
+ * the target, both in ticks over `qty`; `rr` is reward/risk. For a BUY the stop
+ * sits below entry and the target above; for a SELL it is inverted. Returns zeros
+ * (and rr=0) for degenerate inputs.
+ */
+export function riskReward({
+  side,
+  entry,
+  stop,
+  target,
+  qty,
+}: {
+  side: Side;
+  entry: number;
+  stop: number;
+  target: number;
+  qty: number;
+}): { riskCents: number; rewardCents: number; rr: number } {
+  const zero = { riskCents: 0, rewardCents: 0, rr: 0 };
+  if (!(entry > 0) || !(qty > 0)) return zero;
+  const riskPerUnit = side === "buy" ? entry - stop : stop - entry;
+  const rewardPerUnit = side === "buy" ? target - entry : entry - target;
+  const riskCents = stop > 0 && riskPerUnit > 0 ? Math.round(riskPerUnit * qty) : 0;
+  const rewardCents = target > 0 && rewardPerUnit > 0 ? Math.round(rewardPerUnit * qty) : 0;
+  const rr = riskCents > 0 && rewardCents > 0 ? rewardCents / riskCents : 0;
+  return { riskCents, rewardCents, rr };
+}
+
+/**
+ * A ROUGH, clearly-labelled estimated liquidation price + margin required for a
+ * fresh isolated position at `leverage`. margin = notional / leverage; the
+ * liquidation offset is where equity erodes to the maintenance fraction:
+ *   long  liq = entry * (1 - 1/lev + m)
+ *   short liq = entry * (1 + 1/lev - m)   where m = maintenanceMarginBps/10000.
+ * Callers MUST surface liqPrice as "(est.)" — it is not authoritative. Returns
+ * null liqPrice / 0 margin for unusable inputs.
+ */
+export function liquidationPreview({
+  side,
+  entry,
+  qty,
+  leverage,
+  maintenanceMarginBps,
+}: {
+  side: Side;
+  entry: number;
+  qty: number;
+  leverage: number;
+  maintenanceMarginBps: number;
+}): { liqPrice: number | null; marginRequiredCents: number } {
+  if (!(entry > 0) || !(qty > 0) || !(leverage > 0)) {
+    return { liqPrice: null, marginRequiredCents: 0 };
+  }
+  const notional = entry * qty;
+  const marginRequiredCents = Math.ceil(notional / leverage);
+  const maintFrac = maintenanceMarginBps > 0 ? maintenanceMarginBps / 10000 : 0;
+  const invLev = 1 / leverage;
+  const px =
+    side === "buy"
+      ? entry * (1 - invLev + maintFrac)
+      : entry * (1 + invLev - maintFrac);
+  const liqPrice = Number.isFinite(px) && px > 0 ? px : null;
+  return { liqPrice, marginRequiredCents };
+}
+
+/**
+ * Breakeven price after round-trip fees at `feeBps` per side (entry + exit).
+ * A BUY must sell above cost, a SELL must buy back below cost:
+ *   buy  be = entry * (1 + 2*feeFrac)
+ *   sell be = entry * (1 - 2*feeFrac)
+ * Returns 0 for unusable inputs. Fees below 0 are treated as 0.
+ */
+export function breakevenPrice({
+  side,
+  entry,
+  feeBps,
+}: {
+  side: Side;
+  entry: number;
+  feeBps: number;
+}): number {
+  if (!(entry > 0)) return 0;
+  const feeFrac = feeBps > 0 ? feeBps / 10000 : 0;
+  const roundTrip = 2 * feeFrac;
+  const px = side === "buy" ? entry * (1 + roundTrip) : entry * (1 - roundTrip);
+  if (!Number.isFinite(px) || px <= 0) return 0;
+  return Math.round(px);
+}
+
+/** One scheduled TWAP child slice. */
+export interface TwapSlice {
+  seq: number;
+  qty: number;
+  atMs: number;
+}
+
+/**
+ * Even-split TWAP schedule: `totalQty` across `slices` child orders spread over
+ * `durationMs` starting at `startMs`. Base qty is floor(total/slices); any
+ * remainder is added to the LAST slice, so quantities always sum to the total.
+ * Slice `seq` s (0-based) fires at startMs + s * (durationMs / slices) — one at
+ * the start and the rest evenly through the window. Guards: <1 slice becomes 1;
+ * non-positive total/duration return []; slices is capped at totalQty so no slice
+ * ever gets 0 qty (min-1-qty-per-slice).
+ */
+export function twapSchedule({
+  totalQty,
+  slices,
+  durationMs,
+  startMs,
+}: {
+  totalQty: number;
+  slices: number;
+  durationMs: number;
+  startMs: number;
+}): TwapSlice[] {
+  const total = Math.floor(totalQty);
+  if (!(total > 0)) return [];
+  if (!(durationMs > 0)) return [];
+  let n = Math.max(1, Math.floor(slices));
+  // Never schedule a zero-qty slice — cap slice count at the total qty.
+  if (n > total) n = total;
+  const base = Math.floor(total / n);
+  const remainder = total - base * n;
+  const step = durationMs / n;
+  const out: TwapSlice[] = [];
+  for (let s = 0; s < n; s++) {
+    const qty = s === n - 1 ? base + remainder : base;
+    out.push({ seq: s, qty, atMs: Math.round(startMs + s * step) });
+  }
+  return out;
+}
+
+/**
+ * Iceberg clip breakdown: how many `visibleQty`-sized clips cover `totalQty`, and
+ * the (possibly smaller) size of the final clip. Guards: non-positive total or
+ * visible returns a single zero-clip descriptor. When visible >= total it is one
+ * clip of the whole size.
+ */
+export function icebergClips({
+  totalQty,
+  visibleQty,
+}: {
+  totalQty: number;
+  visibleQty: number;
+}): { clips: number; clipQty: number; lastClipQty: number } {
+  const total = Math.floor(totalQty);
+  const visible = Math.floor(visibleQty);
+  if (!(total > 0) || !(visible > 0)) {
+    return { clips: 0, clipQty: 0, lastClipQty: 0 };
+  }
+  if (visible >= total) {
+    return { clips: 1, clipQty: total, lastClipQty: total };
+  }
+  const clips = Math.ceil(total / visible);
+  const rem = total - visible * (clips - 1);
+  const lastClipQty = rem > 0 ? rem : visible;
+  return { clips, clipQty: visible, lastClipQty };
+}

--- a/frontend/src/pages/algos/ActiveAlgosPage.tsx
+++ b/frontend/src/pages/algos/ActiveAlgosPage.tsx
@@ -1,0 +1,245 @@
+// Active Algos monitor — a READ + CONTROL view of the client-side TWAP / Iceberg
+// algo orders persisted by algoStore. Per-algo it shows filled/total progress,
+// slices done, the next-slice countdown, and pause / resume / cancel controls.
+// Placement itself happens in the trade ticket's runner (which must be open for
+// that symbol) — this page just reflects and steers the persisted state. Algos
+// run ONLY while a tab is open; cancelling stops all further scheduling.
+import { useEffect, useMemo, useState } from "react";
+import { Timer, Layers, Pause, Play, X, Trash2, Info } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+import {
+  useAlgoOrders,
+  filledQty,
+  slicesDone,
+  progressFrac,
+  nextPending,
+  type AlgoOrder,
+} from "@/lib/algoStore";
+
+function statusTone(s: AlgoOrder["status"]): string {
+  switch (s) {
+    case "running":
+      return "bg-emerald-600/15 text-emerald-600 dark:text-emerald-400";
+    case "paused":
+      return "bg-amber-500/15 text-amber-600 dark:text-amber-400";
+    case "done":
+      return "bg-sky-500/15 text-sky-600 dark:text-sky-400";
+    default:
+      return "bg-muted text-muted-foreground";
+  }
+}
+
+function countdown(a: AlgoOrder, now: number): string {
+  if (a.status !== "running") return "—";
+  const child = nextPending(a);
+  if (!child) return "—";
+  if (a.kind === "twap" && child.atMs != null) {
+    const ms = child.atMs - now;
+    if (ms <= 0) return "due";
+    const s = Math.ceil(ms / 1000);
+    return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+  }
+  // Iceberg replenishes on fill, so "next" is on the prior clip filling.
+  const anyPlaced = a.children.some((c) => c.status === "placed");
+  return anyPlaced ? "on fill" : "next";
+}
+
+function AlgoCard({ a, now }: { a: AlgoOrder; now: number }) {
+  const { setStatus, remove } = useAlgoOrders();
+  const filled = filledQty(a);
+  const done = slicesDone(a);
+  const pct = Math.round(progressFrac(a) * 100);
+  const KindIcon = a.kind === "twap" ? Timer : Layers;
+  const terminal = a.status === "done" || a.status === "cancelled";
+
+  return (
+    <Card data-testid={`algo_card_${a.id}`}>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <KindIcon className="h-4 w-4" />
+            {a.kind === "twap" ? "TWAP" : "Iceberg"}
+            <span className={cn("uppercase", a.side === "buy" ? "text-emerald-600" : "text-rose-600")}>
+              {a.side}
+            </span>
+            <span className="text-sm font-normal text-muted-foreground">
+              {a.symbolLabel ?? `#${a.symbolId}`}
+            </span>
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            {a.paper && <Badge variant="outline">Paper</Badge>}
+            <Badge className={cn("capitalize", statusTone(a.status))}>{a.status}</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div>
+          <div className="mb-1 flex justify-between text-xs text-muted-foreground">
+            <span>
+              Filled {filled} / {a.totalQty} ({pct}%)
+            </span>
+            <span data-testid={`algo_slices_${a.id}`}>
+              {a.kind === "twap"
+                ? `slice ${done}/${a.children.length}`
+                : `clip ${done}/${a.children.length}`}
+            </span>
+          </div>
+          <Progress value={pct} data-testid={`algo_progress_${a.id}`} />
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Child type</span>
+            <span className="uppercase">{a.childType}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Next slice</span>
+            <span className="tabular-nums" data-testid={`algo_countdown_${a.id}`}>
+              {countdown(a, now)}
+            </span>
+          </div>
+          {a.kind === "twap" && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Slices</span>
+              <span>{a.slices}</span>
+            </div>
+          )}
+          {a.kind === "iceberg" && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Visible</span>
+              <span>{a.visibleQty}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          {a.status === "running" && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid={`algo_pause_${a.id}`}
+              onClick={() => setStatus(a.id, "paused")}
+            >
+              <Pause className="mr-1 h-3.5 w-3.5" /> Pause
+            </Button>
+          )}
+          {a.status === "paused" && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid={`algo_resume_${a.id}`}
+              onClick={() => setStatus(a.id, "running")}
+            >
+              <Play className="mr-1 h-3.5 w-3.5" /> Resume
+            </Button>
+          )}
+          {!terminal && (
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              data-testid={`algo_cancel_${a.id}`}
+              onClick={() => setStatus(a.id, "cancelled")}
+            >
+              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+            </Button>
+          )}
+          {terminal && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              data-testid={`algo_remove_${a.id}`}
+              onClick={() => remove(a.id)}
+            >
+              <Trash2 className="mr-1 h-3.5 w-3.5" /> Remove
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ActiveAlgosPage() {
+  const { algos, clearTerminal } = useAlgoOrders();
+  // Live "now" so countdowns tick.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const active = useMemo(
+    () => algos.filter((a) => a.status === "running" || a.status === "paused"),
+    [algos],
+  );
+  const terminal = useMemo(
+    () => algos.filter((a) => a.status === "done" || a.status === "cancelled"),
+    [algos],
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="flex items-center gap-2 text-xl font-semibold">
+          <Timer className="h-5 w-5" /> Active Algos
+        </h1>
+        {terminal.length > 0 && (
+          <Button type="button" variant="outline" size="sm" onClick={clearTerminal} data-testid="algo_clear_terminal">
+            Clear finished
+          </Button>
+        )}
+      </div>
+
+      <div
+        className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/[0.06] p-3 text-sm"
+        data-testid="algo_client_side_banner"
+      >
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <div>
+          <p className="font-medium text-amber-700 dark:text-amber-300">
+            Client-side algos run only while this tab is open.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Child orders are scheduled locally from the trade ticket — keep the ticket for the
+            algo&apos;s symbol open. Closing the tab pauses scheduling; cancelling stops it for good.
+          </p>
+        </div>
+      </div>
+
+      {algos.length === 0 ? (
+        <p className="py-10 text-center text-sm text-muted-foreground" data-testid="algo_empty">
+          No algo orders yet. Start a TWAP or Iceberg from a market&apos;s trade ticket (Algo mode).
+        </p>
+      ) : (
+        <>
+          {active.length > 0 && (
+            <div className="space-y-3">
+              {active.map((a) => (
+                <AlgoCard key={a.id} a={a} now={now} />
+              ))}
+            </div>
+          )}
+          {terminal.length > 0 && (
+            <>
+              <h2 className="pt-2 text-sm font-semibold text-muted-foreground">Finished</h2>
+              <div className="space-y-3 opacity-80">
+                {terminal.map((a) => (
+                  <AlgoCard key={a.id} a={a} now={now} />
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -48,6 +48,21 @@ import { toast } from "sonner";
 import { usePaperMode, selectMarketPrice, isPaperOrderType } from "@/lib/paperMode";
 import { placeOrder as placePaperOrder, type PaperAccount } from "@/lib/paperEngine";
 import { loadAccount as loadPaperAccount, saveAccount as savePaperAccount, PAPER_ACCOUNT_KEY } from "@/lib/paperStore";
+import {
+  positionSizeQty,
+  riskReward,
+  liquidationPreview,
+  breakevenPrice,
+  twapSchedule,
+  icebergClips,
+} from "@/lib/orderCalc";
+import {
+  useAlgoOrders,
+  nextAlgoId,
+  type AlgoOrder,
+  type AlgoChild,
+} from "@/lib/algoStore";
+import { useAlgoRunner } from "@/lib/algoRunner";
 
 type OrderType = "limit" | "market" | "stop" | "stop_limit" | "take_profit" | "quote" | "oto" | "oco" | "funding";
 type Section = "trade" | "positions" | "orders" | "fills";
@@ -393,6 +408,8 @@ export function TradeTicket({
   // paper engine instead of the live /me/orders mutations.
   const { enabled: paperMode, setEnabled: setPaperMode } = usePaperMode();
   const [paperAcct, setPaperAcct] = useState<PaperAccount>(() => loadPaperAccount());
+  const algoStore = useAlgoOrders();
+  const [, forceAlgoTick] = useState(0);
   // Re-read the paper account if another surface (Paper page / other tab) mutates it.
   useEffect(() => {
     const reload = (e?: StorageEvent) => {
@@ -441,6 +458,23 @@ export function TradeTicket({
   const [riskOpen, setRiskOpen] = useState(false);
   const [riskAmt, setRiskAmt] = useState("");
   const [riskStop, setRiskStop] = useState("");
+  // Calculators — extra depth inputs (R:R target, leverage, fee bps).
+  const [calcTarget, setCalcTarget] = useState("");
+  const [calcLeverage, setCalcLeverage] = useState("10");
+  const [calcFeeBps, setCalcFeeBps] = useState("10");
+  const [riskPct, setRiskPct] = useState("1");
+  // Bracket helper — optional attached take-profit + stop-loss on an entry.
+  const [bracketOn, setBracketOn] = useState(false);
+  const [bracketTp, setBracketTp] = useState("");
+  const [bracketSl, setBracketSl] = useState("");
+  // Algo mode — client-side TWAP / Iceberg.
+  const [algoMode, setAlgoMode] = useState(false);
+  const [algoKind, setAlgoKind] = useState<"twap" | "iceberg">("twap");
+  const [algoQty, setAlgoQty] = useState("");
+  const [algoSlices, setAlgoSlices] = useState("5");
+  const [algoDurationSec, setAlgoDurationSec] = useState("60");
+  const [algoVisible, setAlgoVisible] = useState("");
+  const [algoChildType, setAlgoChildType] = useState<"market" | "limit">("market");
 
   const seq = useRef(0);
   const nextClordid = () => `t${Date.now()}${seq.current++ % 100}`;
@@ -588,6 +622,67 @@ export function TradeTicket({
     vibrate("tick");
     resetArmed();
   };
+
+  // ── Order-entry DEPTH calculators (all pure, via orderCalc). ──────────
+  const riskPctN = parseInt(riskPct) || 0;
+  const calcTargetN = parseInt(calcTarget) || 0;
+  const calcLeverageN = parseInt(calcLeverage) || 0;
+  const calcFeeBpsN = parseInt(calcFeeBps) || 0;
+  // Risk% sizing keys off the account equity (paper cash in paper mode).
+  const equityForSizing = avail;
+  const riskPctSuggestedQty = positionSizeQty({
+    equityCents: equityForSizing,
+    riskPct: riskPctN,
+    entryPrice: riskEntry,
+    stopPrice: riskStopN,
+  });
+  const rr = riskReward({
+    side,
+    entry: riskEntry,
+    stop: riskStopN,
+    target: calcTargetN,
+    qty: qtyN || suggestedQty || riskPctSuggestedQty,
+  });
+  const liqPrev = liquidationPreview({
+    side,
+    entry: previewPrice,
+    qty: qtyN,
+    leverage: calcLeverageN,
+    maintenanceMarginBps: ASSUMED_MAINT_MARGIN_BPS,
+  });
+  const breakeven = breakevenPrice({ side, entry: previewPrice, feeBps: calcFeeBpsN });
+  const applyRiskPctQty = () => {
+    if (riskPctSuggestedQty <= 0) return;
+    setQty(String(riskPctSuggestedQty));
+    vibrate("tick");
+    resetArmed();
+  };
+
+  // ── Bracket helper: attached TP + SL exits on the entry. ──────────────
+  const bracketTpN = parseInt(bracketTp) || 0;
+  const bracketSlN = parseInt(bracketSl) || 0;
+  // Bracket only makes sense on a plain entry (limit / market) with a qty.
+  const bracketEligible = orderType === "limit" || orderType === "market";
+  const bracketReady = bracketOn && bracketEligible && qtyN > 0 && (bracketTpN > 0 || bracketSlN > 0);
+
+  // ── Algo mode derived preview. ───────────────────────────────────────
+  const algoQtyN = parseInt(algoQty) || 0;
+  const algoSlicesN = parseInt(algoSlices) || 0;
+  const algoDurationSecN = parseInt(algoDurationSec) || 0;
+  const algoVisibleN = parseInt(algoVisible) || 0;
+  const twapPreview = twapSchedule({
+    totalQty: algoQtyN,
+    slices: algoSlicesN,
+    durationMs: algoDurationSecN * 1000,
+    startMs: 0,
+  });
+  const icebergPreview = icebergClips({ totalQty: algoQtyN, visibleQty: algoVisibleN });
+  const algoStartReady =
+    algoQtyN > 0 &&
+    (algoChildType === "market" || priceN > 0) &&
+    (algoKind === "twap"
+      ? twapPreview.length > 0 && algoDurationSecN > 0
+      : icebergPreview.clips > 0);
 
   // One-click bid/ask/market prefill — sets side + price only; the user still
   // confirms and submits through the existing money-safety path.
@@ -798,11 +893,16 @@ export function TradeTicket({
             ? (Date.now() + parseInt(expiryMin) * 60000) * 1_000_000
             : undefined,
       };
+      const entryQty = qtyN;
+      const entrySide = side;
+      const attachBracket = bracketReady;
       void handleAck(placeM.mutateAsync(body), {
         workingSide: side,
         workingPrice: priceN,
         workingQty: isMarket ? 0 : qtyN,
         okMsg: (a) => `Placed #${a.orderid ?? "?"}`,
+      }).then(() => {
+        if (attachBracket) placeBracketExits(entrySide, entryQty);
       });
     } else if (orderType === "stop" || orderType === "stop_limit" || orderType === "take_profit") {
       const algoType = orderType === "stop" ? "stop_market" : orderType === "stop_limit" ? "stop_limit" : "take_profit";
@@ -887,6 +987,54 @@ export function TradeTicket({
     );
   }
 
+  // Bracket: place the linked TP + SL exit legs after the entry submits. TP is a
+  // take-profit exit and SL a stop-market exit, both on the OPPOSITE side of the
+  // entry (a long brackets with sell exits). Reuses the existing algo order types;
+  // if a leg is rejected the user gets a clear, non-fatal message.
+  function placeBracketExits(entrySide: OrderSide, entryQty: number) {
+    if (entryQty <= 0) return;
+    const exitSide: OrderSide = entrySide === "buy" ? "sell" : "buy";
+    const legs: Promise<AnyAck>[] = [];
+    if (bracketTpN > 0) {
+      legs.push(
+        algoM.mutateAsync({
+          algo_type: "take_profit",
+          symbolid: symbolId,
+          side: exitSide,
+          qty: entryQty,
+          stop_price: bracketTpN,
+        }) as Promise<AnyAck>,
+      );
+    }
+    if (bracketSlN > 0) {
+      legs.push(
+        algoM.mutateAsync({
+          algo_type: "stop_market",
+          symbolid: symbolId,
+          side: exitSide,
+          qty: entryQty,
+          stop_price: bracketSlN,
+        }) as Promise<AnyAck>,
+      );
+    }
+    if (legs.length === 0) return;
+    Promise.allSettled(legs).then((results) => {
+      const ok = results.filter((r) => r.status === "fulfilled" && isAck(r.value as AnyAck)).length;
+      const rejected = results.length - ok;
+      if (rejected > 0) {
+        setMsg({
+          text: `Entry placed; ${ok}/${results.length} bracket exit(s) attached — ${rejected} rejected by the venue`,
+          error: true,
+        });
+        toast.error("Some bracket legs were rejected");
+      } else {
+        setMsg({ text: `Bracket attached: ${ok} exit leg(s) armed`, error: false });
+        toast.success("Bracket exits attached");
+      }
+      account.refetch();
+    });
+  }
+
   const cancelOne = (clo: string) => {
     // Paper resting orders are local-only — never hit the real cancel endpoint.
     if (paperMode) {
@@ -967,6 +1115,103 @@ export function TradeTicket({
         return "Submit";
     }
   }, [armed, side, qty, orderType, isBorrow, paperMode]);
+
+  // ── ALGO ORDERS: client-side runner wiring. ──────────────────────────
+  // The runner places child orders for RUNNING algos on THIS symbol via the
+  // same primitives the ticket uses. Live children go through placeM; paper
+  // children route to the shared paper engine. Runs only while mounted.
+  const placeLiveChild = async (args: {
+    side: OrderSide;
+    type: "market" | "limit";
+    price?: number;
+    qty: number;
+  }): Promise<{ filled: boolean; fillPrice?: number }> => {
+    const isMarket = args.type === "market";
+    const a = await placeM.mutateAsync({
+      symbolid: symbolId,
+      side: args.side,
+      price: isMarket ? 0 : args.price ?? 0,
+      qty: args.qty,
+      clordid: nextClordid(),
+      market: isMarket || undefined,
+    });
+    if (isAck(a)) {
+      const fl = a.fills ?? [];
+      if (fl.length) {
+        const filledQ = fl.reduce((sum, x) => sum + (x.qty ?? 0), 0);
+        const fillPrice = fl[0]?.price;
+        if (filledQ >= args.qty) return { filled: true, fillPrice };
+      }
+      // Placed but not (fully) filled — for a market child treat as filled, for a
+      // limit child leave resting (advance on the next ack cycle).
+      return { filled: isMarket, fillPrice: undefined };
+    }
+    throw new Error(ackMessage(a) ?? "child rejected");
+  };
+
+  useAlgoRunner({
+    symbolId,
+    quotes: { bestBid, bestAsk, lastPrice },
+    placeLiveChild,
+    paperAccount: paperAcct,
+    commitPaper: (acctNext) => {
+      setPaperAcct(acctNext);
+      savePaperAccount(acctNext);
+    },
+    onProgress: () => forceAlgoTick((n) => n + 1),
+  });
+
+  // Build + persist a new algo, then it starts running immediately (status
+  // "running" is picked up by the runner on its next tick).
+  function startAlgo() {
+    if (!algoStartReady) return;
+    const now = Date.now();
+    const isTwap = algoKind === "twap";
+    let children: AlgoChild[];
+    if (isTwap) {
+      children = twapPreview.map((sl) => ({
+        seq: sl.seq,
+        qty: sl.qty,
+        atMs: now + sl.atMs,
+        status: "pending" as const,
+      }));
+    } else {
+      const ic = icebergClips({ totalQty: algoQtyN, visibleQty: algoVisibleN });
+      children = [];
+      for (let i = 0; i < ic.clips; i++) {
+        children.push({
+          seq: i,
+          qty: i === ic.clips - 1 ? ic.lastClipQty : ic.clipQty,
+          status: "pending" as const,
+        });
+      }
+    }
+    const order: AlgoOrder = {
+      id: nextAlgoId(),
+      kind: algoKind,
+      symbolId,
+      symbolLabel: `#${symbolId}`,
+      side,
+      childType: algoChildType,
+      limitPrice: algoChildType === "limit" ? priceN : undefined,
+      totalQty: algoQtyN,
+      slices: isTwap ? twapPreview.length : undefined,
+      durationMs: isTwap ? algoDurationSecN * 1000 : undefined,
+      visibleQty: isTwap ? undefined : algoVisibleN,
+      paper: paperMode,
+      status: "running",
+      children,
+      createdAt: now,
+      updatedAt: now,
+    };
+    algoStore.add(order);
+    vibrate("success");
+    toast.success(`${isTwap ? "TWAP" : "Iceberg"} started — ${children.length} ${isTwap ? "slices" : "clips"}`);
+    setMsg({
+      text: `${isTwap ? "TWAP" : "Iceberg"} ${side} ${algoQtyN} started (${children.length} children)`,
+      error: false,
+    });
+  }
 
   const sections: { id: Section; label: string; count?: number }[] = [
     { id: "trade", label: "Trade" },
@@ -1199,6 +1444,79 @@ export function TradeTicket({
               </p>
             )}
 
+            {/* ── ALGO MODE (client-side TWAP / Iceberg) ─────────────── */}
+            {!isPm && (
+              <div className="rounded-lg border p-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold">Algo order</p>
+                    <p className="text-[11px] text-muted-foreground">Client-side TWAP / Iceberg</p>
+                  </div>
+                  <Switch checked={algoMode} onCheckedChange={setAlgoMode} data-testid="algo_mode_toggle" />
+                </div>
+                {algoMode && (
+                  <div className="mt-3 space-y-3">
+                    <div className="flex gap-1.5">
+                      <Pill active={algoKind === "twap"} onClick={() => setAlgoKind("twap")} tag="algo_kind_twap">
+                        TWAP
+                      </Pill>
+                      <Pill active={algoKind === "iceberg"} onClick={() => setAlgoKind("iceberg")} tag="algo_kind_iceberg">
+                        Iceberg
+                      </Pill>
+                    </div>
+                    <div className="flex gap-1.5">
+                      <Pill active={algoChildType === "market"} onClick={() => setAlgoChildType("market")} tag="algo_child_market">
+                        Market children
+                      </Pill>
+                      <Pill active={algoChildType === "limit"} onClick={() => setAlgoChildType("limit")} tag="algo_child_limit">
+                        Limit children
+                      </Pill>
+                    </div>
+                    {algoChildType === "limit" && (
+                      <Field label="Child limit price" value={price} onChange={setPrice} dataField="price" />
+                    )}
+                    <Field label="Total quantity" value={algoQty} onChange={setAlgoQty} />
+                    {algoKind === "twap" ? (
+                      <div className="grid grid-cols-2 gap-2">
+                        <Field label="# slices" value={algoSlices} onChange={setAlgoSlices} />
+                        <Field label="Duration (sec)" value={algoDurationSec} onChange={setAlgoDurationSec} />
+                      </div>
+                    ) : (
+                      <Field label="Visible clip size" value={algoVisible} onChange={setAlgoVisible} />
+                    )}
+                    <div className="rounded-md border bg-muted/20 p-2 text-xs" data-testid="algo_preview">
+                      {algoKind === "twap" ? (
+                        <span>
+                          {twapPreview.length > 0
+                            ? `${twapPreview.length} slice(s) · ~${formatQty(twapPreview[0]!.qty, scaler)}/slice over ${algoDurationSecN}s`
+                            : "Enter qty, slices & duration"}
+                        </span>
+                      ) : (
+                        <span>
+                          {icebergPreview.clips > 0
+                            ? `${icebergPreview.clips} clip(s) · ${formatQty(icebergPreview.clipQty, scaler)} visible, last ${formatQty(icebergPreview.lastClipQty, scaler)}`
+                            : "Enter total & visible size"}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-amber-600 dark:text-amber-400">
+                      Client-side algos run only while this tab is open.
+                      {paperMode ? " Children route to your paper account." : ""}
+                    </p>
+                    <Button
+                      type="button"
+                      className={cn("w-full", side === "buy" ? "bg-emerald-600 hover:bg-emerald-600/90" : "bg-rose-600 hover:bg-rose-600/90")}
+                      disabled={!algoStartReady}
+                      onClick={startAlgo}
+                      data-testid="algo_start"
+                    >
+                      Start {algoKind === "twap" ? "TWAP" : "Iceberg"} ({side === "buy" ? "Buy" : "Sell"})
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* One-click bid/ask + market quick-actions (prefill only — the
                 user still confirms/submits via the existing path). */}
             {!isPm && orderType !== "quote" && orderType !== "funding" && (bestBid || bestAsk) && (
@@ -1385,6 +1703,31 @@ export function TradeTicket({
               </div>
             )}
 
+            {/* ── BRACKET HELPER: attached TP + SL on the entry ──────── */}
+            {!isPm && bracketEligible && !algoMode && (
+              <div className="rounded-lg border p-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold">Bracket exits</p>
+                    <p className="text-[11px] text-muted-foreground">
+                      Attach take-profit + stop-loss on this {side === "buy" ? "long" : "short"} entry
+                    </p>
+                  </div>
+                  <Switch checked={bracketOn} onCheckedChange={setBracketOn} data-testid="bracket_toggle" />
+                </div>
+                {bracketOn && (
+                  <div className="mt-3 grid grid-cols-2 gap-2">
+                    <Field label="Take-profit price" value={bracketTp} onChange={setBracketTp} />
+                    <Field label="Stop-loss price" value={bracketSl} onChange={setBracketSl} />
+                    <p className="col-span-2 text-[11px] text-muted-foreground" data-testid="bracket_note">
+                      Exits are placed as {side === "buy" ? "Sell" : "Buy"} take-profit / stop after the entry submits.
+                      {bracketReady ? "" : " Enter a qty and at least one exit price."}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* TIF (limit only) */}
             {orderType === "limit" && (
               <div>
@@ -1517,7 +1860,7 @@ export function TradeTicket({
                   className="flex w-full items-center justify-between text-xs font-semibold text-primary"
                   onClick={() => setRiskOpen((v) => !v)}
                 >
-                  <span>Position-size calculator</span>
+                  <span>Calculators</span>
                   <span aria-hidden>{riskOpen ? "▲" : "▼"}</span>
                 </button>
                 {riskOpen && (
@@ -1545,6 +1888,79 @@ export function TradeTicket({
                     >
                       Apply qty
                     </Button>
+                    {/* Risk% sizing — size off a % of account equity. */}
+                    <div className="rounded-md border bg-muted/20 p-2">
+                      <div className="grid grid-cols-2 gap-2">
+                        <Field label="Risk % of equity" value={riskPct} onChange={setRiskPct} />
+                        <div className="flex flex-col justify-end pb-1 text-xs">
+                          <span className="text-muted-foreground">Suggested qty</span>
+                          <span className="font-semibold tabular-nums" data-testid="riskpct_suggested_qty">
+                            {riskPctSuggestedQty > 0 ? formatQty(riskPctSuggestedQty, scaler) : "—"}
+                          </span>
+                        </div>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="mt-2 w-full"
+                        data-testid="riskpct_apply"
+                        disabled={riskPctSuggestedQty <= 0}
+                        onClick={applyRiskPctQty}
+                      >
+                        Apply risk% qty
+                      </Button>
+                    </div>
+                    {/* Risk : Reward readout. */}
+                    <div className="rounded-md border bg-muted/20 p-2 text-xs">
+                      <Field label="Target price" value={calcTarget} onChange={setCalcTarget} />
+                      <div className="mt-2 grid grid-cols-3 gap-1 tabular-nums">
+                        <div>
+                          <div className="text-muted-foreground">Risk</div>
+                          <div data-testid="rr_risk">{rr.riskCents > 0 ? formatPrice(rr.riskCents, scaler) : "—"}</div>
+                        </div>
+                        <div>
+                          <div className="text-muted-foreground">Reward</div>
+                          <div data-testid="rr_reward">{rr.rewardCents > 0 ? formatPrice(rr.rewardCents, scaler) : "—"}</div>
+                        </div>
+                        <div>
+                          <div className="text-muted-foreground">R:R</div>
+                          <div data-testid="rr_ratio" className={rr.rr >= 1 ? "text-emerald-600 dark:text-emerald-400" : ""}>
+                            {rr.rr > 0 ? `${rr.rr.toFixed(2)}:1` : "—"}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    {/* Est. liq (leverage) + breakeven. */}
+                    <div className="rounded-md border bg-muted/20 p-2 text-xs">
+                      <div className="grid grid-cols-2 gap-2">
+                        <Field label="Leverage (x)" value={calcLeverage} onChange={setCalcLeverage} />
+                        <Field label="Fee (bps/side)" value={calcFeeBps} onChange={setCalcFeeBps} />
+                      </div>
+                      <div className="mt-2 space-y-0.5">
+                        <div className="flex justify-between">
+                          <span className="text-muted-foreground">Margin required</span>
+                          <span className="tabular-nums" data-testid="calc_margin_req">
+                            {liqPrev.marginRequiredCents > 0 ? `~${formatPrice(liqPrev.marginRequiredCents, scaler)}` : "—"}
+                          </span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-muted-foreground">Est. liq. price</span>
+                          <span className="tabular-nums" data-testid="calc_liq_price">
+                            {liqPrev.liqPrice != null ? `~${formatPrice(Math.round(liqPrev.liqPrice), scaler)} (est.)` : "—"}
+                          </span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-muted-foreground">Breakeven (fees)</span>
+                          <span className="tabular-nums" data-testid="calc_breakeven">
+                            {breakeven > 0 ? formatPrice(breakeven, scaler) : "—"}
+                          </span>
+                        </div>
+                      </div>
+                      <p className="mt-1 text-[10px] text-muted-foreground">
+                        Liquidation is a rough estimate under an assumed maintenance margin — not the venue's authoritative figure.
+                      </p>
+                    </div>
                     <div>
                       <label className="text-xs text-muted-foreground">% of buying power</label>
                       <div className="mt-1 flex gap-1.5">


### PR DESCRIPTION
## Order-ticket depth — calculators, bracket helper, client-side algos

Deepens the trade ticket with pro order-entry tooling. Calculators are pure/client-side (**work now**); the bracket + algos route through the existing order path and honor paper-mode. Client-side algos run only while the app/tab is open (banner + no orphaned timers).

**Pure order math (tick-safe):** position sizing (risk% of equity + stop), risk/reward, est. liquidation price + margin required, breakeven (fees), TWAP slice schedule, iceberg clip plan.

- **Calculators panel** — risk% sizer (one-tap apply) + R:R + est. liq/margin + breakeven (reuses the existing `(est.)` preview).
- **Bracket helper** — entry + attached take-profit + stop-loss via existing take_profit/stop/oco types; degrades clearly if a leg is rejected (server-side only; not placed in paper mode).
- **Algo mode** — TWAP (qty/slices/duration) + Iceberg (qty/visible/replenish); children placed via the same submit path (paper-mode → paper engine); a persisted store + an **Active-Algos monitor** (progress, next-slice countdown, pause/resume/cancel).

### Web (new `/algos` "Active Algos")
`lib/orderCalc.ts` (+28 vitest) + `algoStore.ts` + `algoRunner.ts` + `pages/algos/ActiveAlgosPage`; `TradeTicket.tsx` extended.

### Android (new Active-Algos screen, registered in `MoreRoutes`)
`OrderCalc.kt` (+27 JVM tests) + `AlgoModels`/`AlgoOrderStore` (DataStore)/`AlgoManager` (@Singleton scheduler; heals RUNNING→PAUSED on cold start)/`AlgoModule` + `ActiveAlgos` Screen/ViewModel; `TradeTicket`/`TradingViewModel`/`UiState` extended.

No new deps; existing order types + OFF paths unchanged. Gates: web tsc 0 · vite build · vitest 28/28; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (OrderCalc 27/27, MoreCatalog 6/6, full suite 5086/0-fail).

**Honest constraint:** client-side algos place children while a ticket for that symbol is open (the monitor always steers state); full unattended execution needs a backend algo engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
