### PR TITLE
feat(onboarding): welcome tour + per-surface intros for the new surfaces (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityCenterScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/activity/ActivityCenterScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.testlogon.android.feature.onboarding.SurfaceIntro
+import com.testlogon.android.feature.onboarding.OnboardingModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.feature.markets.ui.MarketColors
 import com.testlogon.android.feature.markets.ui.MarketSurface
@@ -71,6 +73,7 @@ fun ActivityCenterRoute(
                 onRefresh = viewModel::refresh,
             )
             CategoryChips(selected = state.selected, onSelect = viewModel::selectCategory)
+            SurfaceIntro(OnboardingModel.INTRO_ACTIVITY_CENTER)
             if (state.degradedSources.isNotEmpty()) {
                 Text(
                     "Some feeds unavailable: " + state.degradedSources.joinToString(", "),

--- a/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutBoardScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/bailout/BailoutBoardScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.testlogon.android.feature.onboarding.SurfaceIntro
+import com.testlogon.android.feature.onboarding.OnboardingModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.core.ui.state.ErrorState
 import com.testlogon.android.core.ui.state.LoadingState
@@ -71,6 +73,7 @@ fun BailoutBoardRoute(
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                item { SurfaceIntro(OnboardingModel.INTRO_BAILOUTS) }
                 item {
                     Text(
                         "Inject rescue capital into a distressed-but-solvent position for a slice of it (and its uPnL). Bids clear at a single least-dilutive share.",

--- a/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardScreen.kt
@@ -76,6 +76,7 @@ import com.testlogon.android.feature.dashboard.states.DashboardStaleBanner
 import com.testlogon.android.feature.dashboard.widgets.HighlightsWidget
 import com.testlogon.android.feature.dashboard.widgets.SummaryWidget
 import com.testlogon.android.feature.more.MoreHub
+import com.testlogon.android.feature.onboarding.WelcomeTour
 import com.testlogon.android.feature.more.accent
 import com.testlogon.android.navigation.BroadcastBrowseDest
 import com.testlogon.android.navigation.ComposePostDest
@@ -112,6 +113,9 @@ fun DashboardRoute(
             }
         }
     }
+
+    // First-run guided tour of the new trading/investing surfaces (persisted show-once).
+    WelcomeTour(onOpenRoute = onOpenRoute)
 
     DashboardScreen(
         state = state,

--- a/android/app/src/main/java/com/testlogon/android/feature/invest/InvestScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/invest/InvestScreen.kt
@@ -42,6 +42,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.core.ui.state.EmptyState
 import com.testlogon.android.core.ui.state.ErrorState
 import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.feature.onboarding.SurfaceIntro
+import com.testlogon.android.feature.onboarding.OnboardingModel
 
 /**
  * The unified INVEST hub — one front door aggregating every investable/tradeable product (markets,
@@ -109,6 +111,7 @@ private fun InvestContent(
         contentPadding = PaddingValues(vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
+        item { SurfaceIntro(OnboardingModel.INTRO_INVEST) }
         item {
             OutlinedTextField(
                 value = state.query,

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/ActiveAlgosScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/ActiveAlgosScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.testlogon.android.feature.onboarding.SurfaceIntro
+import com.testlogon.android.feature.onboarding.OnboardingModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.data.exchange.OrderSide
 import com.testlogon.android.feature.markets.ui.MarketColors
@@ -89,6 +91,7 @@ private fun ActiveAlgosScreen(
         },
     ) { pad ->
         Column(Modifier.fillMaxSize().padding(pad).padding(horizontal = 12.dp)) {
+            SurfaceIntro(OnboardingModel.INTRO_ACTIVE_ALGOS)
             Spacer(Modifier.height(8.dp))
             Box(
                 Modifier.fillMaxWidth()

--- a/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingModel.kt
@@ -1,0 +1,156 @@
+package com.testlogon.android.feature.onboarding
+
+import com.testlogon.android.navigation.MoreRoutes
+
+/**
+ * PURE onboarding registry + helpers (no Android, no I/O) for the trading/investing guided tours.
+ *
+ * Two mechanisms share this model:
+ *  - the first-run **Welcome tour** ([tourSteps]) — a stepper introducing the new surfaces, each step
+ *    optionally carrying a [OnboardingStep.route] the "Go there" button navigates to;
+ *  - per-surface **intro callouts** ([surfaceIntros]) shown once at the top of a key screen.
+ *
+ * Persistence is a monotonic set of already-seen [OnboardingStep.id]s (never un-set except by an
+ * explicit reset). All helpers here are pure functions over that set so they are trivially unit-tested.
+ */
+object OnboardingModel {
+
+    /** A single tour step or surface-intro descriptor. [route] (when non-null) is an in-app route. */
+    data class OnboardingStep(
+        val id: String,
+        val title: String,
+        val body: String,
+        val route: String? = null,
+    )
+
+    // ---- stable ids (also the DataStore seen-set keys) ----
+
+    /** The whole first-run welcome tour is gated behind ONE id (seen once, never re-nags). */
+    const val WELCOME_TOUR_ID: String = "welcome_tour"
+
+    const val INTRO_INVEST: String = "intro_invest"
+    const val INTRO_STRATEGIES: String = "intro_strategies"
+    const val INTRO_TOKENS: String = "intro_tokens"
+    const val INTRO_BAILOUTS: String = "intro_bailouts"
+    const val INTRO_PORTFOLIO_ANALYTICS: String = "intro_portfolio_analytics"
+    const val INTRO_ACTIVITY_CENTER: String = "intro_activity_center"
+    const val INTRO_ACTIVE_ALGOS: String = "intro_active_algos"
+
+    /**
+     * The ordered welcome-tour steps. First is an intro card (no route); the rest each spotlight one
+     * shipped surface with a "Go there" into its existing [MoreRoutes] route.
+     */
+    fun tourSteps(): List<OnboardingStep> = listOf(
+        OnboardingStep(
+            id = "tour_welcome",
+            title = "Welcome to Trading & Investing",
+            body = "We just added a full trading and investing suite. Take a quick tour of what is new, or skip and explore on your own anytime.",
+            route = null,
+        ),
+        OnboardingStep(
+            id = "tour_invest",
+            title = "Invest hub",
+            body = "One front door for everything investable: live markets, creator tokens, strategy funds and open opportunities. Search filters them all at once.",
+            route = MoreRoutes.INVEST,
+        ),
+        OnboardingStep(
+            id = "tour_strategies",
+            title = "Strategy funds",
+            body = "Browse investable baskets built by other users, or create, backtest and publish your own strategy.",
+            route = MoreRoutes.STRATEGIES,
+        ),
+        OnboardingStep(
+            id = "tour_tokens",
+            title = "Creator tokens",
+            body = "Mint a revenue-share token or trade the ones already listed. Tap any token for its market and details.",
+            route = MoreRoutes.TOKENS,
+        ),
+        OnboardingStep(
+            id = "tour_bailouts",
+            title = "Bailouts",
+            body = "The rescuer opportunity board: step in on margin-distressed positions before liquidation via pre-emptive bailout auctions.",
+            route = MoreRoutes.BAILOUTS,
+        ),
+        OnboardingStep(
+            id = "tour_portfolio_analytics",
+            title = "Portfolio analytics",
+            body = "A cross-venue view of your holdings, performance and allocation across custody, spot, margin and staking.",
+            route = MoreRoutes.PORTFOLIO_ANALYTICS,
+        ),
+        OnboardingStep(
+            id = "tour_active_algos",
+            title = "Active algos",
+            body = "Monitor your running TWAP and Iceberg algo orders, with live progress and pause or cancel controls.",
+            route = MoreRoutes.ACTIVE_ALGOS,
+        ),
+        OnboardingStep(
+            id = "tour_activity_center",
+            title = "Activity center",
+            body = "A consolidated, filterable timeline of every account event across trading, custody and money movement.",
+            route = MoreRoutes.ACTIVITY_CENTER,
+        ),
+        OnboardingStep(
+            id = "tour_tax",
+            title = "Tax & gains",
+            body = "A read-only cost-basis report of your tax lots and realized gains, ready when you need it.",
+            route = MoreRoutes.TAX_REPORT,
+        ),
+    )
+
+    /** The per-surface intro callouts, keyed by their stable id. */
+    fun surfaceIntros(): Map<String, OnboardingStep> = listOf(
+        OnboardingStep(
+            id = INTRO_INVEST,
+            title = "This is your Invest hub",
+            body = "Everything you can invest in lives here — markets, creator tokens, strategy funds and opportunities. Use search to filter across all of them, then tap See all to dive into a section.",
+        ),
+        OnboardingStep(
+            id = INTRO_STRATEGIES,
+            title = "Strategy funds",
+            body = "Invest in baskets published by other users, or tap Create to define, backtest and publish your own strategy.",
+        ),
+        OnboardingStep(
+            id = INTRO_TOKENS,
+            title = "Creator tokens",
+            body = "Trade listed revenue-share tokens or mint your own. Tap a token to open its market and details.",
+        ),
+        OnboardingStep(
+            id = INTRO_BAILOUTS,
+            title = "Bailout board",
+            body = "Rescue margin-distressed positions before liquidation and earn the bailout premium. Tap an opportunity to review and bid.",
+        ),
+        OnboardingStep(
+            id = INTRO_PORTFOLIO_ANALYTICS,
+            title = "Portfolio analytics",
+            body = "A read-only cross-venue snapshot of your holdings, performance and allocation. Pull to refresh for the latest.",
+        ),
+        OnboardingStep(
+            id = INTRO_ACTIVITY_CENTER,
+            title = "Activity center",
+            body = "Your consolidated, day-grouped account timeline. Use the filters to narrow to the event types you care about.",
+        ),
+        OnboardingStep(
+            id = INTRO_ACTIVE_ALGOS,
+            title = "Active algos",
+            body = "Watch your running TWAP and Iceberg orders here. Each card shows live progress and lets you pause or cancel.",
+        ),
+    ).associateBy { it.id }
+
+    // ---- pure helpers over the seen-set ----
+
+    /** True when [id] has NOT yet been recorded in [seen] (i.e. it should still be shown). */
+    fun shouldShow(id: String, seen: Set<String>): Boolean = id !in seen
+
+    /** Returns a new seen-set with [id] added (monotonic; never removes). Idempotent. */
+    fun markSeen(id: String, seen: Set<String>): Set<String> =
+        if (id in seen) seen else seen + id
+
+    /** Look up a surface-intro descriptor by id, or null when unknown. */
+    fun surfaceIntro(id: String): OnboardingStep? = surfaceIntros()[id]
+
+    /** All ids this model can persist (welcome tour + every surface intro) — used by reset/debug. */
+    fun allIds(): Set<String> = buildSet {
+        add(WELCOME_TOUR_ID)
+        addAll(surfaceIntros().keys)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingModule.kt
@@ -1,0 +1,17 @@
+package com.testlogon.android.feature.onboarding
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Binds the durable onboarding seen-set store (DataStore) for injection into the tour ViewModels. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class OnboardingModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindOnboardingStore(impl: DataStoreOnboardingStore): OnboardingStore
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingStore.kt
@@ -1,0 +1,64 @@
+package com.testlogon.android.feature.onboarding
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.onboardingDataStore by preferencesDataStore(name = "onboarding")
+
+/**
+ * Durable "already-seen" set for the trading/investing onboarding (welcome tour + per-surface intros),
+ * persisted as one string-set in DataStore. Mirrors the failure-safe pattern of
+ * [com.testlogon.android.feature.paper.PaperAccountStore]: a store error degrades to "nothing seen" /
+ * a no-op write, never throws. Interface seam so ViewModels can inject an in-memory fake on the JVM.
+ *
+ * The set only ever grows via [markSeen] (monotonic show-once); [resetAll] is the single un-set path,
+ * used by the Settings "Product tour" replay control.
+ */
+interface OnboardingStore {
+    /** A live stream of the seen-set (emits the current set immediately, then on every change). */
+    fun seenIds(): Flow<Set<String>>
+
+    /** Record [id] as seen (idempotent). A subsequent [seenIds] contains it. */
+    suspend fun markSeen(id: String)
+
+    /** Clear every recorded id so all tours/intros show again. */
+    suspend fun resetAll()
+}
+
+@Singleton
+class DataStoreOnboardingStore @Inject constructor(
+    @ApplicationContext context: Context,
+) : OnboardingStore {
+
+    private val dataStore = context.onboardingDataStore
+
+    override fun seenIds(): Flow<Set<String>> = dataStore.data
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .map { prefs -> prefs[Keys.SEEN].orEmpty() }
+
+    override suspend fun markSeen(id: String) {
+        runCatching {
+            dataStore.edit { prefs ->
+                prefs[Keys.SEEN] = OnboardingModel.markSeen(id, prefs[Keys.SEEN].orEmpty())
+            }
+        }
+    }
+
+    override suspend fun resetAll() {
+        runCatching { dataStore.edit { it.remove(Keys.SEEN) } }
+    }
+
+    private object Keys {
+        val SEEN = stringSetPreferencesKey("onboarding_seen_ids")
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,40 @@
+package com.testlogon.android.feature.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Shared Hilt ViewModel backing BOTH onboarding UIs (the first-run welcome tour and every per-surface
+ * intro callout). It exposes the persisted seen-set as a [StateFlow] and forwards mark/reset to the
+ * [OnboardingStore]. Keeping this a plain injected VM means individual screens gain onboarding with a
+ * single `OnboardingHost { ... }` / `SurfaceIntro(id)` call and no signature changes.
+ */
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val store: OnboardingStore,
+) : ViewModel() {
+
+    /** The live seen-set; null while the first value is still loading (so nothing flashes prematurely). */
+    val seenIds: StateFlow<Set<String>?> = store.seenIds()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = null,
+        )
+
+    /** Record [id] as seen (welcome-tour completion or an intro dismissal). */
+    fun markSeen(id: String) {
+        viewModelScope.launch { store.markSeen(id) }
+    }
+
+    /** Replay everything: clears the whole seen-set (Settings "Product tour" control). */
+    fun resetAll() {
+        viewModelScope.launch { store.resetAll() }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/onboarding/SurfaceIntro.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/onboarding/SurfaceIntro.kt
@@ -1,0 +1,92 @@
+package com.testlogon.android.feature.onboarding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Lightbulb
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * A dismissible, persisted-once intro callout for the top of a new trading/investing screen. Renders
+ * the [OnboardingModel] surface-intro registered under [introId] (a one-paragraph "what this is + key
+ * action"); dismissing records the id as seen so it never shows again (until the Settings replay reset).
+ *
+ * Self-contained: it owns its [OnboardingViewModel], so a screen adds it with a single call and no
+ * signature change. Renders nothing while the seen-set is loading, once dismissed, or for an unknown id.
+ */
+@Composable
+fun SurfaceIntro(
+    introId: String,
+    modifier: Modifier = Modifier,
+    viewModel: OnboardingViewModel = hiltViewModel(),
+) {
+    val step = OnboardingModel.surfaceIntro(introId) ?: return
+    val seen by viewModel.seenIds.collectAsStateWithLifecycle()
+    val current = seen ?: return // still loading -> render nothing yet
+    if (!OnboardingModel.shouldShow(introId, current)) return
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag("surface_intro_$introId"),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, bottom = 12.dp, end = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                Icons.Outlined.Lightbulb,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Column(
+                modifier = Modifier.weight(1f).padding(top = 2.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = step.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Text(
+                    text = step.body,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            IconButton(
+                onClick = { viewModel.markSeen(introId) },
+                modifier = Modifier
+                    .align(Alignment.Top)
+                    .testTag("surface_intro_dismiss_$introId"),
+            ) {
+                Icon(
+                    Icons.Outlined.Close,
+                    contentDescription = "Dismiss",
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/onboarding/WelcomeTour.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/onboarding/WelcomeTour.kt
@@ -1,0 +1,134 @@
+package com.testlogon.android.feature.onboarding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * The first-run **Welcome tour**: a stepper dialog that walks the new trading/investing surfaces. It
+ * shows automatically ONCE (gated on [OnboardingModel.WELCOME_TOUR_ID] in the seen-set) and can be
+ * replayed from Settings. Each step shows a title + body; steps with a route add a "Go there" button
+ * that completes the tour and navigates via [onOpenRoute] (the caller uses existing routes). Skip and
+ * Done (last step) both persist completion.
+ *
+ * Drop this at the top of a host screen (the Dashboard):
+ *   `WelcomeTour(onOpenRoute = onOpenRoute)`
+ * It renders nothing once completed or while the seen-set is loading.
+ */
+@Composable
+fun WelcomeTour(
+    onOpenRoute: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: OnboardingViewModel = hiltViewModel(),
+) {
+    val seen by viewModel.seenIds.collectAsStateWithLifecycle()
+    val current = seen ?: return // still loading
+    if (!OnboardingModel.shouldShow(OnboardingModel.WELCOME_TOUR_ID, current)) return
+
+    WelcomeTourDialog(
+        onComplete = { viewModel.markSeen(OnboardingModel.WELCOME_TOUR_ID) },
+        onOpenRoute = onOpenRoute,
+        modifier = modifier,
+    )
+}
+
+/** Pure-ish stepper UI (no store); split out so it is easy to preview/drive. */
+@Composable
+private fun WelcomeTourDialog(
+    onComplete: () -> Unit,
+    onOpenRoute: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val steps = remember { OnboardingModel.tourSteps() }
+    if (steps.isEmpty()) return
+    var index by rememberSaveable { mutableIntStateOf(0) }
+    val step = steps[index.coerceIn(0, steps.lastIndex)]
+    val isFirst = index == 0
+    val isLast = index == steps.lastIndex
+
+    AlertDialog(
+        onDismissRequest = onComplete,
+        modifier = modifier.testTag("welcome_tour_dialog"),
+        title = {
+            Column {
+                Text(
+                    text = "Step ${index + 1} of ${steps.size}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(text = step.title, style = MaterialTheme.typography.titleLarge)
+            }
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(text = step.body, style = MaterialTheme.typography.bodyMedium)
+                step.route?.let { route ->
+                    TextButton(
+                        onClick = {
+                            onComplete()
+                            onOpenRoute(route)
+                        },
+                        modifier = Modifier.testTag("welcome_tour_goto"),
+                    ) {
+                        Text("Go there")
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            if (isLast) {
+                TextButton(
+                    onClick = onComplete,
+                    modifier = Modifier.testTag("welcome_tour_done"),
+                ) {
+                    Text("Done")
+                }
+            } else {
+                TextButton(
+                    onClick = { index += 1 },
+                    modifier = Modifier.testTag("welcome_tour_next"),
+                ) {
+                    Text("Next")
+                }
+            }
+        },
+        dismissButton = {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                if (!isFirst) {
+                    TextButton(
+                        onClick = { index -= 1 },
+                        modifier = Modifier.testTag("welcome_tour_back"),
+                    ) {
+                        Text("Back")
+                    }
+                }
+                TextButton(
+                    onClick = onComplete,
+                    modifier = Modifier.testTag("welcome_tour_skip"),
+                ) {
+                    Text("Skip")
+                }
+            }
+        },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.testlogon.android.feature.onboarding.SurfaceIntro
+import com.testlogon.android.feature.onboarding.OnboardingModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.util.Locale
 
@@ -97,6 +99,7 @@ fun PortfolioAnalyticsScreen(
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
+            item { SurfaceIntro(OnboardingModel.INTRO_PORTFOLIO_ANALYTICS) }
             item { HeaderCard(state) }
 
             when {

--- a/android/app/src/main/java/com/testlogon/android/feature/settings/appearance/AppearanceSettingsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/appearance/AppearanceSettingsScreen.kt
@@ -30,6 +30,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.R
+import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.outlined.TravelExplore
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.testlogon.android.core.network.AppThemeMode
 import com.testlogon.android.core.network.AppearancePreferences
 
@@ -46,6 +51,7 @@ fun AppearanceSettingsRoute(
         dynamicColorSupported = viewModel.dynamicColorSupported,
         onModeSelected = viewModel::onModeSelected,
         onDynamicColorChanged = viewModel::onDynamicColorChanged,
+        onReplayProductTour = viewModel::onReplayProductTour,
         onBack = onBack,
         modifier = modifier,
     )
@@ -58,6 +64,7 @@ fun AppearanceSettingsScreen(
     dynamicColorSupported: Boolean,
     onModeSelected: (AppThemeMode) -> Unit,
     onDynamicColorChanged: (Boolean) -> Unit,
+    onReplayProductTour: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -102,8 +109,41 @@ fun AppearanceSettingsScreen(
                     onCheckedChange = onDynamicColorChanged,
                 )
             }
+            HorizontalDivider()
+            ProductTourRow(onReplayProductTour = onReplayProductTour)
         }
     }
+}
+
+/**
+ * A Settings control that replays the trading/investing product tour: taps clear the onboarding
+ * seen-set (welcome tour + every surface intro) so they show again, and a short inline confirmation
+ * is shown. Reachable from the Appearance settings screen.
+ */
+@Composable
+private fun ProductTourRow(onReplayProductTour: () -> Unit) {
+    var replayed by remember { mutableStateOf(false) }
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("appearance_product_tour")
+            .clickable {
+                onReplayProductTour()
+                replayed = true
+            },
+        headlineContent = { Text(stringResource(R.string.settings_product_tour_title)) },
+        supportingContent = {
+            Text(
+                if (replayed) {
+                    stringResource(R.string.settings_product_tour_replayed)
+                } else {
+                    stringResource(R.string.settings_product_tour_subtitle)
+                },
+                style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = { Icon(Icons.Outlined.TravelExplore, contentDescription = null) },
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/testlogon/android/feature/settings/appearance/AppearanceSettingsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/appearance/AppearanceSettingsViewModel.kt
@@ -2,11 +2,14 @@ package com.testlogon.android.feature.settings.appearance
 
 import android.os.Build
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.network.AppThemeMode
 import com.testlogon.android.core.network.AppearancePreferences
 import com.testlogon.android.core.network.ThemePreferencesStore
+import com.testlogon.android.feature.onboarding.OnboardingStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -17,6 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class AppearanceSettingsViewModel @Inject constructor(
     private val store: ThemePreferencesStore,
+    private val onboardingStore: OnboardingStore,
 ) : ViewModel() {
 
     val uiState: StateFlow<AppearancePreferences> = store.preferences
@@ -27,4 +31,12 @@ class AppearanceSettingsViewModel @Inject constructor(
     fun onModeSelected(mode: AppThemeMode) = store.setMode(mode)
 
     fun onDynamicColorChanged(enabled: Boolean) = store.setDynamicColor(enabled)
+
+    /**
+     * Replay the trading/investing product tour: clears the whole onboarding seen-set so the first-run
+     * welcome tour and every per-surface intro callout show again.
+     */
+    fun onReplayProductTour() {
+        viewModelScope.launch { onboardingStore.resetAll() }
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMarketScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyMarketScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.testlogon.android.feature.onboarding.SurfaceIntro
+import com.testlogon.android.feature.onboarding.OnboardingModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.core.ui.state.EmptyState
 import com.testlogon.android.core.ui.state.ErrorState
@@ -77,6 +79,7 @@ fun StrategyMarketRoute(
         },
     ) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            SurfaceIntro(OnboardingModel.INTRO_STRATEGIES)
             TabRow(selectedTabIndex = if (state.tab == StrategyListTab.MARKET) 0 else 1) {
                 Tab(
                     selected = state.tab == StrategyListTab.MARKET,

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.testlogon.android.feature.onboarding.SurfaceIntro
+import com.testlogon.android.feature.onboarding.OnboardingModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.core.ui.state.EmptyState
 import com.testlogon.android.core.ui.state.ErrorState
@@ -78,6 +80,7 @@ fun TokensMarketRoute(
         },
     ) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            SurfaceIntro(OnboardingModel.INTRO_TOKENS)
             TabRow(selectedTabIndex = if (state.tab == TokenListTab.MARKET) 0 else 1) {
                 Tab(
                     selected = state.tab == TokenListTab.MARKET,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -241,6 +241,9 @@
     <string name="appearance_mode_system">System default</string>
     <string name="appearance_dynamic_color">Use dynamic color</string>
     <string name="appearance_dynamic_color_subtitle">Match colors to your wallpaper (Android 12+).</string>
+    <string name="settings_product_tour_title">Product tour</string>
+    <string name="settings_product_tour_subtitle">Replay the trading &amp; investing welcome tour and show all intro tips again.</string>
+    <string name="settings_product_tour_replayed">Tour reset. It will show next time you open Home and the new screens.</string>
 
     <!-- Media (call) preferences (AND-079) -->
     <string name="media_prefs_title">Media</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/onboarding/OnboardingModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/onboarding/OnboardingModelTest.kt
@@ -1,0 +1,127 @@
+package com.testlogon.android.feature.onboarding
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Thorough unit tests for the PURE [OnboardingModel] registry + seen-set helpers. */
+class OnboardingModelTest {
+
+    @Test
+    fun shouldShow_true_whenIdNotSeen() {
+        assertTrue(OnboardingModel.shouldShow("x", emptySet()))
+        assertTrue(OnboardingModel.shouldShow("x", setOf("y", "z")))
+    }
+
+    @Test
+    fun shouldShow_false_whenIdSeen() {
+        assertFalse(OnboardingModel.shouldShow("x", setOf("x")))
+        assertFalse(OnboardingModel.shouldShow("x", setOf("x", "y")))
+    }
+
+    @Test
+    fun markSeen_addsId() {
+        assertEquals(setOf("x"), OnboardingModel.markSeen("x", emptySet()))
+        assertEquals(setOf("a", "x"), OnboardingModel.markSeen("x", setOf("a")))
+    }
+
+    @Test
+    fun markSeen_isIdempotent_returnsSameInstanceWhenAlreadyPresent() {
+        val seen = setOf("x", "y")
+        val after = OnboardingModel.markSeen("x", seen)
+        assertEquals(seen, after)
+        assertTrue("no-op should return the same set instance", seen === after)
+    }
+
+    @Test
+    fun markSeen_isMonotonic_neverRemoves() {
+        var seen = emptySet<String>()
+        seen = OnboardingModel.markSeen("a", seen)
+        seen = OnboardingModel.markSeen("b", seen)
+        seen = OnboardingModel.markSeen("a", seen)
+        assertEquals(setOf("a", "b"), seen)
+    }
+
+    @Test
+    fun tourSteps_notEmpty_firstStepHasNoRoute() {
+        val steps = OnboardingModel.tourSteps()
+        assertTrue(steps.size >= 8)
+        assertNull("intro/welcome step should not navigate", steps.first().route)
+    }
+
+    @Test
+    fun tourSteps_haveUniqueIds() {
+        val ids = OnboardingModel.tourSteps().map { it.id }
+        assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun tourSteps_allTitlesAndBodiesNonBlank() {
+        OnboardingModel.tourSteps().forEach {
+            assertTrue("blank title for ${it.id}", it.title.isNotBlank())
+            assertTrue("blank body for ${it.id}", it.body.isNotBlank())
+        }
+    }
+
+    @Test
+    fun tourSteps_routedStepsCarryRoutes_atLeastSix() {
+        val routed = OnboardingModel.tourSteps().count { it.route != null }
+        assertTrue("expected several routed steps, got $routed", routed >= 6)
+    }
+
+    @Test
+    fun surfaceIntros_containAllSevenExpectedIds() {
+        val intros = OnboardingModel.surfaceIntros()
+        val expected = setOf(
+            OnboardingModel.INTRO_INVEST,
+            OnboardingModel.INTRO_STRATEGIES,
+            OnboardingModel.INTRO_TOKENS,
+            OnboardingModel.INTRO_BAILOUTS,
+            OnboardingModel.INTRO_PORTFOLIO_ANALYTICS,
+            OnboardingModel.INTRO_ACTIVITY_CENTER,
+            OnboardingModel.INTRO_ACTIVE_ALGOS,
+        )
+        assertEquals(expected, intros.keys)
+    }
+
+    @Test
+    fun surfaceIntro_lookup_matchesKeyAndHasContent() {
+        val invest = OnboardingModel.surfaceIntro(OnboardingModel.INTRO_INVEST)
+        assertNotNull(invest)
+        assertEquals(OnboardingModel.INTRO_INVEST, invest!!.id)
+        assertTrue(invest.title.isNotBlank())
+        assertTrue(invest.body.isNotBlank())
+    }
+
+    @Test
+    fun surfaceIntro_unknownId_returnsNull() {
+        assertNull(OnboardingModel.surfaceIntro("nope"))
+    }
+
+    @Test
+    fun surfaceIntros_haveNoRoute() {
+        OnboardingModel.surfaceIntros().values.forEach {
+            assertNull("surface intro ${it.id} should not carry a route", it.route)
+        }
+    }
+
+    @Test
+    fun allIds_includeWelcomeTourAndEverySurfaceIntro() {
+        val all = OnboardingModel.allIds()
+        assertTrue(all.contains(OnboardingModel.WELCOME_TOUR_ID))
+        assertTrue(all.containsAll(OnboardingModel.surfaceIntros().keys))
+        // welcome tour + 7 surface intros
+        assertEquals(1 + OnboardingModel.surfaceIntros().size, all.size)
+    }
+
+    @Test
+    fun welcomeTour_gatedByStableId_showsThenHidesAfterSeen() {
+        var seen = emptySet<String>()
+        assertTrue(OnboardingModel.shouldShow(OnboardingModel.WELCOME_TOUR_ID, seen))
+        seen = OnboardingModel.markSeen(OnboardingModel.WELCOME_TOUR_ID, seen)
+        assertFalse(OnboardingModel.shouldShow(OnboardingModel.WELCOME_TOUR_ID, seen))
+    }
+}

--- a/frontend/src/components/onboarding/SurfaceIntro.tsx
+++ b/frontend/src/components/onboarding/SurfaceIntro.tsx
@@ -1,0 +1,45 @@
+// Dismissible per-surface intro callout shown once at the top of a new trading /
+// investing page. Persisted via the shared `onboarding.v1` seen-set (keyed
+// "intro:<surfaceId>"), so once dismissed it stays gone until the user resets
+// intros from Settings. Additive + reversible.
+
+import { Info, X } from "lucide-react";
+
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { surfaceIntro, useOnboarding, shouldShow } from "@/lib/onboarding";
+
+interface SurfaceIntroProps {
+  /** Raw surface id from TRADING_SURFACES, e.g. "invest" / "strategies". */
+  surfaceId: string;
+}
+
+/**
+ * Renders a one-paragraph "what this is + key action" callout for `surfaceId`,
+ * or nothing once it has been dismissed (or if the id is unknown).
+ */
+export default function SurfaceIntro({ surfaceId }: SurfaceIntroProps) {
+  const entry = surfaceIntro(surfaceId);
+  const { seen, mark } = useOnboarding();
+
+  if (!entry) return null;
+  if (!shouldShow(entry.id, seen)) return null;
+
+  return (
+    <Alert className="relative pr-10" data-testid={`surface-intro-${surfaceId}`}>
+      <Info className="h-4 w-4" />
+      <AlertTitle>{entry.title}</AlertTitle>
+      <AlertDescription className="text-sm leading-relaxed">{entry.body}</AlertDescription>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute right-1.5 top-1.5 h-7 w-7 text-muted-foreground"
+        onClick={() => mark(entry.id)}
+        aria-label="Dismiss"
+        data-testid={`surface-intro-dismiss-${surfaceId}`}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </Alert>
+  );
+}

--- a/frontend/src/components/onboarding/WelcomeTour.tsx
+++ b/frontend/src/components/onboarding/WelcomeTour.tsx
@@ -1,0 +1,161 @@
+// First-run Welcome tour: a stepper Dialog that introduces the new trading /
+// investing surfaces. Auto-shows ONCE on the first authenticated load (gated on
+// the persisted `onboarding.v1` seen-set + auth), and can be re-triggered from
+// Settings ("Replay welcome tour") via the `openWelcomeTour()` imperative.
+//
+// Additive: mounted in HomePage; renders nothing unless it should show.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Sparkles } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  WELCOME_TOUR_ID,
+  tourSteps,
+  useOnboarding,
+  shouldShow,
+} from "@/lib/onboarding";
+
+/** Same-tab event used to imperatively (re-)open the tour from Settings. */
+const OPEN_WELCOME_TOUR_EVENT = "tl:openWelcomeTour";
+
+/** Imperatively open the welcome tour (used by the Settings "Replay" button). */
+export function openWelcomeTour(): void {
+  try {
+    window.dispatchEvent(new Event(OPEN_WELCOME_TOUR_EVENT));
+  } catch {
+    /* SSR — no-op */
+  }
+}
+
+export default function WelcomeTour() {
+  const navigate = useNavigate();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const { seen, mark } = useOnboarding();
+  const steps = useMemo(() => tourSteps(), []);
+
+  const [open, setOpen] = useState(false);
+  const [idx, setIdx] = useState(0);
+
+  // Auto-show once, on the first authenticated load, if not already completed.
+  useEffect(() => {
+    if (isAuthenticated && shouldShow(WELCOME_TOUR_ID, seen)) {
+      setIdx(0);
+      setOpen(true);
+    }
+    // Only react to auth flipping true / the seen-set changing; we intentionally
+    // do not reopen after the user dismisses within the same session.
+  }, [isAuthenticated, seen]);
+
+  // Imperative re-open (Settings "Replay welcome tour").
+  useEffect(() => {
+    const onOpen = () => {
+      setIdx(0);
+      setOpen(true);
+    };
+    window.addEventListener(OPEN_WELCOME_TOUR_EVENT, onOpen);
+    return () => window.removeEventListener(OPEN_WELCOME_TOUR_EVENT, onOpen);
+  }, []);
+
+  const complete = useCallback(() => {
+    mark(WELCOME_TOUR_ID);
+    setOpen(false);
+  }, [mark]);
+
+  const step = steps[idx];
+  const isFirst = idx === 0;
+  const isLast = idx === steps.length - 1;
+
+  if (!step) return null;
+
+  const goThere = () => {
+    complete();
+    if (step.route) navigate(step.route);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        // Closing via overlay / X counts as "skip" — persist so it won't re-nag.
+        if (!v) complete();
+        setOpen(v);
+      }}
+    >
+      <DialogContent className="sm:max-w-md" data-testid="welcome-tour">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-primary" />
+            {step.title}
+          </DialogTitle>
+          <DialogDescription className="pt-1 text-sm leading-relaxed">
+            {step.body}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step.route ? (
+          <div>
+            <Button variant="outline" size="sm" onClick={goThere} data-testid="welcome-tour-go">
+              Go there
+              <ArrowRight className="ml-1.5 h-4 w-4" />
+            </Button>
+          </div>
+        ) : null}
+
+        {/* progress dots */}
+        <div className="flex items-center justify-center gap-1.5 pt-1">
+          {steps.map((s, i) => (
+            <span
+              key={s.id}
+              className={
+                i === idx
+                  ? "h-1.5 w-4 rounded-full bg-primary transition-all"
+                  : "h-1.5 w-1.5 rounded-full bg-muted transition-all"
+              }
+            />
+          ))}
+        </div>
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button variant="ghost" size="sm" onClick={complete} data-testid="welcome-tour-skip">
+            Skip
+          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setIdx((i) => Math.max(0, i - 1))}
+              disabled={isFirst}
+              data-testid="welcome-tour-back"
+            >
+              Back
+            </Button>
+            {isLast ? (
+              <Button size="sm" onClick={complete} data-testid="welcome-tour-done">
+                Done
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                onClick={() => setIdx((i) => Math.min(steps.length - 1, i + 1))}
+                data-testid="welcome-tour-next"
+              >
+                Next
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/onboarding.test.ts
+++ b/frontend/src/lib/onboarding.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ONBOARDING_KEY,
+  loadSeen,
+  saveSeen,
+  shouldShow,
+  markSeen,
+  resetOnboarding,
+  tourSteps,
+  surfaceIntros,
+  surfaceIntro,
+} from "@/lib/onboarding";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("shouldShow / markSeen (pure)", () => {
+  it("shows an id that is not in the seen-set", () => {
+    expect(shouldShow("welcome", new Set())).toBe(true);
+  });
+
+  it("hides an id once seen", () => {
+    const seen = new Set<string>(["welcome"]);
+    expect(shouldShow("welcome", seen)).toBe(false);
+  });
+
+  it("markSeen returns a NEW set and does not mutate the input", () => {
+    const orig = new Set<string>();
+    const next = markSeen("welcome", orig);
+    expect(orig.has("welcome")).toBe(false);
+    expect(next.has("welcome")).toBe(true);
+    expect(next).not.toBe(orig);
+  });
+
+  it("markSeen is idempotent", () => {
+    const once = markSeen("x", new Set());
+    const twice = markSeen("x", once);
+    expect([...twice]).toEqual(["x"]);
+  });
+});
+
+describe("persistence store", () => {
+  it("loadSeen returns an empty set when nothing is stored", () => {
+    expect(loadSeen().size).toBe(0);
+  });
+
+  it("saveSeen round-trips through localStorage", () => {
+    saveSeen(new Set(["welcome", "intro:invest"]));
+    const raw = window.localStorage.getItem(ONBOARDING_KEY);
+    expect(raw).toBeTruthy();
+    const loaded = loadSeen();
+    expect(loaded.has("welcome")).toBe(true);
+    expect(loaded.has("intro:invest")).toBe(true);
+    expect(loaded.size).toBe(2);
+  });
+
+  it("loadSeen tolerates corrupt JSON", () => {
+    window.localStorage.setItem(ONBOARDING_KEY, "{not json");
+    expect(loadSeen().size).toBe(0);
+  });
+
+  it("loadSeen ignores a non-array payload", () => {
+    window.localStorage.setItem(ONBOARDING_KEY, JSON.stringify({ a: 1 }));
+    expect(loadSeen().size).toBe(0);
+  });
+
+  it("loadSeen filters non-string members", () => {
+    window.localStorage.setItem(ONBOARDING_KEY, JSON.stringify(["welcome", 3, null]));
+    const loaded = loadSeen();
+    expect([...loaded]).toEqual(["welcome"]);
+  });
+
+  it("saveSeen dispatches the same-tab onboarding event", () => {
+    let fired = false;
+    const handler = () => {
+      fired = true;
+    };
+    window.addEventListener("tl:onboarding", handler);
+    saveSeen(new Set(["welcome"]));
+    window.removeEventListener("tl:onboarding", handler);
+    expect(fired).toBe(true);
+  });
+
+  it("resetOnboarding clears the stored seen-set", () => {
+    saveSeen(new Set(["welcome", "intro:invest"]));
+    resetOnboarding();
+    expect(loadSeen().size).toBe(0);
+  });
+});
+
+describe("registry", () => {
+  it("tourSteps leads with the welcome step and includes surfaces with routes", () => {
+    const steps = tourSteps();
+    expect(steps.length).toBeGreaterThan(1);
+    const first = steps[0]!;
+    expect(first.id).toBe("welcome");
+    expect(first.route).toBeUndefined();
+    // every non-welcome step must carry a deep-link + copy.
+    for (const s of steps.slice(1)) {
+      expect(s.route).toBeTruthy();
+      expect(s.title.length).toBeGreaterThan(0);
+      expect(s.body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("tourSteps ids are unique", () => {
+    const ids = tourSteps().map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("surfaceIntros are namespaced under intro: and carry routes", () => {
+    const intros = surfaceIntros();
+    expect(intros.length).toBeGreaterThan(0);
+    for (const e of intros) {
+      expect(e.id.startsWith("intro:")).toBe(true);
+      expect(e.route).toBeTruthy();
+      expect(e.body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("surfaceIntro looks up a single entry by raw surface id", () => {
+    const invest = surfaceIntro("invest");
+    expect(invest).toBeDefined();
+    expect(invest?.id).toBe("intro:invest");
+    expect(invest?.route).toBe("/invest");
+  });
+
+  it("surfaceIntro returns undefined for an unknown surface", () => {
+    expect(surfaceIntro("nope")).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/onboarding.ts
+++ b/frontend/src/lib/onboarding.ts
@@ -1,0 +1,194 @@
+// Product onboarding: first-run Welcome tour + per-surface dismissible intros
+// for the trading / investing surfaces. Framework-free + event-based, mirroring
+// the price-alerts / paper-mode store pattern: a single persisted "seen" set in
+// localStorage under `onboarding.v1`, a same-tab `tl:onboarding` event, and
+// cross-tab sync via the native `storage` event.
+//
+// The step/intro copy is derived from the shared TRADING_SURFACES registry so
+// the tour and the Home quick-links stay in lock-step.
+
+import { useCallback, useEffect, useState } from "react";
+import { TRADING_SURFACES } from "@/pages/home/tradingSurfaces";
+
+/** localStorage key for the persisted "seen" set. */
+export const ONBOARDING_KEY = "onboarding.v1";
+
+/** Fired (same-tab) whenever the seen-set changes. */
+export const ONBOARDING_EVENT = "tl:onboarding";
+
+/** Stable id of the first-run welcome tour (persisted once completed/skipped). */
+export const WELCOME_TOUR_ID = "welcome-tour";
+
+/** A single tour step or per-surface intro entry. */
+export interface OnboardingEntry {
+  /** Stable id — the localStorage seen-set member + React key + test anchor. */
+  id: string;
+  title: string;
+  body: string;
+  /** Optional deep-link ("Go there" / used by the surface intro's page). */
+  route?: string;
+}
+
+// ── Registry (derived from TRADING_SURFACES for copy) ────────────────────────
+
+/** Longer per-surface blurbs keyed by TRADING_SURFACES id (fallback: tile desc). */
+const SURFACE_BLURB: Record<string, string> = {
+  invest:
+    "Your one front door to everything investable — markets, creator tokens, strategy funds, staking and open opportunities. Start here, then dive deeper.",
+  strategies:
+    "Invest in NAV-unit funds: baskets of target weights you can paper-trade and backtest before buying in at net asset value.",
+  tokens:
+    "Mint and trade creator tokens — tradeable revenue-share claims issued by content creators, with their own order books.",
+  bailouts:
+    "Rescue distressed-but-solvent margin positions by injecting capital for a position-share before a forced liquidation.",
+  "portfolio-analytics":
+    "Client-computed allocation, concentration, exposure and risk across custody, spot, margin, tokens, funds and staking.",
+  "activity-center":
+    "A single feed of fills, funding, liquidations and other account events so nothing that moves your money slips by.",
+  algos:
+    "Monitor your working TWAP and iceberg algorithms — progress, slices and controls — while they execute.",
+  "custody-providers":
+    "Connect an external custodian to hold and settle assets, then manage the connection from one place.",
+  "reports-tax":
+    "Realized gains and tax-lot reporting you can review and export come tax time.",
+};
+
+/** Map a TRADING_SURFACES tile into an onboarding entry (id/title/body/route). */
+function surfaceEntry(id: string): OnboardingEntry | undefined {
+  const s = TRADING_SURFACES.find((t) => t.id === id);
+  if (!s) return undefined;
+  return { id, title: s.label, body: SURFACE_BLURB[id] ?? s.desc, route: s.path };
+}
+
+/** The ordered surface ids the onboarding walks through. */
+const SURFACE_ORDER = [
+  "invest",
+  "strategies",
+  "tokens",
+  "bailouts",
+  "portfolio-analytics",
+  "activity-center",
+  "algos",
+];
+
+/**
+ * The ordered welcome-tour steps: a leading "welcome" step, then a walk through
+ * the headline new surfaces (each with a "Go there" deep-link). Pure.
+ */
+export function tourSteps(): OnboardingEntry[] {
+  const intro: OnboardingEntry = {
+    id: "welcome",
+    title: "Welcome to Investing on TestLogon",
+    body: "We just added a full suite of trading & investing surfaces. Take a 60-second tour, or skip and explore on your own — you can replay this anytime from Settings.",
+  };
+  const steps = SURFACE_ORDER.map((id) => surfaceEntry(id)).filter(
+    (e): e is OnboardingEntry => e != null,
+  );
+  return [intro, ...steps];
+}
+
+/** The per-surface intro callouts, keyed by their own stable ids ("intro:<id>"). */
+export function surfaceIntros(): OnboardingEntry[] {
+  return SURFACE_ORDER.map((id) => {
+    const e = surfaceEntry(id);
+    return e ? { ...e, id: `intro:${id}` } : undefined;
+  }).filter((e): e is OnboardingEntry => e != null);
+}
+
+/** Look up a single surface intro entry by its raw surface id (e.g. "invest"). */
+export function surfaceIntro(surfaceId: string): OnboardingEntry | undefined {
+  return surfaceIntros().find((e) => e.id === `intro:${surfaceId}`);
+}
+
+// ── Persisted seen-set store ─────────────────────────────────────────────────
+
+/** Load the persisted seen-set (ids that should no longer auto-show). */
+export function loadSeen(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(ONBOARDING_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set(parsed.filter((x) => typeof x === "string"));
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+/** Persist the seen-set and notify same-tab listeners. */
+export function saveSeen(seen: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ONBOARDING_KEY, JSON.stringify([...seen]));
+  } catch {
+    /* quota / private-mode — degrade to no-op */
+  }
+  try {
+    window.dispatchEvent(new Event(ONBOARDING_EVENT));
+  } catch {
+    /* SSR — no-op */
+  }
+}
+
+// ── Pure helpers (unit-tested) ───────────────────────────────────────────────
+
+/** True when the entry `id` has not yet been marked seen. */
+export function shouldShow(id: string, seen: Set<string>): boolean {
+  return !seen.has(id);
+}
+
+/**
+ * Return a NEW seen-set with `id` added (pure — does not persist). Callers that
+ * want persistence pass the result to `saveSeen`.
+ */
+export function markSeen(id: string, seen: Set<string>): Set<string> {
+  const next = new Set(seen);
+  next.add(id);
+  return next;
+}
+
+/** Clear ALL onboarding state (welcome tour + every surface intro) + persist. */
+export function resetOnboarding(): void {
+  saveSeen(new Set());
+}
+
+// ── React hook (thin wrapper over the store; not part of the pure surface) ────
+
+/**
+ * Subscribe to the persisted seen-set. Returns the current set plus a `mark`
+ * helper that persists + fans the change out to every consumer (same + cross
+ * tab). Re-reads on the same-tab `tl:onboarding` event and native `storage`.
+ */
+export function useOnboarding(): {
+  seen: Set<string>;
+  mark: (id: string) => void;
+  reset: () => void;
+} {
+  const [seen, setSeen] = useState<Set<string>>(() => loadSeen());
+
+  useEffect(() => {
+    const reload = () => setSeen(loadSeen());
+    window.addEventListener("storage", reload);
+    window.addEventListener(ONBOARDING_EVENT, reload);
+    return () => {
+      window.removeEventListener("storage", reload);
+      window.removeEventListener(ONBOARDING_EVENT, reload);
+    };
+  }, []);
+
+  const mark = useCallback((id: string) => {
+    setSeen((prev) => {
+      const next = markSeen(id, prev);
+      saveSeen(next);
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    resetOnboarding();
+    setSeen(new Set());
+  }, []);
+
+  return { seen, mark, reset };
+}

--- a/frontend/src/pages/activity-center/ActivityCenterPage.tsx
+++ b/frontend/src/pages/activity-center/ActivityCenterPage.tsx
@@ -1,3 +1,4 @@
+import SurfaceIntro from "@/components/onboarding/SurfaceIntro";
 import * as React from "react";
 import { Link } from "react-router-dom";
 import {
@@ -179,6 +180,8 @@ export default function ActivityCenterPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-4 p-4">
+      <SurfaceIntro surfaceId="activity-center" />
+
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Activity className="h-6 w-6 text-primary" />

--- a/frontend/src/pages/algos/ActiveAlgosPage.tsx
+++ b/frontend/src/pages/algos/ActiveAlgosPage.tsx
@@ -4,6 +4,7 @@
 // Placement itself happens in the trade ticket's runner (which must be open for
 // that symbol) — this page just reflects and steers the persisted state. Algos
 // run ONLY while a tab is open; cancelling stops all further scheduling.
+import SurfaceIntro from "@/components/onboarding/SurfaceIntro";
 import { useEffect, useMemo, useState } from "react";
 import { Timer, Layers, Pause, Play, X, Trash2, Info } from "lucide-react";
 
@@ -188,6 +189,8 @@ export default function ActiveAlgosPage() {
 
   return (
     <div className="mx-auto max-w-3xl space-y-4 p-4">
+      <SurfaceIntro surfaceId="algos" />
+
       <div className="flex items-center justify-between">
         <h1 className="flex items-center gap-2 text-xl font-semibold">
           <Timer className="h-5 w-5" /> Active Algos

--- a/frontend/src/pages/bailouts/BailoutsBoardPage.tsx
+++ b/frontend/src/pages/bailouts/BailoutsBoardPage.tsx
@@ -1,3 +1,4 @@
+import SurfaceIntro from "@/components/onboarding/SurfaceIntro";
 import { useMemo, useState } from "react";
 import { LifeBuoy, RefreshCw } from "lucide-react";
 import { PageHeader } from "@/components/shared/PageHeader";
@@ -35,6 +36,8 @@ export default function BailoutsBoardPage() {
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6 p-4 sm:p-6">
+      <SurfaceIntro surfaceId="bailouts" />
+
       <PageHeader
         title="Bailouts"
         description="Rescue distressed but still-solvent margin positions — inject capital for a position-share before a forced liquidation."

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -47,6 +47,7 @@ import {
   formatReturnBps,
 } from "@/pages/home/tradingSurfaces";
 import { formatPrice, formatQty } from "@/pages/markets/format";
+import WelcomeTour from "@/components/onboarding/WelcomeTour";
 
 // local helpers
 
@@ -757,6 +758,8 @@ function TradingInvestingCard() {
 export default function HomePage() {
   return (
     <div className="space-y-4">
+      <WelcomeTour />
+
       <div className="flex items-center gap-2">
         <HomeIcon className="h-6 w-6 text-primary" />
         <div>

--- a/frontend/src/pages/invest/InvestHubPage.tsx
+++ b/frontend/src/pages/invest/InvestHubPage.tsx
@@ -1,3 +1,4 @@
+import SurfaceIntro from "@/components/onboarding/SurfaceIntro";
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -571,6 +572,8 @@ export default function InvestHubPage() {
 
   return (
     <div className="mx-auto w-full max-w-6xl space-y-8 p-4 md:p-6">
+      <SurfaceIntro surfaceId="invest" />
+
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <Sparkles className="h-6 w-6 text-primary" />

--- a/frontend/src/pages/portfolio/PortfolioAnalyticsPage.tsx
+++ b/frontend/src/pages/portfolio/PortfolioAnalyticsPage.tsx
@@ -11,6 +11,7 @@
 // EVERYTHING degrades independently: any source that 404s/403s is excluded and
 // its contribution simply drops out; thin/absent history flips the risk section
 // to a "recent window only / limited history" banner. All reads, no mutations.
+import SurfaceIntro from "@/components/onboarding/SurfaceIntro";
 import { useMemo, useState } from "react";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import {
@@ -484,6 +485,8 @@ export default function PortfolioAnalyticsPage() {
   return (
     <div className="space-y-4">
       {/* Header */}
+      <SurfaceIntro surfaceId="portfolio-analytics" />
+
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
           <ShieldAlert className="h-6 w-6 text-primary" />

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import { Phone, Keyboard } from "lucide-react";
+import { Phone, Keyboard, Sparkles } from "lucide-react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,9 @@ import { JiraIntegrationSettings } from "./JiraIntegrationSettings";
 import { TradingSettings } from "./TradingSettings";
 import { BailoutSettings } from "./BailoutSettings";
 import { openShortcutsHelp } from "@/components/layout/KeyboardShortcutsHost";
+import { openWelcomeTour } from "@/components/onboarding/WelcomeTour";
+import { resetOnboarding } from "@/lib/onboarding";
+import { toast } from "@/components/ui/use-toast";
 
 export default function SettingsPage() {
   const { t } = useTranslation();
@@ -111,6 +114,37 @@ export default function SettingsPage() {
           <Button variant="outline" onClick={() => openShortcutsHelp()}>
             View keyboard shortcuts
           </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Sparkles className="h-4 w-4" />
+            Product tour
+          </CardTitle>
+        </CardHeader>
+        <Separator />
+        <CardContent className="space-y-3 pt-4">
+          <p className="text-sm text-muted-foreground">
+            Re-run the welcome tour of the trading &amp; investing surfaces, or bring back the
+            dismissed intro callouts on each page.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => openWelcomeTour()} data-testid="replay-welcome-tour">
+              Replay welcome tour
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                resetOnboarding();
+                toast({ title: "Intros reset", description: "The welcome tour and page intros will show again." });
+              }}
+              data-testid="reset-onboarding"
+            >
+              Reset all intros
+            </Button>
+          </div>
         </CardContent>
       </Card>
 

--- a/frontend/src/pages/strategies/StrategyMarketPage.tsx
+++ b/frontend/src/pages/strategies/StrategyMarketPage.tsx
@@ -1,3 +1,4 @@
+import SurfaceIntro from "@/components/onboarding/SurfaceIntro";
 import { Link } from "react-router-dom";
 import { Boxes, Plus, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -136,6 +137,8 @@ export default function StrategyMarketPage() {
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <SurfaceIntro surfaceId="strategies" />
+
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Boxes className="h-6 w-6 text-primary" />

--- a/frontend/src/pages/tokens/TokenMarketPage.tsx
+++ b/frontend/src/pages/tokens/TokenMarketPage.tsx
@@ -1,3 +1,4 @@
+import SurfaceIntro from "@/components/onboarding/SurfaceIntro";
 import { Link } from "react-router-dom";
 import { Coins, Plus, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -75,6 +76,8 @@ export default function TokenMarketPage() {
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <SurfaceIntro surfaceId="tokens" />
+
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Coins className="h-6 w-6 text-primary" />


### PR DESCRIPTION
## Onboarding / guided tours for the new surfaces

Show-once, persisted onboarding for everything shipped this run. **Pure client-side, additive, no backend, no new routes.**

Two mechanisms: (1) a first-run **Welcome tour** — a stepper walking the new surfaces (Skip/Back/Next/Done + a "Go there" deep-link per step); (2) dismissible **per-surface intro callouts** at the top of the 7 key new pages. Plus a Settings **"Product tour" replay / reset** control.

### Web
`lib/onboarding.ts` (+16 vitest) — registry derived from `tradingSurfaces` + persisted `onboarding.v1` seen-set + pure `shouldShow`/`markSeen`/`resetOnboarding`/`tourSteps`; `components/onboarding/WelcomeTour.tsx` + `SurfaceIntro.tsx`. WelcomeTour on HomePage; SurfaceIntro on invest/strategies/tokens/bailouts/portfolio-analytics/activity-center/algos; Settings replay card.

### Android
`feature/onboarding` — `OnboardingModel` (registry + pure helpers, +15 JVM tests) + `OnboardingStore` (DataStore) + Hilt module + `OnboardingViewModel` + `WelcomeTour` + `SurfaceIntro`. WelcomeTour on DashboardRoute; SurfaceIntro on the 7 matching screens; Appearance-settings "Product tour" replay row.

No new deps, `MoreRoutes` untouched. Gates: web tsc 0 · vite build · vitest 16/16; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (OnboardingModel 15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
