### PR TITLE
feat(alerts): price/NAV alerts for creator tokens & strategy funds (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlert.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlert.kt
@@ -1,18 +1,35 @@
 package com.testlogon.android.data.exchange.alerts
 
 /**
- * Which way the last price must cross the [PriceAlert.priceTicks] threshold to fire.
- *  - [ABOVE]: fires when last price crosses from at/below the threshold to strictly above it.
- *  - [BELOW]: fires when last price crosses from at/above the threshold to strictly below it.
+ * Which way the observed value must cross the [PriceAlert.priceTicks] threshold to fire.
+ *  - [ABOVE]: fires when the value crosses from at/below the threshold to strictly above it.
+ *  - [BELOW]: fires when the value crosses from at/above the threshold to strictly below it.
  */
 enum class PriceAlertDirection { ABOVE, BELOW }
 
 /**
- * One user-authored price alert. [priceTicks] is the threshold in the symbol's raw integer ticks
- * (parsed from the user's decimal input via the symbol's priceScaler), NOT a display double, so it is
- * compared directly against the raw last-trade price. [armed] is the one-shot latch: an armed alert
- * fires once when the price CROSSES the threshold (edge trigger), which stamps [triggeredTs] and sets
- * [armed] = false so it never re-fires until the user re-arms it.
+ * What an alert watches. EXTENDS the original symbol-only alerts (mirrors the parallel web change):
+ *  - [SYMBOL]: an exchange instrument last price (raw integer ticks, scaled by the symbol scaler).
+ *  - [TOKEN]: a creator revenue-share token last/clearing price (integer CENTS).
+ *  - [STRATEGY]: a strategy fund NAV per unit (integer CENTS).
+ * The comparison in every case is a pure integer edge-cross against [PriceAlert.priceTicks].
+ */
+enum class PriceAlertSubject { SYMBOL, TOKEN, STRATEGY }
+
+/**
+ * One user-authored price alert. Generalized over a [subject] kind:
+ *  - For [PriceAlertSubject.SYMBOL] the subject is [symbolId] and [priceTicks] is the threshold in the
+ *    symbol raw integer ticks (parsed via the symbol priceScaler).
+ *  - For [PriceAlertSubject.TOKEN] / [PriceAlertSubject.STRATEGY] the subject is [subjectId] (the token
+ *    id / strategy id) and [priceTicks] is the threshold in integer CENTS (token last/clearing price,
+ *    or strategy NAV per unit).
+ *
+ * [subjectId] is the canonical subject key for all kinds; for a SYMBOL alert it is the symbolId as a
+ * string (kept in sync with the legacy [symbolId] field for backward compatibility). [subjectLabel] is
+ * a cached human ticker/name for rendering when the live catalogue cannot resolve the id.
+ *
+ * [armed] is the one-shot latch: an armed alert fires once when the value CROSSES the threshold (edge
+ * trigger), which stamps [triggeredTs] and sets [armed] = false so it never re-fires until re-armed.
  */
 data class PriceAlert(
     val id: String,
@@ -23,15 +40,18 @@ data class PriceAlert(
     val createdTs: Long,
     val triggeredTs: Long? = null,
     val armed: Boolean = true,
+    val subject: PriceAlertSubject = PriceAlertSubject.SYMBOL,
+    val subjectId: String = symbolId.toString(),
+    val subjectLabel: String? = null,
 )
 
 /**
  * Pure, deterministic edge-trigger evaluation for a single [PriceAlert] — the unit-tested seam.
  *
- * An armed alert fires when the last price CROSSES its threshold between two consecutive observations
- * (not merely when the price sits on the far side). The caller supplies [prevTicks] (the last price the
- * evaluator saw for this symbol on the previous tick, or null if this is the first observation) and
- * [lastTicks] (the current last price). Crossing is edge-detected so an alert armed while the price is
+ * An armed alert fires when the value CROSSES its threshold between two consecutive observations
+ * (not merely when the value sits on the far side). The caller supplies [prevTicks] (the value the
+ * evaluator saw for this subject on the previous tick, or null if this is the first observation) and
+ * [lastTicks] (the current value). Crossing is edge-detected so an alert armed while the value is
  * already past the threshold does not immediately fire — it fires only on a genuine crossing.
  *
  * One-shot: on a fire the returned alert has [PriceAlert.armed] = false and [PriceAlert.triggeredTs]
@@ -41,18 +61,17 @@ data class PriceAlert(
 object PriceAlertEval {
 
     /**
-     * The outcome of evaluating one alert against one price tick: the (possibly updated) [alert] and
+     * The outcome of evaluating one alert against one observation: the (possibly updated) [alert] and
      * whether it [fired] on this tick (so the caller can raise a notification exactly once).
      */
     data class Result(val alert: PriceAlert, val fired: Boolean)
 
     /**
-     * Evaluate [alert] given the previous ([prevTicks]) and current ([lastTicks]) last prices.
+     * Evaluate [alert] given the previous ([prevTicks]) and current ([lastTicks]) observed values.
      *
      *  - Returns the alert unchanged with fired=false when it is not armed, already triggered, or the
-     *    price did not cross the threshold this tick.
-     *  - On the first observation ([prevTicks] == null) an alert never fires: with no prior price there
-     *    is no edge, so opening the app while the price is already past the threshold does not fire.
+     *    value did not cross the threshold this tick.
+     *  - On the first observation ([prevTicks] == null) an alert never fires.
      *  - ABOVE crosses when prev <= threshold < last. BELOW crosses when prev >= threshold > last.
      */
     fun evaluate(
@@ -63,17 +82,45 @@ object PriceAlertEval {
     ): Result {
         if (!alert.armed || alert.triggeredTs != null) return Result(alert, false)
         if (prevTicks == null) return Result(alert, false)
-
-        val threshold = alert.priceTicks
-        val crossed = when (alert.direction) {
-            PriceAlertDirection.ABOVE -> prevTicks <= threshold && lastTicks > threshold
-            PriceAlertDirection.BELOW -> prevTicks >= threshold && lastTicks < threshold
+        if (!alertCrossed(prevTicks, lastTicks, alert.direction, alert.priceTicks)) {
+            return Result(alert, false)
         }
-        if (!crossed) return Result(alert, false)
-
-        return Result(
-            alert = alert.copy(armed = false, triggeredTs = nowMs),
-            fired = true,
-        )
+        return Result(alert = alert.copy(armed = false, triggeredTs = nowMs), fired = true)
     }
+}
+
+/**
+ * PURE edge-trigger predicate shared by the evaluator and the unit tests: did the value cross the
+ * [target] this observation, in the [condition] direction?
+ *  - [PriceAlertDirection.ABOVE]: true when prev <= target && curr > target.
+ *  - [PriceAlertDirection.BELOW]: true when prev >= target && curr < target.
+ * Edge-detected, so a value that was already past the target and stays there does NOT cross.
+ */
+fun alertCrossed(prev: Long, curr: Long, condition: PriceAlertDirection, target: Long): Boolean =
+    when (condition) {
+        PriceAlertDirection.ABOVE -> prev <= target && curr > target
+        PriceAlertDirection.BELOW -> prev >= target && curr < target
+    }
+
+/**
+ * PURE human label for an alert across all subject kinds, e.g. "BTC above 65000" or "ACME token below
+ * 250". [subjectName] is the resolved ticker/name (falls back to the alert cached [PriceAlert.subjectLabel]
+ * then to a "#id" form). [formatTarget] renders the integer threshold for the subject (symbol scaler /
+ * cents), defaulting to the raw integer when omitted.
+ */
+fun alertLabel(
+    alert: PriceAlert,
+    subjectName: String? = null,
+    formatTarget: (Long) -> String = { it.toString() },
+): String {
+    val name = subjectName
+        ?: alert.subjectLabel?.takeIf { it.isNotBlank() }
+        ?: ("#" + alert.subjectId)
+    val kindTag = when (alert.subject) {
+        PriceAlertSubject.SYMBOL -> ""
+        PriceAlertSubject.TOKEN -> " token"
+        PriceAlertSubject.STRATEGY -> " NAV"
+    }
+    val dir = if (alert.direction == PriceAlertDirection.ABOVE) "above" else "below"
+    return name + kindTag + " " + dir + " " + formatTarget(alert.priceTicks)
 }

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsEvaluator.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsEvaluator.kt
@@ -6,17 +6,20 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Runs the pure [PriceAlertEval] over the user's persisted [PriceAlert]s against the live last prices
- * the Markets poll already fetches — no new always-on worker; it is driven from the on-screen poll
- * loop (the Markets VM) exactly like the derived-alerts poller.
+ * Runs the pure [PriceAlertEval] over the user persisted [PriceAlert]s against live values the on-screen
+ * polls already fetch - no new always-on worker. It supports all three subject kinds:
+ *  - SYMBOL: last price (raw ticks) from the Markets poll (via [evaluate], driven by the Markets VM).
+ *  - TOKEN:  creator-token last/clearing price (cents) via [evaluateSubjects].
+ *  - STRATEGY: strategy fund NAV per unit (cents) via [evaluateSubjects].
  *
  * On a fire it: (1) persists the alert as disarmed + triggered (one-shot), and (2) raises it through
  * the SAME [TradingAlertsStore] as a [TradingAlertKind.PRICE] alert so it appears in the shared alerts
  * inbox alongside fills/liquidations/etc. The caller receives the freshly-fired [TradingAlert]s so it
- * can post a system notification (consistent with how the derived poller returns its new alerts).
+ * can post a system notification.
  *
- * Edge-detection state (the previous last price per symbol) is held in-memory here so an alert armed
- * while the price is already past the threshold does not fire until a genuine crossing.
+ * Edge-detection state (the previous value per subject) is held in-memory here, keyed by a composite of
+ * subject kind + id, so a token and a symbol that happen to share an id never collide and an alert armed
+ * while the value is already past the threshold does not fire until a genuine crossing.
  */
 @Singleton
 class PriceAlertsEvaluator @Inject constructor(
@@ -24,80 +27,128 @@ class PriceAlertsEvaluator @Inject constructor(
     private val alertsStore: TradingAlertsStore,
     private val clock: AlertClock,
 ) {
-    /** Previous last price (raw ticks) seen per symbolId, for edge detection across ticks. */
-    private val prevTicks = HashMap<Int, Long>()
+    /** Previous observed value per composite subject key, for edge detection across ticks. */
+    private val prevValue = HashMap<String, Long>()
 
-    /** The user's persisted price alerts (newest-created first) for the management screen. */
+    /** The user persisted price alerts (newest-created first) for the management screen. */
     fun alerts(): Flow<List<PriceAlert>> = store.alerts()
 
     suspend fun add(alert: PriceAlert) = store.upsert(alert)
     suspend fun delete(id: String) = store.delete(id)
     suspend fun rearm(id: String) = store.rearm(id)
 
-    /**
-     * Evaluate every armed alert whose symbol has a fresh last price in [lastBySymbol] (raw ticks).
-     * Persists any one-shot fires and mirrors them into the shared alerts inbox; returns the newly
-     * raised [TradingAlert]s (empty when nothing crossed). Never throws.
-     *
-     * [instruments] is used only to render a human label ("BTC crossed above 65000") from the symbolId
-     * and to format the threshold via the symbol scaler; a missing instrument falls back to "#id".
-     */
+    private fun key(subject: PriceAlertSubject, subjectId: String) = subject.name + ":" + subjectId
+
     suspend fun evaluate(
         lastBySymbol: Map<Int, Long>,
         instruments: List<Instrument>,
     ): List<TradingAlert> {
         if (lastBySymbol.isEmpty()) return emptyList()
-        val current = store.snapshot()
+        val current = store.snapshot().filter { it.subject == PriceAlertSubject.SYMBOL }
         if (current.isEmpty()) {
-            // Still advance edge state so a later-added alert edge-detects correctly.
-            lastBySymbol.forEach { (sym, ticks) -> prevTicks[sym] = ticks }
+            lastBySymbol.forEach { (sym, ticks) -> prevValue[key(PriceAlertSubject.SYMBOL, sym.toString())] = ticks }
             return emptyList()
         }
 
         val now = clock.nowMs()
         val byId = instruments.associateBy { it.symbolId }
         val fired = ArrayList<TradingAlert>()
-        var changed = false
+        val updatedById = HashMap<String, PriceAlert>()
 
-        val updated = current.map { alert ->
-            val last = lastBySymbol[alert.symbolId] ?: return@map alert
-            val prev = prevTicks[alert.symbolId]
-            val result = PriceAlertEval.evaluate(alert, prev, last, now)
+        current.forEach { alert ->
+            val last = lastBySymbol[alert.symbolId] ?: return@forEach
+            val k = key(PriceAlertSubject.SYMBOL, alert.symbolId.toString())
+            val result = PriceAlertEval.evaluate(alert, prevValue[k], last, now)
             if (result.fired) {
-                changed = true
-                fired += toTradingAlert(result.alert, last, byId[alert.symbolId], now)
+                val instr = byId[alert.symbolId]
+                fired += toTradingAlert(
+                    alert = result.alert,
+                    lastValue = last,
+                    subjectName = instr?.symbol,
+                    format = { raw -> fmt(instr?.display(raw) ?: raw.toDouble()) },
+                    now = now,
+                )
+                updatedById[alert.id] = result.alert
             }
-            result.alert
         }
 
-        // Advance edge state AFTER evaluating this tick.
-        lastBySymbol.forEach { (sym, ticks) -> prevTicks[sym] = ticks }
+        lastBySymbol.forEach { (sym, ticks) -> prevValue[key(PriceAlertSubject.SYMBOL, sym.toString())] = ticks }
 
-        if (changed) store.replaceAll(updated)
+        if (updatedById.isNotEmpty()) persistFires(updatedById)
         if (fired.isNotEmpty()) alertsStore.addAlerts(fired)
         return fired
     }
 
+    suspend fun evaluateSubjects(
+        subject: PriceAlertSubject,
+        valueById: Map<String, Long>,
+        labelById: Map<String, String> = emptyMap(),
+    ): List<TradingAlert> {
+        if (valueById.isEmpty()) return emptyList()
+        val current = store.snapshot().filter { it.subject == subject }
+        if (current.isEmpty()) {
+            valueById.forEach { (id, v) -> prevValue[key(subject, id)] = v }
+            return emptyList()
+        }
+
+        val now = clock.nowMs()
+        val fired = ArrayList<TradingAlert>()
+        val updatedById = HashMap<String, PriceAlert>()
+
+        current.forEach { alert ->
+            val value = valueById[alert.subjectId] ?: return@forEach
+            val k = key(subject, alert.subjectId)
+            val result = PriceAlertEval.evaluate(alert, prevValue[k], value, now)
+            if (result.fired) {
+                val name = labelById[alert.subjectId] ?: alert.subjectLabel
+                fired += toTradingAlert(
+                    alert = result.alert,
+                    lastValue = value,
+                    subjectName = name,
+                    format = { raw -> fmtCents(raw) },
+                    now = now,
+                )
+                updatedById[alert.id] = result.alert
+            }
+        }
+
+        valueById.forEach { (id, v) -> prevValue[key(subject, id)] = v }
+
+        if (updatedById.isNotEmpty()) persistFires(updatedById)
+        if (fired.isNotEmpty()) alertsStore.addAlerts(fired)
+        return fired
+    }
+
+    private suspend fun persistFires(updatedById: Map<String, PriceAlert>) {
+        if (updatedById.isEmpty()) return
+        val all = store.snapshot().map { updatedById[it.id] ?: it }
+        store.replaceAll(all)
+    }
+
     private fun toTradingAlert(
         alert: PriceAlert,
-        lastTicks: Long,
-        instrument: Instrument?,
+        lastValue: Long,
+        subjectName: String?,
+        format: (Long) -> String,
         now: Long,
     ): TradingAlert {
-        val label = instrument?.symbol ?: ("#" + alert.symbolId)
+        val label = subjectName ?: alert.subjectLabel ?: ("#" + alert.subjectId)
         val dir = if (alert.direction == PriceAlertDirection.ABOVE) "above" else "below"
-        val threshold = instrument?.display(alert.priceTicks) ?: alert.priceTicks.toDouble()
-        val lastDisp = instrument?.display(lastTicks) ?: lastTicks.toDouble()
-        val thresholdStr = fmt(threshold)
+        val kindWord = when (alert.subject) {
+            PriceAlertSubject.SYMBOL -> "price"
+            PriceAlertSubject.TOKEN -> "token"
+            PriceAlertSubject.STRATEGY -> "NAV"
+        }
         val body = buildString {
-            append(label).append(" crossed ").append(dir).append(' ').append(thresholdStr)
-            append(" (last ").append(fmt(lastDisp)).append(')')
-            alert.note?.takeIf { it.isNotBlank() }?.let { append(" — ").append(it) }
+            append(label).append(SP).append(kindWord).append(" crossed ").append(dir).append(SP)
+            append(format(alert.priceTicks))
+            append(" (now ").append(format(lastValue)).append(RP)
+            alert.note?.takeIf { it.isNotBlank() }?.let { append(" - ").append(it) }
         }
         return TradingAlert(
             id = "price:" + alert.id + ":" + alert.triggeredTs,
             kind = TradingAlertKind.PRICE,
-            title = label + " price alert",
+            title = label + " " + kindWord + " alert",
             body = body,
             eventTsNs = 0L,
             createdAtMs = now,
@@ -106,4 +157,16 @@ class PriceAlertsEvaluator @Inject constructor(
 
     private fun fmt(v: Double): String =
         if (v == v.toLong().toDouble()) v.toLong().toString() else v.toString()
+
+    private fun fmtCents(cents: Long): String {
+        val sign = if (cents < 0) "-" else ""
+        val abs = kotlin.math.abs(cents)
+        return sign + "$" + (abs / 100) + "." + (abs % 100).toString().padStart(2, ZERO)
+    }
+
+    private companion object {
+        const val SP = ' '
+        const val RP = ')'
+        const val ZERO = '0'
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/alerts/PriceAlertsStore.kt
@@ -130,6 +130,11 @@ internal data class PriceAlertJson(
     val createdTs: Long = 0L,
     val triggeredTs: Long? = null,
     val armed: Boolean = true,
+    // Added for the generalized SYMBOL|TOKEN|STRATEGY alert. Absent in legacy persisted entries, which
+    // therefore migrate transparently to a SYMBOL alert keyed by symbolId (subject == null default).
+    val subject: String? = null,
+    val subjectId: String? = null,
+    val subjectLabel: String? = null,
 )
 
 internal fun PriceAlertJson.toDomain() = PriceAlert(
@@ -142,6 +147,11 @@ internal fun PriceAlertJson.toDomain() = PriceAlert(
     createdTs = createdTs,
     triggeredTs = triggeredTs,
     armed = armed,
+    // Transparent migration: legacy entries (subject == null) become SYMBOL alerts keyed by symbolId.
+    subject = runCatching { subject?.let { PriceAlertSubject.valueOf(it) } }.getOrNull()
+        ?: PriceAlertSubject.SYMBOL,
+    subjectId = subjectId ?: symbolId.toString(),
+    subjectLabel = subjectLabel,
 )
 
 internal fun PriceAlert.toJson() = PriceAlertJson(
@@ -153,4 +163,7 @@ internal fun PriceAlert.toJson() = PriceAlertJson(
     createdTs = createdTs,
     triggeredTs = triggeredTs,
     armed = armed,
+    subject = subject.name,
+    subjectId = subjectId,
+    subjectLabel = subjectLabel,
 )

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsScreen.kt
@@ -47,16 +47,17 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.testlogon.android.data.exchange.Instrument
 import com.testlogon.android.data.exchange.alerts.PriceAlert
 import com.testlogon.android.data.exchange.alerts.PriceAlertDirection
+import com.testlogon.android.data.exchange.alerts.PriceAlertSubject
 import com.testlogon.android.feature.markets.ui.MarketColors
 import com.testlogon.android.feature.markets.ui.MarketSurface
 
 /**
- * Price Alerts management route: an add form (symbol picker + above/below + price + optional note) over
- * a list of the user's active + triggered alerts, each showing the live current price with delete and
- * (for triggered) re-arm. Reachable from the Trading Alerts screen. Renders on the dark exchange palette.
+ * (Generalized) Price Alerts management route: an add form (subject-kind toggle Symbol/Creator Token/
+ * Strategy -> subject picker + above/below + threshold + optional note) over a list of the user active +
+ * triggered alerts across ALL kinds, each showing the live current value with delete and (for triggered)
+ * re-arm. Reachable from the Trading Alerts screen. Renders on the dark exchange palette.
  */
 @Composable
 fun PriceAlertsRoute(
@@ -73,10 +74,7 @@ fun PriceAlertsRoute(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 item {
-                    AddAlertForm(
-                        instruments = state.instruments,
-                        onAdd = { sym, dir, price, note -> viewModel.add(sym, dir, price, note) },
-                    )
+                    AddAlertForm(state = state, viewModel = viewModel)
                 }
                 if (state.alerts.isEmpty()) {
                     item { EmptyState() }
@@ -84,15 +82,14 @@ fun PriceAlertsRoute(
                     if (state.active.isNotEmpty()) {
                         item { SectionLabel("ACTIVE") }
                         items(state.active, key = { it.id }) { alert ->
-                            AlertRow(alert, state.instrument(alert.symbolId), state.lastFor(alert.symbolId),
-                                onDelete = { viewModel.delete(alert.id) }, onRearm = null)
+                            AlertRow(alert, state, onDelete = { viewModel.delete(alert.id) }, onRearm = null)
                         }
                     }
                     if (state.triggered.isNotEmpty()) {
                         item { SectionLabel("TRIGGERED") }
                         items(state.triggered, key = { it.id }) { alert ->
-                            AlertRow(alert, state.instrument(alert.symbolId), state.lastFor(alert.symbolId),
-                                onDelete = { viewModel.delete(alert.id) }, onRearm = { viewModel.rearm(alert.id) })
+                            AlertRow(alert, state, onDelete = { viewModel.delete(alert.id) },
+                                onRearm = { viewModel.rearm(alert.id) })
                         }
                     }
                 }
@@ -112,85 +109,59 @@ private fun Header(onBack: () -> Unit) {
         }
         Column(modifier = Modifier.weight(1f)) {
             Text("Price alerts", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 22.sp)
-            Text("Notify me when a symbol crosses a price", color = MarketColors.TextSecondary, fontSize = 12.sp)
+            Text("Notify me when a symbol, token or fund crosses a value",
+                color = MarketColors.TextSecondary, fontSize = 12.sp)
         }
     }
 }
 
 @Composable
-private fun AddAlertForm(
-    instruments: List<Instrument>,
-    onAdd: (Int, PriceAlertDirection, String, String?) -> Boolean,
-) {
-    var symbolId by remember(instruments) { mutableStateOf(instruments.firstOrNull()?.symbolId) }
-    var direction by remember { mutableStateOf(PriceAlertDirection.ABOVE) }
-    var price by remember { mutableStateOf("") }
-    var note by remember { mutableStateOf("") }
-    var error by remember { mutableStateOf<String?>(null) }
+private fun KindToggle(kind: PriceAlertSubject, onSelect: (PriceAlertSubject) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        KindChip("Symbol", "symbol", kind == PriceAlertSubject.SYMBOL) { onSelect(PriceAlertSubject.SYMBOL) }
+        KindChip("Creator Token", "token", kind == PriceAlertSubject.TOKEN) { onSelect(PriceAlertSubject.TOKEN) }
+        KindChip("Strategy", "strategy", kind == PriceAlertSubject.STRATEGY) { onSelect(PriceAlertSubject.STRATEGY) }
+    }
+}
 
-    Column(
-        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
-            .background(MarketColors.Surface).border(1.dp, MarketColors.Border, RoundedCornerShape(12.dp))
-            .padding(14.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
+@Composable
+private fun KindChip(label: String, tag: String, selected: Boolean, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier.clip(RoundedCornerShape(8.dp))
+            .background(if (selected) MarketColors.Accent else MarketColors.SurfaceAlt)
+            .border(1.dp, if (selected) MarketColors.Accent else MarketColors.Border, RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick).padding(horizontal = 10.dp, vertical = 8.dp)
+            .testTag("price_alert_kind_" + tag),
     ) {
-        Text("New alert", color = MarketColors.TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            SymbolPicker(instruments = instruments, selected = symbolId, onSelect = { symbolId = it },
-                modifier = Modifier.weight(1f))
-            DirectionToggle(direction = direction, onSelect = { direction = it })
-        }
-        OutlinedTextField(
-            value = price, onValueChange = { price = it; error = null },
-            label = { Text("Price") }, singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-            modifier = Modifier.fillMaxWidth().testTag("price_alert_price"),
-        )
-        OutlinedTextField(
-            value = note, onValueChange = { note = it },
-            label = { Text("Note (optional)") }, singleLine = true,
-            modifier = Modifier.fillMaxWidth().testTag("price_alert_note"),
-        )
-        error?.let { Text(it, color = MarketColors.Down, fontSize = 12.sp) }
-        Box(
-            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
-                .background(MarketColors.Accent).clickable {
-                    val sym = symbolId
-                    if (sym == null) { error = "Pick a symbol" }
-                    else if (!onAdd(sym, direction, price, note)) { error = "Enter a valid price" }
-                    else { price = ""; note = ""; error = null }
-                }.padding(vertical = 12.dp).testTag("price_alert_add"),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text("Add alert", color = MarketColors.Bg, fontWeight = FontWeight.Bold, fontSize = 14.sp)
-        }
+        Text(label, color = if (selected) MarketColors.Bg else MarketColors.TextSecondary,
+            fontWeight = FontWeight.SemiBold, fontSize = 12.sp)
     }
 }
 
 @Composable
-private fun SymbolPicker(
-    instruments: List<Instrument>,
-    selected: Int?,
-    onSelect: (Int) -> Unit,
+private fun LabeledPicker(
+    label: String,
+    options: List<Pair<String, String>>,
+    onSelect: (String) -> Unit,
+    tagPrefix: String,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val label = instruments.firstOrNull { it.symbolId == selected }?.symbol ?: "Symbol"
     Box(modifier = modifier) {
         Box(
             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
                 .border(1.dp, MarketColors.Border, RoundedCornerShape(8.dp))
                 .clickable { expanded = true }.padding(horizontal = 12.dp, vertical = 12.dp)
-                .testTag("price_alert_symbol"),
+                .testTag(tagPrefix),
         ) {
             Text(label, color = MarketColors.TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            instruments.forEach { instrument ->
+            options.forEach { (id, text) ->
                 DropdownMenuItem(
-                    text = { Text(instrument.symbol) },
-                    onClick = { onSelect(instrument.symbolId); expanded = false },
-                    modifier = Modifier.testTag("price_alert_symbol_${instrument.symbolId}"),
+                    text = { Text(text) },
+                    onClick = { onSelect(id); expanded = false },
+                    modifier = Modifier.testTag(tagPrefix + "_" + id),
                 )
             }
         }
@@ -212,7 +183,7 @@ private fun Chip(label: String, selected: Boolean, accent: Color, onClick: () ->
             .background(if (selected) accent else MarketColors.SurfaceAlt)
             .border(1.dp, if (selected) accent else MarketColors.Border, RoundedCornerShape(8.dp))
             .clickable(onClick = onClick).padding(horizontal = 14.dp, vertical = 12.dp)
-            .testTag("price_alert_dir_${label.lowercase()}"),
+            .testTag("price_alert_dir_" + label.lowercase()),
     ) {
         Text(label, color = if (selected) MarketColors.Bg else MarketColors.TextSecondary,
             fontWeight = FontWeight.SemiBold, fontSize = 13.sp)
@@ -227,18 +198,98 @@ private fun SectionLabel(text: String) {
 }
 
 @Composable
+private fun AddAlertForm(
+    state: PriceAlertsUiState,
+    viewModel: PriceAlertsViewModel,
+) {
+    var kind by remember { mutableStateOf(PriceAlertSubject.SYMBOL) }
+    var symbolId by remember(state.instruments) { mutableStateOf(state.instruments.firstOrNull()?.symbolId) }
+    var tokenId by remember(state.tokens) { mutableStateOf(state.tokens.firstOrNull()?.tokenId) }
+    var strategyId by remember(state.strategies) { mutableStateOf(state.strategies.firstOrNull()?.strategyId) }
+    var direction by remember { mutableStateOf(PriceAlertDirection.ABOVE) }
+    var price by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
+            .background(MarketColors.Surface).border(1.dp, MarketColors.Border, RoundedCornerShape(12.dp))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text("New alert", color = MarketColors.TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+        KindToggle(kind = kind, onSelect = { kind = it; error = null })
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            when (kind) {
+                PriceAlertSubject.SYMBOL -> LabeledPicker(
+                    label = state.instruments.firstOrNull { it.symbolId == symbolId }?.symbol ?: "Symbol",
+                    options = state.instruments.map { it.symbolId.toString() to it.symbol },
+                    onSelect = { symbolId = it.toIntOrNull() }, tagPrefix = "price_alert_symbol",
+                    modifier = Modifier.weight(1f),
+                )
+                PriceAlertSubject.TOKEN -> LabeledPicker(
+                    label = state.tokens.firstOrNull { it.tokenId == tokenId }
+                        ?.let { it.ticker.ifBlank { it.name } } ?: "Token",
+                    options = state.tokens.map { it.tokenId to it.ticker.ifBlank { it.name } },
+                    onSelect = { tokenId = it }, tagPrefix = "price_alert_token",
+                    modifier = Modifier.weight(1f),
+                )
+                PriceAlertSubject.STRATEGY -> LabeledPicker(
+                    label = state.strategies.firstOrNull { it.strategyId == strategyId }?.name ?: "Strategy",
+                    options = state.strategies.map { it.strategyId to it.name },
+                    onSelect = { strategyId = it }, tagPrefix = "price_alert_strategy",
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            DirectionToggle(direction = direction, onSelect = { direction = it })
+        }
+        OutlinedTextField(
+            value = price, onValueChange = { price = it; error = null },
+            label = { Text(if (kind == PriceAlertSubject.SYMBOL) "Price" else "Price (USD)") }, singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+            modifier = Modifier.fillMaxWidth().testTag("price_alert_price"),
+        )
+        OutlinedTextField(
+            value = note, onValueChange = { note = it },
+            label = { Text("Note (optional)") }, singleLine = true,
+            modifier = Modifier.fillMaxWidth().testTag("price_alert_note"),
+        )
+        error?.let { Text(it, color = MarketColors.Down, fontSize = 12.sp) }
+        Box(
+            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+                .background(MarketColors.Accent).clickable {
+                    val ok = when (kind) {
+                        PriceAlertSubject.SYMBOL -> symbolId?.let { viewModel.add(it, direction, price, note) } ?: false
+                        PriceAlertSubject.TOKEN -> tokenId?.let { viewModel.addToken(it, direction, price, note) } ?: false
+                        PriceAlertSubject.STRATEGY -> strategyId?.let { viewModel.addStrategy(it, direction, price, note) } ?: false
+                    }
+                    if (!ok) { error = "Pick a subject and enter a valid price" }
+                    else { price = ""; note = ""; error = null }
+                }.padding(vertical = 12.dp).testTag("price_alert_add"),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text("Add alert", color = MarketColors.Bg, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+        }
+    }
+}
+
+@Composable
 private fun AlertRow(
     alert: PriceAlert,
-    instrument: Instrument?,
-    lastTicks: Long?,
+    state: PriceAlertsUiState,
     onDelete: () -> Unit,
     onRearm: (() -> Unit)?,
 ) {
     val accent = if (alert.direction == PriceAlertDirection.ABOVE) MarketColors.Up else MarketColors.Down
-    val label = instrument?.symbol ?: ("#" + alert.symbolId)
     val dir = if (alert.direction == PriceAlertDirection.ABOVE) "above" else "below"
-    val threshold = instrument?.display(alert.priceTicks)?.let { fmt(it) } ?: alert.priceTicks.toString()
-    val current = lastTicks?.let { instrument?.display(it)?.let(::fmt) ?: it.toString() }
+    val label = subjectLabel(alert, state)
+    val kindTag = when (alert.subject) {
+        PriceAlertSubject.SYMBOL -> ""
+        PriceAlertSubject.TOKEN -> " token"
+        PriceAlertSubject.STRATEGY -> " NAV"
+    }
+    val threshold = formatValue(alert, alert.priceTicks, state)
+    val current = state.currentValue(alert)?.let { formatValue(alert, it, state) }
     Row(
         modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
             .background(MarketColors.Surface).border(1.dp, MarketColors.Border, RoundedCornerShape(12.dp))
@@ -247,7 +298,7 @@ private fun AlertRow(
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("$label $dir $threshold", color = MarketColors.TextPrimary,
+                Text(label + kindTag + " " + dir + " " + threshold, color = MarketColors.TextPrimary,
                     fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
                 Spacer(Modifier.width(8.dp))
                 Box(modifier = Modifier.size(6.dp).clip(RoundedCornerShape(3.dp)).background(accent))
@@ -255,9 +306,9 @@ private fun AlertRow(
             Spacer(Modifier.size(3.dp))
             Text(
                 buildString {
-                    append("current ").append(current ?: "—")
-                    if (alert.triggeredTs != null) append("  •  triggered")
-                    alert.note?.let { append("  •  ").append(it) }
+                    append("current ").append(current ?: "-")
+                    if (alert.triggeredTs != null) append("  -  triggered")
+                    alert.note?.let { append("  -  ").append(it) }
                 },
                 color = MarketColors.TextSecondary, fontSize = 12.sp,
             )
@@ -267,17 +318,32 @@ private fun AlertRow(
                 modifier = Modifier.clip(RoundedCornerShape(8.dp))
                     .border(1.dp, MarketColors.Accent, RoundedCornerShape(8.dp))
                     .clickable(onClick = onRearm).padding(horizontal = 12.dp, vertical = 8.dp)
-                    .testTag("price_alert_rearm_${alert.id}"),
+                    .testTag("price_alert_rearm_" + alert.id),
             ) {
                 Text("Re-arm", color = MarketColors.Accent, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
             }
             Spacer(Modifier.width(6.dp))
         }
-        IconButton(onClick = onDelete, modifier = Modifier.testTag("price_alert_delete_${alert.id}")) {
+        IconButton(onClick = onDelete, modifier = Modifier.testTag("price_alert_delete_" + alert.id)) {
             Icon(Icons.Filled.Delete, contentDescription = "Delete", tint = MarketColors.TextSecondary)
         }
     }
 }
+
+/** Resolve a human subject label for a row across all kinds, falling back to the cached label / id. */
+private fun subjectLabel(alert: PriceAlert, state: PriceAlertsUiState): String = when (alert.subject) {
+    PriceAlertSubject.SYMBOL -> state.instrument(alert.symbolId)?.symbol
+    PriceAlertSubject.TOKEN -> state.token(alert.subjectId)?.let { it.ticker.ifBlank { it.name } }
+    PriceAlertSubject.STRATEGY -> state.strategy(alert.subjectId)?.name
+} ?: alert.subjectLabel ?: ("#" + alert.subjectId)
+
+/** Format an integer value for a row: symbol scaler for SYMBOL, dollars for TOKEN/STRATEGY cents. */
+private fun formatValue(alert: PriceAlert, raw: Long, state: PriceAlertsUiState): String =
+    when (alert.subject) {
+        PriceAlertSubject.SYMBOL ->
+            state.instrument(alert.symbolId)?.display(raw)?.let(::fmt) ?: raw.toString()
+        PriceAlertSubject.TOKEN, PriceAlertSubject.STRATEGY -> fmtCents(raw)
+    }
 
 @Composable
 private fun EmptyState() {
@@ -287,10 +353,18 @@ private fun EmptyState() {
     ) {
         Text("No price alerts", color = MarketColors.TextPrimary, fontWeight = FontWeight.Bold, fontSize = 16.sp)
         Spacer(Modifier.size(6.dp))
-        Text("Add one above to be notified when a symbol crosses your price.",
+        Text("Add one above to be notified when a symbol, token or fund crosses your value.",
             color = MarketColors.TextSecondary, fontSize = 13.sp)
     }
 }
 
 private fun fmt(v: Double): String =
     if (v == v.toLong().toDouble()) v.toLong().toString() else v.toString()
+
+private fun fmtCents(cents: Long): String {
+    val sign = if (cents < 0) "-" else ""
+    val abs = kotlin.math.abs(cents)
+    return sign + "USD " + (abs / 100) + "." + (abs % 100).toString().padStart(2, ZERO_CHAR)
+}
+
+private const val ZERO_CHAR = '0'

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsUiState.kt
@@ -2,22 +2,42 @@ package com.testlogon.android.feature.markets.alerts.pricealerts
 
 import com.testlogon.android.data.exchange.Instrument
 import com.testlogon.android.data.exchange.alerts.PriceAlert
+import com.testlogon.android.data.exchange.alerts.PriceAlertSubject
+import com.testlogon.android.data.strategies.Strategy
+import com.testlogon.android.data.tokens.Token
 
 /**
- * Immutable state for the Price Alerts management screen.
+ * Immutable state for the (generalized) Price Alerts management screen, now covering SYMBOL, TOKEN and
+ * STRATEGY subjects.
  *
  * [instruments] is the symbol catalogue for the add-form picker; [lastTicks] is the latest raw last
- * price per symbolId (updated by the on-screen poll) used to render each alert's "current price" and
- * to validate the add form. [alerts] is the persisted user-authored set (newest-created first).
+ * price per symbolId (updated by the on-screen poll). [tokens] / [strategies] are the creator-token and
+ * strategy-fund catalogues for their pickers, and [tokenPriceById] / [strategyNavById] hold the latest
+ * live value (integer CENTS) per token id / strategy id used to render each alert row current value.
+ * [alerts] is the persisted user-authored set (newest-created first, all kinds).
  */
 data class PriceAlertsUiState(
     val alerts: List<PriceAlert> = emptyList(),
     val instruments: List<Instrument> = emptyList(),
     val lastTicks: Map<Int, Long> = emptyMap(),
+    val tokens: List<Token> = emptyList(),
+    val strategies: List<Strategy> = emptyList(),
+    val tokenPriceById: Map<String, Long> = emptyMap(),
+    val strategyNavById: Map<String, Long> = emptyMap(),
 ) {
     val active: List<PriceAlert> get() = alerts.filter { it.armed && it.triggeredTs == null }
     val triggered: List<PriceAlert> get() = alerts.filter { !(it.armed && it.triggeredTs == null) }
 
     fun instrument(symbolId: Int): Instrument? = instruments.firstOrNull { it.symbolId == symbolId }
     fun lastFor(symbolId: Int): Long? = lastTicks[symbolId]
+
+    fun token(id: String): Token? = tokens.firstOrNull { it.tokenId == id }
+    fun strategy(id: String): Strategy? = strategies.firstOrNull { it.strategyId == id }
+
+    /** Current live value (integer cents/ticks) for an alert of any kind, or null when unknown. */
+    fun currentValue(alert: PriceAlert): Long? = when (alert.subject) {
+        PriceAlertSubject.SYMBOL -> lastTicks[alert.symbolId]
+        PriceAlertSubject.TOKEN -> tokenPriceById[alert.subjectId]
+        PriceAlertSubject.STRATEGY -> strategyNavById[alert.subjectId]
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/alerts/pricealerts/PriceAlertsViewModel.kt
@@ -7,14 +7,18 @@ import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.Instrument
 import com.testlogon.android.data.exchange.alerts.PriceAlert
 import com.testlogon.android.data.exchange.alerts.PriceAlertDirection
+import com.testlogon.android.data.exchange.alerts.PriceAlertSubject
 import com.testlogon.android.data.exchange.alerts.PriceAlertsEvaluator
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.strategies.Strategy
+import com.testlogon.android.data.tokens.Token
+import com.testlogon.android.data.tokens.TokensRepository
 import com.testlogon.android.feature.markets.trade.TradingNotifier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -23,26 +27,40 @@ import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
 
-/**
- * Drives the Price Alerts management screen. The alerts list is the persisted evaluator store stream;
- * the VM additionally loads the symbol catalogue for the add-form picker and polls each symbol's last
- * price (reusing [ExchangeRepository], consistent with the on-screen polling elsewhere) so each row
- * shows its live current price. It ALSO runs the evaluator on that same poll so an alert fires + notifies
- * even while the user is sitting on this screen (not only from the Markets list).
- */
 @HiltViewModel
 class PriceAlertsViewModel @Inject constructor(
     private val evaluator: PriceAlertsEvaluator,
     private val repository: ExchangeRepository,
+    private val tokensRepository: TokensRepository,
+    private val strategiesRepository: StrategiesRepository,
     private val notifier: TradingNotifier,
 ) : ViewModel() {
 
     private val _lastTicks = MutableStateFlow<Map<Int, Long>>(emptyMap())
     private val _instruments = MutableStateFlow<List<Instrument>>(emptyList())
+    private val _tokens = MutableStateFlow<List<Token>>(emptyList())
+    private val _strategies = MutableStateFlow<List<Strategy>>(emptyList())
+    private val _tokenPrices = MutableStateFlow<Map<String, Long>>(emptyMap())
+    private val _strategyNavs = MutableStateFlow<Map<String, Long>>(emptyMap())
+
+    private val catalogues = combine(_instruments, _tokens, _strategies) { instruments, tokens, strategies ->
+        Triple(instruments, tokens, strategies)
+    }
+    private val liveValues = combine(_lastTicks, _tokenPrices, _strategyNavs) { ticks, tokenPx, navs ->
+        Triple(ticks, tokenPx, navs)
+    }
 
     val uiState: StateFlow<PriceAlertsUiState> =
-        combine(evaluator.alerts(), _instruments, _lastTicks) { alerts, instruments, ticks ->
-            PriceAlertsUiState(alerts = alerts, instruments = instruments, lastTicks = ticks)
+        combine(evaluator.alerts(), catalogues, liveValues) { alerts, cat, live ->
+            PriceAlertsUiState(
+                alerts = alerts,
+                instruments = cat.first,
+                tokens = cat.second,
+                strategies = cat.third,
+                lastTicks = live.first,
+                tokenPriceById = live.second,
+                strategyNavById = live.third,
+            )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), PriceAlertsUiState())
 
     init {
@@ -53,12 +71,13 @@ class PriceAlertsViewModel @Inject constructor(
         viewModelScope.launch {
             val instruments = (repository.symbols() as? ApiResult.Success)?.data.orEmpty()
             _instruments.value = instruments
-            pollPrices(instruments)
+            _tokens.value = (tokensRepository.market() as? ApiResult.Success)?.data.orEmpty()
+            _strategies.value = (strategiesRepository.market() as? ApiResult.Success)?.data.orEmpty()
+            poll(instruments)
         }
     }
 
-    /** Poll last prices per symbol + run the evaluator while the screen is alive. */
-    private suspend fun pollPrices(instruments: List<Instrument>) {
+    private suspend fun poll(instruments: List<Instrument>) {
         while (viewModelScope.isActive) {
             val ticks = HashMap<Int, Long>()
             for (instrument in instruments) {
@@ -69,17 +88,38 @@ class PriceAlertsViewModel @Inject constructor(
                 if (raw != null) ticks[instrument.symbolId] = raw
             }
             _lastTicks.update { ticks.ifEmpty { it } }
-            evaluator.evaluate(ticks, instruments).forEach { alert ->
-                notifier.notifyTradingAlert(title = alert.title, body = alert.body, distress = false)
+
+            val tokens = (tokensRepository.market() as? ApiResult.Success)?.data.orEmpty()
+            if (tokens.isNotEmpty()) _tokens.value = tokens
+            val tokenPrices = HashMap<String, Long>()
+            val tokenLabels = HashMap<String, String>()
+            tokens.forEach { t ->
+                t.clearingPrice?.let { tokenPrices[t.tokenId] = it }
+                tokenLabels[t.tokenId] = t.ticker.ifBlank { t.name }
             }
+            if (tokenPrices.isNotEmpty()) _tokenPrices.update { tokenPrices }
+
+            val strategies = (strategiesRepository.market() as? ApiResult.Success)?.data.orEmpty()
+            if (strategies.isNotEmpty()) _strategies.value = strategies
+            val navs = HashMap<String, Long>()
+            val strategyLabels = HashMap<String, String>()
+            strategies.forEach { s ->
+                s.navPerUnit?.let { navs[s.strategyId] = it }
+                strategyLabels[s.strategyId] = s.name
+            }
+            if (navs.isNotEmpty()) _strategyNavs.update { navs }
+
+            (evaluator.evaluate(ticks, instruments) +
+                evaluator.evaluateSubjects(PriceAlertSubject.TOKEN, tokenPrices, tokenLabels) +
+                evaluator.evaluateSubjects(PriceAlertSubject.STRATEGY, navs, strategyLabels))
+                .forEach { alert ->
+                    notifier.notifyTradingAlert(title = alert.title, body = alert.body, distress = false)
+                }
+
             delay(POLL_MS)
         }
     }
 
-    /**
-     * Add an alert from the form. [priceText] is the user's decimal input, converted to raw ticks via
-     * the symbol scaler ([Instrument.priceScaler]). Returns false (and adds nothing) on invalid input.
-     */
     fun add(symbolId: Int, direction: PriceAlertDirection, priceText: String, note: String?): Boolean {
         val instrument = _instruments.value.firstOrNull { it.symbolId == symbolId } ?: return false
         val ticks = parseTicks(priceText, instrument) ?: return false
@@ -90,8 +130,53 @@ class PriceAlertsViewModel @Inject constructor(
             priceTicks = ticks,
             note = note?.trim()?.takeIf { it.isNotEmpty() },
             createdTs = System.currentTimeMillis(),
+            subject = PriceAlertSubject.SYMBOL,
+            subjectId = symbolId.toString(),
+            subjectLabel = instrument.symbol,
         )
         viewModelScope.launch { evaluator.add(alert) }
+        return true
+    }
+
+    fun addToken(tokenId: String, direction: PriceAlertDirection, priceText: String, note: String?): Boolean {
+        val token = _tokens.value.firstOrNull { it.tokenId == tokenId } ?: return false
+        val cents = parseCents(priceText) ?: return false
+        viewModelScope.launch {
+            evaluator.add(
+                PriceAlert(
+                    id = UUID.randomUUID().toString(),
+                    symbolId = -1,
+                    direction = direction,
+                    priceTicks = cents,
+                    note = note?.trim()?.takeIf { it.isNotEmpty() },
+                    createdTs = System.currentTimeMillis(),
+                    subject = PriceAlertSubject.TOKEN,
+                    subjectId = tokenId,
+                    subjectLabel = token.ticker.ifBlank { token.name },
+                ),
+            )
+        }
+        return true
+    }
+
+    fun addStrategy(strategyId: String, direction: PriceAlertDirection, priceText: String, note: String?): Boolean {
+        val strategy = _strategies.value.firstOrNull { it.strategyId == strategyId } ?: return false
+        val cents = parseCents(priceText) ?: return false
+        viewModelScope.launch {
+            evaluator.add(
+                PriceAlert(
+                    id = UUID.randomUUID().toString(),
+                    symbolId = -1,
+                    direction = direction,
+                    priceTicks = cents,
+                    note = note?.trim()?.takeIf { it.isNotEmpty() },
+                    createdTs = System.currentTimeMillis(),
+                    subject = PriceAlertSubject.STRATEGY,
+                    subjectId = strategyId,
+                    subjectLabel = strategy.name,
+                ),
+            )
+        }
         return true
     }
 
@@ -101,12 +186,17 @@ class PriceAlertsViewModel @Inject constructor(
     companion object {
         private const val POLL_MS = 2_000L
 
-        /** Convert a user decimal string into raw ticks: round(decimal * priceScaler). Null if invalid. */
         fun parseTicks(priceText: String, instrument: Instrument): Long? {
             val value = priceText.trim().toDoubleOrNull() ?: return null
             if (value <= 0.0 || value.isNaN() || value.isInfinite()) return null
             val scaler = instrument.priceScaler.coerceAtLeast(1)
             return kotlin.math.round(value * scaler).toLong()
+        }
+
+        fun parseCents(priceText: String): Long? {
+            val value = priceText.trim().toDoubleOrNull() ?: return null
+            if (value <= 0.0 || value.isNaN() || value.isInfinite()) return null
+            return kotlin.math.round(value * 100.0).toLong()
         }
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/alerts/PriceAlertEvalTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/alerts/PriceAlertEvalTest.kt
@@ -119,3 +119,113 @@ class PriceAlertEvalTest {
         assertEquals(NOW + 100, r2.alert.triggeredTs)
     }
 }
+
+/**
+ * EXTENDED coverage for the generalized SYMBOL|TOKEN|STRATEGY alerts: the pure [alertCrossed] predicate
+ * (both directions, edge cases), [alertLabel] rendering per kind, and the evaluator over token/strategy
+ * subjects (default kind, subjectId defaulting from symbolId).
+ */
+class PriceAlertGeneralizedTest {
+
+    private val NOW = 9_000L
+
+    private fun tokenAlert(dir: PriceAlertDirection = PriceAlertDirection.ABOVE, cents: Long = 25000) =
+        PriceAlert(
+            id = "t1", symbolId = -1, direction = dir, priceTicks = cents, note = null,
+            createdTs = 0L, subject = PriceAlertSubject.TOKEN, subjectId = "tok-abc", subjectLabel = "ACME",
+        )
+
+    // ---- alertCrossed pure predicate ----
+
+    @Test
+    fun crossed_above_true_onUpwardCross() {
+        assertTrue(alertCrossed(90, 110, PriceAlertDirection.ABOVE, 100))
+    }
+
+    @Test
+    fun crossed_above_true_whenPrevOnThreshold() {
+        assertTrue(alertCrossed(100, 101, PriceAlertDirection.ABOVE, 100))
+    }
+
+    @Test
+    fun crossed_above_false_whenStaysBelow() {
+        assertFalse(alertCrossed(80, 95, PriceAlertDirection.ABOVE, 100))
+    }
+
+    @Test
+    fun crossed_above_false_whenAlreadyAbove() {
+        assertFalse(alertCrossed(120, 140, PriceAlertDirection.ABOVE, 100))
+    }
+
+    @Test
+    fun crossed_below_true_onDownwardCross() {
+        assertTrue(alertCrossed(110, 90, PriceAlertDirection.BELOW, 100))
+    }
+
+    @Test
+    fun crossed_below_true_whenPrevOnThreshold() {
+        assertTrue(alertCrossed(100, 99, PriceAlertDirection.BELOW, 100))
+    }
+
+    @Test
+    fun crossed_below_false_onUpwardMove() {
+        assertFalse(alertCrossed(90, 110, PriceAlertDirection.BELOW, 100))
+    }
+
+    @Test
+    fun crossed_below_false_whenAlreadyBelow() {
+        assertFalse(alertCrossed(80, 60, PriceAlertDirection.BELOW, 100))
+    }
+
+    // ---- default subject / migration defaults ----
+
+    @Test
+    fun defaultAlert_isSymbolKind_withSubjectIdFromSymbolId() {
+        val a = PriceAlert(id = "a", symbolId = 42, direction = PriceAlertDirection.ABOVE, priceTicks = 1, createdTs = 0L)
+        assertEquals(PriceAlertSubject.SYMBOL, a.subject)
+        assertEquals("42", a.subjectId)
+    }
+
+    // ---- alertLabel per kind ----
+
+    @Test
+    fun label_symbol_hasNoKindTag() {
+        val a = PriceAlert(id = "a", symbolId = 1, direction = PriceAlertDirection.ABOVE, priceTicks = 65000, createdTs = 0L, subjectLabel = "BTC")
+        assertEquals("BTC above 65000", alertLabel(a))
+    }
+
+    @Test
+    fun label_token_hasTokenTag_andUsesResolvedName() {
+        val a = tokenAlert(PriceAlertDirection.BELOW, 25000)
+        assertEquals("ACME token below 250", alertLabel(a, subjectName = "ACME", formatTarget = { (it / 100).toString() }))
+    }
+
+    @Test
+    fun label_strategy_hasNavTag() {
+        val a = PriceAlert(
+            id = "s", symbolId = -1, direction = PriceAlertDirection.ABOVE, priceTicks = 10000, createdTs = 0L,
+            subject = PriceAlertSubject.STRATEGY, subjectId = "str-1", subjectLabel = "Momentum",
+        )
+        assertEquals("Momentum NAV above 10000", alertLabel(a))
+    }
+
+    @Test
+    fun label_fallsBackToHashId_whenNoName() {
+        val a = PriceAlert(
+            id = "s", symbolId = -1, direction = PriceAlertDirection.ABOVE, priceTicks = 1, createdTs = 0L,
+            subject = PriceAlertSubject.TOKEN, subjectId = "xyz",
+        )
+        assertEquals("#xyz token above 1", alertLabel(a))
+    }
+
+    // ---- token subject evaluated by the same pure eval ----
+
+    @Test
+    fun tokenAlert_firesOnUpwardCrossViaEvaluate() {
+        val r = PriceAlertEval.evaluate(tokenAlert(PriceAlertDirection.ABOVE, 25000), prevTicks = 24000, lastTicks = 26000, nowMs = NOW)
+        assertTrue(r.fired)
+        assertFalse(r.alert.armed)
+        assertEquals(NOW, r.alert.triggeredTs)
+        assertEquals(PriceAlertSubject.TOKEN, r.alert.subject)
+    }
+}

--- a/frontend/src/components/layout/PriceAlertEvaluator.tsx
+++ b/frontend/src/components/layout/PriceAlertEvaluator.tsx
@@ -3,6 +3,9 @@ import * as React from "react";
 import { useCandles, useSymbols } from "@/hooks/useMarketData";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
 import { formatPrice } from "@/pages/markets/format";
+import { formatCents } from "@/lib/tokens";
+import { useToken } from "@/hooks/useTokens";
+import { useStrategy, useStrategyNav } from "@/hooks/useStrategies";
 import {
   pushExternalTradingAlert,
   type ExternalTradingAlert,
@@ -35,10 +38,42 @@ function usePriceAlerts(): PriceAlert[] {
 }
 
 /**
+ * Shared fire path: for each armed alert whose current value MEETS its
+ * condition, push a `price` alert into the trading bell and mark it triggered
+ * (one-shot). `value` is in the subject's native integer units; `render`
+ * formats it for display. `subjectName` is the resolved display label.
+ */
+function fireCrossings(
+  alerts: PriceAlert[],
+  value: number,
+  subjectName: string,
+  render: (v: number) => string,
+) {
+  if (value == null || !Number.isFinite(value)) return;
+  for (const alert of alerts) {
+    if (!alert.armed) continue;
+    if (!evaluate(alert, value)) continue;
+    const dir = alert.direction === "above" ? "above" : "below";
+    const fieldWord = alert.field === "nav" ? "NAV" : "price";
+    const targetLabel = render(alert.price);
+    const detail: ExternalTradingAlert = {
+      id: `price:${alert.id}:${alert.triggeredTs ?? "armed"}`,
+      kind: "price",
+      title: `${subjectName} ${fieldWord} crossed ${dir} ${targetLabel}`,
+      message: alert.note
+        ? alert.note
+        : `Now ${render(value)} · target ${targetLabel}`,
+      ts: Date.now(),
+    };
+    // One-shot: stamp + disarm BEFORE pushing so a fast re-render can't double-fire.
+    markPriceAlertTriggered(alert.id, detail.ts);
+    pushExternalTradingAlert(detail);
+  }
+}
+
+/**
  * Watches ONE symbol's last price (candle close) and evaluates every armed
- * alert on that symbol. On a fire it pushes a `price` alert into the trading
- * bell (toast + OS notification) and marks the alert triggered (one-shot).
- * Renders nothing.
+ * alert on that symbol. Renders nothing.
  */
 function SymbolPriceWatcher({
   symbolId,
@@ -58,35 +93,66 @@ function SymbolPriceWatcher({
 
   React.useEffect(() => {
     if (lastClose == null || !Number.isFinite(lastClose)) return;
-    for (const alert of alerts) {
-      if (!alert.armed) continue;
-      if (!evaluate(alert, lastClose)) continue;
-      const dir = alert.direction === "above" ? "above" : "below";
-      const priceLabel = formatPrice(alert.price, scaler);
-      const detail: ExternalTradingAlert = {
-        id: `price:${alert.id}:${alert.triggeredTs ?? "armed"}`,
-        kind: "price",
-        title: `${name} crossed ${dir} ${priceLabel}`,
-        message: alert.note
-          ? alert.note
-          : `Last ${formatPrice(lastClose, scaler)} · target ${priceLabel}`,
-        ts: Date.now(),
-      };
-      // One-shot: stamp + disarm BEFORE pushing so a fast re-render can't double-fire.
-      markPriceAlertTriggered(alert.id, detail.ts);
-      pushExternalTradingAlert(detail);
-    }
-    // Re-run when the price or the alert set for this symbol changes.
+    fireCrossings(alerts, lastClose, name, (v) => formatPrice(v, scaler));
   }, [lastClose, alerts, scaler, name]);
 
   return null;
 }
 
 /**
- * App-chrome-level evaluator: for each distinct symbol that has an ARMED price
- * alert, mount a hidden watcher that polls its last price and fires crossings
- * through the trading-alerts bell. Mount this next to <TradingAlertsBell/> so it
- * runs whenever the user is logged in.
+ * Watches ONE creator token's last / clearing price (integer cents). Degrades
+ * silently on 404 (token backend not shipped) — no read, no fire. Renders nothing.
+ */
+function TokenPriceWatcher({
+  tokenId,
+  alerts,
+}: {
+  tokenId: string;
+  alerts: PriceAlert[];
+}) {
+  const { data } = useToken(tokenId);
+  const last = data?.clearing_price;
+  const name = data?.ticker ?? data?.name ?? tokenId;
+
+  React.useEffect(() => {
+    if (last == null || !Number.isFinite(last)) return;
+    fireCrossings(alerts, last, name, (v) => formatCents(v));
+  }, [last, alerts, name]);
+
+  return null;
+}
+
+/**
+ * Watches ONE strategy fund's NAV per unit (integer cents), polled by
+ * useStrategyNav. Falls back to the strategy detail's nav_per_unit when the NAV
+ * snapshot endpoint 404s. Degrades silently when neither is available. Renders
+ * nothing.
+ */
+function StrategyNavWatcher({
+  strategyId,
+  alerts,
+}: {
+  strategyId: string;
+  alerts: PriceAlert[];
+}) {
+  const navQ = useStrategyNav(strategyId);
+  const stratQ = useStrategy(strategyId);
+  const nav = navQ.data?.nav_per_unit ?? stratQ.data?.nav_per_unit;
+  const name = stratQ.data?.name ?? strategyId;
+
+  React.useEffect(() => {
+    if (nav == null || !Number.isFinite(nav)) return;
+    fireCrossings(alerts, nav, name, (v) => formatCents(v));
+  }, [nav, alerts, name]);
+
+  return null;
+}
+
+/**
+ * App-chrome-level evaluator: for each distinct SUBJECT (symbol / token /
+ * strategy) that has an ARMED alert, mount a hidden watcher that polls its
+ * current value and fires crossings through the trading-alerts bell. Mount this
+ * next to <TradingAlertsBell/> so it runs whenever the user is logged in.
  */
 export default function PriceAlertEvaluator({ enabled = true }: { enabled?: boolean }) {
   const alerts = usePriceAlerts();
@@ -98,29 +164,51 @@ export default function PriceAlertEvaluator({ enabled = true }: { enabled?: bool
     return m;
   }, [symbolsData]);
 
-  // Group armed alerts by symbol; only distinct armed symbols get a watcher.
+  // Group armed alerts by subject; only distinct armed subjects get a watcher.
   const grouped = React.useMemo(() => {
-    const m = new Map<number, PriceAlert[]>();
-    if (!enabled) return m;
+    const symbols = new Map<number, PriceAlert[]>();
+    const tokens = new Map<string, PriceAlert[]>();
+    const strategies = new Map<string, PriceAlert[]>();
+    if (!enabled) return { symbols, tokens, strategies };
     for (const a of alerts) {
       if (!a.armed) continue;
-      const list = m.get(a.symbolId) ?? [];
-      list.push(a);
-      m.set(a.symbolId, list);
+      if (a.subjectKind === "token") {
+        const list = tokens.get(a.subjectId) ?? [];
+        list.push(a);
+        tokens.set(a.subjectId, list);
+      } else if (a.subjectKind === "strategy") {
+        const list = strategies.get(a.subjectId) ?? [];
+        list.push(a);
+        strategies.set(a.subjectId, list);
+      } else {
+        const list = symbols.get(a.symbolId) ?? [];
+        list.push(a);
+        symbols.set(a.symbolId, list);
+      }
     }
-    return m;
+    return { symbols, tokens, strategies };
   }, [alerts, enabled]);
 
   if (!enabled) return null;
 
   return (
     <>
-      {[...grouped.entries()].map(([symbolId, symAlerts]) => (
+      {[...grouped.symbols.entries()].map(([symbolId, symAlerts]) => (
         <SymbolPriceWatcher
-          key={symbolId}
+          key={`sym:${symbolId}`}
           symbolId={symbolId}
           symbol={byId.get(symbolId)}
           alerts={symAlerts}
+        />
+      ))}
+      {[...grouped.tokens.entries()].map(([tokenId, tokAlerts]) => (
+        <TokenPriceWatcher key={`tok:${tokenId}`} tokenId={tokenId} alerts={tokAlerts} />
+      ))}
+      {[...grouped.strategies.entries()].map(([strategyId, stratAlerts]) => (
+        <StrategyNavWatcher
+          key={`strat:${strategyId}`}
+          strategyId={strategyId}
+          alerts={stratAlerts}
         />
       ))}
     </>

--- a/frontend/src/lib/priceAlerts.test.ts
+++ b/frontend/src/lib/priceAlerts.test.ts
@@ -1,14 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  addPriceAlert,
+  alertCrossed,
+  alertLabel,
   evaluate,
+  loadPriceAlerts,
+  parseCentsToInt,
   parsePriceToTicks,
+  PRICE_ALERTS_KEY,
+  subjectFallbackName,
+  subjectKindLabel,
   type PriceAlert,
 } from "@/lib/priceAlerts";
 
 function makeAlert(over: Partial<PriceAlert>): PriceAlert {
   return {
     id: "a1",
+    subjectKind: "symbol",
+    subjectId: "1",
+    field: "price",
     symbolId: 1,
     direction: "above",
     price: 65000,
@@ -19,7 +30,7 @@ function makeAlert(over: Partial<PriceAlert>): PriceAlert {
   };
 }
 
-describe("evaluate (pure price-alert edge trigger)", () => {
+describe("evaluate (pure price-alert level trigger)", () => {
   it("above: does NOT fire while price is below the threshold", () => {
     const a = makeAlert({ direction: "above", price: 65000 });
     expect(evaluate(a, 64999)).toBe(false);
@@ -43,7 +54,6 @@ describe("evaluate (pure price-alert edge trigger)", () => {
   });
 
   it("one-shot: a disarmed (already-fired) alert never fires again", () => {
-    // Simulate the store's one-shot: after firing we disarm.
     const fired = makeAlert({ direction: "above", price: 65000, armed: false, triggeredTs: 123 });
     expect(evaluate(fired, 66000)).toBe(false);
     expect(evaluate(fired, 70000)).toBe(false);
@@ -60,18 +70,85 @@ describe("evaluate (pure price-alert edge trigger)", () => {
     expect(evaluate(a, Number.POSITIVE_INFINITY)).toBe(false);
   });
 
-  it("full lifecycle: armed→fires→disarm(one-shot)→re-arm→fires", () => {
-    // armed, below threshold: no fire
+  it("full lifecycle: armed->fires->disarm(one-shot)->re-arm->fires", () => {
     let a = makeAlert({ direction: "above", price: 65000, armed: true });
     expect(evaluate(a, 64000)).toBe(false);
-    // crosses up: fire
     expect(evaluate(a, 65500)).toBe(true);
-    // store disarms after firing (one-shot)
     a = { ...a, armed: false, triggeredTs: Date.now() };
     expect(evaluate(a, 66000)).toBe(false);
-    // user re-arms
     a = { ...a, armed: true, triggeredTs: null };
     expect(evaluate(a, 66000)).toBe(true);
+  });
+
+  it("evaluates token (cents) and strategy (nav-cents) subjects the same way", () => {
+    const tok = makeAlert({ subjectKind: "token", field: "price", direction: "above", price: 12_50 });
+    expect(evaluate(tok, 12_49)).toBe(false);
+    expect(evaluate(tok, 12_50)).toBe(true);
+    const strat = makeAlert({ subjectKind: "strategy", field: "nav", direction: "below", price: 10_00 });
+    expect(evaluate(strat, 10_01)).toBe(false);
+    expect(evaluate(strat, 9_99)).toBe(true);
+  });
+});
+
+describe("alertCrossed (pure edge trigger)", () => {
+  it("above: fires only on the transition across the threshold", () => {
+    expect(alertCrossed(64999, 65001, "above", 65000)).toBe(true); // crossed up
+    expect(alertCrossed(65001, 65002, "above", 65000)).toBe(false); // already above
+    expect(alertCrossed(64000, 64999, "above", 65000)).toBe(false); // still below
+  });
+
+  it("above: exact-touch of the threshold counts as a cross", () => {
+    expect(alertCrossed(64999, 65000, "above", 65000)).toBe(true);
+    expect(alertCrossed(65000, 65001, "above", 65000)).toBe(false); // prev already met
+  });
+
+  it("below: fires only on the transition down across the threshold", () => {
+    expect(alertCrossed(3001, 2999, "below", 3000)).toBe(true); // crossed down
+    expect(alertCrossed(2999, 2998, "below", 3000)).toBe(false); // already below
+    expect(alertCrossed(4000, 3001, "below", 3000)).toBe(false); // still above
+  });
+
+  it("no prior sample: falls back to a level check on the first value", () => {
+    expect(alertCrossed(null, 65000, "above", 65000)).toBe(true);
+    expect(alertCrossed(undefined, 64999, "above", 65000)).toBe(false);
+    expect(alertCrossed(Number.NaN, 2999, "below", 3000)).toBe(true);
+  });
+
+  it("ignores non-finite current values", () => {
+    expect(alertCrossed(64000, Number.NaN, "above", 65000)).toBe(false);
+    expect(alertCrossed(64000, Number.POSITIVE_INFINITY, "above", 65000)).toBe(false);
+  });
+});
+
+describe("alertLabel + subject labels", () => {
+  it("labels a symbol price alert with the resolved name", () => {
+    const a = makeAlert({ subjectKind: "symbol", direction: "above", price: 65000 });
+    expect(alertLabel(a, "BTC", (v) => v.toLocaleString())).toBe("BTC price above 65,000");
+  });
+
+  it("labels a token alert (price / cents)", () => {
+    const a = makeAlert({ subjectKind: "token", field: "price", direction: "below", price: 12_50 });
+    expect(alertLabel(a, "MOON", (v) => `$${(v / 100).toFixed(2)}`)).toBe("MOON price below $12.50");
+  });
+
+  it("labels a strategy alert (NAV / cents)", () => {
+    const a = makeAlert({ subjectKind: "strategy", field: "nav", direction: "above", price: 100_00 });
+    expect(alertLabel(a, "Alpha Fund", (v) => `$${(v / 100).toFixed(2)}`)).toBe(
+      "Alpha Fund NAV above $100.00",
+    );
+  });
+
+  it("falls back to a #id / subjectId name when unresolved", () => {
+    const sym = makeAlert({ subjectKind: "symbol", symbolId: 7 });
+    expect(alertLabel(sym, undefined, (v) => String(v))).toContain("#7");
+    const tok = makeAlert({ subjectKind: "token", subjectId: "tok_abc" });
+    expect(subjectFallbackName(tok)).toBe("tok_abc");
+  });
+
+  it("subjectKindLabel maps each kind", () => {
+    expect(subjectKindLabel("symbol")).toBe("Symbol");
+    expect(subjectKindLabel("token")).toBe("Creator token");
+    expect(subjectKindLabel("strategy")).toBe("Strategy");
   });
 });
 
@@ -83,8 +160,8 @@ describe("parsePriceToTicks", () => {
   });
 
   it("rounds to the nearest tick", () => {
-    expect(parsePriceToTicks("1.007", 100)).toBe(101); // 100.7 -> 101
-    expect(parsePriceToTicks("1.002", 100)).toBe(100); // 100.2 -> 100
+    expect(parsePriceToTicks("1.007", 100)).toBe(101);
+    expect(parsePriceToTicks("1.002", 100)).toBe(100);
   });
 
   it("rejects blank / non-numeric / negative input", () => {
@@ -96,5 +173,100 @@ describe("parsePriceToTicks", () => {
 
   it("defaults scaler to 1 when unset", () => {
     expect(parsePriceToTicks("42")).toBe(42);
+  });
+});
+
+describe("parseCentsToInt", () => {
+  it("scales a dollar amount into integer cents", () => {
+    expect(parseCentsToInt("12.50")).toBe(1250);
+    expect(parseCentsToInt("100")).toBe(10000);
+    expect(parseCentsToInt("0.99")).toBe(99);
+  });
+
+  it("rounds to the nearest cent", () => {
+    expect(parseCentsToInt("1.007")).toBe(101); // 100.7 -> 101
+    expect(parseCentsToInt("1.004")).toBe(100); // 100.4 -> 100
+  });
+
+  it("rejects blank / non-numeric / negative input", () => {
+    expect(parseCentsToInt("")).toBeNull();
+    expect(parseCentsToInt("abc")).toBeNull();
+    expect(parseCentsToInt("-1")).toBeNull();
+  });
+});
+
+describe("persistence + legacy migration", () => {
+  beforeEach(() => {
+    try {
+      localStorage.clear();
+    } catch {
+      /* jsdom */
+    }
+  });
+  afterEach(() => {
+    try {
+      localStorage.clear();
+    } catch {
+      /* jsdom */
+    }
+  });
+
+  it("migrates a legacy symbol-only entry to the generalized shape", () => {
+    // Legacy row: no subjectKind / subjectId / field.
+    const legacy = [
+      {
+        id: "legacy1",
+        symbolId: 3,
+        direction: "above",
+        price: 65000,
+        createdTs: 1,
+        triggeredTs: null,
+        armed: true,
+      },
+    ];
+    localStorage.setItem(PRICE_ALERTS_KEY, JSON.stringify(legacy));
+    const loaded = loadPriceAlerts();
+    expect(loaded).toHaveLength(1);
+    const only = loaded[0]!;
+    expect(only.subjectKind).toBe("symbol");
+    expect(only.subjectId).toBe("3");
+    expect(only.field).toBe("price");
+    expect(only.symbolId).toBe(3);
+  });
+
+  it("round-trips a token alert and a strategy alert", () => {
+    addPriceAlert({ subjectKind: "token", subjectId: "tok_1", direction: "above", price: 12_50 });
+    addPriceAlert({
+      subjectKind: "strategy",
+      subjectId: "strat_1",
+      field: "nav",
+      direction: "below",
+      price: 100_00,
+    });
+    const loaded = loadPriceAlerts();
+    expect(loaded).toHaveLength(2);
+    const tok = loaded.find((a) => a.subjectKind === "token");
+    const strat = loaded.find((a) => a.subjectKind === "strategy");
+    expect(tok?.field).toBe("price");
+    expect(tok?.subjectId).toBe("tok_1");
+    expect(strat?.field).toBe("nav");
+    expect(strat?.subjectId).toBe("strat_1");
+  });
+
+  it("defaults a bare add to a symbol subject (back-compat callers)", () => {
+    addPriceAlert({ symbolId: 9, direction: "above", price: 100 });
+    const loaded = loadPriceAlerts();
+    const only = loaded[0]!;
+    expect(only.subjectKind).toBe("symbol");
+    expect(only.subjectId).toBe("9");
+    expect(only.field).toBe("price");
+  });
+
+  it("drops malformed rows", () => {
+    localStorage.setItem(
+      PRICE_ALERTS_KEY,
+      JSON.stringify([{ id: "ok", symbolId: 1, direction: "above", price: 1, createdTs: 1, armed: true }, { junk: true }, 5]),
+    );
+    expect(loadPriceAlerts()).toHaveLength(1);
   });
 });

--- a/frontend/src/lib/priceAlerts.ts
+++ b/frontend/src/lib/priceAlerts.ts
@@ -1,25 +1,54 @@
 /**
  * Price-alert store — client-side, localStorage-persisted watch list of
- * "notify me when <symbol> crosses <price>" rules.
+ * "notify me when <subject> crosses <target>" rules.
  *
- * Prices are stored as INTEGER TICKS (int64-scaled, same units the market-data
- * endpoints use). Callers convert user-entered decimals to ticks via the
- * symbol's `price_scaler` (see parsePriceToTicks) before persisting.
+ * SUBJECT KINDS (generalized 2026-08):
+ *  - "symbol"   : a market symbol_id; watches last price in INTEGER TICKS
+ *                 (int64-scaled by the symbol's price_scaler). field = "price".
+ *  - "token"    : a creator revenue-share token (token_id); watches the token's
+ *                 last / clearing price in INTEGER CENTS. field = "price".
+ *  - "strategy" : a strategy-fund (strategy_id); watches NAV per unit in
+ *                 INTEGER CENTS. field = "nav".
  *
- * The evaluator (useEvaluatePriceAlerts) polls each armed alert's symbol last
- * price and, on an EDGE CROSS of the threshold, fires it once (one-shot).
+ * The `target` is always an integer in the subject's native units (ticks for a
+ * symbol, cents for a token / strategy) — callers convert user-entered decimals
+ * via parsePriceToTicks / parseCentsToInt before persisting.
+ *
+ * The evaluator (PriceAlertEvaluator) polls each armed alert's current value
+ * and, on an EDGE CROSS of the threshold, fires it once (one-shot) through the
+ * SAME trading-alerts bell path as symbol alerts (pushExternalTradingAlert).
+ *
+ * BACK-COMPAT: legacy entries persisted before the generalization only carried
+ * { symbolId, direction, price, ... }. loadPriceAlerts() normalizes those to a
+ * "symbol" subject transparently, so the storage key is unchanged (v1).
  */
 
 export type PriceAlertDirection = "above" | "below";
 
+/** What the alert watches. */
+export type AlertSubjectKind = "symbol" | "token" | "strategy";
+
+/** The observed field on the subject ("price" for symbol/token, "nav" for strategy). */
+export type AlertField = "price" | "nav";
+
 export interface PriceAlert {
   /** Stable id. */
   id: string;
-  /** Market symbol_id this alert watches. */
+  /** What kind of thing this alert watches. */
+  subjectKind: AlertSubjectKind;
+  /**
+   * The subject identifier: a stringified symbol_id for "symbol", a token_id for
+   * "token", a strategy_id for "strategy". (symbolId is retained below for the
+   * "symbol" kind for back-compat with the existing evaluator/UI.)
+   */
+  subjectId: string;
+  /** Observed field: "price" (symbol/token) or "nav" (strategy). */
+  field: AlertField;
+  /** Legacy: market symbol_id this alert watches (only meaningful for "symbol"). */
   symbolId: number;
-  /** Fire when price goes above / below the threshold. */
+  /** Fire when the value goes above / below the threshold. */
   direction: PriceAlertDirection;
-  /** Threshold price in integer ticks (int64-scaled). */
+  /** Threshold in the subject's native integer units (ticks for symbol, cents otherwise). */
   price: number;
   /** Optional free-text note shown on the alert. */
   note?: string;
@@ -31,24 +60,63 @@ export interface PriceAlert {
   armed: boolean;
 }
 
+/** condition is an alias for direction in the generalized vocabulary. */
+export type AlertCondition = PriceAlertDirection;
+
 export const PRICE_ALERTS_KEY = "md.priceAlerts.v1";
 
 /** Fired (same-tab) whenever the stored list changes so views re-read it. */
 export const PRICE_ALERTS_EVENT = "tl:priceAlertsChanged";
 
-// ── Persistence ─────────────────────────────────────────────────────
+// -- Persistence ------------------------------------------------------
 
-function isPriceAlert(x: unknown): x is PriceAlert {
-  if (!x || typeof x !== "object") return false;
+/**
+ * Normalize a raw stored object into a fully-shaped PriceAlert, filling the
+ * generalized fields (subjectKind / subjectId / field) for legacy symbol-only
+ * entries. Returns null if the object is not a usable alert.
+ */
+function normalizeAlert(x: unknown): PriceAlert | null {
+  if (!x || typeof x !== "object") return null;
   const a = x as Record<string, unknown>;
-  return (
-    typeof a.id === "string" &&
-    typeof a.symbolId === "number" &&
-    (a.direction === "above" || a.direction === "below") &&
-    typeof a.price === "number" &&
-    typeof a.createdTs === "number" &&
-    typeof a.armed === "boolean"
-  );
+  if (typeof a.id !== "string") return null;
+  if (a.direction !== "above" && a.direction !== "below") return null;
+  if (typeof a.price !== "number") return null;
+  if (typeof a.createdTs !== "number") return null;
+  if (typeof a.armed !== "boolean") return null;
+
+  const kind: AlertSubjectKind =
+    a.subjectKind === "token" || a.subjectKind === "strategy" || a.subjectKind === "symbol"
+      ? a.subjectKind
+      : "symbol";
+
+  // Legacy entries only have symbolId; derive subjectId/field from the kind.
+  const symbolId = typeof a.symbolId === "number" ? a.symbolId : 0;
+  let subjectId: string;
+  if (typeof a.subjectId === "string" && a.subjectId) {
+    subjectId = a.subjectId;
+  } else {
+    subjectId = String(symbolId);
+  }
+  const field: AlertField =
+    a.field === "nav" || a.field === "price"
+      ? a.field
+      : kind === "strategy"
+        ? "nav"
+        : "price";
+
+  return {
+    id: a.id,
+    subjectKind: kind,
+    subjectId,
+    field,
+    symbolId,
+    direction: a.direction,
+    price: a.price,
+    note: typeof a.note === "string" ? a.note : undefined,
+    createdTs: a.createdTs,
+    triggeredTs: typeof a.triggeredTs === "number" ? a.triggeredTs : null,
+    armed: a.armed,
+  };
 }
 
 export function loadPriceAlerts(): PriceAlert[] {
@@ -56,7 +124,13 @@ export function loadPriceAlerts(): PriceAlert[] {
     const raw = localStorage.getItem(PRICE_ALERTS_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter(isPriceAlert) : [];
+    if (!Array.isArray(parsed)) return [];
+    const out: PriceAlert[] = [];
+    for (const item of parsed) {
+      const norm = normalizeAlert(item);
+      if (norm) out.push(norm);
+    }
+    return out;
   } catch {
     return [];
   }
@@ -75,7 +149,7 @@ function savePriceAlerts(list: PriceAlert[]): void {
   }
 }
 
-// ── CRUD ────────────────────────────────────────────────────────────
+// -- CRUD -------------------------------------------------------------
 
 function genId(): string {
   try {
@@ -89,17 +163,36 @@ function genId(): string {
 }
 
 export interface NewPriceAlertInput {
-  symbolId: number;
+  /** Defaults to "symbol" when omitted (back-compat with existing callers). */
+  subjectKind?: AlertSubjectKind;
+  /** Subject id (token_id / strategy_id / stringified symbol_id). */
+  subjectId?: string;
+  /** Observed field; defaults from the kind when omitted. */
+  field?: AlertField;
+  /** Legacy symbol id; when present without subjectId, seeds subjectId for "symbol". */
+  symbolId?: number;
   direction: PriceAlertDirection;
-  /** Threshold in integer ticks. */
+  /** Threshold in the subject's native integer units. */
   price: number;
   note?: string;
 }
 
+/** Default observed field for a subject kind. */
+export function defaultFieldForKind(kind: AlertSubjectKind): AlertField {
+  return kind === "strategy" ? "nav" : "price";
+}
+
 export function addPriceAlert(input: NewPriceAlertInput): PriceAlert {
+  const kind: AlertSubjectKind = input.subjectKind ?? "symbol";
+  const symbolId = input.symbolId ?? 0;
+  const subjectId = input.subjectId ?? (kind === "symbol" ? String(symbolId) : "");
+  const field = input.field ?? defaultFieldForKind(kind);
   const alert: PriceAlert = {
     id: genId(),
-    symbolId: input.symbolId,
+    subjectKind: kind,
+    subjectId,
+    field,
+    symbolId,
     direction: input.direction,
     price: input.price,
     note: input.note?.trim() ? input.note.trim() : undefined,
@@ -131,7 +224,7 @@ export function markPriceAlertTriggered(id: string, ts = Date.now()): void {
   updatePriceAlert(id, { armed: false, triggeredTs: ts });
 }
 
-// ── Tick <-> decimal conversion ─────────────────────────────────────
+// -- Decimal <-> integer conversion -----------------------------------
 
 /**
  * Parse a user-entered decimal price string into integer ticks using the
@@ -145,25 +238,99 @@ export function parsePriceToTicks(input: string, scaler = 1): number | null {
   return Math.round(n * (scaler || 1));
 }
 
-// ── Pure evaluation ─────────────────────────────────────────────────
+/**
+ * Parse a user-entered dollar string into INTEGER CENTS (for token / strategy
+ * targets). Returns null for blank / non-numeric / negative input.
+ */
+export function parseCentsToInt(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n * 100);
+}
+
+// -- Pure evaluation --------------------------------------------------
 
 /**
- * Decide whether an alert should fire given the latest price (in ticks).
+ * Pure edge-cross test: given the PREVIOUS observed value and the CURRENT value,
+ * decide whether the value just crossed the threshold in the requested
+ * direction. This is a true edge trigger — it fires only on the transition, not
+ * while the value merely sits past the threshold:
  *
- * Edge-triggered: an armed alert fires only on the tick where the price CROSSES
- * the threshold — i.e. the price now MEETS the condition (above: price >=
- * threshold; below: price <= threshold). The one-shot / re-arm behavior lives in
- * the store (markPriceAlertTriggered / rearmPriceAlert); this helper only reads
- * `alert.armed`, so a disarmed alert never fires and a re-armed one can fire
- * again.
+ *   above: prev <  target AND curr >= target
+ *   below: prev >  target AND curr <= target
  *
- * Returns true = fire now, false = do nothing.
+ * When `prev` is null/undefined/non-finite (no prior sample yet) we treat the
+ * first sample as a LEVEL check (fire if the condition is already met), matching
+ * the legacy one-shot behavior where the first poll can fire. Callers that want
+ * strict edges pass a real prior value.
  */
-export function evaluate(alert: PriceAlert, lastPriceTicks: number): boolean {
+export function alertCrossed(
+  prev: number | null | undefined,
+  curr: number,
+  condition: AlertCondition,
+  target: number,
+): boolean {
+  if (!Number.isFinite(curr)) return false;
+  const meets = condition === "above" ? curr >= target : curr <= target;
+  if (!meets) return false;
+  if (prev == null || !Number.isFinite(prev)) return true;
+  // Only fire on the transition into the met state.
+  const prevMet = condition === "above" ? prev >= target : prev <= target;
+  return !prevMet;
+}
+
+/**
+ * Decide whether an alert should fire given the latest value (in the subject's
+ * native integer units). LEVEL-based one-shot: an armed alert fires when the
+ * value MEETS the condition (above: value >= threshold; below: value <=
+ * threshold). The one-shot / re-arm behavior lives in the store
+ * (markPriceAlertTriggered / rearmPriceAlert); this helper only reads
+ * `alert.armed`, so a disarmed alert never fires and a re-armed one can again.
+ */
+export function evaluate(alert: PriceAlert, lastValue: number): boolean {
   if (!alert.armed) return false;
-  if (!Number.isFinite(lastPriceTicks)) return false;
+  if (!Number.isFinite(lastValue)) return false;
   if (alert.direction === "above") {
-    return lastPriceTicks >= alert.price;
+    return lastValue >= alert.price;
   }
-  return lastPriceTicks <= alert.price;
+  return lastValue <= alert.price;
+}
+
+/** Human short label for the subject kind. */
+export function subjectKindLabel(kind: AlertSubjectKind): string {
+  switch (kind) {
+    case "token":
+      return "Creator token";
+    case "strategy":
+      return "Strategy";
+    case "symbol":
+    default:
+      return "Symbol";
+  }
+}
+
+/**
+ * Human one-line label for an alert, e.g.
+ *   "BTC price above 65,000"  (symbol, name resolved by the caller)
+ *   "Strategy NAV below $12.50".
+ * `subjectName` is the resolved display name (symbol ticker / token ticker /
+ * fund name); when omitted, a "#id"-style fallback is used. `format` renders the
+ * threshold in the subject's units (ticks -> decimal, or cents -> "$x.xx").
+ */
+export function alertLabel(
+  alert: PriceAlert,
+  subjectName: string | undefined,
+  format: (value: number) => string,
+): string {
+  const name = subjectName ?? subjectFallbackName(alert);
+  const fieldWord = alert.field === "nav" ? "NAV" : "price";
+  return `${name} ${fieldWord} ${alert.direction} ${format(alert.price)}`;
+}
+
+/** "#id"-style fallback display name when a subject cannot be resolved. */
+export function subjectFallbackName(alert: PriceAlert): string {
+  if (alert.subjectKind === "symbol") return `#${alert.symbolId}`;
+  return alert.subjectId ? alert.subjectId : "?";
 }

--- a/frontend/src/pages/alerts/PriceAlertsPage.tsx
+++ b/frontend/src/pages/alerts/PriceAlertsPage.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useSearchParams } from "react-router-dom";
 import { BellRing, Plus, Trash2, RotateCcw, ArrowUp, ArrowDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -21,17 +22,25 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSymbols, useCandles } from "@/hooks/useMarketData";
+import { useTokenMarket, useMyTokens } from "@/hooks/useTokens";
+import { useStrategyMarket, useMyStrategies, useStrategyNav } from "@/hooks/useStrategies";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
+import type { Token } from "@/api/endpoints/tokens";
+import type { Strategy } from "@/api/endpoints/strategies";
 import { formatPrice } from "@/pages/markets/format";
+import { formatCents } from "@/lib/tokens";
 import { relativeTime } from "@/hooks/useTradingAlerts";
 import {
   addPriceAlert,
   loadPriceAlerts,
+  parseCentsToInt,
   parsePriceToTicks,
   rearmPriceAlert,
   removePriceAlert,
+  subjectKindLabel,
   PRICE_ALERTS_EVENT,
   PRICE_ALERTS_KEY,
+  type AlertSubjectKind,
   type PriceAlert,
   type PriceAlertDirection,
 } from "@/lib/priceAlerts";
@@ -54,8 +63,8 @@ function usePriceAlerts(): PriceAlert[] {
   return alerts;
 }
 
-/** Small live current-price readout for a symbol (candle close). */
-function CurrentPrice({ symbolId, scaler }: { symbolId: number; scaler: number }) {
+/** Small live current-price readout for a SYMBOL (candle close). */
+function SymbolCurrentPrice({ symbolId, scaler }: { symbolId: number; scaler: number }) {
   const { data } = useCandles(symbolId, 60, symbolId > 0, 1);
   const bars = data?.bars;
   const lastBar = bars && bars.length ? bars[bars.length - 1] : undefined;
@@ -63,19 +72,50 @@ function CurrentPrice({ symbolId, scaler }: { symbolId: number; scaler: number }
   return <span className="tabular-nums">{formatPrice(last, scaler)}</span>;
 }
 
+/** Live NAV readout for a STRATEGY (polled). */
+function StrategyCurrentNav({ strategyId }: { strategyId: string }) {
+  const { data } = useStrategyNav(strategyId);
+  return <span className="tabular-nums">{formatCents(data?.nav_per_unit)}</span>;
+}
+
 function AlertRow({
   alert,
   symbol,
+  tokensById,
+  strategiesById,
   now,
 }: {
   alert: PriceAlert;
   symbol: MarketSymbol | undefined;
+  tokensById: Map<string, Token>;
+  strategiesById: Map<string, Strategy>;
   now: number;
 }) {
-  const scaler = symbol?.price_scaler ?? 1;
-  const name = symbol?.symbol ?? `#${alert.symbolId}`;
   const fired = !!alert.triggeredTs;
   const DirIcon = alert.direction === "above" ? ArrowUp : ArrowDown;
+
+  // Resolve display name + threshold rendering per subject kind.
+  let name: string;
+  let thresholdLabel: string;
+  let current: React.ReactNode;
+  if (alert.subjectKind === "token") {
+    const t = tokensById.get(alert.subjectId);
+    name = t?.ticker ?? t?.name ?? alert.subjectId;
+    thresholdLabel = formatCents(alert.price);
+    current = <span className="tabular-nums">{formatCents(t?.clearing_price)}</span>;
+  } else if (alert.subjectKind === "strategy") {
+    const s = strategiesById.get(alert.subjectId);
+    name = s?.name ?? alert.subjectId;
+    thresholdLabel = formatCents(alert.price);
+    current = <StrategyCurrentNav strategyId={alert.subjectId} />;
+  } else {
+    const scaler = symbol?.price_scaler ?? 1;
+    name = symbol?.symbol ?? `#${alert.symbolId}`;
+    thresholdLabel = formatPrice(alert.price, scaler);
+    current = <SymbolCurrentPrice symbolId={alert.symbolId} scaler={scaler} />;
+  }
+  const fieldWord = alert.field === "nav" ? "NAV" : "price";
+
   return (
     <div
       className={cn(
@@ -85,13 +125,16 @@ function AlertRow({
     >
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline" className="text-muted-foreground">
+            {subjectKindLabel(alert.subjectKind)}
+          </Badge>
           <span className="font-medium">{name}</span>
           <Badge
             variant={alert.direction === "above" ? "default" : "secondary"}
             className="gap-1"
           >
             <DirIcon className="h-3 w-3" />
-            {alert.direction} {formatPrice(alert.price, scaler)}
+            {fieldWord} {alert.direction} {thresholdLabel}
           </Badge>
           {fired ? (
             <Badge variant="outline" className="text-muted-foreground">
@@ -106,9 +149,7 @@ function AlertRow({
         {alert.note && (
           <p className="mt-1 truncate text-sm text-muted-foreground">{alert.note}</p>
         )}
-        <p className="mt-1 text-xs text-muted-foreground">
-          Current: <CurrentPrice symbolId={alert.symbolId} scaler={scaler} />
-        </p>
+        <p className="mt-1 text-xs text-muted-foreground">Current: {current}</p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {fired && (
@@ -135,28 +176,85 @@ function AlertRow({
   );
 }
 
+/** De-dupe two token/strategy lists (mine + market) into one id-keyed map. */
+function mergeById<T>(lists: (T[] | undefined)[], keyOf: (x: T) => string): Map<string, T> {
+  const m = new Map<string, T>();
+  for (const list of lists) {
+    for (const item of list ?? []) {
+      const k = keyOf(item);
+      if (k && !m.has(k)) m.set(k, item);
+    }
+  }
+  return m;
+}
+
 export default function PriceAlertsPage() {
   const alerts = usePriceAlerts();
+
+  // -- Subject data sources -------------------------------------------
   const { data: symbolsData } = useSymbols();
   const symbols = React.useMemo(() => symbolsData?.symbols ?? [], [symbolsData]);
-  const byId = React.useMemo(() => {
+  const symbolsById = React.useMemo(() => {
     const m = new Map<number, MarketSymbol>();
     for (const s of symbols) m.set(s.symbol_id, s);
     return m;
   }, [symbols]);
 
-  // Add-form state.
-  const [symbolId, setSymbolId] = React.useState<string>("");
+  const tokenMarketQ = useTokenMarket();
+  const myTokensQ = useMyTokens();
+  const tokensById = React.useMemo(
+    () => mergeById<Token>([tokenMarketQ.data?.tokens, myTokensQ.data?.tokens], (t) => t.token_id),
+    [tokenMarketQ.data, myTokensQ.data],
+  );
+  const tokens = React.useMemo(() => [...tokensById.values()], [tokensById]);
+
+  const strategyMarketQ = useStrategyMarket();
+  const myStrategiesQ = useMyStrategies();
+  const strategiesById = React.useMemo(
+    () =>
+      mergeById<Strategy>(
+        [strategyMarketQ.data?.strategies, myStrategiesQ.data?.strategies],
+        (s) => s.strategy_id,
+      ),
+    [strategyMarketQ.data, myStrategiesQ.data],
+  );
+  const strategies = React.useMemo(() => [...strategiesById.values()], [strategiesById]);
+
+  // -- Deep-link prefill (e.g. from a token / strategy "Set alert" button) ----
+  // ?kind=token&id=<token_id> | ?kind=strategy&id=<strategy_id> | ?kind=symbol&id=<symbol_id>
+  const [searchParams] = useSearchParams();
+  const prefillKind = ((): AlertSubjectKind => {
+    const k = searchParams.get("kind");
+    return k === "token" || k === "strategy" || k === "symbol" ? k : "symbol";
+  })();
+  const prefillId = searchParams.get("id") ?? "";
+
+  // -- Add-form state -------------------------------------------------
+  const [subjectKind, setSubjectKind] = React.useState<AlertSubjectKind>(prefillKind);
+  const [symbolId, setSymbolId] = React.useState<string>(
+    prefillKind === "symbol" ? prefillId : "",
+  );
+  const [tokenId, setTokenId] = React.useState<string>(
+    prefillKind === "token" ? prefillId : "",
+  );
+  const [strategyId, setStrategyId] = React.useState<string>(
+    prefillKind === "strategy" ? prefillId : "",
+  );
   const [direction, setDirection] = React.useState<PriceAlertDirection>("above");
   const [priceStr, setPriceStr] = React.useState("");
   const [note, setNote] = React.useState("");
   const [error, setError] = React.useState<string | null>(null);
 
-  // Default the symbol select to the first symbol once loaded.
+  // Default each selector to its first option once loaded.
   React.useEffect(() => {
-    const first = symbols[0];
-    if (!symbolId && first) setSymbolId(String(first.symbol_id));
+    if (!symbolId && symbols[0]) setSymbolId(String(symbols[0].symbol_id));
   }, [symbols, symbolId]);
+  React.useEffect(() => {
+    if (!tokenId && tokens[0]) setTokenId(tokens[0].token_id);
+  }, [tokens, tokenId]);
+  React.useEffect(() => {
+    if (!strategyId && strategies[0]) setStrategyId(strategies[0].strategy_id);
+  }, [strategies, strategyId]);
 
   const [now, setNow] = React.useState(() => Date.now());
   React.useEffect(() => {
@@ -164,29 +262,71 @@ export default function PriceAlertsPage() {
     return () => clearInterval(t);
   }, []);
 
-  const selectedSymbol = symbolId ? byId.get(Number(symbolId)) : undefined;
+  const selectedSymbol = symbolId ? symbolsById.get(Number(symbolId)) : undefined;
+  const isCents = subjectKind !== "symbol"; // token / strategy targets are dollars->cents
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    const sid = Number(symbolId);
-    if (!Number.isFinite(sid) || sid <= 0) {
-      setError("Choose a symbol.");
-      return;
+
+    if (subjectKind === "symbol") {
+      const sid = Number(symbolId);
+      if (!Number.isFinite(sid) || sid <= 0) {
+        setError("Choose a symbol.");
+        return;
+      }
+      const scaler = selectedSymbol?.price_scaler ?? 1;
+      const ticks = parsePriceToTicks(priceStr, scaler);
+      if (ticks == null) {
+        setError("Enter a valid price.");
+        return;
+      }
+      addPriceAlert({ subjectKind: "symbol", symbolId: sid, direction, price: ticks, note });
+    } else if (subjectKind === "token") {
+      if (!tokenId) {
+        setError("Choose a creator token.");
+        return;
+      }
+      const cents = parseCentsToInt(priceStr);
+      if (cents == null) {
+        setError("Enter a valid price ($).");
+        return;
+      }
+      addPriceAlert({
+        subjectKind: "token",
+        subjectId: tokenId,
+        field: "price",
+        direction,
+        price: cents,
+        note,
+      });
+    } else {
+      if (!strategyId) {
+        setError("Choose a strategy.");
+        return;
+      }
+      const cents = parseCentsToInt(priceStr);
+      if (cents == null) {
+        setError("Enter a valid NAV ($).");
+        return;
+      }
+      addPriceAlert({
+        subjectKind: "strategy",
+        subjectId: strategyId,
+        field: "nav",
+        direction,
+        price: cents,
+        note,
+      });
     }
-    const scaler = selectedSymbol?.price_scaler ?? 1;
-    const ticks = parsePriceToTicks(priceStr, scaler);
-    if (ticks == null) {
-      setError("Enter a valid price.");
-      return;
-    }
-    addPriceAlert({ symbolId: sid, direction, price: ticks, note });
     setPriceStr("");
     setNote("");
   };
 
   const active = alerts.filter((a) => a.armed);
   const triggered = alerts.filter((a) => !a.armed);
+
+  const fieldNoun = subjectKind === "strategy" ? "NAV" : "price";
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-6 p-4 sm:p-6">
@@ -195,7 +335,7 @@ export default function PriceAlertsPage() {
         <div>
           <h1 className="text-xl font-semibold">Price alerts</h1>
           <p className="text-sm text-muted-foreground">
-            Get notified when a market crosses your target price.
+            Get notified when a market, creator token, or strategy fund crosses your target.
           </p>
         </div>
       </div>
@@ -204,27 +344,97 @@ export default function PriceAlertsPage() {
         <CardHeader>
           <CardTitle className="text-base">New alert</CardTitle>
           <CardDescription>
-            Alerts fire once when the last price crosses your threshold, then pause
+            Alerts fire once when the {fieldNoun} crosses your threshold, then pause
             so you can re-arm them.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={onSubmit} className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label htmlFor="pa-symbol">Symbol</Label>
-              <Select value={symbolId} onValueChange={setSymbolId}>
-                <SelectTrigger id="pa-symbol">
-                  <SelectValue placeholder="Select symbol" />
+              <Label htmlFor="pa-kind">Watch</Label>
+              <Select
+                value={subjectKind}
+                onValueChange={(v) => {
+                  setSubjectKind(v as AlertSubjectKind);
+                  setError(null);
+                }}
+              >
+                <SelectTrigger id="pa-kind">
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {symbols.map((s) => (
-                    <SelectItem key={s.symbol_id} value={String(s.symbol_id)}>
-                      {s.symbol}
-                    </SelectItem>
-                  ))}
+                  <SelectItem value="symbol">Symbol</SelectItem>
+                  <SelectItem value="token">Creator token</SelectItem>
+                  <SelectItem value="strategy">Strategy</SelectItem>
                 </SelectContent>
               </Select>
             </div>
+
+            {subjectKind === "symbol" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="pa-symbol">Symbol</Label>
+                <Select value={symbolId} onValueChange={setSymbolId}>
+                  <SelectTrigger id="pa-symbol">
+                    <SelectValue placeholder="Select symbol" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {symbols.map((s) => (
+                      <SelectItem key={s.symbol_id} value={String(s.symbol_id)}>
+                        {s.symbol}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {subjectKind === "token" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="pa-token">Creator token</Label>
+                <Select value={tokenId} onValueChange={setTokenId}>
+                  <SelectTrigger id="pa-token">
+                    <SelectValue placeholder="Select token" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {tokens.length === 0 ? (
+                      <SelectItem value="__none" disabled>
+                        No tokens available
+                      </SelectItem>
+                    ) : (
+                      tokens.map((t) => (
+                        <SelectItem key={t.token_id} value={t.token_id}>
+                          {t.ticker} — {t.name}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {subjectKind === "strategy" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="pa-strategy">Strategy</Label>
+                <Select value={strategyId} onValueChange={setStrategyId}>
+                  <SelectTrigger id="pa-strategy">
+                    <SelectValue placeholder="Select strategy" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {strategies.length === 0 ? (
+                      <SelectItem value="__none" disabled>
+                        No strategies available
+                      </SelectItem>
+                    ) : (
+                      strategies.map((s) => (
+                        <SelectItem key={s.strategy_id} value={s.strategy_id}>
+                          {s.name}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             <div className="space-y-1.5">
               <Label htmlFor="pa-dir">Condition</Label>
@@ -236,28 +446,41 @@ export default function PriceAlertsPage() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="above">Price rises above</SelectItem>
-                  <SelectItem value="below">Price falls below</SelectItem>
+                  <SelectItem value="above">{fieldNoun} rises above</SelectItem>
+                  <SelectItem value="below">{fieldNoun} falls below</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="pa-price">Target price</Label>
+              <Label htmlFor="pa-price">
+                {subjectKind === "strategy" ? "Target NAV" : "Target price"}
+                {isCents ? " ($)" : ""}
+              </Label>
               <Input
                 id="pa-price"
                 inputMode="decimal"
-                placeholder="e.g. 65000"
+                placeholder={isCents ? "e.g. 12.50" : "e.g. 65000"}
                 value={priceStr}
                 onChange={(e) => setPriceStr(e.target.value)}
               />
-              {selectedSymbol && (
+              {subjectKind === "symbol" && selectedSymbol && (
                 <p className="text-xs text-muted-foreground">
                   Current:{" "}
-                  <CurrentPrice
+                  <SymbolCurrentPrice
                     symbolId={selectedSymbol.symbol_id}
                     scaler={selectedSymbol.price_scaler}
                   />
+                </p>
+              )}
+              {subjectKind === "token" && tokenId && (
+                <p className="text-xs text-muted-foreground">
+                  Current: {formatCents(tokensById.get(tokenId)?.clearing_price)}
+                </p>
+              )}
+              {subjectKind === "strategy" && strategyId && (
+                <p className="text-xs text-muted-foreground">
+                  Current: <StrategyCurrentNav strategyId={strategyId} />
                 </p>
               )}
             </div>
@@ -290,15 +513,22 @@ export default function PriceAlertsPage() {
         {active.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-10 text-center">
             <BellRing className="h-6 w-6 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">No active price alerts</p>
+            <p className="text-sm text-muted-foreground">No active alerts</p>
             <p className="text-xs text-muted-foreground">
-              Add one above to get notified on a price move.
+              Add one above to get notified on a price or NAV move.
             </p>
           </div>
         ) : (
           <div className="space-y-2">
             {active.map((a) => (
-              <AlertRow key={a.id} alert={a} symbol={byId.get(a.symbolId)} now={now} />
+              <AlertRow
+                key={a.id}
+                alert={a}
+                symbol={symbolsById.get(a.symbolId)}
+                tokensById={tokensById}
+                strategiesById={strategiesById}
+                now={now}
+              />
             ))}
           </div>
         )}
@@ -311,7 +541,14 @@ export default function PriceAlertsPage() {
           </h2>
           <div className="space-y-2">
             {triggered.map((a) => (
-              <AlertRow key={a.id} alert={a} symbol={byId.get(a.symbolId)} now={now} />
+              <AlertRow
+                key={a.id}
+                alert={a}
+                symbol={symbolsById.get(a.symbolId)}
+                tokensById={tokensById}
+                strategiesById={strategiesById}
+                now={now}
+              />
             ))}
           </div>
         </section>

--- a/frontend/src/pages/strategies/StrategyDetailPage.tsx
+++ b/frontend/src/pages/strategies/StrategyDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, Boxes, FlaskConical, Pencil, Rocket, Lock } from "lucide-react";
+import { ArrowLeft, BellRing, Boxes, FlaskConical, Pencil, Rocket, Lock } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -182,6 +182,11 @@ export default function StrategyDetailPage() {
           {header}
         </div>
         <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to={`/markets/price-alerts?kind=strategy&id=${encodeURIComponent(id ?? "")}`}>
+              <BellRing className="mr-1 h-4 w-4" /> Set NAV alert
+            </Link>
+          </Button>
           <Button asChild variant="outline" size="sm">
             <Link to={`/strategies/${encodeURIComponent(id ?? "")}/backtest`}>
               <FlaskConical className="mr-1 h-4 w-4" /> Paper &amp; backtest

--- a/frontend/src/pages/tokens/TokenDetailPage.tsx
+++ b/frontend/src/pages/tokens/TokenDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, Coins, Snowflake } from "lucide-react";
+import { ArrowLeft, BellRing, Coins, Snowflake } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -103,6 +103,11 @@ export default function TokenDetailPage() {
           </Link>
         </Button>
         {header}
+        <Button asChild variant="outline" size="sm" className="ml-auto gap-1">
+          <Link to={`/markets/price-alerts?kind=token&id=${encodeURIComponent(id ?? "")}`}>
+            <BellRing className="h-4 w-4" /> Set price alert
+          </Link>
+        </Button>
       </div>
 
       {tokenQ.isError ? (


### PR DESCRIPTION
## Price/NAV alerts for creator tokens & strategy funds

Generalizes the shipped price-alerts feature to a **subject kind** (symbol | token | strategy): symbol/token alerts on price, strategy alerts on NAV per unit. Existing symbol alerts **migrate transparently** and keep working. Client-derived, edge-triggered on crossing, fired through the same alert path (bell + Activity Center); degrade-on-404 (token/strategy reads simply never fire until live).

### Web
`lib/priceAlerts.ts` (+30 vitest) — subject kind + price/nav fields + pure `alertCrossed` (edge-trigger) + `alertLabel` + legacy migration; `PriceAlertEvaluator.tsx` per-subject watchers (symbol candle / token clearing_price / strategy nav_per_unit); `PriceAlertsPage` Watch selector + kind-aware pickers; Token & Strategy detail "Set alert" deep-links.

### Android
`data/exchange/alerts` — `PriceAlert` (subject kind + pure `alertCrossed`/`alertLabel`), `PriceAlertsStore` (legacy→SYMBOL migration), `PriceAlertsEvaluator` (token/strategy subjects, composite kind:id edge state, same PRICE path); +14 JVM tests. `PriceAlerts` Screen/UiState/ViewModel — subject-kind toggle + token/strategy catalogs from the repos.

No new deps, no new routes (MoreCatalog untouched). Gates: web tsc 0 · vite build · vitest 30/30; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (+14 alert tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
