### PR TITLE
feat(home): surface trading/investing hub on the dashboard + mobile nav (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -26,6 +29,16 @@ import androidx.compose.material.icons.outlined.MovieCreation
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Storefront
 import androidx.compose.material.icons.outlined.TrendingUp
+import androidx.compose.material.icons.outlined.ShowChart
+import androidx.compose.material.icons.outlined.CandlestickChart
+import androidx.compose.material.icons.outlined.Insights
+import androidx.compose.material.icons.outlined.Assessment
+import androidx.compose.material.icons.outlined.PieChart
+import androidx.compose.material.icons.outlined.Gavel
+import androidx.compose.material.icons.outlined.Savings
+import androidx.compose.material.icons.outlined.ReceiptLong
+import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.Paid
 import androidx.compose.material.icons.outlined.Videocam
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -66,6 +79,7 @@ import com.testlogon.android.feature.more.MoreHub
 import com.testlogon.android.feature.more.accent
 import com.testlogon.android.navigation.BroadcastBrowseDest
 import com.testlogon.android.navigation.ComposePostDest
+import com.testlogon.android.navigation.MoreRoutes
 
 /**
  * AND-066 — route-level Dashboard entry wired into the Home tab. Collects state lifecycle-aware,
@@ -214,6 +228,9 @@ private fun DashboardLaunchpad(
         }
 
         item { ShortcutsSection(onOpenHub = onOpenHub, onOpenMore = onOpenMore) }
+
+        // Trading & Investing quick-access: links to already-shipped invest/markets surfaces.
+        item { TradingSection(onOpenRoute = onOpenRoute) }
 
         // Activity / content: real widgets when present, else a slim inline note.
         if (data != null && !data.isEmpty) {
@@ -430,6 +447,139 @@ private fun ShortcutsSection(
             },
             right = { Box(modifier = Modifier.weight(1f)) {} },
         )
+    }
+}
+
+@Composable
+private fun TradingSection(
+    onOpenRoute: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = stringResource(R.string.dashboard_trading_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.semantics { heading() },
+        )
+        val scheme = MaterialTheme.colorScheme
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .testTag(DashboardTestTags.TRADING_SECTION),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            TradingCard(
+                icon = Icons.Outlined.TrendingUp,
+                label = stringResource(R.string.dashboard_trading_invest),
+                testTag = DashboardTestTags.TRADING_INVEST,
+                circleColor = scheme.primaryContainer,
+                iconTint = scheme.onPrimaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.INVEST) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.CandlestickChart,
+                label = stringResource(R.string.dashboard_trading_markets),
+                testTag = DashboardTestTags.TRADING_MARKETS,
+                circleColor = scheme.tertiaryContainer,
+                iconTint = scheme.onTertiaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.MARKETS) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.Insights,
+                label = stringResource(R.string.dashboard_trading_strategies),
+                testTag = DashboardTestTags.TRADING_STRATEGIES,
+                circleColor = scheme.secondaryContainer,
+                iconTint = scheme.onSecondaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.STRATEGIES) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.PieChart,
+                label = stringResource(R.string.dashboard_trading_portfolio_analytics),
+                testTag = DashboardTestTags.TRADING_PORTFOLIO_ANALYTICS,
+                circleColor = scheme.primaryContainer,
+                iconTint = scheme.onPrimaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.PORTFOLIO_ANALYTICS) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.Assessment,
+                label = stringResource(R.string.dashboard_trading_activity_center),
+                testTag = DashboardTestTags.TRADING_ACTIVITY_CENTER,
+                circleColor = scheme.tertiaryContainer,
+                iconTint = scheme.onTertiaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.ACTIVITY_CENTER) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.ShowChart,
+                label = stringResource(R.string.dashboard_trading_active_algos),
+                testTag = DashboardTestTags.TRADING_ACTIVE_ALGOS,
+                circleColor = scheme.secondaryContainer,
+                iconTint = scheme.onSecondaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.ACTIVE_ALGOS) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.Paid,
+                label = stringResource(R.string.dashboard_trading_tokens),
+                testTag = DashboardTestTags.TRADING_TOKENS,
+                circleColor = scheme.primaryContainer,
+                iconTint = scheme.onPrimaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.TOKENS) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.Gavel,
+                label = stringResource(R.string.dashboard_trading_bailouts),
+                testTag = DashboardTestTags.TRADING_BAILOUTS,
+                circleColor = scheme.tertiaryContainer,
+                iconTint = scheme.onTertiaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.BAILOUTS) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.AccountBalance,
+                label = stringResource(R.string.dashboard_trading_custody_providers),
+                testTag = DashboardTestTags.TRADING_CUSTODY_PROVIDERS,
+                circleColor = scheme.secondaryContainer,
+                iconTint = scheme.onSecondaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.CUSTODY_PROVIDERS) },
+            )
+            TradingCard(
+                icon = Icons.Outlined.ReceiptLong,
+                label = stringResource(R.string.dashboard_trading_tax_gains),
+                testTag = DashboardTestTags.TRADING_TAX_GAINS,
+                circleColor = scheme.primaryContainer,
+                iconTint = scheme.onPrimaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.TAX_REPORT) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TradingCard(
+    icon: ImageVector,
+    label: String,
+    testTag: String,
+    circleColor: Color,
+    iconTint: Color,
+    onClick: () -> Unit,
+) {
+    Card(onClick = onClick, modifier = Modifier.width(104.dp).testTag(testTag)) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier.size(40.dp).clip(CircleShape).background(circleColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(icon, contentDescription = null, tint = iconTint, modifier = Modifier.size(22.dp))
+            }
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardTestTags.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardTestTags.kt
@@ -28,4 +28,17 @@ object DashboardTestTags {
     const val HUB_COMMUNITY = "dashboard_hub_community"
     const val HUB_SHOP = "dashboard_hub_shop"
     const val HUB_ALL = "dashboard_hub_all"
+
+    // Trading & Investing quick-access section.
+    const val TRADING_SECTION = "dashboard_trading_section"
+    const val TRADING_INVEST = "dashboard_trading_invest"
+    const val TRADING_MARKETS = "dashboard_trading_markets"
+    const val TRADING_STRATEGIES = "dashboard_trading_strategies"
+    const val TRADING_PORTFOLIO_ANALYTICS = "dashboard_trading_portfolio_analytics"
+    const val TRADING_ACTIVITY_CENTER = "dashboard_trading_activity_center"
+    const val TRADING_ACTIVE_ALGOS = "dashboard_trading_active_algos"
+    const val TRADING_TOKENS = "dashboard_trading_tokens"
+    const val TRADING_BAILOUTS = "dashboard_trading_bailouts"
+    const val TRADING_CUSTODY_PROVIDERS = "dashboard_trading_custody_providers"
+    const val TRADING_TAX_GAINS = "dashboard_trading_tax_gains"
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -45,6 +45,19 @@
     <string name="dashboard_activity_placeholder_title">No activity yet</string>
     <string name="dashboard_activity_placeholder_body">Your activity will show up here.</string>
 
+    <!-- Trading & Investing section on the Home launchpad -->
+    <string name="dashboard_trading_title">Trading &amp; Investing</string>
+    <string name="dashboard_trading_invest">Invest</string>
+    <string name="dashboard_trading_markets">Markets</string>
+    <string name="dashboard_trading_strategies">Strategy funds</string>
+    <string name="dashboard_trading_portfolio_analytics">Portfolio analytics</string>
+    <string name="dashboard_trading_activity_center">Activity center</string>
+    <string name="dashboard_trading_active_algos">Active algos</string>
+    <string name="dashboard_trading_tokens">Creator tokens</string>
+    <string name="dashboard_trading_bailouts">Bailouts</string>
+    <string name="dashboard_trading_custody_providers">Custody providers</string>
+    <string name="dashboard_trading_tax_gains">Tax &amp; gains</string>
+
     <!-- "More" hub (AND-067) -->
     <string name="more_title">More</string>
     <string name="more_empty">Nothing here yet</string>

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -46,6 +46,14 @@ import {
   UserCog,
   Bot,
   LayoutGrid,
+  Sparkles,
+  CandlestickChart,
+  Boxes,
+  ShieldAlert,
+  Timer,
+  Landmark,
+  Building2,
+  Receipt,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -68,9 +76,21 @@ const PRIMARY_TABS = [
   { label: "Messages", i18nKey: "nav.messages", path: "/messages", icon: MessageSquare },
   { label: "Files", i18nKey: "nav.files", path: "/files", icon: FolderOpen },
   { label: "Shop", i18nKey: "nav.shop", path: "/shop", icon: Store },
+  { label: "Invest", i18nKey: "nav.invest", path: "/invest", icon: Sparkles },
 ];
 
 const MORE_LINKS = [
+  // ── Trading & Investing (surfaced prominently) ──
+  { label: "Invest", i18nKey: "nav.invest", path: "/invest", icon: Sparkles },
+  { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: CandlestickChart },
+  { label: "Strategy Funds", i18nKey: "nav.strategies", path: "/strategies", icon: Boxes },
+  { label: "Portfolio Risk", i18nKey: "nav.portfolioRisk", path: "/portfolio/analytics", icon: ShieldAlert },
+  { label: "Activity Center", i18nKey: "nav.activityCenter", path: "/activity-center", icon: Bell },
+  { label: "Active Algos", i18nKey: "nav.activeAlgos", path: "/algos", icon: Timer },
+  { label: "Creator Tokens", i18nKey: "nav.creatorTokens", path: "/tokens", icon: Landmark },
+  { label: "Bailouts", i18nKey: "nav.bailouts", path: "/bailouts", icon: LifeBuoy },
+  { label: "Custody Providers", i18nKey: "nav.custodyProviders", path: "/custody/providers", icon: Building2 },
+  { label: "Tax & Gains", i18nKey: "nav.taxGains", path: "/reports/tax", icon: Receipt },
   { label: "Call History", i18nKey: "nav.callHistory", path: "/calls/history", icon: Phone },
   { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: Rss },
   { label: "Discover", i18nKey: "nav.discover", path: "/discover", icon: Compass },

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   ArrowUpRight,
   Bell,
+  Sparkles,
   CandlestickChart,
   CheckCircle2,
   Circle,
@@ -36,6 +37,15 @@ import { getBalance } from "@/api/endpoints/custody";
 import { getFillsFees, type FillFee } from "@/api/endpoints/trading";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
 import { loadDefaultSymbol } from "@/lib/tradingPrefs";
+import { useActivityUnread } from "@/hooks/useActivity";
+import { useAlgoOrders } from "@/lib/algoStore";
+import { useStrategyMarket } from "@/hooks/useStrategies";
+import {
+  TRADING_SURFACES,
+  formatUnreadBadge,
+  pickTopStrategy,
+  formatReturnBps,
+} from "@/pages/home/tradingSurfaces";
 import { formatPrice, formatQty } from "@/pages/markets/format";
 
 // local helpers
@@ -600,6 +610,148 @@ function OnboardingCard() {
   );
 }
 
+
+// 6. Trading & Investing surfaces
+
+function SnapshotTile({
+  label,
+  value,
+  hint,
+  to,
+}: {
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+  to: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className="flex flex-col gap-0.5 rounded-lg border border-border bg-muted/30 px-3 py-2 hover:border-primary/40 hover:bg-muted/60"
+    >
+      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className="num text-lg font-bold tabular-nums leading-tight">{value}</span>
+      {hint && <span className="truncate text-[11px] text-muted-foreground">{hint}</span>}
+    </Link>
+  );
+}
+
+function TradingInvestingCard() {
+  // Live snapshots — all reuse existing hooks and degrade to "—" on 404 / empty.
+  const marginQ = useMarginAccount();
+  const spotQ = useSpotBalance();
+  const custodyQ = useQuery({
+    queryKey: ["home", "custody", "balance"],
+    queryFn: getBalance,
+    retry: false,
+    refetchInterval: 30_000,
+  });
+  const unread = useActivityUnread();
+  const { algos } = useAlgoOrders();
+  const strategyMarketQ = useStrategyMarket();
+
+  const equity = useMemo(() => {
+    let sum = 0;
+    let anySource = false;
+    if (marginQ.isSuccess) {
+      sum += num(marginQ.data?.balance);
+      anySource = true;
+    }
+    if (spotQ.isSuccess) {
+      sum += (spotQ.data?.balances ?? []).reduce((a, b) => a + num(b.balance), 0);
+      anySource = true;
+    }
+    if (custodyQ.isSuccess) {
+      for (const v of Object.values(custodyQ.data?.balances ?? {})) sum += num(v as number | string);
+      anySource = true;
+    }
+    return anySource
+      ? sum.toLocaleString(undefined, { maximumFractionDigits: 2 })
+      : "—";
+  }, [marginQ.isSuccess, spotQ.isSuccess, custodyQ.isSuccess, marginQ.data, spotQ.data, custodyQ.data]);
+
+  const runningAlgos = useMemo(
+    () => algos.filter((a) => a.status === "running").length,
+    [algos],
+  );
+
+  const unreadBadge = formatUnreadBadge(unread);
+  const topStrategy = useMemo(
+    () => pickTopStrategy(strategyMarketQ.data?.strategies),
+    [strategyMarketQ.data],
+  );
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm">Trading & Investing</CardTitle>
+        </div>
+        <Link
+          to="/invest"
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          Invest hub <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Live snapshot tiles (indicative; reuse existing feeds) */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <SnapshotTile
+            label="Equity (indicative)"
+            value={equity}
+            hint="Across trading & custody"
+            to="/portfolio"
+          />
+          <SnapshotTile
+            label="Activity"
+            value={unreadBadge ? `${unreadBadge} new` : "Up to date"}
+            hint="Fills, funding, liquidations"
+            to="/activity-center"
+          />
+          <SnapshotTile
+            label="Active algos"
+            value={runningAlgos}
+            hint="Running now"
+            to="/algos"
+          />
+          <SnapshotTile
+            label="Top strategy"
+            value={topStrategy ? formatReturnBps(topStrategy.inception_return_bps) : "—"}
+            hint={topStrategy ? topStrategy.name : "Explore strategy funds"}
+            to="/strategies"
+          />
+        </div>
+
+        {/* Quick-link grid to every trading / investing surface */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+          {TRADING_SURFACES.map((sfc) => {
+            const Icon = sfc.icon;
+            return (
+              <Link
+                key={sfc.id}
+                to={sfc.path}
+                className="flex flex-col gap-1 rounded-lg border border-border p-3 transition-colors hover:border-primary/50 hover:bg-muted/60"
+              >
+                <span className="flex items-center gap-2">
+                  <Icon className="h-4 w-4 shrink-0 text-primary" />
+                  <span className="text-sm font-medium leading-tight">{sfc.label}</span>
+                </span>
+                <span className="text-[11px] leading-snug text-muted-foreground">
+                  {sfc.desc}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 // Page
 
 export default function HomePage() {
@@ -625,6 +777,8 @@ export default function HomePage() {
       </div>
 
       <RecentActivityCard />
+
+      <TradingInvestingCard />
     </div>
   );
 }

--- a/frontend/src/pages/home/tradingSurfaces.test.ts
+++ b/frontend/src/pages/home/tradingSurfaces.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  TRADING_SURFACES,
+  formatUnreadBadge,
+  pickTopStrategy,
+  formatReturnBps,
+} from "./tradingSurfaces";
+
+describe("TRADING_SURFACES", () => {
+  it("lists the ten trading/investing surfaces with unique ids and absolute paths", () => {
+    expect(TRADING_SURFACES).toHaveLength(10);
+    const ids = new Set(TRADING_SURFACES.map((s) => s.id));
+    expect(ids.size).toBe(10);
+    for (const s of TRADING_SURFACES) {
+      expect(s.path.startsWith("/")).toBe(true);
+      expect(s.label.length).toBeGreaterThan(0);
+      expect(s.desc.length).toBeGreaterThan(0);
+      expect(typeof s.icon).toBe("object");
+    }
+  });
+
+  it("covers the exact expected routes", () => {
+    const paths = TRADING_SURFACES.map((s) => s.path).sort();
+    expect(paths).toEqual(
+      [
+        "/invest",
+        "/markets",
+        "/strategies",
+        "/portfolio/analytics",
+        "/activity-center",
+        "/algos",
+        "/tokens",
+        "/bailouts",
+        "/custody/providers",
+        "/reports/tax",
+      ].sort(),
+    );
+  });
+});
+
+describe("formatUnreadBadge", () => {
+  it("returns null for zero / negative / nullish / non-finite", () => {
+    expect(formatUnreadBadge(0)).toBeNull();
+    expect(formatUnreadBadge(-3)).toBeNull();
+    expect(formatUnreadBadge(undefined)).toBeNull();
+    expect(formatUnreadBadge(null)).toBeNull();
+    expect(formatUnreadBadge(NaN)).toBeNull();
+  });
+  it("formats positive counts and caps at 99+", () => {
+    expect(formatUnreadBadge(1)).toBe("1");
+    expect(formatUnreadBadge(42)).toBe("42");
+    expect(formatUnreadBadge(99)).toBe("99");
+    expect(formatUnreadBadge(100)).toBe("99+");
+    expect(formatUnreadBadge(2500)).toBe("99+");
+  });
+  it("floors fractional counts", () => {
+    expect(formatUnreadBadge(3.9)).toBe("3");
+  });
+});
+
+describe("pickTopStrategy", () => {
+  it("returns undefined for empty / absent lists", () => {
+    expect(pickTopStrategy(undefined)).toBeUndefined();
+    expect(pickTopStrategy(null)).toBeUndefined();
+    expect(pickTopStrategy([])).toBeUndefined();
+  });
+  it("picks the highest inception return", () => {
+    const top = pickTopStrategy([
+      { name: "A", inception_return_bps: 100 },
+      { name: "B", inception_return_bps: 500 },
+      { name: "C", inception_return_bps: 250 },
+    ]);
+    expect(top?.name).toBe("B");
+  });
+  it("tie-breaks by AUM", () => {
+    const top = pickTopStrategy([
+      { name: "A", inception_return_bps: 300, aum_cents: 1000 },
+      { name: "B", inception_return_bps: 300, aum_cents: 9000 },
+    ]);
+    expect(top?.name).toBe("B");
+  });
+  it("treats missing return as lowest", () => {
+    const top = pickTopStrategy([
+      { name: "A" },
+      { name: "B", inception_return_bps: 10 },
+    ]);
+    expect(top?.name).toBe("B");
+  });
+});
+
+describe("formatReturnBps", () => {
+  it("formats signed percentages", () => {
+    expect(formatReturnBps(1230)).toBe("+12.3%");
+    expect(formatReturnBps(-450)).toBe("-4.5%");
+    expect(formatReturnBps(0)).toBe("0.0%");
+  });
+  it("degrades on nullish / non-finite", () => {
+    expect(formatReturnBps(undefined)).toBe("—");
+    expect(formatReturnBps(null)).toBe("—");
+    expect(formatReturnBps(NaN)).toBe("—");
+  });
+});

--- a/frontend/src/pages/home/tradingSurfaces.ts
+++ b/frontend/src/pages/home/tradingSurfaces.ts
@@ -1,0 +1,85 @@
+// Config + pure helpers for the Home "Trading & Investing" section.
+//
+// The tile list is the single source of truth for the quick-link grid on the
+// Home dashboard AND (icon/label reused) the mobile "More" trading block. Every
+// route here is already shipped + routed; icons/labels mirror the Sidebar so the
+// two navigations stay visually consistent. Kept dependency-free (icon is a
+// lucide component ref) so the pure helpers below are unit-testable in isolation.
+
+import type { LucideIcon } from "lucide-react";
+import {
+  CandlestickChart,
+  Sparkles,
+  Boxes,
+  ShieldAlert,
+  Bell,
+  Timer,
+  Landmark,
+  LifeBuoy,
+  Building2,
+  Receipt,
+} from "lucide-react";
+
+export interface TradingSurface {
+  /** Stable id (used as React key + test anchor). */
+  id: string;
+  label: string;
+  /** One-line description shown under the label on the dashboard card. */
+  desc: string;
+  path: string;
+  icon: LucideIcon;
+}
+
+/**
+ * The ten trading / investing surfaces to surface on Home + mobile nav.
+ * Order = rough "start here -> deeper tooling" flow.
+ */
+export const TRADING_SURFACES: TradingSurface[] = [
+  { id: "invest", label: "Invest", desc: "Your investing hub", path: "/invest", icon: Sparkles },
+  { id: "markets", label: "Markets", desc: "Live order books & charts", path: "/markets", icon: CandlestickChart },
+  { id: "strategies", label: "Strategy Funds", desc: "Invest in NAV-unit funds", path: "/strategies", icon: Boxes },
+  { id: "portfolio-analytics", label: "Portfolio Risk", desc: "Exposure & risk analytics", path: "/portfolio/analytics", icon: ShieldAlert },
+  { id: "activity-center", label: "Activity Center", desc: "Fills, funding & liquidations", path: "/activity-center", icon: Bell },
+  { id: "algos", label: "Active Algos", desc: "TWAP & iceberg monitors", path: "/algos", icon: Timer },
+  { id: "tokens", label: "Creator Tokens", desc: "Mint & trade creator tokens", path: "/tokens", icon: Landmark },
+  { id: "bailouts", label: "Bailouts", desc: "Liquidity relief programs", path: "/bailouts", icon: LifeBuoy },
+  { id: "custody-providers", label: "Custody Providers", desc: "Connect a custodian", path: "/custody/providers", icon: Building2 },
+  { id: "reports-tax", label: "Tax & Gains", desc: "Realized gains & tax lots", path: "/reports/tax", icon: Receipt },
+];
+
+/** Format an unread/activity count for a small badge (caps at 99+). */
+export function formatUnreadBadge(n: number | undefined | null): string | null {
+  if (n == null || !Number.isFinite(n) || n <= 0) return null;
+  const v = Math.floor(n);
+  return v > 99 ? "99+" : String(v);
+}
+
+/** A minimal shape used by the "top strategy" teaser picker (subset of Strategy). */
+export interface TopStrategyLike {
+  name: string;
+  inception_return_bps?: number;
+  aum_cents?: number;
+}
+
+/**
+ * Pick the single "top" strategy for the Home teaser: highest inception return
+ * (bps), tie-broken by AUM. Returns undefined for an empty/absent list so the
+ * caller can degrade gracefully. Pure — no fetching.
+ */
+export function pickTopStrategy<T extends TopStrategyLike>(list: T[] | undefined | null): T | undefined {
+  if (!Array.isArray(list) || list.length === 0) return undefined;
+  return list.reduce((best, cur) => {
+    const b = best.inception_return_bps ?? -Infinity;
+    const c = cur.inception_return_bps ?? -Infinity;
+    if (c > b) return cur;
+    if (c === b && (cur.aum_cents ?? 0) > (best.aum_cents ?? 0)) return cur;
+    return best;
+  });
+}
+
+/** Format a bps return as a signed percentage string (e.g. +12.3%). */
+export function formatReturnBps(bps: number | undefined | null): string {
+  if (bps == null || !Number.isFinite(bps)) return "—";
+  const pct = bps / 100;
+  return `${pct > 0 ? "+" : ""}${pct.toFixed(1)}%`;
+}


### PR DESCRIPTION
## Home dashboard + bottom-nav wiring for the new surfaces

Makes everything shipped this run reachable without digging. **Purely additive** — no existing dashboard content, bottom-nav tabs, routes, or MoreCatalog changed; links to already-registered routes.

Surfaces: Invest hub · Markets · Strategy funds · Portfolio Risk · Activity Center · Active Algos · Creator Tokens · Bailouts · Custody Providers · Tax & Gains.

### Web
- `pages/home/tradingSurfaces.ts` (+11 vitest) — single source of truth for the 10 surfaces + pure helpers.
- `HomePage.tsx` — additive "Trading & Investing" section: 4 live snapshot tiles (indicative equity, unread Activity, running algos, top strategy; degrade to "—") + a quick-link grid to all 10.
- `MobileNav.tsx` — added an "Invest" bottom-nav tab + prepended the trading block to the "More" sheet; nothing dropped.

### Android
- `DashboardScreen.kt` — additive "Trading & Investing" section (row of 10 quick-access cards) navigating via `onOpenRoute` to the registered `MoreRoutes` consts; + test tags + strings.
- **Bottom bar left intact by design** (5 slots are all core social tabs); Home tab → the new trading hub is the primary path, full set also under More. (Say the word if you'd rather I add a dedicated trading tab despite crowding.)

No new deps. Gates: web tsc 0 · vite build · vitest 11/11; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
