### PR TITLE
feat(dca): recurring buys (DCA) plan management + schedule preview (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/dca/DcaApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/dca/DcaApi.kt
@@ -1,0 +1,127 @@
+package com.testlogon.android.data.dca
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.network.json.LenientInt
+import com.testlogon.android.core.network.json.LenientLong
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * Retrofit interface for the DCA / RECURRING-BUYS surface (schedule recurring buys of a symbol / creator
+ * token / strategy fund, funded from the USD cash wallet). Mirrors the web data contract EXACTLY. Paths
+ * are relative (no leading slash) so they resolve against the shared authenticated Retrofit base URL; the
+ * session cookie + CSRF header are attached by the core-network interceptor chain.
+ *
+ * The periodic EXECUTION of a plan is a SERVER-SIDE runner; this client owns only plan CRUD + schedule
+ * preview + history. Every read DEGRADES on 404 (the me/dca backend runner is pending) to an honest
+ * empty/pending state; mutations pass a rejection (or undeployed 404) through as a clear error, never a
+ * silent success. All methods are suspend; a non-2xx surfaces as retrofit2.HttpException.
+ */
+interface DcaApi {
+
+    /** GET me/dca/plans -> {plans:[...]}. Read degrades on 404. */
+    @GET("me/dca/plans")
+    suspend fun plans(): DcaPlansEnvelopeDto
+
+    /** POST me/dca/plans {plan fields} -> the created plan. */
+    @Headers("Content-Type: application/json")
+    @POST("me/dca/plans")
+    suspend fun createPlan(@Body body: CreateDcaPlanRequestDto): DcaPlanDto
+
+    /** POST me/dca/plans/{id}/pause -> the updated plan. */
+    @POST("me/dca/plans/{id}/pause")
+    suspend fun pause(@Path("id") id: String): DcaPlanDto
+
+    /** POST me/dca/plans/{id}/resume -> the updated plan. */
+    @POST("me/dca/plans/{id}/resume")
+    suspend fun resume(@Path("id") id: String): DcaPlanDto
+
+    /** POST me/dca/plans/{id}/cancel -> the updated plan. */
+    @POST("me/dca/plans/{id}/cancel")
+    suspend fun cancel(@Path("id") id: String): DcaPlanDto
+
+    /** GET me/dca/plans/{id}/history -> {runs:[...]}. Read degrades on 404. */
+    @GET("me/dca/plans/{id}/history")
+    suspend fun history(@Path("id") id: String): DcaHistoryEnvelopeDto
+
+    /** POST me/dca/plans/{id}/run-now -> the run result (best-effort; runner-owned). */
+    @POST("me/dca/plans/{id}/run-now")
+    suspend fun runNow(@Path("id") id: String): DcaRunNowResultDto
+}
+
+// ---- Wire DTOs (codegen-only Moshi; numerics lenient; every field defaulted so a partial shape parses) ----
+
+@JsonClass(generateAdapter = true)
+data class DcaPlansEnvelopeDto(
+    @Json(name = "plans") val plans: List<DcaPlanDto>? = null,
+)
+
+/** The plan target (what the recurring buy purchases). */
+@JsonClass(generateAdapter = true)
+data class DcaTargetDto(
+    @Json(name = "kind") val kind: String? = null,
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "label") val label: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class DcaPlanDto(
+    @Json(name = "plan_id") val planId: String? = null,
+    @Json(name = "target") val target: DcaTargetDto? = null,
+    @LenientLong @Json(name = "amount_cents") val amountCents: Long? = null,
+    @Json(name = "frequency") val frequency: String? = null,
+    @LenientInt @Json(name = "day_of_week") val dayOfWeek: Int? = null,
+    @LenientInt @Json(name = "day_of_month") val dayOfMonth: Int? = null,
+    @LenientLong @Json(name = "start_ts") val startTs: Long? = null,
+    @LenientLong @Json(name = "end_ts") val endTs: Long? = null,
+    @LenientLong @Json(name = "total_budget_cents") val totalBudgetCents: Long? = null,
+    @Json(name = "funding") val funding: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @LenientLong @Json(name = "next_run_ts") val nextRunTs: Long? = null,
+    @LenientLong @Json(name = "spent_cents") val spentCents: Long? = null,
+    @LenientInt @Json(name = "buys_count") val buysCount: Int? = null,
+    @LenientLong @Json(name = "created_ts") val createdTs: Long? = null,
+)
+
+/** Body for POST me/dca/plans. Mirrors the web create contract. */
+@JsonClass(generateAdapter = true)
+data class CreateDcaPlanRequestDto(
+    @Json(name = "target") val target: DcaTargetDto,
+    @Json(name = "amount_cents") val amountCents: Long,
+    @Json(name = "frequency") val frequency: String,
+    @Json(name = "day_of_week") val dayOfWeek: Int? = null,
+    @Json(name = "day_of_month") val dayOfMonth: Int? = null,
+    @Json(name = "start_ts") val startTs: Long,
+    @Json(name = "end_ts") val endTs: Long? = null,
+    @Json(name = "total_budget_cents") val totalBudgetCents: Long? = null,
+    @Json(name = "funding") val funding: String = "usd_wallet",
+)
+
+@JsonClass(generateAdapter = true)
+data class DcaHistoryEnvelopeDto(
+    @Json(name = "runs") val runs: List<DcaRunDto>? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class DcaRunDto(
+    // ts is epoch SECONDS on the wire (matching the other money surfaces); converted to ms at mapping.
+    @LenientLong @Json(name = "ts") val ts: Long? = null,
+    @LenientLong @Json(name = "amount_cents") val amountCents: Long? = null,
+    // Quantity filled in base units, when executed (lenient: may arrive as a quoted number).
+    @LenientLong @Json(name = "filled_qty") val filledQty: Long? = null,
+    // Fill price in CENTS, when executed.
+    @LenientLong @Json(name = "price") val price: Long? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "note") val note: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class DcaRunNowResultDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/dca/DcaDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/dca/DcaDomain.kt
@@ -1,0 +1,105 @@
+package com.testlogon.android.data.dca
+
+/**
+ * Null-safe domain models for the DCA / RECURRING-BUYS surface. Wire DTOs are coerced here so the
+ * ViewModel / UI never see nullable wire fields. Money is integer CENTS end-to-end; schedule times are
+ * epoch-millis Longs. filled_qty / price are kept as display STRINGS (the contract does not pin a unit /
+ * scaler for them, so they are shown verbatim rather than mis-scaled).
+ */
+
+/** What a recurring buy purchases. */
+enum class DcaTargetKind(val wire: String) {
+    SYMBOL("symbol"),
+    TOKEN("token"),
+    STRATEGY("strategy"),
+    UNKNOWN("unknown");
+
+    companion object {
+        fun fromWire(v: String?): DcaTargetKind = when (v?.trim()?.lowercase()) {
+            "symbol" -> SYMBOL
+            "token" -> TOKEN
+            "strategy" -> STRATEGY
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** How often a plan buys. */
+enum class DcaFrequency(val wire: String) {
+    DAILY("daily"),
+    WEEKLY("weekly"),
+    MONTHLY("monthly"),
+    UNKNOWN("unknown");
+
+    companion object {
+        fun fromWire(v: String?): DcaFrequency = when (v?.trim()?.lowercase()) {
+            "daily" -> DAILY
+            "weekly" -> WEEKLY
+            "monthly" -> MONTHLY
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** Plan lifecycle. */
+enum class DcaStatus(val wire: String) {
+    ACTIVE("active"),
+    PAUSED("paused"),
+    COMPLETED("completed"),
+    CANCELLED("cancelled"),
+    UNKNOWN("unknown");
+
+    companion object {
+        fun fromWire(v: String?): DcaStatus = when (v?.trim()?.lowercase()) {
+            "active" -> ACTIVE
+            "paused" -> PAUSED
+            "completed" -> COMPLETED
+            "cancelled", "canceled" -> CANCELLED
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** The buy target: a kind + backend id + human label. */
+data class DcaTarget(
+    val kind: DcaTargetKind,
+    val id: String,
+    val label: String,
+)
+
+/**
+ * A recurring-buy plan. [dayOfWeek] (1=Mon..7=Sun) is only meaningful for [DcaFrequency.WEEKLY];
+ * [dayOfMonth] (1..31, capped to 28 at run-time) only for [DcaFrequency.MONTHLY]. Times are epoch-ms.
+ */
+data class DcaPlan(
+    val planId: String,
+    val target: DcaTarget,
+    val amountCents: Long,
+    val frequency: DcaFrequency,
+    val dayOfWeek: Int? = null,
+    val dayOfMonth: Int? = null,
+    val startTs: Long,
+    val endTs: Long? = null,
+    val totalBudgetCents: Long? = null,
+    val funding: String = "usd_wallet",
+    val status: DcaStatus,
+    val nextRunTs: Long? = null,
+    val spentCents: Long = 0L,
+    val buysCount: Int = 0,
+    val createdTs: Long = 0L,
+) {
+    val isMutable: Boolean get() = status == DcaStatus.ACTIVE || status == DcaStatus.PAUSED
+}
+
+/**
+ * One executed (or attempted) recurring buy. [ts] is epoch-MILLIS (converted from the wire seconds).
+ * [filledQty] is base units; [priceCents] is the fill price in CENTS; both null until executed.
+ */
+data class DcaRun(
+    val ts: Long,
+    val amountCents: Long,
+    val filledQty: Long?,
+    val priceCents: Long?,
+    val status: String,
+    val note: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/dca/DcaRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/dca/DcaRepository.kt
@@ -1,0 +1,170 @@
+package com.testlogon.android.data.dca
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer for the DCA / RECURRING-BUYS surface over [DcaApi].
+ *
+ * READS ([plans], [history]) DEGRADE on a 404 / HTTP error to an honest EMPTY value so the screen shows a
+ * truthful "no plans yet / pending backend runner" state rather than an error; a real transport failure
+ * surfaces as [ApiResult.NetworkError] so the UI can offer retry. MUTATIONS ([createPlan], [pause],
+ * [resume], [cancel], [runNow]) pass failures through as [ApiResult.Failure]/[ApiResult.NetworkError] — a
+ * rejection (or undeployed 404) surfaces as a clear error and NEVER a silent success. CancellationException
+ * is always re-thrown.
+ */
+interface DcaRepository {
+    suspend fun plans(): ApiResult<List<DcaPlan>>
+    suspend fun createPlan(request: CreateDcaPlanRequestDto): ApiResult<DcaPlan>
+    suspend fun pause(planId: String): ApiResult<DcaPlan>
+    suspend fun resume(planId: String): ApiResult<DcaPlan>
+    suspend fun cancel(planId: String): ApiResult<DcaPlan>
+    suspend fun history(planId: String): ApiResult<List<DcaRun>>
+    suspend fun runNow(planId: String): ApiResult<Unit>
+}
+
+@Singleton
+class DcaRepositoryImpl @Inject constructor(
+    private val api: DcaApi,
+    private val errorParser: ApiErrorParser,
+) : DcaRepository {
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    /** All plans. A 404 (undeployed runner) degrades to an empty list; network errors surface. */
+    override suspend fun plans(): ApiResult<List<DcaPlan>> = withContext(io) {
+        try {
+            ApiResult.Success((api.plans().plans ?: emptyList()).mapNotNull { it.toDomain() })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(emptyList())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    /** History for a plan. A 404 degrades to an empty list; network errors surface. */
+    override suspend fun history(planId: String): ApiResult<List<DcaRun>> = withContext(io) {
+        try {
+            ApiResult.Success((api.history(planId).runs ?: emptyList()).mapNotNull { it.toDomain() })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Success(emptyList())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    override suspend fun createPlan(request: CreateDcaPlanRequestDto): ApiResult<DcaPlan> = call {
+        api.createPlan(request).toDomain() ?: error("Malformed plan in response")
+    }
+
+    override suspend fun pause(planId: String): ApiResult<DcaPlan> = call {
+        api.pause(planId).toDomain() ?: error("Malformed plan in response")
+    }
+
+    override suspend fun resume(planId: String): ApiResult<DcaPlan> = call {
+        api.resume(planId).toDomain() ?: error("Malformed plan in response")
+    }
+
+    override suspend fun cancel(planId: String): ApiResult<DcaPlan> = call {
+        api.cancel(planId).toDomain() ?: error("Malformed plan in response")
+    }
+
+    override suspend fun runNow(planId: String): ApiResult<Unit> = call {
+        api.runNow(planId)
+        Unit
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = withContext(io) {
+        try {
+            ApiResult.Success(block())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            ApiResult.Failure(errorParser.from(e))
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+}
+
+// ---- DTO -> domain mappers ----
+
+/** Wire timestamps are epoch SECONDS (matching the other money surfaces); the app works in millis. */
+private const val SEC_TO_MS: Long = 1_000L
+private fun secToMs(sec: Long?): Long? = sec?.let { it * SEC_TO_MS }
+
+private fun DcaTargetDto.toDomain(): DcaTarget? {
+    val tid = id?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    val kind = DcaTargetKind.fromWire(kind)
+    val lbl = label?.trim()?.takeIf { it.isNotBlank() } ?: tid
+    return DcaTarget(kind = kind, id = tid, label = lbl)
+}
+
+private fun DcaPlanDto.toDomain(): DcaPlan? {
+    val pid = planId?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    val tgt = target?.toDomain() ?: return null
+    return DcaPlan(
+        planId = pid,
+        target = tgt,
+        amountCents = amountCents ?: 0L,
+        frequency = DcaFrequency.fromWire(frequency),
+        dayOfWeek = dayOfWeek,
+        dayOfMonth = dayOfMonth,
+        startTs = secToMs(startTs) ?: 0L,
+        endTs = secToMs(endTs),
+        totalBudgetCents = totalBudgetCents,
+        funding = funding?.trim()?.takeIf { it.isNotBlank() } ?: "usd_wallet",
+        status = DcaStatus.fromWire(status),
+        nextRunTs = secToMs(nextRunTs),
+        spentCents = spentCents ?: 0L,
+        buysCount = buysCount ?: 0,
+        createdTs = secToMs(createdTs) ?: 0L,
+    )
+}
+
+private fun DcaRunDto.toDomain(): DcaRun? {
+    val t = secToMs(ts) ?: return null
+    return DcaRun(
+        ts = t,
+        amountCents = amountCents ?: 0L,
+        filledQty = filledQty,
+        priceCents = price,
+        status = status?.trim()?.takeIf { it.isNotBlank() } ?: "unknown",
+        note = note?.trim()?.takeIf { it.isNotBlank() },
+    )
+}
+
+/** Provides [DcaApi] on the shared authenticated Retrofit + binds the repository impl. */
+@Module
+@InstallIn(SingletonComponent::class)
+object DcaApiModule {
+    @Provides
+    @Singleton
+    fun provideDcaApi(retrofit: Retrofit): DcaApi = retrofit.create(DcaApi::class.java)
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DcaDataModule {
+    @Binds
+    @Singleton
+    abstract fun bindDcaRepository(impl: DcaRepositoryImpl): DcaRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaCreateScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaCreateScreen.kt
@@ -1,0 +1,354 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class, androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.dca
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.Divider
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.dca.DcaFrequency
+
+/**
+ * Create a DCA / recurring-buy plan: pick a target across the three markets (exchange symbol / creator
+ * token / strategy fund), set the USD amount + cadence + start (optional end / total budget), funded from
+ * the USD cash wallet. Submit is gated by the pure [DcaSchedule.validatePlan] and a money-safety confirm
+ * that shows a schedule preview (the next runs). Explicit that scheduled buys run server-side.
+ */
+@Composable
+fun DcaCreateRoute(
+    onBack: () -> Unit,
+    onCreated: (String) -> Unit,
+    onAddCash: () -> Unit,
+    viewModel: DcaCreateViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var showConfirm by remember { mutableStateOf(false) }
+    var showStartPicker by remember { mutableStateOf(false) }
+    var showEndPicker by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.createdPlanId) {
+        state.createdPlanId?.let(onCreated)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("New recurring buy") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            // ---- Target ----
+            Text("What to buy", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            if (state.loadingTargets) {
+                CircularProgressIndicator(modifier = Modifier.height(22.dp), strokeWidth = 2.dp)
+            } else {
+                TargetGroup("Markets", state.symbols, state.selectedTarget, viewModel::onSelectTarget)
+                TargetGroup("Creator tokens", state.tokens, state.selectedTarget, viewModel::onSelectTarget)
+                TargetGroup("Strategies", state.strategies, state.selectedTarget, viewModel::onSelectTarget)
+                if (state.symbols.isEmpty() && state.tokens.isEmpty() && state.strategies.isEmpty()) {
+                    Text(
+                        "No investable targets are available right now.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("dca_no_targets"),
+                    )
+                }
+            }
+            state.selectedTarget?.let {
+                Spacer(Modifier.height(4.dp))
+                Text("Selected: ${it.label}", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold, modifier = Modifier.testTag("dca_selected_target"))
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Divider()
+            Spacer(Modifier.height(16.dp))
+
+            // ---- Amount ----
+            Text("Amount per buy", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.amountText,
+                onValueChange = viewModel::onAmountText,
+                label = { Text("Amount (USD)") },
+                prefix = { Text("$") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                supportingText = { Text("Minimum ${DcaFormat.formatCentsUsd(DcaFormat.MIN_AMOUNT_CENTS)}.") },
+                modifier = Modifier.fillMaxWidth().testTag("dca_amount"),
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            // ---- Frequency ----
+            Text("How often", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FrequencyChip("Daily", state.frequency == DcaFrequency.DAILY) { viewModel.onFrequency(DcaFrequency.DAILY) }
+                FrequencyChip("Weekly", state.frequency == DcaFrequency.WEEKLY) { viewModel.onFrequency(DcaFrequency.WEEKLY) }
+                FrequencyChip("Monthly", state.frequency == DcaFrequency.MONTHLY) { viewModel.onFrequency(DcaFrequency.MONTHLY) }
+            }
+
+            if (state.frequency == DcaFrequency.WEEKLY) {
+                Spacer(Modifier.height(8.dp))
+                Text("Day of week", style = MaterialTheme.typography.labelLarge)
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    (1..7).forEach { d ->
+                        FilterChip(
+                            selected = state.dayOfWeek == d,
+                            onClick = { viewModel.onDayOfWeek(d) },
+                            label = { Text(DcaFormat.dayOfWeekLabel(d).take(3)) },
+                            modifier = Modifier.testTag("dca_dow_$d"),
+                        )
+                    }
+                }
+            }
+            if (state.frequency == DcaFrequency.MONTHLY) {
+                Spacer(Modifier.height(8.dp))
+                Text("Day of month (1–28)", style = MaterialTheme.typography.labelLarge)
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(onClick = { viewModel.onDayOfMonth(state.dayOfMonth - 1) }, enabled = state.dayOfMonth > 1) { Text("−") }
+                    Text("${state.dayOfMonth}", style = MaterialTheme.typography.titleMedium, modifier = Modifier.testTag("dca_dom_value"))
+                    OutlinedButton(onClick = { viewModel.onDayOfMonth(state.dayOfMonth + 1) }, enabled = state.dayOfMonth < 28) { Text("+") }
+                }
+                Text("Days after the 28th are capped at the 28th so no month is skipped.", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // ---- Start / End ----
+            Text("Start", style = MaterialTheme.typography.titleMedium)
+            OutlinedButton(onClick = { showStartPicker = true }, modifier = Modifier.testTag("dca_start_btn")) {
+                Text("Starts ${DcaFormat.formatDate(state.startTs)}")
+            }
+
+            Spacer(Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Switch(checked = state.endEnabled, onCheckedChange = viewModel::onEndEnabled, modifier = Modifier.testTag("dca_end_switch"))
+                Spacer(Modifier.height(0.dp))
+                Text("  Set an end date", style = MaterialTheme.typography.bodyMedium)
+            }
+            if (state.endEnabled) {
+                OutlinedButton(onClick = { showEndPicker = true }) {
+                    Text("Ends ${DcaFormat.formatDate(state.endTs ?: 0L)}")
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Switch(checked = state.budgetEnabled, onCheckedChange = viewModel::onBudgetEnabled, modifier = Modifier.testTag("dca_budget_switch"))
+                Text("  Cap total budget", style = MaterialTheme.typography.bodyMedium)
+            }
+            if (state.budgetEnabled) {
+                OutlinedTextField(
+                    value = state.budgetText,
+                    onValueChange = viewModel::onBudgetText,
+                    label = { Text("Total budget (USD)") },
+                    prefix = { Text("$") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.fillMaxWidth().testTag("dca_budget_amount"),
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Divider()
+            Spacer(Modifier.height(12.dp))
+
+            // ---- Funding ----
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(Modifier.padding(14.dp)) {
+                    Text("Funded from your USD cash balance", style = MaterialTheme.typography.titleSmall)
+                    if (state.walletAvailable) {
+                        Text("Balance ${DcaFormat.formatCentsUsd(state.walletBalanceCents)}", style = MaterialTheme.typography.bodyMedium)
+                    } else {
+                        Text("Cash balance unavailable on this account.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    TextButton(onClick = onAddCash, modifier = Modifier.testTag("dca_add_cash")) { Text("Add cash") }
+                }
+            }
+
+            (state.validation as? DcaSchedule.Validation.Invalid)?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(it.reason, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall, modifier = Modifier.testTag("dca_validation"))
+            }
+            state.errorMessage?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("dca_create_error"))
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = { showConfirm = true },
+                enabled = state.canPreview && !state.submitting,
+                modifier = Modifier.fillMaxWidth().testTag("dca_review_btn"),
+            ) {
+                if (state.submitting) CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
+                else Text("Review & schedule")
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+
+    // ---- schedule preview + money-safety confirm ----
+    if (showConfirm) {
+        val preview = state.toPreviewPlan()
+        val runs = preview?.let { DcaSchedule.upcomingRuns(it, it.startTs, 5) }.orEmpty()
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text("Confirm recurring buy") },
+            text = {
+                Column {
+                    ConfirmRow("Buy", state.selectedTarget?.label ?: "—", emphasize = true)
+                    ConfirmRow("Amount", DcaFormat.formatCentsUsd(state.amountCents ?: 0L))
+                    ConfirmRow("Cadence", DcaFormat.frequencyLabel(state.frequency, state.dayOfWeek, state.dayOfMonth))
+                    ConfirmRow("Funding", "USD cash balance")
+                    if (state.budgetEnabled) ConfirmRow("Total budget", DcaFormat.formatCentsUsd(state.budgetCents ?: 0L))
+                    Spacer(Modifier.height(8.dp))
+                    Text("Next runs", style = MaterialTheme.typography.labelLarge)
+                    if (runs.isEmpty()) {
+                        Text("No upcoming runs for these settings.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                    } else {
+                        runs.forEachIndexed { i, ms ->
+                            Text("${i + 1}. ${DcaFormat.formatDateWithDow(ms)}", style = MaterialTheme.typography.bodySmall, modifier = Modifier.testTag("dca_preview_$i"))
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "Scheduling this creates a plan that runs automatically on the server. Each run charges your USD cash balance for the buy amount.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = { showConfirm = false; viewModel.confirmCreate() },
+                    enabled = runs.isNotEmpty(),
+                    modifier = Modifier.testTag("dca_confirm_btn"),
+                ) { Text("Schedule") }
+            },
+            dismissButton = { TextButton(onClick = { showConfirm = false }) { Text("Cancel") } },
+        )
+    }
+
+    if (showStartPicker) {
+        val pickerState = rememberDatePickerState(initialSelectedDateMillis = state.startTs.takeIf { it > 0 })
+        DatePickerDialog(
+            onDismissRequest = { showStartPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    pickerState.selectedDateMillis?.let(viewModel::onStartTs)
+                    showStartPicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = { TextButton(onClick = { showStartPicker = false }) { Text("Cancel") } },
+        ) { DatePicker(state = pickerState) }
+    }
+
+    if (showEndPicker) {
+        val pickerState = rememberDatePickerState(initialSelectedDateMillis = state.endTs)
+        DatePickerDialog(
+            onDismissRequest = { showEndPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    pickerState.selectedDateMillis?.let(viewModel::onEndTs)
+                    showEndPicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = { TextButton(onClick = { showEndPicker = false }) { Text("Cancel") } },
+        ) { DatePicker(state = pickerState) }
+    }
+}
+
+@Composable
+private fun TargetGroup(
+    title: String,
+    options: List<DcaTargetOption>,
+    selected: DcaTargetOption?,
+    onSelect: (DcaTargetOption) -> Unit,
+) {
+    if (options.isEmpty()) return
+    Text(title, style = MaterialTheme.typography.labelLarge, modifier = Modifier.padding(top = 8.dp))
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        options.take(30).forEach { opt ->
+            FilterChip(
+                selected = selected?.kind == opt.kind && selected.id == opt.id,
+                onClick = { onSelect(opt) },
+                label = { Text(opt.label) },
+                modifier = Modifier.testTag("dca_target_${opt.kind.wire}_${opt.id}"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FrequencyChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    FilterChip(selected = selected, onClick = onClick, label = { Text(label) }, modifier = Modifier.testTag("dca_freq_$label"))
+}
+
+@Composable
+private fun ConfirmRow(label: String, value: String, emphasize: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaCreateViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaCreateViewModel.kt
@@ -1,0 +1,202 @@
+package com.testlogon.android.feature.dca
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.cash.CashRepository
+import com.testlogon.android.data.dca.CreateDcaPlanRequestDto
+import com.testlogon.android.data.dca.DcaFrequency
+import com.testlogon.android.data.dca.DcaPlan
+import com.testlogon.android.data.dca.DcaRepository
+import com.testlogon.android.data.dca.DcaTargetDto
+import com.testlogon.android.data.dca.DcaTargetKind
+import com.testlogon.android.data.exchange.ExchangeRepository
+import com.testlogon.android.data.strategies.StrategiesRepository
+import com.testlogon.android.data.tokens.TokensRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** A pickable buy target across the three markets (symbol / creator token / strategy fund). */
+data class DcaTargetOption(
+    val kind: DcaTargetKind,
+    val id: String,
+    val label: String,
+    val sublabel: String? = null,
+)
+
+/** UI state for the create-plan flow. */
+data class DcaCreateUiState(
+    val loadingTargets: Boolean = true,
+    val symbols: List<DcaTargetOption> = emptyList(),
+    val tokens: List<DcaTargetOption> = emptyList(),
+    val strategies: List<DcaTargetOption> = emptyList(),
+    val selectedTarget: DcaTargetOption? = null,
+    val amountText: String = "",
+    val frequency: DcaFrequency = DcaFrequency.WEEKLY,
+    val dayOfWeek: Int = 1,        // Mon..Sun, for WEEKLY
+    val dayOfMonth: Int = 1,       // 1..28 (capped), for MONTHLY
+    val startTs: Long = 0L,
+    val endEnabled: Boolean = false,
+    val endTs: Long? = null,
+    val budgetEnabled: Boolean = false,
+    val budgetText: String = "",
+    // Funding: the USD cash wallet.
+    val walletBalanceCents: Long = 0L,
+    val walletAvailable: Boolean = false,
+    val submitting: Boolean = false,
+    val errorMessage: String? = null,
+    val createdPlanId: String? = null,
+) {
+    val amountCents: Long? get() = DcaFormat.parseDollarsToCents(amountText)
+    val budgetCents: Long? get() = if (budgetEnabled) DcaFormat.parseDollarsToCents(budgetText) else null
+
+    /** Validate purely (schedule + money); target existence checked separately. */
+    val validation: DcaSchedule.Validation
+        get() {
+            val amt = amountCents ?: return DcaSchedule.Validation.Invalid("Enter a buy amount.")
+            return DcaSchedule.validatePlan(
+                amountCents = amt,
+                frequency = frequency,
+                dayOfWeek = if (frequency == DcaFrequency.WEEKLY) dayOfWeek else null,
+                dayOfMonth = if (frequency == DcaFrequency.MONTHLY) dayOfMonth else null,
+                startTs = startTs,
+                endTs = if (endEnabled) endTs else null,
+                totalBudgetCents = budgetCents,
+            )
+        }
+
+    val canPreview: Boolean get() = selectedTarget != null && validation is DcaSchedule.Validation.Ok
+
+    /** Build a preview plan (planId placeholder) for the schedule preview + confirm. */
+    fun toPreviewPlan(): DcaPlan? {
+        val t = selectedTarget ?: return null
+        val amt = amountCents ?: return null
+        return DcaPlan(
+            planId = "preview",
+            target = com.testlogon.android.data.dca.DcaTarget(t.kind, t.id, t.label),
+            amountCents = amt,
+            frequency = frequency,
+            dayOfWeek = if (frequency == DcaFrequency.WEEKLY) dayOfWeek else null,
+            dayOfMonth = if (frequency == DcaFrequency.MONTHLY) dayOfMonth else null,
+            startTs = startTs,
+            endTs = if (endEnabled) endTs else null,
+            totalBudgetCents = budgetCents,
+            status = com.testlogon.android.data.dca.DcaStatus.ACTIVE,
+        )
+    }
+}
+
+/**
+ * Drives the CREATE-plan flow. Loads pickable targets from the three shipped markets (exchange symbols +
+ * creator tokens + strategy funds), each degrading independently on 404, and reads the USD cash-wallet
+ * balance so the funding source can be shown + linked. The pure [DcaSchedule.validatePlan] gates submit,
+ * and a schedule preview (next N runs) is shown behind the money-safety confirm. Submit surfaces a
+ * rejection / undeployed 404 as a clear error, never a silent success.
+ */
+@HiltViewModel
+class DcaCreateViewModel @Inject constructor(
+    private val dcaRepository: DcaRepository,
+    private val exchangeRepository: ExchangeRepository,
+    private val tokensRepository: TokensRepository,
+    private val strategiesRepository: StrategiesRepository,
+    private val cashRepository: CashRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DcaCreateUiState(startTs = todayUtcStartMs()))
+    val uiState: StateFlow<DcaCreateUiState> = _uiState.asStateFlow()
+
+    init {
+        loadTargets()
+        loadWallet()
+    }
+
+    private fun todayUtcStartMs(): Long {
+        val now = System.currentTimeMillis()
+        return (now / DcaSchedule.MS_PER_DAY) * DcaSchedule.MS_PER_DAY
+    }
+
+    private fun loadTargets() {
+        _uiState.update { it.copy(loadingTargets = true) }
+        viewModelScope.launch {
+            val symbols = (exchangeRepository.symbols() as? ApiResult.Success)?.data.orEmpty().map {
+                DcaTargetOption(DcaTargetKind.SYMBOL, it.symbolId.toString(), it.symbol, if (it.isPerpetual) "Perp" else "Spot")
+            }
+            val tokens = (tokensRepository.market() as? ApiResult.Success)?.data.orEmpty().map {
+                DcaTargetOption(DcaTargetKind.TOKEN, it.tokenId, it.name, it.ticker)
+            }
+            val strategies = (strategiesRepository.market() as? ApiResult.Success)?.data.orEmpty().map {
+                DcaTargetOption(DcaTargetKind.STRATEGY, it.strategyId, it.name, "Strategy fund")
+            }
+            _uiState.update { it.copy(loadingTargets = false, symbols = symbols, tokens = tokens, strategies = strategies) }
+        }
+    }
+
+    private fun loadWallet() {
+        viewModelScope.launch {
+            when (val w = cashRepository.wallet()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(walletBalanceCents = w.data.balanceCents, walletAvailable = w.data.available)
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    fun onSelectTarget(option: DcaTargetOption) = _uiState.update { it.copy(selectedTarget = option, errorMessage = null) }
+    fun onAmountText(v: String) = _uiState.update { it.copy(amountText = DcaFormat.sanitizeAmountInput(v), errorMessage = null) }
+    fun onFrequency(f: DcaFrequency) = _uiState.update { it.copy(frequency = f, errorMessage = null) }
+    fun onDayOfWeek(d: Int) = _uiState.update { it.copy(dayOfWeek = d.coerceIn(1, 7)) }
+    fun onDayOfMonth(d: Int) = _uiState.update { it.copy(dayOfMonth = d.coerceIn(1, 28)) }
+    fun onStartTs(ms: Long) = _uiState.update { it.copy(startTs = (ms / DcaSchedule.MS_PER_DAY) * DcaSchedule.MS_PER_DAY, errorMessage = null) }
+    fun onEndEnabled(on: Boolean) = _uiState.update {
+        it.copy(endEnabled = on, endTs = if (on) (it.endTs ?: it.startTs + 30 * DcaSchedule.MS_PER_DAY) else it.endTs, errorMessage = null)
+    }
+    fun onEndTs(ms: Long) = _uiState.update { it.copy(endTs = (ms / DcaSchedule.MS_PER_DAY) * DcaSchedule.MS_PER_DAY, errorMessage = null) }
+    fun onBudgetEnabled(on: Boolean) = _uiState.update { it.copy(budgetEnabled = on, errorMessage = null) }
+    fun onBudgetText(v: String) = _uiState.update { it.copy(budgetText = DcaFormat.sanitizeAmountInput(v), errorMessage = null) }
+    fun consumeError() = _uiState.update { it.copy(errorMessage = null) }
+
+    /** Called AFTER the money-safety confirm is accepted. */
+    fun confirmCreate() {
+        val s = _uiState.value
+        val target = s.selectedTarget
+        val amt = s.amountCents
+        val v = s.validation
+        if (target == null) {
+            _uiState.update { it.copy(errorMessage = "Pick something to buy.") }
+            return
+        }
+        if (amt == null || v is DcaSchedule.Validation.Invalid) {
+            _uiState.update { it.copy(errorMessage = (v as? DcaSchedule.Validation.Invalid)?.reason ?: "Check the plan details.") }
+            return
+        }
+        val body = CreateDcaPlanRequestDto(
+            target = DcaTargetDto(kind = target.kind.wire, id = target.id, label = target.label),
+            amountCents = amt,
+            frequency = s.frequency.wire,
+            dayOfWeek = if (s.frequency == DcaFrequency.WEEKLY) s.dayOfWeek else null,
+            dayOfMonth = if (s.frequency == DcaFrequency.MONTHLY) s.dayOfMonth else null,
+            startTs = s.startTs / 1_000L, // wire is epoch SECONDS
+            endTs = if (s.endEnabled) s.endTs?.let { it / 1_000L } else null,
+            totalBudgetCents = s.budgetCents,
+            funding = "usd_wallet",
+        )
+        _uiState.update { it.copy(submitting = true, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = dcaRepository.createPlan(body)) {
+                is ApiResult.Success -> _uiState.update { it.copy(submitting = false, createdPlanId = r.data.planId) }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = r.error.message.ifBlank { "Recurring buys aren't available yet. No plan was created." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(submitting = false, errorMessage = "No connection. No plan was created.")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaDetailScreen.kt
@@ -1,0 +1,214 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.dca
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.dca.DcaPlan
+import com.testlogon.android.data.dca.DcaRun
+import com.testlogon.android.data.dca.DcaStatus
+
+/**
+ * DCA plan DETAIL: the plan summary, an upcoming-runs preview (computed by the pure [DcaSchedule]),
+ * pause / resume / cancel + a run-now request, and the run history. Honest about the server-side runner:
+ * history degrades on 404 to a "pending backend runner" state and run-now reports that the server executes
+ * recurring buys rather than faking a fill.
+ */
+@Composable
+fun DcaDetailRoute(
+    onBack: () -> Unit,
+    viewModel: DcaDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Plan detail") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            when {
+                state.loading -> {
+                    Row(Modifier.fillMaxWidth().padding(24.dp), horizontalArrangement = Arrangement.Center) { CircularProgressIndicator() }
+                }
+                state.notFound -> {
+                    Text("This plan couldn't be found.", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "It may have been cancelled, or the server-side recurring-buy runner may still be rolling out.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("dca_detail_notfound"),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedButton(onClick = viewModel::refresh) { Text("Retry") }
+                }
+                else -> {
+                    val plan = state.plan
+                    if (plan != null) PlanDetailBody(plan, state, viewModel)
+                }
+            }
+
+            state.errorMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("dca_detail_error"))
+            }
+            state.successMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(it, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("dca_detail_success"))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlanDetailBody(plan: DcaPlan, state: DcaDetailUiState, viewModel: DcaDetailViewModel) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(plan.target.label, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+            Text("${DcaFormat.targetKindLabel(plan.target.kind)} · ${DcaFormat.statusLabel(plan.status)}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(10.dp))
+            DetailRow("Amount", DcaFormat.formatCentsUsd(plan.amountCents))
+            DetailRow("Cadence", DcaFormat.frequencyLabel(plan.frequency, plan.dayOfWeek, plan.dayOfMonth))
+            DetailRow("Funding", "USD cash balance")
+            DetailRow("Starts", DcaFormat.formatDate(plan.startTs))
+            plan.endTs?.let { DetailRow("Ends", DcaFormat.formatDate(it)) }
+            DetailRow("Next buy", plan.nextRunTs?.let { DcaFormat.formatDate(it) } ?: "—")
+            DetailRow("Spent", "${DcaFormat.formatCentsUsd(plan.spentCents)} · ${plan.buysCount} buys")
+            DcaSchedule.budgetRemainingCents(plan)?.let { remaining ->
+                DetailRow("Budget left", "${DcaFormat.formatCentsUsd(remaining)} (~${DcaSchedule.estimatedRunsRemaining(plan) ?: 0} buys)")
+                DcaSchedule.budgetProgress(plan)?.let { p ->
+                    Spacer(Modifier.height(4.dp))
+                    LinearProgressIndicator(progress = { p }, modifier = Modifier.fillMaxWidth())
+                }
+            }
+        }
+    }
+
+    // ---- upcoming preview ----
+    val upcoming = DcaSchedule.upcomingRuns(plan, System.currentTimeMillis(), 5)
+    if (upcoming.isNotEmpty()) {
+        Spacer(Modifier.height(16.dp))
+        Text("Upcoming runs", style = MaterialTheme.typography.titleMedium)
+        upcoming.forEachIndexed { i, ms ->
+            Text("${i + 1}. ${DcaFormat.formatDateWithDow(ms)}", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(vertical = 2.dp).testTag("dca_upcoming_$i"))
+        }
+    }
+
+    // ---- actions ----
+    Spacer(Modifier.height(16.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        when (plan.status) {
+            DcaStatus.ACTIVE -> {
+                OutlinedButton(onClick = viewModel::pause, enabled = !state.acting, modifier = Modifier.testTag("dca_detail_pause")) { Text("Pause") }
+                OutlinedButton(onClick = viewModel::cancel, enabled = !state.acting) { Text("Cancel") }
+            }
+            DcaStatus.PAUSED -> {
+                OutlinedButton(onClick = viewModel::resume, enabled = !state.acting, modifier = Modifier.testTag("dca_detail_resume")) { Text("Resume") }
+                OutlinedButton(onClick = viewModel::cancel, enabled = !state.acting) { Text("Cancel") }
+            }
+            else -> Unit
+        }
+    }
+    if (plan.isMutable) {
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = viewModel::runNow, enabled = !state.acting, modifier = Modifier.fillMaxWidth().testTag("dca_run_now")) {
+            if (state.acting) CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp) else Text("Run now")
+        }
+        Text(
+            "Recurring buys run on the server on schedule; \"Run now\" only requests an immediate run.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    // ---- history ----
+    Spacer(Modifier.height(20.dp))
+    Divider()
+    Spacer(Modifier.height(12.dp))
+    Text("History", style = MaterialTheme.typography.titleMedium)
+    if (state.runs.isEmpty()) {
+        Text(
+            if (state.historyPendingBackend) "No runs yet. Executed buys will appear here once the server runner runs this plan." else "No runs yet.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag("dca_history_empty"),
+        )
+    } else {
+        state.runs.forEach { run -> RunRow(run) }
+    }
+    Spacer(Modifier.height(24.dp))
+}
+
+@Composable
+private fun RunRow(run: DcaRun) {
+    Column(Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(DcaFormat.formatDate(run.ts), style = MaterialTheme.typography.bodyMedium)
+            Text(DcaFormat.formatCentsUsd(run.amountCents), style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
+        }
+        val detail = buildString {
+            run.filledQty?.let { append("Qty $it") }
+            run.priceCents?.let {
+                if (isNotEmpty()) append(" @ ")
+                append(DcaFormat.formatCentsUsd(it))
+            }
+            if (isNotEmpty()) append(" · ")
+            append(run.status)
+            run.note?.let { append(" — ").also { _ -> append(it) } }
+        }
+        Text(detail, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Divider(Modifier.padding(top = 6.dp))
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(Modifier.fillMaxWidth().padding(vertical = 3.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaDetailViewModel.kt
@@ -1,0 +1,123 @@
+package com.testlogon.android.feature.dca
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.dca.DcaPlan
+import com.testlogon.android.data.dca.DcaRepository
+import com.testlogon.android.data.dca.DcaRun
+import com.testlogon.android.navigation.DcaDetailDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** UI state for a single plan's detail (plan + run history). */
+data class DcaDetailUiState(
+    val loading: Boolean = true,
+    val plan: DcaPlan? = null,
+    val runs: List<DcaRun> = emptyList(),
+    val historyPendingBackend: Boolean = false,
+    val acting: Boolean = false,
+    val errorMessage: String? = null,
+    val successMessage: String? = null,
+    /** The plan id was not found in the plans list (e.g. runner pending / bad deep-link). */
+    val notFound: Boolean = false,
+)
+
+/**
+ * Drives the DCA plan DETAIL: resolves the plan from the plans list (the runner has no per-plan GET in the
+ * contract), loads its run history (degrades on 404 to an honest "pending backend runner" empty state),
+ * and exposes pause / resume / cancel + run-now. run-now is best-effort and runner-owned: on a 404 it
+ * reports an honest "the server runner will execute this" message rather than faking a fill.
+ */
+@HiltViewModel
+class DcaDetailViewModel @Inject constructor(
+    private val repository: DcaRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val planId: String = savedStateHandle.get<String>(DcaDetailDest.ARG_PLAN_ID).orEmpty()
+
+    private val _uiState = MutableStateFlow(DcaDetailUiState())
+    val uiState: StateFlow<DcaDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.update { it.copy(loading = true, errorMessage = null) }
+        viewModelScope.launch {
+            val plan = when (val r = repository.plans()) {
+                is ApiResult.Success -> r.data.firstOrNull { it.planId == planId }
+                is ApiResult.Failure -> {
+                    _uiState.update { it.copy(loading = false, errorMessage = r.error.message.ifBlank { "Couldn't load this plan." }) }
+                    return@launch
+                }
+                is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(loading = false, errorMessage = "No connection. Pull to retry.") }
+                    return@launch
+                }
+            }
+            if (plan == null) {
+                _uiState.update { it.copy(loading = false, notFound = true) }
+                return@launch
+            }
+            _uiState.update { it.copy(loading = false, plan = plan, notFound = false) }
+
+            when (val h = repository.history(planId)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(runs = h.data.sortedByDescending { r -> r.ts }, historyPendingBackend = h.data.isEmpty())
+                }
+                else -> Unit // history is optional; leave the pending state.
+            }
+        }
+    }
+
+    fun consumeMessages() = _uiState.update { it.copy(errorMessage = null, successMessage = null) }
+
+    fun pause() = mutate("Plan paused.") { repository.pause(planId) }
+    fun resume() = mutate("Plan resumed.") { repository.resume(planId) }
+    fun cancel() = mutate("Plan cancelled.") { repository.cancel(planId) }
+
+    fun runNow() {
+        _uiState.update { it.copy(acting = true, errorMessage = null, successMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.runNow(planId)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(acting = false, successMessage = "Run requested. The server runner executes recurring buys.") }
+                    refresh()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(acting = false, errorMessage = r.error.message.ifBlank { "Run-now isn't available yet — the server runner will execute this plan on schedule." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(acting = false, errorMessage = "No connection. Nothing changed.")
+                }
+            }
+        }
+    }
+
+    private fun mutate(okMessage: String, block: suspend () -> ApiResult<DcaPlan>) {
+        _uiState.update { it.copy(acting = true, errorMessage = null, successMessage = null) }
+        viewModelScope.launch {
+            when (val r = block()) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(acting = false, plan = r.data, successMessage = okMessage) }
+                    refresh()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(acting = false, errorMessage = r.error.message.ifBlank { "That action isn't available right now." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(acting = false, errorMessage = "No connection. Nothing changed.")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaFormat.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaFormat.kt
@@ -1,0 +1,94 @@
+package com.testlogon.android.feature.dca
+
+import com.testlogon.android.data.dca.DcaFrequency
+import com.testlogon.android.data.dca.DcaStatus
+import com.testlogon.android.data.dca.DcaTargetKind
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Display + input helpers for the DCA / recurring-buys UI. Money stays integer CENTS; parsing uses
+ * BigDecimal so "10.99" -> 1099 exactly (no binary-float drift), mirroring CashMath. Schedule instants
+ * are epoch-ms and are rendered in UTC so the label matches the UTC-day scheduling done by DcaSchedule.
+ */
+object DcaFormat {
+
+    const val MIN_AMOUNT_CENTS: Long = 100L // $1 minimum buy
+
+    private val DATE_FMT = SimpleDateFormat("MMM d, yyyy", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }
+    private val DATE_DOW_FMT = SimpleDateFormat("EEE, MMM d, yyyy", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }
+
+    /** Parse a user-entered dollar string to integer cents, or null when blank / non-numeric / negative. */
+    fun parseDollarsToCents(text: String): Long? {
+        val cleaned = text.trim().removePrefix("$").replace(",", "").trim()
+        if (cleaned.isEmpty()) return null
+        val dec = cleaned.toBigDecimalOrNull() ?: return null
+        if (dec.signum() < 0) return null
+        return dec.movePointRight(2).setScale(0, RoundingMode.DOWN).toLong()
+    }
+
+    /** Keep digits + a single decimal point, cap to 2 fractional digits. */
+    fun sanitizeAmountInput(v: String): String {
+        val filtered = v.filter { it.isDigit() || it == '.' }
+        val firstDot = filtered.indexOf('.')
+        if (firstDot < 0) return filtered.take(12)
+        val intPart = filtered.substring(0, firstDot).take(12)
+        val fracPart = filtered.substring(firstDot + 1).replace(".", "").take(2)
+        return "$intPart.$fracPart"
+    }
+
+    fun formatCents(cents: Long): String =
+        BigDecimal(cents).movePointLeft(2).setScale(2, RoundingMode.HALF_UP).toPlainString()
+
+    fun formatCentsUsd(cents: Long): String = "$" + formatCents(cents)
+
+    /** Render an epoch-ms instant as a UTC date (matches UTC-day scheduling). 0/negative -> em dash. */
+    fun formatDate(ms: Long): String = if (ms <= 0L) "—" else DATE_FMT.format(Date(ms))
+
+    fun formatDateWithDow(ms: Long): String = if (ms <= 0L) "—" else DATE_DOW_FMT.format(Date(ms))
+
+    /** ISO day-of-week (1=Mon..7=Sun) -> short label. */
+    fun dayOfWeekLabel(dow: Int?): String = when (dow) {
+        1 -> "Monday"
+        2 -> "Tuesday"
+        3 -> "Wednesday"
+        4 -> "Thursday"
+        5 -> "Friday"
+        6 -> "Saturday"
+        7 -> "Sunday"
+        else -> "—"
+    }
+
+    /** Human summary of the cadence, e.g. "Weekly on Wednesday" / "Monthly on day 15" / "Daily". */
+    fun frequencyLabel(frequency: DcaFrequency, dayOfWeek: Int?, dayOfMonth: Int?): String = when (frequency) {
+        DcaFrequency.DAILY -> "Daily"
+        DcaFrequency.WEEKLY -> "Weekly on ${dayOfWeekLabel(dayOfWeek)}"
+        DcaFrequency.MONTHLY -> "Monthly on day ${dayOfMonth?.coerceIn(1, 28) ?: 1}"
+        DcaFrequency.UNKNOWN -> "—"
+    }
+
+    fun statusLabel(status: DcaStatus): String = when (status) {
+        DcaStatus.ACTIVE -> "Active"
+        DcaStatus.PAUSED -> "Paused"
+        DcaStatus.COMPLETED -> "Completed"
+        DcaStatus.CANCELLED -> "Cancelled"
+        DcaStatus.UNKNOWN -> "Unknown"
+    }
+
+    fun targetKindLabel(kind: DcaTargetKind): String = when (kind) {
+        DcaTargetKind.SYMBOL -> "Market"
+        DcaTargetKind.TOKEN -> "Creator token"
+        DcaTargetKind.STRATEGY -> "Strategy"
+        DcaTargetKind.UNKNOWN -> "Target"
+    }
+
+    /** A buy amount is valid when it parses to >= the $1 minimum. */
+    fun isAmountValid(text: String): Boolean {
+        val cents = parseDollarsToCents(text) ?: return false
+        return cents >= MIN_AMOUNT_CENTS
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaPlansScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaPlansScreen.kt
@@ -1,0 +1,212 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.dca
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.data.dca.DcaPlan
+import com.testlogon.android.data.dca.DcaStatus
+
+/**
+ * The DCA / RECURRING-BUYS plans list. Lists each plan's target / amount / cadence / next-run / budget
+ * progress / status with pause / resume / cancel, opens a plan's detail, and launches the create flow. A
+ * banner is explicit that once scheduled, recurring buys run SERVER-SIDE. Loading degrades on 404 to an
+ * honest "pending backend runner" empty state.
+ */
+@Composable
+fun DcaPlansRoute(
+    onBack: () -> Unit,
+    onCreate: () -> Unit,
+    onOpenPlan: (String) -> Unit,
+    viewModel: DcaPlansViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Recurring buys") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = onCreate,
+                icon = { Icon(Icons.Filled.Add, contentDescription = null) },
+                text = { Text("New plan") },
+                modifier = Modifier.testTag("dca_create_fab"),
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+        ) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(14.dp)) {
+                    Text("Dollar-cost averaging", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Schedule recurring buys funded from your USD cash balance. Once scheduled, buys run automatically on the server — you don't need the app open.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            state.errorMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("dca_error"))
+                Spacer(Modifier.height(4.dp))
+                OutlinedButton(onClick = viewModel::refresh) { Text("Retry") }
+            }
+            state.successMessage?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(it, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.testTag("dca_success"))
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            when {
+                state.loading -> {
+                    Row(Modifier.fillMaxWidth().padding(24.dp), horizontalArrangement = Arrangement.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.isEmpty -> {
+                    Column(Modifier.fillMaxWidth().padding(top = 24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("No recurring buys yet", style = MaterialTheme.typography.titleMedium)
+                        Text(
+                            if (state.emptyPendingBackend) {
+                                "Create a plan to start dollar-cost averaging. (The recurring-buy runner is server-side and may still be rolling out.)"
+                            } else {
+                                "Create a plan to start dollar-cost averaging."
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp).testTag("dca_empty"),
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        Button(onClick = onCreate) { Text("Create a plan") }
+                    }
+                }
+                else -> {
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        items(state.plans, key = { it.planId }) { plan ->
+                            DcaPlanCard(
+                                plan = plan,
+                                acting = state.actingPlanId == plan.planId,
+                                onOpen = { onOpenPlan(plan.planId) },
+                                onPause = { viewModel.pause(plan.planId) },
+                                onResume = { viewModel.resume(plan.planId) },
+                                onCancel = { viewModel.cancel(plan.planId) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DcaPlanCard(
+    plan: DcaPlan,
+    acting: Boolean,
+    onOpen: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag("dca_plan_${plan.planId}")) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(plan.target.label, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                    Text(
+                        "${DcaFormat.targetKindLabel(plan.target.kind)} · ${DcaFormat.formatCentsUsd(plan.amountCents)} ${DcaFormat.frequencyLabel(plan.frequency, plan.dayOfWeek, plan.dayOfMonth).lowercase()}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                AssistChip(onClick = onOpen, label = { Text(DcaFormat.statusLabel(plan.status)) })
+            }
+
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "Next buy: ${plan.nextRunTs?.let { DcaFormat.formatDate(it) } ?: "—"}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                "Spent ${DcaFormat.formatCentsUsd(plan.spentCents)} · ${plan.buysCount} buys",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            DcaSchedule.budgetProgress(plan)?.let { p ->
+                Spacer(Modifier.height(6.dp))
+                LinearProgressIndicator(progress = { p }, modifier = Modifier.fillMaxWidth())
+                Text(
+                    "${DcaFormat.formatCentsUsd(plan.spentCents)} of ${DcaFormat.formatCentsUsd(plan.totalBudgetCents ?: 0L)} budget",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(onClick = onOpen, modifier = Modifier.testTag("dca_open_${plan.planId}")) { Text("Details") }
+                when (plan.status) {
+                    DcaStatus.ACTIVE -> {
+                        OutlinedButton(onClick = onPause, enabled = !acting) { Text("Pause") }
+                        OutlinedButton(onClick = onCancel, enabled = !acting) { Text("Cancel") }
+                    }
+                    DcaStatus.PAUSED -> {
+                        OutlinedButton(onClick = onResume, enabled = !acting) { Text("Resume") }
+                        OutlinedButton(onClick = onCancel, enabled = !acting) { Text("Cancel") }
+                    }
+                    else -> Unit
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaPlansViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaPlansViewModel.kt
@@ -1,0 +1,90 @@
+package com.testlogon.android.feature.dca
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.dca.DcaPlan
+import com.testlogon.android.data.dca.DcaRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** UI state for the DCA plans list. */
+data class DcaPlansUiState(
+    val loading: Boolean = true,
+    val plans: List<DcaPlan> = emptyList(),
+    val actingPlanId: String? = null,
+    val errorMessage: String? = null,
+    val successMessage: String? = null,
+    /** True when the last load succeeded but returned no plans (runner may be pending backend-side). */
+    val emptyPendingBackend: Boolean = false,
+) {
+    val isEmpty: Boolean get() = !loading && plans.isEmpty()
+}
+
+/**
+ * Drives the DCA / recurring-buys PLANS list. Loading DEGRADES on 404 to an honest empty state that names
+ * the pending backend runner; the per-plan pause / resume / cancel mutations surface a rejection (or a 404
+ * from an undeployed runner) as a clear error, never a silent success, and refresh the list on success.
+ */
+@HiltViewModel
+class DcaPlansViewModel @Inject constructor(
+    private val repository: DcaRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DcaPlansUiState())
+    val uiState: StateFlow<DcaPlansUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.update { it.copy(loading = true, errorMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.plans()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        loading = false,
+                        plans = r.data.sortedWith(compareBy({ p -> p.status.ordinal }, { p -> p.nextRunTs ?: Long.MAX_VALUE })),
+                        emptyPendingBackend = r.data.isEmpty(),
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(loading = false, errorMessage = r.error.message.ifBlank { "Couldn't load your recurring buys." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(loading = false, errorMessage = "No connection. Pull to retry.")
+                }
+            }
+        }
+    }
+
+    fun consumeMessages() = _uiState.update { it.copy(errorMessage = null, successMessage = null) }
+
+    fun pause(planId: String) = mutate(planId, "Plan paused.") { repository.pause(planId) }
+    fun resume(planId: String) = mutate(planId, "Plan resumed.") { repository.resume(planId) }
+    fun cancel(planId: String) = mutate(planId, "Plan cancelled.") { repository.cancel(planId) }
+
+    private fun mutate(planId: String, okMessage: String, block: suspend () -> ApiResult<DcaPlan>) {
+        _uiState.update { it.copy(actingPlanId = planId, errorMessage = null, successMessage = null) }
+        viewModelScope.launch {
+            when (val r = block()) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(actingPlanId = null, successMessage = okMessage) }
+                    refresh()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(actingPlanId = null, errorMessage = r.error.message.ifBlank { "That action isn't available right now." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(actingPlanId = null, errorMessage = "No connection. Nothing changed.")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/dca/DcaSchedule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/dca/DcaSchedule.kt
@@ -1,0 +1,217 @@
+package com.testlogon.android.feature.dca
+
+import com.testlogon.android.data.dca.DcaFrequency
+import com.testlogon.android.data.dca.DcaPlan
+import com.testlogon.android.data.dca.DcaStatus
+
+/**
+ * PURE, Android-free schedule + budget math for DCA / RECURRING BUYS. Kept out of the ViewModel so the
+ * next-run / upcoming-runs / budget rules are JVM-unit testable without Compose / Hilt / java.time.
+ *
+ * Design (mirrors EventSlotter's discipline): NO java.time, NO Android. All date math is done in UTC on
+ * epoch-millis via a tiny proleptic-Gregorian civil-date conversion (days-from-epoch <-> y/m/d). This is
+ * deterministic and desugaring-free. Callers own display-zone formatting; scheduling here is UTC-day
+ * granular, which is exactly what a once-per-day/week/month runner needs.
+ *
+ * Money is integer CENTS throughout. Day-of-week is 1=Mon..7=Sun (ISO). Day-of-month is 1..31 but is
+ * CAPPED at 28 at scheduling time so a plan never skips short months (Feb) — per the contract.
+ */
+object DcaSchedule {
+
+    const val MS_PER_DAY: Long = 86_400_000L
+    const val DAY_OF_MONTH_CAP: Int = 28
+    const val DEFAULT_PREVIEW_RUNS: Int = 5
+
+    // ---- civil-date <-> days-from-epoch (Howard Hinnant's algorithm; proleptic Gregorian, UTC) ----
+
+    private data class Civil(val year: Long, val month: Int, val day: Int)
+
+    /** Floor-divide epoch-ms to whole UTC days since 1970-01-01. */
+    private fun epochDay(ms: Long): Long = Math.floorDiv(ms, MS_PER_DAY)
+
+    /** Start-of-UTC-day epoch-ms for a given days-from-epoch. */
+    private fun dayStartMs(days: Long): Long = days * MS_PER_DAY
+
+    /** days-from-epoch -> civil date (UTC). */
+    private fun toCivil(days: Long): Civil {
+        val z = days + 719_468L
+        val era = (if (z >= 0) z else z - 146_096) / 146_097
+        val doe = z - era * 146_097 // [0, 146096]
+        val yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365 // [0, 399]
+        val y = yoe + era * 400
+        val doy = doe - (365 * yoe + yoe / 4 - yoe / 100) // [0, 365]
+        val mp = (5 * doy + 2) / 153 // [0, 11]
+        val d = (doy - (153 * mp + 2) / 5 + 1).toInt() // [1, 31]
+        val m = (if (mp < 10) mp + 3 else mp - 9).toInt() // [1, 12]
+        return Civil(year = if (m <= 2) y + 1 else y, month = m, day = d)
+    }
+
+    /** civil date (UTC) -> days-from-epoch. */
+    private fun fromCivil(year: Long, month: Int, day: Int): Long {
+        val y = if (month <= 2) year - 1 else year
+        val era = (if (y >= 0) y else y - 399) / 400
+        val yoe = y - era * 400 // [0, 399]
+        val doy = (153 * (if (month > 2) month - 3 else month + 9) + 2) / 5 + (day - 1) // [0, 365]
+        val doe = yoe * 365 + yoe / 4 - yoe / 100 + doy // [0, 146096]
+        return era * 146_097 + doe - 719_468
+    }
+
+    /** ISO day-of-week for a days-from-epoch value: 1=Mon..7=Sun. 1970-01-01 was a Thursday (=4). */
+    private fun isoDowFromDays(days: Long): Int {
+        val r = Math.floorMod(days + 3, 7L).toInt() // shift so Monday=0
+        return r + 1
+    }
+
+    /** Days in [month] of [year] (UTC / proleptic Gregorian). */
+    private fun daysInMonth(year: Long, month: Int): Int {
+        val nextMonthYear = if (month == 12) year + 1 else year
+        val nextMonth = if (month == 12) 1 else month + 1
+        return (fromCivil(nextMonthYear, nextMonth, 1) - fromCivil(year, month, 1)).toInt()
+    }
+
+    // ---- validation ----
+
+    sealed interface Validation {
+        data object Ok : Validation
+        data class Invalid(val reason: String) : Validation
+    }
+
+    /**
+     * Validate a candidate plan's SCHEDULE + money fields (kind-agnostic; target existence is the picker's
+     * job). Enforces: positive amount, a known frequency with its required day part, a start, an end (if
+     * set) strictly after start, and a total budget (if set) at least one buy.
+     */
+    fun validatePlan(
+        amountCents: Long,
+        frequency: DcaFrequency,
+        dayOfWeek: Int?,
+        dayOfMonth: Int?,
+        startTs: Long,
+        endTs: Long?,
+        totalBudgetCents: Long?,
+    ): Validation {
+        if (amountCents <= 0L) return Validation.Invalid("Enter a buy amount greater than \$0.")
+        if (startTs <= 0L) return Validation.Invalid("Pick a start date.")
+        when (frequency) {
+            DcaFrequency.WEEKLY -> if (dayOfWeek == null || dayOfWeek !in 1..7) {
+                return Validation.Invalid("Pick a day of the week.")
+            }
+            DcaFrequency.MONTHLY -> if (dayOfMonth == null || dayOfMonth !in 1..31) {
+                return Validation.Invalid("Pick a day of the month.")
+            }
+            DcaFrequency.DAILY -> Unit
+            DcaFrequency.UNKNOWN -> return Validation.Invalid("Pick a frequency.")
+        }
+        if (endTs != null && endTs <= startTs) return Validation.Invalid("End date must be after the start date.")
+        if (totalBudgetCents != null && totalBudgetCents < amountCents) {
+            return Validation.Invalid("Total budget must cover at least one buy.")
+        }
+        return Validation.Ok
+    }
+
+    // ---- next-run / upcoming-runs ----
+
+    /**
+     * The next scheduled run at or after [fromMs] for [plan], or null when the plan will never run again
+     * (terminal status, past its end, or budget exhausted). Runs land at the START of the scheduled UTC day.
+     */
+    fun nextRun(plan: DcaPlan, fromMs: Long): Long? {
+        if (plan.status == DcaStatus.CANCELLED || plan.status == DcaStatus.COMPLETED) return null
+        if (plan.frequency == DcaFrequency.UNKNOWN) return null
+        if (plan.amountCents <= 0L) return null
+        if (budgetRemainingCents(plan)?.let { it < plan.amountCents } == true) return null
+
+        // The search floor is the later of the plan start and the requested from-time, aligned to day.
+        val floorMs = maxOf(plan.startTs, fromMs)
+        val floorDay = epochDay(floorMs)
+        val startDay = epochDay(plan.startTs)
+        val baseFloorDay = maxOf(floorDay, startDay)
+
+        val runDay: Long = when (plan.frequency) {
+            DcaFrequency.DAILY -> baseFloorDay
+            DcaFrequency.WEEKLY -> {
+                val target = (plan.dayOfWeek ?: return null).coerceIn(1, 7)
+                val delta = Math.floorMod((target - isoDowFromDays(baseFloorDay)).toLong(), 7L)
+                baseFloorDay + delta
+            }
+            DcaFrequency.MONTHLY -> {
+                val targetDom = (plan.dayOfMonth ?: return null).coerceIn(1, 31).coerceAtMost(DAY_OF_MONTH_CAP)
+                var probe = baseFloorDay
+                var result: Long = -1
+                var guard = 0
+                while (guard < 480) { // up to 40 years of months, ample
+                    val c = toCivil(probe)
+                    val dom = targetDom.coerceAtMost(daysInMonth(c.year, c.month))
+                    val candidate = fromCivil(c.year, c.month, dom)
+                    if (candidate >= baseFloorDay) {
+                        result = candidate
+                        break
+                    }
+                    // move probe to the 1st of next month
+                    val ny = if (c.month == 12) c.year + 1 else c.year
+                    val nm = if (c.month == 12) 1 else c.month + 1
+                    probe = fromCivil(ny, nm, 1)
+                    guard++
+                }
+                if (result < 0) return null
+                result
+            }
+            DcaFrequency.UNKNOWN -> return null
+        }
+
+        val runMs = dayStartMs(runDay)
+        if (plan.endTs != null && runMs > plan.endTs) return null
+        return runMs
+    }
+
+    /**
+     * The next [n] scheduled runs at or after [fromMs] (respecting start / end / budget), earliest first.
+     * Fewer than [n] entries when the plan completes (end reached or budget exhausted) sooner.
+     */
+    fun upcomingRuns(plan: DcaPlan, fromMs: Long, n: Int = DEFAULT_PREVIEW_RUNS): List<Long> {
+        if (n <= 0) return emptyList()
+        val out = ArrayList<Long>(n)
+        // Track a shrinking budget so previews stop when funds run out.
+        var remaining = budgetRemainingCents(plan)
+        var cursor = fromMs
+        var guard = 0
+        while (out.size < n && guard < n * 32 + 64) {
+            guard++
+            if (remaining != null && remaining < plan.amountCents) break
+            val next = nextRun(plan, cursor) ?: break
+            out.add(next)
+            if (remaining != null) remaining -= plan.amountCents
+            // advance the cursor a full day past this run so the next search moves to a later day
+            cursor = next + MS_PER_DAY
+        }
+        return out
+    }
+
+    // ---- budget ----
+
+    /**
+     * Cents left in the plan's total budget = total_budget - spent (>= 0), or null when the plan has no
+     * total-budget cap (runs indefinitely until end/cancel).
+     */
+    fun budgetRemainingCents(plan: DcaPlan): Long? {
+        val total = plan.totalBudgetCents ?: return null
+        return (total - plan.spentCents).coerceAtLeast(0L)
+    }
+
+    /**
+     * How many more buys the remaining budget funds, or null when uncapped. Integer floor of
+     * remaining / amount; 0 when a buy no longer fits.
+     */
+    fun estimatedRunsRemaining(plan: DcaPlan): Int? {
+        val remaining = budgetRemainingCents(plan) ?: return null
+        if (plan.amountCents <= 0L) return 0
+        return (remaining / plan.amountCents).toInt()
+    }
+
+    /** Budget progress in [0f, 1f] (spent / total), or null when uncapped. Guards a zero/negative total. */
+    fun budgetProgress(plan: DcaPlan): Float? {
+        val total = plan.totalBudgetCents ?: return null
+        if (total <= 0L) return null
+        return (plan.spentCents.toDouble() / total.toDouble()).coerceIn(0.0, 1.0).toFloat()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1688,6 +1688,17 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.ACCOUNT,
         ),
+        // DCA / RECURRING BUYS: schedule recurring buys of a symbol / creator token / strategy fund,
+        // funded from the USD cash wallet. Plan CRUD + schedule preview + history are client-side; the
+        // periodic execution is a server-side runner (reads degrade-on-404 until it ships).
+        MoreEntry(
+            id = "dca",
+            labelRes = R.string.more_entry_dca,
+            icon = Icons.Outlined.Schedule,
+            route = MoreRoutes.DCA,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
         // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: the rescuer opportunity board (BROWSE open
         // bailouts to inject rescue capital for a position-share). The distress overview + per-position
         // auction + auto-bailout setting are reached from here / the margin position surface. All reads

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -331,6 +331,9 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // USER-CREATED STRATEGIES / BASKETS (investable funds): marketplace + builder + detail
         // (invest/redeem at NAV) + paper-run/backtest. Endpoints degrade-on-404 (backend pending).
         strategiesDestinations(navController)
+        // DCA / RECURRING BUYS: plan CRUD + schedule preview + history; execution is a server-side
+        // runner (reads degrade-on-404 until it ships). Funded from the USD cash wallet.
+        dcaDestinations(navController)
         // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: distress overview + rescuer board + per-position
         // auction + auto-bailout setting. Endpoints degrade-on-404 (backend pending); distress never fabricated.
         bailoutDestinations(navController)

--- a/android/app/src/main/java/com/testlogon/android/navigation/DcaNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/DcaNavigation.kt
@@ -1,0 +1,64 @@
+package com.testlogon.android.navigation
+
+import android.net.Uri
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.feature.dca.DcaCreateRoute
+import com.testlogon.android.feature.dca.DcaDetailRoute
+import com.testlogon.android.feature.dca.DcaPlansRoute
+
+/**
+ * DCA / RECURRING-BUYS destinations, registered in the AUTHENTICATED nav graph.
+ *
+ * [DcaPlansDest] is the plans list (the navigable hub entry); [DcaCreateDest] is the create flow;
+ * [DcaDetailDest] is the per-plan detail + history + run-now. Plan CRUD + schedule preview live in the
+ * client; the periodic EXECUTION is a server-side runner, so every read degrades on 404 to an honest
+ * pending state. Back pops the stack.
+ */
+data object DcaPlansDest {
+    const val ROUTE = "dca"
+}
+
+data object DcaCreateDest {
+    const val ROUTE = "dca/create"
+}
+
+data object DcaDetailDest {
+    const val ROUTE = "dca/detail/{planId}"
+    const val ARG_PLAN_ID = "planId"
+
+    fun build(planId: String): String = "dca/detail/${Uri.encode(planId)}"
+}
+
+/** Registers the DCA plans list + create + detail destinations. */
+fun NavGraphBuilder.dcaDestinations(navController: NavHostController) {
+    composable(DcaPlansDest.ROUTE) {
+        DcaPlansRoute(
+            onBack = { navController.popBackStack() },
+            onCreate = { navController.navigate(DcaCreateDest.ROUTE) { launchSingleTop = true } },
+            onOpenPlan = { id -> navController.navigate(DcaDetailDest.build(id)) { launchSingleTop = true } },
+        )
+    }
+    composable(DcaCreateDest.ROUTE) {
+        DcaCreateRoute(
+            onBack = { navController.popBackStack() },
+            onCreated = { id ->
+                // Replace the create screen with the new plan's detail so Back returns to the list.
+                navController.navigate(DcaDetailDest.build(id)) {
+                    launchSingleTop = true
+                    popUpTo(DcaCreateDest.ROUTE) { inclusive = true }
+                }
+            },
+            onAddCash = { navController.navigate(CashDest.ROUTE) { launchSingleTop = true } },
+        )
+    }
+    composable(
+        route = DcaDetailDest.ROUTE,
+        arguments = listOf(navArgument(DcaDetailDest.ARG_PLAN_ID) { type = NavType.StringType }),
+    ) {
+        DcaDetailRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -413,6 +413,11 @@ object MoreRoutes {
     // detail routes reached from there. All reads degrade-on-404 (the me/strategies backend is pending).
     const val STRATEGIES = StrategyMarketDest.ROUTE
 
+    // DCA / RECURRING BUYS: schedule recurring buys of a symbol / creator token / strategy fund, funded
+    // from the USD cash wallet. Plan CRUD + schedule preview + history live client-side; periodic
+    // EXECUTION is a server-side runner (reads degrade-on-404 until it ships).
+    const val DCA = DcaPlansDest.ROUTE
+
     // MARGIN DISTRESS / PRE-EMPTIVE BAILOUT AUCTION: the rescuer opportunity board (the navigable hub
     // BROWSE entry) + the distress overview + auto-bailout account setting. Per-position auction is a
     // detail route reached from those. All reads degrade-on-404 (the margin-distress backend is pending).
@@ -726,6 +731,7 @@ object MoreRoutes {
             INVEST,
             TOKENS,
             STRATEGIES,
+            DCA,
             BAILOUTS,
             MARGIN_DISTRESS,
             BAILOUT_SETTINGS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4313,6 +4313,7 @@
     <string name="more_entry_analysis">Analysis</string>
     <string name="more_entry_tokens">Creator Tokens</string>
     <string name="more_entry_strategies">Strategies &amp; Baskets</string>
+    <string name="more_entry_dca">Recurring Buys (DCA)</string>
     <string name="more_entry_bailouts">Bailout Auctions</string>
     <string name="more_entry_trading_alerts">Trading alerts</string>
     <string name="more_entry_activity_center">Activity Center</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/dca/DcaScheduleTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/dca/DcaScheduleTest.kt
@@ -1,0 +1,257 @@
+package com.testlogon.android.feature.dca
+
+import com.testlogon.android.data.dca.DcaFrequency
+import com.testlogon.android.data.dca.DcaPlan
+import com.testlogon.android.data.dca.DcaStatus
+import com.testlogon.android.data.dca.DcaTarget
+import com.testlogon.android.data.dca.DcaTargetKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure schedule + budget math for DCA / recurring buys. All times are epoch-ms in UTC.
+ *
+ * Anchors used (verified against the proleptic-Gregorian UTC calendar):
+ *  - 2024-01-01 00:00:00 UTC = 1_704_067_200_000 ms, a MONDAY (ISO dow = 1).
+ *  - 2024-02-29 00:00:00 UTC = 1_709_164_800_000 ms (leap day).
+ */
+class DcaScheduleTest {
+
+    private val day = DcaSchedule.MS_PER_DAY
+    private val mon2024 = 1_704_067_200_000L // 2024-01-01 UTC, Monday
+
+    private fun plan(
+        amountCents: Long = 1_000L,
+        frequency: DcaFrequency = DcaFrequency.DAILY,
+        dayOfWeek: Int? = null,
+        dayOfMonth: Int? = null,
+        startTs: Long = mon2024,
+        endTs: Long? = null,
+        totalBudgetCents: Long? = null,
+        status: DcaStatus = DcaStatus.ACTIVE,
+        spentCents: Long = 0L,
+    ) = DcaPlan(
+        planId = "p1",
+        target = DcaTarget(DcaTargetKind.SYMBOL, "1", "BTCUSDC"),
+        amountCents = amountCents,
+        frequency = frequency,
+        dayOfWeek = dayOfWeek,
+        dayOfMonth = dayOfMonth,
+        startTs = startTs,
+        endTs = endTs,
+        totalBudgetCents = totalBudgetCents,
+        status = status,
+        spentCents = spentCents,
+    )
+
+    // ---- nextRun: daily ----
+
+    @Test
+    fun nextRun_daily_beforeStart_returnsStartDay() {
+        val p = plan(frequency = DcaFrequency.DAILY, startTs = mon2024)
+        assertEquals(mon2024, DcaSchedule.nextRun(p, mon2024 - 10 * day))
+    }
+
+    @Test
+    fun nextRun_daily_midDay_returnsSameDayStart() {
+        val p = plan(frequency = DcaFrequency.DAILY, startTs = mon2024)
+        // A from-time in the afternoon of day+3 -> the run lands at the START of that same day.
+        val from = mon2024 + 3 * day + 43_200_000L
+        assertEquals(mon2024 + 3 * day, DcaSchedule.nextRun(p, from))
+    }
+
+    // ---- nextRun: weekly ----
+
+    @Test
+    fun nextRun_weekly_advancesToTargetDow() {
+        // Start Monday; want Wednesday (ISO 3) -> +2 days.
+        val p = plan(frequency = DcaFrequency.WEEKLY, dayOfWeek = 3, startTs = mon2024)
+        assertEquals(mon2024 + 2 * day, DcaSchedule.nextRun(p, mon2024))
+    }
+
+    @Test
+    fun nextRun_weekly_targetIsStartDow_returnsStart() {
+        // Start Monday; want Monday (ISO 1) -> same day.
+        val p = plan(frequency = DcaFrequency.WEEKLY, dayOfWeek = 1, startTs = mon2024)
+        assertEquals(mon2024, DcaSchedule.nextRun(p, mon2024))
+    }
+
+    @Test
+    fun nextRun_weekly_wrapsToNextWeek() {
+        // From a Wednesday, want Tuesday (ISO 2) -> should wrap 6 days forward.
+        val wed = mon2024 + 2 * day
+        val p = plan(frequency = DcaFrequency.WEEKLY, dayOfWeek = 2, startTs = mon2024)
+        assertEquals(wed + 6 * day, DcaSchedule.nextRun(p, wed))
+    }
+
+    // ---- nextRun: monthly ----
+
+    @Test
+    fun nextRun_monthly_landsOnDayOfMonth() {
+        // Start 2024-01-01, want the 15th -> 2024-01-15.
+        val p = plan(frequency = DcaFrequency.MONTHLY, dayOfMonth = 15, startTs = mon2024)
+        val jan15 = mon2024 + 14 * day
+        assertEquals(jan15, DcaSchedule.nextRun(p, mon2024))
+    }
+
+    @Test
+    fun nextRun_monthly_afterDom_rollsToNextMonth() {
+        // Want the 1st but ask from the 15th -> next month's 1st (Feb 1 = +31 days from Jan 1).
+        val p = plan(frequency = DcaFrequency.MONTHLY, dayOfMonth = 1, startTs = mon2024)
+        val jan15 = mon2024 + 14 * day
+        val feb1 = mon2024 + 31 * day
+        assertEquals(feb1, DcaSchedule.nextRun(p, jan15))
+    }
+
+    @Test
+    fun nextRun_monthly_dayOfMonthAbove28_isCappedTo28() {
+        // Contract: day_of_month > 28 is capped at 28 so Feb is never skipped.
+        val p = plan(frequency = DcaFrequency.MONTHLY, dayOfMonth = 31, startTs = mon2024)
+        // From Feb 1 2024 -> Feb 28 (capped), NOT skipped.
+        val feb1 = mon2024 + 31 * day
+        val feb28 = feb1 + 27 * day
+        assertEquals(feb28, DcaSchedule.nextRun(p, feb1))
+    }
+
+    // ---- start / end / status guards ----
+
+    @Test
+    fun nextRun_pastEnd_returnsNull() {
+        val p = plan(frequency = DcaFrequency.DAILY, startTs = mon2024, endTs = mon2024 + 2 * day)
+        assertNull(DcaSchedule.nextRun(p, mon2024 + 5 * day))
+    }
+
+    @Test
+    fun nextRun_cancelledOrCompleted_returnsNull() {
+        assertNull(DcaSchedule.nextRun(plan(status = DcaStatus.CANCELLED), mon2024))
+        assertNull(DcaSchedule.nextRun(plan(status = DcaStatus.COMPLETED), mon2024))
+    }
+
+    @Test
+    fun nextRun_budgetExhausted_returnsNull() {
+        // total 1000, spent 500, amount 1000 -> remaining 500 < 1000 -> no run.
+        val p = plan(amountCents = 1_000L, totalBudgetCents = 1_000L, spentCents = 500L)
+        assertNull(DcaSchedule.nextRun(p, mon2024))
+    }
+
+    @Test
+    fun nextRun_unknownFrequency_returnsNull() {
+        assertNull(DcaSchedule.nextRun(plan(frequency = DcaFrequency.UNKNOWN), mon2024))
+    }
+
+    // ---- upcomingRuns ----
+
+    @Test
+    fun upcomingRuns_daily_returnsNConsecutiveDays() {
+        val p = plan(frequency = DcaFrequency.DAILY, startTs = mon2024)
+        val runs = DcaSchedule.upcomingRuns(p, mon2024, 5)
+        assertEquals(listOf(mon2024, mon2024 + day, mon2024 + 2 * day, mon2024 + 3 * day, mon2024 + 4 * day), runs)
+    }
+
+    @Test
+    fun upcomingRuns_weekly_returnsWeeklyCadence() {
+        val p = plan(frequency = DcaFrequency.WEEKLY, dayOfWeek = 1, startTs = mon2024)
+        val runs = DcaSchedule.upcomingRuns(p, mon2024, 3)
+        assertEquals(listOf(mon2024, mon2024 + 7 * day, mon2024 + 14 * day), runs)
+    }
+
+    @Test
+    fun upcomingRuns_stopsAtEnd() {
+        // End after the 3rd day -> only 3 daily runs fit.
+        val p = plan(frequency = DcaFrequency.DAILY, startTs = mon2024, endTs = mon2024 + 2 * day)
+        val runs = DcaSchedule.upcomingRuns(p, mon2024, 10)
+        assertEquals(3, runs.size)
+    }
+
+    @Test
+    fun upcomingRuns_stopsWhenBudgetRunsOut() {
+        // Budget funds exactly 2 buys of 1000 (spent 0, total 2000).
+        val p = plan(amountCents = 1_000L, frequency = DcaFrequency.DAILY, totalBudgetCents = 2_000L)
+        val runs = DcaSchedule.upcomingRuns(p, mon2024, 10)
+        assertEquals(2, runs.size)
+    }
+
+    // ---- budget helpers ----
+
+    @Test
+    fun budgetRemaining_null_whenUncapped() {
+        assertNull(DcaSchedule.budgetRemainingCents(plan(totalBudgetCents = null)))
+    }
+
+    @Test
+    fun budgetRemaining_flooredAtZero() {
+        val p = plan(totalBudgetCents = 1_000L, spentCents = 1_500L)
+        assertEquals(0L, DcaSchedule.budgetRemainingCents(p))
+    }
+
+    @Test
+    fun estimatedRunsRemaining_integerFloor() {
+        val p = plan(amountCents = 1_000L, totalBudgetCents = 3_500L, spentCents = 0L)
+        assertEquals(3, DcaSchedule.estimatedRunsRemaining(p))
+    }
+
+    @Test
+    fun budgetProgress_ratioAndBounds() {
+        val p = plan(totalBudgetCents = 1_000L, spentCents = 250L)
+        assertEquals(0.25f, DcaSchedule.budgetProgress(p)!!, 0.0001f)
+        // over-spend clamps to 1.
+        val over = plan(totalBudgetCents = 1_000L, spentCents = 5_000L)
+        assertEquals(1.0f, DcaSchedule.budgetProgress(over)!!, 0.0001f)
+        // uncapped -> null.
+        assertNull(DcaSchedule.budgetProgress(plan(totalBudgetCents = null)))
+    }
+
+    // ---- validatePlan ----
+
+    @Test
+    fun validate_rejectsNonPositiveAmount() {
+        val v = DcaSchedule.validatePlan(0L, DcaFrequency.DAILY, null, null, mon2024, null, null)
+        assertTrue(v is DcaSchedule.Validation.Invalid)
+    }
+
+    @Test
+    fun validate_weeklyRequiresDayOfWeek() {
+        val bad = DcaSchedule.validatePlan(1_000L, DcaFrequency.WEEKLY, null, null, mon2024, null, null)
+        assertTrue(bad is DcaSchedule.Validation.Invalid)
+        val ok = DcaSchedule.validatePlan(1_000L, DcaFrequency.WEEKLY, 3, null, mon2024, null, null)
+        assertEquals(DcaSchedule.Validation.Ok, ok)
+    }
+
+    @Test
+    fun validate_monthlyRequiresDayOfMonth() {
+        val bad = DcaSchedule.validatePlan(1_000L, DcaFrequency.MONTHLY, null, null, mon2024, null, null)
+        assertTrue(bad is DcaSchedule.Validation.Invalid)
+        val ok = DcaSchedule.validatePlan(1_000L, DcaFrequency.MONTHLY, null, 15, mon2024, null, null)
+        assertEquals(DcaSchedule.Validation.Ok, ok)
+    }
+
+    @Test
+    fun validate_endMustBeAfterStart() {
+        val bad = DcaSchedule.validatePlan(1_000L, DcaFrequency.DAILY, null, null, mon2024, mon2024, null)
+        assertTrue(bad is DcaSchedule.Validation.Invalid)
+    }
+
+    @Test
+    fun validate_totalBudgetMustCoverOneBuy() {
+        val bad = DcaSchedule.validatePlan(1_000L, DcaFrequency.DAILY, null, null, mon2024, null, 500L)
+        assertTrue(bad is DcaSchedule.Validation.Invalid)
+        val ok = DcaSchedule.validatePlan(1_000L, DcaFrequency.DAILY, null, null, mon2024, null, 1_000L)
+        assertEquals(DcaSchedule.Validation.Ok, ok)
+    }
+
+    @Test
+    fun validate_happyPathDaily() {
+        assertEquals(
+            DcaSchedule.Validation.Ok,
+            DcaSchedule.validatePlan(2_500L, DcaFrequency.DAILY, null, null, mon2024, mon2024 + 30 * day, 50_000L),
+        )
+    }
+
+    @Test
+    fun nextRun_notNull_forActiveDaily_sanity() {
+        assertNotNull(DcaSchedule.nextRun(plan(), mon2024))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,6 +73,9 @@ const StrategyMarketPage = lazy(() => import("@/pages/strategies/StrategyMarketP
 const StrategyBuilderPage = lazy(() => import("@/pages/strategies/StrategyBuilderPage"));
 const StrategyDetailPage = lazy(() => import("@/pages/strategies/StrategyDetailPage"));
 const StrategyBacktestPage = lazy(() => import("@/pages/strategies/StrategyBacktestPage"));
+const DcaPlansPage = lazy(() => import("@/pages/dca/DcaPlansPage"));
+const DcaCreatePage = lazy(() => import("@/pages/dca/DcaCreatePage"));
+const DcaDetailPage = lazy(() => import("@/pages/dca/DcaDetailPage"));
 const MarketAnalysisPage = lazy(() => import("@/pages/analysis/MarketAnalysisPage"));
 const PaperTradingPage = lazy(() => import("@/pages/paper/PaperTradingPage"));
 const PriceAlertsPage = lazy(() => import("@/pages/alerts/PriceAlertsPage"));
@@ -777,6 +780,9 @@ export default function App() {
           <Route path="strategies/:id/edit" element={<StrategyBuilderPage />} />
           <Route path="strategies/:id/backtest" element={<StrategyBacktestPage />} />
           <Route path="bailouts" element={<BailoutsBoardPage />} />
+          <Route path="dca" element={<DcaPlansPage />} />
+          <Route path="dca/new" element={<DcaCreatePage />} />
+          <Route path="dca/:id" element={<DcaDetailPage />} />
           <Route path="invest" element={<InvestHubPage />} />
           <Route path="analysis" element={<MarketAnalysisPage />} />
           <Route path="markets/price-alerts" element={<PriceAlertsPage />} />

--- a/frontend/src/api/endpoints/dca.ts
+++ b/frontend/src/api/endpoints/dca.ts
@@ -1,0 +1,115 @@
+import { api } from "@/api/client";
+import type {
+  DcaPlan,
+  DcaTarget,
+  DcaFrequency,
+} from "@/lib/dca";
+
+/**
+ * DCA / RECURRING BUYS surface (`/me/dca/*`).
+ *
+ * A user schedules recurring dollar-cost-average buys of a TARGET — a market
+ * SYMBOL, a creator TOKEN, or a STRATEGY / basket fund — funded from their USD
+ * CASH WALLET (`/custody/cash`). The FRONTEND owns plan CRUD + a schedule
+ * preview + execution history; the periodic execution itself is a SERVER-SIDE
+ * runner: "recurring buys run automatically server-side once scheduled."
+ *
+ * CONVENTIONS (locked): every monetary amount is INTEGER CENTS; `start_ts` /
+ * `end_ts` / `next_run_ts` are epoch SECONDS. NONE of these endpoints exist on
+ * the backend yet — every GET degrades on 404/absent to an empty-but-honest
+ * state (callers use `retry:false` + render a "recurring buys need the backend
+ * runner" note), and every mutation surfaces a clear error (never silently
+ * "succeeds").
+ */
+
+export type { DcaPlan, DcaTarget, DcaFrequency } from "@/lib/dca";
+
+export interface DcaPlansResult {
+  plans: DcaPlan[];
+}
+
+/** One executed (or attempted) recurring-buy run. */
+export interface DcaRun {
+  /** Epoch seconds of the run. */
+  ts: number;
+  /** Amount debited from the USD wallet, in cents. */
+  amount_cents: number;
+  /** Quantity filled (base units), when the buy executed. */
+  filled_qty?: number;
+  /** Fill price in cents, when executed. */
+  price?: number;
+  /** Run outcome. */
+  status: "filled" | "partial" | "skipped" | "failed" | string;
+  /** Human note on skip / failure (insufficient funds, etc.). */
+  note?: string;
+}
+
+export interface DcaHistoryResult {
+  runs: DcaRun[];
+}
+
+/** Generic mutation ack; carries a message on the failure paths. */
+export interface DcaAck {
+  ok?: boolean;
+  status?: string;
+  plan_id?: string;
+  detail?: string;
+  error?: string;
+  note?: string;
+  reason?: string | number;
+}
+
+// -- Requests ---------------------------------------------------------
+
+export interface CreateDcaPlanRequest {
+  target: DcaTarget;
+  amount_cents: number;
+  frequency: DcaFrequency;
+  day_of_week?: number;
+  day_of_month?: number;
+  /** Epoch seconds. */
+  start_ts: number;
+  /** Epoch seconds. */
+  end_ts?: number;
+  total_budget_cents?: number;
+}
+
+// -- Calls (all 404 until the backend ships — callers degrade) --------
+
+/** The caller's recurring-buy plans. */
+export const getDcaPlans = () => api.get<DcaPlansResult>("/me/dca/plans");
+
+/** Create a recurring-buy plan (server schedules the runner). */
+export const createDcaPlan = (body: CreateDcaPlanRequest) =>
+  api.post<DcaPlan>("/me/dca/plans", body);
+
+/** Pause an active plan (no runs until resumed). */
+export const pauseDcaPlan = (id: string) =>
+  api.post<DcaPlan>(`/me/dca/plans/${encodeURIComponent(id)}/pause`, {});
+
+/** Resume a paused plan. */
+export const resumeDcaPlan = (id: string) =>
+  api.post<DcaPlan>(`/me/dca/plans/${encodeURIComponent(id)}/resume`, {});
+
+/** Cancel a plan permanently. */
+export const cancelDcaPlan = (id: string) =>
+  api.post<DcaPlan>(`/me/dca/plans/${encodeURIComponent(id)}/cancel`, {});
+
+/** Execution history for one plan. */
+export const getDcaHistory = (id: string) =>
+  api.get<DcaHistoryResult>(`/me/dca/plans/${encodeURIComponent(id)}/history`);
+
+/** Trigger a single buy now (the backend executes one run out-of-band). */
+export const runDcaPlanNow = (id: string) =>
+  api.post<DcaAck>(`/me/dca/plans/${encodeURIComponent(id)}/run-now`, {});
+
+// -- Helpers ----------------------------------------------------------
+
+/** Best human message off any DCA ack (error / detail / reject reason). */
+export const dcaAckMessage = (a: DcaAck | null | undefined): string | undefined => {
+  if (!a) return undefined;
+  if (a.detail) return a.detail;
+  if (a.error) return a.error;
+  if (a.note) return a.note;
+  return a.reason != null ? `rejected (${a.reason})` : undefined;
+};

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -194,6 +194,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Custody Providers", i18nKey: "nav.custodyProviders", path: "/custody/providers", icon: <Building2 className="h-5 w-5" /> },
       { label: "Creator Tokens", i18nKey: "nav.creatorTokens", path: "/tokens", icon: <Landmark className="h-5 w-5" /> },
       { label: "Strategies", i18nKey: "nav.strategies", path: "/strategies", icon: <Boxes className="h-5 w-5" /> },
+      { label: "Recurring buys", i18nKey: "nav.recurringBuys", path: "/dca", icon: <CalendarClock className="h-5 w-5" /> },
       { label: "Referrals", i18nKey: "nav.referrals", path: "/referrals", icon: <Share2 className="h-5 w-5" /> },
       { label: "Promo Codes", i18nKey: "nav.promoCodes", path: "/promo", icon: <Tag className="h-5 w-5" /> },
       { label: "Affiliates", i18nKey: "nav.affiliates", path: "/affiliates", icon: <Link2 className="h-5 w-5" /> },

--- a/frontend/src/hooks/useDca.ts
+++ b/frontend/src/hooks/useDca.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import * as dca from "@/api/endpoints/dca";
+import { ApiError } from "@/api/client";
+
+/**
+ * React-query hooks for the DCA / RECURRING BUYS surface. Mirrors the
+ * `useStrategies` / `useTokens` conventions: reads use `retry:false` because
+ * EVERY route 404s until the SERVER-SIDE runner ships (callers render an honest
+ * empty / "recurring buys need the backend runner" state); mutations surface a
+ * clear error toast on failure (never silent).
+ */
+
+export const dcaKeys = {
+  all: ["me", "dca"] as const,
+  plans: ["me", "dca", "plans"] as const,
+  history: (id: string) => ["me", "dca", "history", id] as const,
+};
+
+const HISTORY_POLL_MS = 20_000;
+
+// -- Reads (degrade on 404 — retry:false) -----------------------------
+
+export function useDcaPlans(enabled = true) {
+  return useQuery({
+    queryKey: dcaKeys.plans,
+    queryFn: dca.getDcaPlans,
+    enabled,
+    retry: false,
+  });
+}
+
+export function useDcaHistory(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: dcaKeys.history(id ?? ""),
+    queryFn: () => dca.getDcaHistory(id!),
+    enabled: enabled && !!id,
+    retry: false,
+    refetchInterval: HISTORY_POLL_MS,
+  });
+}
+
+/** True when a query error is the expected "backend not shipped yet" 404. */
+export function isPendingBackend(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+/** Human error message for a failed mutation (404 -> "not available yet"). */
+function mutationErrorText(err: unknown, action: string): string {
+  if (err instanceof ApiError) {
+    if (err.status === 404) {
+      return `${action} is not available yet — the recurring-buys backend runner has not shipped.`;
+    }
+    return err.detail || `${action} failed.`;
+  }
+  return `${action} failed.`;
+}
+
+// -- Mutations (clear error toast on failure — never silent) ----------
+
+export function useCreateDcaPlan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: dca.CreateDcaPlanRequest) => dca.createDcaPlan(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: dcaKeys.plans }),
+    onError: (err) => toast.error(mutationErrorText(err, "Creating the plan")),
+  });
+}
+
+export function usePauseDcaPlan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => dca.pauseDcaPlan(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: dcaKeys.plans }),
+    onError: (err) => toast.error(mutationErrorText(err, "Pausing the plan")),
+  });
+}
+
+export function useResumeDcaPlan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => dca.resumeDcaPlan(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: dcaKeys.plans }),
+    onError: (err) => toast.error(mutationErrorText(err, "Resuming the plan")),
+  });
+}
+
+export function useCancelDcaPlan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => dca.cancelDcaPlan(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: dcaKeys.plans }),
+    onError: (err) => toast.error(mutationErrorText(err, "Cancelling the plan")),
+  });
+}
+
+export function useRunDcaPlanNow(id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => dca.runDcaPlanNow(id!),
+    onSuccess: () => {
+      if (id) qc.invalidateQueries({ queryKey: dcaKeys.history(id) });
+      qc.invalidateQueries({ queryKey: dcaKeys.plans });
+    },
+    onError: (err) => toast.error(mutationErrorText(err, "Running the buy now")),
+  });
+}

--- a/frontend/src/lib/dca.test.ts
+++ b/frontend/src/lib/dca.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  secToMs,
+  msToSec,
+  clampDayOfMonth,
+  clampDayOfWeek,
+  nextRun,
+  upcomingRuns,
+  budgetRemainingCents,
+  estimatedRunsRemaining,
+  budgetSpentFraction,
+  validatePlan,
+  formatCents,
+  frequencyLabel,
+  ordinal,
+  MIN_AMOUNT_CENTS,
+  MAX_DAY_OF_MONTH,
+  type DcaPlan,
+  type DcaPlanDraft,
+} from "./dca";
+
+/** Build a plan from partial overrides with sane defaults. */
+function makePlan(over: Partial<DcaPlan> = {}): DcaPlan {
+  return {
+    plan_id: "p1",
+    target: { kind: "symbol", id: "1", label: "BTC-USD" },
+    amount_cents: 5000,
+    frequency: "daily",
+    start_ts: msToSec(Date.UTC(2026, 0, 1, 12, 0, 0)),
+    funding: "usd_wallet",
+    status: "active",
+    next_run_ts: msToSec(Date.UTC(2026, 0, 1, 12, 0, 0)),
+    spent_cents: 0,
+    buys_count: 0,
+    created_ts: msToSec(Date.UTC(2026, 0, 1, 0, 0, 0)),
+    ...over,
+  };
+}
+
+describe("time + clamp helpers", () => {
+  it("converts seconds <-> ms", () => {
+    expect(secToMs(1000)).toBe(1_000_000);
+    expect(secToMs(undefined)).toBe(0);
+    expect(msToSec(1_500)).toBe(1);
+    expect(msToSec(1_999)).toBe(1);
+  });
+
+  it("clamps day-of-month to [1,28]", () => {
+    expect(clampDayOfMonth(0)).toBe(1);
+    expect(clampDayOfMonth(15)).toBe(15);
+    expect(clampDayOfMonth(31)).toBe(28);
+    expect(clampDayOfMonth(undefined)).toBe(1);
+  });
+
+  it("clamps day-of-week to [0,6]", () => {
+    expect(clampDayOfWeek(-1)).toBe(0);
+    expect(clampDayOfWeek(3)).toBe(3);
+    expect(clampDayOfWeek(9)).toBe(6);
+  });
+});
+
+describe("upcomingRuns — daily", () => {
+  it("projects consecutive days from the start when fromMs precedes start", () => {
+    const start = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const plan = makePlan({ frequency: "daily", start_ts: msToSec(start) });
+    const runs = upcomingRuns(plan, start - 5 * 86_400_000, 3);
+    expect(runs).toEqual([
+      start,
+      start + 86_400_000,
+      start + 2 * 86_400_000,
+    ]);
+  });
+
+  it("starts at the next daily boundary when fromMs is mid-schedule", () => {
+    const start = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const plan = makePlan({ frequency: "daily", start_ts: msToSec(start) });
+    // ask from 2.5 days in -> next run is day 3 at the start time-of-day.
+    const from = start + 2 * 86_400_000 + 3_600_000;
+    const runs = upcomingRuns(plan, from, 2);
+    expect(runs[0]).toBe(start + 3 * 86_400_000);
+    expect(runs[1]).toBe(start + 4 * 86_400_000);
+  });
+});
+
+describe("upcomingRuns — weekly", () => {
+  it("lands on the requested day_of_week each week", () => {
+    // 2026-01-01 is a Thursday (getDay()===4) in local time on most TZs, but we
+    // assert only the cadence + DOW invariant, which is TZ-agnostic.
+    const start = new Date(2026, 0, 5, 9, 0, 0).getTime(); // Jan 5 2026 local
+    const plan = makePlan({
+      frequency: "weekly",
+      day_of_week: 1, // Monday
+      start_ts: msToSec(start),
+    });
+    const runs = upcomingRuns(plan, start, 3);
+    expect(runs.length).toBe(3);
+    for (const r of runs) expect(new Date(r).getDay()).toBe(1);
+    // 7 days apart.
+    expect(runs[1]! - runs[0]!).toBe(7 * 86_400_000);
+    expect(runs[2]! - runs[1]!).toBe(7 * 86_400_000);
+  });
+});
+
+describe("upcomingRuns — monthly", () => {
+  it("lands on the requested day_of_month each month", () => {
+    const start = new Date(2026, 0, 15, 8, 0, 0).getTime(); // Jan 15 2026 local
+    const plan = makePlan({
+      frequency: "monthly",
+      day_of_month: 15,
+      start_ts: msToSec(start),
+    });
+    const runs = upcomingRuns(plan, start, 3);
+    expect(runs.length).toBe(3);
+    expect(new Date(runs[0]!).getDate()).toBe(15);
+    expect(new Date(runs[0]!).getMonth()).toBe(0);
+    expect(new Date(runs[1]!).getMonth()).toBe(1); // Feb
+    expect(new Date(runs[1]!).getDate()).toBe(15);
+    expect(new Date(runs[2]!).getMonth()).toBe(2); // Mar
+  });
+
+  it("caps day_of_month at 28 so February is always valid", () => {
+    const start = new Date(2026, 0, 31, 8, 0, 0).getTime();
+    const plan = makePlan({
+      frequency: "monthly",
+      day_of_month: 31, // will be clamped to 28
+      start_ts: msToSec(start),
+    });
+    const runs = upcomingRuns(plan, start, 3);
+    for (const r of runs) {
+      expect(new Date(r).getDate()).toBe(28);
+    }
+    // Jan 28 precedes the Jan-31 start, so the first run is Feb 28 (non-leap 2026).
+    expect(new Date(runs[0]!).getMonth()).toBe(1);
+    expect(new Date(runs[0]!).getDate()).toBe(28);
+    expect(new Date(runs[1]!).getMonth()).toBe(2); // Mar
+  });
+});
+
+describe("upcomingRuns — bounds + status", () => {
+  it("returns nothing for paused / cancelled / completed", () => {
+    const plan = makePlan({ status: "paused" });
+    expect(upcomingRuns(plan, secToMs(plan.start_ts), 5)).toEqual([]);
+    expect(upcomingRuns(makePlan({ status: "cancelled" }), 0, 5)).toEqual([]);
+    expect(upcomingRuns(makePlan({ status: "completed" }), 0, 5)).toEqual([]);
+  });
+
+  it("stops at end_ts", () => {
+    const start = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const end = start + 2 * 86_400_000; // allow days 0,1,2
+    const plan = makePlan({
+      frequency: "daily",
+      start_ts: msToSec(start),
+      end_ts: msToSec(end),
+    });
+    const runs = upcomingRuns(plan, start, 10);
+    expect(runs.length).toBe(3);
+    expect(runs[runs.length - 1]).toBe(end);
+  });
+
+  it("stops when the budget can no longer afford another buy", () => {
+    const start = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const plan = makePlan({
+      frequency: "daily",
+      amount_cents: 5000,
+      total_budget_cents: 12000, // affords 2 more (spent 0)
+      spent_cents: 0,
+      start_ts: msToSec(start),
+    });
+    const runs = upcomingRuns(plan, start, 10);
+    expect(runs.length).toBe(2);
+  });
+
+  it("returns nothing once the budget is exhausted", () => {
+    const plan = makePlan({
+      amount_cents: 5000,
+      total_budget_cents: 10000,
+      spent_cents: 10000,
+    });
+    expect(upcomingRuns(plan, secToMs(plan.start_ts), 5)).toEqual([]);
+  });
+
+  it("guards zero / negative n and amount", () => {
+    expect(upcomingRuns(makePlan(), 0, 0)).toEqual([]);
+    expect(upcomingRuns(makePlan({ amount_cents: 0 }), 0, 3)).toEqual([]);
+  });
+});
+
+describe("nextRun", () => {
+  it("returns the first upcoming run", () => {
+    const start = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const plan = makePlan({ frequency: "daily", start_ts: msToSec(start) });
+    expect(nextRun(plan, start - 86_400_000)).toBe(start);
+  });
+
+  it("returns null when there is no future run", () => {
+    expect(nextRun(makePlan({ status: "cancelled" }), 0)).toBeNull();
+  });
+});
+
+describe("budget math", () => {
+  it("computes remaining budget for a capped plan", () => {
+    expect(budgetRemainingCents(makePlan({ total_budget_cents: 10000, spent_cents: 3000 }))).toBe(
+      7000,
+    );
+    expect(budgetRemainingCents(makePlan({ total_budget_cents: 10000, spent_cents: 15000 }))).toBe(
+      0,
+    );
+  });
+
+  it("returns null remaining for an uncapped plan", () => {
+    expect(budgetRemainingCents(makePlan({ total_budget_cents: undefined }))).toBeNull();
+  });
+
+  it("estimates whole runs remaining", () => {
+    expect(
+      estimatedRunsRemaining(makePlan({ amount_cents: 5000, total_budget_cents: 12000, spent_cents: 0 })),
+    ).toBe(2);
+    expect(estimatedRunsRemaining(makePlan({ total_budget_cents: undefined }))).toBeNull();
+  });
+
+  it("computes spent fraction, clamped", () => {
+    expect(budgetSpentFraction(makePlan({ total_budget_cents: 10000, spent_cents: 2500 }))).toBe(
+      0.25,
+    );
+    expect(budgetSpentFraction(makePlan({ total_budget_cents: 10000, spent_cents: 99999 }))).toBe(1);
+    expect(budgetSpentFraction(makePlan({ total_budget_cents: undefined }))).toBe(0);
+  });
+});
+
+describe("validatePlan", () => {
+  const base: DcaPlanDraft = {
+    target: { kind: "symbol", id: "1", label: "BTC" },
+    amount_cents: 5000,
+    frequency: "daily",
+    start_ts: msToSec(Date.UTC(2026, 0, 1)),
+  };
+
+  it("accepts a valid daily draft", () => {
+    expect(validatePlan(base).valid).toBe(true);
+  });
+
+  it("requires a target", () => {
+    const v = validatePlan({ ...base, target: null });
+    expect(v.valid).toBe(false);
+    expect(v.errors).toContain("no_target");
+  });
+
+  it("enforces the minimum amount", () => {
+    const v = validatePlan({ ...base, amount_cents: MIN_AMOUNT_CENTS - 1 });
+    expect(v.errors).toContain("amount_below_min");
+  });
+
+  it("requires a valid day_of_week for weekly", () => {
+    expect(validatePlan({ ...base, frequency: "weekly", day_of_week: 9 }).errors).toContain(
+      "invalid_day_of_week",
+    );
+    expect(validatePlan({ ...base, frequency: "weekly", day_of_week: 2 }).valid).toBe(true);
+  });
+
+  it("requires a valid day_of_month for monthly", () => {
+    expect(
+      validatePlan({ ...base, frequency: "monthly", day_of_month: MAX_DAY_OF_MONTH + 1 }).errors,
+    ).toContain("invalid_day_of_month");
+    expect(validatePlan({ ...base, frequency: "monthly", day_of_month: 15 }).valid).toBe(true);
+  });
+
+  it("rejects end <= start", () => {
+    expect(
+      validatePlan({ ...base, end_ts: base.start_ts }).errors,
+    ).toContain("end_before_start");
+    expect(validatePlan({ ...base, end_ts: base.start_ts + 86_400 }).valid).toBe(true);
+  });
+
+  it("rejects a budget below one buy", () => {
+    expect(
+      validatePlan({ ...base, amount_cents: 5000, total_budget_cents: 4000 }).errors,
+    ).toContain("budget_below_amount");
+    expect(
+      validatePlan({ ...base, amount_cents: 5000, total_budget_cents: 5000 }).valid,
+    ).toBe(true);
+  });
+});
+
+describe("formatting", () => {
+  it("formats cents", () => {
+    expect(formatCents(123456)).toBe("$1,234.56");
+    expect(formatCents(undefined)).toBe("—");
+  });
+
+  it("builds ordinals", () => {
+    expect(ordinal(1)).toBe("1st");
+    expect(ordinal(2)).toBe("2nd");
+    expect(ordinal(3)).toBe("3rd");
+    expect(ordinal(4)).toBe("4th");
+    expect(ordinal(11)).toBe("11th");
+    expect(ordinal(15)).toBe("15th");
+    expect(ordinal(21)).toBe("21st");
+  });
+
+  it("labels the cadence", () => {
+    expect(frequencyLabel("daily")).toBe("Daily");
+    expect(frequencyLabel("weekly", 1)).toBe("Weekly on Monday");
+    expect(frequencyLabel("monthly", undefined, 15)).toBe("Monthly on the 15th");
+  });
+});

--- a/frontend/src/lib/dca.ts
+++ b/frontend/src/lib/dca.ts
@@ -1,0 +1,407 @@
+/**
+ * Pure, framework-free math for the DCA / RECURRING BUYS surface.
+ *
+ * A user schedules recurring dollar-cost-average buys of a target (a market
+ * SYMBOL, a creator TOKEN, or a STRATEGY / basket fund), funded from their USD
+ * cash wallet. The FRONTEND owns plan CRUD + a schedule PREVIEW (the next N run
+ * timestamps) + execution HISTORY; the periodic execution itself is a
+ * SERVER-SIDE runner ("recurring buys run automatically server-side once
+ * scheduled").
+ *
+ * CONVENTIONS (locked): every monetary amount is INTEGER CENTS. Nothing here
+ * touches React, the network, or the DOM — deterministic and unit-tested in
+ * `dca.test.ts`. Timestamps are epoch MILLISECONDS at the boundary of these
+ * helpers (`fromMs`, returned run times); the wire `start_ts` / `end_ts` /
+ * `next_run_ts` are epoch SECONDS (matching the rest of the money surfaces), so
+ * callers convert with the tiny helpers below.
+ */
+
+// -- Wire types (mirror api/endpoints/dca.ts, duplicated to keep this pure) --
+
+export type DcaTargetKind = "symbol" | "token" | "strategy";
+export type DcaFrequency = "daily" | "weekly" | "monthly";
+export type DcaStatus = "active" | "paused" | "completed" | "cancelled";
+
+export interface DcaTarget {
+  kind: DcaTargetKind;
+  id: string;
+  label: string;
+}
+
+export interface DcaPlan {
+  plan_id: string;
+  target: DcaTarget;
+  amount_cents: number;
+  frequency: DcaFrequency;
+  /** 0 (Sun) .. 6 (Sat) — required for weekly. */
+  day_of_week?: number;
+  /** 1 .. 28 — required for monthly (capped at 28 so every month is valid). */
+  day_of_month?: number;
+  /** Epoch SECONDS the schedule starts. */
+  start_ts: number;
+  /** Epoch SECONDS the schedule ends (optional). */
+  end_ts?: number;
+  /** Optional lifetime budget cap, in cents. */
+  total_budget_cents?: number;
+  funding: "usd_wallet";
+  status: DcaStatus;
+  /** Epoch SECONDS of the next scheduled run (server-authoritative when live). */
+  next_run_ts: number;
+  /** Cents spent so far across executed buys. */
+  spent_cents: number;
+  /** Number of buys executed so far. */
+  buys_count: number;
+  created_ts: number;
+}
+
+// -- Constants ---------------------------------------------------------
+
+/** Minimum per-buy amount, in cents ($1.00). */
+export const MIN_AMOUNT_CENTS = 100;
+
+/** Highest valid day-of-month — capped so Feb/short months always have it. */
+export const MAX_DAY_OF_MONTH = 28;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// -- Time helpers ------------------------------------------------------
+
+/** Epoch seconds -> epoch milliseconds. */
+export function secToMs(sec: number | undefined | null): number {
+  return (Number.isFinite(sec as number) ? (sec as number) : 0) * 1000;
+}
+
+/** Epoch milliseconds -> epoch seconds (floored). */
+export function msToSec(ms: number): number {
+  return Math.floor((Number.isFinite(ms) ? ms : 0) / 1000);
+}
+
+/** Clamp a day-of-month into the valid [1, 28] range. */
+export function clampDayOfMonth(dom: number | undefined | null): number {
+  const n = Math.floor(Number.isFinite(dom as number) ? (dom as number) : 1);
+  return Math.min(MAX_DAY_OF_MONTH, Math.max(1, n));
+}
+
+/** Clamp a day-of-week into the valid [0, 6] range. */
+export function clampDayOfWeek(dow: number | undefined | null): number {
+  const n = Math.floor(Number.isFinite(dow as number) ? (dow as number) : 0);
+  return Math.min(6, Math.max(0, n));
+}
+
+// -- Schedule projection ----------------------------------------------
+
+/**
+ * The next run time (epoch MS) for a plan at-or-after `fromMs`, or `null` when
+ * the plan will never run again (completed / cancelled / paused, past end, or
+ * budget exhausted).
+ *
+ * The projection is a pure function of the plan fields and `fromMs`; it does NOT
+ * read the server `next_run_ts` (that is used for display only, since the runner
+ * is authoritative once it ships). The first candidate is the later of the
+ * plan start and `fromMs`; from there we advance by the cadence.
+ */
+export function nextRun(plan: DcaPlan, fromMs: number): number | null {
+  const runs = upcomingRuns(plan, fromMs, 1);
+  return runs.length ? runs[0]! : null;
+}
+
+/**
+ * Project the next `n` run timestamps (epoch MS) at-or-after `fromMs`,
+ * respecting start / end and the budget cap (a plan stops once it can no longer
+ * afford another buy). Returns fewer than `n` when the schedule ends first.
+ *
+ *  - daily   : every calendar day from the start anchor.
+ *  - weekly  : the plan's `day_of_week` each week (defaults to the start's DOW).
+ *  - monthly : the plan's `day_of_month` each month (capped at 28), so Feb and
+ *              30-day months are always valid.
+ *
+ * A paused / cancelled / completed plan yields no runs. Runs beyond `end_ts` (or
+ * beyond the affordable budget) are dropped.
+ */
+export function upcomingRuns(plan: DcaPlan, fromMs: number, n: number): number[] {
+  const out: number[] = [];
+  if (!plan || n <= 0) return out;
+  if (plan.status === "paused" || plan.status === "cancelled" || plan.status === "completed") {
+    return out;
+  }
+  if (!Number.isFinite(plan.amount_cents) || plan.amount_cents <= 0) return out;
+
+  const startMs = secToMs(plan.start_ts);
+  const endMs = plan.end_ts != null ? secToMs(plan.end_ts) : null;
+
+  // How many more buys can the budget still afford (null -> unlimited)?
+  const remainingBudget =
+    plan.total_budget_cents != null && plan.total_budget_cents > 0
+      ? Math.max(0, plan.total_budget_cents - Math.max(0, plan.spent_cents))
+      : null;
+  let buysLeft =
+    remainingBudget != null ? Math.floor(remainingBudget / plan.amount_cents) : Infinity;
+  if (buysLeft <= 0) return out;
+
+  const anchor = Math.max(startMs, fromMs);
+
+  let cursor: number | null;
+  switch (plan.frequency) {
+    case "daily":
+      cursor = firstDailyOnOrAfter(startMs, anchor);
+      break;
+    case "weekly":
+      cursor = firstWeeklyOnOrAfter(startMs, anchor, plan.day_of_week);
+      break;
+    case "monthly":
+      cursor = firstMonthlyOnOrAfter(startMs, anchor, plan.day_of_month);
+      break;
+    default:
+      return out;
+  }
+
+  while (cursor != null && out.length < n && buysLeft > 0) {
+    if (endMs != null && cursor > endMs) break;
+    out.push(cursor);
+    buysLeft -= 1;
+    cursor = advance(cursor, plan.frequency, plan.day_of_month);
+  }
+  return out;
+}
+
+/** First daily run on-or-after `anchor`, aligned to the start's time-of-day. */
+function firstDailyOnOrAfter(startMs: number, anchor: number): number {
+  if (anchor <= startMs) return startMs;
+  const elapsed = anchor - startMs;
+  const periods = Math.ceil(elapsed / MS_PER_DAY);
+  return startMs + periods * MS_PER_DAY;
+}
+
+/** First weekly run on-or-after `anchor` on the plan's day-of-week. */
+function firstWeeklyOnOrAfter(startMs: number, anchor: number, dow?: number): number {
+  const targetDow = dow != null ? clampDayOfWeek(dow) : new Date(startMs).getDay();
+  const base = new Date(startMs);
+  const floor = Math.max(startMs, anchor);
+  let d = withTimeOfDay(new Date(floor), base);
+  // Walk day-by-day to the first matching DOW that is on-or-after the floor.
+  while (d.getTime() < floor || d.getDay() !== targetDow) {
+    d = new Date(d.getTime() + MS_PER_DAY);
+    d = withTimeOfDay(d, base);
+  }
+  return d.getTime();
+}
+
+/** First monthly run on-or-after `anchor` on the plan's day-of-month. */
+function firstMonthlyOnOrAfter(startMs: number, anchor: number, dom?: number): number {
+  const base = new Date(startMs);
+  const targetDom = dom != null ? clampDayOfMonth(dom) : clampDayOfMonth(base.getDate());
+  const floor = Math.max(startMs, anchor);
+  const from = new Date(floor);
+  let year = from.getFullYear();
+  let month = from.getMonth();
+  for (let i = 0; i < 600; i++) {
+    const cand = makeMonthly(year, month, targetDom, base);
+    if (cand >= floor) return cand;
+    month += 1;
+    if (month > 11) {
+      month = 0;
+      year += 1;
+    }
+  }
+  return makeMonthly(year, month, targetDom, base);
+}
+
+/** Advance one cadence step from `ms`. */
+function advance(ms: number, freq: DcaFrequency, dom?: number): number {
+  if (freq === "daily") return ms + MS_PER_DAY;
+  if (freq === "weekly") return ms + 7 * MS_PER_DAY;
+  // monthly: same day-of-month next month (capped), preserving time-of-day.
+  const base = new Date(ms);
+  const targetDom = dom != null ? clampDayOfMonth(dom) : clampDayOfMonth(base.getDate());
+  let year = base.getFullYear();
+  let month = base.getMonth() + 1;
+  if (month > 11) {
+    month = 0;
+    year += 1;
+  }
+  return makeMonthly(year, month, targetDom, base);
+}
+
+/** Build a Date at year/month/day with the time-of-day copied from `base`. */
+function makeMonthly(year: number, month: number, dom: number, base: Date): number {
+  const d = new Date(
+    year,
+    month,
+    dom,
+    base.getHours(),
+    base.getMinutes(),
+    base.getSeconds(),
+    base.getMilliseconds(),
+  );
+  return d.getTime();
+}
+
+/** Copy the hours/min/sec/ms of `base` onto the date part of `d`. */
+function withTimeOfDay(d: Date, base: Date): Date {
+  return new Date(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+    base.getHours(),
+    base.getMinutes(),
+    base.getSeconds(),
+    base.getMilliseconds(),
+  );
+}
+
+// -- Budget math -------------------------------------------------------
+
+/**
+ * Remaining budget (cents) for a capped plan = max(0, total - spent). Returns
+ * null for an uncapped plan (no total_budget_cents).
+ */
+export function budgetRemainingCents(plan: DcaPlan): number | null {
+  if (plan.total_budget_cents == null || !(plan.total_budget_cents > 0)) return null;
+  return Math.max(0, plan.total_budget_cents - Math.max(0, plan.spent_cents));
+}
+
+/**
+ * Estimated whole buys remaining for a capped plan = floor(remaining / amount).
+ * Returns null for an uncapped plan (unbounded), 0 when exhausted.
+ */
+export function estimatedRunsRemaining(plan: DcaPlan): number | null {
+  const remaining = budgetRemainingCents(plan);
+  if (remaining == null) return null;
+  if (!(plan.amount_cents > 0)) return 0;
+  return Math.floor(remaining / plan.amount_cents);
+}
+
+/** Fraction (0..1) of the budget already spent, for a progress gauge. Uncapped -> 0. */
+export function budgetSpentFraction(plan: DcaPlan): number {
+  if (plan.total_budget_cents == null || !(plan.total_budget_cents > 0)) return 0;
+  const f = Math.max(0, plan.spent_cents) / plan.total_budget_cents;
+  return Math.min(1, Math.max(0, f));
+}
+
+// -- Validation --------------------------------------------------------
+
+export type DcaValidationError =
+  | "no_target"
+  | "amount_below_min"
+  | "invalid_frequency"
+  | "invalid_day_of_week"
+  | "invalid_day_of_month"
+  | "end_before_start"
+  | "budget_below_amount";
+
+export interface DcaPlanDraft {
+  target?: DcaTarget | null;
+  amount_cents: number;
+  frequency: DcaFrequency;
+  day_of_week?: number;
+  day_of_month?: number;
+  /** Epoch SECONDS. */
+  start_ts: number;
+  /** Epoch SECONDS. */
+  end_ts?: number;
+  total_budget_cents?: number;
+}
+
+export interface DcaValidation {
+  valid: boolean;
+  errors: DcaValidationError[];
+}
+
+/**
+ * Validate a plan draft before creation: a target must be chosen, the amount
+ * must be >= the minimum, the frequency must be valid with a valid day for the
+ * weekly / monthly cadence, any end must be strictly after the start, and any
+ * total budget must cover at least one buy.
+ */
+export function validatePlan(draft: DcaPlanDraft): DcaValidation {
+  const errors: DcaValidationError[] = [];
+
+  if (!draft.target || !draft.target.id) errors.push("no_target");
+
+  if (!Number.isFinite(draft.amount_cents) || draft.amount_cents < MIN_AMOUNT_CENTS) {
+    errors.push("amount_below_min");
+  }
+
+  if (
+    draft.frequency !== "daily" &&
+    draft.frequency !== "weekly" &&
+    draft.frequency !== "monthly"
+  ) {
+    errors.push("invalid_frequency");
+  }
+
+  if (draft.frequency === "weekly") {
+    const d = draft.day_of_week;
+    if (d == null || !Number.isInteger(d) || d < 0 || d > 6) errors.push("invalid_day_of_week");
+  }
+
+  if (draft.frequency === "monthly") {
+    const d = draft.day_of_month;
+    if (d == null || !Number.isInteger(d) || d < 1 || d > MAX_DAY_OF_MONTH) {
+      errors.push("invalid_day_of_month");
+    }
+  }
+
+  if (draft.end_ts != null && Number.isFinite(draft.end_ts)) {
+    if (draft.end_ts <= draft.start_ts) errors.push("end_before_start");
+  }
+
+  if (
+    draft.total_budget_cents != null &&
+    draft.total_budget_cents > 0 &&
+    Number.isFinite(draft.amount_cents) &&
+    draft.amount_cents > 0 &&
+    draft.total_budget_cents < draft.amount_cents
+  ) {
+    errors.push("budget_below_amount");
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// -- Formatting --------------------------------------------------------
+
+/** Integer cents -> "$1,234.56". Non-finite -> "—". */
+export function formatCents(cents: number | undefined | null): string {
+  if (cents == null || !Number.isFinite(cents)) return "—";
+  return `$${(cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/** Human day-of-week name for 0..6. */
+export const DOW_LABELS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/** Human summary of a plan cadence, e.g. "Weekly on Monday", "Monthly on the 15th". */
+export function frequencyLabel(
+  frequency: DcaFrequency,
+  dayOfWeek?: number,
+  dayOfMonth?: number,
+): string {
+  if (frequency === "daily") return "Daily";
+  if (frequency === "weekly") {
+    const dow = dayOfWeek != null ? DOW_LABELS[clampDayOfWeek(dayOfWeek)] : "Monday";
+    return `Weekly on ${dow}`;
+  }
+  if (frequency === "monthly") {
+    const dom = clampDayOfMonth(dayOfMonth ?? 1);
+    return `Monthly on the ${ordinal(dom)}`;
+  }
+  return frequency;
+}
+
+/** English ordinal for 1..28. */
+export function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+}

--- a/frontend/src/pages/dca/DcaCreatePage.tsx
+++ b/frontend/src/pages/dca/DcaCreatePage.tsx
@@ -1,0 +1,399 @@
+import { useMemo, useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { CalendarClock, Wallet, ArrowLeft, CalendarCheck } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { getWallet } from "@/api/endpoints/billing";
+import { useCreateDcaPlan } from "@/hooks/useDca";
+import type { DcaFrequency, DcaTarget, DcaPlan } from "@/lib/dca";
+import {
+  MIN_AMOUNT_CENTS,
+  DOW_LABELS,
+  formatCents,
+  validatePlan,
+  upcomingRuns,
+  frequencyLabel,
+  msToSec,
+  ordinal,
+} from "@/lib/dca";
+import { TargetPicker, ServerRunnerNote } from "./DcaShared";
+
+/** Parse a "$" dollar string into integer cents (NaN-safe). */
+function dollarsToCents(v: string): number {
+  const n = Number.parseFloat(v.replace(/[^0-9.]/g, ""));
+  if (!Number.isFinite(n)) return NaN;
+  return Math.round(n * 100);
+}
+
+/** A datetime-local input value (yyyy-MM-ddThh:mm) -> epoch seconds, or 0. */
+function localToSec(v: string): number {
+  if (!v) return 0;
+  const ms = new Date(v).getTime();
+  return Number.isFinite(ms) ? msToSec(ms) : 0;
+}
+
+/** Default the start field to "now" in the datetime-local format. */
+function nowLocal(): string {
+  const d = new Date();
+  d.setSeconds(0, 0);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(
+    d.getMinutes(),
+  )}`;
+}
+
+const ERROR_TEXT: Record<string, string> = {
+  no_target: "Choose a target to buy.",
+  amount_below_min: `Amount must be at least ${formatCents(MIN_AMOUNT_CENTS)}.`,
+  invalid_frequency: "Choose a valid frequency.",
+  invalid_day_of_week: "Choose a day of the week.",
+  invalid_day_of_month: "Choose a day of the month (1–28).",
+  end_before_start: "The end must be after the start.",
+  budget_below_amount: "The total budget must cover at least one buy.",
+};
+
+export default function DcaCreatePage() {
+  const navigate = useNavigate();
+  const create = useCreateDcaPlan();
+  const walletQ = useQuery({ queryKey: ["ui", "billing", "wallet"], queryFn: getWallet, retry: false });
+
+  const [target, setTarget] = useState<DcaTarget | null>(null);
+  const [amountStr, setAmountStr] = useState("");
+  const [frequency, setFrequency] = useState<DcaFrequency>("weekly");
+  const [dayOfWeek, setDayOfWeek] = useState(1); // Monday
+  const [dayOfMonth, setDayOfMonth] = useState(1);
+  const [startStr, setStartStr] = useState(nowLocal());
+  const [endStr, setEndStr] = useState("");
+  const [budgetStr, setBudgetStr] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const amountCents = dollarsToCents(amountStr);
+  const startSec = localToSec(startStr);
+  const endSec = endStr ? localToSec(endStr) : undefined;
+  const budgetCents = budgetStr ? dollarsToCents(budgetStr) : undefined;
+
+  const draft = useMemo(
+    () => ({
+      target,
+      amount_cents: amountCents,
+      frequency,
+      day_of_week: frequency === "weekly" ? dayOfWeek : undefined,
+      day_of_month: frequency === "monthly" ? dayOfMonth : undefined,
+      start_ts: startSec,
+      end_ts: endSec,
+      total_budget_cents: budgetCents,
+    }),
+    [target, amountCents, frequency, dayOfWeek, dayOfMonth, startSec, endSec, budgetCents],
+  );
+
+  const validation = validatePlan(draft);
+
+  // Schedule preview — project the next 5 runs from the draft.
+  const preview = useMemo(() => {
+    if (!validation.valid || !target) return [];
+    const previewPlan: DcaPlan = {
+      plan_id: "preview",
+      target,
+      amount_cents: amountCents,
+      frequency,
+      day_of_week: frequency === "weekly" ? dayOfWeek : undefined,
+      day_of_month: frequency === "monthly" ? dayOfMonth : undefined,
+      start_ts: startSec,
+      end_ts: endSec,
+      total_budget_cents: budgetCents,
+      funding: "usd_wallet",
+      status: "active",
+      next_run_ts: startSec,
+      spent_cents: 0,
+      buys_count: 0,
+      created_ts: msToSec(Date.now()),
+    };
+    return upcomingRuns(previewPlan, Date.now(), 5);
+  }, [validation.valid, target, amountCents, frequency, dayOfWeek, dayOfMonth, startSec, endSec, budgetCents]);
+
+  const walletCents = walletQ.data?.wallet_balance_cents;
+  const insufficientForFirst =
+    walletCents != null && Number.isFinite(amountCents) && amountCents > walletCents;
+
+  function submit() {
+    if (!target || !validation.valid) return;
+    create.mutate(
+      {
+        target,
+        amount_cents: amountCents,
+        frequency,
+        day_of_week: frequency === "weekly" ? dayOfWeek : undefined,
+        day_of_month: frequency === "monthly" ? dayOfMonth : undefined,
+        start_ts: startSec,
+        end_ts: endSec,
+        total_budget_cents: budgetCents,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Recurring buy scheduled.");
+          navigate("/dca");
+        },
+        onSettled: () => setConfirmOpen(false),
+      },
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-6 p-4 md:p-6">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/dca">
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back
+          </Link>
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <CalendarClock className="h-6 w-6 text-primary" />
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">New recurring buy</h1>
+          <p className="text-sm text-muted-foreground">
+            Schedule a dollar-cost-average buy funded from your USD cash wallet.
+          </p>
+        </div>
+      </div>
+
+      <ServerRunnerNote />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">1 · What to buy</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TargetPicker value={target} onChange={setTarget} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">2 · How much &amp; how often</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="dca-amount">Amount per buy (USD)</Label>
+            <Input
+              id="dca-amount"
+              inputMode="decimal"
+              placeholder="50.00"
+              value={amountStr}
+              onChange={(e) => setAmountStr(e.target.value)}
+              data-testid="dca-amount"
+            />
+            <p className="text-xs text-muted-foreground">
+              Minimum {formatCents(MIN_AMOUNT_CENTS)} per buy.
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Frequency</Label>
+              <Select value={frequency} onValueChange={(v) => setFrequency(v as DcaFrequency)}>
+                <SelectTrigger data-testid="dca-frequency">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="daily">Daily</SelectItem>
+                  <SelectItem value="weekly">Weekly</SelectItem>
+                  <SelectItem value="monthly">Monthly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {frequency === "weekly" && (
+              <div className="space-y-1.5">
+                <Label>Day of week</Label>
+                <Select value={String(dayOfWeek)} onValueChange={(v) => setDayOfWeek(Number(v))}>
+                  <SelectTrigger data-testid="dca-dow">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DOW_LABELS.map((d, i) => (
+                      <SelectItem key={d} value={String(i)}>
+                        {d}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {frequency === "monthly" && (
+              <div className="space-y-1.5">
+                <Label>Day of month</Label>
+                <Select value={String(dayOfMonth)} onValueChange={(v) => setDayOfMonth(Number(v))}>
+                  <SelectTrigger data-testid="dca-dom">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
+                      <SelectItem key={d} value={String(d)}>
+                        {ordinal(d)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">Capped at the 28th so every month runs.</p>
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="dca-start">Start</Label>
+            <Input
+              id="dca-start"
+              type="datetime-local"
+              value={startStr}
+              onChange={(e) => setStartStr(e.target.value)}
+              data-testid="dca-start"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">3 · Optional limits</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="dca-end">End date (optional)</Label>
+            <Input
+              id="dca-end"
+              type="datetime-local"
+              value={endStr}
+              onChange={(e) => setEndStr(e.target.value)}
+              data-testid="dca-end"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="dca-budget">Total budget (optional, USD)</Label>
+            <Input
+              id="dca-budget"
+              inputMode="decimal"
+              placeholder="No cap"
+              value={budgetStr}
+              onChange={(e) => setBudgetStr(e.target.value)}
+              data-testid="dca-budget"
+            />
+            <p className="text-xs text-muted-foreground">
+              The plan completes once this much has been spent.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <CalendarCheck className="h-4 w-4" /> Schedule preview
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!validation.valid ? (
+            <ul className="space-y-1 text-sm text-muted-foreground">
+              {validation.errors.map((e) => (
+                <li key={e}>· {ERROR_TEXT[e] ?? e}</li>
+              ))}
+            </ul>
+          ) : preview.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              This plan has no upcoming runs (check the end date / budget).
+            </p>
+          ) : (
+            <div className="space-y-2 text-sm">
+              <p className="text-muted-foreground">
+                {frequencyLabel(frequency, dayOfWeek, dayOfMonth)} · {formatCents(amountCents)} of{" "}
+                <span className="font-medium text-foreground">{target?.label}</span>. Next{" "}
+                {preview.length} buys:
+              </p>
+              <ol className="space-y-1" data-testid="dca-preview">
+                {preview.map((ms, i) => (
+                  <li key={ms} className="flex items-center justify-between tabular-nums">
+                    <span>
+                      {i + 1}.{" "}
+                      {new Date(ms).toLocaleString(undefined, {
+                        dateStyle: "medium",
+                        timeStyle: "short",
+                      })}
+                    </span>
+                    <span className="text-muted-foreground">{formatCents(amountCents)}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        <Wallet className="h-3.5 w-3.5 shrink-0" />
+        {walletQ.isError ? (
+          <span>
+            USD cash wallet balance unavailable.{" "}
+            <Link to="/custody/cash" className="font-medium text-primary underline-offset-4 hover:underline">
+              Add cash
+            </Link>
+          </span>
+        ) : walletCents != null ? (
+          <span>
+            USD cash wallet: <span className="font-medium text-foreground">{formatCents(walletCents)}</span>
+            {insufficientForFirst ? " — below the first buy amount." : ""}{" "}
+            <Link to="/custody/cash" className="font-medium text-primary underline-offset-4 hover:underline">
+              Add cash
+            </Link>
+          </span>
+        ) : (
+          <span>Buys draw from your USD cash wallet.</span>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button asChild variant="ghost">
+          <Link to="/dca">Cancel</Link>
+        </Button>
+        <Button
+          onClick={() => setConfirmOpen(true)}
+          disabled={!validation.valid || create.isPending}
+          data-testid="dca-submit"
+        >
+          Schedule recurring buy
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Schedule this recurring buy?"
+        description={
+          target
+            ? `${frequencyLabel(frequency, dayOfWeek, dayOfMonth)}, ${formatCents(
+                amountCents,
+              )} of ${target.label} will be bought automatically server-side, debiting your USD cash wallet each time${
+                budgetCents ? ` until ${formatCents(budgetCents)} is spent` : ""
+              }. You can pause or cancel any time.`
+            : undefined
+        }
+        confirmLabel="Schedule"
+        loading={create.isPending}
+        onConfirm={submit}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/dca/DcaDetailPage.tsx
+++ b/frontend/src/pages/dca/DcaDetailPage.tsx
@@ -1,0 +1,365 @@
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  CalendarClock,
+  ArrowLeft,
+  Pause,
+  Play,
+  Ban,
+  Zap,
+  Wallet,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import {
+  useDcaPlans,
+  useDcaHistory,
+  usePauseDcaPlan,
+  useResumeDcaPlan,
+  useCancelDcaPlan,
+  useRunDcaPlanNow,
+} from "@/hooks/useDca";
+import type { DcaPlan, DcaStatus } from "@/lib/dca";
+import {
+  formatCents,
+  frequencyLabel,
+  nextRun,
+  upcomingRuns,
+  budgetRemainingCents,
+  estimatedRunsRemaining,
+  budgetSpentFraction,
+} from "@/lib/dca";
+import { PendingBackend, ServerRunnerNote, targetKindLabel } from "./DcaShared";
+
+const STATUS_VARIANT: Record<DcaStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  active: "default",
+  paused: "secondary",
+  completed: "outline",
+  cancelled: "destructive",
+};
+
+function fmtTs(sec: number): string {
+  if (!Number.isFinite(sec) || sec <= 0) return "—";
+  return new Date(sec * 1000).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-1.5 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+export default function DcaDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const plansQ = useDcaPlans();
+  const historyQ = useDcaHistory(id);
+  const pause = usePauseDcaPlan();
+  const resume = useResumeDcaPlan();
+  const cancel = useCancelDcaPlan();
+  const runNow = useRunDcaPlanNow(id);
+
+  const [cancelOpen, setCancelOpen] = useState(false);
+  const [runOpen, setRunOpen] = useState(false);
+
+  const plan: DcaPlan | undefined = (plansQ.data?.plans ?? []).find((p) => p.plan_id === id);
+
+  if (plansQ.isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-4 p-4 md:p-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (plansQ.isError) {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-4 p-4 md:p-6">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/dca">
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back
+          </Link>
+        </Button>
+        <PendingBackend label="This recurring-buy plan" />
+      </div>
+    );
+  }
+
+  if (!plan) {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-4 p-4 md:p-6">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/dca">
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back
+          </Link>
+        </Button>
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          This plan was not found. It may have been cancelled.
+        </div>
+      </div>
+    );
+  }
+
+  const remaining = budgetRemainingCents(plan);
+  const runsLeft = estimatedRunsRemaining(plan);
+  const nextMs = plan.status === "active" ? nextRun(plan, Date.now()) : null;
+  const upcoming = plan.status === "active" ? upcomingRuns(plan, Date.now(), 5) : [];
+  const runs = historyQ.data?.runs ?? [];
+  const isActive = plan.status === "active";
+  const isPaused = plan.status === "paused";
+  const isLive = isActive || isPaused;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4 md:p-6">
+      <Button asChild variant="ghost" size="sm">
+        <Link to="/dca">
+          <ArrowLeft className="mr-1 h-4 w-4" /> Back to recurring buys
+        </Link>
+      </Button>
+
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">{plan.target.label}</h1>
+            <p className="text-sm text-muted-foreground">
+              {targetKindLabel(plan.target.kind)} ·{" "}
+              {frequencyLabel(plan.frequency, plan.day_of_week, plan.day_of_month)} ·{" "}
+              {formatCents(plan.amount_cents)} per buy
+            </p>
+          </div>
+        </div>
+        <Badge variant={STATUS_VARIANT[plan.status] ?? "outline"}>{plan.status}</Badge>
+      </div>
+
+      <ServerRunnerNote />
+
+      <div className="flex flex-wrap gap-2">
+        {isActive && (
+          <Button
+            variant="outline"
+            onClick={() => pause.mutate(plan.plan_id)}
+            disabled={pause.isPending}
+            data-testid="detail-pause"
+          >
+            <Pause className="mr-1.5 h-4 w-4" /> Pause
+          </Button>
+        )}
+        {isPaused && (
+          <Button
+            variant="outline"
+            onClick={() => resume.mutate(plan.plan_id)}
+            disabled={resume.isPending}
+            data-testid="detail-resume"
+          >
+            <Play className="mr-1.5 h-4 w-4" /> Resume
+          </Button>
+        )}
+        {isLive && (
+          <Button
+            onClick={() => setRunOpen(true)}
+            disabled={runNow.isPending}
+            data-testid="detail-run-now"
+          >
+            <Zap className="mr-1.5 h-4 w-4" /> Buy now
+          </Button>
+        )}
+        {isLive && (
+          <Button variant="ghost" onClick={() => setCancelOpen(true)} className="text-destructive">
+            <Ban className="mr-1.5 h-4 w-4" /> Cancel plan
+          </Button>
+        )}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Plan</CardTitle>
+          </CardHeader>
+          <CardContent className="divide-y">
+            <InfoRow label="Amount per buy" value={formatCents(plan.amount_cents)} />
+            <InfoRow
+              label="Frequency"
+              value={frequencyLabel(plan.frequency, plan.day_of_week, plan.day_of_month)}
+            />
+            <InfoRow label="Started" value={fmtTs(plan.start_ts)} />
+            <InfoRow label="Ends" value={plan.end_ts ? fmtTs(plan.end_ts) : "No end"} />
+            <InfoRow
+              label="Next run"
+              value={nextMs != null ? fmtTs(Math.floor(nextMs / 1000)) : "—"}
+            />
+            <InfoRow
+              label="Funding"
+              value={
+                <span className="inline-flex items-center gap-1">
+                  <Wallet className="h-3.5 w-3.5" /> USD cash wallet
+                </span>
+              }
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Progress</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <InfoRow label="Buys executed" value={plan.buys_count} />
+            <InfoRow label="Total spent" value={formatCents(plan.spent_cents)} />
+            {plan.total_budget_cents != null && plan.total_budget_cents > 0 ? (
+              <>
+                <InfoRow label="Total budget" value={formatCents(plan.total_budget_cents)} />
+                <InfoRow label="Remaining" value={formatCents(remaining ?? 0)} />
+                <InfoRow
+                  label="Est. buys left"
+                  value={runsLeft != null ? runsLeft : "—"}
+                />
+                <div className="pt-1">
+                  <Progress value={Math.round(budgetSpentFraction(plan) * 100)} className="h-2" />
+                </div>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">No budget cap — this plan runs until cancelled.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {upcoming.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Upcoming runs</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ol className="space-y-1 text-sm">
+              {upcoming.map((ms, i) => (
+                <li key={ms} className="flex items-center justify-between tabular-nums">
+                  <span>
+                    {i + 1}. {fmtTs(Math.floor(ms / 1000))}
+                  </span>
+                  <span className="text-muted-foreground">{formatCents(plan.amount_cents)}</span>
+                </li>
+              ))}
+            </ol>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Execution history</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {historyQ.isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ) : historyQ.isError ? (
+            <PendingBackend label="Execution history" />
+          ) : runs.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No buys have run yet. The server-side runner records each execution here.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>When</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                  <TableHead className="text-right">Filled qty</TableHead>
+                  <TableHead className="text-right">Price</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {runs.map((r, i) => (
+                  <TableRow key={`${r.ts}-${i}`} data-testid="dca-run-row">
+                    <TableCell className="text-sm tabular-nums">{fmtTs(r.ts)}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCents(r.amount_cents)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {r.filled_qty != null ? r.filled_qty : "—"}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {r.price != null ? formatCents(r.price) : "—"}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          r.status === "filled"
+                            ? "default"
+                            : r.status === "failed"
+                              ? "destructive"
+                              : "secondary"
+                        }
+                      >
+                        {r.status}
+                      </Badge>
+                      {r.note ? (
+                        <span className="ml-2 text-xs text-muted-foreground">{r.note}</span>
+                      ) : null}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={runOpen}
+        onOpenChange={setRunOpen}
+        title="Buy now?"
+        description={`This executes one ${formatCents(
+          plan.amount_cents,
+        )} buy of ${plan.target.label} immediately, debiting your USD cash wallet, in addition to the scheduled runs.`}
+        confirmLabel="Buy now"
+        loading={runNow.isPending}
+        onConfirm={() =>
+          runNow.mutate(undefined, {
+            onSuccess: () => toast.success("Buy queued."),
+            onSettled: () => setRunOpen(false),
+          })
+        }
+      />
+
+      <ConfirmDialog
+        open={cancelOpen}
+        onOpenChange={setCancelOpen}
+        title="Cancel this recurring buy?"
+        description={`This permanently stops the ${formatCents(
+          plan.amount_cents,
+        )} ${plan.frequency} buy of ${plan.target.label}. Buys already executed are unaffected.`}
+        variant="danger"
+        confirmLabel="Cancel plan"
+        cancelLabel="Keep plan"
+        loading={cancel.isPending}
+        onConfirm={() =>
+          cancel.mutate(plan.plan_id, { onSettled: () => setCancelOpen(false) })
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/dca/DcaPlansPage.tsx
+++ b/frontend/src/pages/dca/DcaPlansPage.tsx
@@ -1,0 +1,249 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { CalendarClock, Plus, Pause, Play, Ban, Wallet } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import {
+  useDcaPlans,
+  usePauseDcaPlan,
+  useResumeDcaPlan,
+  useCancelDcaPlan,
+} from "@/hooks/useDca";
+import type { DcaPlan, DcaStatus } from "@/lib/dca";
+import {
+  formatCents,
+  frequencyLabel,
+  nextRun,
+  budgetRemainingCents,
+  budgetSpentFraction,
+} from "@/lib/dca";
+import { PendingBackend, ServerRunnerNote, targetKindLabel } from "./DcaShared";
+
+const STATUS_VARIANT: Record<DcaStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  active: "default",
+  paused: "secondary",
+  completed: "outline",
+  cancelled: "destructive",
+};
+
+function StatusBadge({ status }: { status: DcaStatus }) {
+  return <Badge variant={STATUS_VARIANT[status] ?? "outline"}>{status}</Badge>;
+}
+
+function nextRunLabel(plan: DcaPlan): string {
+  if (plan.status !== "active") return "—";
+  const ms = nextRun(plan, Date.now());
+  if (ms == null) return "—";
+  return new Date(ms).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function BudgetCell({ plan }: { plan: DcaPlan }) {
+  const remaining = budgetRemainingCents(plan);
+  if (remaining == null) {
+    return <span className="text-muted-foreground">Uncapped · {formatCents(plan.spent_cents)} spent</span>;
+  }
+  const pct = Math.round(budgetSpentFraction(plan) * 100);
+  return (
+    <div className="min-w-[8rem] space-y-1">
+      <div className="flex justify-between text-xs">
+        <span>{formatCents(plan.spent_cents)}</span>
+        <span className="text-muted-foreground">/ {formatCents(plan.total_budget_cents)}</span>
+      </div>
+      <Progress value={pct} className="h-1.5" />
+    </div>
+  );
+}
+
+export default function DcaPlansPage() {
+  const plansQ = useDcaPlans();
+  const pause = usePauseDcaPlan();
+  const resume = useResumeDcaPlan();
+  const cancel = useCancelDcaPlan();
+
+  const [cancelTarget, setCancelTarget] = useState<DcaPlan | null>(null);
+
+  const plans = plansQ.data?.plans ?? [];
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Recurring buys</h1>
+            <p className="text-sm text-muted-foreground">
+              Dollar-cost-average into a market, creator token, or strategy on a schedule — funded
+              from your USD cash wallet.
+            </p>
+          </div>
+        </div>
+        <Button asChild data-testid="new-dca-cta">
+          <Link to="/dca/new">
+            <Plus className="mr-1.5 h-4 w-4" /> New recurring buy
+          </Link>
+        </Button>
+      </div>
+
+      <ServerRunnerNote />
+
+      <p className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Wallet className="h-3.5 w-3.5" />
+        Buys draw from your USD cash wallet.{" "}
+        <Link to="/custody/cash" className="font-medium text-primary underline-offset-4 hover:underline">
+          Add cash
+        </Link>
+      </p>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">My plans</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {plansQ.isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ) : plansQ.isError ? (
+            <PendingBackend label="Your recurring-buy plans" />
+          ) : plans.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+              You have no recurring buys yet.{" "}
+              <Link
+                to="/dca/new"
+                className="font-medium text-primary underline-offset-4 hover:underline"
+              >
+                Create one
+              </Link>
+              .
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Target</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                  <TableHead>Frequency</TableHead>
+                  <TableHead>Next run</TableHead>
+                  <TableHead>Budget</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="w-[9rem]" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {plans.map((p) => (
+                  <TableRow key={p.plan_id} data-testid="dca-plan-row">
+                    <TableCell className="max-w-[14rem]">
+                      <Link
+                        to={`/dca/${encodeURIComponent(p.plan_id)}`}
+                        className="block truncate font-medium hover:underline"
+                      >
+                        {p.target.label}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">
+                        {targetKindLabel(p.target.kind)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCents(p.amount_cents)}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {frequencyLabel(p.frequency, p.day_of_week, p.day_of_month)}
+                    </TableCell>
+                    <TableCell className="text-sm tabular-nums">{nextRunLabel(p)}</TableCell>
+                    <TableCell>
+                      <BudgetCell plan={p} />
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={p.status} />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center justify-end gap-1">
+                        {p.status === "active" && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => pause.mutate(p.plan_id)}
+                            disabled={pause.isPending}
+                            title="Pause"
+                            data-testid="dca-pause"
+                          >
+                            <Pause className="h-4 w-4" />
+                          </Button>
+                        )}
+                        {p.status === "paused" && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => resume.mutate(p.plan_id)}
+                            disabled={resume.isPending}
+                            title="Resume"
+                            data-testid="dca-resume"
+                          >
+                            <Play className="h-4 w-4" />
+                          </Button>
+                        )}
+                        {(p.status === "active" || p.status === "paused") && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setCancelTarget(p)}
+                            title="Cancel"
+                            data-testid="dca-cancel"
+                          >
+                            <Ban className="h-4 w-4 text-destructive" />
+                          </Button>
+                        )}
+                        <Button asChild variant="ghost" size="sm">
+                          <Link to={`/dca/${encodeURIComponent(p.plan_id)}`}>Open</Link>
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={cancelTarget != null}
+        onOpenChange={(o) => !o && setCancelTarget(null)}
+        title="Cancel this recurring buy?"
+        description={
+          cancelTarget
+            ? `This permanently stops the ${formatCents(
+                cancelTarget.amount_cents,
+              )} ${cancelTarget.frequency} buy of ${cancelTarget.target.label}. Buys already executed are unaffected.`
+            : undefined
+        }
+        variant="danger"
+        confirmLabel="Cancel plan"
+        cancelLabel="Keep plan"
+        loading={cancel.isPending}
+        onConfirm={() => {
+          if (cancelTarget) {
+            cancel.mutate(cancelTarget.plan_id, { onSettled: () => setCancelTarget(null) });
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/dca/DcaShared.tsx
+++ b/frontend/src/pages/dca/DcaShared.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from "react";
+import { Info, ServerCog, Search } from "lucide-react";
+import type { DcaTarget, DcaTargetKind } from "@/lib/dca";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useSymbols } from "@/hooks/useMarketData";
+import { useTokenMarket } from "@/hooks/useTokens";
+import { useStrategyMarket } from "@/hooks/useStrategies";
+
+/**
+ * Honest "recurring buys need the backend runner" note shown when a `/me/dca/*`
+ * read 404s (the surface is UI-complete but the SERVER-SIDE runner has not
+ * shipped). Reused across every DCA screen so the empty state reads the same.
+ */
+export function PendingBackend({ label = "This data" }: { label?: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-dashed bg-muted/30 p-4 text-sm text-muted-foreground">
+      <Info className="mt-0.5 h-4 w-4 shrink-0" />
+      <div>
+        <p className="font-medium text-foreground">Recurring buys need the backend runner</p>
+        <p>
+          {label} is not available yet — the recurring-buys endpoints and the periodic executor
+          have not shipped on this environment. The surface is wired and will populate automatically
+          once they do.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Small labelled note making the execution model explicit: once a plan is
+ * scheduled, the buys run AUTOMATICALLY on a SERVER-SIDE runner — the browser
+ * does not need to be open.
+ */
+export function ServerRunnerNote() {
+  return (
+    <p className="flex items-start gap-2 rounded-md border border-sky-300/50 bg-sky-50 px-3 py-2 text-xs text-sky-800 dark:border-sky-500/30 dark:bg-sky-950/40 dark:text-sky-300">
+      <ServerCog className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>
+        <span className="font-semibold">How it runs:</span> recurring buys run{" "}
+        <span className="font-semibold">automatically server-side</span> once scheduled — you
+        don&rsquo;t need to keep this page open. Each buy debits your USD cash wallet.
+      </span>
+    </p>
+  );
+}
+
+const KIND_LABELS: Record<DcaTargetKind, string> = {
+  symbol: "Market",
+  token: "Creator token",
+  strategy: "Strategy",
+};
+
+interface TargetOption extends DcaTarget {
+  sublabel?: string;
+}
+
+/**
+ * A unified target picker across the three investable target kinds — market
+ * SYMBOLS (`useSymbols`), creator TOKENS (`useTokenMarket`), and STRATEGY funds
+ * (`useStrategyMarket`). Each source degrades independently (tokens/strategies
+ * 404 until their backends ship), so the picker simply shows whatever is
+ * available. The selected target carries its stable id + a human label.
+ */
+export function TargetPicker({
+  value,
+  onChange,
+}: {
+  value: DcaTarget | null;
+  onChange: (t: DcaTarget) => void;
+}) {
+  const [kind, setKind] = useState<DcaTargetKind>("symbol");
+  const [q, setQ] = useState("");
+
+  const symbols = useSymbols();
+  const tokens = useTokenMarket();
+  const strategies = useStrategyMarket();
+
+  const options: TargetOption[] = useMemo(() => {
+    if (kind === "symbol") {
+      return (symbols.data?.symbols ?? []).map((s) => ({
+        kind: "symbol" as const,
+        id: String(s.symbol_id),
+        label: s.symbol,
+        sublabel: s.is_perpetual ? "Perp" : "Spot",
+      }));
+    }
+    if (kind === "token") {
+      return (tokens.data?.tokens ?? []).map((t) => ({
+        kind: "token" as const,
+        id: t.token_id,
+        label: `${t.name} (${t.ticker})`,
+        sublabel: "Creator token",
+      }));
+    }
+    return (strategies.data?.strategies ?? []).map((s) => ({
+      kind: "strategy" as const,
+      id: s.strategy_id,
+      label: s.name,
+      sublabel: s.kind === "rule" ? "Rule-based" : "Basket",
+    }));
+  }, [kind, symbols.data, tokens.data, strategies.data]);
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    const base = needle
+      ? options.filter((o) => o.label.toLowerCase().includes(needle))
+      : options;
+    return base.slice(0, 50);
+  }, [options, q]);
+
+  const loading =
+    (kind === "symbol" && symbols.isLoading) ||
+    (kind === "token" && tokens.isLoading) ||
+    (kind === "strategy" && strategies.isLoading);
+
+  return (
+    <div className="space-y-3">
+      <Tabs value={kind} onValueChange={(v) => setKind(v as DcaTargetKind)}>
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="symbol">Markets</TabsTrigger>
+          <TabsTrigger value="token">Tokens</TabsTrigger>
+          <TabsTrigger value="strategy">Strategies</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder={`Search ${KIND_LABELS[kind].toLowerCase()}s…`}
+          className="pl-8"
+          data-testid="target-search"
+        />
+      </div>
+
+      <div className="max-h-56 overflow-y-auto rounded-md border">
+        {loading ? (
+          <div className="p-4 text-center text-sm text-muted-foreground">Loading…</div>
+        ) : filtered.length === 0 ? (
+          <div className="p-4 text-center text-sm text-muted-foreground">
+            {kind === "symbol"
+              ? "No markets found."
+              : `No ${KIND_LABELS[kind].toLowerCase()}s available yet on this environment.`}
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {filtered.map((o) => {
+              const selected = value?.kind === o.kind && value?.id === o.id;
+              return (
+                <li key={`${o.kind}:${o.id}`}>
+                  <button
+                    type="button"
+                    onClick={() => onChange({ kind: o.kind, id: o.id, label: o.label })}
+                    data-testid="target-option"
+                    className={
+                      "flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-accent " +
+                      (selected ? "bg-accent font-medium" : "")
+                    }
+                  >
+                    <span className="truncate">{o.label}</span>
+                    {o.sublabel ? (
+                      <Badge variant="outline" className="shrink-0 text-[10px]">
+                        {o.sublabel}
+                      </Badge>
+                    ) : null}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {value ? (
+        <p className="text-xs text-muted-foreground">
+          Selected: <span className="font-medium text-foreground">{value.label}</span>{" "}
+          <Badge variant="secondary" className="ml-1 text-[10px]">
+            {KIND_LABELS[value.kind]}
+          </Badge>
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">No target selected yet.</p>
+      )}
+    </div>
+  );
+}
+
+/** Human label for a target kind (exported for reuse in tables). */
+export function targetKindLabel(kind: DcaTargetKind): string {
+  return KIND_LABELS[kind] ?? kind;
+}


### PR DESCRIPTION
## DCA / recurring buys — plan management + schedule preview

Schedule recurring dollar-cost-average buys of a symbol / creator token / strategy fund, funded from the USD cash wallet. Frontend owns plan **CRUD + schedule preview (next-run math) + budget tracking + history**; periodic execution is a **server-side runner** (degrade-on-404 until it ships) — stated explicitly in-UI.

### Contract (none deployed; reads degrade-on-404, mutations error clearly)
`GET/POST /me/dca/plans` · `POST /me/dca/plans/{id}/{pause|resume|cancel}` · `GET /me/dca/plans/{id}/history` · `POST .../run-now`. Wire `*_ts` = epoch seconds; amounts integer cents.

### Web (`/dca`, "Recurring buys" nav)
`lib/dca.ts` (+29 vitest) — `nextRun`/`upcomingRuns` (daily / weekly[dow] / monthly[dom, capped 28], respecting start/end + budget), budget/validation helpers; `api/endpoints/dca.ts` + `hooks/useDca.ts`; pages: Plans (pause/resume/cancel), Create (target picker across symbol/token/strategy, amount, freq+day, start/end/budget, funding=USD wallet w/ balance check + Add-cash link, live "next 5 buys" preview, money-safety confirm), Detail (history + run-now).

### Android (new `feature/dca` + `data/dca`, registered in `MoreRoutes`)
`DcaSchedule.kt` (mirror of web, pure UTC civil-date math; +27 JVM tests) + typed `DcaApi/Domain/Repository` (degrade-on-404) + Plans/Create/Detail screens+VMs; `MoreCatalog` + `MoreRoutes.REGISTERED` + `AuthenticatedGraph`.

No new deps. Gates: web tsc 0 · vite build · vitest 29/29; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (DcaSchedule 27/27, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
