### PR TITLE
test(trading): ViewModel coverage for the remaining 6 surfaces via testability seams (Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/activity/ActivityLastSeenStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/activity/ActivityLastSeenStore.kt
@@ -20,19 +20,32 @@ private val Context.activityLastSeenDataStore by preferencesDataStore(name = "ac
  * has acknowledged) so unread markers survive re-entry / process death. Only a single Long is stored -
  * never any event payload. Reads degrade to 0 (everything unread) on an IO error.
  */
+/**
+ * Contract for the Activity Center last-seen high-water mark. Extracted as an interface so the
+ * ViewModel can be unit-tested against an in-memory fake; [ActivityLastSeenStoreImpl] is the real
+ * DataStore-backed implementation.
+ */
+interface ActivityLastSeenStore {
+    /** Hot stream of the persisted last-seen millis (0 when never set). */
+    val lastSeen: Flow<Long>
+
+    /** Advance the mark to [ts] (never moves it backwards). */
+    suspend fun setLastSeen(ts: Long)
+}
+
 @Singleton
-class ActivityLastSeenStore @Inject constructor(
+class ActivityLastSeenStoreImpl @Inject constructor(
     @ApplicationContext context: Context,
-) {
+) : ActivityLastSeenStore {
     private val dataStore = context.activityLastSeenDataStore
 
     /** Hot stream of the persisted last-seen millis (0 when never set). */
-    val lastSeen: Flow<Long> = dataStore.data
+    override val lastSeen: Flow<Long> = dataStore.data
         .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
         .map { it[KEY_LAST_SEEN] ?: 0L }
 
     /** Advance the mark to [ts] (never moves it backwards). */
-    suspend fun setLastSeen(ts: Long) {
+    override suspend fun setLastSeen(ts: Long) {
         dataStore.edit { prefs ->
             val current = prefs[KEY_LAST_SEEN] ?: 0L
             if (ts > current) prefs[KEY_LAST_SEEN] = ts
@@ -42,4 +55,13 @@ class ActivityLastSeenStore @Inject constructor(
     private companion object {
         val KEY_LAST_SEEN = longPreferencesKey("activity_last_seen_ms")
     }
+}
+
+/** Binds the Activity last-seen store contract to its DataStore-backed implementation. */
+@dagger.Module
+@dagger.hilt.InstallIn(dagger.hilt.components.SingletonComponent::class)
+abstract class ActivityLastSeenStoreModule {
+    @dagger.Binds
+    @Singleton
+    abstract fun bindActivityLastSeenStore(impl: ActivityLastSeenStoreImpl): ActivityLastSeenStore
 }

--- a/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/custody/CustodyRepository.kt
@@ -24,14 +24,25 @@ import javax.inject.Singleton
  * POST is not auto-retried. The custody<->trading bridge is four real routes (fund/settle x
  * spot/margin); a 422 rejection surfaces as a Failure whose parsed reason the ViewModel renders.
  */
+/**
+ * NARROW read-only custody contract exposing only the balance + staking reads consumed by the
+ * portfolio/invest aggregation ViewModels. Extracted so those ViewModels can be unit-tested against a
+ * lightweight fake without standing up the full Retrofit-backed [CustodyRepository]. The full
+ * repository implements it, so runtime wiring is unchanged.
+ */
+interface CustodyReader {
+    suspend fun getBalance(): ApiResult<CustodyBalances>
+    suspend fun getStaking(): ApiResult<StakingDashboard>
+}
+
 @Singleton
 class CustodyRepository @Inject constructor(
     private val api: CustodyApi,
     private val errorParser: ApiErrorParser,
-) {
+) : CustodyReader {
     private val io: CoroutineDispatcher = Dispatchers.IO
 
-    suspend fun getBalance(): ApiResult<CustodyBalances> = call {
+    override suspend fun getBalance(): ApiResult<CustodyBalances> = call {
         api.balance().toDomain()
     }
 
@@ -139,7 +150,7 @@ class CustodyRepository @Inject constructor(
      * surface. Providers + positions are fetched sequentially; if positions 404 but providers succeed the
      * providers still render (positions default empty).
      */
-    suspend fun getStaking(): ApiResult<StakingDashboard> = withContext(io) {
+    override suspend fun getStaking(): ApiResult<StakingDashboard> = withContext(io) {
         try {
             val providers = api.stakingProviders().providers.orEmpty().map { it.toDomain() }
             val posDto = api.stakingPositions()
@@ -482,4 +493,13 @@ object CustodyDataModule {
     @Provides
     @Singleton
     fun provideCustodyApi(retrofit: Retrofit): CustodyApi = retrofit.create(CustodyApi::class.java)
+}
+
+/** Binds the narrow read-only custody contract to the full [CustodyRepository]. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CustodyReaderModule {
+    @dagger.Binds
+    @Singleton
+    abstract fun bindCustodyReader(impl: CustodyRepository): CustodyReader
 }

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/watchlist/WatchlistStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/watchlist/WatchlistStore.kt
@@ -21,39 +21,64 @@ import javax.inject.Singleton
  * Migration is transparent: on first construction any legacy entries (bare symbolIds under [KEY_FAV],
  * or un-prefixed keys) are folded into the unified set via [migrateLegacy] and written back.
  */
+/**
+ * Device-local UNIFIED watchlist store contract: the single source of truth for the starred set across
+ * exchange SYMBOLs, creator TOKENs, and STRATEGY funds. Extracted as an interface so ViewModels can be
+ * unit-tested against a lightweight in-memory fake; [WatchlistStoreImpl] is the real Context-backed impl.
+ */
+interface WatchlistStore {
+    /** The full unified watchlist, live. */
+    val items: StateFlow<Set<WatchItem>>
+
+    /** Snapshot read of the current unified set. */
+    fun current(): Set<WatchItem>
+
+    /** True when (kind, id) is currently watched. */
+    fun isWatched(kind: WatchKind, id: String): Boolean
+
+    /** Toggle (kind, id) in the watchlist, persisting the result. Returns the new watched-state. */
+    fun toggle(kind: WatchKind, id: String): Boolean
+
+    /** Remove (kind, id) if present. */
+    fun remove(kind: WatchKind, id: String)
+
+    /** Convenience: the SYMBOL entries as a numeric id set (the markets filter shape). */
+    fun symbolIds(): Set<Int>
+}
+
 @Singleton
-class WatchlistStore @Inject constructor(
+class WatchlistStoreImpl @Inject constructor(
     @ApplicationContext context: Context,
-) {
+) : WatchlistStore {
     private val prefs: SharedPreferences =
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
     private val _items = MutableStateFlow(loadAndMigrate())
 
     /** The full unified watchlist, live. */
-    val items: StateFlow<Set<WatchItem>> = _items.asStateFlow()
+    override val items: StateFlow<Set<WatchItem>> = _items.asStateFlow()
 
     /** Snapshot read of the current unified set. */
-    fun current(): Set<WatchItem> = _items.value
+    override fun current(): Set<WatchItem> = _items.value
 
     /** True when (kind, id) is currently watched. */
-    fun isWatched(kind: WatchKind, id: String): Boolean = isWatched(_items.value, kind, id)
+    override fun isWatched(kind: WatchKind, id: String): Boolean = isWatched(_items.value, kind, id)
 
     /** Toggle (kind, id) in the watchlist, persisting the result. Returns the new watched-state. */
-    fun toggle(kind: WatchKind, id: String): Boolean {
+    override fun toggle(kind: WatchKind, id: String): Boolean {
         val next = toggleWatch(_items.value, kind, id)
         persist(next)
         return isWatched(next, kind, id)
     }
 
     /** Remove (kind, id) if present. */
-    fun remove(kind: WatchKind, id: String) {
+    override fun remove(kind: WatchKind, id: String) {
         val existing = _items.value.firstOrNull { it.kind == kind && it.id == id } ?: return
         persist(_items.value - existing)
     }
 
     /** Convenience: the SYMBOL entries as a numeric id set (the markets filter shape). */
-    fun symbolIds(): Set<Int> = symbolIds(_items.value)
+    override fun symbolIds(): Set<Int> = symbolIds(_items.value)
 
     private fun persist(next: Set<WatchItem>) {
         prefs.edit()
@@ -92,4 +117,13 @@ class WatchlistStore @Inject constructor(
         const val KEY_FAV = "favorites"
         const val KEY_ITEMS = "watch_items"
     }
+}
+
+/** Binds the unified watchlist store contract to its Context-backed implementation. */
+@dagger.Module
+@dagger.hilt.InstallIn(dagger.hilt.components.SingletonComponent::class)
+abstract class WatchlistStoreModule {
+    @dagger.Binds
+    @Singleton
+    abstract fun bindWatchlistStore(impl: WatchlistStoreImpl): WatchlistStore
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/invest/InvestViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/invest/InvestViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.data.bailout.BailoutRepository
-import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.custody.CustodyReader
 import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.TradingRepository
 import com.testlogon.android.data.strategies.StrategiesRepository
@@ -82,7 +82,7 @@ class InvestViewModel @Inject constructor(
     private val exchange: ExchangeRepository,
     private val tokens: TokensRepository,
     private val strategies: StrategiesRepository,
-    private val custody: CustodyRepository,
+    private val custody: CustodyReader,
     private val bailout: BailoutRepository,
     private val trading: TradingRepository,
 ) : ViewModel() {

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsViewModel.kt
@@ -3,7 +3,7 @@ package com.testlogon.android.feature.portfolioanalytics
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
-import com.testlogon.android.data.custody.CustodyRepository
+import com.testlogon.android.data.custody.CustodyReader
 import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.Instrument
 import com.testlogon.android.data.exchange.PriceMap
@@ -24,7 +24,7 @@ import kotlin.math.roundToLong
 
 /**
  * Read-only Portfolio Analytics ViewModel. Fans out the SIX independent holding sources in parallel —
- * custody balances + staking ([CustodyRepository]); spot + margin + indicative prices
+ * custody balances + staking ([CustodyReader]); spot + margin + indicative prices
  * ([TradingRepository]); creator tokens ([TokensRepository]); strategy funds ([StrategiesRepository])
  * — normalizes each into a [NormalizedPosition] in indicative USD cents, then folds everything through
  * the pure [PortfolioAnalyticsMath]. Per-asset return series for the risk math come from the exchange
@@ -34,7 +34,7 @@ import kotlin.math.roundToLong
  */
 @HiltViewModel
 class PortfolioAnalyticsViewModel @Inject constructor(
-    private val custody: CustodyRepository,
+    private val custody: CustodyReader,
     private val trading: TradingRepository,
     private val exchange: ExchangeRepository,
     private val tokens: TokensRepository,

--- a/android/app/src/test/java/com/testlogon/android/feature/activity/ActivityCenterViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/activity/ActivityCenterViewModelTest.kt
@@ -1,0 +1,92 @@
+package com.testlogon.android.feature.activity
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.FillFee
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.Liquidity
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.feature.trading.FakeActivityLastSeenStore
+import com.testlogon.android.feature.trading.FakeTradingRepository
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * ViewModel coverage for [ActivityCenterViewModel] using the [com.testlogon.android.data.activity.ActivityLastSeenStore]
+ * interface seam: a degrade case where every feed fails (empty timeline + degraded-source banner) and a
+ * happy path where the fills feed produces events, plus markAllRead() advancing the fake store.
+ */
+class ActivityCenterViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    private fun sampleFill(ts: Long) = FillFee(
+        symbolId = 1,
+        price = 100,
+        qty = 5,
+        side = OrderSide.BUY,
+        liquidity = Liquidity.TAKER,
+        fee = 1,
+        feeAsset = 0,
+        tsNs = ts,
+    )
+
+    @Test
+    fun degrade_allFeedsFail_toEmptyWithDegradedSources() = runTest(mainRule.dispatcher) {
+        val trading = FakeTradingRepository().apply {
+            val net = ApiResult.NetworkError(java.io.IOException(), isTimeout = false)
+            fillsFeesResult = net
+            fundingPaymentsResult = net
+            liquidationsResult = net
+            marginAccountResult = net
+            pmResolutionsResult = net
+        }
+        val vm = ActivityCenterViewModel(trading, FakeActivityLastSeenStore())
+        backgroundScope.launch { vm.state.collect {} }
+        advanceUntilIdle()
+        val s = vm.state.value
+        assertFalse(s.loading)
+        assertTrue(s.days.isEmpty())
+        assertEquals(0, s.total)
+        // Trades / Funding / Liquidations / System all reported as degraded (margin 403 is not a source).
+        assertTrue(s.degradedSources.containsAll(listOf("Trades", "Funding", "Liquidations", "System")))
+    }
+
+    @Test
+    fun happy_fillsProduceEventsAndUnread() = runTest(mainRule.dispatcher) {
+        val trading = FakeTradingRepository().apply {
+            fillsFeesResult = ApiResult.Success(FillsFees(listOf(sampleFill(2_000_000L), sampleFill(3_000_000L)), 2))
+        }
+        val vm = ActivityCenterViewModel(trading, FakeActivityLastSeenStore())
+        backgroundScope.launch { vm.state.collect {} }
+        backgroundScope.launch { vm.unreadCount.collect {} }
+        advanceUntilIdle()
+        val s = vm.state.value
+        assertEquals(2, s.total)
+        assertTrue(s.days.isNotEmpty())
+        assertEquals(2, vm.unreadCount.value)
+    }
+
+    @Test
+    fun markAllRead_advancesStore_clearsUnread() = runTest(mainRule.dispatcher) {
+        val store = FakeActivityLastSeenStore()
+        val trading = FakeTradingRepository().apply {
+            fillsFeesResult = ApiResult.Success(FillsFees(listOf(sampleFill(2_000_000L)), 1))
+        }
+        val vm = ActivityCenterViewModel(trading, store)
+        backgroundScope.launch { vm.unreadCount.collect {} }
+        advanceUntilIdle()
+        assertEquals(1, vm.unreadCount.value)
+        vm.markAllRead()
+        advanceUntilIdle()
+        assertTrue(store.setCalls >= 1)
+        assertEquals(0, vm.unreadCount.value)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/invest/InvestViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/invest/InvestViewModelTest.kt
@@ -1,0 +1,78 @@
+package com.testlogon.android.feature.invest
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.feature.trading.FakeBailoutRepository
+import com.testlogon.android.feature.trading.FakeCustodyReader
+import com.testlogon.android.feature.trading.FakeExchangeRepository
+import com.testlogon.android.feature.trading.FakeStrategiesRepository
+import com.testlogon.android.feature.trading.FakeTokensRepository
+import com.testlogon.android.feature.trading.FakeTradingRepository
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * ViewModel coverage for [InvestViewModel] via the [com.testlogon.android.data.custody.CustodyReader]
+ * seam: an all-degraded case (every section pending, Content phase), a happy path where the markets
+ * section is populated from the exchange fake, and a transport failure -> retryable Error.
+ */
+class InvestViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    private fun vm(exchange: FakeExchangeRepository = FakeExchangeRepository()) = InvestViewModel(
+        exchange = exchange,
+        tokens = FakeTokensRepository(),
+        strategies = FakeStrategiesRepository(),
+        custody = FakeCustodyReader(),
+        bailout = FakeBailoutRepository(),
+        trading = FakeTradingRepository(),
+    )
+
+    @Test
+    fun degrade_allEmpty_toContentAllPending() = runTest(mainRule.dispatcher) {
+        val vm = vm()
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(InvestUiState.Phase.Content, s.phase)
+        assertTrue(s.markets.pending)
+        assertTrue(s.tokens.pending)
+        assertTrue(s.strategies.pending)
+        assertTrue(s.staking.pending)
+        assertTrue(s.opportunities.pending)
+        assertEquals(0, s.totalCount)
+    }
+
+    @Test
+    fun happy_marketsPopulated() = runTest(mainRule.dispatcher) {
+        val exchange = FakeExchangeRepository(
+            symbolsResult = ApiResult.Success(
+                listOf(
+                    Instrument(symbol = "BTC-USD", symbolId = 1, priceScaler = 1, lotSize = 1, referencePrice = 100, isPerpetual = false),
+                    Instrument(symbol = "ETH-PERP", symbolId = 2, priceScaler = 1, lotSize = 1, referencePrice = 50, isPerpetual = true),
+                ),
+            ),
+        )
+        val vm = vm(exchange)
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(InvestUiState.Phase.Content, s.phase)
+        assertEquals(2, s.markets.items.size)
+        assertTrue(s.totalCount >= 2)
+    }
+
+    @Test
+    fun transportFailure_toRetryableError() = runTest(mainRule.dispatcher) {
+        val exchange = FakeExchangeRepository(symbolsResult = ApiResult.NetworkError(java.io.IOException(), isTimeout = false))
+        val vm = vm(exchange)
+        advanceUntilIdle()
+        assertEquals(InvestUiState.Phase.Error, vm.uiState.value.phase)
+        assertTrue(vm.uiState.value.errorMessage != null)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/portfolioanalytics/PortfolioAnalyticsViewModelTest.kt
@@ -1,0 +1,73 @@
+package com.testlogon.android.feature.portfolioanalytics
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.custody.CustodyAssets
+import com.testlogon.android.data.custody.CustodyBalances
+import com.testlogon.android.data.exchange.PriceMap
+import com.testlogon.android.feature.trading.FakeCustodyReader
+import com.testlogon.android.feature.trading.FakeExchangeRepository
+import com.testlogon.android.feature.trading.FakeStrategiesRepository
+import com.testlogon.android.feature.trading.FakeTokensRepository
+import com.testlogon.android.feature.trading.FakeTradingRepository
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * ViewModel coverage for [PortfolioAnalyticsViewModel] via the new [com.testlogon.android.data.custody.CustodyReader]
+ * seam: an all-degraded case (every source empty -> allEmpty, no crash) and a happy path where a funded
+ * custody balance + a price map produce a valued position.
+ */
+class PortfolioAnalyticsViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    private fun vm(
+        custody: FakeCustodyReader = FakeCustodyReader(),
+        trading: FakeTradingRepository = FakeTradingRepository(),
+    ) = PortfolioAnalyticsViewModel(
+        custody = custody,
+        trading = trading,
+        exchange = FakeExchangeRepository(),
+        tokens = FakeTokensRepository(),
+        strategies = FakeStrategiesRepository(),
+    )
+
+    @Test
+    fun degrade_allEmpty_noCrash() = runTest(mainRule.dispatcher) {
+        val vm = vm()
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertFalse(s.loading)
+        assertTrue(s.allEmpty)
+        assertTrue(s.positions.isEmpty())
+        assertEquals(0L, s.totalValueCents)
+    }
+
+    @Test
+    fun happy_fundedCustodyValued() = runTest(mainRule.dispatcher) {
+        val custody = FakeCustodyReader(
+            balanceResult = ApiResult.Success(
+                CustodyBalances(vault = "v", tier = "T1", rows = CustodyAssets.mergeBalances(mapOf("ETH" to 2.0))),
+            ),
+        )
+        val trading = FakeTradingRepository().apply {
+            pricesResult = ApiResult.Success(
+                PriceMap(prices = mapOf("ETH" to 1_000.0), quote = "USD", source = "test", stub = false, note = null),
+            )
+        }
+        val vm = vm(custody, trading)
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertFalse(s.allEmpty)
+        assertTrue(s.positions.any { it.key == "ETH" })
+        // 2 ETH * $1000 = $2000 = 200_000 cents.
+        assertEquals(200_000L, s.totalValueCents)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/strategies/StrategyDetailViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/strategies/StrategyDetailViewModelTest.kt
@@ -1,0 +1,71 @@
+package com.testlogon.android.feature.strategies
+
+import androidx.lifecycle.SavedStateHandle
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.feature.trading.FakeStrategiesRepository
+import com.testlogon.android.feature.trading.FakeWatchlistStore
+import com.testlogon.android.feature.trading.sampleStrategyFake
+import com.testlogon.android.navigation.StrategyDetailDest
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * ViewModel coverage for [StrategyDetailViewModel] via the [com.testlogon.android.data.exchange.watchlist.WatchlistStore]
+ * seam: degrade-to-empty Content (strategy read folds 404 to Success(null)), a happy path with a
+ * strategy, a transport failure -> retryable Error, and the watch-star toggle calling the fake store.
+ */
+class StrategyDetailViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    private fun handle(id: String) = SavedStateHandle(mapOf(StrategyDetailDest.ARG_STRATEGY_ID to id))
+
+    @Test
+    fun degrade_nullStrategy_toContent() = runTest(mainRule.dispatcher) {
+        val vm = StrategyDetailViewModel(FakeStrategiesRepository(), FakeWatchlistStore(), handle("s-1"))
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(StrategyDetailUiState.Phase.Content, s.phase)
+        assertNull(s.strategy)
+    }
+
+    @Test
+    fun happy_strategySurfaced() = runTest(mainRule.dispatcher) {
+        val repo = FakeStrategiesRepository(strategyResult = ApiResult.Success(sampleStrategyFake("s-1", "Alpha")))
+        val vm = StrategyDetailViewModel(repo, FakeWatchlistStore(), handle("s-1"))
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(StrategyDetailUiState.Phase.Content, s.phase)
+        assertEquals("Alpha", s.strategy?.name)
+    }
+
+    @Test
+    fun transportFailure_toRetryableError() = runTest(mainRule.dispatcher) {
+        val repo = FakeStrategiesRepository(strategyResult = ApiResult.NetworkError(java.io.IOException(), isTimeout = false))
+        val vm = StrategyDetailViewModel(repo, FakeWatchlistStore(), handle("s-1"))
+        advanceUntilIdle()
+        assertEquals(StrategyDetailUiState.Phase.Error, vm.uiState.value.phase)
+        assertTrue(vm.uiState.value.errorMessage != null)
+    }
+
+    @Test
+    fun toggleWatch_callsStore() = runTest(mainRule.dispatcher) {
+        val store = FakeWatchlistStore()
+        val vm = StrategyDetailViewModel(FakeStrategiesRepository(), store, handle("s-1"))
+        advanceUntilIdle()
+        assertFalse(vm.isWatched.value)
+        vm.toggleWatch()
+        advanceUntilIdle()
+        assertEquals(WatchKind.STRATEGY to "s-1", store.toggleCalls.single())
+        assertTrue(store.isWatched(WatchKind.STRATEGY, "s-1"))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/tokens/TokenDetailViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/tokens/TokenDetailViewModelTest.kt
@@ -1,0 +1,64 @@
+package com.testlogon.android.feature.tokens
+
+import androidx.lifecycle.SavedStateHandle
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.feature.trading.FakeTokensRepository
+import com.testlogon.android.feature.trading.FakeWatchlistStore
+import com.testlogon.android.feature.trading.sampleTokenFake
+import com.testlogon.android.navigation.TokenDetailDest
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * ViewModel coverage for [TokenDetailViewModel] using the [com.testlogon.android.data.exchange.watchlist.WatchlistStore]
+ * interface seam: degrade-to-empty Content when the repo returns nulls (404 folded), a happy path with
+ * a token, and the watch-star toggle calling through to the fake store.
+ */
+class TokenDetailViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    private fun handle(id: String) = SavedStateHandle(mapOf(TokenDetailDest.ARG_TOKEN_ID to id))
+
+    @Test
+    fun degrade_nullReads_toContentWithNullToken() = runTest(mainRule.dispatcher) {
+        val vm = TokenDetailViewModel(FakeTokensRepository(), FakeWatchlistStore(), handle("tok-1"))
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(TokenDetailUiState.Phase.Content, s.phase)
+        assertNull(s.token)
+        assertNull(s.errorMessage)
+    }
+
+    @Test
+    fun happy_tokenSurfaced() = runTest(mainRule.dispatcher) {
+        val repo = FakeTokensRepository(tokenResult = ApiResult.Success(sampleTokenFake("tok-1", "AAA")))
+        val vm = TokenDetailViewModel(repo, FakeWatchlistStore(), handle("tok-1"))
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(TokenDetailUiState.Phase.Content, s.phase)
+        assertEquals("AAA", s.token?.ticker)
+    }
+
+    @Test
+    fun toggleWatch_callsStore() = runTest(mainRule.dispatcher) {
+        val store = FakeWatchlistStore()
+        val vm = TokenDetailViewModel(FakeTokensRepository(), store, handle("tok-1"))
+        advanceUntilIdle()
+        assertFalse(vm.isWatched.value)
+        vm.toggleWatch()
+        advanceUntilIdle()
+        assertEquals(1, store.toggleCalls.size)
+        assertEquals(WatchKind.TOKEN to "tok-1", store.toggleCalls.first())
+        assertTrue(store.isWatched(WatchKind.TOKEN, "tok-1"))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/trading/RepoFakes.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/trading/RepoFakes.kt
@@ -1,0 +1,84 @@
+package com.testlogon.android.feature.trading
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.strategies.InvestorPosition
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.strategies.Strategy
+import com.testlogon.android.data.strategies.StrategyAck
+import com.testlogon.android.data.strategies.StrategyFees
+import com.testlogon.android.data.strategies.StrategyHolding
+import com.testlogon.android.data.strategies.StrategyNav
+import com.testlogon.android.data.strategies.UpsertStrategyRequestDto
+import com.testlogon.android.data.tokens.AuctionStatus
+import com.testlogon.android.data.tokens.Token
+import com.testlogon.android.data.tokens.TokenAck
+import com.testlogon.android.data.tokens.TokenAuction
+import com.testlogon.android.data.tokens.TokenCapTable
+import com.testlogon.android.data.tokens.TokenRevenue
+import com.testlogon.android.data.tokens.TokenStatus
+import com.testlogon.android.data.tokens.TokenUpkeep
+import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.data.tokens.UpkeepStatus
+
+/**
+ * Shared (non-private, feature.trading-package) fakes for the token + strategy repositories, usable
+ * across the trading-surface ViewModel tests. Reads default to empty/null Successes (mirroring the
+ * repos' degrade-on-404 folding); individual reads are overridable via the `var` fields.
+ */
+
+class FakeTokensRepository(
+    var marketResult: ApiResult<List<Token>> = ApiResult.Success(emptyList()),
+    var issuedResult: ApiResult<List<Token>> = ApiResult.Success(emptyList()),
+    var tokenResult: ApiResult<Token?> = ApiResult.Success(null),
+) : TokensRepository {
+    override suspend fun issued(): ApiResult<List<Token>> = issuedResult
+    override suspend fun market(): ApiResult<List<Token>> = marketResult
+    override suspend fun openAuctions(): ApiResult<List<TokenAuction>> = ApiResult.Success(emptyList())
+    override suspend fun token(id: String): ApiResult<Token?> = tokenResult
+    override suspend fun capTable(id: String): ApiResult<TokenCapTable> = ApiResult.Success(TokenCapTable(id, 0, emptyList()))
+    override suspend fun auction(id: String): ApiResult<TokenAuction?> = ApiResult.Success(null)
+    override suspend fun revenue(id: String): ApiResult<TokenRevenue> = ApiResult.Success(TokenRevenue(id, 0, 0, 0, emptyList()))
+    override suspend fun upkeep(id: String): ApiResult<TokenUpkeep> = ApiResult.Success(TokenUpkeep(id, "", 0, 0, 0, 0, UpkeepStatus.UNKNOWN))
+    override suspend fun mint(name: String, ticker: String, totalSupply: Long, revenueShareBps: Int) = ApiResult.Success(sampleTokenFake("x", ticker))
+    override suspend fun list(id: String, offeredPctBps: Int, reservePrice: Long, closeTs: Long) = ApiResult.Success(TokenAuction("a", id, 0, 0, AuctionStatus.OPEN))
+    override suspend fun placeBid(id: String, qty: Long, limitPrice: Long) = ApiResult.Success(TokenAck(true))
+    override suspend fun clearAuction(id: String) = ApiResult.Success(TokenAuction("a", id, 0, 0, AuctionStatus.CLEARED))
+    override suspend fun claimRevenue(id: String) = ApiResult.Success(TokenAck(true))
+    override suspend fun payUpkeep(id: String) = ApiResult.Success(TokenAck(true))
+}
+
+fun sampleTokenFake(id: String, ticker: String, clearingPrice: Long? = null) = Token(
+    tokenId = id,
+    name = "Token $ticker",
+    ticker = ticker,
+    totalSupply = 1_000_000L,
+    revenueShareBps = 1_000,
+    status = TokenStatus.LISTED,
+    clearingPrice = clearingPrice,
+)
+
+class FakeStrategiesRepository(
+    var mineResult: ApiResult<List<Strategy>> = ApiResult.Success(emptyList()),
+    var marketResult: ApiResult<List<Strategy>> = ApiResult.Success(emptyList()),
+    var strategyResult: ApiResult<Strategy?> = ApiResult.Success(null),
+    var navResult: ApiResult<StrategyNav?> = ApiResult.Success(null),
+    var positionResult: ApiResult<InvestorPosition?> = ApiResult.Success(null),
+) : StrategiesRepository {
+    var investResult: ApiResult<StrategyAck> = ApiResult.Success(StrategyAck(true))
+    var redeemResult: ApiResult<StrategyAck> = ApiResult.Success(StrategyAck(true))
+    override suspend fun mine(): ApiResult<List<Strategy>> = mineResult
+    override suspend fun market(): ApiResult<List<Strategy>> = marketResult
+    override suspend fun strategy(id: String): ApiResult<Strategy?> = strategyResult
+    override suspend fun nav(id: String): ApiResult<StrategyNav?> = navResult
+    override suspend fun holdings(id: String): ApiResult<List<StrategyHolding>> = ApiResult.Success(emptyList())
+    override suspend fun position(id: String): ApiResult<InvestorPosition?> = positionResult
+    override suspend fun fees(id: String): ApiResult<StrategyFees> = ApiResult.Success(StrategyFees(id, 0, 0, 0, emptyList()))
+    override suspend fun create(body: UpsertStrategyRequestDto) = ApiResult.Success(sampleStrategyFake("x", "x"))
+    override suspend fun update(id: String, body: UpsertStrategyRequestDto) = ApiResult.Success(sampleStrategyFake(id, "x"))
+    override suspend fun publish(id: String) = ApiResult.Success(sampleStrategyFake(id, "x"))
+    override suspend fun invest(id: String, amountCents: Long) = investResult
+    override suspend fun redeem(id: String, units: Long) = redeemResult
+}
+
+fun sampleStrategyFake(id: String, name: String, aumCents: Long? = null, navPerUnit: Long? = null, inceptionReturnBps: Int? = null) =
+    Strategy(strategyId = id, name = name, aumCents = aumCents, navPerUnit = navPerUnit, inceptionReturnBps = inceptionReturnBps)

--- a/android/app/src/test/java/com/testlogon/android/feature/trading/StoreFakes.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/trading/StoreFakes.kt
@@ -1,0 +1,51 @@
+package com.testlogon.android.feature.trading
+
+import com.testlogon.android.data.activity.ActivityLastSeenStore
+import com.testlogon.android.data.exchange.watchlist.WatchItem
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.data.exchange.watchlist.WatchlistStore
+import com.testlogon.android.data.exchange.watchlist.isWatched
+import com.testlogon.android.data.exchange.watchlist.symbolIds
+import com.testlogon.android.data.exchange.watchlist.toggleWatch
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * In-memory [WatchlistStore] fake for ViewModel tests. Reuses the pure watchlist helpers so the toggle
+ * / remove / symbolIds semantics match the real store exactly, without SharedPreferences/Context.
+ * [toggleCalls] records the (kind, id) toggles so a test can assert the star affordance calls through.
+ */
+class FakeWatchlistStore(initial: Set<WatchItem> = emptySet()) : WatchlistStore {
+    private val _items = MutableStateFlow(initial)
+    override val items: StateFlow<Set<WatchItem>> = _items.asStateFlow()
+
+    val toggleCalls = mutableListOf<Pair<WatchKind, String>>()
+    val removeCalls = mutableListOf<Pair<WatchKind, String>>()
+
+    override fun current(): Set<WatchItem> = _items.value
+    override fun isWatched(kind: WatchKind, id: String): Boolean = isWatched(_items.value, kind, id)
+    override fun toggle(kind: WatchKind, id: String): Boolean {
+        toggleCalls.add(kind to id)
+        _items.value = toggleWatch(_items.value, kind, id)
+        return isWatched(_items.value, kind, id)
+    }
+    override fun remove(kind: WatchKind, id: String) {
+        removeCalls.add(kind to id)
+        _items.value = _items.value.filterNot { it.kind == kind && it.id == id }.toSet()
+    }
+    override fun symbolIds(): Set<Int> = symbolIds(_items.value)
+}
+
+/** In-memory [ActivityLastSeenStore] fake: a monotonic last-seen mark, no DataStore. */
+class FakeActivityLastSeenStore(initial: Long = 0L) : ActivityLastSeenStore {
+    private val _lastSeen = MutableStateFlow(initial)
+    override val lastSeen: Flow<Long> = _lastSeen.asStateFlow()
+    var setCalls = 0
+        private set
+    override suspend fun setLastSeen(ts: Long) {
+        setCalls++
+        if (ts > _lastSeen.value) _lastSeen.value = ts
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/trading/TradingFakes.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/trading/TradingFakes.kt
@@ -1,0 +1,134 @@
+package com.testlogon.android.feature.trading
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.bailout.BailoutAck
+import com.testlogon.android.data.bailout.BailoutAuction
+import com.testlogon.android.data.bailout.BailoutPrefs
+import com.testlogon.android.data.bailout.BailoutRepository
+import com.testlogon.android.data.bailout.DistressPosition
+import com.testlogon.android.data.custody.CustodyBalances
+import com.testlogon.android.data.custody.CustodyReader
+import com.testlogon.android.data.custody.StakingDashboard
+import com.testlogon.android.data.exchange.AuctionsBrowse
+import com.testlogon.android.data.exchange.Candle
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.exchange.FeeSchedule
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FundingPayments
+import com.testlogon.android.data.exchange.HistoryBars
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.LiveOrders
+import com.testlogon.android.data.exchange.Liquidations
+import com.testlogon.android.data.exchange.MarginAccount
+import com.testlogon.android.data.exchange.OrderBook
+import com.testlogon.android.data.exchange.OrderSide
+import com.testlogon.android.data.exchange.PmResolution
+import com.testlogon.android.data.exchange.PmState
+import com.testlogon.android.data.exchange.PriceMap
+import com.testlogon.android.data.exchange.SpotBalance
+import com.testlogon.android.data.exchange.StakeRequestsBrowse
+import com.testlogon.android.data.exchange.Trade
+import com.testlogon.android.data.exchange.TradingRepository
+
+/**
+ * Shared JVM test doubles for the trading-surface ViewModel tests. Reads default to honest empty
+ * Successes (mirroring the degrade-on-404 folding the real repos do); the fields are `var` so a happy
+ * path can override just what it needs. Mutations are unused by the read-only VMs under test and throw.
+ */
+
+/** Narrow custody read fake — the seam that unblocks Portfolio/Invest testing. */
+class FakeCustodyReader(
+    var balanceResult: ApiResult<CustodyBalances> = ApiResult.Success(CustodyBalances(vault = "", tier = "-", rows = emptyList())),
+    var stakingResult: ApiResult<StakingDashboard> = ApiResult.Success(StakingDashboard.unavailable()),
+) : CustodyReader {
+    override suspend fun getBalance(): ApiResult<CustodyBalances> = balanceResult
+    override suspend fun getStaking(): ApiResult<StakingDashboard> = stakingResult
+}
+
+private fun unused(): Nothing = throw UnsupportedOperationException("not used by the VM under test")
+
+/** ExchangeRepository fake: symbols/orderBook/trades/candles/history overridable; empty by default. */
+open class FakeExchangeRepository(
+    var symbolsResult: ApiResult<List<Instrument>> = ApiResult.Success(emptyList()),
+) : ExchangeRepository {
+    var orderBookResult: (Int) -> ApiResult<OrderBook> = { ApiResult.Success(OrderBook(it, emptyList(), emptyList(), null, null)) }
+    var tradesResult: (Int) -> ApiResult<List<Trade>> = { ApiResult.Success(emptyList()) }
+    var candlesResult: (Int) -> ApiResult<List<Candle>> = { ApiResult.Success(emptyList()) }
+    var historyResult: (Int) -> ApiResult<HistoryBars> = { ApiResult.Success(HistoryBars(it, "1d", emptyList())) }
+
+    override suspend fun symbols(): ApiResult<List<Instrument>> = symbolsResult
+    override suspend fun orderBook(symbolId: Int, depth: Int): ApiResult<OrderBook> = orderBookResult(symbolId)
+    override suspend fun candles(symbolId: Int, intervalSec: Int): ApiResult<List<Candle>> = candlesResult(symbolId)
+    override suspend fun trades(symbolId: Int): ApiResult<List<Trade>> = tradesResult(symbolId)
+    override suspend fun getHistory(symbolId: Int, interval: String, from: Long?, to: Long?, cursor: String?): ApiResult<HistoryBars> =
+        historyResult(symbolId)
+}
+
+/** TradingRepository fake: only the read methods the VMs use are meaningfully overridable. */
+open class FakeTradingRepository : TradingRepository {
+    var spotBalanceResult: ApiResult<SpotBalance> = ApiResult.Success(SpotBalance(emptyList(), ""))
+    var marginAccountResult: ApiResult<MarginAccount> = ApiResult.Success(MarginAccount(0, 0, 0, 0, null, 0, false, ""))
+    var pricesResult: ApiResult<PriceMap> = ApiResult.Success(PriceMap.unavailable())
+    var fillsFeesResult: ApiResult<FillsFees> = ApiResult.Success(FillsFees(emptyList(), 0))
+    var fundingPaymentsResult: ApiResult<FundingPayments> = ApiResult.Success(FundingPayments(emptyList(), 0))
+    var liquidationsResult: ApiResult<Liquidations> = ApiResult.Success(Liquidations(emptyList(), 0))
+    var pmResolutionsResult: ApiResult<List<PmResolution>> = ApiResult.Success(emptyList())
+    var stakeRequestsBrowseResult: ApiResult<StakeRequestsBrowse> = ApiResult.Success(StakeRequestsBrowse.unavailable())
+    var auctionsBrowseResult: ApiResult<AuctionsBrowse> = ApiResult.Success(AuctionsBrowse.unavailable())
+
+    override suspend fun spotBalance(): ApiResult<SpotBalance> = spotBalanceResult
+    override suspend fun marginAccount(): ApiResult<MarginAccount> = marginAccountResult
+    override suspend fun getPrices(): ApiResult<PriceMap> = pricesResult
+    override suspend fun fillsFees(): ApiResult<FillsFees> = fillsFeesResult
+    override suspend fun fundingPayments(): ApiResult<FundingPayments> = fundingPaymentsResult
+    override suspend fun liquidations(): ApiResult<Liquidations> = liquidationsResult
+    override suspend fun pmResolutions(): ApiResult<List<PmResolution>> = pmResolutionsResult
+    override suspend fun stakeRequestsBrowse(): ApiResult<StakeRequestsBrowse> = stakeRequestsBrowseResult
+    override suspend fun auctionsBrowse(): ApiResult<AuctionsBrowse> = auctionsBrowseResult
+
+    // ---- unused mutations / config / other reads ----
+    override suspend fun placeOrder(symbolId: Int, side: OrderSide, price: Long, qty: Long, clordid: String, market: Boolean?, tif: String?, postOnly: Boolean?, hidden: Boolean?, aon: Boolean?, displayQty: Long?, minQty: Long?, expiryNs: Long?) = unused()
+    override suspend fun amendOrder(clordid: String, newQty: Long, newPrice: Long?) = unused()
+    override suspend fun cancelOrder(clordid: String) = unused()
+    override suspend fun execEvents() = unused()
+    override suspend fun pmState(symbolId: Int): ApiResult<PmState> = unused()
+    override suspend fun placeOco(symbolId: Int, aSide: OrderSide, aPrice: Long, aQty: Long, bSide: OrderSide, bPrice: Long, bQty: Long) = unused()
+    override suspend fun placeFunding(rateBps: Long, qty: Long, isBorrow: Boolean, durationSeconds: Long?, symbolId: Int?) = unused()
+    override suspend fun spotDeposit(asset: Int, amount: Long) = unused()
+    override suspend fun deposit(amount: Long) = unused()
+    override suspend fun marginConfig(symbolId: Int, initialMarginBps: Long, maintenanceMarginBps: Long, liquidationFeeBps: Long, hourlyBorrowRateBps: Long, makerFeeBps: Long, takerFeeBps: Long, maxPositionQty: Long) = unused()
+    override suspend fun cancelAll() = unused()
+    override suspend fun placeQuote(symbolId: Int, bidPrice: Long, askPrice: Long, bidQty: Long, askQty: Long) = unused()
+    override suspend fun placeAlgo(algoType: String, symbolId: Int, side: OrderSide, qty: Long, stopPrice: Long?, limitPrice: Long?) = unused()
+    override suspend fun placeOto(symbolId: Int, parentSide: OrderSide, parentPrice: Long, parentQty: Long, childSide: OrderSide, childPrice: Long, childQty: Long) = unused()
+    override suspend fun feeSchedule(symbolId: Int): ApiResult<FeeSchedule> = unused()
+    override suspend fun ordersLive(): ApiResult<LiveOrders> = unused()
+    override suspend fun matchingAlgo(symbolId: Int, algo: Int, specialistMpid: String?, specialistPct: Int?) = unused()
+    override suspend fun spreadConfig(spreadSymbolId: Int, leg1: Int, leg2: Int, leg1Ratio: Int?, leg2Ratio: Int?) = unused()
+    override suspend fun tradingParams(symbolId: Int, maxQty: Int?, maxNotional: Long?, priceBandPct: Long?, circuitBreakerPct: Long?, minBlockSize: Int?) = unused()
+    override suspend fun riskConfig(maxNotional: Long, windowSeconds: Int, mpid: String?) = unused()
+    override suspend fun spotIndex(symbolId: Int, spotIndexPrice: Long) = unused()
+    override suspend fun spotConfig(symbolId: Int, baseAsset: Int, quoteAsset: Int) = unused()
+    override suspend fun pmConfig(symbolId: Int, faceValue: Long, resolver: String?) = unused()
+    override suspend fun pmGroupConfig(groupId: Int, outcomes: List<Int>, faceValue: Long, resolver: String?) = unused()
+    override suspend fun pmResolve(symbolId: Int, outcome: String, source: String?) = unused()
+    override suspend fun pmGroupResolve(groupId: Int, winningSymbolId: Int, source: String?) = unused()
+    override suspend fun stakeRequest(symbolId: Int?, minCollateral: Long, maxStakePct: Long, lockupSeconds: Int, durationSeconds: Int) = unused()
+    override suspend fun stakeOffer(requestId: Long, collateralAmount: Long, stakePct: Long) = unused()
+    override suspend fun auctionRequest(symbolId: Int?, qty: Int, reservePrice: Long?, durationSeconds: Int?) = unused()
+    override suspend fun auctionBid(auctionId: Long, price: Long, qty: Int) = unused()
+}
+
+/** BailoutRepository fake: bailouts() overridable; everything else degrade-empty / unused. */
+open class FakeBailoutRepository(
+    var bailoutsResult: ApiResult<List<BailoutAuction>> = ApiResult.Success(emptyList()),
+) : BailoutRepository {
+    override suspend fun distress(): ApiResult<List<DistressPosition>> = ApiResult.Success(emptyList())
+    override suspend fun bailouts(): ApiResult<List<BailoutAuction>> = bailoutsResult
+    override suspend fun positionBailout(symbolId: Int): ApiResult<BailoutAuction?> = ApiResult.Success(null)
+    override suspend fun prefs(): ApiResult<BailoutPrefs> = unused()
+    override suspend fun openBailout(symbolId: Int, maxShareBps: Int, closeTs: Long?): ApiResult<BailoutAuction> = unused()
+    override suspend fun placeBid(auctionId: String, capitalCents: Long, shareBps: Int): ApiResult<BailoutAck> = unused()
+    override suspend fun clear(auctionId: String): ApiResult<BailoutAuction> = unused()
+    override suspend fun putPrefs(autoEnabled: Boolean, defaultMaxShareBps: Int): ApiResult<BailoutPrefs> = unused()
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/watchlist/WatchlistViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/watchlist/WatchlistViewModelTest.kt
@@ -1,0 +1,78 @@
+package com.testlogon.android.feature.watchlist
+
+import com.testlogon.android.MainDispatcherRule
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.Instrument
+import com.testlogon.android.data.exchange.watchlist.WatchItem
+import com.testlogon.android.data.exchange.watchlist.WatchKind
+import com.testlogon.android.feature.trading.FakeExchangeRepository
+import com.testlogon.android.feature.trading.FakeStrategiesRepository
+import com.testlogon.android.feature.trading.FakeTokensRepository
+import com.testlogon.android.feature.trading.FakeWatchlistStore
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * ViewModel-level coverage for [WatchlistViewModel] using the new [com.testlogon.android.data.exchange.watchlist.WatchlistStore]
+ * interface seam. Empty store -> Empty phase; a populated store enriches rows (degrading per-item to
+ * skeleton labels when the enrichment repos return empty); remove() calls through to the store.
+ */
+class WatchlistViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    private fun vm(store: FakeWatchlistStore, symbols: List<Instrument> = emptyList()) = WatchlistViewModel(
+        watchlist = store,
+        exchange = FakeExchangeRepository(symbolsResult = ApiResult.Success(symbols)),
+        tokens = FakeTokensRepository(),
+        strategies = FakeStrategiesRepository(),
+    )
+
+    @Test
+    fun empty_store_toEmptyPhase() = runTest(mainRule.dispatcher) {
+        val vm = vm(FakeWatchlistStore())
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(WatchlistUiState.Phase.Empty, s.phase)
+        assertTrue(s.rows.isEmpty())
+    }
+
+    @Test
+    fun happy_populated_rendersRows() = runTest(mainRule.dispatcher) {
+        val store = FakeWatchlistStore(
+            setOf(
+                WatchItem(WatchKind.SYMBOL, "1"),
+                WatchItem(WatchKind.TOKEN, "tok-a"),
+                WatchItem(WatchKind.STRATEGY, "strat-a"),
+            ),
+        )
+        val vm = vm(
+            store,
+            symbols = listOf(Instrument(symbol = "BTC-USD", symbolId = 1, priceScaler = 1, lotSize = 1, referencePrice = 100, isPerpetual = false)),
+        )
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        assertEquals(WatchlistUiState.Phase.Content, s.phase)
+        assertEquals(3, s.rows.size)
+        // The symbol row picked up its instrument label from the exchange fake.
+        assertTrue(s.rows.any { it.title == "BTC-USD" })
+    }
+
+    @Test
+    fun remove_callsStore_andReRenders() = runTest(mainRule.dispatcher) {
+        val item = WatchItem(WatchKind.TOKEN, "tok-a")
+        val store = FakeWatchlistStore(setOf(item))
+        val vm = vm(store)
+        advanceUntilIdle()
+        vm.remove(item)
+        advanceUntilIdle()
+        assertEquals(1, store.removeCalls.size)
+        assertEquals(WatchKind.TOKEN to "tok-a", store.removeCalls.first())
+        assertEquals(WatchlistUiState.Phase.Empty, vm.uiState.value.phase)
+    }
+}


### PR DESCRIPTION
## Android ViewModel coverage — close the hardening-pass gap

Adds minimal, **behavior-preserving testability seams** so the 6 previously-skipped VMs (Context/DataStore-backed collaborators) are unit-testable with plain fakes — **no mockk/Robolectric, no new deps** — then tests them.

### Seams (interface + Hilt `@Binds`; concrete class stays the impl; Hilt graph valid)
- `WatchlistStore` → interface + `WatchlistStoreImpl` (injection sites already used the type name; persistence unchanged)
- `ActivityLastSeenStore` → interface + Impl
- `CustodyReader` → **narrow** read interface (`getBalance`/`getStaking` only) implemented by `CustodyRepository`; `PortfolioAnalytics` + `Invest` VMs inject it

### Tests (mirror `DashboardViewModelTest`; shared fakes in `feature/trading/`)
**18 new** across Watchlist(3) / TokenDetail(3) / StrategyDetail(4) / ActivityCenter(3) / PortfolioAnalytics(2) / Invest(3) — degrade/empty + happy-path + watch-star toggle. All 6 VMs now covered.

No new deps, no runtime behavior change. Gate: assembleDebug + testDebugUnitTest BUILD SUCCESSFUL, full suite **5156 / 0 failures**, MoreCatalog 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
