### PR TITLE
test(trading): harden shipped surfaces — render-smoke + ViewModel tests + required-CI gating

### DIFF
--- a/.github/workflows/payment-incident-critical-paths.yml
+++ b/.github/workflows/payment-incident-critical-paths.yml
@@ -60,4 +60,33 @@ jobs:
             src/pages/admin/__tests__/PaymentIncidentQueuePage.test.tsx \
             src/pages/admin/__tests__/PaymentIncidentQueuePage.e2e.test.tsx \
             src/pages/billing/__tests__/BillingOverview.paymentIssues.test.tsx \
-            src/pages/billing/__tests__/BillingOverview.paymentIssues.e2e.test.tsx
+            src/pages/billing/__tests__/BillingOverview.paymentIssues.e2e.test.tsx \
+            src/lib/paperEngine.test.ts \
+            src/lib/paperBlotter.test.ts \
+            src/lib/paperMode.test.ts \
+            src/lib/instrumentClass.test.ts \
+            src/lib/marketStats.test.ts \
+            src/lib/tokens.test.ts \
+            src/lib/bailout.test.ts \
+            src/lib/tradingCredentials.test.ts \
+            src/lib/custodyProviders.test.ts \
+            src/lib/strategies.test.ts \
+            src/lib/discover.test.ts \
+            src/lib/portfolioAnalytics.test.ts \
+            src/lib/taxLots.test.ts \
+            src/lib/activity.test.ts \
+            src/lib/orderCalc.test.ts \
+            src/lib/priceAlerts.test.ts \
+            src/lib/watchlist.test.ts \
+            src/lib/onboarding.test.ts \
+            src/pages/invest/InvestHubPage.smoke.test.tsx \
+            src/pages/strategies/StrategyMarketPage.smoke.test.tsx \
+            src/pages/tokens/TokenMarketPage.smoke.test.tsx \
+            src/pages/bailouts/BailoutsBoardPage.smoke.test.tsx \
+            src/pages/portfolio/PortfolioAnalyticsPage.smoke.test.tsx \
+            src/pages/activity-center/ActivityCenterPage.smoke.test.tsx \
+            src/pages/algos/ActiveAlgosPage.smoke.test.tsx \
+            src/pages/watchlist/WatchlistPage.smoke.test.tsx \
+            src/pages/reports/TaxReportPage.smoke.test.tsx \
+            src/pages/analysis/MarketAnalysisPage.smoke.test.tsx \
+            src/pages/custody/CustodyProvidersPage.smoke.test.tsx

--- a/android/app/src/test/java/com/testlogon/android/feature/bailout/BailoutBoardViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/bailout/BailoutBoardViewModelTest.kt
@@ -1,0 +1,94 @@
+package com.testlogon.android.feature.bailout
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.bailout.BailoutAck
+import com.testlogon.android.data.bailout.BailoutAuction
+import com.testlogon.android.data.bailout.BailoutPrefs
+import com.testlogon.android.data.bailout.BailoutRepository
+import com.testlogon.android.data.bailout.BailoutStatus
+import com.testlogon.android.data.bailout.DistressPosition
+import com.testlogon.android.data.bailout.PositionSide
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+private fun sampleAuction(id: String) = BailoutAuction(
+    auctionId = id,
+    symbolId = 1,
+    ownerSub = "u1",
+    side = PositionSide.LONG,
+    qty = 10,
+    capitalNeededCents = 100_00,
+    maxShareBps = 5_000,
+    status = BailoutStatus.OPEN,
+    liqPrice = 90_00,
+    markPrice = 95_00,
+)
+
+private class FakeBailoutRepo(
+    var bailoutsResult: ApiResult<List<BailoutAuction>> = ApiResult.Success(emptyList()),
+) : BailoutRepository {
+    override suspend fun distress(): ApiResult<List<DistressPosition>> = ApiResult.Success(emptyList())
+    override suspend fun bailouts(): ApiResult<List<BailoutAuction>> = bailoutsResult
+    override suspend fun positionBailout(symbolId: Int): ApiResult<BailoutAuction?> = ApiResult.Success(null)
+    override suspend fun prefs(): ApiResult<BailoutPrefs> = ApiResult.Success(BailoutPrefs(false, 0))
+    override suspend fun openBailout(symbolId: Int, maxShareBps: Int, closeTs: Long?) =
+        ApiResult.Success(sampleAuction("a"))
+    override suspend fun placeBid(auctionId: String, capitalCents: Long, shareBps: Int) =
+        ApiResult.Success(BailoutAck(true))
+    override suspend fun clear(auctionId: String) = ApiResult.Success(sampleAuction(auctionId))
+    override suspend fun putPrefs(autoEnabled: Boolean, defaultMaxShareBps: Int) =
+        ApiResult.Success(BailoutPrefs(autoEnabled, defaultMaxShareBps))
+}
+
+/**
+ * ViewModel-level coverage for [BailoutBoardViewModel]: 404 -> honest empty Content (never fabricates
+ * distress), happy path with a fake repo returning open auctions, and transport failure -> retryable
+ * Error. Complements the pure BailoutMath tests.
+ */
+class BailoutBoardViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    @Test
+    fun degrade_404_toEmptyContent() = runTest(mainRule.dispatcher) {
+        // A 404 arrives as Failure; the VM degrades that to an empty Content board (no distress).
+        val vm = BailoutBoardViewModel(
+            FakeBailoutRepo(bailoutsResult = ApiResult.Failure(ApiError(status = 404, message = "not found"))),
+        )
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(BailoutBoardUiState.Phase.Content, s.phase)
+        assertTrue(s.auctions.isEmpty())
+    }
+
+    @Test
+    fun happy_openAuctions_populated() = runTest(mainRule.dispatcher) {
+        val vm = BailoutBoardViewModel(
+            FakeBailoutRepo(bailoutsResult = ApiResult.Success(listOf(sampleAuction("a1"), sampleAuction("a2")))),
+        )
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(BailoutBoardUiState.Phase.Content, s.phase)
+        assertEquals(2, s.auctions.size)
+        assertNull(s.errorMessage)
+    }
+
+    @Test
+    fun transportFailure_toRetryableError() = runTest(mainRule.dispatcher) {
+        val vm = BailoutBoardViewModel(
+            FakeBailoutRepo(bailoutsResult = ApiResult.NetworkError(java.io.IOException(), isTimeout = false)),
+        )
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(BailoutBoardUiState.Phase.Error, s.phase)
+        assertTrue(s.errorMessage != null)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/strategies/StrategyMarketViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/strategies/StrategyMarketViewModelTest.kt
@@ -1,0 +1,88 @@
+package com.testlogon.android.feature.strategies
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.strategies.InvestorPosition
+import com.testlogon.android.data.strategies.Strategy
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.strategies.StrategyAck
+import com.testlogon.android.data.strategies.StrategyFees
+import com.testlogon.android.data.strategies.StrategyHolding
+import com.testlogon.android.data.strategies.StrategyNav
+import com.testlogon.android.data.strategies.UpsertStrategyRequestDto
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+private fun sampleStrategy(id: String, name: String) = Strategy(strategyId = id, name = name)
+
+private class FakeStrategiesRepo(
+    var marketResult: ApiResult<List<Strategy>> = ApiResult.Success(emptyList()),
+    var mineResult: ApiResult<List<Strategy>> = ApiResult.Success(emptyList()),
+) : StrategiesRepository {
+    override suspend fun mine(): ApiResult<List<Strategy>> = mineResult
+    override suspend fun market(): ApiResult<List<Strategy>> = marketResult
+    override suspend fun strategy(id: String): ApiResult<Strategy?> = ApiResult.Success(null)
+    override suspend fun nav(id: String): ApiResult<StrategyNav?> = ApiResult.Success(null)
+    override suspend fun holdings(id: String): ApiResult<List<StrategyHolding>> = ApiResult.Success(emptyList())
+    override suspend fun position(id: String): ApiResult<InvestorPosition?> = ApiResult.Success(null)
+    override suspend fun fees(id: String): ApiResult<StrategyFees> = ApiResult.Success(StrategyFees(id, 0, 0, 0, emptyList()))
+    override suspend fun create(body: UpsertStrategyRequestDto) = ApiResult.Success(sampleStrategy("x", "x"))
+    override suspend fun update(id: String, body: UpsertStrategyRequestDto) = ApiResult.Success(sampleStrategy(id, "x"))
+    override suspend fun publish(id: String) = ApiResult.Success(sampleStrategy(id, "x"))
+    override suspend fun invest(id: String, amountCents: Long) = ApiResult.Success(StrategyAck(true))
+    override suspend fun redeem(id: String, units: Long) = ApiResult.Success(StrategyAck(true))
+}
+
+/**
+ * ViewModel-level coverage for [StrategyMarketViewModel]: degrade-on-404 -> empty Content, happy path
+ * with a fake repo returning marketplace + authored strategies, and transport failure -> retryable
+ * Error. Complements the pure StrategyMath tests.
+ */
+class StrategyMarketViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    @Test
+    fun degrade_bothEmpty_toEmptyContent() = runTest(mainRule.dispatcher) {
+        val vm = StrategyMarketViewModel(FakeStrategiesRepo())
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(StrategyMarketUiState.Phase.Content, s.phase)
+        assertTrue(s.market.isEmpty())
+        assertTrue(s.mine.isEmpty())
+        assertNull(s.errorMessage)
+    }
+
+    @Test
+    fun happy_marketAndMine_populated() = runTest(mainRule.dispatcher) {
+        val repo = FakeStrategiesRepo(
+            marketResult = ApiResult.Success(listOf(sampleStrategy("s1", "Alpha"), sampleStrategy("s2", "Beta"))),
+            mineResult = ApiResult.Success(listOf(sampleStrategy("s3", "Mine"))),
+        )
+        val vm = StrategyMarketViewModel(repo)
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(StrategyMarketUiState.Phase.Content, s.phase)
+        assertEquals(2, s.market.size)
+        assertEquals(1, s.mine.size)
+        assertEquals(2, s.rows.size)
+        vm.selectTab(StrategyListTab.MINE)
+        assertEquals(1, vm.uiState.value.rows.size)
+    }
+
+    @Test
+    fun transportFailure_toRetryableError() = runTest(mainRule.dispatcher) {
+        val repo = FakeStrategiesRepo(mineResult = ApiResult.NetworkError(java.io.IOException(), isTimeout = false))
+        val vm = StrategyMarketViewModel(repo)
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(StrategyMarketUiState.Phase.Error, s.phase)
+        assertTrue(s.errorMessage != null)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/tokens/TokensMarketViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/tokens/TokensMarketViewModelTest.kt
@@ -1,0 +1,110 @@
+package com.testlogon.android.feature.tokens
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.tokens.AuctionStatus
+import com.testlogon.android.data.tokens.Token
+import com.testlogon.android.data.tokens.TokenAck
+import com.testlogon.android.data.tokens.TokenAuction
+import com.testlogon.android.data.tokens.TokenCapTable
+import com.testlogon.android.data.tokens.TokenRevenue
+import com.testlogon.android.data.tokens.TokenStatus
+import com.testlogon.android.data.tokens.TokenUpkeep
+import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.data.tokens.UpkeepStatus
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+private fun sampleToken(id: String, ticker: String) = Token(
+    tokenId = id,
+    name = "Token $ticker",
+    ticker = ticker,
+    totalSupply = 1_000_000L,
+    revenueShareBps = 1_000,
+    status = TokenStatus.LISTED,
+)
+
+/** Fake honoring the repo contract: reads return the configured [ApiResult]; mutations are unused. */
+private class FakeTokensRepo(
+    var marketResult: ApiResult<List<Token>> = ApiResult.Success(emptyList()),
+    var issuedResult: ApiResult<List<Token>> = ApiResult.Success(emptyList()),
+) : TokensRepository {
+    override suspend fun issued(): ApiResult<List<Token>> = issuedResult
+    override suspend fun market(): ApiResult<List<Token>> = marketResult
+    override suspend fun openAuctions(): ApiResult<List<TokenAuction>> = ApiResult.Success(emptyList())
+    override suspend fun token(id: String): ApiResult<Token?> = ApiResult.Success(null)
+    override suspend fun capTable(id: String): ApiResult<TokenCapTable> =
+        ApiResult.Success(TokenCapTable(id, 0, emptyList()))
+    override suspend fun auction(id: String): ApiResult<TokenAuction?> = ApiResult.Success(null)
+    override suspend fun revenue(id: String): ApiResult<TokenRevenue> =
+        ApiResult.Success(TokenRevenue(id, 0, 0, 0, emptyList()))
+    override suspend fun upkeep(id: String): ApiResult<TokenUpkeep> =
+        ApiResult.Success(TokenUpkeep(id, "", 0, 0, 0, 0, UpkeepStatus.UNKNOWN))
+    override suspend fun mint(name: String, ticker: String, totalSupply: Long, revenueShareBps: Int) =
+        ApiResult.Success(sampleToken("x", ticker))
+    override suspend fun list(id: String, offeredPctBps: Int, reservePrice: Long, closeTs: Long) =
+        ApiResult.Success(TokenAuction("a", id, 0, 0, AuctionStatus.OPEN))
+    override suspend fun placeBid(id: String, qty: Long, limitPrice: Long) = ApiResult.Success(TokenAck(true))
+    override suspend fun clearAuction(id: String) =
+        ApiResult.Success(TokenAuction("a", id, 0, 0, AuctionStatus.CLEARED))
+    override suspend fun claimRevenue(id: String) = ApiResult.Success(TokenAck(true))
+    override suspend fun payUpkeep(id: String) = ApiResult.Success(TokenAck(true))
+}
+
+/**
+ * ViewModel-level coverage for [TokensMarketViewModel] (beyond the pure TokenMath tests): the
+ * degrade-on-404 -> empty Content path (repo already folds 404 to empty Success) and the happy path
+ * with a fake repo returning market + issued rows. A transport failure -> retryable Error is also
+ * asserted so the "no connection" branch is exercised.
+ */
+class TokensMarketViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    @Test
+    fun degrade_bothEmpty_toEmptyContent() = runTest(mainRule.dispatcher) {
+        // 404 already folded to empty Success inside the repo -> honest empty Content, no crash.
+        val vm = TokensMarketViewModel(FakeTokensRepo())
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(TokensMarketUiState.Phase.Content, s.phase)
+        assertTrue(s.market.isEmpty())
+        assertTrue(s.issued.isEmpty())
+        assertTrue(s.rows.isEmpty())
+        assertNull(s.errorMessage)
+    }
+
+    @Test
+    fun happy_marketAndIssued_populated() = runTest(mainRule.dispatcher) {
+        val repo = FakeTokensRepo(
+            marketResult = ApiResult.Success(listOf(sampleToken("t1", "AAA"), sampleToken("t2", "BBB"))),
+            issuedResult = ApiResult.Success(listOf(sampleToken("t3", "CCC"))),
+        )
+        val vm = TokensMarketViewModel(repo)
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(TokensMarketUiState.Phase.Content, s.phase)
+        assertEquals(2, s.market.size)
+        assertEquals(1, s.issued.size)
+        // MARKET tab is the default -> rows mirror the market slice.
+        assertEquals(2, s.rows.size)
+        vm.selectTab(TokenListTab.ISSUED)
+        assertEquals(1, vm.uiState.value.rows.size)
+    }
+
+    @Test
+    fun transportFailure_toRetryableError() = runTest(mainRule.dispatcher) {
+        val repo = FakeTokensRepo(marketResult = ApiResult.NetworkError(java.io.IOException(), isTimeout = false))
+        val vm = TokensMarketViewModel(repo)
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(TokensMarketUiState.Phase.Error, s.phase)
+        assertTrue(s.errorMessage != null)
+    }
+}

--- a/frontend/src/pages/activity-center/ActivityCenterPage.smoke.test.tsx
+++ b/frontend/src/pages/activity-center/ActivityCenterPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import ActivityCenterPage from "@/pages/activity-center/ActivityCenterPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <ActivityCenterPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("ActivityCenterPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when every read 404s", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Activity Center/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/algos/ActiveAlgosPage.smoke.test.tsx
+++ b/frontend/src/pages/algos/ActiveAlgosPage.smoke.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+// This page is fed by the client-side algoStore (localStorage), not the network,
+// but we still mock the api leaf to reject so a smoke mount never hits fetch.
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import ActiveAlgosPage from "@/pages/algos/ActiveAlgosPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <ActiveAlgosPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("ActiveAlgosPage render smoke (empty store)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("mounts and shows its heading + client-side banner with no persisted algos", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Active Algos/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("algo_client_side_banner")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/analysis/MarketAnalysisPage.smoke.test.tsx
+++ b/frontend/src/pages/analysis/MarketAnalysisPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import MarketAnalysisPage from "@/pages/analysis/MarketAnalysisPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <MarketAnalysisPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("MarketAnalysisPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when symbols/history 404", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Analysis/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/bailouts/BailoutsBoardPage.smoke.test.tsx
+++ b/frontend/src/pages/bailouts/BailoutsBoardPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import BailoutsBoardPage from "@/pages/bailouts/BailoutsBoardPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <BailoutsBoardPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("BailoutsBoardPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading + honest pending-backend state on 404", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /^Bailouts$/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/custody/CustodyProvidersPage.smoke.test.tsx
+++ b/frontend/src/pages/custody/CustodyProvidersPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import CustodyProvidersPage from "@/pages/custody/CustodyProvidersPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <CustodyProvidersPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("CustodyProvidersPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when provider reads 404", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Custody providers/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/invest/InvestHubPage.smoke.test.tsx
+++ b/frontend/src/pages/invest/InvestHubPage.smoke.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+// Degrade path: the shared api leaf rejects with a 404 ApiError for every read.
+// ApiError / withApiBase / normalizeErrorDetail stay REAL so instanceof checks
+// and any imports keep working.
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import InvestHubPage from "@/pages/invest/InvestHubPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <InvestHubPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("InvestHubPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when every read 404s", async () => {
+    renderPage();
+    expect(await screen.findByRole("heading", { level: 1, name: /^Invest$/i })).toBeInTheDocument();
+    expect(screen.getByTestId("discover-search")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/portfolio/PortfolioAnalyticsPage.smoke.test.tsx
+++ b/frontend/src/pages/portfolio/PortfolioAnalyticsPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import PortfolioAnalyticsPage from "@/pages/portfolio/PortfolioAnalyticsPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <PortfolioAnalyticsPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("PortfolioAnalyticsPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when every source 404s", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Portfolio Risk/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/reports/TaxReportPage.smoke.test.tsx
+++ b/frontend/src/pages/reports/TaxReportPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import TaxReportPage from "@/pages/reports/TaxReportPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <TaxReportPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TaxReportPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when the fills feed 404s", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Tax & Gains/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/strategies/StrategyMarketPage.smoke.test.tsx
+++ b/frontend/src/pages/strategies/StrategyMarketPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import StrategyMarketPage from "@/pages/strategies/StrategyMarketPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <StrategyMarketPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("StrategyMarketPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when every read 404s", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Strategies & Baskets/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/tokens/TokenMarketPage.smoke.test.tsx
+++ b/frontend/src/pages/tokens/TokenMarketPage.smoke.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import TokenMarketPage from "@/pages/tokens/TokenMarketPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <TokenMarketPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TokenMarketPage render smoke (degrade path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("mounts and shows its heading without throwing when every read 404s", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /Creator Tokens/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/watchlist/WatchlistPage.smoke.test.tsx
+++ b/frontend/src/pages/watchlist/WatchlistPage.smoke.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    api: vi.fn(() => Promise.reject(new actual.ApiError(404, "Not found"))),
+  };
+});
+
+import WatchlistPage from "@/pages/watchlist/WatchlistPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <WatchlistPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("WatchlistPage render smoke (empty watchlist)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("mounts and shows its heading without throwing when reads 404 and the list is empty", async () => {
+    renderPage();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: /^Watchlist$/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Hardening pass — lock in the shipped trading/investing work

No product code changed. Adds tests that actually **gate on every PR**.

### Web
- **11 render-smoke tests** (one per new page) — each mounts the page in `MemoryRouter` + `QueryClientProvider` with `@/api/client` mocked to 404 (degrade path) and asserts it renders without throwing (`ApiError` kept real via `importActual`).
- **Required-CI gating**: `payment-incident-critical-paths.yml` — additively adds the 18 trading pure-lib suites + the 11 smoke tests to the **required** `vitest run` (all pre-existing entries kept, YAML validated). **29 files / 365 tests now gate every PR.** (This PR's own required check exercises them.)

### Android
- **3 ViewModel unit tests** (TokensMarket / StrategyMarket / BailoutBoard), DashboardViewModelTest pattern (MainDispatcherRule + runTest + fake repos): degrade-on-404 empty state, happy-path, transport-error retryable — in the already-gated `testDebugUnitTest`. (Detail/Watchlist/Activity/Portfolio/Invest VMs skipped — inject concrete Context-backed stores; would need mockk/Robolectric or a testability seam, out of scope for no-new-deps.)

Gates: web tsc 0 · vite build · vitest 365/365 (trading globs); android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (full suite 5138/0-fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
