### PR TITLE
feat(watchlist): unified cross-instrument watchlist (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/watchlist/WatchlistItem.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/watchlist/WatchlistItem.kt
@@ -1,0 +1,85 @@
+package com.testlogon.android.data.exchange.watchlist
+
+/**
+ * UNIFIED cross-instrument watchlist model + FRAMEWORK-FREE pure helpers.
+ *
+ * The watchlist historically held only exchange symbols (a set of numeric symbolIds persisted under the
+ * legacy [WatchKind.SYMBOL] contract). It now holds three kinds of watchable thing — exchange SYMBOLs,
+ * creator TOKENs, and STRATEGY funds — under one set. Each entry is identified by a stable per-kind id
+ * ([WatchItem.id]): the symbolId string for a symbol, the tokenId for a token, the strategyId for a
+ * strategy. Serialisation is a single flat string "KIND:id" ([watchKey]); legacy bare-integer entries
+ * (no "KIND:" prefix) migrate transparently to [WatchKind.SYMBOL] via [migrateLegacy].
+ *
+ * Everything here is pure (no Android / coroutine dependency) so it is unit-testable on the JVM.
+ */
+enum class WatchKind { SYMBOL, TOKEN, STRATEGY }
+
+/** One watched item: its [kind] and the per-kind stable [id]. */
+data class WatchItem(val kind: WatchKind, val id: String) {
+    /** The flat serialised key for this item. */
+    val key: String get() = watchKey(kind, id)
+}
+
+/** Convenience: a symbol watch item from the numeric symbolId. */
+fun symbolWatch(symbolId: Int): WatchItem = WatchItem(WatchKind.SYMBOL, symbolId.toString())
+
+/** The flat serialised key for a (kind, id) pair — "SYMBOL:1", "TOKEN:abc", "STRATEGY:xyz". */
+fun watchKey(kind: WatchKind, id: String): String = "${kind.name}:$id"
+
+/**
+ * Parse one persisted key back into a [WatchItem]. A key WITHOUT a recognised "KIND:" prefix is a
+ * LEGACY symbol entry (the pre-unification format was a bare symbolId) and maps to [WatchKind.SYMBOL].
+ * Returns null only for a blank token.
+ */
+fun parseWatchKey(raw: String): WatchItem? {
+    val s = raw.trim()
+    if (s.isEmpty()) return null
+    val idx = s.indexOf(':')
+    if (idx > 0) {
+        val kindStr = s.substring(0, idx)
+        val id = s.substring(idx + 1)
+        val kind = WatchKind.entries.firstOrNull { it.name == kindStr }
+        if (kind != null && id.isNotEmpty()) return WatchItem(kind, id)
+    }
+    // Legacy bare-id (symbol) entry.
+    return WatchItem(WatchKind.SYMBOL, s)
+}
+
+/**
+ * Migrate a raw persisted set of keys (possibly a mix of legacy bare symbolIds and new "KIND:id"
+ * keys) into the canonical [WatchItem] set. Blank/garbage tokens are dropped. Idempotent: running it on
+ * an already-migrated set yields the same set.
+ */
+fun migrateLegacy(raw: Set<String>): Set<WatchItem> =
+    raw.mapNotNull { parseWatchKey(it) }.toSet()
+
+/** True when [items] contains an entry matching [kind] + [id]. */
+fun isWatched(items: Set<WatchItem>, kind: WatchKind, id: String): Boolean =
+    items.any { it.kind == kind && it.id == id }
+
+/**
+ * Toggle (kind, id) in [items]: remove it when present, add it otherwise. Returns a NEW set (never
+ * mutates the input) so it composes cleanly with immutable state.
+ */
+fun toggleWatch(items: Set<WatchItem>, kind: WatchKind, id: String): Set<WatchItem> {
+    val existing = items.firstOrNull { it.kind == kind && it.id == id }
+    return if (existing != null) items - existing else items + WatchItem(kind, id)
+}
+
+/** Only the SYMBOL entries, as the numeric symbolId set (the shape the markets filter consumes). */
+fun symbolIds(items: Set<WatchItem>): Set<Int> =
+    items.filter { it.kind == WatchKind.SYMBOL }.mapNotNull { it.id.toIntOrNull() }.toSet()
+
+/** Serialise a set to the flat persisted key set. */
+fun serialize(items: Set<WatchItem>): Set<String> = items.map { it.key }.toSet()
+
+/** A stable display order: group by kind (SYMBOL, TOKEN, STRATEGY) then by id within each kind. */
+fun sortForDisplay(items: Collection<WatchItem>): List<WatchItem> =
+    items.sortedWith(compareBy({ it.kind.ordinal }, { it.id }))
+
+/** Short human label for a kind badge. */
+fun kindLabel(kind: WatchKind): String = when (kind) {
+    WatchKind.SYMBOL -> "Symbol"
+    WatchKind.TOKEN -> "Token"
+    WatchKind.STRATEGY -> "Strategy"
+}

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/watchlist/WatchlistStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/watchlist/WatchlistStore.kt
@@ -1,0 +1,95 @@
+package com.testlogon.android.data.exchange.watchlist
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Device-local UNIFIED watchlist store: the single source of truth for the starred set across
+ * exchange SYMBOLs, creator TOKENs, and STRATEGY funds.
+ *
+ * Persistence lives in the SAME [PREFS] file the symbol watchlist has always used ("markets_prefs")
+ * so nothing else has to move. The new canonical value is a serialised [WatchItem] set under
+ * [KEY_ITEMS]; the ORIGINAL symbol-only set under [KEY_FAV] (bare symbolId strings) is kept in sync on
+ * every write so the existing Markets Watchlist filter (which reads that key) keeps working unchanged.
+ *
+ * Migration is transparent: on first construction any legacy entries (bare symbolIds under [KEY_FAV],
+ * or un-prefixed keys) are folded into the unified set via [migrateLegacy] and written back.
+ */
+@Singleton
+class WatchlistStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    private val _items = MutableStateFlow(loadAndMigrate())
+
+    /** The full unified watchlist, live. */
+    val items: StateFlow<Set<WatchItem>> = _items.asStateFlow()
+
+    /** Snapshot read of the current unified set. */
+    fun current(): Set<WatchItem> = _items.value
+
+    /** True when (kind, id) is currently watched. */
+    fun isWatched(kind: WatchKind, id: String): Boolean = isWatched(_items.value, kind, id)
+
+    /** Toggle (kind, id) in the watchlist, persisting the result. Returns the new watched-state. */
+    fun toggle(kind: WatchKind, id: String): Boolean {
+        val next = toggleWatch(_items.value, kind, id)
+        persist(next)
+        return isWatched(next, kind, id)
+    }
+
+    /** Remove (kind, id) if present. */
+    fun remove(kind: WatchKind, id: String) {
+        val existing = _items.value.firstOrNull { it.kind == kind && it.id == id } ?: return
+        persist(_items.value - existing)
+    }
+
+    /** Convenience: the SYMBOL entries as a numeric id set (the markets filter shape). */
+    fun symbolIds(): Set<Int> = symbolIds(_items.value)
+
+    private fun persist(next: Set<WatchItem>) {
+        prefs.edit()
+            .putStringSet(KEY_ITEMS, serialize(next))
+            // Keep the legacy symbol-only key in lock-step for the existing Markets filter / any reader.
+            .putStringSet(KEY_FAV, symbolIds(next).map { it.toString() }.toSet())
+            .apply()
+        _items.value = next
+    }
+
+    /**
+     * Load the canonical items, folding in any legacy symbol-only entries. If a migration actually
+     * changed the persisted shape (first run after upgrade), write the canonical form back so both keys
+     * are consistent going forward.
+     */
+    private fun loadAndMigrate(): Set<WatchItem> {
+        val itemKeys = prefs.getStringSet(KEY_ITEMS, null)
+        val legacyFav = prefs.getStringSet(KEY_FAV, emptySet()).orEmpty()
+        val fromItems = migrateLegacy(itemKeys.orEmpty())
+        val fromLegacy = migrateLegacy(legacyFav)
+        val merged = fromItems + fromLegacy
+        val needsWriteBack = itemKeys == null || serialize(merged) != itemKeys ||
+            legacyFav != symbolIds(merged).map { it.toString() }.toSet()
+        if (needsWriteBack) {
+            prefs.edit()
+                .putStringSet(KEY_ITEMS, serialize(merged))
+                .putStringSet(KEY_FAV, symbolIds(merged).map { it.toString() }.toSet())
+                .apply()
+        }
+        return merged
+    }
+
+    companion object {
+        // Same file + legacy key the symbol watchlist has always used (see MarketsViewModel).
+        const val PREFS = "markets_prefs"
+        const val KEY_FAV = "favorites"
+        const val KEY_ITEMS = "watch_items"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/MarketsViewModel.kt
@@ -1,6 +1,5 @@
 package com.testlogon.android.feature.markets
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
@@ -9,6 +8,8 @@ import com.testlogon.android.data.exchange.Instrument
 import com.testlogon.android.data.exchange.TradingRepository
 import com.testlogon.android.data.exchange.PmState
 import com.testlogon.android.data.exchange.TradingUiPrefsStore
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.data.exchange.watchlist.WatchlistStore
 import com.testlogon.android.data.exchange.alerts.TradingAlertKind
 import com.testlogon.android.data.exchange.alerts.PriceAlertsEvaluator
 import com.testlogon.android.data.exchange.alerts.TradingAlertsPoller
@@ -16,7 +17,6 @@ import com.testlogon.android.feature.markets.trade.TradingNotifier
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -37,19 +37,18 @@ class MarketsViewModel @Inject constructor(
     private val repository: ExchangeRepository,
     private val trading: TradingRepository,
     private val prefsStore: TradingUiPrefsStore,
+    private val watchlist: WatchlistStore,
     private val alertsPoller: TradingAlertsPoller,
     private val priceAlerts: PriceAlertsEvaluator,
     private val notifier: TradingNotifier,
-    @ApplicationContext appContext: Context,
 ) : ViewModel() {
 
     /** Unread trading-alerts count for the header bell badge. */
     val unreadAlerts = alertsPoller.unreadCount()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
 
-    private val prefs = appContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
-    private val _uiState = MutableStateFlow(MarketsUiState(favorites = readFavorites()))
+    private val _uiState = MutableStateFlow(MarketsUiState(favorites = watchlist.symbolIds()))
     val uiState: StateFlow<MarketsUiState> = _uiState.asStateFlow()
 
     /**
@@ -111,17 +110,11 @@ class MarketsViewModel @Inject constructor(
 
     fun onRetry() = load()
 
-    /** Toggle an instrument in the persisted watchlist. */
+    /** Toggle an instrument in the persisted UNIFIED watchlist (symbol entries). */
     fun toggleFavorite(symbolId: Int) {
-        val next = _uiState.value.favorites.toMutableSet().apply {
-            if (!add(symbolId)) remove(symbolId)
-        }
-        prefs.edit().putStringSet(KEY_FAV, next.map { it.toString() }.toSet()).apply()
-        _uiState.update { it.copy(favorites = next) }
+        watchlist.toggle(WatchKind.SYMBOL, symbolId.toString())
+        _uiState.update { it.copy(favorites = watchlist.symbolIds()) }
     }
-
-    private fun readFavorites(): Set<Int> =
-        prefs.getStringSet(KEY_FAV, emptySet()).orEmpty().mapNotNull { it.toIntOrNull() }.toSet()
 
     private fun load() {
         _uiState.update { it.copy(phase = MarketsUiState.Phase.Loading, errorMessage = null) }
@@ -309,8 +302,6 @@ class MarketsViewModel @Inject constructor(
         const val SPARK_INTERVAL_SEC = 60
         const val SPARK_POINTS = 30
         const val OFFLINE_FALLBACK = "Couldn't reach the market-data service. Tap retry."
-        const val PREFS = "markets_prefs"
-        const val KEY_FAV = "favorites"
         const val ALERTS_POLL_MS = 8_000L
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -54,6 +54,7 @@ import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Insights
 import androidx.compose.material.icons.outlined.Tune
+import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.TrendingUp
 import androidx.compose.material.icons.outlined.Loyalty
 import androidx.compose.material.icons.outlined.Apartment
@@ -1634,6 +1635,17 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_markets,
             icon = Icons.Outlined.TrendingUp,
             route = MoreRoutes.MARKETS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
+        // UNIFIED cross-instrument watchlist: one list of every starred item across exchange
+        // symbols + creator tokens + strategy funds, with a per-kind badge + live price/NAV.
+        // Degrades per-item on 404 (token/strategy backends pending); deep-links to each detail.
+        MoreEntry(
+            id = "watchlist",
+            labelRes = R.string.more_entry_watchlist,
+            icon = Icons.Outlined.Star,
+            route = MoreRoutes.WATCHLIST,
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -64,6 +66,7 @@ fun StrategyDetailRoute(
     viewModel: StrategyDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val watched by viewModel.isWatched.collectAsStateWithLifecycle()
     val snackbar = remember { SnackbarHostState() }
     var showInvest by remember { mutableStateOf(false) }
     var showRedeem by remember { mutableStateOf(false) }
@@ -82,6 +85,14 @@ fun StrategyDetailRoute(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = viewModel::toggleWatch, modifier = Modifier.testTag("strategy_watch_toggle")) {
+                        Icon(
+                            imageVector = if (watched) Icons.Filled.Star else Icons.Filled.StarBorder,
+                            contentDescription = if (watched) "Remove from watchlist" else "Add to watchlist",
+                        )
                     }
                 },
             )

--- a/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/strategies/StrategyDetailViewModel.kt
@@ -10,11 +10,17 @@ import com.testlogon.android.data.strategies.Strategy
 import com.testlogon.android.data.strategies.StrategyFees
 import com.testlogon.android.data.strategies.StrategyHolding
 import com.testlogon.android.data.strategies.StrategyNav
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.data.exchange.watchlist.WatchlistStore
+import com.testlogon.android.data.exchange.watchlist.isWatched as isWatchedIn
 import com.testlogon.android.navigation.StrategyDetailDest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -50,6 +56,7 @@ data class StrategyDetailUiState(
 @HiltViewModel
 class StrategyDetailViewModel @Inject constructor(
     private val repository: StrategiesRepository,
+    private val watchlist: WatchlistStore,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -57,6 +64,18 @@ class StrategyDetailViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(StrategyDetailUiState(strategyId = strategyId))
     val uiState: StateFlow<StrategyDetailUiState> = _uiState.asStateFlow()
+
+    /** Whether this strategy is on the unified watchlist (drives the detail star). */
+    val isWatched: StateFlow<Boolean> = watchlist.items
+        .map { items -> isWatchedIn(items, WatchKind.STRATEGY, strategyId) }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            watchlist.isWatched(WatchKind.STRATEGY, strategyId),
+        )
+
+    /** Toggle this strategy on/off the unified watchlist. */
+    fun toggleWatch() { watchlist.toggle(WatchKind.STRATEGY, strategyId) }
 
     init { load() }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -68,6 +70,7 @@ fun TokenDetailRoute(
     viewModel: TokenDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val watched by viewModel.isWatched.collectAsStateWithLifecycle()
     val snackbar = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -85,6 +88,14 @@ fun TokenDetailRoute(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = viewModel::toggleWatch, modifier = Modifier.testTag("token_watch_toggle")) {
+                        Icon(
+                            imageVector = if (watched) Icons.Filled.Star else Icons.Filled.StarBorder,
+                            contentDescription = if (watched) "Remove from watchlist" else "Add to watchlist",
+                        )
                     }
                 },
             )

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokenDetailViewModel.kt
@@ -10,11 +10,16 @@ import com.testlogon.android.data.tokens.TokenCapTable
 import com.testlogon.android.data.tokens.TokenRevenue
 import com.testlogon.android.data.tokens.TokenUpkeep
 import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.data.exchange.watchlist.WatchlistStore
+import com.testlogon.android.data.exchange.watchlist.isWatched as isWatchedIn
 import com.testlogon.android.navigation.TokenDetailDest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -45,6 +50,7 @@ data class TokenDetailUiState(
 @HiltViewModel
 class TokenDetailViewModel @Inject constructor(
     private val repository: TokensRepository,
+    private val watchlist: WatchlistStore,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -52,6 +58,18 @@ class TokenDetailViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(TokenDetailUiState(tokenId = tokenId))
     val uiState: StateFlow<TokenDetailUiState> = _uiState.asStateFlow()
+
+    /** Whether this token is on the unified watchlist (drives the detail star). */
+    val isWatched: StateFlow<Boolean> = watchlist.items
+        .map { items -> isWatchedIn(items, WatchKind.TOKEN, tokenId) }
+        .stateIn(
+            viewModelScope,
+            kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5_000),
+            watchlist.isWatched(WatchKind.TOKEN, tokenId),
+        )
+
+    /** Toggle this token on/off the unified watchlist. */
+    fun toggleWatch() { watchlist.toggle(WatchKind.TOKEN, tokenId) }
 
     init {
         load()

--- a/android/app/src/main/java/com/testlogon/android/feature/watchlist/WatchlistScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/watchlist/WatchlistScreen.kt
@@ -1,0 +1,197 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.watchlist
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.exchange.watchlist.WatchItem
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.data.exchange.watchlist.kindLabel
+
+/**
+ * UNIFIED Watchlist screen: one list of every starred item across exchange SYMBOLs, creator TOKENs,
+ * and STRATEGY funds, each with a per-kind badge, live price/NAV + change (degrades to "—" on 404),
+ * a remove (un-star) affordance, and a tap that deep-links to the item's detail. New navigable
+ * destination reached from the More hub.
+ */
+@Composable
+fun WatchlistRoute(
+    onBack: () -> Unit,
+    onOpen: (route: String) -> Unit,
+    viewModel: WatchlistViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Watchlist") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (state.phase) {
+                WatchlistUiState.Phase.Loading -> LoadingState(message = "Loading watchlist")
+                WatchlistUiState.Phase.Empty -> EmptyState(
+                    title = "Your watchlist is empty",
+                    body = "Star a symbol, creator token, or strategy fund to follow it here.",
+                )
+                WatchlistUiState.Phase.Content -> WatchlistContent(
+                    rows = state.rows,
+                    onOpen = onOpen,
+                    onRemove = viewModel::remove,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WatchlistContent(
+    rows: List<WatchRow>,
+    onOpen: (String) -> Unit,
+    onRemove: (WatchItem) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().testTag("watchlist_list"),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(rows, key = { it.item.key }) { row ->
+            WatchRowCard(row = row, onOpen = onOpen, onRemove = onRemove)
+        }
+    }
+}
+
+@Composable
+private fun WatchRowCard(
+    row: WatchRow,
+    onOpen: (String) -> Unit,
+    onRemove: (WatchItem) -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onOpen(row.route) }
+            .testTag("watch_row_${row.item.key}"),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            KindBadge(row.item.kind)
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = row.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = row.subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = row.priceText ?: "—",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Medium,
+                )
+                if (row.changeText != null) {
+                    val color = when (row.changeUp) {
+                        true -> Color(0xFF2E7D32)
+                        false -> Color(0xFFC62828)
+                        null -> MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                    Text(text = row.changeText, style = MaterialTheme.typography.bodySmall, color = color)
+                }
+            }
+            IconButton(
+                onClick = { onRemove(row.item) },
+                modifier = Modifier.testTag("watch_remove_${row.item.key}"),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Star,
+                    contentDescription = "Remove from watchlist",
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun KindBadge(kind: WatchKind) {
+    val bg = when (kind) {
+        WatchKind.SYMBOL -> MaterialTheme.colorScheme.primaryContainer
+        WatchKind.TOKEN -> MaterialTheme.colorScheme.tertiaryContainer
+        WatchKind.STRATEGY -> MaterialTheme.colorScheme.secondaryContainer
+    }
+    val fg = when (kind) {
+        WatchKind.SYMBOL -> MaterialTheme.colorScheme.onPrimaryContainer
+        WatchKind.TOKEN -> MaterialTheme.colorScheme.onTertiaryContainer
+        WatchKind.STRATEGY -> MaterialTheme.colorScheme.onSecondaryContainer
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(bg)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = kindLabel(kind),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = fg,
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/watchlist/WatchlistViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/watchlist/WatchlistViewModel.kt
@@ -1,0 +1,184 @@
+package com.testlogon.android.feature.watchlist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.watchlist.WatchItem
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.data.exchange.watchlist.WatchlistStore
+import com.testlogon.android.data.exchange.watchlist.sortForDisplay
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.tokens.TokensRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * One render-ready row of the UNIFIED watchlist. [item] carries the kind + id; [title]/[subtitle] are
+ * kind-appropriate labels; [priceText]/[changeText] are the live price/NAV surface (null while loading
+ * or when the backend degrades on 404). [route] is the destination this row deep-links to.
+ */
+data class WatchRow(
+    val item: WatchItem,
+    val title: String,
+    val subtitle: String,
+    val priceText: String? = null,
+    val changeText: String? = null,
+    val changeUp: Boolean? = null,
+    val route: String,
+)
+
+data class WatchlistUiState(
+    val phase: Phase = Phase.Loading,
+    val rows: List<WatchRow> = emptyList(),
+) {
+    enum class Phase { Loading, Content, Empty }
+}
+
+/**
+ * Drives the unified Watchlist screen. Reads the starred set from [WatchlistStore] (which already
+ * spans symbols + tokens + strategies), then enriches each item with a live price/NAV + change from
+ * its existing repository. Every enrichment read DEGRADES quietly on 404 (the token/strategy backends
+ * are pending) — the row still renders with its label and a "—" price. Removing an item mutates the
+ * shared store, so the change reflects everywhere (markets filter, detail stars) immediately.
+ */
+@HiltViewModel
+class WatchlistViewModel @Inject constructor(
+    private val watchlist: WatchlistStore,
+    private val exchange: ExchangeRepository,
+    private val tokens: TokensRepository,
+    private val strategies: StrategiesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(WatchlistUiState())
+    val uiState: StateFlow<WatchlistUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    /** Remove an item from the unified watchlist and re-render. */
+    fun remove(item: WatchItem) {
+        watchlist.remove(item.kind, item.id)
+        load()
+    }
+
+    private fun load() {
+        val items = sortForDisplay(watchlist.current())
+        if (items.isEmpty()) {
+            _uiState.update { WatchlistUiState(phase = WatchlistUiState.Phase.Empty, rows = emptyList()) }
+            return
+        }
+        // First render the skeleton rows (labels + routes) so the list appears instantly, then enrich.
+        _uiState.update {
+            WatchlistUiState(
+                phase = WatchlistUiState.Phase.Content,
+                rows = items.map { skeletonRow(it) },
+            )
+        }
+        viewModelScope.launch { enrich(items) }
+    }
+
+    private fun skeletonRow(item: WatchItem): WatchRow = when (item.kind) {
+        WatchKind.SYMBOL -> WatchRow(
+            item = item,
+            title = "Symbol #${item.id}",
+            subtitle = "Exchange market",
+            route = "markets/${item.id}",
+        )
+        WatchKind.TOKEN -> WatchRow(
+            item = item,
+            title = "Token",
+            subtitle = "Creator revenue-share token",
+            route = "tokens/detail/${android.net.Uri.encode(item.id)}",
+        )
+        WatchKind.STRATEGY -> WatchRow(
+            item = item,
+            title = "Strategy",
+            subtitle = "Strategy fund",
+            route = "strategies/detail/${android.net.Uri.encode(item.id)}",
+        )
+    }
+
+    /** Enrich each row with a live price/NAV + label, degrading quietly per-item on 404/absent. */
+    private suspend fun enrich(items: List<WatchItem>) {
+        // Load the instrument catalogue once for symbol labels/prices (degrades to empty).
+        val instruments: List<Instrument> =
+            (exchange.symbols() as? ApiResult.Success)?.data.orEmpty()
+
+        for (item in items) {
+            val enriched = when (item.kind) {
+                WatchKind.SYMBOL -> enrichSymbol(item, instruments)
+                WatchKind.TOKEN -> enrichToken(item)
+                WatchKind.STRATEGY -> enrichStrategy(item)
+            }
+            _uiState.update { state ->
+                state.copy(rows = state.rows.map { if (it.item == item) enriched else it })
+            }
+        }
+    }
+
+    private suspend fun enrichSymbol(item: WatchItem, instruments: List<Instrument>): WatchRow {
+        val id = item.id.toIntOrNull()
+        val instrument = instruments.firstOrNull { it.symbolId == id }
+        val title = instrument?.symbol ?: "Symbol #${item.id}"
+        val subtitle = when {
+            instrument == null -> "Exchange market"
+            instrument.isPerpetual -> "Perpetual"
+            else -> "Spot"
+        }
+        var priceText: String? = null
+        if (id != null) {
+            val last = (exchange.trades(id) as? ApiResult.Success)?.data?.firstOrNull()?.price
+            val book = (exchange.orderBook(id) as? ApiResult.Success)?.data
+            val raw = last?.let { instrument?.display(it) } ?: book?.mid
+            if (raw != null) priceText = formatUsd(raw)
+        }
+        return skeletonRow(item).copy(title = title, subtitle = subtitle, priceText = priceText)
+    }
+
+    private suspend fun enrichToken(item: WatchItem): WatchRow {
+        val token = (tokens.token(item.id) as? ApiResult.Success)?.data
+        val title = token?.let { it.ticker.ifBlank { it.name } }?.ifBlank { "Token" } ?: "Token"
+        val subtitle = token?.name?.takeIf { it.isNotBlank() && it != title }
+            ?: "Creator revenue-share token"
+        val priceText = token?.clearingPrice?.let { centsToUsd(it) }
+        return skeletonRow(item).copy(title = title, subtitle = subtitle, priceText = priceText)
+    }
+
+    private suspend fun enrichStrategy(item: WatchItem): WatchRow {
+        val strategy = (strategies.strategy(item.id) as? ApiResult.Success)?.data
+        val nav = (strategies.nav(item.id) as? ApiResult.Success)?.data
+        val title = strategy?.name?.ifBlank { "Strategy" } ?: "Strategy"
+        val navPerUnit = nav?.navPerUnit ?: strategy?.navPerUnit
+        val priceText = navPerUnit?.let { "NAV " + centsToUsd(it) }
+        val retBps = nav?.inceptionReturnBps ?: strategy?.inceptionReturnBps
+        val changeText = retBps?.let { formatBpsPct(it) }
+        val changeUp = retBps?.let { it >= 0 }
+        return skeletonRow(item).copy(
+            title = title,
+            subtitle = "Strategy fund",
+            priceText = priceText,
+            changeText = changeText,
+            changeUp = changeUp,
+        )
+    }
+
+    private fun formatUsd(value: Double): String = "$" + String.format("%,.2f", value)
+
+    private fun centsToUsd(cents: Long): String = "$" + String.format("%,.2f", cents / 100.0)
+
+    private fun formatBpsPct(bps: Int): String {
+        val pct = bps / 100.0
+        val sign = if (pct >= 0) "+" else ""
+        return "$sign" + String.format("%.2f", pct) + "%"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -313,6 +313,9 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         adminDashboardDestination(navController)
         // Markets (exchange market-data, VIEW-ONLY): instrument list + per-symbol chart/book/tape.
         marketsDestinations(navController)
+        // UNIFIED cross-instrument watchlist: one list of starred symbols + creator tokens +
+        // strategy funds. Owns no detail routes; each row deep-links to the existing detail dest.
+        watchlistDestination(navController)
         // Unified INVEST hub: aggregates markets + creator tokens + strategy funds + staking +
         // open opportunities client-side into one front door. Owns no detail routes — each card /
         // see-all navigates to the existing per-product destination in this same graph.

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -390,6 +390,9 @@ object MoreRoutes {
     // Markets (exchange market-data, VIEW-ONLY): instrument list -> per-symbol chart/book/tape.
     const val MARKETS = MarketsDest.ROUTE
 
+    // UNIFIED cross-instrument watchlist (starred symbols + creator tokens + strategy funds).
+    const val WATCHLIST = WatchlistDest.ROUTE
+
     // Unified INVEST hub: one front door aggregating markets + creator tokens + strategy funds +
     // staking + open opportunities. Degrades per-section on 404; owns no detail routes.
     const val INVEST = InvestDest.ROUTE
@@ -710,6 +713,7 @@ object MoreRoutes {
             WEBHOOKS,
             ADMIN_DASHBOARD,
             MARKETS,
+            WATCHLIST,
             INVEST,
             TOKENS,
             STRATEGIES,

--- a/android/app/src/main/java/com/testlogon/android/navigation/WatchlistNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/WatchlistNavigation.kt
@@ -1,0 +1,27 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.watchlist.WatchlistRoute
+
+/**
+ * UNIFIED Watchlist destination, registered in the AUTHENTICATED nav graph.
+ *
+ * [WatchlistDest] is the single list of every starred item across exchange symbols, creator tokens,
+ * and strategy funds. It owns no detail routes: each row deep-links (via the route string the
+ * view-model computes) back into the existing per-product detail destinations in this same graph.
+ */
+data object WatchlistDest {
+    const val ROUTE = "watchlist"
+}
+
+/** Registers the unified Watchlist list destination (Back pops the back stack). */
+fun NavGraphBuilder.watchlistDestination(navController: NavHostController) {
+    composable(WatchlistDest.ROUTE) {
+        WatchlistRoute(
+            onBack = { navController.popBackStack() },
+            onOpen = { route -> navController.navigate(route) { launchSingleTop = true } },
+        )
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4305,6 +4305,7 @@
     <string name="more_entry_global_search">Search</string>
     <string name="more_entry_invest">Invest Hub</string>
     <string name="more_entry_markets">Markets</string>
+    <string name="more_entry_watchlist">Watchlist</string>
     <string name="more_entry_analysis">Analysis</string>
     <string name="more_entry_tokens">Creator Tokens</string>
     <string name="more_entry_strategies">Strategies &amp; Baskets</string>

--- a/android/app/src/test/java/com/testlogon/android/data/exchange/watchlist/WatchlistItemTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/exchange/watchlist/WatchlistItemTest.kt
@@ -1,0 +1,141 @@
+package com.testlogon.android.data.exchange.watchlist
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure JVM tests for the framework-free unified-watchlist helpers. */
+class WatchlistItemTest {
+
+    @Test
+    fun watchKey_encodesKindAndId() {
+        assertEquals("SYMBOL:1", watchKey(WatchKind.SYMBOL, "1"))
+        assertEquals("TOKEN:abc", watchKey(WatchKind.TOKEN, "abc"))
+        assertEquals("STRATEGY:xyz", watchKey(WatchKind.STRATEGY, "xyz"))
+    }
+
+    @Test
+    fun symbolWatch_buildsSymbolItem() {
+        val w = symbolWatch(7)
+        assertEquals(WatchKind.SYMBOL, w.kind)
+        assertEquals("7", w.id)
+        assertEquals("SYMBOL:7", w.key)
+    }
+
+    @Test
+    fun parseWatchKey_prefixedRoundTrips() {
+        assertEquals(WatchItem(WatchKind.TOKEN, "abc"), parseWatchKey("TOKEN:abc"))
+        assertEquals(WatchItem(WatchKind.STRATEGY, "s-1"), parseWatchKey("STRATEGY:s-1"))
+        // Token ids may themselves contain colons; only the first delimiter splits.
+        assertEquals(WatchItem(WatchKind.TOKEN, "a:b:c"), parseWatchKey("TOKEN:a:b:c"))
+    }
+
+    @Test
+    fun parseWatchKey_legacyBareIdIsSymbol() {
+        assertEquals(WatchItem(WatchKind.SYMBOL, "3"), parseWatchKey("3"))
+        assertEquals(WatchItem(WatchKind.SYMBOL, "42"), parseWatchKey(" 42 "))
+    }
+
+    @Test
+    fun parseWatchKey_blankIsNull() {
+        assertNull(parseWatchKey(""))
+        assertNull(parseWatchKey("   "))
+    }
+
+    @Test
+    fun migrateLegacy_mixedSetFoldsCorrectly() {
+        val raw = setOf("1", "2", "TOKEN:t1", "STRATEGY:s1", "", "  ")
+        val migrated = migrateLegacy(raw)
+        assertEquals(
+            setOf(
+                symbolWatch(1),
+                symbolWatch(2),
+                WatchItem(WatchKind.TOKEN, "t1"),
+                WatchItem(WatchKind.STRATEGY, "s1"),
+            ),
+            migrated,
+        )
+    }
+
+    @Test
+    fun migrateLegacy_isIdempotent() {
+        val once = migrateLegacy(setOf("1", "TOKEN:t1"))
+        val twice = migrateLegacy(serialize(once))
+        assertEquals(once, twice)
+    }
+
+    @Test
+    fun isWatched_matchesByKindAndId() {
+        val items = setOf(symbolWatch(1), WatchItem(WatchKind.TOKEN, "1"))
+        assertTrue(isWatched(items, WatchKind.SYMBOL, "1"))
+        assertTrue(isWatched(items, WatchKind.TOKEN, "1"))
+        // Same id, different kind is NOT the same item.
+        assertFalse(isWatched(items, WatchKind.STRATEGY, "1"))
+        assertFalse(isWatched(items, WatchKind.SYMBOL, "2"))
+    }
+
+    @Test
+    fun toggleWatch_addsThenRemoves_withoutMutatingInput() {
+        val start = emptySet<WatchItem>()
+        val added = toggleWatch(start, WatchKind.TOKEN, "t1")
+        assertTrue(isWatched(added, WatchKind.TOKEN, "t1"))
+        assertTrue(start.isEmpty()) // input untouched
+        val removed = toggleWatch(added, WatchKind.TOKEN, "t1")
+        assertFalse(isWatched(removed, WatchKind.TOKEN, "t1"))
+    }
+
+    @Test
+    fun toggleWatch_kindIsolated() {
+        var items = setOf(symbolWatch(1))
+        items = toggleWatch(items, WatchKind.STRATEGY, "1")
+        assertEquals(2, items.size)
+        assertTrue(isWatched(items, WatchKind.SYMBOL, "1"))
+        assertTrue(isWatched(items, WatchKind.STRATEGY, "1"))
+    }
+
+    @Test
+    fun symbolIds_extractsOnlyNumericSymbols() {
+        val items = setOf(
+            symbolWatch(1),
+            symbolWatch(5),
+            WatchItem(WatchKind.TOKEN, "9"),
+            WatchItem(WatchKind.STRATEGY, "3"),
+        )
+        assertEquals(setOf(1, 5), symbolIds(items))
+    }
+
+    @Test
+    fun serialize_roundTripsThroughMigrate() {
+        val items = setOf(symbolWatch(2), WatchItem(WatchKind.TOKEN, "abc"))
+        assertEquals(items, migrateLegacy(serialize(items)))
+    }
+
+    @Test
+    fun sortForDisplay_groupsByKindThenId() {
+        val items = listOf(
+            WatchItem(WatchKind.STRATEGY, "s1"),
+            symbolWatch(2),
+            WatchItem(WatchKind.TOKEN, "t1"),
+            symbolWatch(1),
+        )
+        val sorted = sortForDisplay(items)
+        assertEquals(
+            listOf(
+                symbolWatch(1),
+                symbolWatch(2),
+                WatchItem(WatchKind.TOKEN, "t1"),
+                WatchItem(WatchKind.STRATEGY, "s1"),
+            ),
+            sorted,
+        )
+    }
+
+    @Test
+    fun kindLabel_isHumanReadable() {
+        assertEquals("Symbol", kindLabel(WatchKind.SYMBOL))
+        assertEquals("Token", kindLabel(WatchKind.TOKEN))
+        assertEquals("Strategy", kindLabel(WatchKind.STRATEGY))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,6 +61,7 @@ const PostDetailPage = lazy(() => import("@/pages/feed/PostDetailPage"));
 const DelegateFeedPage = lazy(() => import("@/pages/feed/DelegateFeedPage"));
 const HomePage = lazy(() => import("@/pages/home/HomePage"));
 const MarketsPage = lazy(() => import("@/pages/markets/MarketsPage"));
+const WatchlistPage = lazy(() => import("@/pages/watchlist/WatchlistPage"));
 const ActiveAlgosPage = lazy(() => import("@/pages/algos/ActiveAlgosPage"));
 const SymbolDetailPage = lazy(() => import("@/pages/markets/SymbolDetailPage"));
 const TokenMarketPage = lazy(() => import("@/pages/tokens/TokenMarketPage"));
@@ -761,6 +762,7 @@ export default function App() {
           <Route path="feed" element={<FeedPage />} />
           <Route path="home" element={<HomePage />} />
           <Route path="markets" element={<MarketsPage />} />
+          <Route path="watchlist" element={<WatchlistPage />} />
           <Route path="markets/:symbolId" element={<SymbolDetailPage />} />
           <Route path="tokens" element={<TokenMarketPage />} />
           <Route path="tokens/new" element={<MintTokenPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -150,6 +150,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Feed", i18nKey: "nav.feed", path: "/feed", icon: <Rss className="h-5 w-5" /> },
       { label: "Trading Home", i18nKey: "nav.tradingHome", path: "/home", icon: <Gauge className="h-5 w-5" /> },
       { label: "Markets", i18nKey: "nav.markets", path: "/markets", icon: <CandlestickChart className="h-5 w-5" /> },
+      { label: "Watchlist", i18nKey: "nav.watchlist", path: "/watchlist", icon: <Star className="h-5 w-5" /> },
       { label: "Invest", i18nKey: "nav.invest", path: "/invest", icon: <Sparkles className="h-5 w-5" /> },
       { label: "Analysis", i18nKey: "nav.analysis", path: "/analysis", icon: <LineChart className="h-5 w-5" /> },
       { label: "Price Alerts", i18nKey: "nav.priceAlerts", path: "/markets/price-alerts", icon: <Bell className="h-5 w-5" /> },

--- a/frontend/src/hooks/useWatchlist.ts
+++ b/frontend/src/hooks/useWatchlist.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  loadWatchlist,
+  saveWatchlist,
+  isWatched,
+  toggleWatch as toggleWatchPure,
+  removeWatch as removeWatchPure,
+  WATCHLIST_EVENT,
+  WATCHLIST_KEY,
+  type WatchItem,
+  type WatchKind,
+} from "@/lib/watchlist";
+
+/**
+ * React binding for the UNIFIED cross-instrument watchlist.
+ *
+ * Wraps the pure `@/lib/watchlist` store with localStorage persistence and a
+ * cross-component/cross-tab sync layer: every consumer reads the same list and
+ * a `toggle` from one surface (a star on the token detail page, say) reflects
+ * instantly on the /watchlist page and the market browser's Watchlist tab.
+ *
+ * Legacy symbol-only payloads are migrated transparently on first read
+ * (see `migrateLegacy`), so the existing symbol watchlist keeps working.
+ */
+export function useWatchlist() {
+  const [items, setItems] = useState<WatchItem[]>(loadWatchlist);
+
+  // Re-read on same-tab mutations (custom event) + other-tab writes (storage).
+  useEffect(() => {
+    const reread = () => setItems(loadWatchlist());
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === null || e.key === WATCHLIST_KEY) reread();
+    };
+    window.addEventListener(WATCHLIST_EVENT, reread);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(WATCHLIST_EVENT, reread);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  const toggle = useCallback((kind: WatchKind, id: string | number) => {
+    setItems((prev) => {
+      const next = toggleWatchPure(prev, kind, id);
+      saveWatchlist(next);
+      return next;
+    });
+  }, []);
+
+  const remove = useCallback((kind: WatchKind, id: string | number) => {
+    setItems((prev) => {
+      const next = removeWatchPure(prev, kind, id);
+      saveWatchlist(next);
+      return next;
+    });
+  }, []);
+
+  const has = useCallback(
+    (kind: WatchKind, id: string | number) => isWatched(items, kind, id),
+    [items],
+  );
+
+  return { items, has, toggle, remove };
+}

--- a/frontend/src/lib/watchlist.test.ts
+++ b/frontend/src/lib/watchlist.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  watchKey,
+  kindLabel,
+  isWatched,
+  toggleWatch,
+  removeWatch,
+  migrateLegacy,
+  sortWatchItems,
+  type WatchItem,
+} from "./watchlist";
+
+describe("watchKey", () => {
+  it("builds a stable composite key", () => {
+    expect(watchKey("symbol", 3)).toBe("symbol:3");
+    expect(watchKey("token", "tk_1")).toBe("token:tk_1");
+    expect(watchKey("strategy", "st_9")).toBe("strategy:st_9");
+  });
+  it("normalizes numeric and string ids to the same key", () => {
+    expect(watchKey("symbol", 3)).toBe(watchKey("symbol", "3"));
+  });
+});
+
+describe("kindLabel", () => {
+  it("maps kinds to human labels", () => {
+    expect(kindLabel("symbol")).toBe("Symbol");
+    expect(kindLabel("token")).toBe("Token");
+    expect(kindLabel("strategy")).toBe("Strategy");
+  });
+});
+
+describe("isWatched", () => {
+  const list: WatchItem[] = [
+    { kind: "symbol", id: "1" },
+    { kind: "token", id: "tk_a" },
+  ];
+  it("finds present items across kinds (number or string id)", () => {
+    expect(isWatched(list, "symbol", 1)).toBe(true);
+    expect(isWatched(list, "symbol", "1")).toBe(true);
+    expect(isWatched(list, "token", "tk_a")).toBe(true);
+  });
+  it("does not confuse the same id across different kinds", () => {
+    expect(isWatched(list, "strategy", "1")).toBe(false);
+    expect(isWatched(list, "token", "1")).toBe(false);
+  });
+});
+
+describe("toggleWatch", () => {
+  it("adds an absent item to the end and coerces id to string", () => {
+    const next = toggleWatch([], "symbol", 5);
+    expect(next).toEqual([{ kind: "symbol", id: "5" }]);
+  });
+  it("removes a present item", () => {
+    const start: WatchItem[] = [{ kind: "symbol", id: "5" }];
+    expect(toggleWatch(start, "symbol", 5)).toEqual([]);
+  });
+  it("is immutable (does not mutate the input)", () => {
+    const start: WatchItem[] = [{ kind: "token", id: "tk_a" }];
+    const copy = [...start];
+    toggleWatch(start, "strategy", "st_1");
+    expect(start).toEqual(copy);
+  });
+  it("preserves insertion order when appending different kinds", () => {
+    let l: WatchItem[] = [];
+    l = toggleWatch(l, "symbol", 1);
+    l = toggleWatch(l, "token", "tk_a");
+    l = toggleWatch(l, "strategy", "st_1");
+    expect(l.map((x) => watchKey(x.kind, x.id))).toEqual([
+      "symbol:1",
+      "token:tk_a",
+      "strategy:st_1",
+    ]);
+  });
+});
+
+describe("removeWatch", () => {
+  it("removes by kind+id and is a no-op when absent", () => {
+    const start: WatchItem[] = [
+      { kind: "symbol", id: "1" },
+      { kind: "token", id: "tk_a" },
+    ];
+    expect(removeWatch(start, "symbol", 1)).toEqual([{ kind: "token", id: "tk_a" }]);
+    expect(removeWatch(start, "strategy", "nope")).toEqual(start);
+  });
+});
+
+describe("migrateLegacy", () => {
+  it("migrates a bare legacy number[] to symbol items", () => {
+    expect(migrateLegacy([1, 2, 3])).toEqual([
+      { kind: "symbol", id: "1" },
+      { kind: "symbol", id: "2" },
+      { kind: "symbol", id: "3" },
+    ]);
+  });
+  it("accepts the new object shape and normalizes ids", () => {
+    expect(
+      migrateLegacy([
+        { kind: "token", id: "tk_a" },
+        { kind: "strategy", id: 7 },
+      ]),
+    ).toEqual([
+      { kind: "token", id: "tk_a" },
+      { kind: "strategy", id: "7" },
+    ]);
+  });
+  it("drops unknown kinds, empty ids, and junk entries", () => {
+    expect(
+      migrateLegacy([
+        { kind: "bogus", id: "x" },
+        { kind: "symbol", id: "" },
+        null,
+        NaN,
+        true,
+        { id: "no-kind" },
+      ]),
+    ).toEqual([]);
+  });
+  it("de-duplicates by composite key, first occurrence wins", () => {
+    expect(
+      migrateLegacy([
+        { kind: "symbol", id: "1" },
+        1,
+        { kind: "symbol", id: "1" },
+      ]),
+    ).toEqual([{ kind: "symbol", id: "1" }]);
+  });
+  it("returns [] for non-array / malformed input", () => {
+    expect(migrateLegacy(null)).toEqual([]);
+    expect(migrateLegacy(undefined)).toEqual([]);
+    expect(migrateLegacy("nope")).toEqual([]);
+    expect(migrateLegacy(42)).toEqual([]);
+  });
+  it("does not lose token/strategy entries when mixed with legacy symbols", () => {
+    expect(
+      migrateLegacy([2, { kind: "token", id: "tk_a" }, 5]),
+    ).toEqual([
+      { kind: "symbol", id: "2" },
+      { kind: "token", id: "tk_a" },
+      { kind: "symbol", id: "5" },
+    ]);
+  });
+});
+
+describe("sortWatchItems", () => {
+  it("groups by kind (symbol -> token -> strategy), stable within a kind", () => {
+    const list: WatchItem[] = [
+      { kind: "strategy", id: "st_1" },
+      { kind: "symbol", id: "9" },
+      { kind: "token", id: "tk_a" },
+      { kind: "symbol", id: "3" },
+    ];
+    expect(sortWatchItems(list).map((x) => watchKey(x.kind, x.id))).toEqual([
+      "symbol:9",
+      "symbol:3",
+      "token:tk_a",
+      "strategy:st_1",
+    ]);
+  });
+  it("does not mutate the input", () => {
+    const list: WatchItem[] = [
+      { kind: "token", id: "tk_a" },
+      { kind: "symbol", id: "1" },
+    ];
+    const copy = [...list];
+    sortWatchItems(list);
+    expect(list).toEqual(copy);
+  });
+});

--- a/frontend/src/lib/watchlist.ts
+++ b/frontend/src/lib/watchlist.ts
@@ -1,0 +1,150 @@
+/**
+ * UNIFIED cross-instrument watchlist (framework-free, pure functions).
+ *
+ * The market browser shipped a symbol-only watchlist persisted at
+ * `md.watchlist.v1` as a bare `number[]` (an ordered list of `symbol_id`s).
+ * This module GENERALIZES that store to hold three kinds of instrument —
+ * exchange symbols, creator revenue-share tokens, and strategy funds — as
+ * ordered `WatchItem`s, while transparently MIGRATING any legacy symbol-only
+ * payload found under the same key. Insertion order is preserved.
+ *
+ * Everything here is pure + storage-agnostic where practical: the mutation
+ * helpers take/return arrays; a thin localStorage + event layer at the bottom
+ * lets React components subscribe (`watchlist:changed`) and stay in sync.
+ */
+
+export type WatchKind = "symbol" | "token" | "strategy";
+
+/** One watched instrument. `id` is a string for tokens/strategies and the
+ *  stringified `symbol_id` for symbols (so the store is uniformly keyed). */
+export interface WatchItem {
+  kind: WatchKind;
+  id: string;
+}
+
+/** Persistence key — UNCHANGED from the legacy symbol watchlist so existing
+ *  entries are picked up and migrated in place (no orphaned key). */
+export const WATCHLIST_KEY = "md.watchlist.v1";
+
+/** Broadcast event name; components re-read on this (same-tab) + `storage`. */
+export const WATCHLIST_EVENT = "watchlist:changed";
+
+const KIND_ORDER: Record<WatchKind, number> = { symbol: 0, token: 1, strategy: 2 };
+const KIND_LABEL: Record<WatchKind, string> = {
+  symbol: "Symbol",
+  token: "Token",
+  strategy: "Strategy",
+};
+
+/** Stable composite key for an item — used for identity + React keys. */
+export function watchKey(kind: WatchKind, id: string | number): string {
+  return `${kind}:${id}`;
+}
+
+/** Human-facing badge label for a kind. */
+export function kindLabel(kind: WatchKind): string {
+  return KIND_LABEL[kind] ?? kind;
+}
+
+function isWatchKind(v: unknown): v is WatchKind {
+  return v === "symbol" || v === "token" || v === "strategy";
+}
+
+/** True if `item` is in `list`. */
+export function isWatched(list: WatchItem[], kind: WatchKind, id: string | number): boolean {
+  const key = watchKey(kind, id);
+  return list.some((w) => watchKey(w.kind, w.id) === key);
+}
+
+/** Return a new list with the item toggled (added to the end if absent). */
+export function toggleWatch(list: WatchItem[], kind: WatchKind, id: string | number): WatchItem[] {
+  const sid = String(id);
+  const key = watchKey(kind, sid);
+  if (list.some((w) => watchKey(w.kind, w.id) === key)) {
+    return list.filter((w) => watchKey(w.kind, w.id) !== key);
+  }
+  return [...list, { kind, id: sid }];
+}
+
+/** Return a new list with the item removed (no-op if absent). */
+export function removeWatch(list: WatchItem[], kind: WatchKind, id: string | number): WatchItem[] {
+  const key = watchKey(kind, id);
+  return list.filter((w) => watchKey(w.kind, w.id) !== key);
+}
+
+/**
+ * Coerce ANY persisted payload into a clean `WatchItem[]`.
+ *  - A bare `number[]` (or numeric-string[]) is the LEGACY symbol watchlist →
+ *    each entry becomes `{kind:"symbol", id}` (default kind on migration).
+ *  - An array of `{kind,id}` objects is the new shape → validated + normalized
+ *    (ids coerced to string, unknown kinds dropped).
+ * Duplicates (by composite key) are removed, first occurrence wins, order kept.
+ */
+export function migrateLegacy(raw: unknown): WatchItem[] {
+  if (!Array.isArray(raw)) return [];
+  const out: WatchItem[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    let item: WatchItem | null = null;
+    if (typeof entry === "number" && Number.isFinite(entry)) {
+      item = { kind: "symbol", id: String(entry) };
+    } else if (typeof entry === "string" && entry.trim() !== "") {
+      // A bare string in the legacy array is treated as a symbol id.
+      item = { kind: "symbol", id: entry };
+    } else if (entry && typeof entry === "object") {
+      const k = (entry as Record<string, unknown>).kind;
+      const idv = (entry as Record<string, unknown>).id;
+      if (isWatchKind(k) && (typeof idv === "string" || typeof idv === "number")) {
+        const id = String(idv);
+        if (id.trim() !== "") item = { kind: k, id };
+      }
+    }
+    if (!item) continue;
+    const key = watchKey(item.kind, item.id);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+/**
+ * Deterministic display order: group by kind (symbol → token → strategy),
+ * preserving each item's original insertion order within its kind. Returns a
+ * new array; input is not mutated.
+ */
+export function sortWatchItems(list: WatchItem[]): WatchItem[] {
+  return list
+    .map((item, i) => ({ item, i }))
+    .sort((a, b) => {
+      const ko = KIND_ORDER[a.item.kind] - KIND_ORDER[b.item.kind];
+      return ko !== 0 ? ko : a.i - b.i;
+    })
+    .map((x) => x.item);
+}
+
+// ── Storage + event layer (thin; the pure API above is what tests target) ──
+
+/** Read + migrate the persisted watchlist. Safe on SSR / storage errors. */
+export function loadWatchlist(): WatchItem[] {
+  try {
+    if (typeof localStorage === "undefined") return [];
+    const raw = localStorage.getItem(WATCHLIST_KEY);
+    return migrateLegacy(raw ? JSON.parse(raw) : []);
+  } catch {
+    return [];
+  }
+}
+
+/** Persist + broadcast a same-tab change so all listeners re-read. */
+export function saveWatchlist(list: WatchItem[]): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(WATCHLIST_KEY, JSON.stringify(list));
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(WATCHLIST_EVENT));
+    }
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}

--- a/frontend/src/pages/markets/MarketsPage.tsx
+++ b/frontend/src/pages/markets/MarketsPage.tsx
@@ -11,6 +11,7 @@ import { useSymbols, useCandles } from "@/hooks/useMarketData";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
 import { formatPrice } from "./format";
 import { loadDefaultSymbol } from "@/lib/tradingPrefs";
+import { useWatchlist } from "@/hooks/useWatchlist";
 import {
   ALL_CLASS,
   CLASS_EMPTY_COPY,
@@ -33,19 +34,6 @@ const FALLBACK_SYMBOLS: MarketSymbol[] = [
   { symbol: "ETHUSDC", symbol_id: 2, instrument_id: 2, price_scaler: 1, lot_size: 1, reference_price: 3000, matching_algo: "price_time", is_perpetual: false, funding_interval_s: 0 },
   { symbol: "SOLUSDC", symbol_id: 3, instrument_id: 3, price_scaler: 1, lot_size: 1, reference_price: 150, matching_algo: "price_time", is_perpetual: false, funding_interval_s: 0 },
 ];
-
-// Client-side watchlist. Stable insertion order preserved as an id array.
-const WATCHLIST_KEY = "md.watchlist.v1";
-
-function loadWatchlist(): number[] {
-  try {
-    const raw = localStorage.getItem(WATCHLIST_KEY);
-    const parsed = raw ? JSON.parse(raw) : [];
-    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "number") : [];
-  } catch {
-    return [];
-  }
-}
 
 /** Format a funding interval (seconds) as a compact human string. */
 function formatInterval(seconds: number | undefined): string {
@@ -194,20 +182,20 @@ export default function MarketsPage() {
   const [query, setQuery] = useState("");
   const [watchTab, setWatchTab] = useState<WatchTab>("all");
   const [classTab, setClassTab] = useState<ClassTab>(ALL_CLASS);
-  const [watchlist, setWatchlist] = useState<number[]>(loadWatchlist);
+  // Unified cross-instrument watchlist; this page shows/toggles the SYMBOL kind.
+  const { items: watchItems, has: hasWatch, toggle: toggleWatch } = useWatchlist();
+  const watchlist = useMemo(
+    () =>
+      watchItems
+        .filter((w) => w.kind === "symbol")
+        .map((w) => Number(w.id))
+        .filter((n) => Number.isFinite(n)),
+    [watchItems],
+  );
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(WATCHLIST_KEY, JSON.stringify(watchlist));
-    } catch {
-      /* ignore */
-    }
-  }, [watchlist]);
+  const toggleFav = (id: number) => toggleWatch("symbol", id);
 
-  const toggleFav = (id: number) =>
-    setWatchlist((w) => (w.includes(id) ? w.filter((x) => x !== id) : [...w, id]));
-
-  const isFav = (id: number) => watchlist.includes(id);
+  const isFav = (id: number) => hasWatch("symbol", id);
 
   // Search + watchlist pre-filter (class-agnostic), shared by both the class
   // probe scope and the final rows so we only probe what could be shown.

--- a/frontend/src/pages/strategies/StrategyDetailPage.tsx
+++ b/frontend/src/pages/strategies/StrategyDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, BellRing, Boxes, FlaskConical, Pencil, Rocket, Lock } from "lucide-react";
+import { ArrowLeft, BellRing, Boxes, FlaskConical, Pencil, Rocket, Lock, Star } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -50,6 +50,8 @@ import {
   type InvestBlockReason,
 } from "@/lib/strategies";
 import { PendingBackend, PooledNavNote } from "./PendingBackend";
+import { cn } from "@/lib/utils";
+import { useWatchlist } from "@/hooks/useWatchlist";
 
 const STATUS_VARIANT: Record<StrategyStatus, "default" | "secondary" | "destructive" | "outline"> = {
   draft: "outline",
@@ -88,6 +90,9 @@ export default function StrategyDetailPage() {
   const isCreator = !!strategy && !!userId && strategy.creator_sub === userId;
   const isDraft = strategy?.status === "draft";
   const isPublished = strategy?.status === "published";
+
+  const { has: hasWatch, toggle: toggleWatch } = useWatchlist();
+  const isWatched = !!id && hasWatch("strategy", id);
 
   const symName = (sid: number) =>
     symbolsQ.data?.symbols.find((s) => s.symbol_id === sid)?.symbol ?? `#${sid}`;
@@ -182,6 +187,16 @@ export default function StrategyDetailPage() {
           {header}
         </div>
         <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-pressed={isWatched}
+            onClick={() => id && toggleWatch("strategy", id)}
+          >
+            <Star className={cn("mr-1 h-4 w-4", isWatched && "fill-amber-400 text-amber-400")} />
+            {isWatched ? "Watching" : "Watch"}
+          </Button>
           <Button asChild variant="outline" size="sm">
             <Link to={`/markets/price-alerts?kind=strategy&id=${encodeURIComponent(id ?? "")}`}>
               <BellRing className="mr-1 h-4 w-4" /> Set NAV alert

--- a/frontend/src/pages/tokens/TokenDetailPage.tsx
+++ b/frontend/src/pages/tokens/TokenDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, BellRing, Coins, Snowflake } from "lucide-react";
+import { ArrowLeft, BellRing, Coins, Snowflake, Star } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -19,6 +19,8 @@ import {
 } from "@/hooks/useTokens";
 import type { Token, TokenStatus } from "@/api/endpoints/tokens";
 import { formatBps, formatCents } from "@/lib/tokens";
+import { cn } from "@/lib/utils";
+import { useWatchlist } from "@/hooks/useWatchlist";
 import { PendingBackend } from "./PendingBackend";
 import { CapTableSection } from "./sections/CapTableSection";
 import { RevenueSection } from "./sections/RevenueSection";
@@ -54,6 +56,9 @@ export default function TokenDetailPage() {
   const token: Token | undefined = tokenQ.data;
   const isIssuer = !!token && !!userId && token.creator_sub === userId;
   const isFrozen = token?.status === "frozen";
+
+  const { has: hasWatch, toggle: toggleWatch } = useWatchlist();
+  const isWatched = !!id && hasWatch("token", id);
 
   const [tab, setTab] = useState("captable");
 
@@ -103,7 +108,18 @@ export default function TokenDetailPage() {
           </Link>
         </Button>
         {header}
-        <Button asChild variant="outline" size="sm" className="ml-auto gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="ml-auto gap-1"
+          aria-pressed={isWatched}
+          onClick={() => id && toggleWatch("token", id)}
+        >
+          <Star className={cn("h-4 w-4", isWatched && "fill-amber-400 text-amber-400")} />
+          {isWatched ? "Watching" : "Watch"}
+        </Button>
+        <Button asChild variant="outline" size="sm" className="gap-1">
           <Link to={`/markets/price-alerts?kind=token&id=${encodeURIComponent(id ?? "")}`}>
             <BellRing className="h-4 w-4" /> Set price alert
           </Link>

--- a/frontend/src/pages/watchlist/WatchlistPage.tsx
+++ b/frontend/src/pages/watchlist/WatchlistPage.tsx
@@ -1,0 +1,278 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { Star, Coins, Landmark, Boxes, CandlestickChart } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { useWatchlist } from "@/hooks/useWatchlist";
+import { useSymbols, useCandles } from "@/hooks/useMarketData";
+import { useTokenMarket } from "@/hooks/useTokens";
+import { useStrategyMarket } from "@/hooks/useStrategies";
+import { formatPrice } from "@/pages/markets/format";
+import { formatCents, formatBps } from "@/lib/tokens";
+import { sortWatchItems, kindLabel, type WatchItem } from "@/lib/watchlist";
+
+const KIND_ICON = {
+  symbol: <CandlestickChart className="h-4 w-4 text-muted-foreground" />,
+  token: <Coins className="h-4 w-4 text-muted-foreground" />,
+  strategy: <Boxes className="h-4 w-4 text-muted-foreground" />,
+} as const;
+
+const KIND_VARIANT = {
+  symbol: "default",
+  token: "secondary",
+  strategy: "outline",
+} as const;
+
+function UnwatchButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label="Remove from watchlist"
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        onClick();
+      }}
+    >
+      <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
+    </button>
+  );
+}
+
+/** A watched exchange symbol row — live last/change from 60s candles. */
+function SymbolRow({
+  symbolId,
+  onRemove,
+}: {
+  symbolId: number;
+  onRemove: () => void;
+}) {
+  const symbolsQ = useSymbols();
+  const sym = (symbolsQ.data?.symbols ?? []).find((s) => s.symbol_id === symbolId);
+  const scaler = sym?.price_scaler || 1;
+  const candles = useCandles(symbolId, 60, true, 60);
+  const bars = candles.data?.bars ?? [];
+  const closes = bars.map((b) => b.close);
+  const last = closes.length ? closes[closes.length - 1]! : sym?.reference_price;
+  const first = closes.length ? closes[0]! : undefined;
+  const changePct =
+    first != null && first !== 0 && last != null ? ((last - first) / first) * 100 : undefined;
+  const up = (changePct ?? 0) >= 0;
+
+  const label = sym?.symbol ?? `Symbol ${symbolId}`;
+  const to = `/markets/${symbolId}`;
+
+  return (
+    <WatchRow
+      to={to}
+      kind="symbol"
+      title={label}
+      subtitle="Exchange symbol"
+      value={last != null ? formatPrice(last, scaler) : "—"}
+      change={changePct == null ? "—" : `${up ? "+" : ""}${changePct.toFixed(2)}%`}
+      changeUp={changePct == null ? undefined : up}
+      onRemove={onRemove}
+    />
+  );
+}
+
+/** A watched creator token row — clearing price from the token market feed. */
+function TokenRow({ tokenId, onRemove }: { tokenId: string; onRemove: () => void }) {
+  const marketQ = useTokenMarket();
+  const tok = (marketQ.data?.tokens ?? []).find((t) => t.token_id === tokenId);
+  const title = tok ? `${tok.ticker}` : `Token ${tokenId}`;
+  const subtitle = tok?.name ?? "Creator token";
+  return (
+    <WatchRow
+      to={`/tokens/${encodeURIComponent(tokenId)}`}
+      kind="token"
+      title={title}
+      subtitle={subtitle}
+      value={tok?.clearing_price != null ? formatCents(tok.clearing_price) : "—"}
+      change={tok ? tok.status : "—"}
+      onRemove={onRemove}
+    />
+  );
+}
+
+/** A watched strategy fund row — NAV per unit + inception return. */
+function StrategyRow({ strategyId, onRemove }: { strategyId: string; onRemove: () => void }) {
+  const marketQ = useStrategyMarket();
+  const st = (marketQ.data?.strategies ?? []).find((s) => s.strategy_id === strategyId);
+  const title = st?.name ?? `Strategy ${strategyId}`;
+  const ret = st?.inception_return_bps;
+  const up = ret == null ? undefined : ret >= 0;
+  return (
+    <WatchRow
+      to={`/strategies/${encodeURIComponent(strategyId)}`}
+      kind="strategy"
+      title={title}
+      subtitle="Strategy fund"
+      value={st?.nav_per_unit != null ? formatCents(st.nav_per_unit) : "—"}
+      change={ret == null ? "—" : `${up ? "+" : ""}${formatBps(ret)}`}
+      changeUp={up}
+      onRemove={onRemove}
+    />
+  );
+}
+
+/** Shared presentational row (deep-links to the item's detail page). */
+function WatchRow({
+  to,
+  kind,
+  title,
+  subtitle,
+  value,
+  change,
+  changeUp,
+  onRemove,
+}: {
+  to: string;
+  kind: WatchItem["kind"];
+  title: string;
+  subtitle: string;
+  value: string;
+  change: string;
+  changeUp?: boolean;
+  onRemove: () => void;
+}) {
+  return (
+    <TableRow className="cursor-pointer">
+      <TableCell className="w-8 pr-0">
+        <UnwatchButton onClick={onRemove} />
+      </TableCell>
+      <TableCell>
+        <Link to={to} className="flex items-center gap-2">
+          {KIND_ICON[kind]}
+          <div className="min-w-0">
+            <div className="truncate font-medium">{title}</div>
+            <div className="truncate text-xs text-muted-foreground">{subtitle}</div>
+          </div>
+        </Link>
+      </TableCell>
+      <TableCell>
+        <Badge variant={KIND_VARIANT[kind]}>{kindLabel(kind)}</Badge>
+      </TableCell>
+      <TableCell className="text-right tabular-nums">{value}</TableCell>
+      <TableCell
+        className={cn(
+          "text-right tabular-nums",
+          changeUp == null
+            ? "text-muted-foreground"
+            : changeUp
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-rose-600 dark:text-rose-400",
+        )}
+      >
+        {change}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function WatchlistPage() {
+  const { items, remove } = useWatchlist();
+  const ordered = useMemo(() => sortWatchItems(items), [items]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Star className="h-6 w-6 text-amber-400" />
+        <div>
+          <h1 className="text-2xl font-semibold">Watchlist</h1>
+          <p className="text-sm text-muted-foreground">
+            Everything you are following — symbols, creator tokens, and strategy funds — in one place.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Watched instruments</CardTitle>
+          <CardDescription>
+            Prices, clearing prices, and NAVs update live where available. Tap a row to open its detail page.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {ordered.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-center">
+              <Star className="h-8 w-8 text-muted-foreground" />
+              <p className="text-sm font-medium">Your watchlist is empty</p>
+              <p className="max-w-sm text-sm text-muted-foreground">
+                Star a market, creator token, or strategy fund and it will show up here.
+              </p>
+              <div className="mt-2 flex flex-wrap justify-center gap-2">
+                <Button asChild variant="outline" size="sm">
+                  <Link to="/markets">
+                    <CandlestickChart className="mr-1 h-4 w-4" /> Markets
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                  <Link to="/tokens">
+                    <Landmark className="mr-1 h-4 w-4" /> Creator Tokens
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                  <Link to="/strategies">
+                    <Boxes className="mr-1 h-4 w-4" /> Strategies
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8" />
+                  <TableHead>Instrument</TableHead>
+                  <TableHead>Kind</TableHead>
+                  <TableHead className="text-right">Price / NAV</TableHead>
+                  <TableHead className="text-right">Change</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {ordered.map((it) => {
+                  if (it.kind === "symbol") {
+                    return (
+                      <SymbolRow
+                        key={`symbol:${it.id}`}
+                        symbolId={Number(it.id)}
+                        onRemove={() => remove("symbol", it.id)}
+                      />
+                    );
+                  }
+                  if (it.kind === "token") {
+                    return (
+                      <TokenRow
+                        key={`token:${it.id}`}
+                        tokenId={it.id}
+                        onRemove={() => remove("token", it.id)}
+                      />
+                    );
+                  }
+                  return (
+                    <StrategyRow
+                      key={`strategy:${it.id}`}
+                      strategyId={it.id}
+                      onRemove={() => remove("strategy", it.id)}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Unified cross-instrument watchlist — symbols + tokens + strategies

Generalizes the symbol-only watchlist to hold **symbols, creator tokens, and strategy funds** in one list. Existing symbol watchlist **migrates transparently** and keeps working (legacy key mirrored). Client-side, additive, degrade-on-404.

### Web
`lib/watchlist.ts` (+18 vitest) — `WatchItem{kind,id}` store at `md.watchlist.v1` with `migrateLegacy` + pure helpers; `hooks/useWatchlist.ts` + `pages/watchlist/WatchlistPage` (`/watchlist` "Watchlist" nav): all watched items with per-kind badge + live price/NAV/change + remove + deep-links. MarketsPage drives its All/Watchlist tab off the unified hook (unchanged behavior); Token & Strategy detail headers get a watch star.

### Android
`data/exchange/watchlist/WatchlistItem.kt` (pure; +14 JVM tests) + `WatchlistStore` (@Singleton; new `watch_items` key + legacy `favorites` mirrored, transparent migration) + `feature/watchlist` Screen/ViewModel + navigation. MarketsViewModel delegates symbol watchlist to the store; Token & Strategy detail get a star; `MoreCatalog` + `MoreRoutes.REGISTERED` + `AuthenticatedGraph`.

No new deps. Gates: web tsc 0 · vite build · vitest 18/18; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (WatchlistItem 14/14, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
