### PR TITLE
feat(cash): fiat USD deposit/withdraw on-ramp reusing the billing wallet (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/cash/CashApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/cash/CashApi.kt
@@ -1,0 +1,95 @@
+package com.testlogon.android.data.cash
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.network.json.LenientInt
+import com.testlogon.android.core.network.json.LenientLong
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+
+/**
+ * Retrofit interface for the FIAT (USD) wallet — the SAME real /ui/billing/wallet surface the web app
+ * uses (frontend/src/api/endpoints/billing.ts). This is the `pay_with: "USD"` cash balance used for
+ * trading, margin & fees. Paths are relative (no leading slash) so they resolve against the shared
+ * Retrofit base URL; the session cookie + CSRF header are attached by the core-network interceptor
+ * chain. All methods are suspend and return the typed DTO; a non-2xx surfaces as retrofit2.HttpException.
+ *
+ * A distinct thin API (rather than reusing data/billing/BillingApi) keeps the Cash feature self-contained
+ * and adds the deposit/withdraw mutations that BillingApi does not carry.
+ */
+interface CashApi {
+
+    /** GET ui/billing/wallet -> {wallet_balance_cents, currency}. Read degrades on 404. */
+    @GET("ui/billing/wallet")
+    suspend fun wallet(): WalletDto
+
+    /** GET ui/billing/payment-methods -> BARE ARRAY of payment methods. Read degrades on 404. */
+    @GET("ui/billing/payment-methods")
+    suspend fun paymentMethods(): List<CashPaymentMethodDto>
+
+    /** POST ui/billing/wallet/deposit {amount_cents, payment_method_id?} -> deposit result. */
+    @Headers("Content-Type: application/json")
+    @POST("ui/billing/wallet/deposit")
+    suspend fun deposit(@Body body: WalletDepositRequestDto): WalletDepositResultDto
+
+    /** POST ui/billing/wallet/withdraw {amount_cents} -> {ok, wallet_balance_cents}. */
+    @Headers("Content-Type: application/json")
+    @POST("ui/billing/wallet/withdraw")
+    suspend fun withdraw(@Body body: WalletWithdrawRequestDto): WalletWithdrawResultDto
+}
+
+// ---- Wire DTOs (codegen-only Moshi; numerics lenient; every field defaulted so a partial shape parses) ----
+
+/** GET ui/billing/wallet. wallet_balance_cents integer cents; currency e.g. "USD". */
+@JsonClass(generateAdapter = true)
+data class WalletDto(
+    @LenientLong @Json(name = "wallet_balance_cents") val walletBalanceCents: Long? = null,
+    @Json(name = "currency") val currency: String? = null,
+    @LenientLong @Json(name = "updated_at") val updatedAt: Long? = null,
+)
+
+/** One saved payment method (subset consumed by the deposit picker). */
+@JsonClass(generateAdapter = true)
+data class CashPaymentMethodDto(
+    @Json(name = "payment_method_id") val paymentMethodId: String? = null,
+    @Json(name = "method_type") val methodType: String? = null,
+    @Json(name = "label") val label: String? = null,
+    @Json(name = "brand") val brand: String? = null,
+    @Json(name = "last4") val last4: String? = null,
+    @LenientInt @Json(name = "priority") val priority: Int? = null,
+    @Json(name = "is_default") val isDefault: Boolean? = null,
+)
+
+/** Body for POST ui/billing/wallet/deposit. */
+@JsonClass(generateAdapter = true)
+data class WalletDepositRequestDto(
+    @Json(name = "amount_cents") val amountCents: Long,
+    @Json(name = "payment_method_id") val paymentMethodId: String? = null,
+)
+
+/** POST ui/billing/wallet/deposit result: {status, payment_intent_id, wallet_balance_cents}. */
+@JsonClass(generateAdapter = true)
+data class WalletDepositResultDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "payment_intent_id") val paymentIntentId: String? = null,
+    @LenientLong @Json(name = "wallet_balance_cents") val walletBalanceCents: Long? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)
+
+/** Body for POST ui/billing/wallet/withdraw. */
+@JsonClass(generateAdapter = true)
+data class WalletWithdrawRequestDto(
+    @Json(name = "amount_cents") val amountCents: Long,
+)
+
+/** POST ui/billing/wallet/withdraw result: {ok, wallet_balance_cents}. */
+@JsonClass(generateAdapter = true)
+data class WalletWithdrawResultDto(
+    @Json(name = "ok") val ok: Boolean? = null,
+    @LenientLong @Json(name = "wallet_balance_cents") val walletBalanceCents: Long? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/cash/CashDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/cash/CashDomain.kt
@@ -1,0 +1,42 @@
+package com.testlogon.android.data.cash
+
+/**
+ * Null-safe domain models for the FIAT (USD) cash wallet. The wire DTOs are coerced here so the
+ * ViewModel/UI never see nullable wire fields. Money stays integer cents end-to-end (parsed/formatted
+ * in feature/cash/CashMath).
+ */
+
+/** The USD wallet balance. [available] is false when the read degraded (404 / undeployed). */
+data class CashWallet(
+    val balanceCents: Long,
+    val currency: String,
+    val available: Boolean,
+) {
+    companion object {
+        /** Honest "unavailable" wallet for the degrade-on-404 empty state. */
+        fun unavailable(): CashWallet = CashWallet(balanceCents = 0L, currency = "USD", available = false)
+    }
+}
+
+/** A saved payment method usable to fund a deposit. */
+data class CashPaymentMethod(
+    val id: String,
+    val label: String,
+    val isDefault: Boolean,
+)
+
+/** Result of a wallet deposit (mutation). ok=true when the server accepted the charge. */
+data class CashDepositResult(
+    val ok: Boolean,
+    val status: String?,
+    val paymentIntentId: String?,
+    val newBalanceCents: Long?,
+    val reason: String?,
+)
+
+/** Result of a wallet withdrawal (mutation). */
+data class CashWithdrawResult(
+    val ok: Boolean,
+    val newBalanceCents: Long?,
+    val reason: String?,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/cash/CashRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/cash/CashRepository.kt
@@ -1,0 +1,151 @@
+package com.testlogon.android.data.cash
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer for the FIAT (USD) cash wallet over [CashApi] (the real /ui/billing/wallet surface).
+ *
+ * READS ([wallet], [paymentMethods]) DEGRADE on 404/HTTP-error to an honest "unavailable"/empty value
+ * so the screen shows a truthful empty state rather than an error; a real transport failure surfaces as
+ * [ApiResult.NetworkError] so the UI can offer retry. MUTATIONS ([deposit], [withdraw]) pass failures
+ * through as [ApiResult.Failure]/[ApiResult.NetworkError] — a rejection (or undeployed 404) surfaces as
+ * a clear error and NEVER a silent success. CancellationException is always re-thrown.
+ */
+interface CashRepository {
+    suspend fun wallet(): ApiResult<CashWallet>
+    suspend fun paymentMethods(): ApiResult<List<CashPaymentMethod>>
+    suspend fun deposit(amountCents: Long, paymentMethodId: String?): ApiResult<CashDepositResult>
+    suspend fun withdraw(amountCents: Long): ApiResult<CashWithdrawResult>
+}
+
+@Singleton
+class CashRepositoryImpl @Inject constructor(
+    private val api: CashApi,
+    private val errorParser: ApiErrorParser,
+) : CashRepository {
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    /** Wallet balance. A 404 (undeployed) degrades to an honest unavailable wallet; network errors surface. */
+    override suspend fun wallet(): ApiResult<CashWallet> = withContext(io) {
+        try {
+            ApiResult.Success(api.wallet().toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(CashWallet.unavailable())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    /** Payment methods. A 404 degrades to an empty list; network errors surface. */
+    override suspend fun paymentMethods(): ApiResult<List<CashPaymentMethod>> = withContext(io) {
+        try {
+            ApiResult.Success(api.paymentMethods().mapNotNull { it.toDomain() })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(emptyList())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    override suspend fun deposit(amountCents: Long, paymentMethodId: String?): ApiResult<CashDepositResult> = call {
+        api.deposit(
+            WalletDepositRequestDto(
+                amountCents = amountCents,
+                paymentMethodId = paymentMethodId?.trim()?.takeIf { it.isNotBlank() },
+            ),
+        ).toDomain()
+    }
+
+    override suspend fun withdraw(amountCents: Long): ApiResult<CashWithdrawResult> = call {
+        api.withdraw(WalletWithdrawRequestDto(amountCents = amountCents)).toDomain()
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = withContext(io) {
+        try {
+            ApiResult.Success(block())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Failure(errorParser.from(e))
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+}
+
+// ---- DTO -> domain mappers ----
+
+private fun WalletDto.toDomain(): CashWallet = CashWallet(
+    balanceCents = walletBalanceCents ?: 0L,
+    currency = currency?.trim()?.takeIf { it.isNotBlank() } ?: "USD",
+    available = true,
+)
+
+private fun CashPaymentMethodDto.toDomain(): CashPaymentMethod? {
+    val id = paymentMethodId?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    val brandLast4 = listOfNotNull(
+        brand?.trim()?.takeIf { it.isNotBlank() }?.replaceFirstChar { it.uppercase() },
+        last4?.trim()?.takeIf { it.isNotBlank() }?.let { "····$it" },
+    ).joinToString(" ")
+    val label = label?.trim()?.takeIf { it.isNotBlank() }
+        ?: brandLast4.takeIf { it.isNotBlank() }
+        ?: methodType?.trim()?.takeIf { it.isNotBlank() }
+        ?: "Payment method"
+    return CashPaymentMethod(id = id, label = label, isDefault = isDefault == true)
+}
+
+private fun WalletDepositResultDto.toDomain(): CashDepositResult {
+    val statusNorm = status?.trim()?.lowercase()
+    // A missing status but a returned balance still counts as accepted (honest-mock returns {status:"succeeded"}).
+    val ok = statusNorm in setOf("succeeded", "success", "ok", "processing", "pending") || walletBalanceCents != null
+    return CashDepositResult(
+        ok = ok,
+        status = status?.trim()?.takeIf { it.isNotBlank() },
+        paymentIntentId = paymentIntentId?.trim()?.takeIf { it.isNotBlank() },
+        newBalanceCents = walletBalanceCents,
+        reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
+    )
+}
+
+private fun WalletWithdrawResultDto.toDomain(): CashWithdrawResult = CashWithdrawResult(
+    ok = ok == true,
+    newBalanceCents = walletBalanceCents,
+    reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
+)
+
+/** Provides [CashApi] on the shared authenticated Retrofit + binds the repository impl. */
+@Module
+@InstallIn(SingletonComponent::class)
+object CashApiModule {
+    @Provides
+    @Singleton
+    fun provideCashApi(retrofit: Retrofit): CashApi = retrofit.create(CashApi::class.java)
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CashDataModule {
+    @Binds
+    @Singleton
+    abstract fun bindCashRepository(impl: CashRepositoryImpl): CashRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/cash/CashMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/cash/CashMath.kt
@@ -1,0 +1,58 @@
+package com.testlogon.android.feature.cash
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * Pure, Android-free money math for the FIAT (USD) Cash screen. Kept out of the ViewModel so the
+ * money-correctness rules (dollars<->cents parse/format, min-$1 deposit, withdraw <= balance) are unit
+ * testable without Compose/Hilt. Money is integer cents everywhere; parsing uses BigDecimal so
+ * "10.99" -> 1099 exactly (no binary-float drift).
+ */
+object CashMath {
+
+    /** Minimum deposit / withdrawal, in cents ($1.00). */
+    const val MIN_CENTS: Long = 100L
+
+    /**
+     * Parse a user-entered dollar string to integer cents, or null when blank / non-numeric / negative.
+     * Accepts an optional leading "$", commas, and up to 2 decimal places (extra precision is truncated
+     * toward zero). Zero parses to 0 (callers enforce the min separately).
+     */
+    fun parseDollarsToCents(text: String): Long? {
+        val cleaned = text.trim().removePrefix("$").replace(",", "").trim()
+        if (cleaned.isEmpty()) return null
+        val dec = cleaned.toBigDecimalOrNull() ?: return null
+        if (dec.signum() < 0) return null
+        return dec.movePointRight(2).setScale(0, RoundingMode.DOWN).toLong()
+    }
+
+    /** Format integer cents as a plain dollar string with 2 decimals (e.g. 1099 -> "10.99"). No symbol. */
+    fun formatCents(cents: Long): String =
+        BigDecimal(cents).movePointLeft(2).setScale(2, RoundingMode.UNNECESSARY).toPlainString()
+
+    /** Format integer cents as a currency amount with the symbol (e.g. 1099 -> "$10.99"). */
+    fun formatCentsUsd(cents: Long): String = "$" + formatCents(cents)
+
+    /** Keep digits + a single decimal point, cap to 2 fractional digits, drop stray input. */
+    fun sanitizeAmountInput(v: String): String {
+        val filtered = v.filter { it.isDigit() || it == '.' }
+        val firstDot = filtered.indexOf('.')
+        if (firstDot < 0) return filtered.take(12)
+        val intPart = filtered.substring(0, firstDot).take(12)
+        val fracPart = filtered.substring(firstDot + 1).replace(".", "").take(2)
+        return "$intPart.$fracPart"
+    }
+
+    /** A deposit is valid when it parses to >= the $1 minimum. */
+    fun isDepositValid(amountText: String): Boolean {
+        val cents = parseDollarsToCents(amountText) ?: return false
+        return cents >= MIN_CENTS
+    }
+
+    /** A withdrawal is valid when it parses to >= $1 AND does not exceed [balanceCents]. */
+    fun isWithdrawValid(amountText: String, balanceCents: Long): Boolean {
+        val cents = parseDollarsToCents(amountText) ?: return false
+        return cents in MIN_CENTS..balanceCents
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/cash/CashScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/cash/CashScreen.kt
@@ -1,0 +1,297 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.cash
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * The FIAT (USD) "Cash" screen — deposit / withdraw the USD wallet balance used for trading, margin &
+ * fees, wired to the SAME real /ui/billing/wallet endpoints the web app uses. Deposit is gated behind a
+ * payment-method pick + a money-safety confirm; Withdraw is capped at the balance behind a confirm.
+ */
+@Composable
+fun CashRoute(
+    onBack: () -> Unit,
+    viewModel: CashViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDepositConfirm by remember { mutableStateOf(false) }
+    var showWithdrawConfirm by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Cash") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            // ---- Balance ----
+            Card(modifier = Modifier.fillMaxWidth().testTag("cash_balance_card")) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("USD cash balance", style = MaterialTheme.typography.labelLarge)
+                    if (state.loading) {
+                        Spacer(Modifier.height(8.dp))
+                        CircularProgressIndicator(modifier = Modifier.height(22.dp), strokeWidth = 2.dp)
+                    } else if (state.walletUnavailable) {
+                        Text(
+                            "Unavailable",
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Text(
+                            "Your cash wallet isn't available on this account yet.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        Text(
+                            CashMath.formatCentsUsd(state.balanceCents),
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.testTag("cash_balance_value"),
+                        )
+                    }
+                    Text(
+                        "Usable for trading, margin & fees.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            state.successMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(it, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("cash_success"))
+            }
+            state.errorMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("cash_error"))
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // ---- Deposit ----
+            Text("Deposit", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.depositText,
+                onValueChange = viewModel::onDepositText,
+                label = { Text("Amount (USD)") },
+                prefix = { Text("$") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                supportingText = { Text("Minimum ${CashMath.formatCentsUsd(CashMath.MIN_CENTS)}.") },
+                modifier = Modifier.fillMaxWidth().testTag("cash_deposit_amount"),
+            )
+            Spacer(Modifier.height(8.dp))
+            if (state.hasPaymentMethod) {
+                Text("Pay with", style = MaterialTheme.typography.labelLarge)
+                Column {
+                    state.paymentMethods.forEach { pm ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = pm.id == state.selectedPaymentMethodId,
+                                    onClick = { viewModel.onSelectPaymentMethod(pm.id) },
+                                )
+                                .padding(vertical = 4.dp)
+                                .testTag("cash_pm_${pm.id}"),
+                        ) {
+                            RadioButton(
+                                selected = pm.id == state.selectedPaymentMethodId,
+                                onClick = { viewModel.onSelectPaymentMethod(pm.id) },
+                            )
+                            Spacer(Modifier.height(0.dp))
+                            Text(
+                                pm.label + if (pm.isDefault) "  (default)" else "",
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
+            } else {
+                Text(
+                    "No payment method on file. Add one on the web billing page to fund a deposit.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("cash_no_pm"),
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Button(
+                onClick = { showDepositConfirm = true },
+                enabled = state.canDeposit,
+                modifier = Modifier.fillMaxWidth().testTag("cash_deposit_submit"),
+            ) { Text("Deposit") }
+
+            Spacer(Modifier.height(24.dp))
+            Divider()
+            Spacer(Modifier.height(20.dp))
+
+            // ---- Withdraw ----
+            Text("Withdraw", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.withdrawText,
+                onValueChange = viewModel::onWithdrawText,
+                label = { Text("Amount (USD)") },
+                prefix = { Text("$") },
+                singleLine = true,
+                enabled = !state.walletUnavailable,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                supportingText = { Text("Up to your ${CashMath.formatCentsUsd(state.balanceCents)} balance.") },
+                modifier = Modifier.fillMaxWidth().testTag("cash_withdraw_amount"),
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(
+                    onClick = viewModel::onWithdrawMax,
+                    enabled = !state.walletUnavailable && state.balanceCents >= CashMath.MIN_CENTS,
+                    modifier = Modifier.testTag("cash_withdraw_max"),
+                ) { Text("Max") }
+                Button(
+                    onClick = { showWithdrawConfirm = true },
+                    enabled = state.canWithdraw,
+                    modifier = Modifier.fillMaxWidth().testTag("cash_withdraw_submit"),
+                ) {
+                    if (state.submitting) {
+                        CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
+                    } else {
+                        Text("Withdraw")
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDepositConfirm) {
+        val pmLabel = state.paymentMethods.firstOrNull { it.id == state.selectedPaymentMethodId }?.label ?: "—"
+        AlertDialog(
+            onDismissRequest = { showDepositConfirm = false },
+            title = { Text("Confirm deposit") },
+            text = {
+                Column {
+                    CashRow("Action", "Deposit to cash balance")
+                    CashRow("Amount", "$" + state.depositText.ifBlank { "0" }, emphasize = true)
+                    CashRow("Pay with", pmLabel)
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "This charges your payment method now and credits your USD cash balance.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showDepositConfirm = false
+                        viewModel.confirmDeposit()
+                    },
+                    modifier = Modifier.testTag("cash_deposit_confirm"),
+                ) { Text("Deposit") }
+            },
+            dismissButton = { TextButton(onClick = { showDepositConfirm = false }) { Text("Cancel") } },
+        )
+    }
+
+    if (showWithdrawConfirm) {
+        AlertDialog(
+            onDismissRequest = { showWithdrawConfirm = false },
+            title = { Text("Confirm withdrawal") },
+            text = {
+                Column {
+                    CashRow("Action", "Withdraw from cash balance")
+                    CashRow("Amount", "$" + state.withdrawText.ifBlank { "0" }, emphasize = true)
+                    CashRow("Remaining balance", "current ${CashMath.formatCentsUsd(state.balanceCents)}")
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "This moves funds out of your USD cash balance.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showWithdrawConfirm = false
+                        viewModel.confirmWithdraw()
+                    },
+                    modifier = Modifier.testTag("cash_withdraw_confirm"),
+                ) { Text("Withdraw") }
+            },
+            dismissButton = { TextButton(onClick = { showWithdrawConfirm = false }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun CashRow(label: String, value: String, emphasize: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal,
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/cash/CashViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/cash/CashViewModel.kt
@@ -1,0 +1,169 @@
+package com.testlogon.android.feature.cash
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.cash.CashPaymentMethod
+import com.testlogon.android.data.cash.CashRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** UI state for the FIAT (USD) Cash screen. */
+data class CashUiState(
+    val loading: Boolean = true,
+    val walletUnavailable: Boolean = false,
+    val balanceCents: Long = 0L,
+    val currency: String = "USD",
+    val paymentMethods: List<CashPaymentMethod> = emptyList(),
+    val selectedPaymentMethodId: String? = null,
+    val depositText: String = "",
+    val withdrawText: String = "",
+    val submitting: Boolean = false,
+    val errorMessage: String? = null,
+    val successMessage: String? = null,
+) {
+    val hasPaymentMethod: Boolean get() = paymentMethods.isNotEmpty()
+
+    /** Deposit requires a valid >=$1 amount AND a chosen payment method (funds the charge). */
+    val canDeposit: Boolean
+        get() = !submitting && CashMath.isDepositValid(depositText) && selectedPaymentMethodId != null
+
+    /** Withdraw requires a valid amount in [$1, balance]. Only meaningful when the wallet is available. */
+    val canWithdraw: Boolean
+        get() = !submitting && !walletUnavailable && CashMath.isWithdrawValid(withdrawText, balanceCents)
+}
+
+/**
+ * Drives the FIAT (USD) Cash screen against the SAME real /ui/billing/wallet endpoints the web app uses.
+ * Balance + payment-methods reads DEGRADE on 404 to an honest empty/unavailable state; deposit/withdraw
+ * are money mutations gated behind a confirm dialog in the UI (the VM exposes confirmDeposit /
+ * confirmWithdraw, called only after the user accepts). A rejection surfaces as a clear error, never a
+ * silent success. Balance is refreshed after every mutation.
+ */
+@HiltViewModel
+class CashViewModel @Inject constructor(
+    private val repository: CashRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CashUiState())
+    val uiState: StateFlow<CashUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.update { it.copy(loading = true, errorMessage = null) }
+        viewModelScope.launch {
+            when (val w = repository.wallet()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        loading = false,
+                        walletUnavailable = !w.data.available,
+                        balanceCents = w.data.balanceCents,
+                        currency = w.data.currency,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(loading = false, errorMessage = w.error.message.ifBlank { "Couldn't load your cash balance." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(loading = false, errorMessage = "No connection. Pull to retry.")
+                }
+            }
+            when (val pm = repository.paymentMethods()) {
+                is ApiResult.Success -> _uiState.update { s ->
+                    val selected = s.selectedPaymentMethodId
+                        ?: pm.data.firstOrNull { it.isDefault }?.id
+                        ?: pm.data.firstOrNull()?.id
+                    s.copy(paymentMethods = pm.data, selectedPaymentMethodId = selected)
+                }
+                else -> Unit // payment methods are optional; a failure just leaves the picker empty.
+            }
+        }
+    }
+
+    fun onDepositText(v: String) =
+        _uiState.update { it.copy(depositText = CashMath.sanitizeAmountInput(v), errorMessage = null, successMessage = null) }
+
+    fun onWithdrawText(v: String) =
+        _uiState.update { it.copy(withdrawText = CashMath.sanitizeAmountInput(v), errorMessage = null, successMessage = null) }
+
+    fun onSelectPaymentMethod(id: String) = _uiState.update { it.copy(selectedPaymentMethodId = id) }
+
+    fun onWithdrawMax() = _uiState.update { it.copy(withdrawText = CashMath.formatCents(it.balanceCents), errorMessage = null) }
+
+    fun consumeMessages() = _uiState.update { it.copy(errorMessage = null, successMessage = null) }
+
+    /** Called AFTER the deposit confirm is accepted. */
+    fun confirmDeposit() {
+        val s = _uiState.value
+        val cents = CashMath.parseDollarsToCents(s.depositText)
+        val pmId = s.selectedPaymentMethodId
+        if (cents == null || cents < CashMath.MIN_CENTS || pmId == null) {
+            _uiState.update { it.copy(errorMessage = "Enter at least ${CashMath.formatCentsUsd(CashMath.MIN_CENTS)} and pick a payment method.") }
+            return
+        }
+        _uiState.update { it.copy(submitting = true, errorMessage = null, successMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.deposit(cents, pmId)) {
+                is ApiResult.Success -> {
+                    if (r.data.ok) {
+                        _uiState.update {
+                            it.copy(submitting = false, depositText = "", successMessage = "Deposited ${CashMath.formatCentsUsd(cents)} to your cash balance.")
+                        }
+                        refresh()
+                    } else {
+                        _uiState.update {
+                            it.copy(submitting = false, errorMessage = r.data.reason?.ifBlank { null } ?: "Deposit was declined.")
+                        }
+                    }
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = r.error.message.ifBlank { "Deposit isn't available right now. No funds were moved." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = "No connection. No funds were moved.")
+                }
+            }
+        }
+    }
+
+    /** Called AFTER the withdraw confirm is accepted. */
+    fun confirmWithdraw() {
+        val s = _uiState.value
+        val cents = CashMath.parseDollarsToCents(s.withdrawText)
+        if (cents == null || !CashMath.isWithdrawValid(s.withdrawText, s.balanceCents)) {
+            _uiState.update { it.copy(errorMessage = "Enter an amount between ${CashMath.formatCentsUsd(CashMath.MIN_CENTS)} and ${CashMath.formatCentsUsd(it.balanceCents)}.") }
+            return
+        }
+        _uiState.update { it.copy(submitting = true, errorMessage = null, successMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.withdraw(cents)) {
+                is ApiResult.Success -> {
+                    if (r.data.ok) {
+                        _uiState.update {
+                            it.copy(submitting = false, withdrawText = "", successMessage = "Withdrew ${CashMath.formatCentsUsd(cents)} from your cash balance.")
+                        }
+                        refresh()
+                    } else {
+                        _uiState.update {
+                            it.copy(submitting = false, errorMessage = r.data.reason?.ifBlank { null } ?: "Withdrawal was declined.")
+                        }
+                    }
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = r.error.message.ifBlank { "Withdrawal isn't available right now. No funds were moved." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = "No connection. No funds were moved.")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -3,6 +3,7 @@ package com.testlogon.android.feature.more
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.Payments
 import androidx.compose.material.icons.outlined.PieChart
 import androidx.compose.material.icons.outlined.ShowChart
 import androidx.compose.material.icons.outlined.Science
@@ -981,6 +982,14 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_custody,
             icon = Icons.Outlined.AccountBalance,
             route = MoreRoutes.CUSTODY,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "cash",
+            labelRes = R.string.more_entry_cash,
+            icon = Icons.Outlined.Payments,
+            route = MoreRoutes.CASH,
             hub = MoreHub.WALLET,
             section = MoreSection.APP,
         ),

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -218,6 +218,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         activeAlgosDestination(navController)
         // Custody: native crypto custody surface wired to /me/custody/* (officer approvals self-gate on the admin signal).
         custodyDestination(navController)
+        // Cash: native FIAT (USD) wallet deposit/withdraw wired to the /ui/billing/wallet endpoints.
+        cashDestination(navController)
         // External custody providers (Fireblocks / BitGo / internal gateway): connect + per-vault provider + withdrawal approval.
         custodyProvidersDestination(navController)
         // Trading Home / Dashboard: read-only launch surface (reached from More -> Wallet hub top).

--- a/android/app/src/main/java/com/testlogon/android/navigation/CashNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CashNavigation.kt
@@ -1,0 +1,25 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.cash.CashRoute
+
+/**
+ * The FIAT (USD) Cash surface (deposit / withdraw the USD wallet used for trading, margin & fees),
+ * reached from the More -> Wallet hub. Wired to the SAME /ui/billing/wallet endpoints the web app uses
+ * (the shared Retrofit client attaches the session cookie). Reads degrade-on-404 to an honest empty
+ * state; deposit/withdraw are behind a money-safety confirm.
+ */
+data object CashDest {
+    const val ROUTE = "cash"
+}
+
+/** Registers the Cash screen in the authenticated graph. Up / Back pops the back stack. */
+fun NavGraphBuilder.cashDestination(navController: NavHostController) {
+    composable(CashDest.ROUTE) {
+        CashRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -109,6 +109,9 @@ object MoreRoutes {
     // Custody: native crypto custody surface (balances / deposit / withdraw / activity / officer approvals), wired to /me/custody/*.
     const val CUSTODY = CustodyDest.ROUTE
 
+    // Cash: native FIAT (USD) wallet deposit/withdraw wired to /ui/billing/wallet (trading/margin/fees balance).
+    const val CASH = CashDest.ROUTE
+
     // External custody providers (Fireblocks / BitGo / internal gateway): connect + per-vault provider + withdrawal approval.
     const val CUSTODY_PROVIDERS = CustodyProvidersDest.ROUTE
 
@@ -623,6 +626,7 @@ object MoreRoutes {
             ACTIVE_ALGOS,
             HOME,
             CUSTODY,
+            CASH,
             CUSTODY_PROVIDERS,
             PORTFOLIO,
             PORTFOLIO_ANALYTICS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1476,6 +1476,7 @@
     <string name="more_entry_active_algos">Active Algos</string>
     <string name="more_entry_home">Home</string>
     <string name="more_entry_custody">Custody</string>
+    <string name="more_entry_cash">Cash</string>
     <string name="more_entry_custody_providers">Custody providers</string>
     <string name="more_entry_portfolio">Portfolio</string>
     <string name="more_entry_pnl">PnL &amp; performance</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/cash/CashMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/cash/CashMathTest.kt
@@ -1,0 +1,105 @@
+package com.testlogon.android.feature.cash
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Money-correctness for the FIAT (USD) Cash screen: dollars<->cents parse/format (exact, no float
+ * drift), the $1 minimum deposit rule, and withdraw bounded by both the $1 minimum and the balance.
+ */
+class CashMathTest {
+
+    // ---- parseDollarsToCents ----
+
+    @Test
+    fun parse_exactCentsNoFloatDrift() {
+        assertEquals(1099L, CashMath.parseDollarsToCents("10.99"))
+        assertEquals(100L, CashMath.parseDollarsToCents("1"))
+        assertEquals(150L, CashMath.parseDollarsToCents("1.5"))
+        assertEquals(0L, CashMath.parseDollarsToCents("0"))
+    }
+
+    @Test
+    fun parse_acceptsSymbolCommasAndWhitespace() {
+        assertEquals(123456L, CashMath.parseDollarsToCents(" $1,234.56 "))
+    }
+
+    @Test
+    fun parse_truncatesExtraPrecisionTowardZero() {
+        assertEquals(1099L, CashMath.parseDollarsToCents("10.999"))
+    }
+
+    @Test
+    fun parse_rejectsBlankNegativeAndNonNumeric() {
+        assertNull(CashMath.parseDollarsToCents(""))
+        assertNull(CashMath.parseDollarsToCents("   "))
+        assertNull(CashMath.parseDollarsToCents("-5"))
+        assertNull(CashMath.parseDollarsToCents("abc"))
+    }
+
+    // ---- formatCents / formatCentsUsd ----
+
+    @Test
+    fun format_alwaysTwoDecimals() {
+        assertEquals("10.99", CashMath.formatCents(1099L))
+        assertEquals("1.00", CashMath.formatCents(100L))
+        assertEquals("0.00", CashMath.formatCents(0L))
+        assertEquals("1234.56", CashMath.formatCents(123456L))
+    }
+
+    @Test
+    fun formatUsd_prependsSymbol() {
+        assertEquals("$10.99", CashMath.formatCentsUsd(1099L))
+        assertEquals("$0.00", CashMath.formatCentsUsd(0L))
+    }
+
+    @Test
+    fun parseThenFormat_roundTrips() {
+        val cents = CashMath.parseDollarsToCents("42.07")!!
+        assertEquals("42.07", CashMath.formatCents(cents))
+    }
+
+    // ---- sanitizeAmountInput ----
+
+    @Test
+    fun sanitize_stripsNonNumericCapsTwoDecimalsAndFirstDot() {
+        assertEquals("12.34", CashMath.sanitizeAmountInput("1a2.3b4"))
+        assertEquals("1.23", CashMath.sanitizeAmountInput("1.23.45"))
+        assertEquals("100", CashMath.sanitizeAmountInput("100"))
+        assertEquals("", CashMath.sanitizeAmountInput("abc"))
+    }
+
+    // ---- isDepositValid: >= $1 ----
+
+    @Test
+    fun depositValid_requiresAtLeastOneDollar() {
+        assertTrue(CashMath.isDepositValid("1"))
+        assertTrue(CashMath.isDepositValid("1.00"))
+        assertTrue(CashMath.isDepositValid("500"))
+        assertFalse(CashMath.isDepositValid("0.99"))
+        assertFalse(CashMath.isDepositValid("0"))
+        assertFalse(CashMath.isDepositValid(""))
+        assertFalse(CashMath.isDepositValid("-3"))
+    }
+
+    // ---- isWithdrawValid: >= $1 AND <= balance ----
+
+    @Test
+    fun withdrawValid_boundedByMinAndBalance() {
+        val balance = 5000L // $50.00
+        assertTrue(CashMath.isWithdrawValid("1", balance))
+        assertTrue(CashMath.isWithdrawValid("50", balance))
+        assertTrue(CashMath.isWithdrawValid("49.99", balance))
+        assertFalse(CashMath.isWithdrawValid("50.01", balance))     // over balance
+        assertFalse(CashMath.isWithdrawValid("0.99", balance))      // under $1
+        assertFalse(CashMath.isWithdrawValid("", balance))
+    }
+
+    @Test
+    fun withdrawValid_zeroBalanceBlocksEverything() {
+        assertFalse(CashMath.isWithdrawValid("1", 0L))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ const TradingBlotterPage = lazy(() => import("@/pages/blotter/TradingBlotterPage
 const TradingWorkspacePage = lazy(() => import("@/pages/blotter/TradingWorkspacePage"));
 const CustodyPage = lazy(() => import("@/pages/custody/CustodyPage"));
 const CustodyProvidersPage = lazy(() => import("@/pages/custody/CustodyProvidersPage"));
+const CustodyCashPage = lazy(() => import("@/pages/custody/CustodyCashPage"));
 const PortfolioPage = lazy(() => import("@/pages/portfolio/PortfolioPage"));
 const PortfolioAnalyticsPage = lazy(() => import("@/pages/portfolio/PortfolioAnalyticsPage"));
 const BailoutsBoardPage = lazy(() => import("@/pages/bailouts/BailoutsBoardPage"));
@@ -743,6 +744,7 @@ export default function App() {
           <Route path="blotter/single" element={<TradingBlotterPage />} />
           <Route path="custody" element={<CustodyPage />} />
           <Route path="custody/providers" element={<CustodyProvidersPage />} />
+          <Route path="custody/cash" element={<CustodyCashPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
           <Route path="portfolio/analytics" element={<PortfolioAnalyticsPage />} />
           <Route path="pnl" element={<PnLPage />} />

--- a/frontend/src/lib/cashMath.test.ts
+++ b/frontend/src/lib/cashMath.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MIN_CASH_CENTS,
+  dollarsToCents,
+  formatCents,
+  validateDeposit,
+  validateWithdraw,
+} from "@/lib/cashMath";
+
+describe("dollarsToCents", () => {
+  it("parses whole and fractional dollars to cents", () => {
+    expect(dollarsToCents("1")).toBe(100);
+    expect(dollarsToCents("10.50")).toBe(1050);
+    expect(dollarsToCents(".99")).toBe(99);
+    expect(dollarsToCents("0.01")).toBe(1);
+  });
+
+  it("rounds fractional inputs to whole cents", () => {
+    expect(dollarsToCents("1.004")).toBe(100);
+    expect(dollarsToCents("1.006")).toBe(101);
+    expect(dollarsToCents(19.99)).toBe(1999);
+    expect(dollarsToCents("0.125")).toBe(13);
+  });
+
+  it("returns NaN for blank / non-numeric / negative", () => {
+    expect(dollarsToCents("")).toBeNaN();
+    expect(dollarsToCents("   ")).toBeNaN();
+    expect(dollarsToCents("abc")).toBeNaN();
+    expect(dollarsToCents("-5")).toBeNaN();
+    expect(dollarsToCents("1.2.3")).toBeNaN();
+    expect(dollarsToCents(-1)).toBeNaN();
+    expect(dollarsToCents(NaN)).toBeNaN();
+  });
+});
+
+describe("formatCents", () => {
+  it("formats USD cents", () => {
+    expect(formatCents(100)).toBe("$1.00");
+    expect(formatCents(1050)).toBe("$10.50");
+    expect(formatCents(0)).toBe("$0.00");
+  });
+
+  it("falls back to $0.00 for non-finite input", () => {
+    expect(formatCents(NaN)).toBe("$0.00");
+  });
+});
+
+describe("validateDeposit", () => {
+  it("accepts amounts at or above the minimum", () => {
+    expect(validateDeposit("1")).toEqual({ cents: 100, valid: true, reason: null });
+    expect(validateDeposit("250.00").valid).toBe(true);
+  });
+
+  it("rejects below the $1 minimum", () => {
+    const r = validateDeposit("0.50");
+    expect(r.valid).toBe(false);
+    expect(r.cents).toBe(50);
+    expect(r.reason).toContain("Minimum");
+  });
+
+  it("rejects unparseable input", () => {
+    const r = validateDeposit("xyz");
+    expect(r.valid).toBe(false);
+    expect(r.cents).toBeNaN();
+    expect(r.reason).toBe("Enter a valid amount");
+  });
+
+  it("uses MIN_CASH_CENTS as the floor", () => {
+    expect(validateDeposit(MIN_CASH_CENTS / 100).valid).toBe(true);
+    expect(validateDeposit((MIN_CASH_CENTS - 1) / 100).valid).toBe(false);
+  });
+});
+
+describe("validateWithdraw", () => {
+  it("accepts amounts within balance", () => {
+    expect(validateWithdraw("10", 5000).valid).toBe(true);
+    expect(validateWithdraw("50", 5000).valid).toBe(true);
+  });
+
+  it("rejects amounts exceeding balance", () => {
+    const r = validateWithdraw("60", 5000);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain("Exceeds balance");
+  });
+
+  it("rejects below minimum before checking balance", () => {
+    const r = validateWithdraw("0.50", 100000);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain("Minimum");
+  });
+
+  it("treats a non-finite balance as zero", () => {
+    expect(validateWithdraw("1", NaN).valid).toBe(false);
+  });
+});

--- a/frontend/src/lib/cashMath.ts
+++ b/frontend/src/lib/cashMath.ts
@@ -1,0 +1,80 @@
+// Pure money helpers for the Cash (USD) custody/trading surface.
+// Reuses the same money model as the billing wallet: integer USD cents.
+// No React / no network — unit-testable in isolation.
+
+/** Minimum deposit/withdraw, matching the billing wallet's $1.00 floor. */
+export const MIN_CASH_CENTS = 100;
+
+/**
+ * Parse a user-typed dollar string into whole USD cents.
+ * Returns NaN for blank / non-numeric / negative input so callers can
+ * treat it as invalid. Rounds to the nearest cent (avoids fp drift).
+ */
+export function dollarsToCents(input: string | number): number {
+  if (typeof input === "number") {
+    if (!isFinite(input) || input < 0) return NaN;
+    return Math.round(input * 100);
+  }
+  const trimmed = (input ?? "").toString().trim();
+  if (trimmed === "") return NaN;
+  // Reject anything that is not a plain, non-negative decimal number.
+  if (!/^\d*\.?\d+$/.test(trimmed) && !/^\d+\.?\d*$/.test(trimmed)) return NaN;
+  const n = parseFloat(trimmed);
+  if (!isFinite(n) || n < 0) return NaN;
+  return Math.round(n * 100);
+}
+
+/** Format integer USD cents as a localized currency string. */
+export function formatCents(cents: number, currency = "USD"): string {
+  const safe = isFinite(cents) ? cents : 0;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: (currency || "USD").toUpperCase(),
+  }).format(safe / 100);
+}
+
+export interface AmountValidation {
+  /** Parsed whole cents (NaN when unparseable). */
+  cents: number;
+  /** True only when the amount is a fundable/withdrawable value. */
+  valid: boolean;
+  /** A short human reason when invalid, else null. */
+  reason: string | null;
+}
+
+/** Validate a deposit amount: parseable and >= the $1 minimum. */
+export function validateDeposit(input: string | number): AmountValidation {
+  const cents = dollarsToCents(input);
+  if (isNaN(cents)) {
+    return { cents: NaN, valid: false, reason: "Enter a valid amount" };
+  }
+  if (cents < MIN_CASH_CENTS) {
+    return {
+      cents,
+      valid: false,
+      reason: `Minimum is ${formatCents(MIN_CASH_CENTS)}`,
+    };
+  }
+  return { cents, valid: true, reason: null };
+}
+
+/**
+ * Validate a withdraw amount: parseable, >= $1, and <= the available balance.
+ * `balanceCents` is the current usable cash balance.
+ */
+export function validateWithdraw(
+  input: string | number,
+  balanceCents: number,
+): AmountValidation {
+  const base = validateDeposit(input);
+  if (!base.valid) return base;
+  const bal = isFinite(balanceCents) ? balanceCents : 0;
+  if (base.cents > bal) {
+    return {
+      cents: base.cents,
+      valid: false,
+      reason: `Exceeds balance (${formatCents(bal)})`,
+    };
+  }
+  return base;
+}

--- a/frontend/src/pages/custody/CustodyCashPage.tsx
+++ b/frontend/src/pages/custody/CustodyCashPage.tsx
@@ -1,0 +1,335 @@
+// Cash (USD) — the fiat on/off-ramp for the trading & custody area.
+//
+// This surface REUSES the existing billing wallet rails end-to-end:
+//   getWallet / depositToWallet / withdrawFromWallet / getPaymentMethods
+// (frontend/src/api/endpoints/billing.ts). It does NOT introduce a new
+// on-ramp. The billing USD wallet IS the trading/margin/fees cash source
+// (see fees.ts: pay_with "USD" = fiat wallet), so there is no separate
+// custody USD balance to bridge — that relationship is stated in copy.
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Banknote,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Info,
+  AlertTriangle,
+  CreditCard,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { ApiError } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import {
+  getWallet,
+  depositToWallet,
+  withdrawFromWallet,
+  getPaymentMethods,
+} from "@/api/endpoints/billing";
+import {
+  formatCents,
+  validateDeposit,
+  validateWithdraw,
+} from "@/lib/cashMath";
+
+export default function CustodyCashPage() {
+  const qc = useQueryClient();
+
+  const {
+    data: wallet,
+    isLoading: walletLoading,
+    error: walletError,
+  } = useQuery({
+    queryKey: ["billing", "wallet"],
+    queryFn: getWallet,
+    retry: false,
+  });
+
+  const { data: methods = [] } = useQuery({
+    queryKey: ["billing", "payment-methods"],
+    queryFn: getPaymentMethods,
+    retry: false,
+  });
+
+  const balanceCents = wallet?.wallet_balance_cents ?? 0;
+  const currency = (wallet?.currency ?? "usd").toUpperCase();
+
+  // Honest degrade-on-404: the wallet read is expected live, but if the
+  // billing backend isn't reachable we show an "unavailable" state.
+  const walletUnavailable =
+    walletError instanceof ApiError && walletError.status === 404;
+
+  // ── Deposit ────────────────────────────────────────────────────────────
+  const [depositDollars, setDepositDollars] = useState("");
+  const [depositPmId, setDepositPmId] = useState<string>("");
+  const [showDepositConfirm, setShowDepositConfirm] = useState(false);
+
+  const depositCheck = validateDeposit(depositDollars);
+
+  const depositMut = useMutation({
+    mutationFn: () =>
+      depositToWallet({
+        amount_cents: depositCheck.cents,
+        payment_method_id: depositPmId || undefined,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["billing", "wallet"] });
+      toast.success(`Added ${formatCents(depositCheck.cents)} to your cash balance`);
+      setDepositDollars("");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Deposit failed");
+    },
+  });
+
+  // ── Withdraw ───────────────────────────────────────────────────────────
+  const [withdrawDollars, setWithdrawDollars] = useState("");
+  const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false);
+
+  const withdrawCheck = validateWithdraw(withdrawDollars, balanceCents);
+
+  const withdrawMut = useMutation({
+    mutationFn: () => withdrawFromWallet({ amount_cents: withdrawCheck.cents }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["billing", "wallet"] });
+      toast.success(`Withdrew ${formatCents(withdrawCheck.cents)} from your cash balance`);
+      setWithdrawDollars("");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Withdrawal failed");
+    },
+  });
+
+  const noPaymentMethods = methods.length === 0;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl p-4 md:p-6">
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          <Banknote className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold tracking-tight md:text-2xl">Cash (USD)</h1>
+          <p className="text-sm text-muted-foreground">
+            Your fiat balance for the trading account.
+          </p>
+        </div>
+      </div>
+
+      {walletUnavailable ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-16 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+              <AlertTriangle className="h-6 w-6" />
+            </div>
+            <p className="font-medium">Cash is unavailable</p>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              Your USD wallet isn&apos;t reachable on this account yet. Try again
+              later or open{" "}
+              <Link to="/billing?tab=wallet" className="underline">
+                Billing
+              </Link>
+              .
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {/* Balance */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Banknote className="h-5 w-5" />
+                Cash balance
+              </CardTitle>
+              <CardDescription>
+                Usable for trading, margin &amp; fees
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {walletLoading ? (
+                <Skeleton className="h-10 w-40" />
+              ) : (
+                <p className="text-4xl font-bold">
+                  {formatCents(balanceCents, currency)}
+                </p>
+              )}
+              <div className="mt-3 flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+                <Info className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>
+                  This is your USD wallet — the same balance that funds your
+                  trading account, margin and platform fees. Adding cash here
+                  makes it immediately available to trade; there&apos;s no
+                  separate transfer step.
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Deposit */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ArrowDownToLine className="h-5 w-5" />
+                Add cash
+              </CardTitle>
+              <CardDescription>
+                Charge a payment method to fund your trading cash balance
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="cash-deposit-amount">Amount (USD)</Label>
+                <Input
+                  id="cash-deposit-amount"
+                  type="number"
+                  min="1"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={depositDollars}
+                  onChange={(e) => setDepositDollars(e.target.value)}
+                />
+                {depositDollars !== "" && !depositCheck.valid && (
+                  <p className="text-xs text-destructive">{depositCheck.reason}</p>
+                )}
+              </div>
+
+              {noPaymentMethods ? (
+                <div className="flex items-start gap-2 rounded-lg border border-warning/40 bg-warning/10 p-3 text-xs">
+                  <CreditCard className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    You don&apos;t have a payment method yet.{" "}
+                    <Link
+                      to="/billing?tab=methods"
+                      className="font-medium underline"
+                    >
+                      Add a payment method
+                    </Link>{" "}
+                    to add cash.
+                  </span>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <Label htmlFor="cash-deposit-pm">Payment method</Label>
+                  <Select value={depositPmId} onValueChange={setDepositPmId}>
+                    <SelectTrigger id="cash-deposit-pm">
+                      <SelectValue placeholder="Default payment method" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {methods.map((pm) => (
+                        <SelectItem
+                          key={pm.payment_method_id}
+                          value={pm.payment_method_id}
+                        >
+                          {pm.label ??
+                            `${pm.brand ?? pm.method_type} ····${pm.last4}`}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              <Button
+                onClick={() => setShowDepositConfirm(true)}
+                disabled={
+                  !depositCheck.valid || noPaymentMethods || depositMut.isPending
+                }
+              >
+                {depositMut.isPending ? "Adding…" : "Add cash"}
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Withdraw */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ArrowUpFromLine className="h-5 w-5" />
+                Withdraw cash
+              </CardTitle>
+              <CardDescription>
+                Move cash out of your trading account back to your bank
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="cash-withdraw-amount">Amount (USD)</Label>
+                <Input
+                  id="cash-withdraw-amount"
+                  type="number"
+                  min="1"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={withdrawDollars}
+                  onChange={(e) => setWithdrawDollars(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Available: {formatCents(balanceCents, currency)}
+                </p>
+                {withdrawDollars !== "" && !withdrawCheck.valid && (
+                  <p className="text-xs text-destructive">{withdrawCheck.reason}</p>
+                )}
+              </div>
+              <Button
+                variant="outline"
+                onClick={() => setShowWithdrawConfirm(true)}
+                disabled={!withdrawCheck.valid || withdrawMut.isPending}
+              >
+                {withdrawMut.isPending ? "Withdrawing…" : "Withdraw"}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Money-safety confirms */}
+      <ConfirmDialog
+        open={showDepositConfirm}
+        onOpenChange={setShowDepositConfirm}
+        title="Confirm deposit"
+        description={`Charge your payment method and add ${formatCents(
+          depositCheck.cents,
+        )} to your trading cash balance?`}
+        confirmLabel="Add cash"
+        onConfirm={() => {
+          setShowDepositConfirm(false);
+          depositMut.mutate();
+        }}
+      />
+      <ConfirmDialog
+        open={showWithdrawConfirm}
+        onOpenChange={setShowWithdrawConfirm}
+        title="Confirm withdrawal"
+        description={`Withdraw ${formatCents(
+          withdrawCheck.cents,
+        )} from your trading cash balance?`}
+        confirmLabel="Withdraw"
+        onConfirm={() => {
+          setShowWithdrawConfirm(false);
+          withdrawMut.mutate();
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/custody/CustodyPage.tsx
+++ b/frontend/src/pages/custody/CustodyPage.tsx
@@ -27,6 +27,7 @@ import {
   History,
   Sprout,
   Building2,
+  Banknote,
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
@@ -976,7 +977,13 @@ export default function CustodyPage() {
             Hold, receive and send crypto from your custodial vault.
           </p>
         </div>
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link to="/custody/cash">
+              <Banknote className="h-4 w-4" />
+              Cash (USD)
+            </Link>
+          </Button>
           <Button asChild variant="outline" size="sm" className="gap-1.5">
             <Link to="/custody/providers">
               <Building2 className="h-4 w-4" />

--- a/frontend/src/pages/invest/InvestHubPage.tsx
+++ b/frontend/src/pages/invest/InvestHubPage.tsx
@@ -11,10 +11,12 @@ import {
   Rocket,
   ChevronRight,
   Search,
+  Banknote,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
@@ -575,15 +577,23 @@ export default function InvestHubPage() {
       <SurfaceIntro surfaceId="invest" />
 
       <div className="space-y-3">
-        <div className="flex items-center gap-2">
-          <Sparkles className="h-6 w-6 text-primary" />
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">Invest</h1>
-            <p className="text-sm text-muted-foreground">
-              One front door to everything investable — markets, creator tokens, strategy funds,
-              staking & open opportunities.
-            </p>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-6 w-6 text-primary" />
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">Invest</h1>
+              <p className="text-sm text-muted-foreground">
+                One front door to everything investable — markets, creator tokens, strategy funds,
+                staking & open opportunities.
+              </p>
+            </div>
           </div>
+          <Button asChild variant="outline" size="sm" className="shrink-0 gap-1.5">
+            <Link to="/custody/cash">
+              <Banknote className="h-4 w-4" />
+              Add cash
+            </Link>
+          </Button>
         </div>
         <div className="relative max-w-md">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />


### PR DESCRIPTION
## Fiat (USD) Cash on-ramp for trading — reuses the existing billing wallet

Surfaces a fiat deposit/withdraw entry point for traders by **reusing the existing billing wallet** (`/ui/billing/wallet/*`), not a new rail. Per `fees.ts`, that USD wallet **is** the `pay_with:"USD"` balance used for trading, margin & fees — so no separate bridge/transfer is needed (made explicit in copy).

### Web
- `pages/custody/CustodyCashPage` (`/custody/cash`): balance ("Cash — usable for trading, margin & fees") + Deposit (amount ≥ $1 + payment-method select + money-safety confirm) + Withdraw (≤ balance). **Reuses** `getWallet`/`depositToWallet`/`withdrawFromWallet`/`getPaymentMethods` from `billing.ts` and shares its react-query cache; links to `/billing?tab=methods` when no PM.
- `lib/cashMath.ts` (+13 vitest); entry points from the Custody hub + Invest hub ("Add cash").

### Android (no wallet UI existed)
- `data/cash` (Api/Domain/Repository + Hilt) wired to the **same** `/ui/billing/wallet` + `/ui/billing/payment-methods` endpoints (thin module for the deposit/withdraw mutations `BillingApi` lacked); reads degrade-on-404.
- `feature/cash` Screen/ViewModel + `CashMath.kt` (+11 JVM tests): balance, deposit (PM picker + confirm), withdraw (Max + confirm); `MoreCatalog` + `MoreRoutes.REGISTERED` + `AuthenticatedGraph`.

No new deps. Gates: web tsc 0 · vite build · vitest 13/13; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (CashMath 11/11, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
