### PR TITLE
feat(trade): fee-tier gauge on the order ticket (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTierMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/feetiers/FeeTierMath.kt
@@ -150,4 +150,42 @@ object FeeTierMath {
         // fee = notional * bps / 10_000, rounded half-up for a deterministic result.
         return (notionalCents * bps + 5_000L) / 10_000L
     }
+
+    /**
+     * Whether an order of the given [orderTypeId] REMOVES liquidity (pays the TAKER rate) when it
+     * executes. Kept dependency-free: the caller passes the order type's lowercase id/label rather
+     * than the trade module's enum, so this module stays pure and unit-testable.
+     *
+     * Liquidity-taking (taker): market orders and stop / take-profit orders whose triggered leg is a
+     * MARKET order. A resting/plain LIMIT order (and the limit leg of a stop-limit / quote / OTO /
+     * OCO) ADDS liquidity and is charged the MAKER rate. Unknown ids default to taker (the
+     * conservative, never-underquote choice for a fee estimate). Case-insensitive; ignores spaces,
+     * hyphens and underscores so "STOP_LIMIT", "Stop-Limit" and "stop limit" all match.
+     */
+    fun isTakerOrderType(orderTypeId: String?): Boolean {
+        val id = orderTypeId?.lowercase()?.replace("-", "")?.replace("_", "")?.replace(" ", "")?.trim()
+            ?: return true
+        return when (id) {
+            // Maker legs: a resting limit (and the limit-priced legs) add liquidity.
+            "limit", "stoplimit", "quote", "oto", "oco", "funding" -> false
+            // Taker legs: market + stop / take-profit market triggers remove liquidity.
+            "market", "stop", "takeprofit", "tp" -> true
+            else -> true
+        }
+    }
+
+    /**
+     * Estimated fee (integer cents, rounded half-up) for a new order of [notionalCents] value at this
+     * account's [makerBps]/[takerBps] rates, choosing the applicable rate from the [orderTypeId] via
+     * [isTakerOrderType]. Non-positive notional -> 0.
+     */
+    fun orderFeeEstimateCents(
+        notionalCents: Long,
+        makerBps: Int,
+        takerBps: Int,
+        orderTypeId: String?,
+    ): Long {
+        val bps = if (isTakerOrderType(orderTypeId)) takerBps else makerBps
+        return makerTakerFeeCents(notionalCents, bps)
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/SymbolDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/SymbolDetailScreen.kt
@@ -59,6 +59,7 @@ import com.testlogon.android.feature.markets.chart.Timeframe
 import com.testlogon.android.data.exchange.OrderSide
 import com.testlogon.android.feature.markets.trade.TradeTicket
 import com.testlogon.android.feature.markets.trade.TradingViewModel
+import com.testlogon.android.navigation.FeeTiersDest
 import com.testlogon.android.feature.markets.ui.MarketColors
 import com.testlogon.android.feature.markets.ui.MarketSurface
 import java.text.SimpleDateFormat
@@ -71,6 +72,7 @@ private const val PRICE_SCALER = 1L
 @Composable
 fun SymbolDetailRoute(
     onBack: () -> Unit,
+    onOpenRoute: (String) -> Unit = {},
     viewModel: SymbolDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -90,6 +92,7 @@ fun SymbolDetailRoute(
                         onSetTool = viewModel::setTool,
                         onCommitDrawing = viewModel::addDrawing,
                         onClearDrawings = viewModel::clearDrawings,
+                        onOpenFeeTiers = { onOpenRoute(FeeTiersDest.ROUTE) },
                     )
                 }
             }
@@ -140,6 +143,7 @@ private fun SymbolDetailContent(
     onSetTool: (DrawingTool) -> Unit,
     onCommitDrawing: (ChartDrawing) -> Unit,
     onClearDrawings: () -> Unit,
+    onOpenFeeTiers: () -> Unit = {},
 ) {
     val selectedTf = Timeframe.entries.firstOrNull { it.seconds == state.intervalSec } ?: Timeframe.M1
     var chartType by remember { mutableStateOf(ChartType.CANDLES) }
@@ -251,6 +255,7 @@ private fun SymbolDetailContent(
                     lastPrice = state.candles.lastOrNull()?.close,
                     bestBid = state.orderBook?.bestBid,
                     bestAsk = state.orderBook?.bestAsk,
+                    onOpenFeeTiers = onOpenFeeTiers,
                     viewModel = tradingViewModel,
                 )
             }

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradeTicket.kt
@@ -64,6 +64,7 @@ fun TradeTicket(
     modifier: Modifier = Modifier,
     bestBid: Long? = null,
     bestAsk: Long? = null,
+    onOpenFeeTiers: () -> Unit = {},
     viewModel: TradingViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -107,7 +108,7 @@ fun TradeTicket(
         Spacer(Modifier.height(12.dp))
 
         when (state.section) {
-            TicketSection.TRADE -> TradeSection(state, lastPrice, bestBid, bestAsk, viewModel)
+            TicketSection.TRADE -> TradeSection(state, lastPrice, bestBid, bestAsk, onOpenFeeTiers, viewModel)
             TicketSection.POSITIONS -> PositionsSection(state, lastPrice, viewModel)
             TicketSection.ORDERS -> OrdersSection(state, viewModel)
             TicketSection.FILLS -> FillsSection(state)
@@ -150,7 +151,7 @@ fun TradeTicket(
 // ======================= Sections =======================
 
 @Composable
-private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?, bestAsk: Long?, viewModel: TradingViewModel) {
+private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?, bestAsk: Long?, onOpenFeeTiers: () -> Unit, viewModel: TradingViewModel) {
     val sideColor = if (state.side == OrderSide.BUY) MarketColors.Up else MarketColors.Down
     var showDepositConfirm by remember { mutableStateOf(false) }
 
@@ -214,7 +215,7 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?
                 NumberField("Expires in (minutes)", state.expiryMinText, viewModel::setExpiryMin)
             }
             Spacer(Modifier.height(8.dp))
-            OrderPreview(state, refPrice, viewModel)
+            OrderPreview(state, refPrice, onOpenFeeTiers, viewModel)
             RiskCalculator(state, refPrice, viewModel)
             BracketHelper(state, refPrice, viewModel)
             AdvancedSection(state, viewModel)
@@ -225,7 +226,7 @@ private fun TradeSection(state: TradingUiState, lastPrice: Long?, bestBid: Long?
             Spacer(Modifier.height(4.dp))
             Text("Market order — fills immediately at the best available price.", color = MarketColors.TextSecondary, fontSize = 11.sp)
             Spacer(Modifier.height(8.dp))
-            OrderPreview(state, refPrice, viewModel)
+            OrderPreview(state, refPrice, onOpenFeeTiers, viewModel)
             RiskCalculator(state, refPrice, viewModel)
             BracketHelper(state, refPrice, viewModel)
             AdvancedSection(state, viewModel)
@@ -1128,7 +1129,7 @@ private fun QuickQuoteBtn(
  * initial margin the order would lock plus a first-order estimated liquidation price.
  */
 @Composable
-private fun OrderPreview(state: TradingUiState, refPrice: Long?, viewModel: TradingViewModel) {
+private fun OrderPreview(state: TradingUiState, refPrice: Long?, onOpenFeeTiers: () -> Unit, viewModel: TradingViewModel) {
     val notional = OrderMath.notional(refPrice, state.qtyLong)
     val avail = state.account?.availableBalance
     val maxQty = OrderMath.maxQtyForBalance(avail, refPrice)
@@ -1177,6 +1178,8 @@ private fun OrderPreview(state: TradingUiState, refPrice: Long?, viewModel: Trad
         PreviewLine("Margin impact (est.)", if (margin > 0L) fmt(margin.toDouble()) else "--", MarketColors.TextPrimary)
         Spacer(Modifier.height(4.dp))
         PreviewLine("Est. liquidation (est.)", liq?.let { fmt(it.toDouble()) } ?: "--", MarketColors.TextPrimary)
+        Spacer(Modifier.height(8.dp))
+        FeeTierGauge(state, onOpenFeeTiers)
         Spacer(Modifier.height(4.dp))
         Text(
             "Margin/liq. use assumed ${imBps / 100}%/${mmBps / 100}% (venue margin bps not exposed) - indicative only.",
@@ -1184,6 +1187,69 @@ private fun OrderPreview(state: TradingUiState, refPrice: Long?, viewModel: Trad
             fontSize = 10.sp,
         )
     }
+}
+
+/**
+ * Compact FEE-TIER GAUGE for the order preview: the account's current maker/taker VIP tier + rates
+ * (tappable -> the Fee Tiers screen; an "est." badge when the tier is client-estimated rather than an
+ * authoritative backend read) and the estimated fee for the order being entered (current notional x
+ * the applicable rate for the selected order type, updated live). In paper mode there is no real fee,
+ * so it shows "— (no fee, paper)". Hidden entirely until the tier resolves.
+ */
+@Composable
+private fun FeeTierGauge(state: TradingUiState, onOpenFeeTiers: () -> Unit) {
+    if (state.paperMode) {
+        PreviewLine("Est. fee", "— (no fee, paper)", MarketColors.TextFaint)
+        return
+    }
+    if (!state.hasFeeTier) return  // OFF-path: gauge stays hidden until the tier is known.
+
+    val takerBps = state.feeTierTakerBps
+    val makerBps = state.feeTierMakerBps
+    // Tier line: name + rates, tappable through to the Fee Tiers screen; est. badge when estimated.
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .clickable { onOpenFeeTiers() }
+            .testTag("fee_tier_gauge")
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Fee tier", color = MarketColors.TextSecondary, fontSize = 12.sp)
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            if (state.feeTierEstimated) {
+                Text(
+                    "est.",
+                    color = MarketColors.TextFaint,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 10.sp,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(4.dp))
+                        .border(1.dp, MarketColors.Border, RoundedCornerShape(4.dp))
+                        .padding(horizontal = 4.dp, vertical = 1.dp),
+                )
+            }
+            Text(
+                text = "${state.feeTierName} · maker $makerBps / taker $takerBps bps",
+                color = MarketColors.Accent,
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp,
+            )
+        }
+    }
+    Spacer(Modifier.height(4.dp))
+    // Est. fee for the order being entered (live from notional x applicable rate).
+    val fee = state.previewFeeCents
+    val liquidityLabel = if (state.isTakerOrder) "taker" else "maker"
+    val appliedBps = state.previewFeeBps
+    PreviewLine(
+        label = "Est. fee",
+        value = fee?.let { "${fmt(it.toDouble())} ($liquidityLabel $appliedBps bps)" } ?: "-- ($liquidityLabel $appliedBps bps)",
+        valueColor = if (fee != null && fee > 0L) MarketColors.TextPrimary else MarketColors.TextFaint,
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingUiState.kt
@@ -14,6 +14,7 @@ import com.testlogon.android.data.exchange.SpotBalance
 import com.testlogon.android.data.exchange.MarginConfigAck
 import com.testlogon.android.data.exchange.EngineConfigAck
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.feature.feetiers.FeeTierMath
 
 /** Order entry type. LIMIT is the plain resting limit; the rest map to advanced engine endpoints. */
 enum class OrderType(val label: String) {
@@ -146,6 +147,13 @@ data class TradingUiState(
     val pmResolutions: List<com.testlogon.android.data.exchange.PmResolution> = emptyList(),
     val feeSchedule: FeeSchedule? = null,
     val fillsFees: FillsFees? = null,
+    // ---- FEE-TIER GAUGE (maker/taker VIP tier for the current account) ----
+    // Resolved once (authoritative GET me/fees/tier when served; else client-computed from the same
+    // fills feed the Fee Tiers screen uses). Drives the compact tier + est-fee line in the ticket.
+    val feeTierName: String? = null,      // e.g. "Standard"; null until resolved
+    val feeTierMakerBps: Int = 0,         // maker rate for the resolved tier
+    val feeTierTakerBps: Int = 0,         // taker rate for the resolved tier
+    val feeTierEstimated: Boolean = false, // true when client-estimated (no authoritative read)
     val liveOrders: LiveOrders? = null,
     val liquidations: Liquidations? = null,
     val fundingPayments: FundingPayments? = null,
@@ -240,6 +248,27 @@ data class TradingUiState(
 
     /** Exact notional (price x qty) for the ticket preview. */
     val previewNotional: Long? get() = OrderMath.notional(entryRefPrice, qtyLong)
+
+    /** Whether the current [orderType] pays the TAKER rate (removes liquidity) for the fee gauge. */
+    val isTakerOrder: Boolean get() = FeeTierMath.isTakerOrderType(orderType.name)
+
+    /** Whether the account's fee tier has resolved (name + rates available). */
+    val hasFeeTier: Boolean get() = feeTierName != null && (feeTierMakerBps > 0 || feeTierTakerBps > 0)
+
+    /**
+     * Estimated fee (USD cents) for the order being entered: current notional x the applicable
+     * maker/taker rate for [orderType]. Null in paper mode (no fee) or before the tier resolves / with
+     * no notional yet.
+     */
+    val previewFeeCents: Long? get() {
+        if (paperMode || !hasFeeTier) return null
+        val n = previewNotional ?: return null
+        if (n <= 0L) return null
+        return FeeTierMath.orderFeeEstimateCents(n, feeTierMakerBps, feeTierTakerBps, orderType.name)
+    }
+
+    /** bps applied by [previewFeeCents] for the current order type. */
+    val previewFeeBps: Int get() = if (isTakerOrder) feeTierTakerBps else feeTierMakerBps
 
     /** Max whole qty affordable at the reference price from available balance (no leverage). */
     fun maxAffordableQty(refPrice: Long?): Long =

--- a/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/markets/trade/TradingViewModel.kt
@@ -9,6 +9,8 @@ import com.testlogon.android.data.exchange.TradingRepository
 import com.testlogon.android.data.exchange.ExchangeRepository
 import com.testlogon.android.data.exchange.FeeSchedule
 import com.testlogon.android.data.exchange.FillsFees
+import com.testlogon.android.data.exchange.FeeTierAuthoritative
+import com.testlogon.android.feature.feetiers.FeeTierMath
 import com.testlogon.android.data.feed.CurrentUserRepository
 import com.testlogon.android.feature.paper.PaperAccountStore
 import com.testlogon.android.feature.paper.PaperEngine
@@ -77,6 +79,7 @@ class TradingViewModel @Inject constructor(
         pollAccount()
         refreshPm()
         loadFees()
+        resolveFeeTier()
         refreshOrdersLive()
         resolveSymbols()
         loadStakeAuctionBrowse()
@@ -143,6 +146,52 @@ class TradingViewModel @Inject constructor(
                 is ApiResult.Success -> _uiState.update { it.copy(fundingPayments = r.data) }
                 else -> Unit
             }
+        }
+    }
+
+    /**
+     * Resolve the account's maker/taker FEE TIER once for the ticket's fee gauge. Prefers the
+     * AUTHORITATIVE backend read (GET me/fees/tier) when it serves a tier; on null/404 falls back to a
+     * CLIENT estimate computed from the SAME enriched fills feed the Fee Tiers screen uses
+     * (30-day volume -> tier via the pure [FeeTierMath] engine). A total failure just leaves the gauge
+     * hidden (no error surfaced on the ticket). Mirrors FeeTiersViewModel's resolution order.
+     */
+    fun resolveFeeTier() {
+        viewModelScope.launch {
+            val authoritative = (repository.feeTier() as? ApiResult.Success)?.data
+            if (authoritative != null && authoritative.tierId.isNotBlank()) {
+                applyAuthoritativeTier(authoritative)
+                return@launch
+            }
+            // Client estimate from the fills feed (may already be loaded; fetch if not).
+            val fills = _uiState.value.fillsFees?.fills
+                ?: (repository.fillsFees() as? ApiResult.Success)?.data?.fills
+                ?: emptyList()
+            val volume = FeeTierMath.volume30dCents(FeeTierMath.fromFills(fills), System.currentTimeMillis())
+            val tier = FeeTierMath.tierForVolume(volume)
+            _uiState.update {
+                it.copy(
+                    feeTierName = tier.name,
+                    feeTierMakerBps = tier.makerBps,
+                    feeTierTakerBps = tier.takerBps,
+                    feeTierEstimated = true,
+                )
+            }
+        }
+    }
+
+    /** Project an authoritative tier read onto the ticket gauge (canonical table fills any gaps). */
+    private fun applyAuthoritativeTier(a: FeeTierAuthoritative) {
+        val canonical = FeeTierMath.tierById(a.tierId)
+        val makerBps = a.makerBps.takeIf { it > 0 } ?: canonical?.makerBps ?: 0
+        val takerBps = a.takerBps.takeIf { it > 0 } ?: canonical?.takerBps ?: 0
+        _uiState.update {
+            it.copy(
+                feeTierName = a.name.ifBlank { canonical?.name ?: a.tierId },
+                feeTierMakerBps = makerBps,
+                feeTierTakerBps = takerBps,
+                feeTierEstimated = false,
+            )
         }
     }
 

--- a/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MarketsNavigation.kt
@@ -91,6 +91,9 @@ fun NavGraphBuilder.marketsDestinations(navController: NavHostController) {
             navArgument(SymbolDetailDest.ARG_SYMBOL_ID) { type = NavType.IntType },
         ),
     ) {
-        SymbolDetailRoute(onBack = { navController.popBackStack() })
+        SymbolDetailRoute(
+            onBack = { navController.popBackStack() },
+            onOpenRoute = { route -> navController.navigate(route) { launchSingleTop = true } },
+        )
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/feetiers/FeeTierMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/feetiers/FeeTierMathTest.kt
@@ -138,4 +138,48 @@ class FeeTierMathTest {
         assertEquals(0L, FeeTierMath.makerTakerFeeCents(100_000L, 0))
         assertEquals(0L, FeeTierMath.makerTakerFeeCents(-1L, 15))
     }
+
+    @Test
+    fun isTakerOrderType_makerVsTaker_andNormalization() {
+        // Market + stop/take-profit market triggers REMOVE liquidity -> taker.
+        assertTrue(FeeTierMath.isTakerOrderType("market"))
+        assertTrue(FeeTierMath.isTakerOrderType("MARKET"))
+        assertTrue(FeeTierMath.isTakerOrderType("stop"))
+        assertTrue(FeeTierMath.isTakerOrderType("Take-Profit"))
+        // Resting limit + limit-priced legs ADD liquidity -> maker.
+        assertTrue(!FeeTierMath.isTakerOrderType("limit"))
+        assertTrue(!FeeTierMath.isTakerOrderType("LIMIT"))
+        assertTrue(!FeeTierMath.isTakerOrderType("Stop-Limit"))
+        assertTrue(!FeeTierMath.isTakerOrderType("stop_limit"))
+        assertTrue(!FeeTierMath.isTakerOrderType("quote"))
+        assertTrue(!FeeTierMath.isTakerOrderType("oto"))
+        // Unknown / null default to taker (never under-quote a fee estimate).
+        assertTrue(FeeTierMath.isTakerOrderType(null))
+        assertTrue(FeeTierMath.isTakerOrderType("mystery"))
+    }
+
+    @Test
+    fun orderFeeEstimate_picksTakerRateForMarket() {
+        // Standard tier: maker 10bps, taker 15bps. Market = taker: 1_000_00 * 15 / 10000 = 150.
+        assertEquals(150L, FeeTierMath.orderFeeEstimateCents(1_000_00L, 10, 15, "market"))
+    }
+
+    @Test
+    fun orderFeeEstimate_picksMakerRateForLimit() {
+        // Limit = maker: 1_000_00 * 10 / 10000 = 100.
+        assertEquals(100L, FeeTierMath.orderFeeEstimateCents(1_000_00L, 10, 15, "limit"))
+        // Stop-limit is a maker leg too.
+        assertEquals(100L, FeeTierMath.orderFeeEstimateCents(1_000_00L, 10, 15, "Stop-Limit"))
+    }
+
+    @Test
+    fun orderFeeEstimate_guardsAndTierRates() {
+        // Non-positive notional -> 0 regardless of type.
+        assertEquals(0L, FeeTierMath.orderFeeEstimateCents(0L, 10, 15, "market"))
+        assertEquals(0L, FeeTierMath.orderFeeEstimateCents(-5L, 10, 15, "limit"))
+        // Diamond tier: maker 2 / taker 6 bps on 1_000_000_00 notional.
+        // taker: 1_000_000_00 * 6 / 10000 = 60000 ; maker: * 2 / 10000 = 20000.
+        assertEquals(60_000L, FeeTierMath.orderFeeEstimateCents(1_000_000_00L, 2, 6, "market"))
+        assertEquals(20_000L, FeeTierMath.orderFeeEstimateCents(1_000_000_00L, 2, 6, "limit"))
+    }
 }

--- a/frontend/src/hooks/useFeeTier.ts
+++ b/frontend/src/hooks/useFeeTier.ts
@@ -1,0 +1,122 @@
+// Shared MAKER/TAKER FEE-TIER resolver.
+//
+// Resolves the caller's current fee tier ONCE and shares it across surfaces
+// (the Fees page + the trade ticket's fee gauge) via a single react-query key.
+// Mirrors the resolution FeesPage originally did inline:
+//   1. Prefer the AUTHORITATIVE backend read `GET /me/fees/tier` (retry:false;
+//      404s until the exchange edge deploys).
+//   2. On 404 / unavailable, fall back to a CLIENT-COMPUTED tier from the
+//      30-day executed-fill volume (`GET /me/fills/fees`), using the pure
+//      `lib/feeTiers` engine.
+//
+// Returns the resolved tier name + maker/taker bps + whether the numbers are
+// authoritative or an estimate, so callers can badge accordingly.
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getFeeTier, type FeeTierResponse } from "@/api/endpoints/fees";
+import type { FillFee } from "@/api/endpoints/trading";
+import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { useFillsFees } from "@/hooks/useTrading";
+import { useSymbols } from "@/hooks/useMarketData";
+import {
+  volume30dCents,
+  tierForVolume,
+  tierById,
+  type VolumeFill,
+  type FeeTier,
+} from "@/lib/feeTiers";
+
+/** Shared query key so the authoritative tier read is fetched/cached once. */
+export const FEE_TIER_QUERY_KEY = ["fees", "tier"] as const;
+
+export interface ResolvedFeeTier {
+  /** Human tier label (e.g. "Gold"). */
+  tierName: string;
+  /** Stable tier id (matches FEE_TIERS[].id). */
+  tierId: string;
+  /** The caller's maker fee, basis points. */
+  makerBps: number;
+  /** The caller's taker fee, basis points. */
+  takerBps: number;
+  /** 30-day rolling volume backing the tier, USD cents. */
+  volumeCents: number;
+  /** Where the numbers came from. */
+  source: "authoritative" | "estimated";
+  /** True while either the authoritative read or the fills feed is loading. */
+  isPending: boolean;
+}
+
+/**
+ * Resolve the caller's current maker/taker fee tier. Lightweight: it reuses the
+ * shared symbols + fills feeds already in cache and a single authoritative
+ * query key. Never throws — degrades to the client-side estimate.
+ */
+export function useFeeTier(): ResolvedFeeTier {
+  const symbolsQuery = useSymbols();
+  const fillsQuery = useFillsFees();
+
+  const tierQuery = useQuery({
+    queryKey: FEE_TIER_QUERY_KEY,
+    queryFn: getFeeTier,
+    retry: false,
+  });
+
+  // symbolid -> catalog entry (price scaler), same resolver as FeesPage/Tax.
+  const symById = useMemo(() => {
+    const m = new Map<number, MarketSymbol>();
+    for (const s of symbolsQuery.data?.symbols ?? []) m.set(s.symbol_id, s);
+    return m;
+  }, [symbolsQuery.data]);
+
+  const rawFills: FillFee[] = Array.isArray(fillsQuery.data?.fills)
+    ? fillsQuery.data!.fills!
+    : [];
+
+  // Normalize the engine feed -> integer-cents fills (price tick / scaler).
+  const normalized: VolumeFill[] = useMemo(() => {
+    const out: VolumeFill[] = [];
+    for (const f of rawFills) {
+      const scaler = symById.get(f.symbolid)?.price_scaler || 1;
+      const priceCents = Math.round((f.price / scaler) * 100);
+      const qty = Math.abs(f.qty);
+      if (!qty || priceCents <= 0) continue;
+      out.push({ ts: f.ts, priceCents, qty });
+    }
+    return out;
+  }, [rawFills, symById]);
+
+  const estimatedVolumeCents = useMemo(
+    () => volume30dCents(normalized, Date.now()),
+    [normalized],
+  );
+
+  // Prefer the authoritative read when it resolved; else the client estimate.
+  const authoritative: FeeTierResponse | undefined = tierQuery.isSuccess
+    ? tierQuery.data
+    : undefined;
+  const isAuthoritative = !!authoritative;
+
+  const volumeCents = authoritative?.volume_30d_cents ?? estimatedVolumeCents;
+
+  const currentTier: FeeTier =
+    (authoritative && tierById(authoritative.tier_id)) || tierForVolume(volumeCents);
+
+  const makerBps = authoritative?.maker_bps ?? currentTier.makerBps;
+  const takerBps = authoritative?.taker_bps ?? currentTier.takerBps;
+
+  const isPending =
+    tierQuery.isPending ||
+    (!isAuthoritative && (fillsQuery.isLoading || symbolsQuery.isLoading));
+
+  return {
+    tierName: currentTier.name,
+    tierId: currentTier.id,
+    makerBps,
+    takerBps,
+    volumeCents,
+    source: isAuthoritative ? "authoritative" : "estimated",
+    isPending,
+  };
+}

--- a/frontend/src/lib/feeTiers.test.ts
+++ b/frontend/src/lib/feeTiers.test.ts
@@ -8,6 +8,8 @@ import {
   progressToNextFraction,
   volumeToNextTierCents,
   makerTakerFeeCents,
+  isTakerOrderType,
+  orderFeeEstimateCents,
   type VolumeFill,
 } from "./feeTiers";
 
@@ -164,5 +166,47 @@ describe("makerTakerFeeCents", () => {
     expect(makerTakerFeeCents(100_00, 0)).toBe(0);
     expect(makerTakerFeeCents(-1, 15)).toBe(0);
     expect(makerTakerFeeCents(NaN, 15)).toBe(0);
+  });
+});
+
+
+describe("isTakerOrderType", () => {
+  it("classifies book-crossing types as taker", () => {
+    expect(isTakerOrderType("market")).toBe(true);
+    expect(isTakerOrderType("stop")).toBe(true);
+    expect(isTakerOrderType("take_profit")).toBe(true);
+  });
+  it("classifies resting-limit types as maker", () => {
+    expect(isTakerOrderType("limit")).toBe(false);
+    expect(isTakerOrderType("stop_limit")).toBe(false);
+  });
+  it("post-only forces maker even for a would-be taker", () => {
+    expect(isTakerOrderType("market", true)).toBe(false);
+    expect(isTakerOrderType("limit", true)).toBe(false);
+  });
+  it("defaults unknown types to taker (conservative)", () => {
+    expect(isTakerOrderType("weird" as never)).toBe(true);
+    expect(isTakerOrderType("weird" as never, true)).toBe(false);
+  });
+});
+
+describe("orderFeeEstimateCents", () => {
+  it("uses the taker rate for a market order", () => {
+    // $10,000 @ 15bps taker = $15.00
+    expect(orderFeeEstimateCents(1_000_000, 10, 15, "market")).toBe(15_00);
+  });
+  it("uses the maker rate for a resting limit order", () => {
+    // $10,000 @ 10bps maker = $10.00
+    expect(orderFeeEstimateCents(1_000_000, 10, 15, "limit")).toBe(10_00);
+  });
+  it("post-only limit stays on the maker rate", () => {
+    expect(orderFeeEstimateCents(1_000_000, 10, 15, "limit", true)).toBe(10_00);
+  });
+  it("post-only market drops from taker to maker rate", () => {
+    expect(orderFeeEstimateCents(1_000_000, 10, 15, "market", true)).toBe(10_00);
+  });
+  it("guards non-positive notional to 0", () => {
+    expect(orderFeeEstimateCents(0, 10, 15, "market")).toBe(0);
+    expect(orderFeeEstimateCents(-5, 10, 15, "limit")).toBe(0);
   });
 });

--- a/frontend/src/lib/feeTiers.ts
+++ b/frontend/src/lib/feeTiers.ts
@@ -158,3 +158,58 @@ export function makerTakerFeeCents(notionalCents: number, bps: number): number {
   // fee = notional * bps / 10_000. Round half-up for a deterministic result.
   return Math.round((n * b) / 10_000);
 }
+
+
+// ── order-time fee estimate (taker vs maker by order type) ───────────────
+
+/** Order-entry type union understood by {@link isTakerOrderType}. */
+export type FeeOrderType =
+  | "limit"
+  | "market"
+  | "stop"
+  | "stop_limit"
+  | "take_profit"
+  | (string & {});
+
+/**
+ * Whether an order of `type` is expected to pay the TAKER fee. Market and
+ * stop / take-profit orders trigger into a market fill and CROSS the book →
+ * taker. A resting `limit` ADDS liquidity → maker; at entry time a plain limit
+ * is treated as a maker (the typical/optimistic case), and `postOnly` forces
+ * maker. `stop_limit` triggers into a resting LIMIT, so it is a maker too.
+ * Unknown types default to taker (the conservative, higher estimate) unless
+ * `postOnly` is set.
+ */
+export function isTakerOrderType(type: FeeOrderType, postOnly = false): boolean {
+  if (postOnly) return false;
+  switch (type) {
+    case "limit":
+      return false; // resting maker
+    case "stop_limit":
+      return false; // triggers into a resting limit -> maker
+    case "market":
+    case "stop":
+    case "take_profit":
+      return true; // crosses the book -> taker
+    default:
+      return true; // unknown -> conservative taker estimate
+  }
+}
+
+/**
+ * Estimated order fee (integer USD cents, rounded half-up) for `notionalCents`
+ * at the caller's `makerBps` / `takerBps`, choosing the applicable rate from
+ * the order `type` (see {@link isTakerOrderType}). A `postOnly` limit is forced
+ * to the maker rate. Guards non-positive notional -> 0.
+ */
+export function orderFeeEstimateCents(
+  notionalCents: number,
+  makerBps: number,
+  takerBps: number,
+  type: FeeOrderType,
+  postOnly = false,
+): number {
+  const taker = isTakerOrderType(type, postOnly);
+  const bps = taker ? takerBps : makerBps;
+  return makerTakerFeeCents(notionalCents, bps);
+}

--- a/frontend/src/pages/fees/FeesPage.tsx
+++ b/frontend/src/pages/fees/FeesPage.tsx
@@ -12,7 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Percent, Info, RefreshCw, TrendingUp } from "lucide-react";
 
 import { ApiError } from "@/api/client";
-import { getFeeTier, type FeeTierResponse } from "@/api/endpoints/fees";
+import { getFeeTier } from "@/api/endpoints/fees";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -30,9 +30,9 @@ import { useFillsFees } from "@/hooks/useTrading";
 import { useSymbols } from "@/hooks/useMarketData";
 import type { FillFee } from "@/api/endpoints/trading";
 import type { MarketSymbol } from "@/api/endpoints/marketData";
+import { useFeeTier } from "@/hooks/useFeeTier";
 import {
   FEE_TIERS,
-  volume30dCents,
   tierForVolume,
   tierById,
   nextTier,
@@ -62,6 +62,8 @@ export default function FeesPage() {
   const fillsQuery = useFillsFees();
 
   // Authoritative read; 404s until the edge deploys -> degrade to the estimate.
+  // Kept alongside the shared hook (same query key -> one network call) only to
+  // drive the "showing an estimate" notice below.
   const tierQuery = useQuery({
     queryKey: ["fees", "tier"],
     queryFn: getFeeTier,
@@ -90,30 +92,19 @@ export default function FeesPage() {
     return out;
   }, [rawFills, symById]);
 
-  const estimatedVolumeCents = useMemo(
-    () => volume30dCents(normalized, Date.now()),
-    [normalized],
-  );
-
-  // Prefer the authoritative read when it resolved; else the client estimate.
-  const authoritative: FeeTierResponse | undefined =
-    tierQuery.isSuccess ? tierQuery.data : undefined;
-  const isAuthoritative = !!authoritative;
-
-  const volumeCents = authoritative?.volume_30d_cents ?? estimatedVolumeCents;
-
-  // Current tier: from the authoritative id when present (fall back to volume
-  // lookup if the id is unknown), else derive from the estimated volume.
-  const currentTier: FeeTier =
-    (authoritative && tierById(authoritative.tier_id)) || tierForVolume(volumeCents);
+  // Shared resolver (authoritative -> estimate) — the single source of truth
+  // for the tier + maker/taker bps + backing volume, deduped with the ticket.
+  const resolved = useFeeTier();
+  const isAuthoritative = resolved.source === "authoritative";
+  const volumeCents = resolved.volumeCents;
+  const currentTier: FeeTier = tierById(resolved.tierId) || tierForVolume(volumeCents);
 
   const upcoming = nextTier(currentTier);
   const fraction = progressToNextFraction(volumeCents);
   const toNextCents = volumeToNextTierCents(volumeCents);
 
-  // maker/taker rates: authoritative overrides the tier defaults when present.
-  const makerBps = authoritative?.maker_bps ?? currentTier.makerBps;
-  const takerBps = authoritative?.taker_bps ?? currentTier.takerBps;
+  const makerBps = resolved.makerBps;
+  const takerBps = resolved.takerBps;
 
   const feedLoading = fillsQuery.isLoading || symbolsQuery.isLoading;
   const feedUnavailable =

--- a/frontend/src/pages/markets/TradeTicket.tsx
+++ b/frontend/src/pages/markets/TradeTicket.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRegisterShortcuts, type ShortcutEntry } from "@/hooks/useKeyboardShortcuts";
+import { Link } from "react-router-dom";
+import { useFeeTier } from "@/hooks/useFeeTier";
+import { orderFeeEstimateCents } from "@/lib/feeTiers";
 import { useQuery } from "@tanstack/react-query";
 import { getFeeSchedule } from "@/api/endpoints/custody";
 import { cn } from "@/lib/utils";
@@ -589,6 +592,36 @@ export function TradeTicket({
       ? (side === "buy" ? bestAsk : bestBid) ?? lastPrice ?? refPrice
       : refPrice;
   const previewNotional = calcNotional(previewPrice, qtyN);
+  // ── Fee-tier gauge (maker/taker) ──────────────────────────────────────
+  // Resolve the caller's fee tier once (shared with the Fees page). The order
+  // preview shows the tier + the estimated fee for THIS order. Paper orders
+  // incur no real fee, so the gauge shows "no fee (paper)".
+  const feeTier = useFeeTier();
+  // Notional is in engine-tick space (price*qty scaled by price_scaler). The
+  // fee engine works in USD CENTS, so divide out the scaler and *100. The
+  // resulting fee cents convert back to tick space for display via formatPrice.
+  const previewNotionalCents =
+    previewNotional > 0 ? Math.round((previewNotional / (scaler || 1)) * 100) : 0;
+  // A resting limit that is post-only (or plain) pays maker; market/stop cross
+  // -> taker. isTakerOrderType (via orderFeeEstimateCents) owns that mapping.
+  const feeIsTaker =
+    postOnly
+      ? false
+      : orderType === "market" || orderType === "stop" || orderType === "take_profit"
+        ? true
+        : orderType === "limit" || orderType === "stop_limit"
+          ? false
+          : true;
+  const feeRateBps = feeIsTaker ? feeTier.takerBps : feeTier.makerBps;
+  const feeEstCents = orderFeeEstimateCents(
+    previewNotionalCents,
+    feeTier.makerBps,
+    feeTier.takerBps,
+    orderType,
+    postOnly,
+  );
+  // Back to tick space for formatPrice(scaler): cents -> dollars -> ticks.
+  const feeEstTicks = Math.round((feeEstCents / 100) * (scaler || 1));
   const maxAffordableQty = maxQtyForBalance(avail, previewPrice);
   // The exchange does NOT expose initial/maintenance margin bps to the client
   // (the fee schedule only carries maker/taker/liquidation-fee bps). So any
@@ -1796,6 +1829,38 @@ export function TradeTicket({
                   {orderType === "market" && (
                     <span className="text-[10px] text-muted-foreground">at {previewPrice ? formatPrice(previewPrice, scaler) : "—"} (proxy)</span>
                   )}
+                </div>
+                {/* Fee-tier gauge — current maker/taker tier + estimated order fee. */}
+                <div className="flex flex-wrap items-center justify-between gap-1.5 border-b pb-1.5" data-testid="fee_gauge">
+                  <Link
+                    to="/fees"
+                    data-testid="fee_tier_chip"
+                    className="inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+                    title="View your fee tier schedule"
+                  >
+                    <span className="text-foreground">Fee tier: {feeTier.tierName}</span>
+                    <span className="text-muted-foreground">
+                      · maker {feeTier.makerBps} bps / taker {feeTier.takerBps} bps
+                    </span>
+                    {feeTier.source === "estimated" && (
+                      <span className="rounded bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">est</span>
+                    )}
+                  </Link>
+                  <span className="text-xs tabular-nums" data-testid="fee_est">
+                    {paperMode ? (
+                      <span className="text-muted-foreground">no fee (paper)</span>
+                    ) : feeEstCents > 0 ? (
+                      <>
+                        <span className="text-muted-foreground">Est. fee </span>
+                        <span className="font-semibold">{formatPrice(feeEstTicks, scaler)}</span>
+                        <span className="text-[10px] text-muted-foreground">
+                          {" "}({feeIsTaker ? "taker" : "maker"} {feeRateBps} bps)
+                        </span>
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Notional</span>


### PR DESCRIPTION
## Fee-tier gauge on the order ticket

Surfaces the user's maker/taker fee tier + the order's estimated fee right on the trade ticket. Reuses the shipped `feeTiers` lib; resolves the tier from authoritative `/me/fees/tier` with a client-computed (fills-window) fallback.

**Shared helpers (pure, +tests):** `isTakerOrderType(type)` (market/stop/take-profit = taker; resting limit/quote/oto/oco = maker; post-only forces maker) + `orderFeeEstimateCents(...)`.

### Web
`hooks/useFeeTier.ts` (authoritative → client fallback, shared query key); FeesPage refactored to consume it (dedup, identical behavior); `feeTiers.ts` helpers (+9 vitest → 32/32); `TradeTicket.tsx` fee line — tier chip linking to `/fees` (est badge) + live "Est. fee $Z (taker|maker Y bps)", respecting type/post-only; "no fee (paper)" in paper mode.

### Android
`FeeTierMath.kt` same helpers (+4 JVM → 17/17); `TradingViewModel` resolves the tier once (authoritative → client fallback), `TradingUiState` exposes tier + previewFee; `TradeTicket` `FeeTierGauge` in `OrderPreview` (tappable → Fee Tiers route); `onOpenFeeTiers` threaded through SymbolDetail + wired in MarketsNav.

Additive; existing ticket behavior unchanged. No new deps. Gates: web tsc 0 · vite build · vitest 32/32; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (FeeTierMath 17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
