### PR TITLE
feat(rewards): trading-activity reward points (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
@@ -57,6 +57,14 @@ interface RewardsApi {
      */
     @GET("me/referral/leaderboard")
     suspend fun referralLeaderboard(@Query("period") period: String): ReferralLeaderboardDto
+
+    /**
+     * OPTIONAL authoritative TRADING-REWARDS read: points accrued from executed trading volume. Points
+     * accrue server-side; the client shows the earn rate + an estimate from the caller's own 30-day
+     * volume and swaps to these numbers when the endpoint ships. Read degrades on 404 -> client estimate.
+     */
+    @GET("me/rewards/trading")
+    suspend fun tradingRewards(): TradingRewardsDto
 }
 
 // ---- GET me/referral ----
@@ -104,6 +112,16 @@ data class WayToEarnDto(
     @Json(name = "title") val title: String? = null,
     @LenientLong @Json(name = "points") val points: Long? = null,
     @Json(name = "detail") val detail: String? = null,
+)
+
+// ---- GET me/rewards/trading (optional authoritative) ----
+
+@JsonClass(generateAdapter = true)
+data class TradingRewardsDto(
+    @LenientLong @Json(name = "points_per_dollar") val pointsPerDollar: Long? = null,
+    @LenientLong @Json(name = "volume_30d_cents") val volume30dCents: Long? = null,
+    @LenientLong @Json(name = "points_earned_30d") val pointsEarned30d: Long? = null,
+    @LenientLong @Json(name = "lifetime_trading_points") val lifetimeTradingPoints: Long? = null,
 )
 
 // ---- GET me/rewards/history ----

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
@@ -78,6 +78,30 @@ data class Rewards(
     }
 }
 
+/**
+ * OPTIONAL authoritative trading-rewards read (GET me/rewards/trading), mapped to domain. [available]
+ * is false when the read degraded (404 / undeployed) so the card falls back to the CLIENT ESTIMATE
+ * from the caller's own 30-day trading volume. Points are whole integers; volume is integer USD cents.
+ */
+data class TradingRewards(
+    val pointsPerDollar: Long,
+    val volume30dCents: Long,
+    val pointsEarned30d: Long,
+    val lifetimeTradingPoints: Long,
+    val available: Boolean,
+) {
+    companion object {
+        /** Honest "unavailable" value for the degrade-on-404 client-estimate fallback. */
+        fun unavailable(): TradingRewards = TradingRewards(
+            pointsPerDollar = 0L,
+            volume30dCents = 0L,
+            pointsEarned30d = 0L,
+            lifetimeTradingPoints = 0L,
+            available = false,
+        )
+    }
+}
+
 data class RewardsHistoryEntry(
     val ts: Long,
     val type: String,
@@ -145,6 +169,14 @@ internal fun RewardsSummaryDto.toDomain(): Rewards = Rewards(
     cashCents = cashCents ?: 0L,
     lifetimePoints = lifetimePoints ?: 0L,
     waysToEarn = waysToEarn.mapNotNull { it.toDomain() },
+    available = true,
+)
+
+internal fun TradingRewardsDto.toDomain(): TradingRewards = TradingRewards(
+    pointsPerDollar = pointsPerDollar ?: 0L,
+    volume30dCents = volume30dCents ?: 0L,
+    pointsEarned30d = pointsEarned30d ?: 0L,
+    lifetimeTradingPoints = lifetimeTradingPoints ?: 0L,
     available = true,
 )
 

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
@@ -37,6 +37,11 @@ interface RewardsRepository {
     suspend fun rewardsCatalog(): ApiResult<List<CatalogReward>>
     suspend fun redeem(rewardId: String): ApiResult<RedeemResult>
     suspend fun referralLeaderboard(period: LeaderboardPeriod): ApiResult<ReferralLeaderboard>
+    /**
+     * OPTIONAL authoritative trading-rewards read. A 404 (undeployed) degrades to an honest
+     * unavailable value so the card falls back to the client estimate; network errors surface.
+     */
+    suspend fun tradingRewards(): ApiResult<TradingRewards>
 }
 
 @Singleton
@@ -86,6 +91,12 @@ class RewardsRepositoryImpl @Inject constructor(
     override suspend fun referralLeaderboard(period: LeaderboardPeriod): ApiResult<ReferralLeaderboard> = degrading(
         block = { api.referralLeaderboard(period.wire).toDomain(period) },
         onHttpError = { ReferralLeaderboard.unavailable(period) },
+    )
+
+    /** Trading rewards. A 404 (undeployed) degrades to an honest unavailable value; network errors surface. */
+    override suspend fun tradingRewards(): ApiResult<TradingRewards> = degrading(
+        block = { api.tradingRewards().toDomain() },
+        onHttpError = { TradingRewards.unavailable() },
     )
 
     /** Read wrapper: HTTP-error (incl. 404) degrades to [onHttpError]; transport -> NetworkError. */

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
@@ -60,12 +60,15 @@ object RewardsTestTags {
     const val COMING_SOON = "rewards_coming_soon"
     const val REDEEM_PREFIX = "rewards_redeem_"
     const val REDEEM_CONFIRM = "rewards_redeem_confirm"
+    const val TRADING = "rewards_trading_card"
+    const val TRADING_CTA = "rewards_trading_cta"
 }
 
 /** Route-level Rewards entry (reached from the More -> Growth hub). */
 @Composable
 fun RewardsRoute(
     onBack: () -> Unit,
+    onOpenFeeTiers: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: RewardsViewModel = hiltViewModel(),
 ) {
@@ -85,6 +88,7 @@ fun RewardsRoute(
         onBack = onBack,
         onRetry = viewModel::onRetry,
         onRedeem = viewModel::confirmRedeem,
+        onOpenFeeTiers = onOpenFeeTiers,
         snackbarHostState = snackbarHostState,
         modifier = modifier,
     )
@@ -96,6 +100,7 @@ fun RewardsScreen(
     onBack: () -> Unit,
     onRetry: () -> Unit,
     onRedeem: (CatalogReward) -> Unit,
+    onOpenFeeTiers: () -> Unit = {},
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
@@ -136,6 +141,7 @@ fun RewardsScreen(
                 else -> RewardsContent(
                     state = state,
                     onRedeemClick = { pendingRedeem = it },
+                    onOpenFeeTiers = onOpenFeeTiers,
                 )
             }
         }
@@ -179,6 +185,7 @@ fun RewardsScreen(
 private fun RewardsContent(
     state: RewardsUiState,
     onRedeemClick: (CatalogReward) -> Unit,
+    onOpenFeeTiers: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -189,6 +196,7 @@ private fun RewardsContent(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         BalanceCard(state)
+        state.tradingRewards?.let { TradingRewardsCard(it, onOpenFeeTiers) }
         if (state.rewards.waysToEarn.isNotEmpty()) {
             WaysToEarnCard(state)
         }
@@ -197,6 +205,51 @@ private fun RewardsContent(
         }
         if (state.history.isNotEmpty()) {
             HistoryCard(state.history)
+        }
+    }
+}
+
+@Composable
+private fun TradingRewardsCard(
+    summary: TradingRewardsMath.Summary,
+    onOpenFeeTiers: () -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth().testTag(RewardsTestTags.TRADING)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Trading rewards", style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
+                AssistChip(
+                    onClick = {},
+                    label = { Text(if (summary.isAuthoritative) "Live" else "Estimated") },
+                )
+            }
+            Text(
+                "Earn ${RewardsMath.formatPoints(summary.pointsPerDollar)} per $1 traded",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                "Your 30-day volume: ${RewardsMath.formatCentsUsd(summary.volume30dCents)} → ~${RewardsMath.formatPoints(summary.pointsEarned30d)}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (summary.isAuthoritative && summary.lifetimeTradingPoints > 0L) {
+                Text(
+                    "Lifetime trading points: ${RewardsMath.formatPoints(summary.lifetimeTradingPoints)}",
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+            Text(
+                if (summary.isAuthoritative) {
+                    "Points accrue automatically as your trades fill."
+                } else {
+                    "Estimated from your trade history. Points accrue automatically as your trades fill."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedButton(
+                onClick = onOpenFeeTiers,
+                modifier = Modifier.testTag(RewardsTestTags.TRADING_CTA),
+            ) { Text("Trade & view fee tiers") }
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsUiState.kt
@@ -60,6 +60,12 @@ data class RewardsUiState(
     val rewards: Rewards = Rewards.unavailable(),
     val catalog: List<CatalogReward> = emptyList(),
     val history: List<RewardsHistoryEntry> = emptyList(),
+    /**
+     * Resolved TRADING-REWARDS summary for the trading-rewards card: the earn rate + points from the
+     * caller's own 30-day trading volume (authoritative from GET me/rewards/trading when present, else a
+     * client estimate from the same fills feed the Fee-Tier screen uses). Null until first resolved.
+     */
+    val tradingRewards: TradingRewardsMath.Summary? = null,
     val redeeming: Boolean = false,
     val errorMessage: String? = null,
     val successMessage: String? = null,

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsViewModel.kt
@@ -3,6 +3,8 @@ package com.testlogon.android.feature.rewards
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.exchange.TradingRepository
+import com.testlogon.android.feature.feetiers.FeeTierMath
 import com.testlogon.android.data.rewards.CatalogReward
 import com.testlogon.android.data.rewards.RewardsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,6 +30,7 @@ import javax.inject.Inject
 @HiltViewModel
 class RewardsViewModel @Inject constructor(
     private val repository: RewardsRepository,
+    private val trading: TradingRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(RewardsUiState())
@@ -66,7 +69,28 @@ class RewardsViewModel @Inject constructor(
                 is ApiResult.Success -> _uiState.update { it.copy(history = h.data) }
                 else -> Unit
             }
+            loadTradingRewards()
         }
+    }
+
+    /**
+     * Resolve the TRADING-REWARDS card from the OPTIONAL authoritative read (GET me/rewards/trading) and
+     * the SAME live fills feed the Fee-Tier screen uses (GET me/fills/fees) for the client estimate.
+     * Both reads degrade-on-404, so a missing endpoint just yields the estimate (or an empty estimate);
+     * this never blocks the rest of the Rewards screen and never surfaces its own error.
+     */
+    private suspend fun loadTradingRewards() {
+        val authoritative = (repository.tradingRewards() as? ApiResult.Success)?.data
+        val volumeCents = clientVolume30dCents()
+        val summary = TradingRewardsMath.tradingRewardsSummary(volumeCents, authoritative)
+        _uiState.update { it.copy(tradingRewards = summary) }
+    }
+
+    /** The caller's 30-day trading volume (USD cents) from the live fills feed; 0 on any degrade. */
+    private suspend fun clientVolume30dCents(): Long {
+        val fills = (trading.fillsFees() as? ApiResult.Success)?.data?.fills ?: return 0L
+        if (fills.isEmpty()) return 0L
+        return FeeTierMath.volume30dCents(FeeTierMath.fromFills(fills), System.currentTimeMillis())
     }
 
     /** Called AFTER the redeem confirm is accepted. A rejection is a clear error, never a silent success. */

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/TradingRewardsMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/TradingRewardsMath.kt
@@ -1,0 +1,99 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.data.rewards.TradingRewards
+
+/**
+ * Pure, dependency-free (Android/Compose/Hilt-free) math for the TRADING-REWARDS card on the Rewards
+ * surface. Trading earns reward POINTS by executed volume; points accrue SERVER-SIDE, so the client
+ * only shows the earn RATE + an ESTIMATE of points from the caller's own 30-day trading volume, and
+ * swaps to the AUTHORITATIVE numbers when GET me/rewards/trading ships.
+ *
+ * CONVENTIONS: money is INTEGER USD CENTS; points are WHOLE integers. This is an EXACT mirror of the
+ * web client's frontend/src/lib/tradingRewards.ts (same [POINTS_PER_DOLLAR], same floor-to-whole-points
+ * rule, same authoritative-preferred resolution) — do NOT change the rate here without changing both.
+ * Trivially unit-testable (see TradingRewardsMathTest).
+ */
+object TradingRewardsMath {
+
+    /** Canonical earn rate: reward points granted per whole US dollar of executed volume. */
+    const val POINTS_PER_DOLLAR: Long = 1L
+
+    /** Where the trading-rewards numbers came from. */
+    enum class Source { AUTHORITATIVE, ESTIMATED }
+
+    /** Resolved trading-rewards summary backing the card. Points are whole; volume is USD cents. */
+    data class Summary(
+        /** Earn rate, points per whole US dollar of volume. */
+        val pointsPerDollar: Long,
+        /** 30-day trading volume backing the estimate/read, USD cents. */
+        val volume30dCents: Long,
+        /** Points earned from the last-30-day volume. */
+        val pointsEarned30d: Long,
+        /** Lifetime trading points (authoritative only; 0 when estimating). */
+        val lifetimeTradingPoints: Long,
+        /** Whether the numbers are authoritative or a client estimate. */
+        val source: Source,
+    ) {
+        /** True when the numbers came from the authoritative backend read. */
+        val isAuthoritative: Boolean get() = source == Source.AUTHORITATIVE
+    }
+
+    /**
+     * Whole reward points earned for a given trading [volumeCents] (integer USD cents) at
+     * [pointsPerDollar]. Floors to whole points; guards non-positive volume / rate -> 0. Never negative.
+     */
+    fun tradingPointsForVolumeCents(
+        volumeCents: Long,
+        pointsPerDollar: Long = POINTS_PER_DOLLAR,
+    ): Long {
+        if (volumeCents <= 0L || pointsPerDollar <= 0L) return 0L
+        // dollars = cents / 100 (floored); points = floor(dollars * rate). Integer math throughout.
+        return (volumeCents / 100L) * pointsPerDollar
+    }
+
+    /**
+     * Inverse of [tradingPointsForVolumeCents]: the minimum trading volume (integer USD cents) required
+     * to earn [points] at [pointsPerDollar]. Guards non-positive input -> 0. Never negative.
+     */
+    fun volumeForPoints(
+        points: Long,
+        pointsPerDollar: Long = POINTS_PER_DOLLAR,
+    ): Long {
+        if (points <= 0L || pointsPerDollar <= 0L) return 0L
+        // dollars = ceil(points / rate); volume cents = dollars * 100 (least volume that reaches points).
+        val dollars = (points + pointsPerDollar - 1L) / pointsPerDollar
+        return dollars * 100L
+    }
+
+    /**
+     * Resolve the trading-rewards [Summary]. Prefers the AUTHORITATIVE payload when it is present and
+     * carries a positive rate; otherwise falls back to a client ESTIMATE from the caller's [volumeCents]
+     * 30-day volume at [POINTS_PER_DOLLAR]. Never throws.
+     */
+    fun tradingRewardsSummary(
+        volumeCents: Long,
+        authoritative: TradingRewards? = null,
+    ): Summary {
+        if (authoritative != null && authoritative.available && authoritative.pointsPerDollar > 0L) {
+            val vol = authoritative.volume30dCents.coerceAtLeast(0L)
+            val earned = authoritative.pointsEarned30d
+                .takeIf { it > 0L }
+                ?: tradingPointsForVolumeCents(vol, authoritative.pointsPerDollar)
+            return Summary(
+                pointsPerDollar = authoritative.pointsPerDollar,
+                volume30dCents = vol,
+                pointsEarned30d = earned.coerceAtLeast(0L),
+                lifetimeTradingPoints = authoritative.lifetimeTradingPoints.coerceAtLeast(0L),
+                source = Source.AUTHORITATIVE,
+            )
+        }
+        val vol = volumeCents.coerceAtLeast(0L)
+        return Summary(
+            pointsPerDollar = POINTS_PER_DOLLAR,
+            volume30dCents = vol,
+            pointsEarned30d = tradingPointsForVolumeCents(vol, POINTS_PER_DOLLAR),
+            lifetimeTradingPoints = 0L,
+            source = Source.ESTIMATED,
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
@@ -39,6 +39,9 @@ fun NavGraphBuilder.rewardsDestinations(navController: NavHostController) {
         ReferralLeaderboardRoute(onBack = { navController.popBackStack() })
     }
     composable(RewardsDest.ROUTE) {
-        RewardsRoute(onBack = { navController.popBackStack() })
+        RewardsRoute(
+            onBack = { navController.popBackStack() },
+            onOpenFeeTiers = { navController.navigate(FeeTiersDest.ROUTE) },
+        )
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/rewards/TradingRewardsMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/rewards/TradingRewardsMathTest.kt
@@ -1,0 +1,145 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.data.rewards.TradingRewards
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure JVM tests for the TRADING-REWARDS math (points earned by trading volume). Mirrors the web
+ * frontend/src/lib/tradingRewards.test.ts: canonical rate, floor-to-whole-points, negative/zero guards,
+ * the volume<->points inverse, and the authoritative-preferred / estimate-fallback resolution. No
+ * Android / Compose / Hilt.
+ */
+class TradingRewardsMathTest {
+
+    private fun authoritative(
+        rate: Long = 1L,
+        volumeCents: Long = 0L,
+        earned30d: Long = 0L,
+        lifetime: Long = 0L,
+        available: Boolean = true,
+    ) = TradingRewards(
+        pointsPerDollar = rate,
+        volume30dCents = volumeCents,
+        pointsEarned30d = earned30d,
+        lifetimeTradingPoints = lifetime,
+        available = available,
+    )
+
+    // ---- canonical rate ----
+
+    @Test
+    fun pointsPerDollar_isOne_mirroringWeb() {
+        assertEquals(1L, TradingRewardsMath.POINTS_PER_DOLLAR)
+    }
+
+    // ---- tradingPointsForVolumeCents ----
+
+    @Test
+    fun points_floorWholeDollars_atCanonicalRate() {
+        // $1,234.56 -> floor 1234 dollars * 1 pt = 1234 pts
+        assertEquals(1234L, TradingRewardsMath.tradingPointsForVolumeCents(123456L))
+        // exact dollar
+        assertEquals(100L, TradingRewardsMath.tradingPointsForVolumeCents(10000L))
+        // sub-dollar volume rounds down to 0 points
+        assertEquals(0L, TradingRewardsMath.tradingPointsForVolumeCents(99L))
+    }
+
+    @Test
+    fun points_honorCustomRate() {
+        // 3 pts per $ on $500 volume = 1500 pts
+        assertEquals(1500L, TradingRewardsMath.tradingPointsForVolumeCents(50000L, pointsPerDollar = 3L))
+    }
+
+    @Test
+    fun points_guardNegativeAndZero() {
+        assertEquals(0L, TradingRewardsMath.tradingPointsForVolumeCents(0L))
+        assertEquals(0L, TradingRewardsMath.tradingPointsForVolumeCents(-500L))
+        assertEquals(0L, TradingRewardsMath.tradingPointsForVolumeCents(10000L, pointsPerDollar = 0L))
+        assertEquals(0L, TradingRewardsMath.tradingPointsForVolumeCents(10000L, pointsPerDollar = -2L))
+    }
+
+    // ---- volumeForPoints (inverse) ----
+
+    @Test
+    fun volumeForPoints_isInverseAtCanonicalRate() {
+        // 1234 pts at 1/$ needs $1234 = 123400 cents
+        assertEquals(123400L, TradingRewardsMath.volumeForPoints(1234L))
+        // round-trip: points for that volume is at least the requested points
+        val v = TradingRewardsMath.volumeForPoints(1234L)
+        assertTrue(TradingRewardsMath.tradingPointsForVolumeCents(v) >= 1234L)
+    }
+
+    @Test
+    fun volumeForPoints_guardNonPositive() {
+        assertEquals(0L, TradingRewardsMath.volumeForPoints(0L))
+        assertEquals(0L, TradingRewardsMath.volumeForPoints(-10L))
+        assertEquals(0L, TradingRewardsMath.volumeForPoints(100L, pointsPerDollar = 0L))
+    }
+
+    // ---- tradingRewardsSummary: estimate ----
+
+    @Test
+    fun summary_estimate_whenNoAuthoritative() {
+        val s = TradingRewardsMath.tradingRewardsSummary(volumeCents = 250000L, authoritative = null)
+        assertEquals(TradingRewardsMath.Source.ESTIMATED, s.source)
+        assertFalse(s.isAuthoritative)
+        assertEquals(1L, s.pointsPerDollar)
+        assertEquals(250000L, s.volume30dCents)
+        assertEquals(2500L, s.pointsEarned30d)
+        assertEquals(0L, s.lifetimeTradingPoints)
+    }
+
+    @Test
+    fun summary_estimate_whenAuthoritativeUnavailableOrZeroRate() {
+        // degraded 404 -> unavailable domain
+        val degraded = TradingRewardsMath.tradingRewardsSummary(10000L, TradingRewards.unavailable())
+        assertEquals(TradingRewardsMath.Source.ESTIMATED, degraded.source)
+        assertEquals(100L, degraded.pointsEarned30d)
+        // available but non-positive rate also falls back to estimate
+        val zeroRate = TradingRewardsMath.tradingRewardsSummary(10000L, authoritative(rate = 0L, volumeCents = 999999L))
+        assertEquals(TradingRewardsMath.Source.ESTIMATED, zeroRate.source)
+        assertEquals(10000L, zeroRate.volume30dCents)
+    }
+
+    @Test
+    fun summary_estimate_clampsNegativeVolume() {
+        val s = TradingRewardsMath.tradingRewardsSummary(volumeCents = -5000L, authoritative = null)
+        assertEquals(0L, s.volume30dCents)
+        assertEquals(0L, s.pointsEarned30d)
+    }
+
+    // ---- tradingRewardsSummary: authoritative ----
+
+    @Test
+    fun summary_prefersAuthoritative_whenPresentWithPositiveRate() {
+        val a = authoritative(rate = 2L, volumeCents = 500000L, earned30d = 9999L, lifetime = 42000L)
+        val s = TradingRewardsMath.tradingRewardsSummary(volumeCents = 1L, authoritative = a)
+        assertEquals(TradingRewardsMath.Source.AUTHORITATIVE, s.source)
+        assertTrue(s.isAuthoritative)
+        assertEquals(2L, s.pointsPerDollar)
+        assertEquals(500000L, s.volume30dCents)
+        assertEquals(9999L, s.pointsEarned30d) // server-provided earned wins
+        assertEquals(42000L, s.lifetimeTradingPoints)
+    }
+
+    @Test
+    fun summary_authoritative_computesEarnedWhenServerOmitsIt() {
+        // earned30d = 0 (absent in our lenient mapper) -> compute from volume * rate
+        val a = authoritative(rate = 1L, volumeCents = 300000L, earned30d = 0L)
+        val s = TradingRewardsMath.tradingRewardsSummary(volumeCents = 0L, authoritative = a)
+        assertEquals(TradingRewardsMath.Source.AUTHORITATIVE, s.source)
+        assertEquals(3000L, s.pointsEarned30d)
+    }
+
+    @Test
+    fun summary_authoritative_clampsNegatives() {
+        val a = authoritative(rate = 1L, volumeCents = -10L, earned30d = -5L, lifetime = -7L)
+        val s = TradingRewardsMath.tradingRewardsSummary(volumeCents = 0L, authoritative = a)
+        assertEquals(0L, s.volume30dCents)
+        assertEquals(0L, s.pointsEarned30d)
+        assertEquals(0L, s.lifetimeTradingPoints)
+    }
+}

--- a/frontend/src/api/endpoints/rewards.ts
+++ b/frontend/src/api/endpoints/rewards.ts
@@ -125,6 +125,23 @@ export interface ReferralLeaderboard {
 }
 
 
+// ── Trading rewards (points earned by trading volume — NEW) ──────
+
+/**
+ * Authoritative TRADING-REWARDS read: points accrued from executed trading
+ * volume. Points accrue server-side; the frontend shows the earn rate + an
+ * estimate from the caller’s own 30-day volume, and swaps to these numbers
+ * when the endpoint ships. Degrades on 404 -> client estimate (see
+ * `lib/tradingRewards`). Rate is points per whole US dollar of volume.
+ */
+export interface TradingRewards {
+  points_per_dollar: number;
+  volume_30d_cents: number;
+  points_earned_30d: number;
+  lifetime_trading_points: number;
+}
+
+
 // ── Reads (degrade on 404 — callers use retry:false) ─────────────────
 
 export const getReferralSummary = () =>
@@ -141,6 +158,9 @@ export const getRewardsHistory = () =>
 
 export const getRewardsCatalog = () =>
   api.get<RewardsCatalog>("/me/rewards/catalog");
+
+export const getTradingRewards = () =>
+  api.get<TradingRewards>("/me/rewards/trading");
 
 export const getReferralLeaderboard = (period: LeaderboardPeriod = "all") =>
   api.get<ReferralLeaderboard>(`/me/referral/leaderboard?period=${period}`);

--- a/frontend/src/lib/tradingRewards.test.ts
+++ b/frontend/src/lib/tradingRewards.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import type { TradingRewards } from "@/api/endpoints/rewards";
+import {
+  POINTS_PER_DOLLAR,
+  tradingPointsForVolumeCents,
+  tradingRewardsSummary,
+  volumeForPoints,
+} from "@/lib/tradingRewards";
+
+describe("POINTS_PER_DOLLAR", () => {
+  it("is the canonical 1 point per dollar", () => {
+    expect(POINTS_PER_DOLLAR).toBe(1);
+  });
+});
+
+describe("tradingPointsForVolumeCents", () => {
+  it("floors to whole points at the default rate (1 pt / $1)", () => {
+    expect(tradingPointsForVolumeCents(100_00)).toBe(100);
+    expect(tradingPointsForVolumeCents(150_50)).toBe(150); // $150.50 -> 150
+    expect(tradingPointsForVolumeCents(99)).toBe(0); // $0.99 -> 0
+  });
+
+  it("honors a custom rate", () => {
+    expect(tradingPointsForVolumeCents(100_00, 2)).toBe(200);
+    expect(tradingPointsForVolumeCents(100_00, 0.5)).toBe(50);
+  });
+
+  it("guards zero / negative / non-finite volume", () => {
+    expect(tradingPointsForVolumeCents(0)).toBe(0);
+    expect(tradingPointsForVolumeCents(-500_00)).toBe(0);
+    expect(tradingPointsForVolumeCents(Number.NaN)).toBe(0);
+    expect(tradingPointsForVolumeCents(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+
+  it("guards a non-positive rate", () => {
+    expect(tradingPointsForVolumeCents(100_00, 0)).toBe(0);
+    expect(tradingPointsForVolumeCents(100_00, -1)).toBe(0);
+    expect(tradingPointsForVolumeCents(100_00, Number.NaN)).toBe(0);
+  });
+});
+
+describe("volumeForPoints", () => {
+  it("is the inverse at the default rate (returns cents)", () => {
+    expect(volumeForPoints(100)).toBe(100_00);
+    expect(volumeForPoints(1)).toBe(1_00);
+  });
+
+  it("honors a custom rate", () => {
+    expect(volumeForPoints(200, 2)).toBe(100_00);
+    expect(volumeForPoints(50, 0.5)).toBe(100_00);
+  });
+
+  it("round-trips with tradingPointsForVolumeCents on whole dollars", () => {
+    const cents = 1234_00;
+    const pts = tradingPointsForVolumeCents(cents);
+    expect(volumeForPoints(pts)).toBe(cents);
+  });
+
+  it("guards zero / negative / non-finite input", () => {
+    expect(volumeForPoints(0)).toBe(0);
+    expect(volumeForPoints(-10)).toBe(0);
+    expect(volumeForPoints(Number.NaN)).toBe(0);
+    expect(volumeForPoints(100, 0)).toBe(0);
+  });
+});
+
+describe("tradingRewardsSummary", () => {
+  it("estimates from volume when no authoritative payload is present", () => {
+    const s = tradingRewardsSummary(250_00);
+    expect(s.source).toBe("estimated");
+    expect(s.pointsPerDollar).toBe(POINTS_PER_DOLLAR);
+    expect(s.volume30dCents).toBe(250_00);
+    expect(s.pointsEarned30d).toBe(250);
+    expect(s.lifetimeTradingPoints).toBe(0);
+  });
+
+  it("clamps a negative estimate volume to zero", () => {
+    const s = tradingRewardsSummary(-100_00);
+    expect(s.volume30dCents).toBe(0);
+    expect(s.pointsEarned30d).toBe(0);
+    expect(s.source).toBe("estimated");
+  });
+
+  it("prefers a valid authoritative payload", () => {
+    const auth: TradingRewards = {
+      points_per_dollar: 2,
+      volume_30d_cents: 500_00,
+      points_earned_30d: 1000,
+      lifetime_trading_points: 42_000,
+    };
+    const s = tradingRewardsSummary(1_00, auth);
+    expect(s.source).toBe("authoritative");
+    expect(s.pointsPerDollar).toBe(2);
+    expect(s.volume30dCents).toBe(500_00);
+    expect(s.pointsEarned30d).toBe(1000);
+    expect(s.lifetimeTradingPoints).toBe(42_000);
+  });
+
+  it("derives points_earned_30d from volume when the payload omits it", () => {
+    const auth = {
+      points_per_dollar: 1,
+      volume_30d_cents: 300_00,
+      points_earned_30d: Number.NaN,
+      lifetime_trading_points: Number.NaN,
+    } as unknown as TradingRewards;
+    const s = tradingRewardsSummary(0, auth);
+    expect(s.source).toBe("authoritative");
+    expect(s.pointsEarned30d).toBe(300);
+    expect(s.lifetimeTradingPoints).toBe(0);
+  });
+
+  it("falls back to the estimate when the authoritative rate is invalid", () => {
+    const auth = {
+      points_per_dollar: 0,
+      volume_30d_cents: 999_00,
+      points_earned_30d: 999,
+      lifetime_trading_points: 9,
+    } as TradingRewards;
+    const s = tradingRewardsSummary(120_00, auth);
+    expect(s.source).toBe("estimated");
+    expect(s.volume30dCents).toBe(120_00);
+    expect(s.pointsEarned30d).toBe(120);
+  });
+});

--- a/frontend/src/lib/tradingRewards.ts
+++ b/frontend/src/lib/tradingRewards.ts
@@ -1,0 +1,105 @@
+// Pure helpers for the TRADING-REWARDS card on the Rewards surface.
+// No React / no network — unit-testable in isolation.
+//
+// Trading earns reward POINTS by executed volume. Points accrue SERVER-SIDE;
+// the frontend shows the earn RATE + an ESTIMATE of points from the user's own
+// 30-day trading volume, plus an optional AUTHORITATIVE read when the backend
+// ships `GET /me/rewards/trading`.
+//
+// CONVENTIONS: money is INTEGER CENTS; points are WHOLE integers.
+// Canonical rate (shared with Android): 1 reward point per $1 of volume.
+
+import type { TradingRewards } from "@/api/endpoints/rewards";
+
+/** Canonical earn rate: reward points granted per whole US dollar of volume. */
+export const POINTS_PER_DOLLAR = 1;
+
+/**
+ * Whole reward points earned for a given trading volume (integer cents).
+ * Floors to whole points; guards against negative / non-finite input and a
+ * non-positive rate.
+ */
+export function tradingPointsForVolumeCents(
+  volumeCents: number,
+  pointsPerDollar: number = POINTS_PER_DOLLAR,
+): number {
+  const cents = Number.isFinite(volumeCents) ? volumeCents : 0;
+  const rate = Number.isFinite(pointsPerDollar) ? pointsPerDollar : 0;
+  if (cents <= 0 || rate <= 0) return 0;
+  const dollars = cents / 100;
+  return Math.floor(dollars * rate);
+}
+
+/**
+ * Inverse of `tradingPointsForVolumeCents`: the minimum trading volume (integer
+ * cents) required to earn `points` at the given rate. Guards non-positive input.
+ */
+export function volumeForPoints(
+  points: number,
+  pointsPerDollar: number = POINTS_PER_DOLLAR,
+): number {
+  const p = Number.isFinite(points) ? points : 0;
+  const rate = Number.isFinite(pointsPerDollar) ? pointsPerDollar : 0;
+  if (p <= 0 || rate <= 0) return 0;
+  const dollars = p / rate;
+  return Math.round(dollars * 100);
+}
+
+/** Where the trading-rewards numbers came from. */
+export type TradingRewardsSource = "authoritative" | "estimated";
+
+/** Resolved trading-rewards summary for the card. */
+export interface TradingRewardsSummary {
+  /** Earn rate, points per whole US dollar of volume. */
+  pointsPerDollar: number;
+  /** 30-day trading volume backing the estimate/read, USD cents. */
+  volume30dCents: number;
+  /** Points earned from the last-30-day volume. */
+  pointsEarned30d: number;
+  /** Lifetime trading points (authoritative only; 0 when estimating). */
+  lifetimeTradingPoints: number;
+  /** Whether the numbers are authoritative or a client estimate. */
+  source: TradingRewardsSource;
+}
+
+/**
+ * Resolve the trading-rewards summary. Prefers the AUTHORITATIVE payload when
+ * present; otherwise falls back to a client ESTIMATE computed from the caller's
+ * 30-day volume. Never throws.
+ */
+export function tradingRewardsSummary(
+  volumeCents: number,
+  authoritative?: TradingRewards | null,
+): TradingRewardsSummary {
+  if (
+    authoritative &&
+    Number.isFinite(authoritative.points_per_dollar) &&
+    authoritative.points_per_dollar > 0
+  ) {
+    const vol = Number.isFinite(authoritative.volume_30d_cents)
+      ? authoritative.volume_30d_cents
+      : 0;
+    const earned = Number.isFinite(authoritative.points_earned_30d)
+      ? Math.max(0, Math.floor(authoritative.points_earned_30d))
+      : tradingPointsForVolumeCents(vol, authoritative.points_per_dollar);
+    const lifetime = Number.isFinite(authoritative.lifetime_trading_points)
+      ? Math.max(0, Math.floor(authoritative.lifetime_trading_points))
+      : 0;
+    return {
+      pointsPerDollar: authoritative.points_per_dollar,
+      volume30dCents: Math.max(0, vol),
+      pointsEarned30d: earned,
+      lifetimeTradingPoints: lifetime,
+      source: "authoritative",
+    };
+  }
+
+  const vol = Number.isFinite(volumeCents) ? Math.max(0, volumeCents) : 0;
+  return {
+    pointsPerDollar: POINTS_PER_DOLLAR,
+    volume30dCents: vol,
+    pointsEarned30d: tradingPointsForVolumeCents(vol, POINTS_PER_DOLLAR),
+    lifetimeTradingPoints: 0,
+    source: "estimated",
+  };
+}

--- a/frontend/src/pages/rewards/RewardsPage.tsx
+++ b/frontend/src/pages/rewards/RewardsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Award, Coins, Wallet, Sparkles, Gift, Users } from "lucide-react";
+import { Award, Coins, Wallet, Sparkles, Gift, Users, TrendingUp, ArrowRight } from "lucide-react";
 import { toast } from "sonner";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -23,6 +23,7 @@ import {
   getRewards,
   getRewardsHistory,
   getRewardsCatalog,
+  getTradingRewards,
   redeemReward,
 } from "@/api/endpoints/rewards";
 import type { CatalogReward, RewardHistoryEntry } from "@/api/endpoints/rewards";
@@ -32,6 +33,8 @@ import {
   pointsAfterRedeem,
   redeemableCatalog,
 } from "@/lib/rewards";
+import { tradingRewardsSummary } from "@/lib/tradingRewards";
+import { useFeeTier } from "@/hooks/useFeeTier";
 import { PendingRewards } from "./PendingRewards";
 
 function is404(err: unknown): boolean {
@@ -82,11 +85,33 @@ export default function RewardsPage() {
     queryFn: getRewardsCatalog,
     retry: false,
   });
+  const tradingQ = useQuery({
+    queryKey: ["me", "rewards", "trading"],
+    queryFn: getTradingRewards,
+    retry: false,
+  });
+
+  // 30-day executed-trade volume, reused from the shared fee-tier resolver.
+  const feeTier = useFeeTier();
 
   const rewards = rewardsQ.data;
   const points = rewards?.points ?? 0;
   const history: RewardHistoryEntry[] = historyQ.data?.entries ?? [];
   const catalog = redeemableCatalog(catalogQ.data?.rewards ?? [], points);
+
+  // Prefer the authoritative /me/rewards/trading read; else estimate from
+  // the caller’s own 30-day trade volume. Never throws, degrades gracefully.
+  const trading = tradingRewardsSummary(feeTier.volumeCents, tradingQ.data);
+  const tradingVolumeReady = !feeTier.isPending || tradingQ.isSuccess;
+
+  // Surface trading as a first-class "way to earn" alongside the backend list.
+  const tradingWayToEarn = {
+    id: "__trading",
+    title: "Trade to earn points",
+    points: trading.pointsPerDollar,
+    detail: `Earn ${formatPoints(trading.pointsPerDollar, false)} per $1 of trading volume.`,
+  };
+  const waysToEarn = [tradingWayToEarn, ...(rewards?.ways_to_earn ?? [])];
 
   const redeemMut = useMutation({
     mutationFn: (rewardId: string) => redeemReward(rewardId),
@@ -174,13 +199,13 @@ export default function RewardsPage() {
             <CardDescription>Rack up points across the platform.</CardDescription>
           </CardHeader>
           <CardContent>
-            {rewards.ways_to_earn.length === 0 ? (
+            {waysToEarn.length === 0 ? (
               <p className="py-4 text-center text-sm text-muted-foreground">
                 No earning opportunities listed right now.
               </p>
             ) : (
               <ul className="divide-y">
-                {rewards.ways_to_earn.map((w) => (
+                {waysToEarn.map((w) => (
                   <li key={w.id} className="flex items-center justify-between gap-3 py-3">
                     <div>
                       <p className="font-medium">{w.title}</p>
@@ -196,6 +221,84 @@ export default function RewardsPage() {
           </CardContent>
         </Card>
       ) : null}
+
+      {/* Trading rewards — earn points by trading volume */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <TrendingUp className="h-5 w-5" /> Trade to earn points
+              </CardTitle>
+              <CardDescription>
+                Earn{" "}
+                <span className="font-medium text-foreground">
+                  {formatPoints(trading.pointsPerDollar, false)}
+                  {trading.pointsPerDollar === 1 ? " point" : " points"}
+                </span>{" "}
+                per $1 traded. Points accrue automatically on every fill.
+              </CardDescription>
+            </div>
+            <Badge variant={trading.source === "authoritative" ? "default" : "secondary"}>
+              {trading.source === "authoritative" ? "Live" : "Estimated"}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {tradingVolumeReady ? (
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border p-4">
+              <div>
+                <p className="text-xs text-muted-foreground">Your 30-day volume</p>
+                <p className="text-xl font-semibold tabular-nums">
+                  {formatCents(trading.volume30dCents)}
+                </p>
+              </div>
+              <ArrowRight className="h-5 w-5 shrink-0 text-muted-foreground" />
+              <div className="text-right">
+                <p className="text-xs text-muted-foreground">
+                  {trading.source === "authoritative" ? "Points earned" : "~ Estimated points"}
+                </p>
+                <p className="text-xl font-semibold tabular-nums text-primary">
+                  {trading.source === "authoritative" ? "" : "~"}
+                  {formatPoints(trading.pointsEarned30d, false)}
+                </p>
+              </div>
+            </div>
+          ) : feeTier.isPending ? (
+            <Skeleton className="h-20 w-full" />
+          ) : (
+            <p className="rounded-lg border p-4 text-sm text-muted-foreground">
+              Your trading volume is unavailable right now. Start trading to earn{" "}
+              {formatPoints(trading.pointsPerDollar, false)} per $1 of volume.
+            </p>
+          )}
+
+          {trading.source === "authoritative" && trading.lifetimeTradingPoints > 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Lifetime trading points:{" "}
+              <span className="font-medium text-foreground tabular-nums">
+                {formatPoints(trading.lifetimeTradingPoints)}
+              </span>
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Estimated from your recent trade history. Points are credited server-side as
+              your fills settle.
+            </p>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button asChild size="sm">
+              <Link to="/markets">
+                <TrendingUp className="mr-1.5 h-4 w-4" /> Trade now
+              </Link>
+            </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link to="/fees">Volume &amp; tiers</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Redeem catalog */}
       <Card>


### PR DESCRIPTION
## Trading-activity reward points

Surfaces reward points earned by trading volume. Points accrue server-side; the frontend shows the **earn rate** + an **estimate** from the user's own 30-day trading volume (reusing the fills-window volume the fee-tier surface already computes — no new feed), with an optional authoritative override.

Canonical rate (both platforms): **1 reward point per $1 of trading volume**. Optional authoritative `GET /me/rewards/trading` → `{points_per_dollar, volume_30d_cents, points_earned_30d, lifetime_trading_points}`; degrade-on-404 to the client estimate (labelled).

### Web
`lib/tradingRewards.ts` (+14 vitest) — `POINTS_PER_DOLLAR`, `tradingPointsForVolumeCents` (floor+guards), `volumeForPoints`, `tradingRewardsSummary` (authoritative-vs-estimate); `rewards.ts` `getTradingRewards`; RewardsPage "Trade to earn points" card (rate + your 30d volume → ~P points via `useFeeTier().volumeCents`, Live/Estimated badge, auto-accrual note) + a ways-to-earn item.

### Android
`TradingRewardsMath.kt` (mirror; +12 JVM tests); `RewardsViewModel` resolves the summary from the authoritative read + the same fills feed the Fee-Tier screen uses; `RewardsScreen` `TradingRewardsCard`; `RewardsApi/Domain/Repository` gain `tradingRewards()` (degrade-on-404).

No new deps, no route changes. Gates: web tsc 0 · vite build · vitest 14/14; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (TradingRewardsMath 12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
