### PR TITLE
feat(rewards): referral leaderboard (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
@@ -8,6 +8,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 /**
  * Retrofit interface + Moshi DTOs for the REFERRALS + REWARDS surface, mirroring the web contract
@@ -49,6 +50,13 @@ interface RewardsApi {
     @Headers("Content-Type: application/json")
     @POST("me/rewards/redeem")
     suspend fun redeem(@Body body: RedeemRequestDto): RedeemResultDto
+
+    /**
+     * GET me/referral/leaderboard?period=all|month -> top referrers + (optionally) the caller's own
+     * out-of-slice rank. Read degrades on 404 to an honest coming-soon state.
+     */
+    @GET("me/referral/leaderboard")
+    suspend fun referralLeaderboard(@Query("period") period: String): ReferralLeaderboardDto
 }
 
 // ---- GET me/referral ----
@@ -145,4 +153,33 @@ data class RedeemResultDto(
     @LenientLong @Json(name = "points_remaining") val pointsRemaining: Long? = null,
     @Json(name = "detail") val detail: String? = null,
     @Json(name = "error") val error: String? = null,
+)
+
+// ---- GET me/referral/leaderboard ----
+
+@JsonClass(generateAdapter = true)
+data class ReferralLeaderboardDto(
+    @Json(name = "period") val period: String? = null,
+    @LenientLong @Json(name = "updated_ts") val updatedTs: Long? = null,
+    @Json(name = "entries") val entries: List<ReferralLeaderboardEntryDto> = emptyList(),
+    @Json(name = "you") val you: ReferralLeaderboardYouDto? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ReferralLeaderboardEntryDto(
+    @LenientInt @Json(name = "rank") val rank: Int? = null,
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "masked_name") val maskedName: String? = null,
+    @Json(name = "is_you") val isYou: Boolean? = null,
+    @LenientInt @Json(name = "referred_count") val referredCount: Int? = null,
+    @LenientInt @Json(name = "qualified_count") val qualifiedCount: Int? = null,
+    @LenientLong @Json(name = "reward_cents") val rewardCents: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ReferralLeaderboardYouDto(
+    @LenientInt @Json(name = "rank") val rank: Int? = null,
+    @LenientInt @Json(name = "referred_count") val referredCount: Int? = null,
+    @LenientInt @Json(name = "qualified_count") val qualifiedCount: Int? = null,
+    @LenientLong @Json(name = "reward_cents") val rewardCents: Long? = null,
 )

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
@@ -188,3 +188,92 @@ internal fun RedeemResultDto.toDomain(): RedeemResult = RedeemResult(
     pointsRemaining = pointsRemaining,
     reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
 )
+
+// ---- Referral leaderboard ----
+
+/** The leaderboard time window. Unknown/absent -> [ALL] (the widest, most conservative view). */
+enum class LeaderboardPeriod(val wire: String) {
+    ALL("all"),
+    MONTH("month");
+
+    companion object {
+        fun fromWire(value: String?): LeaderboardPeriod = when (value?.trim()?.lowercase()) {
+            "month" -> MONTH
+            else -> ALL
+        }
+    }
+}
+
+/** A single ranked referrer row on the leaderboard. */
+data class LeaderboardEntry(
+    val rank: Int,
+    val id: String,
+    val maskedName: String,
+    val isYou: Boolean,
+    val referredCount: Int,
+    val qualifiedCount: Int,
+    val rewardCents: Long,
+)
+
+/** The caller's own rank when they fall OUTSIDE the shown slice (server-provided). */
+data class LeaderboardYou(
+    val rank: Int,
+    val referredCount: Int,
+    val qualifiedCount: Int,
+    val rewardCents: Long,
+)
+
+data class ReferralLeaderboard(
+    val period: LeaderboardPeriod,
+    val updatedTs: Long,
+    val entries: List<LeaderboardEntry>,
+    val you: LeaderboardYou?,
+    val available: Boolean,
+) {
+    companion object {
+        /** Honest "unavailable" leaderboard for the degrade-on-404 empty state. */
+        fun unavailable(period: LeaderboardPeriod = LeaderboardPeriod.ALL): ReferralLeaderboard =
+            ReferralLeaderboard(
+                period = period,
+                updatedTs = 0L,
+                entries = emptyList(),
+                you = null,
+                available = false,
+            )
+    }
+}
+
+// ---- Mappers (DTO -> domain; TOTAL, absent optionals default) ----
+
+internal fun ReferralLeaderboardEntryDto.toDomain(): LeaderboardEntry? {
+    val id = id?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    return LeaderboardEntry(
+        rank = rank ?: 0,
+        id = id,
+        maskedName = maskedName?.trim()?.takeIf { it.isNotBlank() } ?: "Referrer",
+        isYou = isYou == true,
+        referredCount = referredCount ?: 0,
+        qualifiedCount = qualifiedCount ?: 0,
+        rewardCents = rewardCents ?: 0L,
+    )
+}
+
+internal fun ReferralLeaderboardYouDto.toDomain(): LeaderboardYou? {
+    val rank = rank ?: return null
+    if (rank <= 0) return null
+    return LeaderboardYou(
+        rank = rank,
+        referredCount = referredCount ?: 0,
+        qualifiedCount = qualifiedCount ?: 0,
+        rewardCents = rewardCents ?: 0L,
+    )
+}
+
+internal fun ReferralLeaderboardDto.toDomain(requested: LeaderboardPeriod): ReferralLeaderboard =
+    ReferralLeaderboard(
+        period = LeaderboardPeriod.fromWire(period) .let { if (this.period == null) requested else it },
+        updatedTs = updatedTs ?: 0L,
+        entries = entries.mapNotNull { it.toDomain() },
+        you = you?.toDomain(),
+        available = true,
+    )

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
@@ -36,6 +36,7 @@ interface RewardsRepository {
     suspend fun rewardsHistory(): ApiResult<List<RewardsHistoryEntry>>
     suspend fun rewardsCatalog(): ApiResult<List<CatalogReward>>
     suspend fun redeem(rewardId: String): ApiResult<RedeemResult>
+    suspend fun referralLeaderboard(period: LeaderboardPeriod): ApiResult<ReferralLeaderboard>
 }
 
 @Singleton
@@ -80,6 +81,12 @@ class RewardsRepositoryImpl @Inject constructor(
     override suspend fun redeem(rewardId: String): ApiResult<RedeemResult> = call {
         api.redeem(RedeemRequestDto(rewardId = rewardId.trim())).toDomain()
     }
+
+    /** Referral leaderboard. A 404 (undeployed) degrades to an honest unavailable board; network errors surface. */
+    override suspend fun referralLeaderboard(period: LeaderboardPeriod): ApiResult<ReferralLeaderboard> = degrading(
+        block = { api.referralLeaderboard(period.wire).toDomain(period) },
+        onHttpError = { ReferralLeaderboard.unavailable(period) },
+    )
 
     /** Read wrapper: HTTP-error (incl. 404) degrades to [onHttpError]; transport -> NetworkError. */
     private suspend fun <T> degrading(

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralHubScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralHubScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.Leaderboard
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
@@ -63,12 +64,14 @@ object ReferralHubTestTags {
     const val COMING_SOON = "referral_hub_coming_soon"
     const val SHARE = "referral_hub_share"
     const val COPY = "referral_hub_copy"
+    const val LEADERBOARD = "referral_hub_leaderboard"
 }
 
 /** Route-level Referral hub entry (reached from the More -> Growth hub). */
 @Composable
 fun ReferralHubRoute(
     onBack: () -> Unit,
+    onLeaderboard: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ReferralHubViewModel = hiltViewModel(),
 ) {
@@ -92,6 +95,7 @@ fun ReferralHubRoute(
         onRetry = viewModel::onRetry,
         onShare = viewModel::onShare,
         onCopy = viewModel::onCopy,
+        onLeaderboard = onLeaderboard,
         snackbarHostState = snackbarHostState,
         modifier = modifier,
     )
@@ -104,6 +108,7 @@ fun ReferralHubScreen(
     onRetry: () -> Unit,
     onShare: () -> Unit,
     onCopy: () -> Unit,
+    onLeaderboard: () -> Unit,
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
@@ -136,7 +141,7 @@ fun ReferralHubScreen(
                 // Clean 404 degrade: read succeeded as "unavailable" with no error -> honest coming-soon.
                 !state.available -> ReferralComingSoon()
 
-                else -> ReferralContent(state = state, onShare = onShare, onCopy = onCopy)
+                else -> ReferralContent(state = state, onShare = onShare, onCopy = onCopy, onLeaderboard = onLeaderboard)
             }
         }
     }
@@ -156,6 +161,7 @@ private fun ReferralContent(
     state: ReferralHubUiState,
     onShare: () -> Unit,
     onCopy: () -> Unit,
+    onLeaderboard: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -172,6 +178,10 @@ private fun ReferralContent(
         }
         CodeCard(summary = state.summary, hasShareable = state.hasShareable, onShare = onShare, onCopy = onCopy)
         StatsCard(state.summary)
+        OutlinedButton(onClick = onLeaderboard, modifier = Modifier.fillMaxWidth().testTag(ReferralHubTestTags.LEADERBOARD)) {
+            Icon(Icons.Outlined.Leaderboard, contentDescription = null)
+            Text("View leaderboard", modifier = Modifier.padding(start = 8.dp))
+        }
         if (state.referrals.isNotEmpty()) {
             ReferralListCard(state.referrals)
         }

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralLeaderboardMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralLeaderboardMath.kt
@@ -1,0 +1,90 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.data.rewards.LeaderboardEntry
+import com.testlogon.android.data.rewards.LeaderboardYou
+
+/**
+ * Pure, Android-free math + formatting for the REFERRAL LEADERBOARD (feature/rewards). Kept out of the
+ * ViewModel so ranking, medals, the "your rank" resolution and the shown-slice are unit-testable without
+ * Compose/Hilt. Money is integer cents throughout (formatting delegates to [RewardsMath] for a single
+ * source of truth, no float drift).
+ *
+ * DISTINCT from the social-achievements leaderboard: this ranks REFERRERS by referred/qualified count +
+ * reward earned. Ranking is server-authoritative (entries carry a server `rank`); [sortEntries] only
+ * repairs an out-of-order or rank-less slice so the UI never renders a scrambled list.
+ */
+object ReferralLeaderboardMath {
+
+    /** Default number of top rows the board shows before falling back to the pinned "your rank" row. */
+    const val DEFAULT_TOP_N: Int = 20
+
+    /** A medal tier for the top three ranks; [NONE] for everyone else. */
+    enum class Medal { GOLD, SILVER, BRONZE, NONE }
+
+    /** rank 1/2/3 -> gold/silver/bronze, else none. Non-positive ranks are [Medal.NONE]. */
+    fun rankMedal(rank: Int): Medal = when (rank) {
+        1 -> Medal.GOLD
+        2 -> Medal.SILVER
+        3 -> Medal.BRONZE
+        else -> Medal.NONE
+    }
+
+    /**
+     * Deterministic ranking repair for a slice whose server ranks may be missing/scrambled: order by
+     * qualified_count desc, then referred_count desc, then reward_cents desc, then masked_name asc, then
+     * id asc (stable, total). Does NOT renumber — the row's own `rank` is preserved for display.
+     */
+    fun sortEntries(entries: List<LeaderboardEntry>): List<LeaderboardEntry> =
+        entries.sortedWith(
+            compareByDescending<LeaderboardEntry> { it.qualifiedCount }
+                .thenByDescending { it.referredCount }
+                .thenByDescending { it.rewardCents }
+                .thenBy { it.maskedName.lowercase() }
+                .thenBy { it.id },
+        )
+
+    /** The first [n] rows of the (repaired) slice; [n] is coerced to at least 0. */
+    fun topN(entries: List<LeaderboardEntry>, n: Int = DEFAULT_TOP_N): List<LeaderboardEntry> =
+        sortEntries(entries).take(n.coerceAtLeast(0))
+
+    /** True when the caller already appears in the shown slice (so no pinned "your rank" row is needed). */
+    fun youInSlice(shown: List<LeaderboardEntry>): Boolean = shown.any { it.isYou }
+
+    /**
+     * Resolve the pinned "Your rank" row. Returns null when the caller is already visible in [shown]
+     * (no duplicate) or when the server gave us no out-of-slice [you] rank. Otherwise a synthetic row is
+     * built from [you] so the caller always sees their standing even outside the top N. The synthetic row
+     * is flagged [LeaderboardEntry.isYou] = true and carries a blank id/name (the UI labels it "You").
+     */
+    fun resolveYouRow(shown: List<LeaderboardEntry>, you: LeaderboardYou?): LeaderboardEntry? {
+        if (youInSlice(shown)) return null
+        val y = you ?: return null
+        return LeaderboardEntry(
+            rank = y.rank,
+            id = "",
+            maskedName = "You",
+            isYou = true,
+            referredCount = y.referredCount,
+            qualifiedCount = y.qualifiedCount,
+            rewardCents = y.rewardCents,
+        )
+    }
+
+    // ---- Format helpers (delegate money to RewardsMath; single source of truth) ----
+
+    /** "#12" rank label. Non-positive ranks render as an em dash. */
+    fun formatRank(rank: Int): String = if (rank > 0) "#$rank" else "—"
+
+    /** Integer count with thousands grouping (1250 -> "1,250"). */
+    fun formatCount(count: Int): String = RewardsMath.groupThousands(count.toLong())
+
+    /** Reward earned as USD ("$12.34"). */
+    fun formatRewardCents(cents: Long): String = RewardsMath.formatCentsUsd(cents)
+
+    /** Human label for a period toggle value. */
+    fun periodLabel(period: com.testlogon.android.data.rewards.LeaderboardPeriod): String =
+        when (period) {
+            com.testlogon.android.data.rewards.LeaderboardPeriod.ALL -> "All-time"
+            com.testlogon.android.data.rewards.LeaderboardPeriod.MONTH -> "This month"
+        }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralLeaderboardScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralLeaderboardScreen.kt
@@ -1,0 +1,272 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.rewards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.rewards.LeaderboardEntry
+import com.testlogon.android.data.rewards.LeaderboardPeriod
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/** Stable testTags for the Referral leaderboard screen. */
+object ReferralLeaderboardTestTags {
+    const val SCREEN = "referral_leaderboard_screen"
+    const val CONTENT = "referral_leaderboard_content"
+    const val LOADING = "referral_leaderboard_loading"
+    const val ERROR = "referral_leaderboard_error"
+    const val COMING_SOON = "referral_leaderboard_coming_soon"
+    const val PERIOD_ALL = "referral_leaderboard_period_all"
+    const val PERIOD_MONTH = "referral_leaderboard_period_month"
+    const val YOU_ROW = "referral_leaderboard_you_row"
+}
+
+/** Route-level Referral leaderboard entry (reached from the Refer & earn hub). */
+@Composable
+fun ReferralLeaderboardRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ReferralLeaderboardViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    ReferralLeaderboardScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onPeriodSelected = viewModel::onPeriodSelected,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ReferralLeaderboardScreen(
+    state: ReferralLeaderboardUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onPeriodSelected: (LeaderboardPeriod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(ReferralLeaderboardTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Referral leaderboard") },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("referral_leaderboard_back")) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            PeriodToggle(selected = state.period, onPeriodSelected = onPeriodSelected)
+            Box(modifier = Modifier.fillMaxSize()) {
+                when {
+                    state.loading -> LoadingState(modifier = Modifier.testTag(ReferralLeaderboardTestTags.LOADING))
+
+                    // A genuine read failure (transport / server error) — offer retry.
+                    state.offline || (state.errorMessage != null && !state.available) ->
+                        ErrorState(
+                            message = state.errorMessage ?: "Couldn't load the leaderboard.",
+                            onRetry = onRetry,
+                            modifier = Modifier.testTag(ReferralLeaderboardTestTags.ERROR),
+                        )
+
+                    // Clean 404 degrade, or an available-but-empty board -> honest coming-soon.
+                    !state.available || !state.hasRows -> LeaderboardComingSoon()
+
+                    else -> LeaderboardContent(state = state)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeriodToggle(
+    selected: LeaderboardPeriod,
+    onPeriodSelected: (LeaderboardPeriod) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        FilterChip(
+            selected = selected == LeaderboardPeriod.ALL,
+            onClick = { onPeriodSelected(LeaderboardPeriod.ALL) },
+            label = { Text(ReferralLeaderboardMath.periodLabel(LeaderboardPeriod.ALL)) },
+            modifier = Modifier.testTag(ReferralLeaderboardTestTags.PERIOD_ALL),
+        )
+        FilterChip(
+            selected = selected == LeaderboardPeriod.MONTH,
+            onClick = { onPeriodSelected(LeaderboardPeriod.MONTH) },
+            label = { Text(ReferralLeaderboardMath.periodLabel(LeaderboardPeriod.MONTH)) },
+            modifier = Modifier.testTag(ReferralLeaderboardTestTags.PERIOD_MONTH),
+        )
+    }
+}
+
+@Composable
+private fun LeaderboardComingSoon() {
+    EmptyState(
+        title = "Leaderboard coming soon",
+        body = "The top referrers and your own rank will appear here once the referral leaderboard is enabled for your account.",
+        modifier = Modifier.testTag(ReferralLeaderboardTestTags.COMING_SOON),
+    )
+}
+
+@Composable
+private fun LeaderboardContent(state: ReferralLeaderboardUiState) {
+    LazyColumn(
+        modifier = Modifier
+            .testTag(ReferralLeaderboardTestTags.CONTENT)
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item { HeaderRow() }
+        items(state.shown, key = { it.id.ifBlank { "rank_" + it.rank } }) { entry ->
+            LeaderboardRow(entry = entry, highlighted = entry.isYou)
+        }
+        state.youRow?.let { you ->
+            item {
+                Text(
+                    "Your rank",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+            item {
+                LeaderboardRow(
+                    entry = you,
+                    highlighted = true,
+                    modifier = Modifier.testTag(ReferralLeaderboardTestTags.YOU_ROW),
+                )
+            }
+        }
+        if (state.updatedTs > 0L) {
+            item {
+                Text(
+                    "Updated " + formatUpdated(state.updatedTs),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderRow() {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Rank", style = MaterialTheme.typography.labelMedium, modifier = Modifier.width(52.dp))
+        Text("Referrer", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
+        Text("Qual.", style = MaterialTheme.typography.labelMedium, modifier = Modifier.width(48.dp))
+        Text("Earned", style = MaterialTheme.typography.labelMedium, modifier = Modifier.width(72.dp))
+    }
+}
+
+@Composable
+private fun LeaderboardRow(
+    entry: LeaderboardEntry,
+    highlighted: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val colors = if (highlighted) {
+        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+    } else {
+        CardDefaults.cardColors()
+    }
+    Card(modifier = modifier.fillMaxWidth(), colors = colors) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                modifier = Modifier.width(52.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                medalEmoji(entry.rank)?.let { Text(it) }
+                Text(
+                    ReferralLeaderboardMath.formatRank(entry.rank),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = if (highlighted) FontWeight.Bold else FontWeight.Normal,
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    if (entry.isYou) "You" else entry.maskedName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = if (highlighted) FontWeight.Bold else FontWeight.Normal,
+                )
+                Text(
+                    ReferralLeaderboardMath.formatCount(entry.referredCount) + " referred",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                ReferralLeaderboardMath.formatCount(entry.qualifiedCount),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.width(48.dp),
+            )
+            Text(
+                ReferralLeaderboardMath.formatRewardCents(entry.rewardCents),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.width(72.dp),
+            )
+        }
+    }
+}
+
+private fun medalEmoji(rank: Int): String? = when (ReferralLeaderboardMath.rankMedal(rank)) {
+    ReferralLeaderboardMath.Medal.GOLD -> "🥇"
+    ReferralLeaderboardMath.Medal.SILVER -> "🥈"
+    ReferralLeaderboardMath.Medal.BRONZE -> "🥉"
+    ReferralLeaderboardMath.Medal.NONE -> null
+}
+
+private fun formatUpdated(tsSeconds: Long): String {
+    val millis = if (tsSeconds < 100_000_000_000L) tsSeconds * 1000L else tsSeconds
+    return SimpleDateFormat("MMM d, yyyy h:mm a", Locale.getDefault()).format(Date(millis))
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralLeaderboardViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/ReferralLeaderboardViewModel.kt
@@ -1,0 +1,74 @@
+package com.testlogon.android.feature.rewards
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.rewards.LeaderboardPeriod
+import com.testlogon.android.data.rewards.RewardsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives [ReferralLeaderboardUiState] from [RewardsRepository] against GET me/referral/leaderboard.
+ * Loads the selected [LeaderboardPeriod] on first composition, on retry and on a period-toggle; a 404
+ * degrades to an honest coming-soon state (available=false), a transport failure to a retryable offline
+ * error. The shown top-N slice + the pinned "your rank" row are computed PURELY via
+ * [ReferralLeaderboardMath], so this VM stays free of Android framework types.
+ */
+@HiltViewModel
+class ReferralLeaderboardViewModel @Inject constructor(
+    private val repository: RewardsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ReferralLeaderboardUiState())
+    val uiState: StateFlow<ReferralLeaderboardUiState> = _uiState.asStateFlow()
+
+    init {
+        load(_uiState.value.period)
+    }
+
+    fun onRetry() = load(_uiState.value.period)
+
+    /** Switch the time window (no-op if already selected); reloads for the new period. */
+    fun onPeriodSelected(period: LeaderboardPeriod) {
+        if (period == _uiState.value.period && !_uiState.value.loading) load(period) else load(period)
+    }
+
+    fun load(period: LeaderboardPeriod) {
+        _uiState.update {
+            it.copy(loading = true, period = period, errorMessage = null, offline = false)
+        }
+        viewModelScope.launch {
+            when (val r = repository.referralLeaderboard(period)) {
+                is ApiResult.Success -> {
+                    val board = r.data
+                    val shown = ReferralLeaderboardMath.topN(board.entries)
+                    val youRow = ReferralLeaderboardMath.resolveYouRow(shown, board.you)
+                    _uiState.update {
+                        it.copy(
+                            loading = false,
+                            available = board.available,
+                            board = board,
+                            shown = shown,
+                            youRow = youRow,
+                        )
+                    }
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        loading = false,
+                        errorMessage = r.error.message.ifBlank { "Couldn't load the leaderboard." },
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(loading = false, offline = true, errorMessage = "No connection. Pull to retry.")
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsUiState.kt
@@ -1,6 +1,9 @@
 package com.testlogon.android.feature.rewards
 
 import com.testlogon.android.data.rewards.CatalogReward
+import com.testlogon.android.data.rewards.LeaderboardEntry
+import com.testlogon.android.data.rewards.LeaderboardPeriod
+import com.testlogon.android.data.rewards.ReferralLeaderboard
 import com.testlogon.android.data.rewards.Rewards
 import com.testlogon.android.data.rewards.RewardsHistoryEntry
 import com.testlogon.android.data.rewards.ReferralSummary
@@ -25,6 +28,27 @@ data class ReferralHubUiState(
 ) {
     /** There is something worth sharing when the read succeeded and a code/link exists. */
     val hasShareable: Boolean get() = available && (summary.link.isNotBlank() || summary.code.isNotBlank())
+}
+
+// ---- Referral leaderboard screen ----
+
+data class ReferralLeaderboardUiState(
+    val loading: Boolean = true,
+    /** The currently-selected time window (All-time / This month). */
+    val period: LeaderboardPeriod = LeaderboardPeriod.ALL,
+    /** False when GET me/referral/leaderboard degraded (404 / undeployed) — the screen shows coming-soon. */
+    val available: Boolean = true,
+    val board: ReferralLeaderboard = ReferralLeaderboard.unavailable(),
+    /** The top-N slice actually rendered (server-ranked, repaired for order). */
+    val shown: List<LeaderboardEntry> = emptyList(),
+    /** The pinned "Your rank: #N" row when the caller falls outside [shown]; null otherwise. */
+    val youRow: LeaderboardEntry? = null,
+    val errorMessage: String? = null,
+    val offline: Boolean = false,
+) {
+    /** True when the board has at least one visible row (top slice or the pinned own-rank row). */
+    val hasRows: Boolean get() = shown.isNotEmpty() || youRow != null
+    val updatedTs: Long get() = board.updatedTs
 }
 
 // ---- Rewards screen ----

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -212,6 +212,9 @@ object MoreRoutes {
     const val REFERRAL_HUB = ReferralHubDest.ROUTE
     const val REWARDS = RewardsDest.ROUTE
 
+    // Referral leaderboard (feature/rewards): GET me/referral/leaderboard. Sub-nav from the Refer & earn hub.
+    const val REFERRAL_LEADERBOARD = ReferralLeaderboardDest.ROUTE
+
     // Alerts (system notifications) inbox — mirrors web /alerts.
     const val ALERTS = AlertsDest.ROUTE
 
@@ -661,6 +664,7 @@ object MoreRoutes {
             REFERRALS,
             REFERRAL_HUB,
             REWARDS,
+            REFERRAL_LEADERBOARD,
             ALERTS,
             MY_CONTENT_REVIEW,
             APPEALS,

--- a/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.testlogon.android.feature.rewards.ReferralHubRoute
+import com.testlogon.android.feature.rewards.ReferralLeaderboardRoute
 import com.testlogon.android.feature.rewards.RewardsRoute
 
 /**
@@ -22,10 +23,20 @@ data object RewardsDest {
     const val ROUTE = "rewards"
 }
 
+data object ReferralLeaderboardDest {
+    const val ROUTE = "referral_leaderboard"
+}
+
 /** Registers the Referral hub + Rewards screens in the authenticated graph. Up / Back pops the stack. */
 fun NavGraphBuilder.rewardsDestinations(navController: NavHostController) {
     composable(ReferralHubDest.ROUTE) {
-        ReferralHubRoute(onBack = { navController.popBackStack() })
+        ReferralHubRoute(
+            onBack = { navController.popBackStack() },
+            onLeaderboard = { navController.navigate(ReferralLeaderboardDest.ROUTE) },
+        )
+    }
+    composable(ReferralLeaderboardDest.ROUTE) {
+        ReferralLeaderboardRoute(onBack = { navController.popBackStack() })
     }
     composable(RewardsDest.ROUTE) {
         RewardsRoute(onBack = { navController.popBackStack() })

--- a/android/app/src/test/java/com/testlogon/android/feature/rewards/ReferralLeaderboardMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/rewards/ReferralLeaderboardMathTest.kt
@@ -1,0 +1,156 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.data.rewards.LeaderboardEntry
+import com.testlogon.android.data.rewards.LeaderboardPeriod
+import com.testlogon.android.data.rewards.LeaderboardYou
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure math/rules for the REFERRAL LEADERBOARD: medals, ranking repair, top-N slicing, and the
+ * "your rank" resolution (already-in-slice vs synthetic out-of-slice row). No Android / Compose / Hilt.
+ */
+class ReferralLeaderboardMathTest {
+
+    private fun entry(
+        rank: Int,
+        id: String,
+        isYou: Boolean = false,
+        referred: Int = 0,
+        qualified: Int = 0,
+        rewardCents: Long = 0L,
+        name: String = "N**",
+    ) = LeaderboardEntry(
+        rank = rank,
+        id = id,
+        maskedName = name,
+        isYou = isYou,
+        referredCount = referred,
+        qualifiedCount = qualified,
+        rewardCents = rewardCents,
+    )
+
+    // ---- medals ----
+
+    @Test
+    fun rankMedal_topThreeGetMedals_restNone() {
+        assertEquals(ReferralLeaderboardMath.Medal.GOLD, ReferralLeaderboardMath.rankMedal(1))
+        assertEquals(ReferralLeaderboardMath.Medal.SILVER, ReferralLeaderboardMath.rankMedal(2))
+        assertEquals(ReferralLeaderboardMath.Medal.BRONZE, ReferralLeaderboardMath.rankMedal(3))
+        assertEquals(ReferralLeaderboardMath.Medal.NONE, ReferralLeaderboardMath.rankMedal(4))
+        assertEquals(ReferralLeaderboardMath.Medal.NONE, ReferralLeaderboardMath.rankMedal(0))
+        assertEquals(ReferralLeaderboardMath.Medal.NONE, ReferralLeaderboardMath.rankMedal(-1))
+    }
+
+    // ---- sortEntries ----
+
+    @Test
+    fun sortEntries_ordersByQualifiedThenReferredThenReward() {
+        val a = entry(rank = 3, id = "a", qualified = 1, referred = 10, rewardCents = 100)
+        val b = entry(rank = 1, id = "b", qualified = 5, referred = 5, rewardCents = 50)
+        val c = entry(rank = 2, id = "c", qualified = 3, referred = 20, rewardCents = 999)
+        val sorted = ReferralLeaderboardMath.sortEntries(listOf(a, b, c))
+        assertEquals(listOf("b", "c", "a"), sorted.map { it.id })
+    }
+
+    @Test
+    fun sortEntries_tieBreaksAreDeterministicAndStable() {
+        val a = entry(rank = 1, id = "z", qualified = 5, referred = 5, rewardCents = 100, name = "Alpha")
+        val b = entry(rank = 2, id = "y", qualified = 5, referred = 5, rewardCents = 100, name = "Alpha")
+        // Identical metrics + name -> break by id asc ("y" before "z").
+        val sorted = ReferralLeaderboardMath.sortEntries(listOf(a, b))
+        assertEquals(listOf("y", "z"), sorted.map { it.id })
+    }
+
+    @Test
+    fun sortEntries_preservesDisplayRank_doesNotRenumber() {
+        val a = entry(rank = 7, id = "a", qualified = 9)
+        val b = entry(rank = 9, id = "b", qualified = 1)
+        val sorted = ReferralLeaderboardMath.sortEntries(listOf(b, a))
+        assertEquals(7, sorted.first().rank) // rank field untouched
+        assertEquals("a", sorted.first().id)
+    }
+
+    // ---- topN ----
+
+    @Test
+    fun topN_takesFirstNAfterSort() {
+        val list = (1..30).map { entry(rank = it, id = "id$it", qualified = 100 - it) }
+        val top = ReferralLeaderboardMath.topN(list, 20)
+        assertEquals(20, top.size)
+        assertEquals("id1", top.first().id)
+        assertEquals("id20", top.last().id)
+    }
+
+    @Test
+    fun topN_negativeOrZeroN_yieldsEmpty() {
+        val list = listOf(entry(rank = 1, id = "a"))
+        assertTrue(ReferralLeaderboardMath.topN(list, 0).isEmpty())
+        assertTrue(ReferralLeaderboardMath.topN(list, -5).isEmpty())
+    }
+
+    // ---- youInSlice / resolveYouRow ----
+
+    @Test
+    fun youInSlice_detectsCallerRow() {
+        val shown = listOf(entry(rank = 1, id = "a"), entry(rank = 2, id = "me", isYou = true))
+        assertTrue(ReferralLeaderboardMath.youInSlice(shown))
+        assertFalse(ReferralLeaderboardMath.youInSlice(listOf(entry(rank = 1, id = "a"))))
+    }
+
+    @Test
+    fun resolveYouRow_nullWhenAlreadyInSlice() {
+        val shown = listOf(entry(rank = 2, id = "me", isYou = true))
+        val you = LeaderboardYou(rank = 2, referredCount = 4, qualifiedCount = 3, rewardCents = 500)
+        assertNull(ReferralLeaderboardMath.resolveYouRow(shown, you))
+    }
+
+    @Test
+    fun resolveYouRow_nullWhenNoServerYou() {
+        val shown = listOf(entry(rank = 1, id = "a"))
+        assertNull(ReferralLeaderboardMath.resolveYouRow(shown, null))
+    }
+
+    @Test
+    fun resolveYouRow_buildsSyntheticRowWhenOutsideSlice() {
+        val shown = listOf(entry(rank = 1, id = "a"), entry(rank = 2, id = "b"))
+        val you = LeaderboardYou(rank = 42, referredCount = 7, qualifiedCount = 5, rewardCents = 1234)
+        val row = ReferralLeaderboardMath.resolveYouRow(shown, you)
+        assertNotNull(row)
+        assertEquals(42, row!!.rank)
+        assertTrue(row.isYou)
+        assertEquals(7, row.referredCount)
+        assertEquals(5, row.qualifiedCount)
+        assertEquals(1234L, row.rewardCents)
+    }
+
+    // ---- format helpers ----
+
+    @Test
+    fun formatRank_prependsHash_emDashForNonPositive() {
+        assertEquals("#12", ReferralLeaderboardMath.formatRank(12))
+        assertEquals("—", ReferralLeaderboardMath.formatRank(0))
+        assertEquals("—", ReferralLeaderboardMath.formatRank(-3))
+    }
+
+    @Test
+    fun formatCount_groupsThousands() {
+        assertEquals("1,250", ReferralLeaderboardMath.formatCount(1250))
+        assertEquals("0", ReferralLeaderboardMath.formatCount(0))
+    }
+
+    @Test
+    fun formatRewardCents_isUsd() {
+        assertEquals("$12.34", ReferralLeaderboardMath.formatRewardCents(1234L))
+    }
+
+    @Test
+    fun periodLabel_humanReadable() {
+        assertEquals("All-time", ReferralLeaderboardMath.periodLabel(LeaderboardPeriod.ALL))
+        assertEquals("This month", ReferralLeaderboardMath.periodLabel(LeaderboardPeriod.MONTH))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -181,6 +181,7 @@ const CallRateSettings = lazy(() => import("@/pages/settings/CallRateSettings"))
 const ReferralDashboard = lazy(() => import("@/pages/referrals/ReferralDashboard"));
 const RewardsPage = lazy(() => import("@/pages/rewards/RewardsPage"));
 const RewardsReferralsPage = lazy(() => import("@/pages/rewards/ReferralsPage"));
+const RewardsLeaderboardPage = lazy(() => import("@/pages/rewards/LeaderboardPage"));
 const PromoCodesPage = lazy(() => import("@/pages/promo/PromoCodesPage"));
 const SchedulerPage = lazy(() => import("@/pages/scheduler/SchedulerPage"));
 const RefundRequestsPage = lazy(() => import("@/pages/billing/RefundRequestsPage"));
@@ -873,6 +874,7 @@ export default function App() {
           <Route path="referrals" element={<ReferralDashboard />} />
           <Route path="rewards" element={<RewardsPage />} />
           <Route path="rewards/referrals" element={<RewardsReferralsPage />} />
+          <Route path="rewards/leaderboard" element={<RewardsLeaderboardPage />} />
           <Route path="promo" element={<PromoCodesPage />} />
           <Route path="affiliates" element={<AffiliateDashboard />} />
           <Route path="achievements" element={<AchievementsPage />} />

--- a/frontend/src/api/endpoints/rewards.ts
+++ b/frontend/src/api/endpoints/rewards.ts
@@ -94,6 +94,37 @@ export interface RedeemResult {
   points_remaining: number;
 }
 
+// ── Referral leaderboard (degrade on 404 — NEW) ────────────────────
+
+export type LeaderboardPeriod = "all" | "month";
+
+/** One ranked referrer row on the leaderboard (name masked for privacy). */
+export interface ReferralLeaderboardEntry {
+  rank: number;
+  id: string;
+  masked_name: string;
+  is_you: boolean;
+  referred_count: number;
+  qualified_count: number;
+  reward_cents: number;
+}
+
+/** The signed-in user's own standing (present even when outside the top slice). */
+export interface ReferralLeaderboardYou {
+  rank: number;
+  referred_count: number;
+  qualified_count: number;
+  reward_cents: number;
+}
+
+export interface ReferralLeaderboard {
+  period: LeaderboardPeriod;
+  updated_ts: number;
+  entries: ReferralLeaderboardEntry[];
+  you?: ReferralLeaderboardYou;
+}
+
+
 // ── Reads (degrade on 404 — callers use retry:false) ─────────────────
 
 export const getReferralSummary = () =>
@@ -110,6 +141,9 @@ export const getRewardsHistory = () =>
 
 export const getRewardsCatalog = () =>
   api.get<RewardsCatalog>("/me/rewards/catalog");
+
+export const getReferralLeaderboard = (period: LeaderboardPeriod = "all") =>
+  api.get<ReferralLeaderboard>(`/me/referral/leaderboard?period=${period}`);
 
 // ── Mutation (clear error on 404 — never silent) ─────────────────────
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -198,6 +198,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Referrals", i18nKey: "nav.referrals", path: "/referrals", icon: <Share2 className="h-5 w-5" /> },
       { label: "Rewards", i18nKey: "nav.rewards", path: "/rewards", icon: <Award className="h-5 w-5" /> },
       { label: "Refer & Earn", i18nKey: "nav.referAndEarn", path: "/rewards/referrals", icon: <Users className="h-5 w-5" /> },
+      { label: "Referral Leaderboard", i18nKey: "nav.referralLeaderboard", path: "/rewards/leaderboard", icon: <Trophy className="h-5 w-5" /> },
       { label: "Promo Codes", i18nKey: "nav.promoCodes", path: "/promo", icon: <Tag className="h-5 w-5" /> },
       { label: "Affiliates", i18nKey: "nav.affiliates", path: "/affiliates", icon: <Link2 className="h-5 w-5" /> },
       { label: "Collaborations", i18nKey: "nav.collaborations", path: "/collaborations", icon: <Handshake className="h-5 w-5" /> },

--- a/frontend/src/lib/referralLeaderboard.test.ts
+++ b/frontend/src/lib/referralLeaderboard.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ReferralLeaderboardEntry,
+  ReferralLeaderboardYou,
+} from "@/api/endpoints/rewards";
+import {
+  findYou,
+  formatCount,
+  formatRank,
+  rankMedal,
+  sortEntries,
+  topN,
+} from "@/lib/referralLeaderboard";
+
+function entry(
+  partial: Partial<ReferralLeaderboardEntry>,
+): ReferralLeaderboardEntry {
+  return {
+    rank: partial.rank ?? 1,
+    id: partial.id ?? "u1",
+    masked_name: partial.masked_name ?? "A•• B••",
+    is_you: partial.is_you ?? false,
+    referred_count: partial.referred_count ?? 0,
+    qualified_count: partial.qualified_count ?? 0,
+    reward_cents: partial.reward_cents ?? 0,
+  };
+}
+
+describe("rankMedal", () => {
+  it("maps podium ranks to medals", () => {
+    expect(rankMedal(1)).toBe("gold");
+    expect(rankMedal(2)).toBe("silver");
+    expect(rankMedal(3)).toBe("bronze");
+  });
+
+  it("returns null off the podium and for junk", () => {
+    expect(rankMedal(4)).toBeNull();
+    expect(rankMedal(0)).toBeNull();
+    expect(rankMedal(-1)).toBeNull();
+    expect(rankMedal(Number.NaN)).toBeNull();
+  });
+});
+
+describe("sortEntries", () => {
+  it("sorts by rank ascending", () => {
+    const out = sortEntries([
+      entry({ id: "c", rank: 3 }),
+      entry({ id: "a", rank: 1 }),
+      entry({ id: "b", rank: 2 }),
+    ]);
+    expect(out.map((e) => e.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("breaks rank ties by reward_cents descending, then referred_count", () => {
+    const out = sortEntries([
+      entry({ id: "lowReward", rank: 5, reward_cents: 100, referred_count: 9 }),
+      entry({ id: "hiReward", rank: 5, reward_cents: 900, referred_count: 1 }),
+    ]);
+    expect(out.map((e) => e.id)).toEqual(["hiReward", "lowReward"]);
+  });
+
+  it("is pure (does not mutate input) and tolerates junk", () => {
+    const input = [entry({ id: "b", rank: 2 }), entry({ id: "a", rank: 1 })];
+    const copy = [...input];
+    sortEntries(input);
+    expect(input).toEqual(copy);
+    // @ts-expect-error exercising defensive path
+    expect(sortEntries(null)).toEqual([]);
+  });
+});
+
+describe("topN", () => {
+  const rows = [
+    entry({ id: "a", rank: 1 }),
+    entry({ id: "b", rank: 2 }),
+    entry({ id: "c", rank: 3 }),
+    entry({ id: "d", rank: 4 }),
+  ];
+
+  it("returns the first n sorted entries", () => {
+    expect(topN(rows, 2).map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("clamps out-of-range n", () => {
+    expect(topN(rows, 0)).toEqual([]);
+    expect(topN(rows, -5)).toEqual([]);
+    expect(topN(rows, 99).map((e) => e.id)).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("findYou", () => {
+  const rows = [
+    entry({ id: "a", rank: 1 }),
+    entry({ id: "b", rank: 2 }),
+    entry({ id: "me", rank: 12, is_you: true, reward_cents: 500 }),
+    entry({ id: "c", rank: 3 }),
+  ];
+
+  it("finds the is_you row and pins it when outside the shown slice", () => {
+    const shown = topN(rows.filter((r) => !r.is_you), 2); // a, b
+    const res = findYou(rows, shown);
+    expect(res.entry?.id).toBe("me");
+    expect(res.inShown).toBe(false);
+    expect(res.pinned?.id).toBe("me");
+  });
+
+  it("does not pin when the caller is already shown", () => {
+    const you = entry({ id: "me", rank: 1, is_you: true });
+    const all = [you, entry({ id: "b", rank: 2 })];
+    const shown = topN(all, 5);
+    const res = findYou(all, shown);
+    expect(res.inShown).toBe(true);
+    expect(res.pinned).toBeNull();
+  });
+
+  it("synthesizes a pinned row from the `you` summary when no is_you row exists", () => {
+    const all = [entry({ id: "a", rank: 1 }), entry({ id: "b", rank: 2 })];
+    const you: ReferralLeaderboardYou = {
+      rank: 42,
+      referred_count: 7,
+      qualified_count: 4,
+      reward_cents: 1234,
+    };
+    const res = findYou(all, all, you);
+    expect(res.entry).toBeNull();
+    expect(res.pinned?.rank).toBe(42);
+    expect(res.pinned?.reward_cents).toBe(1234);
+    expect(res.pinned?.is_you).toBe(true);
+  });
+
+  it("returns no pin when the caller cannot be located", () => {
+    const all = [entry({ id: "a", rank: 1 })];
+    const res = findYou(all, all);
+    expect(res.entry).toBeNull();
+    expect(res.pinned).toBeNull();
+  });
+});
+
+describe("formatRank / formatCount", () => {
+  it("formats ranks", () => {
+    expect(formatRank(4)).toBe("#4");
+    expect(formatRank(0)).toBe("—");
+    expect(formatRank(Number.NaN)).toBe("—");
+  });
+
+  it("formats counts with separators", () => {
+    expect(formatCount(12345)).toBe("12,345");
+    expect(formatCount(Number.NaN)).toBe("0");
+  });
+});

--- a/frontend/src/lib/referralLeaderboard.ts
+++ b/frontend/src/lib/referralLeaderboard.ts
@@ -1,0 +1,115 @@
+// Pure helpers for the REFERRAL LEADERBOARD surface.
+// No React / no network — unit-testable in isolation.
+// Money is INTEGER CENTS; ranks are whole positive integers.
+
+import type {
+  ReferralLeaderboardEntry,
+  ReferralLeaderboardYou,
+} from "@/api/endpoints/rewards";
+
+export type RankMedal = "gold" | "silver" | "bronze" | null;
+
+/** The medal for a podium rank (1→gold, 2→silver, 3→bronze), else null. */
+export function rankMedal(rank: number): RankMedal {
+  if (rank === 1) return "gold";
+  if (rank === 2) return "silver";
+  if (rank === 3) return "bronze";
+  return null;
+}
+
+/**
+ * Sort leaderboard entries by rank ascending; ties broken by reward_cents
+ * descending, then referred_count descending. Returns a new array (pure).
+ */
+export function sortEntries(
+  entries: ReferralLeaderboardEntry[],
+): ReferralLeaderboardEntry[] {
+  if (!Array.isArray(entries)) return [];
+  return [...entries].sort((a, b) => {
+    const ra = Number.isFinite(a.rank) ? a.rank : Number.MAX_SAFE_INTEGER;
+    const rb = Number.isFinite(b.rank) ? b.rank : Number.MAX_SAFE_INTEGER;
+    if (ra !== rb) return ra - rb;
+    const rewA = Number.isFinite(a.reward_cents) ? a.reward_cents : 0;
+    const rewB = Number.isFinite(b.reward_cents) ? b.reward_cents : 0;
+    if (rewA !== rewB) return rewB - rewA;
+    const refA = Number.isFinite(a.referred_count) ? a.referred_count : 0;
+    const refB = Number.isFinite(b.referred_count) ? b.referred_count : 0;
+    return refB - refA;
+  });
+}
+
+/** The first `n` sorted entries. Non-positive `n` yields an empty list. */
+export function topN(
+  entries: ReferralLeaderboardEntry[],
+  n: number,
+): ReferralLeaderboardEntry[] {
+  if (!Array.isArray(entries)) return [];
+  const count = Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0;
+  return sortEntries(entries).slice(0, count);
+}
+
+/** Result of locating the caller relative to a shown top slice. */
+export interface FoundYou {
+  /** The caller's row from `entries` (is_you), if any. */
+  entry: ReferralLeaderboardEntry | null;
+  /** True when the caller's row is present within `shown`. */
+  inShown: boolean;
+  /**
+   * A synthetic "your rank" row to pin below the list when the caller is
+   * outside the shown slice. Null when the caller is in the slice or unknown.
+   */
+  pinned: ReferralLeaderboardEntry | null;
+}
+
+/**
+ * Locate the caller within the leaderboard.
+ *
+ * Prefers the `is_you` row in `entries`; falls back to the `you` summary
+ * (synthesizing a display row) when no `is_you` row exists. `shown` is the
+ * already-sliced top-N list actually rendered. When the caller is outside
+ * `shown`, `pinned` carries a row to render below; otherwise `pinned` is null.
+ */
+export function findYou(
+  entries: ReferralLeaderboardEntry[],
+  shown: ReferralLeaderboardEntry[],
+  you?: ReferralLeaderboardYou | null,
+): FoundYou {
+  const all = Array.isArray(entries) ? entries : [];
+  const slice = Array.isArray(shown) ? shown : [];
+
+  const youEntry = all.find((e) => e.is_you) ?? null;
+  const inShownById = youEntry
+    ? slice.some((e) => e.id === youEntry.id)
+    : false;
+
+  // Build the row that represents the caller for pinning purposes.
+  let row: ReferralLeaderboardEntry | null = youEntry;
+  if (!row && you && Number.isFinite(you.rank)) {
+    row = {
+      rank: you.rank,
+      id: "__you__",
+      masked_name: "You",
+      is_you: true,
+      referred_count: you.referred_count ?? 0,
+      qualified_count: you.qualified_count ?? 0,
+      reward_cents: you.reward_cents ?? 0,
+    };
+  }
+
+  const inShown = inShownById;
+  const pinned = row && !inShown ? row : null;
+
+  return { entry: youEntry, inShown, pinned };
+}
+
+/** Format a rank as an ordinal-style badge, e.g. 4 -> "#4". */
+export function formatRank(rank: number): string {
+  const safe = Number.isFinite(rank) ? Math.trunc(rank) : 0;
+  return safe > 0 ? `#${safe}` : "—";
+}
+
+/** Format whole counts with thousands separators, e.g. 12345 -> "12,345". */
+export function formatCount(count: number): string {
+  const safe = Number.isFinite(count) ? Math.trunc(count) : 0;
+  return new Intl.NumberFormat("en-US").format(safe);
+}

--- a/frontend/src/pages/rewards/LeaderboardPage.tsx
+++ b/frontend/src/pages/rewards/LeaderboardPage.tsx
@@ -1,0 +1,217 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { Trophy, Medal, Users, ArrowLeft } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+import { ApiError } from "@/api/client";
+import { getReferralLeaderboard } from "@/api/endpoints/rewards";
+import type {
+  LeaderboardPeriod,
+  ReferralLeaderboardEntry,
+} from "@/api/endpoints/rewards";
+import { formatCents } from "@/lib/rewards";
+import {
+  findYou,
+  formatCount,
+  formatRank,
+  rankMedal,
+  topN,
+} from "@/lib/referralLeaderboard";
+import { PendingRewards } from "./PendingRewards";
+
+const TOP_N = 25;
+
+function is404(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+const MEDAL_CLASS: Record<string, string> = {
+  gold: "text-yellow-500",
+  silver: "text-slate-400",
+  bronze: "text-amber-700",
+};
+
+function RankCell({ rank }: { rank: number }) {
+  const medal = rankMedal(rank);
+  return (
+    <div className="flex items-center gap-1.5 tabular-nums">
+      {medal ? (
+        <Medal className={cn("h-4 w-4", MEDAL_CLASS[medal])} aria-hidden />
+      ) : null}
+      <span className={cn(medal ? "font-semibold" : "text-muted-foreground")}>
+        {formatRank(rank)}
+      </span>
+    </div>
+  );
+}
+
+function LeaderRow({
+  row,
+  highlight,
+}: {
+  row: ReferralLeaderboardEntry;
+  highlight?: boolean;
+}) {
+  return (
+    <TableRow className={cn(highlight && "bg-primary/10 hover:bg-primary/15")}>
+      <TableCell>
+        <RankCell rank={row.rank} />
+      </TableCell>
+      <TableCell className="font-medium">
+        <span className="flex items-center gap-2">
+          {row.masked_name || "—"}
+          {row.is_you ? (
+            <Badge variant="default" className="px-1.5 py-0 text-[10px]">
+              You
+            </Badge>
+          ) : null}
+        </span>
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatCount(row.referred_count)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatCount(row.qualified_count)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatCents(row.reward_cents)}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function LeaderboardPage() {
+  const [period, setPeriod] = useState<LeaderboardPeriod>("all");
+
+  const boardQ = useQuery({
+    queryKey: ["me", "referral", "leaderboard", period],
+    queryFn: () => getReferralLeaderboard(period),
+    retry: false,
+  });
+
+  const board = boardQ.data;
+  const entries = board?.entries ?? [];
+  const shown = topN(entries, TOP_N);
+  const you = findYou(entries, shown, board?.you);
+
+  const boardPending = is404(boardQ.error);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold">
+            <Trophy className="h-6 w-6" /> Referral leaderboard
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            The top referrers ranked by qualified referrals and rewards earned.
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/rewards/referrals">
+            <ArrowLeft className="mr-1.5 h-4 w-4" /> Referrals
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+          <div>
+            <CardTitle>Top referrers</CardTitle>
+            <CardDescription>
+              {board?.updated_ts
+                ? `Updated ${new Date(board.updated_ts * 1000).toLocaleString()}`
+                : "See where you stand against the top referrers."}
+            </CardDescription>
+          </div>
+          <Tabs
+            value={period}
+            onValueChange={(v) => setPeriod(v as LeaderboardPeriod)}
+          >
+            <TabsList>
+              <TabsTrigger value="all">All-time</TabsTrigger>
+              <TabsTrigger value="month">This month</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {boardQ.isLoading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : boardPending ? (
+            <PendingRewards label="The referral leaderboard" />
+          ) : boardQ.isError ? (
+            <p className="text-sm text-destructive">
+              Could not load the leaderboard. Please try again later.
+            </p>
+          ) : shown.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-center">
+              <Trophy className="h-8 w-8 text-muted-foreground" />
+              <p className="font-medium">No rankings yet</p>
+              <p className="max-w-sm text-sm text-muted-foreground">
+                Be the first to climb the board — share your referral link and
+                start earning.
+              </p>
+              <Button asChild variant="outline" size="sm" className="mt-1">
+                <Link to="/rewards/referrals">
+                  <Users className="mr-1.5 h-4 w-4" /> Get your link
+                </Link>
+              </Button>
+            </div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-20">Rank</TableHead>
+                    <TableHead>Referrer</TableHead>
+                    <TableHead className="text-right">Referred</TableHead>
+                    <TableHead className="text-right">Qualified</TableHead>
+                    <TableHead className="text-right">Earned</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {shown.map((row) => (
+                    <LeaderRow key={row.id} row={row} highlight={row.is_you} />
+                  ))}
+                </TableBody>
+              </Table>
+
+              {you.pinned ? (
+                <div className="rounded-lg border border-primary/40 bg-primary/5 p-3">
+                  <p className="mb-2 text-xs font-medium text-muted-foreground">
+                    Your rank
+                  </p>
+                  <Table>
+                    <TableBody>
+                      <LeaderRow row={you.pinned} highlight />
+                    </TableBody>
+                  </Table>
+                </div>
+              ) : null}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <p className="text-xs text-muted-foreground">
+        Rankings are computed server-side from qualified referrals. Names are
+        masked for privacy; only your own row is shown in full.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/rewards/ReferralsPage.tsx
+++ b/frontend/src/pages/rewards/ReferralsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Copy, Share2, Users, CheckCircle, DollarSign, Clock, Gift } from "lucide-react";
+import { Copy, Share2, Users, CheckCircle, DollarSign, Clock, Gift, Trophy } from "lucide-react";
 import { toast } from "sonner";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -120,11 +120,18 @@ export default function ReferralsPage() {
             Share your code, track who joins, and earn a reward for every qualified referral.
           </p>
         </div>
-        <Button asChild variant="outline" size="sm">
-          <Link to="/rewards">
-            <Gift className="mr-1.5 h-4 w-4" /> Rewards
-          </Link>
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to="/rewards/leaderboard">
+              <Trophy className="mr-1.5 h-4 w-4" /> Leaderboard
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/rewards">
+              <Gift className="mr-1.5 h-4 w-4" /> Rewards
+            </Link>
+          </Button>
+        </div>
       </div>
 
       {/* Your code + share */}


### PR DESCRIPTION
## Referral leaderboard — top referrers, all-time / this month

Ranks top referrers (by qualified/referred count + reward earned) with the caller highlighted and their own rank pinned even when outside the shown top. Time-window toggle. Backend-driven, degrade-on-404. Distinct from the social achievements leaderboard.

New read (degrade-on-404 → "coming soon"): `GET /me/referral/leaderboard?period=all|month` → `{period, updated_ts, entries:[{rank,id,masked_name,is_you,referred_count,qualified_count,reward_cents}], you?}`.

### Web (`/rewards/leaderboard`)
`lib/referralLeaderboard.ts` (+13 vitest) — `rankMedal`/`sortEntries`/`topN`/`findYou` (synthetic you-row)/format; `rewards.ts` `getReferralLeaderboard`; `LeaderboardPage` — period tabs, ranked table (medals top 3), caller highlighted, pinned "Your rank" beyond top 25.

### Android (`feature/rewards` + `data/rewards`)
`ReferralLeaderboardMath.kt` (mirror; +14 JVM tests) + Screen/ViewModel; `RewardsApi/Domain/Repository` gain `referralLeaderboard(period)`; ReferralHub "View leaderboard" entry + `RewardsNavigation` dest; route in `MoreRoutes.REGISTERED`.

No new deps. Gates: web tsc 0 · vite build · vitest 13/13; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (14/14, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
