### PR TITLE
feat(nav): dedicated Invest bottom-nav tab (Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/shell/AuthedShell.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/shell/AuthedShell.kt
@@ -9,12 +9,14 @@ import androidx.compose.material.icons.filled.DynamicFeed
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.DynamicFeed
 import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.ShowChart
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -47,6 +49,7 @@ enum class AuthedTab(
     HOME("authed/home", R.string.tab_home, Icons.Filled.Home, Icons.Outlined.Home),
     FEED("authed/feed", R.string.tab_feed, Icons.Filled.DynamicFeed, Icons.Outlined.DynamicFeed),
     DISCOVER("authed/discover", R.string.tab_discover, Icons.Filled.Explore, Icons.Outlined.Explore),
+    INVEST("authed/invest", R.string.tab_invest, Icons.Filled.ShowChart, Icons.Outlined.ShowChart),
     INBOX("authed/inbox", R.string.tab_inbox, Icons.Filled.Forum, Icons.Outlined.Forum),
     ME("authed/me", R.string.tab_me, Icons.Filled.Person, Icons.Outlined.Person, inNavBar = false),
     MORE("authed/more", R.string.tab_more, Icons.Filled.Apps, Icons.Outlined.Apps);
@@ -110,6 +113,8 @@ fun AuthedShellScreen(
                     tabNav.navigateToTab(AuthedTab.ME)
                 com.testlogon.android.navigation.MoreRoutes.SESSIONS -> onOpenSessions()
                 com.testlogon.android.navigation.MoreRoutes.MFA_DEVICES -> onOpenMfaDevices()
+                com.testlogon.android.navigation.MoreRoutes.INVEST ->
+                    tabNav.navigateToTab(AuthedTab.INVEST)
                 else -> onOpenRoute(route)
             }
         }
@@ -184,6 +189,15 @@ fun AuthedShellScreen(
                     onOpenVideo = { videoId ->
                         onOpenRoute(com.testlogon.android.navigation.VideoDetailDest.build(videoId))
                     },
+                )
+            }
+            // Unified INVEST hub, promoted to a first-class bottom-nav tab. The hub owns no detail
+            // routes; each card / see-all deep-links through onOpenRoute into the outer graph, exactly
+            // as when it was reached from the More hub / Dashboard.
+            composable(AuthedTab.INVEST.route) {
+                com.testlogon.android.feature.invest.InvestRoute(
+                    onBack = { tabNav.navigateToTab(AuthedTab.HOME) },
+                    onOpenRoute = onOpenRoute,
                 )
             }
             // Inbox — the conversation list, promoted to a first-class bottom-nav tab. Its row/search/

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -316,9 +316,10 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // UNIFIED cross-instrument watchlist: one list of starred symbols + creator tokens +
         // strategy funds. Owns no detail routes; each row deep-links to the existing detail dest.
         watchlistDestination(navController)
-        // Unified INVEST hub: aggregates markets + creator tokens + strategy funds + staking +
-        // open opportunities client-side into one front door. Owns no detail routes — each card /
-        // see-all navigates to the existing per-product destination in this same graph.
+        // Unified INVEST hub: also a first-class bottom-nav tab (route "authed/invest" in the shell
+        // NavHost). Registered here as "invest" too for full-screen onOpenRoute callers (the
+        // Dashboard trading tile + deep-links). Different route strings -> no duplicate; the More
+        // hub entry jumps to the tab, the Dashboard tile opens this full-screen instance.
         investDestinations(navController)
         // Creator revenue-share TOKENS: mint + browse market + per-token detail (cap table /
         // revenue / upkeep / IPO auction). Endpoints degrade-on-404 (backend pending).

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="tab_more">More</string>
     <string name="tab_discover">Discover</string>
     <string name="tab_inbox">Inbox</string>
+    <string name="tab_invest">Invest</string>
 
     <!-- Dashboard (AND-066 / AND-068 / AND-069) -->
     <string name="dashboard_title">Dashboard</string>


### PR DESCRIPTION
## Dedicated Invest bottom-nav tab (Android)

Promotes the Invest hub to a first-class bottom-nav tab in `AuthedShell` (route `authed/invest`, ShowChart icon), between Discover and Inbox. All existing tabs + order preserved.

- **AuthedShell**: new `AuthedTab.INVEST` rendered in the shell NavHost via `InvestRoute` (deep-links flow through the existing `onOpenRoute`); the More-hub INVEST entry now jumps to the tab.
- **AuthenticatedGraph**: **keeps** `investDestinations` (outer route `invest`) so the Dashboard "Trading & Investing" tile + any `onOpenRoute("invest")` caller still open the hub full-screen. Tab route (`authed/invest`) ≠ outer route (`invest`) → no duplicate-route graph-build crash. *(Restored after the initial pass removed it, which had silently no-op'd the dashboard tile via the `runCatching` onOpenRoute guard — caught in review.)*

`MoreRoutes.REGISTERED` still contains INVEST → `MoreCatalogTest.catalogIntegrity` passes. Gate: assembleDebug + testDebugUnitTest BUILD SUCCESSFUL, MoreCatalog 6/6. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
