### PR TITLE
feat(rewards): convert reward points to USD cash wallet (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
@@ -52,6 +52,15 @@ interface RewardsApi {
     suspend fun redeem(@Body body: RedeemRequestDto): RedeemResultDto
 
     /**
+     * POST me/rewards/redeem-cash {points} -> {ok, cash_cents, points_remaining}. DIRECT convert of reward
+     * points into the USD cash wallet at the canonical rate. Mutation: a rejection / undeployed 404 surfaces
+     * as a clear error, never a silent success.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("me/rewards/redeem-cash")
+    suspend fun redeemCash(@Body body: RedeemCashRequestDto): RedeemCashResultDto
+
+    /**
      * GET me/referral/leaderboard?period=all|month -> top referrers + (optionally) the caller's own
      * out-of-slice rank. Read degrades on 404 to an honest coming-soon state.
      */
@@ -168,6 +177,22 @@ data class RedeemRequestDto(
 @JsonClass(generateAdapter = true)
 data class RedeemResultDto(
     @Json(name = "ok") val ok: Boolean? = null,
+    @LenientLong @Json(name = "points_remaining") val pointsRemaining: Long? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "error") val error: String? = null,
+)
+
+// ---- POST me/rewards/redeem-cash (DIRECT points -> USD cash) ----
+
+@JsonClass(generateAdapter = true)
+data class RedeemCashRequestDto(
+    @Json(name = "points") val points: Long,
+)
+
+@JsonClass(generateAdapter = true)
+data class RedeemCashResultDto(
+    @Json(name = "ok") val ok: Boolean? = null,
+    @LenientLong @Json(name = "cash_cents") val cashCents: Long? = null,
     @LenientLong @Json(name = "points_remaining") val pointsRemaining: Long? = null,
     @Json(name = "detail") val detail: String? = null,
     @Json(name = "error") val error: String? = null,

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
@@ -127,6 +127,18 @@ data class RedeemResult(
     val reason: String?,
 )
 
+/**
+ * Result of POST me/rewards/redeem-cash (DIRECT points -> USD cash mutation). [ok] is true when the
+ * server accepted the conversion; [cashCents] is the amount credited and [pointsRemaining] the new
+ * points balance (both server-authoritative). [reason] carries a rejection message on failure.
+ */
+data class RedeemCashResult(
+    val ok: Boolean,
+    val cashCents: Long?,
+    val pointsRemaining: Long?,
+    val reason: String?,
+)
+
 // ---- Mappers (DTO -> domain; TOTAL, absent optionals default) ----
 
 private fun String?.toReferralStatus(): ReferralStatus = when (this?.trim()?.lowercase()) {
@@ -217,6 +229,13 @@ internal fun CatalogRewardDto.toDomain(): CatalogReward? {
 
 internal fun RedeemResultDto.toDomain(): RedeemResult = RedeemResult(
     ok = ok == true,
+    pointsRemaining = pointsRemaining,
+    reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
+)
+
+internal fun RedeemCashResultDto.toDomain(): RedeemCashResult = RedeemCashResult(
+    ok = ok == true,
+    cashCents = cashCents,
     pointsRemaining = pointsRemaining,
     reason = listOfNotNull(detail, error).firstOrNull { it.isNotBlank() },
 )

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
@@ -36,6 +36,11 @@ interface RewardsRepository {
     suspend fun rewardsHistory(): ApiResult<List<RewardsHistoryEntry>>
     suspend fun rewardsCatalog(): ApiResult<List<CatalogReward>>
     suspend fun redeem(rewardId: String): ApiResult<RedeemResult>
+    /**
+     * DIRECT convert reward points -> USD cash wallet (MUTATION). A rejection or undeployed 404 surfaces
+     * as a clear error, never a silent success (no points/cash are assumed moved on the client).
+     */
+    suspend fun redeemPointsForCash(points: Long): ApiResult<RedeemCashResult>
     suspend fun referralLeaderboard(period: LeaderboardPeriod): ApiResult<ReferralLeaderboard>
     /**
      * OPTIONAL authoritative trading-rewards read. A 404 (undeployed) degrades to an honest
@@ -85,6 +90,11 @@ class RewardsRepositoryImpl @Inject constructor(
     /** Redeem a reward (MUTATION). A rejection or undeployed 404 surfaces as a clear error, never a silent success. */
     override suspend fun redeem(rewardId: String): ApiResult<RedeemResult> = call {
         api.redeem(RedeemRequestDto(rewardId = rewardId.trim())).toDomain()
+    }
+
+    /** Convert points -> USD cash (MUTATION). A rejection or undeployed 404 surfaces as a clear error, never a silent success. */
+    override suspend fun redeemPointsForCash(points: Long): ApiResult<RedeemCashResult> = call {
+        api.redeemCash(RedeemCashRequestDto(points = points)).toDomain()
     }
 
     /** Referral leaderboard. A 404 (undeployed) degrades to an honest unavailable board; network errors surface. */

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsCashMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsCashMath.kt
@@ -1,0 +1,82 @@
+package com.testlogon.android.feature.rewards
+
+/**
+ * Pure, Android-free math + validation for the DIRECT "convert reward points -> USD cash wallet"
+ * redemption. Kept out of the ViewModel/Compose so the rate, minimum, conversion and validation are unit
+ * testable. The canonical rate mirrors the web contract EXACTLY: 100 points = $1.00, i.e. 1 cent per
+ * point ([CENTS_PER_POINT]). Points and cents are integers throughout — no float drift, no fractional
+ * cents. The client only proposes/validates; crediting is entirely server-side (source of truth).
+ */
+object RewardsCashMath {
+
+    /** Canonical rate: 100 points = $1.00 -> exactly 1 USD cent per point. Integer, no rounding. */
+    const val CENTS_PER_POINT: Long = 1L
+
+    /** Minimum redeemable points (500 points = $5.00). Below this the redeem is rejected client-side. */
+    const val MIN_REDEEM_POINTS: Long = 500L
+
+    /** USD cents credited for [points] points (points * [CENTS_PER_POINT]); floored at 0 for non-positive. */
+    fun cashCentsForPoints(points: Long): Long =
+        if (points <= 0L) 0L else points * CENTS_PER_POINT
+
+    /**
+     * Points required to redeem exactly [cashCents] USD cents at the canonical rate. Rounds UP so a preset
+     * dollar target is always fully covered (never under-funds the target). Non-positive -> 0.
+     */
+    fun pointsForCashCents(cashCents: Long): Long {
+        if (cashCents <= 0L) return 0L
+        return (cashCents + CENTS_PER_POINT - 1L) / CENTS_PER_POINT
+    }
+
+    /** The minimum redemption expressed in USD cents (MIN_REDEEM_POINTS at the canonical rate). */
+    fun minRedeemCents(): Long = cashCentsForPoints(MIN_REDEEM_POINTS)
+
+    /** Points left after redeeming [points] from a [balancePoints] wallet, floored at 0 (never negative). */
+    fun pointsAfterRedeem(balancePoints: Long, points: Long): Long =
+        (balancePoints - points).coerceAtLeast(0L)
+
+    /**
+     * Result of validating a proposed points redemption against the wallet balance. Exactly one of the
+     * flags is meaningful when [valid] is false; when [valid] is true the redemption is safe to confirm.
+     */
+    enum class Validation { VALID, NOT_POSITIVE, BELOW_MIN, INSUFFICIENT }
+
+    /**
+     * Validate a DIRECT points->cash redemption of [points] against [balancePoints]:
+     * - [Validation.NOT_POSITIVE] when points <= 0 (nothing to redeem),
+     * - [Validation.BELOW_MIN] when points < [MIN_REDEEM_POINTS],
+     * - [Validation.INSUFFICIENT] when points > balance,
+     * - [Validation.VALID] otherwise.
+     * Order matters: a non-positive/too-small amount is reported before an insufficient-balance check.
+     */
+    fun validatePointsRedemption(points: Long, balancePoints: Long): Validation = when {
+        points <= 0L -> Validation.NOT_POSITIVE
+        points < MIN_REDEEM_POINTS -> Validation.BELOW_MIN
+        points > balancePoints -> Validation.INSUFFICIENT
+        else -> Validation.VALID
+    }
+
+    /** Convenience: true only when [validatePointsRedemption] returns [Validation.VALID]. */
+    fun canRedeem(points: Long, balancePoints: Long): Boolean =
+        validatePointsRedemption(points, balancePoints) == Validation.VALID
+
+    /**
+     * The largest number of points the [balancePoints] wallet can redeem to cash right now: the whole
+     * balance when it is at least the minimum, otherwise 0 (the min is not yet met). Used by the "Max"
+     * preset so it never proposes an invalid amount.
+     */
+    fun maxRedeemablePoints(balancePoints: Long): Long =
+        if (balancePoints >= MIN_REDEEM_POINTS) balancePoints else 0L
+
+    // ---- Formatting (delegates to RewardsMath for a single money/points format source of truth) ----
+
+    /** Format integer cents as a USD currency amount with symbol (500 -> "$5.00"). */
+    fun formatCentsUsd(cents: Long): String = RewardsMath.formatCentsUsd(cents)
+
+    /** Format integer points with grouping ("1,250 pts"). */
+    fun formatPoints(points: Long): String = RewardsMath.formatPoints(points)
+
+    /** Human rate line, e.g. "100 points = $1.00". Pure, JVM-testable. */
+    fun rateLabel(): String =
+        "${formatPoints(100L / CENTS_PER_POINT)} = ${formatCentsUsd(100L)}"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
@@ -24,7 +24,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -41,6 +43,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -62,6 +65,11 @@ object RewardsTestTags {
     const val REDEEM_CONFIRM = "rewards_redeem_confirm"
     const val TRADING = "rewards_trading_card"
     const val TRADING_CTA = "rewards_trading_cta"
+    const val CONVERT_CARD = "rewards_convert_cash_card"
+    const val CONVERT_INPUT = "rewards_convert_cash_input"
+    const val CONVERT_CTA = "rewards_convert_cash_cta"
+    const val CONVERT_CONFIRM = "rewards_convert_cash_confirm"
+    const val CASH_LINK = "rewards_open_cash"
 }
 
 /** Route-level Rewards entry (reached from the More -> Growth hub). */
@@ -69,6 +77,7 @@ object RewardsTestTags {
 fun RewardsRoute(
     onBack: () -> Unit,
     onOpenFeeTiers: () -> Unit = {},
+    onOpenCash: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: RewardsViewModel = hiltViewModel(),
 ) {
@@ -89,6 +98,11 @@ fun RewardsRoute(
         onRetry = viewModel::onRetry,
         onRedeem = viewModel::confirmRedeem,
         onOpenFeeTiers = onOpenFeeTiers,
+        onOpenCash = onOpenCash,
+        onCashPointsChanged = viewModel::onCashPointsChanged,
+        onCashPreset = viewModel::onCashPreset,
+        onCashMax = viewModel::onCashMax,
+        onConvertCash = viewModel::confirmRedeemCash,
         snackbarHostState = snackbarHostState,
         modifier = modifier,
     )
@@ -101,10 +115,16 @@ fun RewardsScreen(
     onRetry: () -> Unit,
     onRedeem: (CatalogReward) -> Unit,
     onOpenFeeTiers: () -> Unit = {},
+    onOpenCash: () -> Unit = {},
+    onCashPointsChanged: (String) -> Unit = {},
+    onCashPreset: (Long) -> Unit = {},
+    onCashMax: () -> Unit = {},
+    onConvertCash: (Long) -> Unit = {},
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     var pendingRedeem by remember { mutableStateOf<CatalogReward?>(null) }
+    var pendingCashPoints by remember { mutableStateOf<Long?>(null) }
 
     Scaffold(
         modifier = modifier.testTag(RewardsTestTags.SCREEN),
@@ -142,6 +162,11 @@ fun RewardsScreen(
                     state = state,
                     onRedeemClick = { pendingRedeem = it },
                     onOpenFeeTiers = onOpenFeeTiers,
+                    onOpenCash = onOpenCash,
+                    onCashPointsChanged = onCashPointsChanged,
+                    onCashPreset = onCashPreset,
+                    onCashMax = onCashMax,
+                    onConvertClick = { pendingCashPoints = it },
                 )
             }
         }
@@ -179,6 +204,39 @@ fun RewardsScreen(
             dismissButton = { TextButton(onClick = { pendingRedeem = null }) { Text("Cancel") } },
         )
     }
+
+    val cashPts = pendingCashPoints
+    if (cashPts != null) {
+        val credited = RewardsCashMath.cashCentsForPoints(cashPts)
+        AlertDialog(
+            onDismissRequest = { pendingCashPoints = null },
+            title = { Text("Convert points to cash") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    RedeemRow("Convert", RewardsCashMath.formatPoints(cashPts), emphasize = true)
+                    RedeemRow("You'll receive", RewardsCashMath.formatCentsUsd(credited), emphasize = true)
+                    RedeemRow("Points after", RewardsCashMath.formatPoints(RewardsCashMath.pointsAfterRedeem(state.points, cashPts)))
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "Redeem ${RewardsCashMath.formatPoints(cashPts)} for ${RewardsCashMath.formatCentsUsd(credited)} to your USD cash wallet.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    enabled = !state.convertingCash,
+                    onClick = {
+                        pendingCashPoints = null
+                        onConvertCash(cashPts)
+                    },
+                    modifier = Modifier.testTag(RewardsTestTags.CONVERT_CONFIRM),
+                ) { Text("Convert") }
+            },
+            dismissButton = { TextButton(onClick = { pendingCashPoints = null }) { Text("Cancel") } },
+        )
+    }
 }
 
 @Composable
@@ -186,6 +244,11 @@ private fun RewardsContent(
     state: RewardsUiState,
     onRedeemClick: (CatalogReward) -> Unit,
     onOpenFeeTiers: () -> Unit,
+    onOpenCash: () -> Unit,
+    onCashPointsChanged: (String) -> Unit,
+    onCashPreset: (Long) -> Unit,
+    onCashMax: () -> Unit,
+    onConvertClick: (Long) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -196,6 +259,14 @@ private fun RewardsContent(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         BalanceCard(state)
+        ConvertToCashCard(
+            state = state,
+            onOpenCash = onOpenCash,
+            onCashPointsChanged = onCashPointsChanged,
+            onCashPreset = onCashPreset,
+            onCashMax = onCashMax,
+            onConvertClick = onConvertClick,
+        )
         state.tradingRewards?.let { TradingRewardsCard(it, onOpenFeeTiers) }
         if (state.rewards.waysToEarn.isNotEmpty()) {
             WaysToEarnCard(state)
@@ -250,6 +321,70 @@ private fun TradingRewardsCard(
                 onClick = onOpenFeeTiers,
                 modifier = Modifier.testTag(RewardsTestTags.TRADING_CTA),
             ) { Text("Trade & view fee tiers") }
+        }
+    }
+}
+
+@Composable
+private fun ConvertToCashCard(
+    state: RewardsUiState,
+    onOpenCash: () -> Unit,
+    onCashPointsChanged: (String) -> Unit,
+    onCashPreset: (Long) -> Unit,
+    onCashMax: () -> Unit,
+    onConvertClick: (Long) -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth().testTag(RewardsTestTags.CONVERT_CARD)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("Convert points to cash", style = MaterialTheme.typography.titleMedium)
+            Text(
+                "Rate: ${RewardsCashMath.rateLabel()} · Min ${RewardsCashMath.formatPoints(RewardsCashMath.MIN_REDEEM_POINTS)} (${RewardsCashMath.formatCentsUsd(RewardsCashMath.minRedeemCents())})",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            OutlinedTextField(
+                value = state.cashPointsInput,
+                onValueChange = onCashPointsChanged,
+                singleLine = true,
+                label = { Text("Points to convert") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth().testTag(RewardsTestTags.CONVERT_INPUT),
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AssistChip(onClick = { onCashPreset(500L) }, label = { Text("$5") })
+                AssistChip(onClick = { onCashPreset(1000L) }, label = { Text("$10") })
+                AssistChip(onClick = onCashMax, label = { Text("Max") })
+            }
+
+            Text(
+                "You'll receive ${RewardsCashMath.formatCentsUsd(state.cashCentsForInput)}",
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            val hint = when (state.cashValidation) {
+                RewardsCashMath.Validation.NOT_POSITIVE -> null
+                RewardsCashMath.Validation.BELOW_MIN ->
+                    "Minimum is ${RewardsCashMath.formatPoints(RewardsCashMath.MIN_REDEEM_POINTS)}."
+                RewardsCashMath.Validation.INSUFFICIENT ->
+                    "You only have ${RewardsCashMath.formatPoints(state.points)}."
+                RewardsCashMath.Validation.VALID -> null
+            }
+            if (hint != null) {
+                Text(hint, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.error)
+            }
+
+            Button(
+                enabled = state.canConvertCash,
+                onClick = { onConvertClick(state.cashPoints) },
+                modifier = Modifier.fillMaxWidth().testTag(RewardsTestTags.CONVERT_CTA),
+            ) { Text(if (state.convertingCash) "Converting..." else "Convert to cash") }
+
+            TextButton(
+                onClick = onOpenCash,
+                modifier = Modifier.testTag(RewardsTestTags.CASH_LINK),
+            ) { Text("Open USD cash wallet") }
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsUiState.kt
@@ -67,11 +67,28 @@ data class RewardsUiState(
      */
     val tradingRewards: TradingRewardsMath.Summary? = null,
     val redeeming: Boolean = false,
+    /** Current raw text in the "convert points to cash" input (digits only; empty = nothing entered). */
+    val cashPointsInput: String = "",
+    /** True while a DIRECT points->cash conversion is in flight (blocks re-submit). */
+    val convertingCash: Boolean = false,
     val errorMessage: String? = null,
     val successMessage: String? = null,
     val offline: Boolean = false,
 ) {
     val points: Long get() = rewards.points
+
+    /** The parsed non-negative points amount from [cashPointsInput]; 0 when empty/blank. */
+    val cashPoints: Long get() = cashPointsInput.trim().toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+
+    /** USD cents the current input would credit at the canonical rate (live "you'll receive"). */
+    val cashCentsForInput: Long get() = RewardsCashMath.cashCentsForPoints(cashPoints)
+
+    /** Validation of the current input against the live points balance. */
+    val cashValidation: RewardsCashMath.Validation
+        get() = RewardsCashMath.validatePointsRedemption(cashPoints, points)
+
+    /** True when the current input is a safe, confirmable points->cash redemption. */
+    val canConvertCash: Boolean get() = cashValidation == RewardsCashMath.Validation.VALID && !convertingCash
 }
 
 /** One-shot side effects handled by the Route (never replayed on rotation). */

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsViewModel.kt
@@ -47,6 +47,24 @@ class RewardsViewModel @Inject constructor(
 
     fun consumeMessages() = _uiState.update { it.copy(errorMessage = null, successMessage = null) }
 
+    /** Update the "convert points to cash" input, keeping only digits (never a sign / decimal). */
+    fun onCashPointsChanged(raw: String) {
+        val digits = raw.filter { it.isDigit() }.take(12)
+        _uiState.update { it.copy(cashPointsInput = digits) }
+    }
+
+    /** Preset: set the input to the points needed for a whole-dollar [cents] target (e.g. $5 / $10). */
+    fun onCashPreset(cents: Long) {
+        val pts = RewardsCashMath.pointsForCashCents(cents)
+        _uiState.update { it.copy(cashPointsInput = pts.toString()) }
+    }
+
+    /** Preset "Max": redeem the entire balance when it meets the minimum (else clears to an empty input). */
+    fun onCashMax() {
+        val max = RewardsCashMath.maxRedeemablePoints(_uiState.value.points)
+        _uiState.update { it.copy(cashPointsInput = if (max > 0L) max.toString() else "") }
+    }
+
     fun load() {
         _uiState.update { it.copy(loading = true, errorMessage = null, offline = false) }
         viewModelScope.launch {
@@ -127,6 +145,65 @@ class RewardsViewModel @Inject constructor(
                 }
                 is ApiResult.NetworkError -> _uiState.update {
                     it.copy(redeeming = false, errorMessage = "No connection. No points were spent.")
+                }
+            }
+        }
+    }
+
+    /**
+     * Called AFTER the "convert points to cash" money-safety confirm is accepted. Re-validates against the
+     * live balance (client-side gate), then POSTs the DIRECT redemption. Crediting is server-side: a
+     * rejection surfaces as a CLEAR error and NEVER a silent success, and balances are re-read from the
+     * server after a success (the client never fabricates the new points/cash balance).
+     */
+    fun confirmRedeemCash(points: Long) {
+        val s = _uiState.value
+        if (s.convertingCash) return
+        when (RewardsCashMath.validatePointsRedemption(points, s.points)) {
+            RewardsCashMath.Validation.NOT_POSITIVE -> {
+                _uiState.update { it.copy(errorMessage = "Enter how many points to convert.") }
+                return
+            }
+            RewardsCashMath.Validation.BELOW_MIN -> {
+                _uiState.update {
+                    it.copy(errorMessage = "Minimum is ${RewardsCashMath.formatPoints(RewardsCashMath.MIN_REDEEM_POINTS)} (${RewardsCashMath.formatCentsUsd(RewardsCashMath.minRedeemCents())}).")
+                }
+                return
+            }
+            RewardsCashMath.Validation.INSUFFICIENT -> {
+                _uiState.update {
+                    it.copy(errorMessage = "You only have ${RewardsCashMath.formatPoints(s.points)} to convert.")
+                }
+                return
+            }
+            RewardsCashMath.Validation.VALID -> Unit
+        }
+        _uiState.update { it.copy(convertingCash = true, errorMessage = null, successMessage = null) }
+        viewModelScope.launch {
+            when (val r = repository.redeemPointsForCash(points)) {
+                is ApiResult.Success -> {
+                    if (r.data.ok) {
+                        val credited = r.data.cashCents ?: RewardsCashMath.cashCentsForPoints(points)
+                        _uiState.update {
+                            it.copy(
+                                convertingCash = false,
+                                cashPointsInput = "",
+                                successMessage = "Converted ${RewardsCashMath.formatPoints(points)} to ${RewardsCashMath.formatCentsUsd(credited)} in your USD cash wallet.",
+                            )
+                        }
+                        // Re-read balances/history from the server (never fabricate the new balance).
+                        load()
+                    } else {
+                        _uiState.update {
+                            it.copy(convertingCash = false, errorMessage = r.data.reason?.ifBlank { null } ?: "Conversion was declined. No points were spent.")
+                        }
+                    }
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(convertingCash = false, errorMessage = r.error.message.ifBlank { "Converting isn't available right now. No points were spent." })
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(convertingCash = false, errorMessage = "No connection. No points were spent.")
                 }
             }
         }

--- a/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
@@ -42,6 +42,7 @@ fun NavGraphBuilder.rewardsDestinations(navController: NavHostController) {
         RewardsRoute(
             onBack = { navController.popBackStack() },
             onOpenFeeTiers = { navController.navigate(FeeTiersDest.ROUTE) },
+            onOpenCash = { navController.navigate(CashDest.ROUTE) },
         )
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/rewards/RewardsCashMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/rewards/RewardsCashMathTest.kt
@@ -1,0 +1,107 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.feature.rewards.RewardsCashMath.Validation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure rules for the DIRECT points->USD-cash redemption: canonical rate (100 pts = $1.00 -> 1 cent/pt),
+ * $5.00 (500 pt) minimum, integer conversion both directions, and the redemption validation ladder
+ * (not-positive -> below-min -> insufficient -> valid). No Android / Compose / Hilt.
+ */
+class RewardsCashMathTest {
+
+    @Test
+    fun canonicalRate_isOneCentPerPointAndFiveDollarMin() {
+        assertEquals(1L, RewardsCashMath.CENTS_PER_POINT)
+        assertEquals(500L, RewardsCashMath.MIN_REDEEM_POINTS)
+        assertEquals(500L, RewardsCashMath.minRedeemCents())
+    }
+
+    @Test
+    fun cashCentsForPoints_convertsAtCanonicalRate() {
+        assertEquals(0L, RewardsCashMath.cashCentsForPoints(0L))
+        assertEquals(500L, RewardsCashMath.cashCentsForPoints(500L))
+        assertEquals(1000L, RewardsCashMath.cashCentsForPoints(1000L))
+        assertEquals(1234L, RewardsCashMath.cashCentsForPoints(1234L))
+    }
+
+    @Test
+    fun cashCentsForPoints_nonPositiveFloorsAtZero() {
+        assertEquals(0L, RewardsCashMath.cashCentsForPoints(-1L))
+        assertEquals(0L, RewardsCashMath.cashCentsForPoints(-999L))
+    }
+
+    @Test
+    fun pointsForCashCents_roundsUpToCoverTarget() {
+        assertEquals(0L, RewardsCashMath.pointsForCashCents(0L))
+        assertEquals(500L, RewardsCashMath.pointsForCashCents(500L))   // $5.00
+        assertEquals(1000L, RewardsCashMath.pointsForCashCents(1000L)) // $10.00
+        assertEquals(0L, RewardsCashMath.pointsForCashCents(-5L))
+    }
+
+    @Test
+    fun conversion_isInverseAtCanonicalRate() {
+        val pts = 750L
+        assertEquals(pts, RewardsCashMath.pointsForCashCents(RewardsCashMath.cashCentsForPoints(pts)))
+    }
+
+    @Test
+    fun pointsAfterRedeem_flooredAtZero() {
+        assertEquals(500L, RewardsCashMath.pointsAfterRedeem(1000L, 500L))
+        assertEquals(0L, RewardsCashMath.pointsAfterRedeem(500L, 500L))
+        assertEquals(0L, RewardsCashMath.pointsAfterRedeem(100L, 500L)) // never negative
+    }
+
+    @Test
+    fun validate_notPositive() {
+        assertEquals(Validation.NOT_POSITIVE, RewardsCashMath.validatePointsRedemption(0L, 10_000L))
+        assertEquals(Validation.NOT_POSITIVE, RewardsCashMath.validatePointsRedemption(-50L, 10_000L))
+    }
+
+    @Test
+    fun validate_belowMin() {
+        assertEquals(Validation.BELOW_MIN, RewardsCashMath.validatePointsRedemption(1L, 10_000L))
+        assertEquals(Validation.BELOW_MIN, RewardsCashMath.validatePointsRedemption(499L, 10_000L))
+    }
+
+    @Test
+    fun validate_insufficientBalance() {
+        assertEquals(Validation.INSUFFICIENT, RewardsCashMath.validatePointsRedemption(600L, 500L))
+        assertEquals(Validation.INSUFFICIENT, RewardsCashMath.validatePointsRedemption(1L.let { 501L }, 500L))
+    }
+
+    @Test
+    fun validate_valid_atMinAndAtFullBalance() {
+        assertEquals(Validation.VALID, RewardsCashMath.validatePointsRedemption(500L, 500L))
+        assertEquals(Validation.VALID, RewardsCashMath.validatePointsRedemption(1000L, 1000L))
+        assertTrue(RewardsCashMath.canRedeem(500L, 500L))
+        assertFalse(RewardsCashMath.canRedeem(499L, 500L))
+    }
+
+    @Test
+    fun validate_belowMinTakesPrecedenceOverInsufficient() {
+        // 300 points is both below the 500 min AND above a 200 balance; below-min is reported first.
+        assertEquals(Validation.BELOW_MIN, RewardsCashMath.validatePointsRedemption(300L, 200L))
+    }
+
+    @Test
+    fun maxRedeemablePoints_wholeBalanceWhenAtLeastMinElseZero() {
+        assertEquals(0L, RewardsCashMath.maxRedeemablePoints(499L))
+        assertEquals(500L, RewardsCashMath.maxRedeemablePoints(500L))
+        assertEquals(12_345L, RewardsCashMath.maxRedeemablePoints(12_345L))
+    }
+
+    @Test
+    fun rateLabel_mirrorsWebContract() {
+        assertEquals("100 pts = $1.00", RewardsCashMath.rateLabel())
+    }
+
+    @Test
+    fun formatting_delegatesToRewardsMath() {
+        assertEquals("$5.00", RewardsCashMath.formatCentsUsd(500L))
+        assertEquals("1,000 pts", RewardsCashMath.formatPoints(1000L))
+    }
+}

--- a/frontend/src/api/endpoints/rewards.ts
+++ b/frontend/src/api/endpoints/rewards.ts
@@ -169,3 +169,19 @@ export const getReferralLeaderboard = (period: LeaderboardPeriod = "all") =>
 
 export const redeemReward = (rewardId: string) =>
   api.post<RedeemResult>("/me/rewards/redeem", { reward_id: rewardId });
+
+
+/** Result of a DIRECT points-to-cash conversion. */
+export interface RedeemCashResult {
+  ok: boolean;
+  cash_cents: number;
+  points_remaining: number;
+}
+
+/**
+ * DIRECT "convert points to USD cash wallet" redemption. The server debits the
+ * points and credits the USD cash wallet (`/custody/cash`). Degrades on 404 —
+ * the caller surfaces a clear error toast (never a silent success).
+ */
+export const redeemPointsForCash = (points: number) =>
+  api.post<RedeemCashResult>("/me/rewards/redeem-cash", { points });

--- a/frontend/src/lib/rewardsCash.test.ts
+++ b/frontend/src/lib/rewardsCash.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CENTS_PER_POINT,
+  MIN_REDEEM_POINTS,
+  cashCentsForPoints,
+  pointsForCashCents,
+  validatePointsRedemption,
+  formatCents,
+  formatPoints,
+} from "@/lib/rewardsCash";
+
+describe("canonical constants", () => {
+  it("uses the shared 1 cent / point rate (100 pts = $1.00)", () => {
+    expect(CENTS_PER_POINT).toBe(1);
+    expect(cashCentsForPoints(100)).toBe(100);
+  });
+
+  it("has a $5.00 minimum (500 points)", () => {
+    expect(MIN_REDEEM_POINTS).toBe(500);
+    expect(cashCentsForPoints(MIN_REDEEM_POINTS)).toBe(500);
+  });
+});
+
+describe("cashCentsForPoints", () => {
+  it("converts points to integer cents at the default rate", () => {
+    expect(cashCentsForPoints(0)).toBe(0);
+    expect(cashCentsForPoints(500)).toBe(500);
+    expect(cashCentsForPoints(1234)).toBe(1234);
+  });
+
+  it("honors a custom cents-per-point rate", () => {
+    expect(cashCentsForPoints(100, 2)).toBe(200);
+  });
+
+  it("floors fractional and clamps negative / non-finite input", () => {
+    expect(cashCentsForPoints(10.9)).toBe(10);
+    expect(cashCentsForPoints(-50)).toBe(0);
+    expect(cashCentsForPoints(Number.NaN)).toBe(0);
+    expect(cashCentsForPoints(100, -3)).toBe(0);
+  });
+});
+
+describe("pointsForCashCents", () => {
+  it("is the integer inverse at the default rate", () => {
+    expect(pointsForCashCents(500)).toBe(500);
+    expect(pointsForCashCents(0)).toBe(0);
+  });
+
+  it("rounds UP to whole points", () => {
+    expect(pointsForCashCents(150, 100)).toBe(2); // $1.50 needs 2 pts @ 100c/pt
+    expect(pointsForCashCents(101, 100)).toBe(2);
+  });
+
+  it("clamps bad input and a zero rate", () => {
+    expect(pointsForCashCents(-100)).toBe(0);
+    expect(pointsForCashCents(Number.NaN)).toBe(0);
+    expect(pointsForCashCents(500, 0)).toBe(0);
+  });
+});
+
+describe("validatePointsRedemption", () => {
+  it("accepts a whole amount at/above min and within balance", () => {
+    expect(validatePointsRedemption(500, 1000)).toEqual({ ok: true });
+    expect(validatePointsRedemption(1000, 1000)).toEqual({ ok: true });
+  });
+
+  it("rejects below the minimum", () => {
+    const r = validatePointsRedemption(499, 10000);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/at least/i);
+  });
+
+  it("rejects more than the balance", () => {
+    const r = validatePointsRedemption(1500, 1000);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/enough/i);
+  });
+
+  it("rejects zero / negative / non-finite", () => {
+    expect(validatePointsRedemption(0, 1000).ok).toBe(false);
+    expect(validatePointsRedemption(-5, 1000).ok).toBe(false);
+    expect(validatePointsRedemption(Number.NaN, 1000).ok).toBe(false);
+  });
+
+  it("rejects fractional points", () => {
+    const r = validatePointsRedemption(500.5, 1000);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/whole/i);
+  });
+});
+
+describe("formatters", () => {
+  it("formats points with separators and optional unit", () => {
+    expect(formatPoints(12345)).toBe("12,345 pts");
+    expect(formatPoints(12345, false)).toBe("12,345");
+    expect(formatPoints(Number.NaN)).toBe("0 pts");
+  });
+
+  it("formats integer cents as USD", () => {
+    expect(formatCents(500)).toBe("$5.00");
+    expect(formatCents(1234)).toBe("$12.34");
+    expect(formatCents(Number.NaN)).toBe("$0.00");
+  });
+});

--- a/frontend/src/lib/rewardsCash.ts
+++ b/frontend/src/lib/rewardsCash.ts
@@ -1,0 +1,87 @@
+// Pure helpers for the DIRECT "convert points to USD cash wallet" redemption.
+// No React / no network — unit-testable in isolation.
+// Money is INTEGER CENTS; points are whole integers.
+//
+// Canonical rate (shared with Android): 100 points = $1.00, i.e. 1 point = 1
+// cent. Minimum redemption is 500 points ($5.00). All arithmetic is integer.
+
+/** Cents credited per point redeemed. 1 point = 1 cent (100 pts = $1.00). */
+export const CENTS_PER_POINT = 1;
+
+/** Minimum points that may be converted to cash in a single redemption. */
+export const MIN_REDEEM_POINTS = 500;
+
+/** Coerce to a safe, whole, non-negative integer point count. */
+function safePoints(points: number): number {
+  return Number.isFinite(points) ? Math.trunc(points) : 0;
+}
+
+/** USD cents received for redeeming `points` at `centsPerPoint`. Integer. */
+export function cashCentsForPoints(
+  points: number,
+  centsPerPoint: number = CENTS_PER_POINT,
+): number {
+  const p = Math.max(0, safePoints(points));
+  const rate = Number.isFinite(centsPerPoint) ? Math.trunc(centsPerPoint) : CENTS_PER_POINT;
+  return p * Math.max(0, rate);
+}
+
+/** Points required to receive `cents` USD (rounded UP to whole points). */
+export function pointsForCashCents(
+  cents: number,
+  centsPerPoint: number = CENTS_PER_POINT,
+): number {
+  const c = Number.isFinite(cents) ? Math.max(0, Math.trunc(cents)) : 0;
+  const rate = Number.isFinite(centsPerPoint) ? Math.trunc(centsPerPoint) : CENTS_PER_POINT;
+  if (rate <= 0) return 0;
+  return Math.ceil(c / rate);
+}
+
+export interface PointsRedemptionCheck {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Validate a proposed points-to-cash redemption against the caller's balance.
+ * Requires: a whole positive integer, at least MIN_REDEEM_POINTS, and no more
+ * than the available balance.
+ */
+export function validatePointsRedemption(
+  points: number,
+  balancePoints: number,
+): PointsRedemptionCheck {
+  const balance = Math.max(0, safePoints(balancePoints));
+
+  if (!Number.isFinite(points) || points <= 0) {
+    return { ok: false, reason: "Enter a number of points to redeem." };
+  }
+  if (!Number.isInteger(points)) {
+    return { ok: false, reason: "Redeem a whole number of points." };
+  }
+  if (points < MIN_REDEEM_POINTS) {
+    return {
+      ok: false,
+      reason: `Redeem at least ${MIN_REDEEM_POINTS.toLocaleString("en-US")} points.`,
+    };
+  }
+  if (points > balance) {
+    return { ok: false, reason: "You do not have enough points." };
+  }
+  return { ok: true };
+}
+
+/** Format whole points with thousands separators, e.g. 12345 -> "12,345 pts". */
+export function formatPoints(points: number, withUnit = true): string {
+  const n = new Intl.NumberFormat("en-US").format(safePoints(points));
+  return withUnit ? `${n} pts` : n;
+}
+
+/** Format integer USD cents as a localized currency string. */
+export function formatCents(cents: number, currency = "USD"): string {
+  const safe = Number.isFinite(cents) ? cents : 0;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: (currency || "USD").toUpperCase(),
+  }).format(safe / 100);
+}

--- a/frontend/src/pages/rewards/RewardsPage.tsx
+++ b/frontend/src/pages/rewards/RewardsPage.tsx
@@ -1,12 +1,23 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Award, Coins, Wallet, Sparkles, Gift, Users, TrendingUp, ArrowRight } from "lucide-react";
+import {
+  Award,
+  Coins,
+  Wallet,
+  Sparkles,
+  Gift,
+  Users,
+  TrendingUp,
+  ArrowRight,
+  DollarSign,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -25,6 +36,7 @@ import {
   getRewardsCatalog,
   getTradingRewards,
   redeemReward,
+  redeemPointsForCash,
 } from "@/api/endpoints/rewards";
 import type { CatalogReward, RewardHistoryEntry } from "@/api/endpoints/rewards";
 import {
@@ -33,6 +45,13 @@ import {
   pointsAfterRedeem,
   redeemableCatalog,
 } from "@/lib/rewards";
+import {
+  CENTS_PER_POINT,
+  MIN_REDEEM_POINTS,
+  cashCentsForPoints,
+  pointsForCashCents,
+  validatePointsRedemption,
+} from "@/lib/rewardsCash";
 import { tradingRewardsSummary } from "@/lib/tradingRewards";
 import { useFeeTier } from "@/hooks/useFeeTier";
 import { PendingRewards } from "./PendingRewards";
@@ -69,6 +88,10 @@ function BalanceCard({
 export default function RewardsPage() {
   const qc = useQueryClient();
   const [pending, setPending] = useState<CatalogReward | null>(null);
+
+  // DIRECT "convert points to cash" flow state.
+  const [convertInput, setConvertInput] = useState("");
+  const [convertConfirm, setConvertConfirm] = useState<number | null>(null);
 
   const rewardsQ = useQuery({
     queryKey: ["me", "rewards", "summary"],
@@ -119,6 +142,7 @@ export default function RewardsPage() {
       toast.success(`Redeemed. ${formatPoints(res.points_remaining)} remaining.`);
       qc.invalidateQueries({ queryKey: ["me", "rewards"] });
       qc.invalidateQueries({ queryKey: ["ui", "billing", "wallet"] });
+      qc.invalidateQueries({ queryKey: ["billing", "wallet"] });
       setPending(null);
     },
     onError: (err: unknown) => {
@@ -133,15 +157,65 @@ export default function RewardsPage() {
     },
   });
 
+  // DIRECT points-to-cash conversion mutation.
+  const convertMut = useMutation({
+    mutationFn: (pts: number) => redeemPointsForCash(pts),
+    onSuccess: (res) => {
+      toast.success(
+        `Converted to cash. ${formatCents(res.cash_cents)} added to your USD wallet — ${formatPoints(res.points_remaining)} remaining.`,
+      );
+      qc.invalidateQueries({ queryKey: ["me", "rewards"] });
+      qc.invalidateQueries({ queryKey: ["ui", "billing", "wallet"] });
+      qc.invalidateQueries({ queryKey: ["billing", "wallet"] });
+      setConvertConfirm(null);
+      setConvertInput("");
+    },
+    onError: (err: unknown) => {
+      if (is404(err)) {
+        toast.error("Cash conversion is not available yet — the rewards backend has not shipped.");
+      } else if (err instanceof ApiError) {
+        toast.error(err.message || "Could not convert your points to cash.");
+      } else {
+        toast.error("Could not convert your points to cash.");
+      }
+      setConvertConfirm(null);
+    },
+  });
+
   const rewardsPending = is404(rewardsQ.error);
   const historyPending = is404(historyQ.error);
   const catalogPending = is404(catalogQ.error);
+
+  // Parsed convert amount + live validation against the current points balance.
+  const convertPoints = useMemo(() => {
+    const trimmed = convertInput.trim();
+    if (trimmed === "") return Number.NaN;
+    return Number(trimmed);
+  }, [convertInput]);
+  const convertValidation = useMemo(
+    () => validatePointsRedemption(convertPoints, points),
+    [convertPoints, points],
+  );
+  const convertCashCents = Number.isFinite(convertPoints)
+    ? cashCentsForPoints(Math.max(0, Math.trunc(convertPoints)))
+    : 0;
+
+  const setPreset = (cents: number) => {
+    // Preset by target USD; clamp to the caller's available balance.
+    const wanted = pointsForCashCents(cents);
+    setConvertInput(String(Math.min(wanted, points)));
+  };
 
   const confirmDescription = pending
     ? pending.kind === "cash"
       ? `Redeem ${formatPoints(pending.cost_points)} for ${formatCents(pending.value_cents)}? This credits your USD cash wallet. You will have ${formatPoints(pointsAfterRedeem(points, pending.cost_points))} left.`
       : `Redeem ${formatPoints(pending.cost_points)} for "${pending.name}"? You will have ${formatPoints(pointsAfterRedeem(points, pending.cost_points))} left.`
     : "";
+
+  const convertDescription =
+    convertConfirm !== null
+      ? `Redeem ${formatPoints(convertConfirm)} for ${formatCents(cashCentsForPoints(convertConfirm))} to your USD cash wallet? You will have ${formatPoints(pointsAfterRedeem(points, convertConfirm))} left.`
+      : "";
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-6">
@@ -300,6 +374,108 @@ export default function RewardsPage() {
         </CardContent>
       </Card>
 
+      {/* Convert points to cash — DIRECT flexible redemption */}
+      {rewards && !rewardsPending ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <DollarSign className="h-5 w-5" /> Convert points to cash
+            </CardTitle>
+            <CardDescription>
+              {formatPoints(100 / CENTS_PER_POINT, false)} points = {formatCents(100)}. Cash lands
+              in your{" "}
+              <Link
+                to="/custody/cash"
+                className="font-medium text-primary underline-offset-4 hover:underline"
+              >
+                USD cash wallet
+              </Link>
+              . Minimum {formatPoints(MIN_REDEEM_POINTS)} ({formatCents(cashCentsForPoints(MIN_REDEEM_POINTS))}).
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="min-w-[10rem] flex-1">
+                <label htmlFor="convert-points" className="text-xs text-muted-foreground">
+                  Points to convert
+                </label>
+                <Input
+                  id="convert-points"
+                  type="number"
+                  inputMode="numeric"
+                  min={MIN_REDEEM_POINTS}
+                  step={1}
+                  placeholder={String(MIN_REDEEM_POINTS)}
+                  value={convertInput}
+                  onChange={(e) => setConvertInput(e.target.value)}
+                  className="mt-1 tabular-nums"
+                />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={points < pointsForCashCents(500)}
+                  onClick={() => setPreset(500)}
+                >
+                  $5
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={points < pointsForCashCents(1000)}
+                  onClick={() => setPreset(1000)}
+                >
+                  $10
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={points < MIN_REDEEM_POINTS}
+                  onClick={() => setConvertInput(String(points))}
+                >
+                  Max
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-3 rounded-lg border p-4">
+              <div>
+                <p className="text-xs text-muted-foreground">You have</p>
+                <p className="text-lg font-semibold tabular-nums">
+                  {formatPoints(points)}
+                </p>
+              </div>
+              <ArrowRight className="h-5 w-5 shrink-0 text-muted-foreground" />
+              <div className="text-right">
+                <p className="text-xs text-muted-foreground">You&apos;ll receive</p>
+                <p className="text-lg font-semibold tabular-nums text-primary">
+                  {formatCents(convertCashCents)}
+                </p>
+              </div>
+            </div>
+
+            {convertInput.trim() !== "" && !convertValidation.ok ? (
+              <p className="text-sm text-destructive">{convertValidation.reason}</p>
+            ) : null}
+
+            <Button
+              className="w-full sm:w-auto"
+              disabled={!convertValidation.ok || convertMut.isPending}
+              onClick={() => {
+                if (convertValidation.ok) setConvertConfirm(Math.trunc(convertPoints));
+              }}
+            >
+              <DollarSign className="mr-1.5 h-4 w-4" />
+              Convert to cash
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
+
       {/* Redeem catalog */}
       <Card>
         <CardHeader>
@@ -437,6 +613,20 @@ export default function RewardsPage() {
         loading={redeemMut.isPending}
         onConfirm={() => {
           if (pending) redeemMut.mutate(pending.id);
+        }}
+      />
+
+      <ConfirmDialog
+        open={convertConfirm !== null}
+        onOpenChange={(o) => {
+          if (!o) setConvertConfirm(null);
+        }}
+        title="Convert points to cash"
+        description={convertDescription}
+        confirmLabel="Convert to cash"
+        loading={convertMut.isPending}
+        onConfirm={() => {
+          if (convertConfirm !== null) convertMut.mutate(convertConfirm);
         }}
       />
     </div>


### PR DESCRIPTION
## Convert reward points → USD cash wallet

A flexible "convert points to cash" redemption **alongside** the fixed catalog: choose a points amount (or $5/$10/Max presets), see the resulting USD live, confirm, and it debits points + credits the USD cash wallet. Canonical rate both platforms: **100 points = $1.00**, min 500 points ($5). Crediting server-side; degrade-on-404.

New: `POST /me/rewards/redeem-cash {points}` → `{ok, cash_cents, points_remaining}`.

### Web
`lib/rewardsCash.ts` (+15 vitest) — rate/min consts + `cashCentsForPoints`/`pointsForCashCents`/`validatePointsRedemption`/format; `rewards.ts` `redeemPointsForCash`; RewardsPage "Convert points to cash" card (rate, input + presets, live receive-$X, validation, money-safety confirm → credits wallet, link to `/custody/cash`). **Also fixed** the existing catalog redeem — it only invalidated `["ui","billing","wallet"]` but the wallet pages key on `["billing","wallet"]`, so the balance didn't refresh; both mutations now invalidate all keys.

### Android
`RewardsCashMath.kt` (mirror; +14 JVM tests); `RewardsApi/Domain/Repository` gain `redeemPointsForCash`; `RewardsUiState/ViewModel` add the convert flow (input/presets/max/validate/confirm → re-load balances); `RewardsScreen` `ConvertToCashCard` + confirm; `RewardsNavigation` `onOpenCash` → Cash screen.

No new deps, no route changes. Gates: web tsc 0 · vite build · vitest 15/15; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (RewardsCashMath 14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
