### PR TITLE
test(trading): deepen hardening — hook + interaction tests (required) + e2e route smoke

### DIFF
--- a/.github/workflows/payment-incident-critical-paths.yml
+++ b/.github/workflows/payment-incident-critical-paths.yml
@@ -89,4 +89,13 @@ jobs:
             src/pages/watchlist/WatchlistPage.smoke.test.tsx \
             src/pages/reports/TaxReportPage.smoke.test.tsx \
             src/pages/analysis/MarketAnalysisPage.smoke.test.tsx \
-            src/pages/custody/CustodyProvidersPage.smoke.test.tsx
+            src/pages/custody/CustodyProvidersPage.smoke.test.tsx \
+            src/hooks/useTokens.test.tsx \
+            src/hooks/useStrategies.test.tsx \
+            src/hooks/useBailouts.test.tsx \
+            src/hooks/useWatchlist.test.tsx \
+            src/hooks/useActivity.test.tsx \
+            src/pages/tokens/MintTokenPage.interaction.test.tsx \
+            src/pages/strategies/StrategyDetailPage.interaction.test.tsx \
+            src/pages/strategies/WatchStar.interaction.test.tsx \
+            src/pages/alerts/PriceAlertsPage.interaction.test.tsx

--- a/frontend/e2e/ci-gate-green.txt
+++ b/frontend/e2e/ci-gate-green.txt
@@ -386,6 +386,7 @@ e2e/tickets.spec.ts
 e2e/tier-manager.spec.ts
 e2e/tip-leaderboard.spec.ts
 e2e/tip-ledger.spec.ts
+e2e/trading-surfaces.spec.ts
 e2e/ups-shipping.spec.ts
 e2e/user-appeals.spec.ts
 e2e/user-blocking.spec.ts

--- a/frontend/e2e/trading-surfaces.spec.ts
+++ b/frontend/e2e/trading-surfaces.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * E2E SMOKE — new trading / investing surfaces (authenticated render).
+ *
+ * Covers the routes added by the trading-blotter + custody/margin programs:
+ *   /invest              — InvestHubPage         (h1 "Invest")
+ *   /strategies          — StrategyMarketPage    (h1 "Strategies & Baskets")
+ *   /tokens              — TokenMarketPage        (h1 "Creator Tokens")
+ *   /bailouts            — BailoutsBoardPage      (PageHeader h1 "Bailouts")
+ *   /portfolio/analytics — PortfolioAnalyticsPage (h1 "Portfolio Risk")
+ *   /activity-center     — ActivityCenterPage     (h1 "Activity Center")
+ *   /algos               — ActiveAlgosPage        (h1 "Active Algos")
+ *   /watchlist           — WatchlistPage          (h1 "Watchlist")
+ *   /reports/tax         — TaxReportPage          (h1 "Tax & Gains")
+ *   /analysis            — MarketAnalysisPage     (h1 "Analysis")
+ *   /custody/providers   — CustodyProvidersPage   (h1 "Custody providers")
+ *
+ * These are deliberately SHALLOW smoke checks: each authenticated navigation
+ * must render the page's primary heading and must NOT surface the app error
+ * boundary ("Something went wrong"). A degraded / empty state is acceptable —
+ * the underlying edge backends may 404 in CI, and the pages are built to
+ * render a heading + empty/pending state rather than crash.
+ *
+ * Auth: shared authenticated page via the canonical injectAuth("alice") helper
+ * (same cookie + auth-store seeding every other spec uses). No API seeding —
+ * these are UI-render smokes only.
+ *
+ * Runs in the (non-required, label-gated) web-e2e CI gate. Listed in
+ * e2e/ci-gate-green.txt so the gate picks it up.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { injectAuth, getSession } from "./helpers/session";
+
+const BASE = "http://localhost:3000";
+
+interface Surface {
+  /** Relative app route (leading slash). */
+  route: string;
+  /** Case-insensitive primary-heading matcher. */
+  heading: RegExp;
+}
+
+const SURFACES: Surface[] = [
+  { route: "/invest", heading: /^invest$/i },
+  { route: "/strategies", heading: /strategies\s*&?\s*baskets/i },
+  { route: "/tokens", heading: /creator tokens/i },
+  { route: "/bailouts", heading: /^bailouts$/i },
+  { route: "/portfolio/analytics", heading: /portfolio risk/i },
+  { route: "/activity-center", heading: /activity center/i },
+  { route: "/algos", heading: /active algos/i },
+  { route: "/watchlist", heading: /^watchlist$/i },
+  { route: "/reports/tax", heading: /tax\s*&?\s*gains/i },
+  { route: "/analysis", heading: /^analysis$/i },
+  { route: "/custody/providers", heading: /custody providers/i },
+];
+
+test.describe("Trading surfaces smoke (authenticated render)", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await injectAuth(page, "alice");
+    // Seed the client-side auth store so ProtectedRoute treats the page as
+    // authenticated (cookies alone only satisfy server-side API auth).
+    await page.goto(`${BASE}/login`, { waitUntil: "domcontentloaded" });
+    await page.evaluate((uid: string) => {
+      const state = { userId: uid, accessToken: null, isAuthenticated: true };
+      localStorage.setItem("auth-store", JSON.stringify({ state, version: 0 }));
+    }, getSession("alice").user_sub);
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
+  });
+
+  for (const { route, heading } of SURFACES) {
+    test(`renders ${route} without crashing`, async () => {
+      await page.goto(`${BASE}${route}`, { waitUntil: "domcontentloaded" });
+
+      // Primary heading/landmark renders (generous wait: lazy chunk + first
+      // data fetch). Degraded/empty state is fine; a crash is not.
+      await expect(
+        page.getByRole("heading", { name: heading }).first(),
+      ).toBeVisible({ timeout: 20_000 });
+
+      // The React error boundary fallback must NOT be present.
+      await expect(page.getByText(/something went wrong/i)).toHaveCount(0);
+
+      // Not bounced to the login screen (ProtectedRoute would redirect an
+      // unauthenticated session).
+      expect(new URL(page.url()).pathname).not.toBe("/login");
+    });
+  }
+});

--- a/frontend/src/hooks/useActivity.test.tsx
+++ b/frontend/src/hooks/useActivity.test.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { ApiError } from "@/api/client";
+import { useActivityEvents } from "./useActivity";
+
+const getFillsFees = vi.fn();
+const getLiquidations = vi.fn();
+const getFundingPayments = vi.fn();
+const getSymbols = vi.fn();
+
+vi.mock("@/api/endpoints/trading", () => ({
+  getFillsFees: (...a: unknown[]) => getFillsFees(...a),
+  getLiquidations: (...a: unknown[]) => getLiquidations(...a),
+  getFundingPayments: (...a: unknown[]) => getFundingPayments(...a),
+}));
+
+vi.mock("@/api/endpoints/marketData", () => ({
+  getSymbols: (...a: unknown[]) => getSymbols(...a),
+  getOrderBook: vi.fn(),
+  getCandles: vi.fn(),
+  getTrades: vi.fn(),
+}));
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+const SYMBOLS = {
+  symbols: [{ symbol_id: 1, symbol: "BTC-USD", price_scaler: 100 }],
+};
+
+describe("useActivityEvents aggregation", () => {
+  beforeEach(() => {
+    getFillsFees.mockReset();
+    getLiquidations.mockReset();
+    getFundingPayments.mockReset();
+    getSymbols.mockReset();
+    getSymbols.mockResolvedValue(SYMBOLS);
+  });
+
+  it("degrades independently: every feed 404 -> empty events, all sources marked unavailable, no throw", async () => {
+    getFillsFees.mockRejectedValue(new ApiError(404, "Not found"));
+    getFundingPayments.mockRejectedValue(new ApiError(404, "Not found"));
+    getLiquidations.mockRejectedValue(new ApiError(404, "Not found"));
+
+    const { result } = renderHook(() => useActivityEvents(), { wrapper: wrapper(newClient()) });
+
+    await waitFor(() => {
+      expect(result.current.sources.fills).toBe(false);
+      expect(result.current.sources.funding).toBe(false);
+      expect(result.current.sources.liquidations).toBe(false);
+    });
+    expect(result.current.events).toEqual([]);
+  });
+
+  it("happy path: merges fills + funding + liquidations into one newest-first timeline", async () => {
+    getFillsFees.mockResolvedValue({
+      fills: [
+        { symbolid: 1, ts: 3000, side: "buy", qty: 1, price: 10000, fee: 5 },
+      ],
+    });
+    getFundingPayments.mockResolvedValue({
+      funding: [{ symbolid: 1, ts: 2000, payment: 12, funding_rate_bps: 3, received: true }],
+    });
+    getLiquidations.mockResolvedValue({
+      liquidations: [{ symbolid: 1, ts: 1000, qty: 1, mark_price: 9000, realized_pnl: -50 }],
+    });
+
+    const { result } = renderHook(() => useActivityEvents(), { wrapper: wrapper(newClient()) });
+
+    await waitFor(() => expect(result.current.events.length).toBeGreaterThan(0));
+    // All three sources available; merged into a single, newest-first list.
+    expect(result.current.sources).toEqual({ fills: true, funding: true, liquidations: true });
+    const tsList = result.current.events.map((e) => e.ts);
+    const sorted = [...tsList].sort((a, b) => b - a);
+    expect(tsList).toEqual(sorted);
+  });
+
+  it("one feed available while another 404s -> partial timeline, only the failed source is unavailable", async () => {
+    getFillsFees.mockResolvedValue({
+      fills: [
+        { symbolid: 1, ts: 3000, side: "buy", qty: 1, price: 10000, fee: 5 },
+      ],
+    });
+    getFundingPayments.mockRejectedValue(new ApiError(404, "Not found"));
+    getLiquidations.mockRejectedValue(new ApiError(404, "Not found"));
+
+    const { result } = renderHook(() => useActivityEvents(), { wrapper: wrapper(newClient()) });
+
+    await waitFor(() => expect(result.current.events.length).toBeGreaterThan(0));
+    expect(result.current.sources.fills).toBe(true);
+    expect(result.current.sources.funding).toBe(false);
+    expect(result.current.sources.liquidations).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useBailouts.test.tsx
+++ b/frontend/src/hooks/useBailouts.test.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { ApiError } from "@/api/client";
+import {
+  useDistress,
+  useBailoutBoard,
+  usePositionBailout,
+  isPendingBackend,
+} from "./useBailouts";
+
+const getDistress = vi.fn();
+const getBailouts = vi.fn();
+const getPositionBailout = vi.fn();
+
+vi.mock("@/api/endpoints/bailouts", () => ({
+  getDistress: (...a: unknown[]) => getDistress(...a),
+  getBailouts: (...a: unknown[]) => getBailouts(...a),
+  getPositionBailout: (...a: unknown[]) => getPositionBailout(...a),
+  getBailoutPrefs: vi.fn(),
+  openBailout: vi.fn(),
+  placeRescueBid: vi.fn(),
+  clearBailout: vi.fn(),
+  putBailoutPrefs: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+describe("useBailouts data hooks", () => {
+  beforeEach(() => {
+    getDistress.mockReset();
+    getBailouts.mockReset();
+    getPositionBailout.mockReset();
+  });
+
+  it("useDistress degrades on 404 without throwing (never fabricates distress)", async () => {
+    getDistress.mockRejectedValue(new ApiError(404, "Not found"));
+    const { result } = renderHook(() => useDistress(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect(isPendingBackend(result.current.error)).toBe(true);
+  });
+
+  it("useDistress happy path returns the server-computed distress read", async () => {
+    getDistress.mockResolvedValue({ positions: [{ symbol_id: 1, in_band: true }] });
+    const { result } = renderHook(() => useDistress(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.positions).toHaveLength(1);
+  });
+
+  it("useBailoutBoard degrades on 404", async () => {
+    getBailouts.mockRejectedValue(new ApiError(404, "Not found"));
+    const { result } = renderHook(() => useBailoutBoard(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("usePositionBailout is idle for a nullish symbol and fetches for a finite one", async () => {
+    const client = newClient();
+    getPositionBailout.mockResolvedValue({ auction_id: "a1", status: "open" });
+
+    const disabled = renderHook(() => usePositionBailout(undefined), { wrapper: wrapper(client) });
+    expect(disabled.result.current.fetchStatus).toBe("idle");
+    expect(getPositionBailout).not.toHaveBeenCalled();
+
+    const enabled = renderHook(() => usePositionBailout(42), { wrapper: wrapper(client) });
+    await waitFor(() => expect(enabled.result.current.isSuccess).toBe(true));
+    expect(getPositionBailout).toHaveBeenCalledWith(42);
+    expect(enabled.result.current.data?.auction_id).toBe("a1");
+  });
+});

--- a/frontend/src/hooks/useStrategies.test.tsx
+++ b/frontend/src/hooks/useStrategies.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { ApiError } from "@/api/client";
+import {
+  useMyStrategies,
+  useStrategyMarket,
+  useStrategy,
+  isPendingBackend,
+} from "./useStrategies";
+
+const getMyStrategies = vi.fn();
+const getStrategyMarket = vi.fn();
+const getStrategy = vi.fn();
+
+vi.mock("@/api/endpoints/strategies", () => ({
+  getMyStrategies: (...a: unknown[]) => getMyStrategies(...a),
+  getStrategyMarket: (...a: unknown[]) => getStrategyMarket(...a),
+  getStrategy: (...a: unknown[]) => getStrategy(...a),
+  createStrategy: vi.fn(),
+  updateStrategy: vi.fn(),
+  publishStrategy: vi.fn(),
+  getStrategyNav: vi.fn(),
+  getStrategyHoldings: vi.fn(),
+  investStrategy: vi.fn(),
+  redeemStrategy: vi.fn(),
+  getStrategyPosition: vi.fn(),
+  getStrategyFees: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+describe("useStrategies data hooks", () => {
+  beforeEach(() => {
+    getMyStrategies.mockReset();
+    getStrategyMarket.mockReset();
+    getStrategy.mockReset();
+  });
+
+  it("useMyStrategies degrades on 404 (error, no throw)", async () => {
+    getMyStrategies.mockRejectedValue(new ApiError(404, "Not found"));
+    const { result } = renderHook(() => useMyStrategies(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect(isPendingBackend(result.current.error)).toBe(true);
+  });
+
+  it("useMyStrategies happy path returns the strategies", async () => {
+    getMyStrategies.mockResolvedValue({ strategies: [{ strategy_id: "s1", name: "Blue Chip" }] });
+    const { result } = renderHook(() => useMyStrategies(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.strategies?.[0]?.name).toBe("Blue Chip");
+  });
+
+  it("useStrategyMarket degrades on 404", async () => {
+    getStrategyMarket.mockRejectedValue(new ApiError(404, "Not found"));
+    const { result } = renderHook(() => useStrategyMarket(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("useStrategy is idle without an id and fetches by id", async () => {
+    const client = newClient();
+    getStrategy.mockResolvedValue({ strategy_id: "s7", name: "Momentum" });
+
+    const disabled = renderHook(() => useStrategy(undefined), { wrapper: wrapper(client) });
+    expect(disabled.result.current.fetchStatus).toBe("idle");
+    expect(getStrategy).not.toHaveBeenCalled();
+
+    const enabled = renderHook(() => useStrategy("s7"), { wrapper: wrapper(client) });
+    await waitFor(() => expect(enabled.result.current.isSuccess).toBe(true));
+    expect(getStrategy).toHaveBeenCalledWith("s7");
+    expect(enabled.result.current.data?.name).toBe("Momentum");
+  });
+});

--- a/frontend/src/hooks/useTokens.test.tsx
+++ b/frontend/src/hooks/useTokens.test.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { ApiError } from "@/api/client";
+import { useMyTokens, useTokenMarket, useToken, isPendingBackend } from "./useTokens";
+
+const getMyTokens = vi.fn();
+const getTokenMarket = vi.fn();
+const getToken = vi.fn();
+
+vi.mock("@/api/endpoints/tokens", () => ({
+  getMyTokens: (...a: unknown[]) => getMyTokens(...a),
+  getTokenMarket: (...a: unknown[]) => getTokenMarket(...a),
+  getToken: (...a: unknown[]) => getToken(...a),
+  // Other endpoints referenced by the hook module (mutations) — never called here.
+  mintToken: vi.fn(),
+  listToken: vi.fn(),
+  getCapTable: vi.fn(),
+  getAuction: vi.fn(),
+  placeAuctionBid: vi.fn(),
+  clearAuction: vi.fn(),
+  getRevenue: vi.fn(),
+  claimRevenue: vi.fn(),
+  getUpkeep: vi.fn(),
+  payUpkeep: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+describe("useTokens data hooks", () => {
+  beforeEach(() => {
+    getMyTokens.mockReset();
+    getTokenMarket.mockReset();
+    getToken.mockReset();
+  });
+
+  it("useMyTokens degrades on 404 (error, no throw, empty data)", async () => {
+    getMyTokens.mockRejectedValue(new ApiError(404, "Not found"));
+    const { result } = renderHook(() => useMyTokens(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect(isPendingBackend(result.current.error)).toBe(true);
+  });
+
+  it("useMyTokens happy path returns the fetched tokens", async () => {
+    getMyTokens.mockResolvedValue({ tokens: [{ token_id: "t1", ticker: "JANE" }] });
+    const { result } = renderHook(() => useMyTokens(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.tokens).toHaveLength(1);
+    expect(result.current.data?.tokens?.[0]?.ticker).toBe("JANE");
+  });
+
+  it("useTokenMarket degrades on 404", async () => {
+    getTokenMarket.mockRejectedValue(new ApiError(404, "Not found"));
+    const { result } = renderHook(() => useTokenMarket(), { wrapper: wrapper(newClient()) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("useToken is disabled when id is undefined and enabled+fetches with an id", async () => {
+    const client = newClient();
+    getToken.mockResolvedValue({ token_id: "t9", ticker: "ACME" });
+
+    const disabled = renderHook(() => useToken(undefined), { wrapper: wrapper(client) });
+    expect(disabled.result.current.fetchStatus).toBe("idle");
+    expect(getToken).not.toHaveBeenCalled();
+
+    const enabled = renderHook(() => useToken("t9"), { wrapper: wrapper(client) });
+    await waitFor(() => expect(enabled.result.current.isSuccess).toBe(true));
+    expect(getToken).toHaveBeenCalledWith("t9");
+    expect(enabled.result.current.data?.ticker).toBe("ACME");
+  });
+});

--- a/frontend/src/hooks/useWatchlist.test.tsx
+++ b/frontend/src/hooks/useWatchlist.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWatchlist } from "./useWatchlist";
+import { WATCHLIST_KEY } from "@/lib/watchlist";
+
+describe("useWatchlist store binding", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("starts empty and toggling a token adds then removes it", () => {
+    const { result } = renderHook(() => useWatchlist());
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.has("token", "t1")).toBe(false);
+
+    act(() => result.current.toggle("token", "t1"));
+    expect(result.current.has("token", "t1")).toBe(true);
+    expect(result.current.items).toEqual([{ kind: "token", id: "t1" }]);
+
+    act(() => result.current.toggle("token", "t1"));
+    expect(result.current.has("token", "t1")).toBe(false);
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("persists toggles to localStorage under the shared key", () => {
+    const { result } = renderHook(() => useWatchlist());
+    act(() => result.current.toggle("strategy", "s9"));
+    const raw = window.localStorage.getItem(WATCHLIST_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string)).toEqual([{ kind: "strategy", id: "s9" }]);
+  });
+
+  it("remove() deletes a specific instrument", () => {
+    const { result } = renderHook(() => useWatchlist());
+    act(() => result.current.toggle("token", "t1"));
+    act(() => result.current.toggle("strategy", "s2"));
+    expect(result.current.items).toHaveLength(2);
+
+    act(() => result.current.remove("token", "t1"));
+    expect(result.current.has("token", "t1")).toBe(false);
+    expect(result.current.has("strategy", "s2")).toBe(true);
+    expect(result.current.items).toEqual([{ kind: "strategy", id: "s2" }]);
+  });
+
+  it("two mounted consumers stay in sync via the change event", () => {
+    const a = renderHook(() => useWatchlist());
+    const b = renderHook(() => useWatchlist());
+
+    act(() => a.result.current.toggle("token", "shared"));
+    // The second consumer re-reads on the same-tab WATCHLIST_EVENT.
+    expect(b.result.current.has("token", "shared")).toBe(true);
+  });
+
+  it("migrates a legacy bare symbol-id array on first read", () => {
+    window.localStorage.setItem(WATCHLIST_KEY, JSON.stringify([101, 202]));
+    const { result } = renderHook(() => useWatchlist());
+    expect(result.current.has("symbol", 101)).toBe(true);
+    expect(result.current.has("symbol", "202")).toBe(true);
+  });
+});

--- a/frontend/src/pages/alerts/PriceAlertsPage.interaction.test.tsx
+++ b/frontend/src/pages/alerts/PriceAlertsPage.interaction.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach, beforeAll } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { loadPriceAlerts, PRICE_ALERTS_KEY } from "@/lib/priceAlerts";
+
+// jsdom lacks the pointer-capture / scroll APIs Radix Select relies on. Polyfill
+// them locally (no global setup / config changes) so the real Select is drivable.
+beforeAll(() => {
+  const proto = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+  proto.hasPointerCapture = () => false;
+  proto.setPointerCapture = () => {};
+  proto.releasePointerCapture = () => {};
+  proto.scrollIntoView = () => {};
+});
+
+function q(data: unknown) {
+  return { data, isLoading: false, isError: false };
+}
+
+vi.mock("@/hooks/useMarketData", () => ({
+  useSymbols: () => q({ symbols: [{ symbol_id: 1, symbol: "BTC-USD", price_scaler: 100 }] }),
+  useCandles: () => q({ bars: [{ close: 6500000 }] }),
+}));
+vi.mock("@/hooks/useTokens", () => ({
+  useTokenMarket: () => q({ tokens: [{ token_id: "tk1", ticker: "JANE", name: "Jane Revenue", clearing_price: 1250 }] }),
+  useMyTokens: () => q({ tokens: [] }),
+}));
+vi.mock("@/hooks/useStrategies", () => ({
+  useStrategyMarket: () => q({ strategies: [{ strategy_id: "st1", name: "Blue Chip Basket" }] }),
+  useMyStrategies: () => q({ strategies: [] }),
+  useStrategyNav: () => q({ nav_per_unit: 10500 }),
+}));
+
+import PriceAlertsPage from "./PriceAlertsPage";
+
+function renderPage(initial = "/markets/price-alerts") {
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      <PriceAlertsPage />
+    </MemoryRouter>,
+  );
+}
+
+/** Drive a Radix Select by opening its trigger and clicking an option. */
+async function selectOption(
+  user: ReturnType<typeof userEvent.setup>,
+  triggerLabel: string,
+  optionName: RegExp,
+) {
+  await user.click(screen.getByLabelText(triggerLabel));
+  await user.click(await screen.findByRole("option", { name: optionName }));
+}
+
+describe("PriceAlertsPage create-alert flow", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("shows the empty state before any alert exists", () => {
+    renderPage();
+    expect(screen.getByText("Active (0)")).toBeInTheDocument();
+    expect(screen.getByText("No active alerts")).toBeInTheDocument();
+  });
+
+  it("creating a Creator-token alert (via deep-link prefill) adds it to the active list + store", async () => {
+    const user = userEvent.setup();
+    // Deep-link prefill selects the token kind + first token without touching the Select.
+    renderPage("/markets/price-alerts?kind=token&id=tk1");
+
+    await waitFor(() => expect(screen.getByLabelText(/Target price/i)).toBeInTheDocument());
+    await user.type(screen.getByLabelText(/Target price/i), "20");
+    await user.click(screen.getByRole("button", { name: /Add alert/i }));
+
+    await waitFor(() => expect(screen.getByText("Active (1)")).toBeInTheDocument());
+    expect(screen.getByText("JANE")).toBeInTheDocument();
+
+    const stored = loadPriceAlerts();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.subjectKind).toBe("token");
+    expect(stored[0]!.subjectId).toBe("tk1");
+    expect(stored[0]!.price).toBe(2000); // $20 -> 2000 cents
+    expect(window.localStorage.getItem(PRICE_ALERTS_KEY)).toBeTruthy();
+  });
+
+  it("creating a Strategy NAV alert (via deep-link prefill) adds it to the active list", async () => {
+    const user = userEvent.setup();
+    renderPage("/markets/price-alerts?kind=strategy&id=st1");
+
+    await waitFor(() => expect(screen.getByLabelText(/Target NAV/i)).toBeInTheDocument());
+    await user.type(screen.getByLabelText(/Target NAV/i), "110");
+    await user.click(screen.getByRole("button", { name: /Add alert/i }));
+
+    await waitFor(() => expect(screen.getByText("Active (1)")).toBeInTheDocument());
+    // The name shows in both the Select value and the alert row -> assert >=1 + a delete control.
+    expect(screen.getAllByText("Blue Chip Basket").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole("button", { name: "Delete alert" })).toBeInTheDocument();
+
+    const stored = loadPriceAlerts();
+    expect(stored[0]!.subjectKind).toBe("strategy");
+    expect(stored[0]!.subjectId).toBe("st1");
+    expect(stored[0]!.field).toBe("nav");
+    expect(stored[0]!.price).toBe(11000);
+  });
+
+  it("switching the Watch kind via the Select changes the target-field label", async () => {
+    const user = userEvent.setup();
+    renderPage(); // defaults to symbol
+    expect(screen.getByLabelText(/Target price/i)).toBeInTheDocument();
+
+    await selectOption(user, "Watch", /^Strategy$/);
+    await waitFor(() => expect(screen.getByLabelText(/Target NAV/i)).toBeInTheDocument());
+  });
+
+  it("blocks submit with an invalid price and surfaces an inline error", async () => {
+    const user = userEvent.setup();
+    renderPage("/markets/price-alerts?kind=token&id=tk1");
+
+    await waitFor(() => expect(screen.getByLabelText(/Target price/i)).toBeInTheDocument());
+    // Leave the price empty -> validation error, no alert added.
+    await user.click(screen.getByRole("button", { name: /Add alert/i }));
+    expect(await screen.findByText(/Enter a valid price/i)).toBeInTheDocument();
+    expect(loadPriceAlerts()).toHaveLength(0);
+    expect(screen.getByText("Active (0)")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/strategies/StrategyDetailPage.interaction.test.tsx
+++ b/frontend/src/pages/strategies/StrategyDetailPage.interaction.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// -- Controllable strategy hooks (isolate the invest-gating logic) --------
+const strategyData: { current: any } = { current: undefined };
+const investMutate = vi.fn();
+
+function q(data: unknown, extra: Record<string, unknown> = {}) {
+  return { data, isLoading: false, isError: false, ...extra };
+}
+
+vi.mock("@/hooks/useStrategies", () => ({
+  useStrategy: () => q(strategyData.current),
+  useStrategyNav: () => q({ nav_per_unit: 10000, aum_cents: strategyData.current?.aum_cents ?? 0 }),
+  useStrategyHoldings: () => q(undefined, { isError: true }),
+  useStrategyPosition: () => q(undefined),
+  useStrategyFees: () => q(undefined),
+  useInvestStrategy: () => ({ mutateAsync: investMutate, isPending: false }),
+  useRedeemStrategy: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  usePublishStrategy: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/useMarketData", () => ({
+  useSymbols: () => q({ symbols: [] }),
+}));
+
+vi.mock("@/hooks/useWatchlist", () => ({
+  useWatchlist: () => ({ has: () => false, toggle: vi.fn(), remove: vi.fn(), items: [] }),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (sel: (s: { userId: string | null }) => unknown) => sel({ userId: "viewer" }),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import StrategyDetailPage from "./StrategyDetailPage";
+
+function makeStrategy(over: Record<string, unknown> = {}) {
+  return {
+    strategy_id: "s1",
+    creator_sub: "someone-else",
+    name: "Blue Chip Basket",
+    description: "",
+    kind: "basket",
+    status: "published",
+    legs: [],
+    rebalance: "none",
+    min_investment_cents: 100_00, // $100 minimum
+    max_aum_cents: 1_000_00, // $1,000 capacity
+    aum_cents: 900_00, // $900 already in -> $100 remaining
+    mgmt_fee_bps: 100,
+    perf_fee_bps: 1000,
+    high_water_mark: true,
+    redemption: { type: "instant" },
+    created_ts: 0,
+    ...over,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/strategies/s1"]}>
+      <Routes>
+        <Route path="/strategies/:id" element={<StrategyDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+async function goToInvestTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("tab", { name: "Invest" }));
+  return screen.getByTestId("invest-amount");
+}
+
+describe("StrategyDetailPage invest gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    strategyData.current = makeStrategy();
+  });
+
+  it("blocks investing below the fund minimum", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const amt = await goToInvestTab(user);
+
+    await user.type(amt, "50"); // $50 < $100 minimum
+    expect(screen.getByText("Amount is below the fund's minimum investment.")).toBeInTheDocument();
+    expect(screen.getByTestId("invest-review")).toBeDisabled();
+  });
+
+  it("blocks investing over the remaining capacity", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const amt = await goToInvestTab(user);
+
+    await user.type(amt, "500"); // $500 > $100 remaining capacity
+    expect(screen.getByText("Amount exceeds the fund's remaining capacity.")).toBeInTheDocument();
+    expect(screen.getByTestId("invest-review")).toBeDisabled();
+  });
+
+  it("enables invest for a valid in-range amount and opens the confirm", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const amt = await goToInvestTab(user);
+
+    investMutate.mockResolvedValue({ units: 1, nav_per_unit: 10000 });
+    await user.type(amt, "100"); // exactly min, within remaining capacity
+    const review = screen.getByTestId("invest-review");
+    await waitFor(() => expect(review).toBeEnabled());
+    await user.click(review);
+
+    expect(await screen.findByText("Confirm investment")).toBeInTheDocument();
+    await user.click(screen.getByTestId("invest-confirm"));
+    await waitFor(() => expect(investMutate).toHaveBeenCalledWith({ amount_cents: 100_00 }));
+  });
+
+  it("disables the invest control entirely when the fund is not published", async () => {
+    strategyData.current = makeStrategy({ status: "draft" });
+    const user = userEvent.setup();
+    renderPage();
+    const amt = await goToInvestTab(user);
+
+    expect(amt).toBeDisabled();
+    expect(screen.getByTestId("invest-review")).toBeDisabled();
+    expect(screen.getByText(/not open for investment yet/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/strategies/WatchStar.interaction.test.tsx
+++ b/frontend/src/pages/strategies/WatchStar.interaction.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { loadWatchlist, isWatched, WATCHLIST_KEY } from "@/lib/watchlist";
+
+// Minimal strategy hook stubs so the page renders; the watch star uses the
+// REAL useWatchlist store so we can assert persistence + reflected state.
+function q(data: unknown, extra: Record<string, unknown> = {}) {
+  return { data, isLoading: false, isError: false, ...extra };
+}
+vi.mock("@/hooks/useStrategies", () => ({
+  useStrategy: () => q({
+    strategy_id: "s1",
+    creator_sub: "other",
+    name: "Blue Chip",
+    description: "",
+    kind: "basket",
+    status: "published",
+    legs: [],
+    rebalance: "none",
+    min_investment_cents: 0,
+    max_aum_cents: 0,
+    mgmt_fee_bps: 0,
+    perf_fee_bps: 0,
+    high_water_mark: false,
+    redemption: { type: "instant" },
+    created_ts: 0,
+  }),
+  useStrategyNav: () => q(undefined),
+  useStrategyHoldings: () => q(undefined, { isError: true }),
+  useStrategyPosition: () => q(undefined),
+  useStrategyFees: () => q(undefined),
+  useInvestStrategy: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRedeemStrategy: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  usePublishStrategy: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/useMarketData", () => ({ useSymbols: () => q({ symbols: [] }) }));
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (sel: (s: { userId: string | null }) => unknown) => sel({ userId: "viewer" }),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import StrategyDetailPage from "./StrategyDetailPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/strategies/s1"]}>
+      <Routes>
+        <Route path="/strategies/:id" element={<StrategyDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Watch-star toggle writes through to the watchlist store", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("clicking the star adds then removes the strategy from the store", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const star = screen.getByRole("button", { name: /watch/i });
+    expect(star).toHaveAttribute("aria-pressed", "false");
+    expect(isWatched(loadWatchlist(), "strategy", "s1")).toBe(false);
+
+    await user.click(star);
+    await waitFor(() => expect(isWatched(loadWatchlist(), "strategy", "s1")).toBe(true));
+    // The store persisted under the shared key.
+    expect(JSON.parse(window.localStorage.getItem(WATCHLIST_KEY) as string)).toEqual([
+      { kind: "strategy", id: "s1" },
+    ]);
+    // And the button reflects the watched state.
+    expect(screen.getByRole("button", { name: /watching/i })).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: /watching/i }));
+    await waitFor(() => expect(isWatched(loadWatchlist(), "strategy", "s1")).toBe(false));
+    expect(JSON.parse(window.localStorage.getItem(WATCHLIST_KEY) as string)).toEqual([]);
+  });
+});

--- a/frontend/src/pages/tokens/MintTokenPage.interaction.test.tsx
+++ b/frontend/src/pages/tokens/MintTokenPage.interaction.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mintToken = vi.fn();
+const navigate = vi.fn();
+
+vi.mock("@/api/endpoints/tokens", async () => {
+  const actual = await vi.importActual<typeof import("@/api/endpoints/tokens")>("@/api/endpoints/tokens");
+  return { ...actual, mintToken: (...a: unknown[]) => mintToken(...a) };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import MintTokenPage from "./MintTokenPage";
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <MintTokenPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("MintTokenPage interaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the submit gated behind validation and shows the field errors", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Name is empty by default -> submit disabled + name error visible.
+    const submit = screen.getByTestId("mint-submit");
+    expect(submit).toBeDisabled();
+    expect(screen.getByText("Name is required.")).toBeInTheDocument();
+
+    // Fill a valid name but an invalid ticker -> still gated with ticker error.
+    await user.type(screen.getByLabelText("Name"), "Jane Doe Revenue");
+    await user.type(screen.getByLabelText("Ticker"), "!"); // fails 2-10 alnum
+    expect(submit).toBeDisabled();
+    expect(screen.getByText("Ticker must be 2-10 letters/numbers.")).toBeInTheDocument();
+  });
+
+  it("gates on a non-positive / out-of-range revenue-share %", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("Name"), "Jane Doe Revenue");
+    await user.type(screen.getByLabelText("Ticker"), "JANE");
+
+    const rev = screen.getByLabelText("Revenue-share %");
+    await user.clear(rev);
+    await user.type(rev, "0");
+    expect(screen.getByText("Revenue-share % must be greater than 0.")).toBeInTheDocument();
+    expect(screen.getByTestId("mint-submit")).toBeDisabled();
+
+    await user.clear(rev);
+    await user.type(rev, "150");
+    expect(screen.getByText("Revenue-share % cannot exceed 100%.")).toBeInTheDocument();
+    expect(screen.getByTestId("mint-submit")).toBeDisabled();
+  });
+
+  it("enables submit when all fields are valid and shows the $100 creation-fee confirm", async () => {
+    const user = userEvent.setup();
+    mintToken.mockResolvedValue({ token_id: "tk_1", ticker: "JANE" });
+    renderPage();
+
+    await user.type(screen.getByLabelText("Name"), "Jane Doe Revenue");
+    await user.type(screen.getByLabelText("Ticker"), "JANE");
+    // supply defaults to 1000000; revShare defaults to 2.5 -> all valid now.
+
+    const submit = screen.getByTestId("mint-submit");
+    await waitFor(() => expect(submit).toBeEnabled());
+    await user.click(submit);
+
+    // The money-safety confirm dialog appears with the $100.00 fee.
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Confirm token mint")).toBeInTheDocument();
+    expect(
+      screen.getByText(/charges a one-time \$100\.00 creation fee/i),
+    ).toBeInTheDocument();
+
+    // Confirming triggers the mint mutation with the composed request.
+    await user.click(screen.getByTestId("mint-confirm"));
+    await waitFor(() => {
+      expect(mintToken).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "Jane Doe Revenue", ticker: "JANE", total_supply: 1000000 }),
+      );
+    });
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith("/tokens/tk_1"));
+  });
+});


### PR DESCRIPTION
## Deeper hardening — hook + interaction tests + e2e route smoke

Second pass, covering the two layers the first didn't: web **data hooks + interaction behavior** (reliable vitest/RTL, gated) and real **browser e2e** route smoke (non-required gate). No product code changed.

### Web vitest (added to the REQUIRED payment-incident vitest run → 42 files)
- **Hook tests** (`renderHook` + mocked api): useTokens / useStrategies / useBailouts / useWatchlist / useActivity — degrade-on-404 + happy path (+ never-fabricate-distress, cross-consumer sync, legacy migration).
- **Interaction tests** (`userEvent`): MintTokenPage validation + $100-fee confirm; StrategyDetailPage invest min-size/capacity gating + unpublished-disable; watch-star toggle persists; PriceAlertsPage token/strategy alert create + kind-switch.
- **9 files / 33 tests, all green.** (This PR's own required check executes them.)

### E2e (non-required web-e2e gate)
`e2e/trading-surfaces.spec.ts` — 11 route smoke tests (authenticated nav → heading renders, no error-boundary, not bounced to login), wired into the gate spec list (`e2e/ci-gate-green.txt`). `playwright --list`: all 11 discovered. Pattern-verified; executes in the label-gated web-e2e CI gate (not run locally — needs the seeded stack).

No new deps. Gates: web tsc 0 · vite build · new vitest 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
