### PR TITLE
feat(fees): maker/taker fee tiers by 30-day trading volume (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingApi.kt
@@ -108,6 +108,13 @@ interface TradingApi {
     suspend fun getFillsFees(): FillsFeesDto
 
     /**
+     * OPTIONAL authoritative maker/taker fee-tier read (30d volume + tier + rates + next tier). 404
+     * until deployed -> the repository folds to null and the screen falls back to the client estimate.
+     */
+    @GET("me/fees/tier")
+    suspend fun getFeeTier(): FeeTierDto
+
+    /**
      * The account's LIVE working (resting) orders straight from the engine (order-management read).
      * Unlike the session-tracked list, this survives app restarts + reflects quote/OTO legs. Parsed
      * defensively ({orders:[{clordid,symbolid,side,price,qty,...}]}); 404/undeployed -> empty feed.

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingDtos.kt
@@ -360,6 +360,32 @@ data class FillFeeDto(
  * GET me/fills/fees (REAL): {status, type:"fills", count, fills:[...]}. The [fills] carry the engine's
  * real per-fill [FillFeeDto.fee] + maker/taker liquidity -> the client no longer estimates the fee.
  */
+/**
+ * OPTIONAL authoritative fee-tier read: GET me/fees/tier. 404 until deployed -> the repository folds
+ * to null and the screen falls back to the client-computed tier. All numeric fields are lenient (the
+ * edge may stringify ids/bps/int64). [nextTier] (when present) carries the id + threshold of the tier
+ * above the current one.
+ */
+@JsonClass(generateAdapter = true)
+data class FeeTierNextDto(
+    @Json(name = "tier_id") val tierId: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "min_volume_cents") val minVolumeCents: Long? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "maker_bps") val makerBps: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "taker_bps") val takerBps: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class FeeTierDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "tier_id") val tierId: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @com.testlogon.android.core.network.json.LenientLong @Json(name = "volume_30d_cents") val volume30dCents: Long? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "maker_bps") val makerBps: Int? = null,
+    @com.testlogon.android.core.network.json.LenientInt @Json(name = "taker_bps") val takerBps: Int? = null,
+    @Json(name = "next_tier") val nextTier: FeeTierNextDto? = null,
+)
+
 @JsonClass(generateAdapter = true)
 data class FillsFeesDto(
     @Json(name = "status") val status: String? = null,

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingModels.kt
@@ -378,6 +378,30 @@ fun FillFeeDto.toDomain(): FillFee = FillFee(
     tsNs = ts ?: 0L,
 )
 
+/**
+ * Authoritative fee-tier read (GET me/fees/tier), mapped to domain. When the backend serves this, the
+ * screen prefers it over the client estimate. [nextTierId] is the id of the tier above (null at top).
+ */
+data class FeeTierAuthoritative(
+    val tierId: String,
+    val name: String,
+    val volume30dCents: Long,
+    val makerBps: Int,
+    val takerBps: Int,
+    val nextTierId: String?,
+    val nextTierMinVolumeCents: Long?,
+)
+
+fun FeeTierDto.toDomain(): FeeTierAuthoritative = FeeTierAuthoritative(
+    tierId = tierId.orEmpty(),
+    name = name.orEmpty(),
+    volume30dCents = volume30dCents ?: 0L,
+    makerBps = makerBps ?: 0,
+    takerBps = takerBps ?: 0,
+    nextTierId = nextTier?.tierId,
+    nextTierMinVolumeCents = nextTier?.minVolumeCents,
+)
+
 fun FillsFeesDto.toDomain(): FillsFees = FillsFees(
     fills = fills.orEmpty().map { it.toDomain() },
     count = count ?: fills.orEmpty().size,

--- a/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/exchange/TradingRepository.kt
@@ -63,6 +63,11 @@ interface TradingRepository {
     /** Fees (custody-exchange-gaps): the caller's fee schedule + the enriched fills-fees feed. */
     suspend fun feeSchedule(symbolId: Int): ApiResult<FeeSchedule>
     suspend fun fillsFees(): ApiResult<FillsFees>
+    /**
+     * OPTIONAL authoritative fee-tier read (GET me/fees/tier). A 404 (endpoint not deployed) folds to
+     * Success(null) so the caller falls back to the client-computed tier; a real error still surfaces.
+     */
+    suspend fun feeTier(): ApiResult<FeeTierAuthoritative?>
     /** LIVE working orders straight from the engine (order-management read; 404 -> empty feed). */
     suspend fun ordersLive(): ApiResult<LiveOrders>
     /** Recent forced-liquidation events (404 -> empty feed). */
@@ -210,6 +215,9 @@ class TradingRepositoryImpl @Inject constructor(
 
     override suspend fun fillsFees(): ApiResult<FillsFees> =
         withContext(io) { emptyOn404(FillsFees(emptyList(), 0)) { api.getFillsFees().toDomain() } }
+
+    override suspend fun feeTier(): ApiResult<FeeTierAuthoritative?> =
+        withContext(io) { emptyOn404<FeeTierAuthoritative?>(null) { api.getFeeTier().toDomain() } }
 
     override suspend fun ordersLive(): ApiResult<LiveOrders> =
         withContext(io) { emptyOn404(LiveOrders(emptyList(), 0)) { api.getOrdersLive().toDomain() } }

--- a/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardScreen.kt
@@ -552,6 +552,14 @@ private fun TradingSection(
                 iconTint = scheme.onPrimaryContainer,
                 onClick = { onOpenRoute(MoreRoutes.TAX_REPORT) },
             )
+            TradingCard(
+                icon = Icons.Outlined.TrendingUp,
+                label = stringResource(R.string.dashboard_trading_fee_tiers),
+                testTag = DashboardTestTags.TRADING_FEE_TIERS,
+                circleColor = scheme.secondaryContainer,
+                iconTint = scheme.onSecondaryContainer,
+                onClick = { onOpenRoute(MoreRoutes.FEE_TIERS) },
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardTestTags.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dashboard/DashboardTestTags.kt
@@ -41,4 +41,5 @@ object DashboardTestTags {
     const val TRADING_BAILOUTS = "dashboard_trading_bailouts"
     const val TRADING_CUSTODY_PROVIDERS = "dashboard_trading_custody_providers"
     const val TRADING_TAX_GAINS = "dashboard_trading_tax_gains"
+    const val TRADING_FEE_TIERS = "dashboard_trading_fee_tiers"
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTierMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTierMath.kt
@@ -1,0 +1,153 @@
+package com.testlogon.android.feature.feetiers
+
+import com.testlogon.android.data.exchange.FillFee
+
+/**
+ * Pure, dependency-free MAKER/TAKER FEE-TIER (VIP schedule) engine, computed CLIENT-SIDE from the
+ * account's executed fills. NO framework, NO I/O, NO Android — every monetary value is an INTEGER in
+ * USD cents and every rate is an integer basis-point (bps), so the arithmetic is exact and the module
+ * is trivially unit-testable (see FeeTierMathTest).
+ *
+ * A trader's fee tier is a function of their 30-day rolling trading VOLUME (sum of executed-fill
+ * NOTIONAL = price*qty). Higher volume -> lower maker & taker rates. [FEE_TIERS] is CANONICAL and is
+ * an EXACT mirror of the web client's frontend/src/lib/feeTiers.ts — do NOT change the
+ * thresholds/rates here without changing both.
+ */
+object FeeTierMath {
+
+    /** One tier in the maker/taker VIP schedule. */
+    data class FeeTier(
+        /** Stable id shared with the authoritative backend read. */
+        val id: String,
+        /** Human label. */
+        val name: String,
+        /** Minimum 30-day volume (USD cents, inclusive) to qualify for this tier. */
+        val minVolumeCents: Long,
+        /** Maker fee, basis points. */
+        val makerBps: Int,
+        /** Taker fee, basis points. */
+        val takerBps: Int,
+    )
+
+    /**
+     * Canonical maker/taker VIP schedule (ascending by threshold). Identical to the web feeTiers.ts:
+     * Standard $0 10/15 ; Bronze $50k 9/14 ; Silver $250k 8/12 ; Gold $1M 6/10 ; Platinum $5M 4/8 ;
+     * Diamond (VIP) $25M 2/6.
+     */
+    val FEE_TIERS: List<FeeTier> = listOf(
+        FeeTier("standard", "Standard", 0L, 10, 15),
+        FeeTier("bronze", "Bronze", 50_000_00L, 9, 14),
+        FeeTier("silver", "Silver", 250_000_00L, 8, 12),
+        FeeTier("gold", "Gold", 1_000_000_00L, 6, 10),
+        FeeTier("platinum", "Platinum", 5_000_000_00L, 4, 8),
+        FeeTier("diamond", "Diamond (VIP)", 25_000_000_00L, 2, 6),
+    )
+
+    /** One normalized executed fill for the volume sum. [ts] is unix seconds OR milliseconds. */
+    data class VolumeFill(
+        /** Unix timestamp — seconds OR milliseconds (engine-native). */
+        val ts: Long,
+        /** Per-unit executed price, integer minor units (cents). */
+        val priceCents: Long,
+        /** Executed quantity (treated as a positive magnitude). */
+        val qty: Long,
+    )
+
+    private const val DAY_MS = 24L * 60L * 60L * 1000L
+
+    // A ts below this is assumed to be seconds; at/above, milliseconds. (~2001 in ms / ~33k AD in s —
+    // the same heuristic the web engine uses.)
+    private const val MS_THRESHOLD = 1_000_000_000_000L
+
+    private fun toMs(ts: Long): Long = if (ts < MS_THRESHOLD) ts * 1000L else ts
+
+    /**
+     * Normalize the account's [FillFee] feed (nanosecond ts, raw integer price/qty — price scalers are
+     * identity today, matching the Tax report) into [VolumeFill]s for the volume sum.
+     */
+    fun fromFills(fills: List<FillFee>): List<VolumeFill> =
+        fills.map { VolumeFill(ts = it.tsNs / 1_000_000L, priceCents = it.price, qty = it.qty) }
+
+    /**
+     * Sum of executed-fill NOTIONAL (priceCents * qty) within the trailing [windowDays] window ending
+     * at [nowMs]. Fills outside the window, or with non-positive price/qty, are ignored. Timestamps
+     * accept seconds OR milliseconds. Never negative.
+     */
+    fun volume30dCents(
+        fills: List<VolumeFill>,
+        nowMs: Long,
+        windowDays: Int = 30,
+    ): Long {
+        if (fills.isEmpty()) return 0L
+        val window = maxOf(0, windowDays).toLong() * DAY_MS
+        val cutoff = nowMs - window
+        var total = 0L
+        for (f in fills) {
+            if (f.priceCents <= 0L || f.qty <= 0L) continue
+            val ms = toMs(f.ts)
+            if (ms < cutoff || ms > nowMs) continue
+            total += f.priceCents * f.qty
+        }
+        return if (total < 0L) 0L else total
+    }
+
+    /**
+     * The highest tier whose [FeeTier.minVolumeCents] is <= [volumeCents]. Negative / empty volume ->
+     * Standard (the first tier). Always returns a tier.
+     */
+    fun tierForVolume(volumeCents: Long): FeeTier {
+        val v = if (volumeCents > 0L) volumeCents else 0L
+        var match = FEE_TIERS.first()
+        for (t in FEE_TIERS) {
+            if (v >= t.minVolumeCents) match = t else break
+        }
+        return match
+    }
+
+    /** Look up a tier by its stable id (e.g. from the authoritative backend read). */
+    fun tierById(id: String): FeeTier? = FEE_TIERS.firstOrNull { it.id == id }
+
+    /** The next-higher tier above [tier], or null when already at the top. */
+    fun nextTier(tier: FeeTier): FeeTier? {
+        val i = FEE_TIERS.indexOfFirst { it.id == tier.id }
+        if (i < 0 || i >= FEE_TIERS.size - 1) return null
+        return FEE_TIERS[i + 1]
+    }
+
+    /**
+     * Progress (0..1) toward the NEXT tier's threshold, measured from the CURRENT tier's threshold.
+     * Returns 1.0 when already at the top tier. Clamped to [0,1].
+     */
+    fun progressToNextFraction(volumeCents: Long): Double {
+        val v = if (volumeCents > 0L) volumeCents else 0L
+        val current = tierForVolume(v)
+        val next = nextTier(current) ?: return 1.0
+        val span = next.minVolumeCents - current.minVolumeCents
+        if (span <= 0L) return 1.0
+        val gained = v - current.minVolumeCents
+        val frac = gained.toDouble() / span.toDouble()
+        return when {
+            frac <= 0.0 -> 0.0
+            frac >= 1.0 -> 1.0
+            else -> frac
+        }
+    }
+
+    /** USD cents of additional volume needed to reach the next tier (0 at top). */
+    fun volumeToNextTierCents(volumeCents: Long): Long {
+        val v = if (volumeCents > 0L) volumeCents else 0L
+        val next = nextTier(tierForVolume(v)) ?: return 0L
+        val remaining = next.minVolumeCents - v
+        return if (remaining > 0L) remaining else 0L
+    }
+
+    /**
+     * Fee (integer cents, rounded half-up) charged on [notionalCents] at [bps] basis points.
+     * bps of 15 = 0.15%. Guards non-positive inputs -> 0.
+     */
+    fun makerTakerFeeCents(notionalCents: Long, bps: Int): Long {
+        if (notionalCents <= 0L || bps <= 0) return 0L
+        // fee = notional * bps / 10_000, rounded half-up for a deterministic result.
+        return (notionalCents * bps + 5_000L) / 10_000L
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTiersScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTiersScreen.kt
@@ -1,0 +1,280 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.feetiers
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.util.Locale
+
+/**
+ * The maker/taker FEE TIER (VIP schedule) surface, reached from the More -> Wallet hub (near Tax).
+ * Shows the caller's current tier + rates, their trailing 30-day trading volume, progress to the next
+ * tier, and the full canonical schedule with the caller's row highlighted. Volume is computed
+ * client-side from the live fills feed (same source as the Tax report); an authoritative backend read
+ * overrides when deployed. No money movement.
+ */
+@Composable
+fun FeeTiersRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: FeeTiersViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    FeeTiersScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun FeeTiersScreen(
+    state: FeeTiersUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Fee tiers") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when {
+            state.loading -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            state.error != null -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+                Text(state.error, color = MaterialTheme.colorScheme.error)
+            }
+            else -> Content(state, padding)
+        }
+    }
+}
+
+@Composable
+private fun Content(state: FeeTiersUiState, padding: PaddingValues) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(
+            start = 16.dp,
+            end = 16.dp,
+            top = padding.calculateTopPadding() + 12.dp,
+            bottom = padding.calculateBottomPadding() + 24.dp,
+        ),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { CurrentTierCard(state) }
+        if (!state.isTopTier) item { ProgressCard(state) }
+        item {
+            Text(
+                "Maker/taker rates are set by your trailing 30-day trading volume. All tiers:",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        item { TableHeader() }
+        items(state.tiers, key = { it.id }) { row -> TierRow(row) }
+        item {
+            val note = if (state.estimated) {
+                if (state.empty) {
+                    "No trades yet, so you are on the Standard tier. Rates shown are estimated from your trade history."
+                } else {
+                    "Estimated from your trade history (30-day fills). The exchange rate applies at match time."
+                }
+            } else {
+                "Confirmed by the exchange."
+            }
+            Text(
+                note,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CurrentTierCard(state: FeeTiersUiState) {
+    Card(
+        Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Your tier",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Text(
+                state.currentTierName,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(12.dp))
+            Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
+                Stat("Maker", bpsPct(state.makerBps))
+                Stat("Taker", bpsPct(state.takerBps))
+                Stat("30-day volume", usd(state.volume30dCents))
+            }
+        }
+    }
+}
+
+@Composable
+private fun Stat(label: String, value: String) {
+    Column {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        Text(
+            value,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
+}
+
+@Composable
+private fun ProgressCard(state: FeeTiersUiState) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                "Progress to " + (state.nextTierName ?: ""),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { state.progressToNext },
+                modifier = Modifier.fillMaxWidth().height(8.dp),
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                usd(state.volumeToNextCents) + " more 30-day volume to reach " + (state.nextTierName ?: "") + ".",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TableHeader() {
+    Row(Modifier.fillMaxWidth().padding(horizontal = 4.dp)) {
+        HeaderCell("Tier", 2.2f)
+        HeaderCell("30d vol", 1.8f)
+        HeaderCell("Maker", 1.2f)
+        HeaderCell("Taker", 1.2f)
+    }
+}
+
+@Composable
+private fun RowScope.HeaderCell(text: String, weight: Float) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.weight(weight),
+    )
+}
+
+@Composable
+private fun TierRow(row: FeeTierRow) {
+    val bg = if (row.isCurrent) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent
+    val fw = if (row.isCurrent) FontWeight.Bold else FontWeight.Normal
+    Row(
+        Modifier.fillMaxWidth().background(bg).padding(horizontal = 4.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Cell(row.name + (if (row.isCurrent) "  (you)" else ""), 2.2f, fw)
+        Cell(usdShort(row.minVolumeCents), 1.8f, fw)
+        Cell(bpsPct(row.makerBps), 1.2f, fw)
+        Cell(bpsPct(row.takerBps), 1.2f, fw)
+    }
+}
+
+@Composable
+private fun RowScope.Cell(text: String, weight: Float, fw: FontWeight) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = fw,
+        fontSize = 14.sp,
+        modifier = Modifier.weight(weight),
+    )
+}
+
+// ---- formatting helpers ----
+
+private fun bpsPct(bps: Int): String = String.format(Locale.US, "%.2f%%", bps / 100.0)
+
+private fun usd(cents: Long): String = "$" + String.format(Locale.US, "%,.2f", cents / 100.0)
+
+private fun usdShort(cents: Long): String {
+    val d = cents / 100.0
+    return when {
+        d >= 1_000_000 -> "$" + trimZeros(d / 1_000_000.0) + "M"
+        d >= 1_000 -> "$" + trimZeros(d / 1_000.0) + "K"
+        else -> "$" + String.format(Locale.US, "%,.0f", d)
+    }
+}
+
+private fun trimZeros(v: Double): String {
+    val s = String.format(Locale.US, "%.1f", v)
+    return if (s.endsWith(".0")) s.dropLast(2) else s
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTiersUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTiersUiState.kt
@@ -1,0 +1,36 @@
+package com.testlogon.android.feature.feetiers
+
+/** One row in the rendered tier table. [isCurrent] highlights the user's tier. */
+data class FeeTierRow(
+    val id: String,
+    val name: String,
+    val minVolumeCents: Long,
+    val makerBps: Int,
+    val takerBps: Int,
+    val isCurrent: Boolean,
+)
+
+/** UI state for the maker/taker fee-tier (VIP schedule) screen. */
+data class FeeTiersUiState(
+    val loading: Boolean = true,
+    val error: String? = null,
+    /** True when there are no fills at all and no authoritative read -> honest empty state. */
+    val empty: Boolean = false,
+    /** True when the tier/volume come from the client estimate (fills feed), not the backend. */
+    val estimated: Boolean = true,
+    /** 30-day rolling trading volume, USD cents. */
+    val volume30dCents: Long = 0L,
+    val currentTierId: String = "standard",
+    val currentTierName: String = "Standard",
+    val makerBps: Int = 10,
+    val takerBps: Int = 15,
+    /** null when already at the top tier. */
+    val nextTierName: String? = null,
+    val nextTierMinVolumeCents: Long? = null,
+    /** cents of additional 30d volume to reach the next tier (0 at top). */
+    val volumeToNextCents: Long = 0L,
+    /** progress 0..1 toward the next tier (1.0 at top). */
+    val progressToNext: Float = 0f,
+    val isTopTier: Boolean = false,
+    val tiers: List<FeeTierRow> = emptyList(),
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTiersViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTiersViewModel.kt
@@ -1,0 +1,153 @@
+package com.testlogon.android.feature.feetiers
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.FeeTierAuthoritative
+import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.TradingRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel for the maker/taker FEE TIER (VIP schedule) screen. Assembles the account's 30-day
+ * trading volume CLIENT-SIDE from the same live fills feed the Tax report uses (GET me/fills/fees;
+ * degrades to empty on 404) and runs the pure [FeeTierMath] engine to derive the current tier, rates,
+ * and progress to the next tier. An OPTIONAL authoritative backend read (GET me/fees/tier) is
+ * PREFERRED when present; on 404 the screen falls back to the client estimate ("estimated from your
+ * trade history"). No money movement.
+ */
+@HiltViewModel
+class FeeTiersViewModel @Inject constructor(
+    private val trading: TradingRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(FeeTiersUiState())
+    val uiState: StateFlow<FeeTiersUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.value = FeeTiersUiState(loading = true)
+        viewModelScope.launch {
+            _uiState.value = coroutineScope {
+                val fillsDef = async { trading.fillsFees() }
+                val tierDef = async { trading.feeTier() }
+                project(fillsDef.await(), tierDef.await(), System.currentTimeMillis())
+            }
+        }
+    }
+
+    internal fun project(
+        fillsResult: ApiResult<FillsFees>,
+        tierResult: ApiResult<FeeTierAuthoritative?>,
+        nowMs: Long,
+    ): FeeTiersUiState {
+        // Prefer the authoritative read when the backend actually served a tier.
+        val authoritative = (tierResult as? ApiResult.Success)?.data
+        if (authoritative != null && authoritative.tierId.isNotBlank()) {
+            return fromAuthoritative(authoritative)
+        }
+
+        // Client estimate from the fills feed.
+        val fills = when (fillsResult) {
+            is ApiResult.Success -> fillsResult.data.fills
+            is ApiResult.NetworkError -> return FeeTiersUiState(loading = false, error = "Network error. Pull to retry.")
+            is ApiResult.Failure -> return FeeTiersUiState(loading = false, error = "Couldn't load trade history.")
+        }
+
+        if (fills.isEmpty()) {
+            // Honest empty state: no fills AND no authoritative read -> show the schedule at Standard.
+            return baseState(
+                estimated = true,
+                empty = true,
+                volumeCents = 0L,
+                tier = FeeTierMath.FEE_TIERS.first(),
+            )
+        }
+
+        val volume = FeeTierMath.volume30dCents(FeeTierMath.fromFills(fills), nowMs)
+        val tier = FeeTierMath.tierForVolume(volume)
+        return baseState(estimated = true, empty = false, volumeCents = volume, tier = tier)
+    }
+
+    private fun fromAuthoritative(a: FeeTierAuthoritative): FeeTiersUiState {
+        // Resolve the authoritative tier against the canonical table for the highlight + full schedule;
+        // fall back to the wire fields when the id is unknown.
+        val canonical = FeeTierMath.tierById(a.tierId)
+        val effectiveTierId = canonical?.id ?: a.tierId
+        val makerBps = a.makerBps.takeIf { it > 0 } ?: canonical?.makerBps ?: 0
+        val takerBps = a.takerBps.takeIf { it > 0 } ?: canonical?.takerBps ?: 0
+        val next = canonical?.let { FeeTierMath.nextTier(it) }
+        val nextName = next?.name ?: a.nextTierId?.let { FeeTierMath.tierById(it)?.name }
+        val nextMin = next?.minVolumeCents ?: a.nextTierMinVolumeCents
+        val toNext = if (nextMin != null) (nextMin - a.volume30dCents).coerceAtLeast(0L) else 0L
+        val progress = if (canonical != null) {
+            FeeTierMath.progressToNextFraction(a.volume30dCents)
+        } else if (nextMin != null && nextMin > 0L) {
+            (a.volume30dCents.toDouble() / nextMin.toDouble()).coerceIn(0.0, 1.0)
+        } else 1.0
+
+        return FeeTiersUiState(
+            loading = false,
+            estimated = false,
+            empty = false,
+            volume30dCents = a.volume30dCents,
+            currentTierId = effectiveTierId,
+            currentTierName = a.name.ifBlank { canonical?.name ?: effectiveTierId },
+            makerBps = makerBps,
+            takerBps = takerBps,
+            nextTierName = nextName,
+            nextTierMinVolumeCents = nextMin,
+            volumeToNextCents = toNext,
+            progressToNext = progress.toFloat(),
+            isTopTier = nextName == null,
+            tiers = tableRows(effectiveTierId),
+        )
+    }
+
+    private fun baseState(
+        estimated: Boolean,
+        empty: Boolean,
+        volumeCents: Long,
+        tier: FeeTierMath.FeeTier,
+    ): FeeTiersUiState {
+        val next = FeeTierMath.nextTier(tier)
+        return FeeTiersUiState(
+            loading = false,
+            estimated = estimated,
+            empty = empty,
+            volume30dCents = volumeCents,
+            currentTierId = tier.id,
+            currentTierName = tier.name,
+            makerBps = tier.makerBps,
+            takerBps = tier.takerBps,
+            nextTierName = next?.name,
+            nextTierMinVolumeCents = next?.minVolumeCents,
+            volumeToNextCents = FeeTierMath.volumeToNextTierCents(volumeCents),
+            progressToNext = FeeTierMath.progressToNextFraction(volumeCents).toFloat(),
+            isTopTier = next == null,
+            tiers = tableRows(tier.id),
+        )
+    }
+
+    private fun tableRows(currentId: String): List<FeeTierRow> =
+        FeeTierMath.FEE_TIERS.map {
+            FeeTierRow(
+                id = it.id,
+                name = it.name,
+                minVolumeCents = it.minVolumeCents,
+                makerBps = it.makerBps,
+                takerBps = it.takerBps,
+                isCurrent = it.id == currentId,
+            )
+        }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1050,6 +1050,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "fee_tiers",
+            labelRes = R.string.more_entry_fee_tiers,
+            icon = Icons.Outlined.TrendingUp,
+            route = MoreRoutes.FEE_TIERS,
+            hub = MoreHub.WALLET,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "catalog",
             labelRes = R.string.more_entry_catalog,
             icon = Icons.Outlined.Storefront,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -236,6 +236,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         reportsDestination(navController)
         // Tax lots & realized-gains: read-only client-side FIFO/LIFO/Average cost-basis report + CSV.
         taxReportDestination(navController)
+        // Fee tiers (maker/taker VIP schedule): client-computed 30d volume + tier + progress; authoritative override.
+        feeTiersDestination(navController)
         // AND-336: backend-mediated Google Drive import picker (authenticated-only).
         driveImportDestination(navController)
         // AND-335: owner share sheet (create/list/revoke share links) + the public share screen

--- a/android/app/src/main/java/com/testlogon/android/navigation/FeeTiersNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/FeeTiersNavigation.kt
@@ -1,0 +1,25 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.feetiers.FeeTiersRoute
+
+/**
+ * The maker/taker FEE TIER (VIP schedule) surface, reached from the More -> Wallet hub (near Tax).
+ * Shows the caller's current tier + rates, their trailing 30-day trading volume (client-computed from
+ * the live fills feed, same source as the Tax report; overridden by an authoritative backend read when
+ * deployed), progress to the next tier, and the full canonical schedule. No money movement.
+ */
+data object FeeTiersDest {
+    const val ROUTE = "fee_tiers"
+}
+
+/** Registers the Fee Tiers screen in the authenticated graph. Up / Back pops the back stack. */
+fun NavGraphBuilder.feeTiersDestination(navController: NavHostController) {
+    composable(FeeTiersDest.ROUTE) {
+        FeeTiersRoute(
+            onBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -135,6 +135,10 @@ object MoreRoutes {
     // Tax lots & realized-gains: read-only client-side cost-basis report (Wallet hub, near Reports).
     const val TAX_REPORT = TaxReportDest.ROUTE
 
+    // Fee tiers (maker/taker VIP schedule by 30-day volume): client-computed from the fills feed;
+    // optional authoritative GET me/fees/tier overrides (Wallet hub, near Tax).
+    const val FEE_TIERS = FeeTiersDest.ROUTE
+
     // AND-219: the purchase history list + search.
     val PURCHASE_HISTORY: String get() = PurchaseHistoryDest.ROUTE
 
@@ -634,6 +638,7 @@ object MoreRoutes {
             PAPER,
             REPORTS,
             TAX_REPORT,
+            FEE_TIERS,
             PURCHASE_HISTORY,
             PAYMENT_METHODS,
             WALLET_TRANSACTIONS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="dashboard_trading_bailouts">Bailouts</string>
     <string name="dashboard_trading_custody_providers">Custody providers</string>
     <string name="dashboard_trading_tax_gains">Tax &amp; gains</string>
+    <string name="dashboard_trading_fee_tiers">Fee tiers</string>
 
     <!-- "More" hub (AND-067) -->
     <string name="more_title">More</string>
@@ -1484,6 +1485,7 @@
     <string name="more_entry_paper_trading">Paper Trading</string>
     <string name="more_entry_reports">Export &amp; reporting</string>
     <string name="more_entry_tax_report">Tax lots &amp; gains</string>
+    <string name="more_entry_fee_tiers">Fee tiers</string>
     <string name="story_ring_unseen">Story from %1$s, unseen</string>
     <string name="story_ring_seen">Story from %1$s, seen</string>
     <string name="story_close">Close stories</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/feetiers/FeeTierMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/feetiers/FeeTierMathTest.kt
@@ -1,0 +1,141 @@
+package com.testlogon.android.feature.feetiers
+
+import com.testlogon.android.feature.feetiers.FeeTierMath.VolumeFill
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure JVM tests for the client-side maker/taker fee-tier engine. */
+class FeeTierMathTest {
+
+    private val nowMs = 1_700_000_000_000L // fixed "now" in ms
+    private fun daysAgoMs(d: Long) = nowMs - d * 24L * 60L * 60L * 1000L
+
+    @Test
+    fun schedule_isCanonical_sixTiersAscending() {
+        val t = FeeTierMath.FEE_TIERS
+        assertEquals(6, t.size)
+        assertEquals(listOf("standard", "bronze", "silver", "gold", "platinum", "diamond"), t.map { it.id })
+        // thresholds strictly ascending
+        for (i in 1 until t.size) assertTrue(t[i].minVolumeCents > t[i - 1].minVolumeCents)
+        // exact canonical thresholds + rates
+        assertEquals(0L, t[0].minVolumeCents); assertEquals(10, t[0].makerBps); assertEquals(15, t[0].takerBps)
+        assertEquals(50_000_00L, t[1].minVolumeCents); assertEquals(9, t[1].makerBps); assertEquals(14, t[1].takerBps)
+        assertEquals(250_000_00L, t[2].minVolumeCents); assertEquals(8, t[2].makerBps); assertEquals(12, t[2].takerBps)
+        assertEquals(1_000_000_00L, t[3].minVolumeCents); assertEquals(6, t[3].makerBps); assertEquals(10, t[3].takerBps)
+        assertEquals(5_000_000_00L, t[4].minVolumeCents); assertEquals(4, t[4].makerBps); assertEquals(8, t[4].takerBps)
+        assertEquals(25_000_000_00L, t[5].minVolumeCents); assertEquals(2, t[5].makerBps); assertEquals(6, t[5].takerBps)
+    }
+
+    @Test
+    fun volume_emptyIsZero() {
+        assertEquals(0L, FeeTierMath.volume30dCents(emptyList(), nowMs))
+    }
+
+    @Test
+    fun volume_sumsNotionalInWindow() {
+        val fills = listOf(
+            VolumeFill(daysAgoMs(1), 100_00L, 3), // 300_00
+            VolumeFill(daysAgoMs(10), 50_00L, 2), // 100_00
+        )
+        assertEquals(400_00L, FeeTierMath.volume30dCents(fills, nowMs))
+    }
+
+    @Test
+    fun volume_excludesOutsideWindowAndFuture() {
+        val fills = listOf(
+            VolumeFill(daysAgoMs(1), 100_00L, 1),   // in
+            VolumeFill(daysAgoMs(31), 100_00L, 1),  // too old
+            VolumeFill(nowMs + 5_000L, 100_00L, 1), // future
+        )
+        assertEquals(100_00L, FeeTierMath.volume30dCents(fills, nowMs))
+    }
+
+    @Test
+    fun volume_ignoresNonPositivePriceOrQty() {
+        val fills = listOf(
+            VolumeFill(daysAgoMs(1), 0L, 5),
+            VolumeFill(daysAgoMs(1), 100_00L, 0),
+            VolumeFill(daysAgoMs(1), -100_00L, 5),
+            VolumeFill(daysAgoMs(1), 100_00L, 2), // only this counts: 200_00
+        )
+        assertEquals(200_00L, FeeTierMath.volume30dCents(fills, nowMs))
+    }
+
+    @Test
+    fun volume_acceptsSecondsTimestamps() {
+        val nowSec = nowMs / 1000L
+        val oneDayAgoSec = nowSec - 24L * 60L * 60L
+        val fills = listOf(VolumeFill(oneDayAgoSec, 100_00L, 4)) // 400_00
+        assertEquals(400_00L, FeeTierMath.volume30dCents(fills, nowMs))
+    }
+
+    @Test
+    fun volume_customWindowDays() {
+        val fills = listOf(
+            VolumeFill(daysAgoMs(3), 100_00L, 1),
+            VolumeFill(daysAgoMs(10), 100_00L, 1),
+        )
+        // 7-day window keeps only the 3-day-ago fill
+        assertEquals(100_00L, FeeTierMath.volume30dCents(fills, nowMs, windowDays = 7))
+    }
+
+    @Test
+    fun tierForVolume_boundariesAndBelowZero() {
+        assertEquals("standard", FeeTierMath.tierForVolume(0L).id)
+        assertEquals("standard", FeeTierMath.tierForVolume(-100L).id)
+        assertEquals("standard", FeeTierMath.tierForVolume(49_999_99L).id)
+        assertEquals("bronze", FeeTierMath.tierForVolume(50_000_00L).id) // inclusive boundary
+        assertEquals("silver", FeeTierMath.tierForVolume(300_000_00L).id)
+        assertEquals("diamond", FeeTierMath.tierForVolume(99_000_000_00L).id)
+    }
+
+    @Test
+    fun nextTier_walksUpAndCapsAtTop() {
+        assertEquals("bronze", FeeTierMath.nextTier(FeeTierMath.tierById("standard")!!)!!.id)
+        assertEquals("diamond", FeeTierMath.nextTier(FeeTierMath.tierById("platinum")!!)!!.id)
+        assertNull(FeeTierMath.nextTier(FeeTierMath.tierById("diamond")!!))
+    }
+
+    @Test
+    fun tierById_unknownIsNull() {
+        assertNull(FeeTierMath.tierById("nope"))
+        assertEquals("gold", FeeTierMath.tierById("gold")!!.id)
+    }
+
+    @Test
+    fun progress_zeroAtTierStart_halfMidway_oneAtTop() {
+        // exactly at bronze start -> 0 toward silver
+        assertEquals(0.0, FeeTierMath.progressToNextFraction(50_000_00L), 1e-9)
+        // midway bronze(50k)->silver(250k) span 200k, +100k => 0.5
+        assertEquals(0.5, FeeTierMath.progressToNextFraction(150_000_00L), 1e-9)
+        // at/above top tier => 1.0
+        assertEquals(1.0, FeeTierMath.progressToNextFraction(25_000_000_00L), 1e-9)
+        assertEquals(1.0, FeeTierMath.progressToNextFraction(99_000_000_00L), 1e-9)
+        // negative => 0 (standard, 0% toward bronze)
+        assertEquals(0.0, FeeTierMath.progressToNextFraction(-5L), 1e-9)
+    }
+
+    @Test
+    fun volumeToNextTier_remainderAndZeroAtTop() {
+        assertEquals(50_000_00L, FeeTierMath.volumeToNextTierCents(0L))
+        assertEquals(100_000_00L, FeeTierMath.volumeToNextTierCents(150_000_00L)) // to silver 250k
+        assertEquals(0L, FeeTierMath.volumeToNextTierCents(25_000_000_00L))
+    }
+
+    @Test
+    fun makerTakerFee_roundsHalfUpAndGuards() {
+        // 1_000_00 cents @ 15bps = 150_00 * ... 100000*15/10000 = 150
+        assertEquals(150L, FeeTierMath.makerTakerFeeCents(100_000L, 15))
+        // 12345 * 10 / 10000 = 12.345 -> round to 12
+        assertEquals(12L, FeeTierMath.makerTakerFeeCents(12345L, 10))
+        // half-up: 5000 * 10 / 10000 = 5.0 exact
+        assertEquals(5L, FeeTierMath.makerTakerFeeCents(5000L, 10))
+        // 7500 * 10 / 10000 = 7.5 -> 8 (half up)
+        assertEquals(8L, FeeTierMath.makerTakerFeeCents(7500L, 10))
+        assertEquals(0L, FeeTierMath.makerTakerFeeCents(0L, 15))
+        assertEquals(0L, FeeTierMath.makerTakerFeeCents(100_000L, 0))
+        assertEquals(0L, FeeTierMath.makerTakerFeeCents(-1L, 15))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/trading/TradingFakes.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/trading/TradingFakes.kt
@@ -28,6 +28,7 @@ import com.testlogon.android.data.exchange.PriceMap
 import com.testlogon.android.data.exchange.SpotBalance
 import com.testlogon.android.data.exchange.StakeRequestsBrowse
 import com.testlogon.android.data.exchange.Trade
+import com.testlogon.android.data.exchange.FeeTierAuthoritative
 import com.testlogon.android.data.exchange.TradingRepository
 
 /**
@@ -70,6 +71,7 @@ open class FakeTradingRepository : TradingRepository {
     var marginAccountResult: ApiResult<MarginAccount> = ApiResult.Success(MarginAccount(0, 0, 0, 0, null, 0, false, ""))
     var pricesResult: ApiResult<PriceMap> = ApiResult.Success(PriceMap.unavailable())
     var fillsFeesResult: ApiResult<FillsFees> = ApiResult.Success(FillsFees(emptyList(), 0))
+    var feeTierResult: ApiResult<FeeTierAuthoritative?> = ApiResult.Success(null)
     var fundingPaymentsResult: ApiResult<FundingPayments> = ApiResult.Success(FundingPayments(emptyList(), 0))
     var liquidationsResult: ApiResult<Liquidations> = ApiResult.Success(Liquidations(emptyList(), 0))
     var pmResolutionsResult: ApiResult<List<PmResolution>> = ApiResult.Success(emptyList())
@@ -80,6 +82,7 @@ open class FakeTradingRepository : TradingRepository {
     override suspend fun marginAccount(): ApiResult<MarginAccount> = marginAccountResult
     override suspend fun getPrices(): ApiResult<PriceMap> = pricesResult
     override suspend fun fillsFees(): ApiResult<FillsFees> = fillsFeesResult
+    override suspend fun feeTier(): ApiResult<FeeTierAuthoritative?> = feeTierResult
     override suspend fun fundingPayments(): ApiResult<FundingPayments> = fundingPaymentsResult
     override suspend fun liquidations(): ApiResult<Liquidations> = liquidationsResult
     override suspend fun pmResolutions(): ApiResult<List<PmResolution>> = pmResolutionsResult

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ const BailoutsBoardPage = lazy(() => import("@/pages/bailouts/BailoutsBoardPage"
 const PnLPage = lazy(() => import("@/pages/pnl/PnLPage"));
 const ReportsPage = lazy(() => import("@/pages/reports/ReportsPage"));
 const TaxReportPage = lazy(() => import("@/pages/reports/TaxReportPage"));
+const FeesPage = lazy(() => import("@/pages/fees/FeesPage"));
 const CatalogPage = lazy(() => import("@/pages/shop/CatalogPage"));
 const ProductDetail = lazy(() => import("@/pages/shop/ProductDetail"));
 const CartPage = lazy(() => import("@/pages/shop/CartPage"));
@@ -750,6 +751,7 @@ export default function App() {
           <Route path="pnl" element={<PnLPage />} />
           <Route path="reports" element={<ReportsPage />} />
           <Route path="reports/tax" element={<TaxReportPage />} />
+          <Route path="fees" element={<FeesPage />} />
           <Route path="content-calendar" element={<ContentCalendarPage />} />
           <Route path="agents/memory/:workerId" element={<AgentMemoryPage />} />
           <Route path="agents/feedback" element={<AgentFeedbackPage />} />

--- a/frontend/src/api/endpoints/fees.ts
+++ b/frontend/src/api/endpoints/fees.ts
@@ -156,3 +156,40 @@ export function describeQuote(q: FeeQuote): QuoteDisplay {
  * this is the default beta set. Trim/extend as the server config evolves.
  */
 export const SUPPORTED_PAY_COINS: PayWith[] = ["USD", "USDC", "BTC", "ETH", "SOL"];
+
+// ============================================================================
+// Maker/taker VIP FEE-TIER by 30-day trading volume (authoritative read).
+//
+// OPTIONAL authoritative read that overrides the client-side estimate computed
+// from the trade-history feed. 404s until the exchange edge exposes it — callers
+// MUST degrade to the client computation (retry:false / catch 404).
+//
+//   GET /me/fees/tier -> FeeTierResponse
+// ============================================================================
+
+export interface FeeTierNext {
+  tier_id: string;
+  name: string;
+  /** 30-day volume (USD cents) required to reach this next tier. */
+  volume_30d_cents: number;
+  maker_bps: number;
+  taker_bps: number;
+}
+
+export interface FeeTierResponse {
+  /** Stable tier id (matches FEE_TIERS[].id in lib/feeTiers.ts). */
+  tier_id: string;
+  name: string;
+  /** The caller's authoritative 30-day rolling volume, USD cents. */
+  volume_30d_cents: number;
+  maker_bps: number;
+  taker_bps: number;
+  /** The next-higher tier, absent when already at the top. */
+  next_tier?: FeeTierNext | null;
+}
+
+/**
+ * The caller's authoritative maker/taker fee tier. 404s until the edge deploys —
+ * callers fall back to the client-side estimate from the fills feed.
+ */
+export const getFeeTier = () => api.get<FeeTierResponse>("/me/fees/tier");

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -107,6 +107,7 @@ import {
   CandlestickChart,
   PieChart,
   TrendingUp,
+  Percent,
   Timer,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -162,6 +163,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "PnL", i18nKey: "nav.pnl", path: "/pnl", icon: <LineChart className="h-5 w-5" /> },
       { label: "Reports", i18nKey: "nav.reports", path: "/reports", icon: <FileText className="h-5 w-5" /> },
       { label: "Tax & Gains", i18nKey: "nav.taxGains", path: "/reports/tax", icon: <Receipt className="h-5 w-5" /> },
+      { label: "Fee Tiers", i18nKey: "nav.feeTiers", path: "/fees", icon: <Percent className="h-5 w-5" /> },
       { label: "Activity", i18nKey: "nav.activity", path: "/activity", icon: <Activity className="h-5 w-5" /> },
       { label: "Activity Center", i18nKey: "nav.activityCenter", path: "/activity-center", icon: <Bell className="h-5 w-5" /> },
       { label: "Discover", i18nKey: "nav.discover", path: "/discover", icon: <Compass className="h-5 w-5" /> },

--- a/frontend/src/lib/feeTiers.test.ts
+++ b/frontend/src/lib/feeTiers.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEE_TIERS,
+  volume30dCents,
+  tierForVolume,
+  tierById,
+  nextTier,
+  progressToNextFraction,
+  volumeToNextTierCents,
+  makerTakerFeeCents,
+  type VolumeFill,
+} from "./feeTiers";
+
+const NOW = Date.parse("2026-06-15T00:00:00Z");
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgoMs = (d: number) => NOW - d * DAY;
+
+describe("FEE_TIERS canonical schedule", () => {
+  it("has the six shared tiers in ascending threshold order", () => {
+    expect(FEE_TIERS.map((t) => t.id)).toEqual([
+      "standard",
+      "bronze",
+      "silver",
+      "gold",
+      "platinum",
+      "diamond",
+    ]);
+    for (let i = 1; i < FEE_TIERS.length; i++) {
+      expect(FEE_TIERS[i]!.minVolumeCents).toBeGreaterThan(FEE_TIERS[i - 1]!.minVolumeCents);
+    }
+  });
+
+  it("matches the exact thresholds and rates", () => {
+    expect(FEE_TIERS[0]).toMatchObject({ minVolumeCents: 0, makerBps: 10, takerBps: 15 });
+    expect(FEE_TIERS[1]).toMatchObject({ minVolumeCents: 50_000_00, makerBps: 9, takerBps: 14 });
+    expect(FEE_TIERS[2]).toMatchObject({ minVolumeCents: 250_000_00, makerBps: 8, takerBps: 12 });
+    expect(FEE_TIERS[3]).toMatchObject({ minVolumeCents: 1_000_000_00, makerBps: 6, takerBps: 10 });
+    expect(FEE_TIERS[4]).toMatchObject({ minVolumeCents: 5_000_000_00, makerBps: 4, takerBps: 8 });
+    expect(FEE_TIERS[5]).toMatchObject({ minVolumeCents: 25_000_000_00, makerBps: 2, takerBps: 6 });
+  });
+});
+
+describe("volume30dCents", () => {
+  it("returns 0 for empty / non-array input", () => {
+    expect(volume30dCents([], NOW)).toBe(0);
+    expect(volume30dCents(undefined as never, NOW)).toBe(0);
+  });
+
+  it("sums notional (price*qty) of fills inside the window", () => {
+    const fills: VolumeFill[] = [
+      { ts: daysAgoMs(1), priceCents: 100_00, qty: 2 }, // 200_00
+      { ts: daysAgoMs(10), priceCents: 50_00, qty: 3 }, // 150_00
+    ];
+    expect(volume30dCents(fills, NOW)).toBe(200_00 + 150_00);
+  });
+
+  it("excludes fills older than the window", () => {
+    const fills: VolumeFill[] = [
+      { ts: daysAgoMs(45), priceCents: 100_00, qty: 10 }, // outside 30d
+      { ts: daysAgoMs(5), priceCents: 100_00, qty: 1 }, // inside
+    ];
+    expect(volume30dCents(fills, NOW)).toBe(100_00);
+  });
+
+  it("respects a custom window", () => {
+    const fills: VolumeFill[] = [
+      { ts: daysAgoMs(20), priceCents: 100_00, qty: 1 },
+      { ts: daysAgoMs(3), priceCents: 100_00, qty: 1 },
+    ];
+    expect(volume30dCents(fills, NOW, 7)).toBe(100_00);
+  });
+
+  it("accepts second-precision timestamps", () => {
+    const fills: VolumeFill[] = [{ ts: Math.floor(daysAgoMs(2) / 1000), priceCents: 10_00, qty: 5 }];
+    expect(volume30dCents(fills, NOW)).toBe(50_00);
+  });
+
+  it("ignores non-positive / non-finite price or qty and floors notional", () => {
+    const fills: VolumeFill[] = [
+      { ts: daysAgoMs(1), priceCents: -100, qty: 5 },
+      { ts: daysAgoMs(1), priceCents: 100, qty: 0 },
+      { ts: daysAgoMs(1), priceCents: NaN, qty: 5 },
+      { ts: daysAgoMs(1), priceCents: 333, qty: 1.5 }, // 499.5 -> 499
+    ];
+    expect(volume30dCents(fills, NOW)).toBe(499);
+  });
+
+  it("never returns negative", () => {
+    expect(volume30dCents([{ ts: daysAgoMs(1), priceCents: -1, qty: -1 }], NOW)).toBe(0);
+  });
+});
+
+describe("tierForVolume / tierById", () => {
+  it("maps volume to the correct tier boundaries", () => {
+    expect(tierForVolume(0).id).toBe("standard");
+    expect(tierForVolume(49_999_99).id).toBe("standard");
+    expect(tierForVolume(50_000_00).id).toBe("bronze");
+    expect(tierForVolume(250_000_00).id).toBe("silver");
+    expect(tierForVolume(1_000_000_00).id).toBe("gold");
+    expect(tierForVolume(5_000_000_00).id).toBe("platinum");
+    expect(tierForVolume(25_000_000_00).id).toBe("diamond");
+    expect(tierForVolume(999_999_999_00).id).toBe("diamond");
+  });
+
+  it("guards negative / non-finite volume to Standard", () => {
+    expect(tierForVolume(-100).id).toBe("standard");
+    expect(tierForVolume(NaN).id).toBe("standard");
+  });
+
+  it("tierById resolves canonical ids", () => {
+    expect(tierById("gold")?.makerBps).toBe(6);
+    expect(tierById("nope")).toBeUndefined();
+  });
+});
+
+describe("nextTier", () => {
+  it("returns the next-higher tier", () => {
+    expect(nextTier(FEE_TIERS[0]!)?.id).toBe("bronze");
+    expect(nextTier(FEE_TIERS[4]!)?.id).toBe("diamond");
+  });
+  it("returns null at the top tier", () => {
+    expect(nextTier(FEE_TIERS[5]!)).toBeNull();
+  });
+});
+
+describe("progressToNextFraction", () => {
+  it("is 0 at the current tier threshold", () => {
+    expect(progressToNextFraction(0)).toBe(0);
+    expect(progressToNextFraction(50_000_00)).toBe(0);
+  });
+  it("is ~0.5 halfway between thresholds", () => {
+    // halfway between bronze(50k) and silver(250k) = 150k
+    expect(progressToNextFraction(150_000_00)).toBeCloseTo(0.5, 5);
+  });
+  it("clamps to 1.0 at the top tier", () => {
+    expect(progressToNextFraction(25_000_000_00)).toBe(1);
+    expect(progressToNextFraction(999_999_999_00)).toBe(1);
+  });
+  it("guards negative volume", () => {
+    expect(progressToNextFraction(-5)).toBe(0);
+  });
+});
+
+describe("volumeToNextTierCents", () => {
+  it("computes the remaining volume to the next tier", () => {
+    expect(volumeToNextTierCents(0)).toBe(50_000_00);
+    expect(volumeToNextTierCents(150_000_00)).toBe(100_000_00); // to silver 250k
+  });
+  it("is 0 at the top tier", () => {
+    expect(volumeToNextTierCents(25_000_000_00)).toBe(0);
+  });
+});
+
+describe("makerTakerFeeCents", () => {
+  it("computes fee = notional * bps / 10000 (rounded)", () => {
+    expect(makerTakerFeeCents(1_000_000_00, 15)).toBe(1_500_00); // $1,000,000 @ 15bps = $1,500
+    expect(makerTakerFeeCents(100_00, 10)).toBe(10); // $100 @ 10bps = $0.10
+  });
+  it("rounds half-up", () => {
+    expect(makerTakerFeeCents(3333, 15)).toBe(5); // 4.9995 -> 5
+  });
+  it("guards non-positive inputs", () => {
+    expect(makerTakerFeeCents(0, 15)).toBe(0);
+    expect(makerTakerFeeCents(100_00, 0)).toBe(0);
+    expect(makerTakerFeeCents(-1, 15)).toBe(0);
+    expect(makerTakerFeeCents(NaN, 15)).toBe(0);
+  });
+});

--- a/frontend/src/lib/feeTiers.ts
+++ b/frontend/src/lib/feeTiers.ts
@@ -1,0 +1,160 @@
+// Pure, dependency-free MAKER/TAKER FEE-TIER (VIP schedule) engine computed
+// CLIENT-SIDE from a normalized executed-fill list. NO framework, NO I/O, NO
+// DOM — every monetary value is an INTEGER in USD cents and every rate is an
+// integer basis-point (bps), so the arithmetic is exact and the module is
+// trivially unit-testable (see feeTiers.test.ts).
+//
+// A trader's fee tier is a function of their 30-day rolling trading VOLUME
+// (sum of executed-fill NOTIONAL = price*qty). Higher volume → lower maker &
+// taker rates. The FEE_TIERS table below is CANONICAL and shared with the
+// Android client — do NOT change the thresholds/rates without changing both.
+
+// ── canonical schedule ───────────────────────────────────────────────
+// thresholds are 30-day rolling volume in USD CENTS; fees are in BPS (1bp =
+// 0.01% = 0.0001). Ordered ascending by threshold (Standard first).
+
+export interface FeeTier {
+  /** Stable id shared with the backend authoritative read. */
+  id: string;
+  /** Human label. */
+  name: string;
+  /** Minimum 30-day volume (USD cents, inclusive) to qualify for this tier. */
+  minVolumeCents: number;
+  /** Maker fee, basis points. */
+  makerBps: number;
+  /** Taker fee, basis points. */
+  takerBps: number;
+}
+
+/** Canonical maker/taker VIP schedule (ascending by threshold). */
+export const FEE_TIERS: readonly FeeTier[] = [
+  { id: "standard", name: "Standard", minVolumeCents: 0, makerBps: 10, takerBps: 15 },
+  { id: "bronze", name: "Bronze", minVolumeCents: 50_000_00, makerBps: 9, takerBps: 14 },
+  { id: "silver", name: "Silver", minVolumeCents: 250_000_00, makerBps: 8, takerBps: 12 },
+  { id: "gold", name: "Gold", minVolumeCents: 1_000_000_00, makerBps: 6, takerBps: 10 },
+  { id: "platinum", name: "Platinum", minVolumeCents: 5_000_000_00, makerBps: 4, takerBps: 8 },
+  { id: "diamond", name: "Diamond (VIP)", minVolumeCents: 25_000_000_00, makerBps: 2, takerBps: 6 },
+] as const;
+
+// ── input shape ──────────────────────────────────────────────────────
+
+/** One normalized executed fill. Integer cents; `ts` is unix sec OR ms. */
+export interface VolumeFill {
+  /** unix timestamp — seconds OR milliseconds (engine-native). */
+  ts: number;
+  /** Per-unit executed price, integer minor units (cents). */
+  priceCents: number;
+  /** Executed quantity (treated as a positive magnitude). */
+  qty: number;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// A ts below this is assumed to be seconds; at/above, milliseconds. (~2001 in
+// ms / ~33k AD in s — the same heuristic the tax report uses.)
+const MS_THRESHOLD = 1e12;
+
+function toMs(ts: number): number {
+  return ts < MS_THRESHOLD ? ts * 1000 : ts;
+}
+
+// ── volume ───────────────────────────────────────────────────────────
+
+/**
+ * Sum of executed-fill NOTIONAL (priceCents * qty, floored to whole cents)
+ * within the trailing `windowDays` window ending at `nowMs`. Fills outside the
+ * window, or with non-positive price/qty, are ignored. Never negative.
+ */
+export function volume30dCents(
+  fills: readonly VolumeFill[],
+  nowMs: number,
+  windowDays = 30,
+): number {
+  if (!Array.isArray(fills) || fills.length === 0) return 0;
+  const window = Math.max(0, windowDays) * DAY_MS;
+  const cutoff = nowMs - window;
+  let total = 0;
+  for (const f of fills) {
+    if (!f) continue;
+    const price = Number(f.priceCents);
+    const qty = Number(f.qty);
+    if (!Number.isFinite(price) || !Number.isFinite(qty)) continue;
+    if (price <= 0 || qty <= 0) continue;
+    const ms = toMs(Number(f.ts));
+    if (!Number.isFinite(ms)) continue;
+    if (ms < cutoff || ms > nowMs) continue;
+    // notional in cents; floor to keep integer cents.
+    total += Math.floor(price * qty);
+  }
+  return total < 0 ? 0 : total;
+}
+
+// ── tier lookup ──────────────────────────────────────────────────────
+
+/**
+ * The highest tier whose `minVolumeCents` is <= `volumeCents`. Negative /
+ * empty volume → Standard (the first tier). Always returns a tier.
+ */
+export function tierForVolume(volumeCents: number): FeeTier {
+  const v = Number.isFinite(volumeCents) && volumeCents > 0 ? volumeCents : 0;
+  let match: FeeTier = FEE_TIERS[0] as FeeTier;
+  for (const t of FEE_TIERS) {
+    if (v >= t.minVolumeCents) match = t;
+    else break;
+  }
+  return match;
+}
+
+/** Look up a tier by its stable id (e.g. from the authoritative backend read). */
+export function tierById(id: string): FeeTier | undefined {
+  return FEE_TIERS.find((t) => t.id === id);
+}
+
+/** The next-higher tier above `tier`, or `null` when already at the top. */
+export function nextTier(tier: FeeTier): FeeTier | null {
+  const i = FEE_TIERS.findIndex((t) => t.id === tier.id);
+  if (i < 0 || i >= FEE_TIERS.length - 1) return null;
+  return FEE_TIERS[i + 1] as FeeTier;
+}
+
+/**
+ * Progress (0..1) toward the NEXT tier's threshold, measured from the CURRENT
+ * tier's threshold. Returns 1.0 when already at the top tier. Clamped to [0,1].
+ */
+export function progressToNextFraction(volumeCents: number): number {
+  const v = Number.isFinite(volumeCents) && volumeCents > 0 ? volumeCents : 0;
+  const current = tierForVolume(v);
+  const next = nextTier(current);
+  if (!next) return 1;
+  const span = next.minVolumeCents - current.minVolumeCents;
+  if (span <= 0) return 1;
+  const gained = v - current.minVolumeCents;
+  const frac = gained / span;
+  if (frac <= 0) return 0;
+  if (frac >= 1) return 1;
+  return frac;
+}
+
+/** USD cents of additional volume needed to reach the next tier (0 at top). */
+export function volumeToNextTierCents(volumeCents: number): number {
+  const v = Number.isFinite(volumeCents) && volumeCents > 0 ? volumeCents : 0;
+  const next = nextTier(tierForVolume(v));
+  if (!next) return 0;
+  const remaining = next.minVolumeCents - v;
+  return remaining > 0 ? remaining : 0;
+}
+
+// ── fee math ─────────────────────────────────────────────────────────
+
+/**
+ * Fee (integer cents, rounded half-up) charged on `notionalCents` at `bps`
+ * basis points. bps of 15 = 0.15%. Guards non-positive inputs → 0.
+ */
+export function makerTakerFeeCents(notionalCents: number, bps: number): number {
+  const n = Number(notionalCents);
+  const b = Number(bps);
+  if (!Number.isFinite(n) || !Number.isFinite(b) || n <= 0 || b <= 0) return 0;
+  // fee = notional * bps / 10_000. Round half-up for a deterministic result.
+  return Math.round((n * b) / 10_000);
+}

--- a/frontend/src/pages/fees/FeesPage.tsx
+++ b/frontend/src/pages/fees/FeesPage.tsx
@@ -1,0 +1,287 @@
+// FEE TIERS BY TRADING VOLUME (maker/taker VIP schedule).
+//
+// Shows the caller their maker/taker fee tier driven by 30-day rolling trading
+// VOLUME. Volume is computed CLIENT-SIDE from the live executed-fill feed
+// (`GET /me/fills/fees`, the same feed the Tax report uses) using the pure
+// `lib/feeTiers` engine. An OPTIONAL authoritative backend read
+// (`GET /me/fees/tier`) overrides the estimate when it resolves; on 404 we
+// fall back to the client computation and label it "estimated".
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Percent, Info, RefreshCw, TrendingUp } from "lucide-react";
+
+import { ApiError } from "@/api/client";
+import { getFeeTier, type FeeTierResponse } from "@/api/endpoints/fees";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { useFillsFees } from "@/hooks/useTrading";
+import { useSymbols } from "@/hooks/useMarketData";
+import type { FillFee } from "@/api/endpoints/trading";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import {
+  FEE_TIERS,
+  volume30dCents,
+  tierForVolume,
+  tierById,
+  nextTier,
+  progressToNextFraction,
+  volumeToNextTierCents,
+  type VolumeFill,
+  type FeeTier,
+} from "@/lib/feeTiers";
+
+/** Format integer cents as a $ decimal string. */
+function money(cents: number): string {
+  return (cents / 100).toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+/** bps -> "0.15%" */
+function bpsPct(bps: number): string {
+  return `${(bps / 100).toLocaleString(undefined, { maximumFractionDigits: 4 })}%`;
+}
+
+export default function FeesPage() {
+  const symbolsQuery = useSymbols();
+  const fillsQuery = useFillsFees();
+
+  // Authoritative read; 404s until the edge deploys -> degrade to the estimate.
+  const tierQuery = useQuery({
+    queryKey: ["fees", "tier"],
+    queryFn: getFeeTier,
+    retry: false,
+  });
+
+  // symbolid -> catalog entry (name + price scaler), same resolver as Tax report.
+  const symById = useMemo(() => {
+    const m = new Map<number, MarketSymbol>();
+    for (const s of symbolsQuery.data?.symbols ?? []) m.set(s.symbol_id, s);
+    return m;
+  }, [symbolsQuery.data]);
+
+  const rawFills: FillFee[] = Array.isArray(fillsQuery.data?.fills) ? fillsQuery.data!.fills! : [];
+
+  // Normalize the engine feed -> integer-cents fills (price int64 tick / scaler).
+  const normalized: VolumeFill[] = useMemo(() => {
+    const out: VolumeFill[] = [];
+    for (const f of rawFills) {
+      const scaler = symById.get(f.symbolid)?.price_scaler || 1;
+      const priceCents = Math.round((f.price / scaler) * 100);
+      const qty = Math.abs(f.qty);
+      if (!qty || priceCents <= 0) continue;
+      out.push({ ts: f.ts, priceCents, qty });
+    }
+    return out;
+  }, [rawFills, symById]);
+
+  const estimatedVolumeCents = useMemo(
+    () => volume30dCents(normalized, Date.now()),
+    [normalized],
+  );
+
+  // Prefer the authoritative read when it resolved; else the client estimate.
+  const authoritative: FeeTierResponse | undefined =
+    tierQuery.isSuccess ? tierQuery.data : undefined;
+  const isAuthoritative = !!authoritative;
+
+  const volumeCents = authoritative?.volume_30d_cents ?? estimatedVolumeCents;
+
+  // Current tier: from the authoritative id when present (fall back to volume
+  // lookup if the id is unknown), else derive from the estimated volume.
+  const currentTier: FeeTier =
+    (authoritative && tierById(authoritative.tier_id)) || tierForVolume(volumeCents);
+
+  const upcoming = nextTier(currentTier);
+  const fraction = progressToNextFraction(volumeCents);
+  const toNextCents = volumeToNextTierCents(volumeCents);
+
+  // maker/taker rates: authoritative overrides the tier defaults when present.
+  const makerBps = authoritative?.maker_bps ?? currentTier.makerBps;
+  const takerBps = authoritative?.taker_bps ?? currentTier.takerBps;
+
+  const feedLoading = fillsQuery.isLoading || symbolsQuery.isLoading;
+  const feedUnavailable =
+    fillsQuery.isError && !isAuthoritative && normalized.length === 0;
+  const hasNoFills = !isAuthoritative && normalized.length === 0;
+
+  const is404 = (e: unknown) => e instanceof ApiError && e.status === 404;
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            <Percent className="h-6 w-6 text-primary" />
+            Fee Tiers
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Your maker/taker fees drop as your 30-day trading volume climbs.
+          </p>
+        </div>
+        <Badge variant={isAuthoritative ? "default" : "secondary"}>
+          {isAuthoritative ? "Live account tier" : "Estimated from your trade history"}
+        </Badge>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>30-day volume</CardDescription>
+            <CardTitle className="text-2xl">
+              {feedLoading && !isAuthoritative ? "..." : money(volumeCents)}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-xs text-muted-foreground">
+            {isAuthoritative
+              ? "As reported by the exchange."
+              : "Computed from your executed fills."}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Current tier</CardDescription>
+            <CardTitle className="flex items-center gap-2 text-2xl">
+              <TrendingUp className="h-5 w-5 text-primary" />
+              {currentTier.name}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-xs text-muted-foreground">
+            {money(currentTier.minVolumeCents)}+ 30-day volume
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Your rates</CardDescription>
+            <CardTitle className="text-2xl">
+              {bpsPct(makerBps)}
+              <span className="text-muted-foreground"> / </span>
+              {bpsPct(takerBps)}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-xs text-muted-foreground">
+            maker {makerBps} bps &middot; taker {takerBps} bps
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Progress to next tier */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">
+            {upcoming ? `Progress to ${upcoming.name}` : "Top tier reached"}
+          </CardTitle>
+          <CardDescription>
+            {upcoming
+              ? `${money(toNextCents)} more volume for ${upcoming.name} - maker ${bpsPct(
+                  upcoming.makerBps,
+                )} / taker ${bpsPct(upcoming.takerBps)}`
+              : "You are on the best maker/taker schedule available."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Progress value={Math.round(fraction * 100)} max={100} />
+          <div className="mt-2 flex justify-between text-xs text-muted-foreground">
+            <span>{currentTier.name}</span>
+            <span>{Math.round(fraction * 100)}%</span>
+            <span>{upcoming ? upcoming.name : "-"}</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* State notices */}
+      {tierQuery.isError && !is404(tierQuery.error) && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertTitle>Showing an estimate</AlertTitle>
+          <AlertDescription>
+            The authoritative tier read is unavailable right now; the numbers
+            above are computed from your recent fills.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {feedUnavailable && (
+        <Alert>
+          <RefreshCw className="h-4 w-4" />
+          <AlertTitle>Trade history unavailable</AlertTitle>
+          <AlertDescription>
+            We could not load your executed fills, so your volume cannot be
+            estimated yet. The tier table below still shows the full schedule.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {!feedUnavailable && hasNoFills && !feedLoading && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertTitle>No trades in the last 30 days</AlertTitle>
+          <AlertDescription>
+            You start on the {FEE_TIERS[0]!.name} tier. Trade to build 30-day
+            volume and unlock lower maker/taker fees.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Full tier table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Full VIP schedule</CardTitle>
+          <CardDescription>
+            Thresholds are 30-day rolling volume in USD. Your tier is highlighted.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Tier</TableHead>
+                <TableHead className="text-right">30-day volume &ge;</TableHead>
+                <TableHead className="text-right">Maker</TableHead>
+                <TableHead className="text-right">Taker</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {FEE_TIERS.map((t) => {
+                const mine = t.id === currentTier.id;
+                return (
+                  <TableRow key={t.id} className={cn(mine && "bg-primary/10 font-medium")}>
+                    <TableCell>
+                      <span className="flex items-center gap-2">
+                        {t.name}
+                        {mine && <Badge variant="default">You</Badge>}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {money(t.minVolumeCents)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{bpsPct(t.makerBps)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{bpsPct(t.takerBps)}</TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Maker/taker fee tiers by 30-day trading volume

A VIP fee-schedule surface: the user's 30-day volume → tier → maker/taker rates, with a progress bar to the next tier + the full tier table. **Works now** — volume is computed client-side from the live fills feed (`/me/fills/fees`, same source as the Tax report). An optional authoritative `GET /me/fees/tier` overrides when the backend ships it; otherwise labelled "estimated from your trade history". Degrade-on-404.

**Canonical schedule (identical both platforms; 30d USD thresholds, bps):** Standard $0 10/15 · Bronze $50k 9/14 · Silver $250k 8/12 · Gold $1M 6/10 · Platinum $5M 4/8 · Diamond(VIP) $25M 2/6.

### Web (`/fees`, "Fee Tiers" nav)
`lib/feeTiers.ts` (+23 vitest) — FEE_TIERS + volume30dCents / tierForVolume / nextTier / progressToNextFraction / makerTakerFeeCents; `fees.ts` `getFeeTier()`; `pages/fees/FeesPage`.

### Android (new `feature/feetiers`, registered in `MoreRoutes`)
`FeeTierMath.kt` (mirror of web; +13 JVM tests) + FeeTiers Screen/ViewModel/UiState + nav; `TradingApi/Dtos/Models/Repository` gain the optional `GET me/fees/tier` (folds 404→null); `MoreCatalog` + `MoreRoutes.REGISTERED` + `AuthenticatedGraph` + Dashboard "Fee tiers" card.

No new deps. Gates: web tsc 0 · vite build · vitest 23/23; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (FeeTierMath 13/13, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
