### PR TITLE
feat(rewards): points expiry + statement (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
@@ -74,6 +74,15 @@ interface RewardsApi {
      */
     @GET("me/rewards/trading")
     suspend fun tradingRewards(): TradingRewardsDto
+
+    /**
+     * OPTIONAL authoritative POINTS-EXPIRY read: the server-computed expiring-soon total, the next
+     * expiry (ts + points), and the remaining earn LOTS (earned_ts, points_remaining, expires_ts).
+     * Points expire [policy_months] after they are earned. Read degrades on 404 -> the client computes
+     * the same shape FIFO from the rewards history, so the surface still works before the endpoint ships.
+     */
+    @GET("me/rewards/expiry")
+    suspend fun rewardsExpiry(): RewardsExpiryDto
 }
 
 // ---- GET me/referral ----
@@ -131,6 +140,24 @@ data class TradingRewardsDto(
     @LenientLong @Json(name = "volume_30d_cents") val volume30dCents: Long? = null,
     @LenientLong @Json(name = "points_earned_30d") val pointsEarned30d: Long? = null,
     @LenientLong @Json(name = "lifetime_trading_points") val lifetimeTradingPoints: Long? = null,
+)
+
+// ---- GET me/rewards/expiry (optional authoritative) ----
+
+@JsonClass(generateAdapter = true)
+data class RewardsExpiryDto(
+    @LenientInt @Json(name = "policy_months") val policyMonths: Int? = null,
+    @LenientLong @Json(name = "expiring_soon_points") val expiringSoonPoints: Long? = null,
+    @LenientLong @Json(name = "next_expiry_ts") val nextExpiryTs: Long? = null,
+    @LenientLong @Json(name = "next_expiry_points") val nextExpiryPoints: Long? = null,
+    @Json(name = "lots") val lots: List<RewardsExpiryLotDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class RewardsExpiryLotDto(
+    @LenientLong @Json(name = "earned_ts") val earnedTs: Long? = null,
+    @LenientLong @Json(name = "points_remaining") val pointsRemaining: Long? = null,
+    @LenientLong @Json(name = "expires_ts") val expiresTs: Long? = null,
 )
 
 // ---- GET me/rewards/history ----

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
@@ -102,6 +102,38 @@ data class TradingRewards(
     }
 }
 
+/**
+ * OPTIONAL authoritative POINTS-EXPIRY read (GET me/rewards/expiry), mapped to domain. [available] is
+ * false when the read degraded (404 / undeployed) so the surface falls back to the CLIENT computation
+ * (same FIFO shape) from the rewards history. Points are whole integers; timestamps are epoch millis.
+ */
+data class PointsExpiryLot(
+    val earnedTs: Long,
+    val pointsRemaining: Long,
+    val expiresTs: Long,
+)
+
+data class PointsExpiry(
+    val policyMonths: Int,
+    val expiringSoonPoints: Long,
+    val nextExpiryTs: Long,
+    val nextExpiryPoints: Long,
+    val lots: List<PointsExpiryLot>,
+    val available: Boolean,
+) {
+    companion object {
+        /** Honest "unavailable" value for the degrade-on-404 client-compute fallback. */
+        fun unavailable(): PointsExpiry = PointsExpiry(
+            policyMonths = 0,
+            expiringSoonPoints = 0L,
+            nextExpiryTs = 0L,
+            nextExpiryPoints = 0L,
+            lots = emptyList(),
+            available = false,
+        )
+    }
+}
+
 data class RewardsHistoryEntry(
     val ts: Long,
     val type: String,
@@ -189,6 +221,27 @@ internal fun TradingRewardsDto.toDomain(): TradingRewards = TradingRewards(
     volume30dCents = volume30dCents ?: 0L,
     pointsEarned30d = pointsEarned30d ?: 0L,
     lifetimeTradingPoints = lifetimeTradingPoints ?: 0L,
+    available = true,
+)
+
+internal fun RewardsExpiryLotDto.toDomain(): PointsExpiryLot? {
+    val earned = earnedTs ?: return null
+    if (earned <= 0L) return null
+    val remaining = (pointsRemaining ?: 0L).coerceAtLeast(0L)
+    if (remaining <= 0L) return null
+    return PointsExpiryLot(
+        earnedTs = earned,
+        pointsRemaining = remaining,
+        expiresTs = expiresTs ?: 0L,
+    )
+}
+
+internal fun RewardsExpiryDto.toDomain(): PointsExpiry = PointsExpiry(
+    policyMonths = (policyMonths ?: 0).coerceAtLeast(0),
+    expiringSoonPoints = (expiringSoonPoints ?: 0L).coerceAtLeast(0L),
+    nextExpiryTs = nextExpiryTs ?: 0L,
+    nextExpiryPoints = (nextExpiryPoints ?: 0L).coerceAtLeast(0L),
+    lots = lots.mapNotNull { it.toDomain() }.sortedBy { it.expiresTs },
     available = true,
 )
 

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsRepository.kt
@@ -47,6 +47,12 @@ interface RewardsRepository {
      * unavailable value so the card falls back to the client estimate; network errors surface.
      */
     suspend fun tradingRewards(): ApiResult<TradingRewards>
+
+    /**
+     * OPTIONAL authoritative POINTS-EXPIRY read. A 404 (undeployed) degrades to an honest unavailable
+     * value so the statement surface falls back to the CLIENT FIFO computation; network errors surface.
+     */
+    suspend fun rewardsExpiry(): ApiResult<PointsExpiry>
 }
 
 @Singleton
@@ -107,6 +113,12 @@ class RewardsRepositoryImpl @Inject constructor(
     override suspend fun tradingRewards(): ApiResult<TradingRewards> = degrading(
         block = { api.tradingRewards().toDomain() },
         onHttpError = { TradingRewards.unavailable() },
+    )
+
+    /** Points expiry. A 404 (undeployed) degrades to an honest unavailable value; network errors surface. */
+    override suspend fun rewardsExpiry(): ApiResult<PointsExpiry> = degrading(
+        block = { api.rewardsExpiry().toDomain() },
+        onHttpError = { PointsExpiry.unavailable() },
     )
 
     /** Read wrapper: HTTP-error (incl. 404) degrades to [onHttpError]; transport -> NetworkError. */

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1237,6 +1237,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.ACCOUNT,
         ),
         MoreEntry(
+            id = "points_statement",
+            labelRes = R.string.more_entry_points_statement,
+            icon = Icons.Outlined.ReceiptLong,
+            route = MoreRoutes.POINTS_STATEMENT,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.ACCOUNT,
+        ),
+        MoreEntry(
             id = "affiliates",
             labelRes = R.string.more_entry_affiliates,
             icon = Icons.Outlined.Hub,

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsExpiryMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsExpiryMath.kt
@@ -1,0 +1,285 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.data.rewards.PointsExpiry
+import com.testlogon.android.data.rewards.PointsExpiryLot
+import com.testlogon.android.data.rewards.RewardsHistoryEntry
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * Pure, Android-free math + formatting for the POINTS STATEMENT + POINTS EXPIRY surface. Kept out of the
+ * ViewModel so the FIFO lot-consumption, expiry policy and running-balance projection are unit testable
+ * without Compose/Hilt. Points are integers throughout; timestamps are epoch millis (UTC for calendar
+ * math). Everything is total and guards the empty case (empty history -> empty result, never a throw).
+ *
+ * CANONICAL POLICY (mirrors web): points expire [EXPIRY_MONTHS] = 12 months after they are EARNED, and
+ * a lot is "expiring soon" when it expires within [EXPIRING_SOON_DAYS] = 60 days of now.
+ *
+ * EARN vs SPEND: a history entry with points > 0 is an EARN (opens a FIFO lot); points < 0 is a SPEND
+ * (redeem / expire / adjust) that consumes the OLDEST open lots first. Remaining (unspent) lots expire
+ * at earnedTs + [EXPIRY_MONTHS]; a lot already past its expiry as of nowMs is dropped from the
+ * upcoming-expirations view (its points are treated as already gone).
+ */
+object PointsExpiryMath {
+
+    /** Points expire this many months after they are earned. Canonical policy (mirrors web). */
+    const val EXPIRY_MONTHS: Int = 12
+
+    /** A lot is "expiring soon" when it expires within this many days of now. Canonical policy. */
+    const val EXPIRING_SOON_DAYS: Int = 60
+
+    private const val DAY_MS: Long = 24L * 60L * 60L * 1000L
+
+    // ---- Calendar ----
+
+    /**
+     * Add [months] calendar months to the UTC instant [ms], clamping the day-of-month (e.g. Jan 31 + 1mo
+     * -> Feb 28/29). Pure + deterministic (fixed UTC zone) so expiry dates are stable across devices.
+     */
+    fun addMonths(ms: Long, months: Int): Long {
+        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        cal.timeInMillis = ms
+        cal.add(Calendar.MONTH, months)
+        return cal.timeInMillis
+    }
+
+    // ---- FIFO expiry computation ----
+
+    /**
+     * An open (unspent) earn lot: [pointsRemaining] of the original earn still live, expiring at
+     * [expiresTs] (= earnedTs + policyMonths). Sorted oldest-earned first by the computation.
+     */
+    data class Lot(val earnedTs: Long, val pointsRemaining: Long, val expiresTs: Long) {
+        fun toDomain(): PointsExpiryLot = PointsExpiryLot(earnedTs, pointsRemaining, expiresTs)
+    }
+
+    /** The client-computed expiry picture: still-live lots + the expiring-soon total + the next expiry. */
+    data class Expiry(
+        val policyMonths: Int,
+        val lots: List<Lot>,
+        val expiringSoonPoints: Long,
+        val nextExpiryTs: Long,
+        val nextExpiryPoints: Long,
+    ) {
+        val livePoints: Long get() = lots.sumOf { it.pointsRemaining }
+    }
+
+    /**
+     * Compute the FIFO expiry picture from the rewards [entries] as of [nowMs]. Earn entries (points > 0)
+     * open lots in chronological order; spend entries (points < 0) consume the OLDEST open lots first.
+     * Each surviving lot expires at earnedTs + [policyMonths] months; lots whose expiry is at/before
+     * [nowMs] are dropped (already expired). Returns the still-live lots (sorted by expiry, soonest
+     * first), the total points expiring within [EXPIRING_SOON_DAYS], and the very next expiry (ts+points).
+     */
+    fun computeExpiryFromHistory(
+        entries: List<RewardsHistoryEntry>,
+        nowMs: Long,
+        policyMonths: Int = EXPIRY_MONTHS,
+    ): Expiry {
+        val months = policyMonths.coerceAtLeast(0)
+        // Mutable FIFO queue of open earn lots (oldest earn first).
+        val open = ArrayDeque<Lot>()
+        // Process in chronological order (ties keep input order via a stable sort on ts).
+        val ordered = entries.sortedBy { it.ts }
+        for (e in ordered) {
+            val pts = e.points
+            when {
+                pts > 0L -> open.addLast(Lot(earnedTs = e.ts, pointsRemaining = pts, expiresTs = addMonths(e.ts, months)))
+                pts < 0L -> consume(open, -pts)
+                else -> Unit // zero-point activity (e.g. informational) never touches lots
+            }
+        }
+        // Drop already-expired lots; keep live ones sorted soonest-expiry first.
+        val live = open
+            .filter { it.pointsRemaining > 0L && it.expiresTs > nowMs }
+            .sortedWith(compareBy({ it.expiresTs }, { it.earnedTs }))
+
+        val soonCutoff = nowMs + EXPIRING_SOON_DAYS.toLong() * DAY_MS
+        val expiringSoon = live.filter { it.expiresTs <= soonCutoff }.sumOf { it.pointsRemaining }
+
+        // Next expiry = the group of lots sharing the soonest expiry ts (their points summed).
+        val soonestTs = live.firstOrNull()?.expiresTs ?: 0L
+        val nextPoints = if (soonestTs > 0L) live.filter { it.expiresTs == soonestTs }.sumOf { it.pointsRemaining } else 0L
+
+        return Expiry(
+            policyMonths = months,
+            lots = live,
+            expiringSoonPoints = expiringSoon,
+            nextExpiryTs = soonestTs,
+            nextExpiryPoints = nextPoints,
+        )
+    }
+
+    /** Consume [amount] points from the oldest open lots first (FIFO), mutating the queue in place. */
+    private fun consume(open: ArrayDeque<Lot>, amount: Long) {
+        var remaining = amount
+        while (remaining > 0L && open.isNotEmpty()) {
+            val head = open.first()
+            if (head.pointsRemaining <= remaining) {
+                remaining -= head.pointsRemaining
+                open.removeFirst()
+            } else {
+                open[0] = head.copy(pointsRemaining = head.pointsRemaining - remaining)
+                remaining = 0L
+            }
+        }
+        // If remaining > 0 the spend exceeds tracked earns (thin/partial history): nothing left to consume.
+    }
+
+    // ---- Statement (running balance) ----
+
+    /**
+     * One row of the points statement: an activity entry with the [runningBalance] AFTER it is applied.
+     * [delta] is the signed points change; [balanceBefore] is the running total before this entry.
+     */
+    data class StatementRow(
+        val ts: Long,
+        val type: String,
+        val description: String,
+        val delta: Long,
+        val balanceBefore: Long,
+        val runningBalance: Long,
+    )
+
+    /**
+     * Project the running-balance statement from [entries]. Rows are returned NEWEST FIRST (most recent
+     * activity on top) but the running balance is accumulated in chronological order so each row's
+     * [runningBalance] is the true balance as of that entry. Empty history -> empty list.
+     */
+    fun statementRows(entries: List<RewardsHistoryEntry>): List<StatementRow> {
+        if (entries.isEmpty()) return emptyList()
+        val ordered = entries.sortedBy { it.ts }
+        var balance = 0L
+        val chrono = ArrayList<StatementRow>(ordered.size)
+        for (e in ordered) {
+            val before = balance
+            balance += e.points
+            chrono.add(
+                StatementRow(
+                    ts = e.ts,
+                    type = e.type,
+                    description = e.description,
+                    delta = e.points,
+                    balanceBefore = before,
+                    runningBalance = balance,
+                )
+            )
+        }
+        return chrono.asReversed()
+    }
+
+    // ---- Period filter ----
+
+    /** Statement period filter for the surface. Pure UTC-year/month boundaries so it is testable. */
+    enum class StatementPeriod { ALL, THIS_YEAR, THIS_MONTH }
+
+    /**
+     * Filter statement [rows] to the [period] relative to [nowMs] (UTC). ALL returns everything; THIS_YEAR
+     * keeps rows whose ts is in the same UTC calendar year as now; THIS_MONTH keeps the same UTC year+month.
+     * Rows with a non-positive ts are only kept under ALL (undated activity can't be placed in a period).
+     */
+    fun filterByPeriod(rows: List<StatementRow>, period: StatementPeriod, nowMs: Long): List<StatementRow> {
+        if (period == StatementPeriod.ALL) return rows
+        val (nowYear, nowMonth) = yearMonthUtc(nowMs)
+        return rows.filter { r ->
+            if (r.ts <= 0L) return@filter false
+            val (y, m) = yearMonthUtc(r.ts)
+            when (period) {
+                StatementPeriod.THIS_YEAR -> y == nowYear
+                StatementPeriod.THIS_MONTH -> y == nowYear && m == nowMonth
+                StatementPeriod.ALL -> true
+            }
+        }
+    }
+
+    private fun yearMonthUtc(ms: Long): Pair<Int, Int> {
+        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        cal.timeInMillis = ms
+        return cal.get(Calendar.YEAR) to (cal.get(Calendar.MONTH) + 1)
+    }
+
+    // ---- CSV export ----
+
+    /**
+     * Build a CSV of the statement [rows] (already period-filtered by the caller, newest first). Header:
+     * date,type,description,points,running_balance. Descriptions are quoted + inner quotes doubled so a
+     * comma/quote never breaks a column. Empty rows -> header only (an honest empty export, never a throw).
+     */
+    fun expiryToCsv(rows: List<StatementRow>): String {
+        val sb = StringBuilder()
+        sb.append("date,type,description,points,running_balance\n")
+        for (r in rows) {
+            sb.append(formatDateUtc(r.ts)).append(',')
+            sb.append(csvField(r.type)).append(',')
+            sb.append(csvField(r.description)).append(',')
+            sb.append(signed(r.delta)).append(',')
+            sb.append(r.runningBalance).append('\n')
+        }
+        return sb.toString()
+    }
+
+    private fun csvField(raw: String): String {
+        val v = raw.replace("\"", "\"\"")
+        return "\"" + v + "\""
+    }
+
+    // ---- Formatting ----
+
+    /** Signed integer points ("+250" / "-100" / "0"). */
+    fun signed(points: Long): String = if (points > 0L) "+$points" else points.toString()
+
+    /** Signed grouped points for the UI ("+1,250 pts" / "-100 pts"). Reuses RewardsMath grouping. */
+    fun signedPointsLabel(points: Long): String {
+        val sign = if (points > 0L) "+" else if (points < 0L) "-" else ""
+        return sign + RewardsMath.formatPoints(kotlin.math.abs(points))
+    }
+
+    /** Format an epoch-millis instant as an ISO date (UTC), "yyyy-MM-dd". Empty for a non-positive ts. */
+    fun formatDateUtc(ms: Long): String {
+        if (ms <= 0L) return ""
+        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        cal.timeInMillis = ms
+        val y = cal.get(Calendar.YEAR)
+        val mo = cal.get(Calendar.MONTH) + 1
+        val d = cal.get(Calendar.DAY_OF_MONTH)
+        return "%04d-%02d-%02d".format(y, mo, d)
+    }
+
+    /**
+     * Merge the OPTIONAL authoritative [PointsExpiry] with the client [Expiry] computation. When the
+     * authoritative read is available AND non-empty it wins (server is the source of truth); otherwise
+     * the client computation is used and [Resolved.estimated] is true so the UI can badge "Est.".
+     */
+    data class Resolved(
+        val policyMonths: Int,
+        val lots: List<PointsExpiryLot>,
+        val expiringSoonPoints: Long,
+        val nextExpiryTs: Long,
+        val nextExpiryPoints: Long,
+        val estimated: Boolean,
+    )
+
+    fun resolve(authoritative: PointsExpiry?, client: Expiry): Resolved {
+        val useAuthoritative = authoritative != null && authoritative.available &&
+            (authoritative.lots.isNotEmpty() || authoritative.expiringSoonPoints > 0L || authoritative.nextExpiryPoints > 0L)
+        return if (useAuthoritative && authoritative != null) {
+            Resolved(
+                policyMonths = if (authoritative.policyMonths > 0) authoritative.policyMonths else EXPIRY_MONTHS,
+                lots = authoritative.lots,
+                expiringSoonPoints = authoritative.expiringSoonPoints,
+                nextExpiryTs = authoritative.nextExpiryTs,
+                nextExpiryPoints = authoritative.nextExpiryPoints,
+                estimated = false,
+            )
+        } else {
+            Resolved(
+                policyMonths = client.policyMonths,
+                lots = client.lots.map { it.toDomain() },
+                expiringSoonPoints = client.expiringSoonPoints,
+                nextExpiryTs = client.nextExpiryTs,
+                nextExpiryPoints = client.nextExpiryPoints,
+                estimated = true,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementScreen.kt
@@ -1,0 +1,364 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.rewards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.rewards.PointsExpiryLot
+
+/** Stable testTags for the Points statement / expiry screen. */
+object PointsStatementTestTags {
+    const val SCREEN = "points_statement_screen"
+    const val CONTENT = "points_statement_content"
+    const val LOADING = "points_statement_loading"
+    const val ERROR = "points_statement_error"
+    const val COMING_SOON = "points_statement_coming_soon"
+    const val EMPTY = "points_statement_empty"
+    const val EXPIRY_BANNER = "points_statement_expiry_banner"
+    const val SHARE = "points_statement_share"
+    const val COPY = "points_statement_copy"
+    const val PERIOD_PREFIX = "points_statement_period_"
+}
+
+/** Route-level Points statement entry (reached from the Rewards screen / More -> Growth hub). */
+@Composable
+fun PointsStatementRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PointsStatementViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PointsStatementScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onPeriod = viewModel::onPeriodChanged,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PointsStatementScreen(
+    state: PointsStatementUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onPeriod: (PointsExpiryMath.StatementPeriod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    Scaffold(
+        modifier = modifier.fillMaxSize().testTag(PointsStatementTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Points statement") },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("points_statement_back")) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (state.hasRows) {
+                        IconButton(
+                            onClick = { sharePointsStatementCsv(context, state.csv, state.csvName) },
+                            modifier = Modifier.testTag(PointsStatementTestTags.SHARE),
+                        ) {
+                            Icon(Icons.Filled.Share, contentDescription = "Share CSV")
+                        }
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+            when {
+                state.loading -> LoadingState(modifier = Modifier.testTag(PointsStatementTestTags.LOADING))
+
+                state.offline -> ErrorState(
+                    message = state.errorMessage ?: "Couldn't load your points.",
+                    onRetry = onRetry,
+                    modifier = Modifier.testTag(PointsStatementTestTags.ERROR),
+                )
+
+                !state.available -> EmptyState(
+                    title = "Points coming soon",
+                    body = "Earn points from referrals and activity, then track your balance, statement and upcoming expirations here. This lights up once rewards are enabled for your account.",
+                    modifier = Modifier.testTag(PointsStatementTestTags.COMING_SOON),
+                )
+
+                state.isEmpty -> EmptyState(
+                    title = "No points activity yet",
+                    body = "Once you earn or redeem points, your running-balance statement and upcoming expirations will appear here.",
+                    modifier = Modifier.testTag(PointsStatementTestTags.EMPTY),
+                )
+
+                else -> PointsStatementContent(
+                    state = state,
+                    onPeriod = onPeriod,
+                    onShare = { sharePointsStatementCsv(context, state.csv, state.csvName) },
+                    onCopy = { copyPointsStatementCsv(context, state.csv) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PointsStatementContent(
+    state: PointsStatementUiState,
+    onPeriod: (PointsExpiryMath.StatementPeriod) -> Unit,
+    onShare: () -> Unit,
+    onCopy: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .testTag(PointsStatementTestTags.CONTENT)
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        BalanceCard(state)
+        if (state.hasExpiringSoon) {
+            ExpiringSoonBanner(state)
+        }
+        ExpiryPolicyCard(state)
+        StatementCard(state, onPeriod = onPeriod, onShare = onShare, onCopy = onCopy)
+        if (state.upcoming.isNotEmpty()) {
+            UpcomingExpirationsCard(state.upcoming, estimated = state.expiryEstimated)
+        }
+    }
+}
+
+@Composable
+private fun BalanceCard(state: PointsStatementUiState) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Points balance", style = MaterialTheme.typography.labelMedium)
+            Text(RewardsMath.formatPoints(state.points), style = MaterialTheme.typography.headlineMedium)
+            Text(
+                "Lifetime earned: ${RewardsMath.formatPoints(state.lifetimePoints)}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExpiringSoonBanner(state: PointsStatementUiState) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().testTag(PointsStatementTestTags.EXPIRY_BANNER),
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    "${RewardsMath.formatPoints(state.expiringSoonPoints)} expiring soon",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                if (state.expiryEstimated) {
+                    AssistChip(onClick = {}, label = { Text("Est.") })
+                }
+            }
+            Text(
+                "${RewardsMath.formatPoints(state.nextExpiryPoints)} expire on ${PointsExpiryMath.formatDateUtc(state.nextExpiryTs)}. Redeem them before then so you don't lose value.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExpiryPolicyCard(state: PointsStatementUiState) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("Expiry policy", style = MaterialTheme.typography.titleMedium)
+            Text(
+                "Points expire ${state.expiryPolicyMonths} months after they are earned. We warn you when points are within ${PointsExpiryMath.EXPIRING_SOON_DAYS} days of expiring.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.expiryEstimated) {
+                Text(
+                    "Expirations are estimated from your activity history until the server publishes an authoritative schedule.",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatementCard(
+    state: PointsStatementUiState,
+    onPeriod: (PointsExpiryMath.StatementPeriod) -> Unit,
+    onShare: () -> Unit,
+    onCopy: () -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text("Statement", style = MaterialTheme.typography.titleMedium)
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                PeriodChip("All", PointsExpiryMath.StatementPeriod.ALL, state.period, onPeriod)
+                PeriodChip("This year", PointsExpiryMath.StatementPeriod.THIS_YEAR, state.period, onPeriod)
+                PeriodChip("This month", PointsExpiryMath.StatementPeriod.THIS_MONTH, state.period, onPeriod)
+            }
+
+            if (!state.hasRows) {
+                Text(
+                    "No activity in this period.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                // Header row.
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Text("Date", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1.1f))
+                    Text("Activity", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1.6f))
+                    Text("Points", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(0.9f), textAlign = TextAlign.End)
+                    Text("Balance", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(0.9f), textAlign = TextAlign.End)
+                }
+                state.rows.forEachIndexed { i, r ->
+                    if (i > 0) Divider()
+                    StatementRowView(r)
+                }
+
+                Spacer(Modifier.height(4.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(
+                        onClick = onShare,
+                        modifier = Modifier.testTag(PointsStatementTestTags.SHARE + "_btn"),
+                    ) {
+                        Icon(Icons.Filled.Share, contentDescription = null, modifier = Modifier.height(18.dp))
+                        Spacer(Modifier.height(0.dp))
+                        Text("Share CSV")
+                    }
+                    OutlinedButton(
+                        onClick = onCopy,
+                        modifier = Modifier.testTag(PointsStatementTestTags.COPY),
+                    ) { Text("Copy CSV") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeriodChip(
+    label: String,
+    value: PointsExpiryMath.StatementPeriod,
+    selected: PointsExpiryMath.StatementPeriod,
+    onPeriod: (PointsExpiryMath.StatementPeriod) -> Unit,
+) {
+    FilterChip(
+        selected = value == selected,
+        onClick = { onPeriod(value) },
+        label = { Text(label) },
+        modifier = Modifier.testTag(PointsStatementTestTags.PERIOD_PREFIX + value.name),
+    )
+}
+
+@Composable
+private fun StatementRowView(r: PointsExpiryMath.StatementRow) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            PointsExpiryMath.formatDateUtc(r.ts).ifBlank { "—" },
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.weight(1.1f),
+        )
+        Text(r.description, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1.6f))
+        Text(
+            PointsExpiryMath.signedPointsLabel(r.delta),
+            style = MaterialTheme.typography.labelLarge,
+            color = if (r.delta < 0L) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(0.9f),
+        )
+        Text(
+            RewardsMath.groupThousands(r.runningBalance),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(0.9f),
+        )
+    }
+}
+
+@Composable
+private fun UpcomingExpirationsCard(upcoming: List<PointsExpiryLot>, estimated: Boolean) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Upcoming expirations", style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
+                if (estimated) AssistChip(onClick = {}, label = { Text("Est.") })
+            }
+            upcoming.forEachIndexed { i, lot ->
+                if (i > 0) Divider()
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "Expires ${PointsExpiryMath.formatDateUtc(lot.expiresTs)}",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Text(
+                            "Earned ${PointsExpiryMath.formatDateUtc(lot.earnedTs)}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Text(RewardsMath.formatPoints(lot.pointsRemaining), style = MaterialTheme.typography.labelLarge)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementShare.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementShare.kt
@@ -1,0 +1,77 @@
+package com.testlogon.android.feature.rewards
+
+import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
+
+/** Cap for the EXTRA_TEXT fast-path — larger exports are shared as a file stream only. */
+private const val STATEMENT_TEXT_MAX_CHARS = 8000
+
+/**
+ * Android side of the points-statement export: writes the built CSV [content] to a shareable cache file
+ * and hands it to the system share sheet via [Intent.ACTION_SEND] (mime text/csv), mirroring the
+ * Tax-report share path exactly. The file lives under cacheDir/attachments/ (an already-declared
+ * FileProvider cache-path root; res/xml/file_paths.xml is not edited). The authority is derived from the
+ * package name so it never drifts from the manifest. Everything is try/caught so a missing chooser /
+ * provider misconfig never crashes; a FileProvider failure falls back to a plain-text ACTION_SEND.
+ */
+fun sharePointsStatementCsv(context: Context, content: String, baseName: String) {
+    if (content.isEmpty()) return
+    try {
+        val dir = File(context.cacheDir, "attachments").apply { mkdirs() }
+        val file = File(dir, "$baseName.csv")
+        file.writeText(content)
+
+        val authority = context.packageName + ".fileprovider"
+        val uri = FileProvider.getUriForFile(context, authority, file)
+
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/csv"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            if (content.length < STATEMENT_TEXT_MAX_CHARS) {
+                putExtra(Intent.EXTRA_TEXT, content)
+            }
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        startChooser(context, send)
+    } catch (_: ActivityNotFoundException) {
+        // No share target available (e.g. a bare emulator): swallow so we never crash.
+    } catch (_: Exception) {
+        // Provider misconfig / IO error: fall back to plain-text sharing so the export still works.
+        sharePointsStatementText(context, content)
+    }
+}
+
+/** Plain-text ACTION_SEND fallback (no FileProvider) — used when the file grant path fails. */
+private fun sharePointsStatementText(context: Context, content: String) {
+    try {
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, content)
+        }
+        startChooser(context, send)
+    } catch (_: Exception) {
+        // Best-effort: never crash the screen.
+    }
+}
+
+private fun startChooser(context: Context, send: Intent) {
+    val chooser = Intent.createChooser(send, "Export points statement")
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(chooser)
+}
+
+/** Copy the statement CSV to the clipboard (best-effort; never crashes). */
+fun copyPointsStatementCsv(context: Context, content: String) {
+    if (content.isEmpty()) return
+    try {
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return
+        clipboard.setPrimaryClip(ClipData.newPlainText("points_statement", content))
+    } catch (_: Exception) {
+        // Best-effort: never crash the screen.
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementUiState.kt
@@ -1,0 +1,58 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.data.rewards.PointsExpiryLot
+import com.testlogon.android.data.rewards.RewardsHistoryEntry
+
+/**
+ * UI state for the POINTS STATEMENT + EXPIRY screen (feature/rewards). The screen shows the current
+ * points balance, an "expiring soon" banner (authoritative from GET me/rewards/expiry when present,
+ * else client-computed FIFO from the rewards history with an "Est." badge), the 12-month expiry-policy
+ * note, a running-balance statement table with a period filter + Share/Copy CSV, and the upcoming
+ * expirations list. Reads degrade-on-404 to an honest empty state; a transport failure is retryable.
+ */
+data class PointsStatementUiState(
+    val loading: Boolean = true,
+    /** False when the rewards balance read degraded (404 / undeployed) — the screen shows coming-soon. */
+    val available: Boolean = true,
+    /** Current points balance (server-authoritative from GET me/rewards). */
+    val points: Long = 0L,
+    /** Lifetime points earned (server-authoritative), shown as context. */
+    val lifetimePoints: Long = 0L,
+    /** The full history the statement + client expiry are computed from. */
+    val history: List<RewardsHistoryEntry> = emptyList(),
+    /** All statement rows (newest first), before the period filter. */
+    val allRows: List<PointsExpiryMath.StatementRow> = emptyList(),
+    /** The currently-selected statement period (All / This year / This month). */
+    val period: PointsExpiryMath.StatementPeriod = PointsExpiryMath.StatementPeriod.ALL,
+    /** The rows actually shown = [allRows] filtered by [period]. */
+    val rows: List<PointsExpiryMath.StatementRow> = emptyList(),
+    /** The resolved expiry picture (authoritative when present, else client estimate). */
+    val expiryPolicyMonths: Int = PointsExpiryMath.EXPIRY_MONTHS,
+    val expiringSoonPoints: Long = 0L,
+    val nextExpiryTs: Long = 0L,
+    val nextExpiryPoints: Long = 0L,
+    /** Upcoming per-lot expirations (soonest first). */
+    val upcoming: List<PointsExpiryLot> = emptyList(),
+    /** True when the expiry picture came from the CLIENT computation (badge "Est."), false when authoritative. */
+    val expiryEstimated: Boolean = true,
+    /** CSV for the currently-shown (period-filtered) statement, ready for the share sheet / clipboard. */
+    val csv: String = "",
+    val csvName: String = "points-statement",
+    val errorMessage: String? = null,
+    val offline: Boolean = false,
+) {
+    /** True when there is a non-zero expiring-soon total worth surfacing in the banner. */
+    val hasExpiringSoon: Boolean get() = expiringSoonPoints > 0L && nextExpiryTs > 0L
+
+    /** True when the shown statement has at least one row (post period filter). */
+    val hasRows: Boolean get() = rows.isNotEmpty()
+
+    /** Honest "nothing yet" state: available, not loading/offline, and no activity at all. */
+    val isEmpty: Boolean
+        get() = available && !loading && !offline && errorMessage == null && allRows.isEmpty()
+}
+
+/** One-shot side effects handled by the Route (never replayed on rotation). */
+sealed interface PointsStatementEffect {
+    data class CopyCsv(val text: String) : PointsStatementEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/PointsStatementViewModel.kt
@@ -1,0 +1,107 @@
+package com.testlogon.android.feature.rewards
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.rewards.PointsExpiry
+import com.testlogon.android.data.rewards.Rewards
+import com.testlogon.android.data.rewards.RewardsHistoryEntry
+import com.testlogon.android.data.rewards.RewardsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives [PointsStatementUiState] from [RewardsRepository]. Loads the points balance (GET me/rewards),
+ * the activity history (GET me/rewards/history) and the OPTIONAL authoritative expiry (GET
+ * me/rewards/expiry). The running-balance statement + the FIFO client-expiry are computed purely by
+ * [PointsExpiryMath]; the authoritative expiry (when deployed + non-empty) overrides the client estimate.
+ *
+ * Reads degrade-on-404 to an honest empty state; a transport failure is a retryable offline error. This
+ * screen is READ-ONLY — it never moves points/cash (redemption lives on the Rewards screen).
+ */
+@HiltViewModel
+class PointsStatementViewModel @Inject constructor(
+    private val repository: RewardsRepository,
+) : ViewModel() {
+
+    private fun now(): Long = System.currentTimeMillis()
+
+    private val _uiState = MutableStateFlow(PointsStatementUiState())
+    val uiState: StateFlow<PointsStatementUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    fun consumeMessages() = _uiState.update { it.copy(errorMessage = null) }
+
+    /** Change the statement period filter; re-projects rows + CSV purely (no network round-trip). */
+    fun onPeriodChanged(period: PointsExpiryMath.StatementPeriod) {
+        _uiState.update { s -> s.copy(period = period).withProjectedRows() }
+    }
+
+    fun load() {
+        _uiState.update { it.copy(loading = true, errorMessage = null, offline = false) }
+        viewModelScope.launch {
+            val now = now()
+            // Balance (drives available + points).
+            val rewards: Rewards = when (val r = repository.rewards()) {
+                is ApiResult.Success -> r.data
+                is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(loading = false, offline = true, errorMessage = "No connection. Pull to retry.") }
+                    return@launch
+                }
+                is ApiResult.Failure -> {
+                    _uiState.update { it.copy(loading = false, errorMessage = r.error.message.ifBlank { "Couldn't load your points." }) }
+                    return@launch
+                }
+            }
+
+            val history: List<RewardsHistoryEntry> = (repository.rewardsHistory() as? ApiResult.Success)?.data ?: emptyList()
+            val authoritative: PointsExpiry? = (repository.rewardsExpiry() as? ApiResult.Success)?.data
+
+            val client = PointsExpiryMath.computeExpiryFromHistory(history, now)
+            val resolved = PointsExpiryMath.resolve(authoritative, client)
+            val allRows = PointsExpiryMath.statementRows(history)
+
+            _uiState.update {
+                it.copy(
+                    loading = false,
+                    available = rewards.available,
+                    points = rewards.points,
+                    lifetimePoints = rewards.lifetimePoints,
+                    history = history,
+                    allRows = allRows,
+                    expiryPolicyMonths = resolved.policyMonths.takeIf { m -> m > 0 } ?: PointsExpiryMath.EXPIRY_MONTHS,
+                    expiringSoonPoints = resolved.expiringSoonPoints,
+                    nextExpiryTs = resolved.nextExpiryTs,
+                    nextExpiryPoints = resolved.nextExpiryPoints,
+                    upcoming = resolved.lots,
+                    expiryEstimated = resolved.estimated,
+                ).withProjectedRows()
+            }
+        }
+    }
+
+    /** Re-derive the shown rows + CSV from [allRows] + the current period. Pure; no network. */
+    private fun PointsStatementUiState.withProjectedRows(): PointsStatementUiState {
+        val filtered = PointsExpiryMath.filterByPeriod(allRows, period, now())
+        val suffix = when (period) {
+            PointsExpiryMath.StatementPeriod.ALL -> "all"
+            PointsExpiryMath.StatementPeriod.THIS_YEAR -> "this-year"
+            PointsExpiryMath.StatementPeriod.THIS_MONTH -> "this-month"
+        }
+        return copy(
+            rows = filtered,
+            csv = PointsExpiryMath.expiryToCsv(filtered),
+            csvName = "points-statement-$suffix",
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
@@ -78,6 +78,7 @@ fun RewardsRoute(
     onBack: () -> Unit,
     onOpenFeeTiers: () -> Unit = {},
     onOpenCash: () -> Unit = {},
+    onOpenStatement: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: RewardsViewModel = hiltViewModel(),
 ) {
@@ -99,6 +100,7 @@ fun RewardsRoute(
         onRedeem = viewModel::confirmRedeem,
         onOpenFeeTiers = onOpenFeeTiers,
         onOpenCash = onOpenCash,
+        onOpenStatement = onOpenStatement,
         onCashPointsChanged = viewModel::onCashPointsChanged,
         onCashPreset = viewModel::onCashPreset,
         onCashMax = viewModel::onCashMax,
@@ -116,6 +118,7 @@ fun RewardsScreen(
     onRedeem: (CatalogReward) -> Unit,
     onOpenFeeTiers: () -> Unit = {},
     onOpenCash: () -> Unit = {},
+    onOpenStatement: () -> Unit = {},
     onCashPointsChanged: (String) -> Unit = {},
     onCashPreset: (Long) -> Unit = {},
     onCashMax: () -> Unit = {},
@@ -163,6 +166,7 @@ fun RewardsScreen(
                     onRedeemClick = { pendingRedeem = it },
                     onOpenFeeTiers = onOpenFeeTiers,
                     onOpenCash = onOpenCash,
+                    onOpenStatement = onOpenStatement,
                     onCashPointsChanged = onCashPointsChanged,
                     onCashPreset = onCashPreset,
                     onCashMax = onCashMax,
@@ -245,6 +249,7 @@ private fun RewardsContent(
     onRedeemClick: (CatalogReward) -> Unit,
     onOpenFeeTiers: () -> Unit,
     onOpenCash: () -> Unit,
+    onOpenStatement: () -> Unit,
     onCashPointsChanged: (String) -> Unit,
     onCashPreset: (Long) -> Unit,
     onCashMax: () -> Unit,
@@ -259,6 +264,10 @@ private fun RewardsContent(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         BalanceCard(state)
+        OutlinedButton(
+            onClick = onOpenStatement,
+            modifier = Modifier.fillMaxWidth().testTag("rewards_open_statement"),
+        ) { Text("View statement & expiry") }
         ConvertToCashCard(
             state = state,
             onOpenCash = onOpenCash,

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -212,6 +212,9 @@ object MoreRoutes {
     const val REFERRAL_HUB = ReferralHubDest.ROUTE
     const val REWARDS = RewardsDest.ROUTE
 
+    // Points statement + expiry (feature/rewards): running-balance ledger + 12-month expiry warnings.
+    const val POINTS_STATEMENT = PointsStatementDest.ROUTE
+
     // Referral leaderboard (feature/rewards): GET me/referral/leaderboard. Sub-nav from the Refer & earn hub.
     const val REFERRAL_LEADERBOARD = ReferralLeaderboardDest.ROUTE
 
@@ -664,6 +667,7 @@ object MoreRoutes {
             REFERRALS,
             REFERRAL_HUB,
             REWARDS,
+            POINTS_STATEMENT,
             REFERRAL_LEADERBOARD,
             ALERTS,
             MY_CONTENT_REVIEW,

--- a/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/RewardsNavigation.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.testlogon.android.feature.rewards.ReferralHubRoute
+import com.testlogon.android.feature.rewards.PointsStatementRoute
 import com.testlogon.android.feature.rewards.ReferralLeaderboardRoute
 import com.testlogon.android.feature.rewards.RewardsRoute
 
@@ -21,6 +22,10 @@ data object ReferralHubDest {
 
 data object RewardsDest {
     const val ROUTE = "rewards"
+}
+
+data object PointsStatementDest {
+    const val ROUTE = "points_statement"
 }
 
 data object ReferralLeaderboardDest {
@@ -43,6 +48,10 @@ fun NavGraphBuilder.rewardsDestinations(navController: NavHostController) {
             onBack = { navController.popBackStack() },
             onOpenFeeTiers = { navController.navigate(FeeTiersDest.ROUTE) },
             onOpenCash = { navController.navigate(CashDest.ROUTE) },
+            onOpenStatement = { navController.navigate(PointsStatementDest.ROUTE) },
         )
+    }
+    composable(PointsStatementDest.ROUTE) {
+        PointsStatementRoute(onBack = { navController.popBackStack() })
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2337,6 +2337,7 @@
     <string name="more_entry_referral_hub">Refer &amp; earn</string>
 
     <string name="more_entry_rewards">Rewards</string>
+    <string name="more_entry_points_statement">Points statement</string>
     <string name="more_entry_affiliates">Affiliates</string>
     <string name="more_entry_promo_codes">Promo codes</string>
     <string name="more_entry_discounts">Affiliate discounts</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/rewards/PointsExpiryMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/rewards/PointsExpiryMathTest.kt
@@ -1,0 +1,240 @@
+package com.testlogon.android.feature.rewards
+
+import com.testlogon.android.data.rewards.PointsExpiry
+import com.testlogon.android.data.rewards.PointsExpiryLot
+import com.testlogon.android.data.rewards.RewardsHistoryEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * Pure math for the POINTS STATEMENT + POINTS EXPIRY surface: 12-month FIFO expiry, expiring-soon (60d),
+ * running-balance statement rows, period filter, CSV export, and the authoritative/client resolve. No
+ * Android / Compose / Hilt. All timestamps are epoch millis (UTC).
+ */
+class PointsExpiryMathTest {
+
+    private fun utc(year: Int, month1: Int, day: Int): Long {
+        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        cal.clear()
+        cal.set(year, month1 - 1, day, 0, 0, 0)
+        return cal.timeInMillis
+    }
+
+    private fun entry(ts: Long, points: Long, type: String = "", desc: String = "activity") =
+        RewardsHistoryEntry(ts = ts, type = type, description = desc, points = points, cashCents = 0L, status = "")
+
+    // ---- policy constants ----
+
+    @Test
+    fun policyConstants_matchWebCanon() {
+        assertEquals(12, PointsExpiryMath.EXPIRY_MONTHS)
+        assertEquals(60, PointsExpiryMath.EXPIRING_SOON_DAYS)
+    }
+
+    // ---- addMonths ----
+
+    @Test
+    fun addMonths_advancesTwelveMonths() {
+        val start = utc(2025, 3, 15)
+        val plus12 = PointsExpiryMath.addMonths(start, 12)
+        assertEquals("2026-03-15", PointsExpiryMath.formatDateUtc(plus12))
+    }
+
+    @Test
+    fun addMonths_clampsEndOfMonth() {
+        // Jan 31 + 1 month -> Feb 28 (2025 not a leap year).
+        val jan31 = utc(2025, 1, 31)
+        val feb = PointsExpiryMath.addMonths(jan31, 1)
+        assertEquals("2025-02-28", PointsExpiryMath.formatDateUtc(feb))
+    }
+
+    // ---- computeExpiryFromHistory ----
+
+    @Test
+    fun compute_emptyHistory_isEmpty() {
+        val r = PointsExpiryMath.computeExpiryFromHistory(emptyList(), utc(2025, 6, 1))
+        assertTrue(r.lots.isEmpty())
+        assertEquals(0L, r.expiringSoonPoints)
+        assertEquals(0L, r.nextExpiryPoints)
+        assertEquals(0L, r.livePoints)
+    }
+
+    @Test
+    fun compute_singleEarn_expiresTwelveMonthsLater() {
+        val earn = utc(2025, 1, 10)
+        val r = PointsExpiryMath.computeExpiryFromHistory(listOf(entry(earn, 500L)), utc(2025, 2, 1))
+        assertEquals(1, r.lots.size)
+        assertEquals(500L, r.lots.first().pointsRemaining)
+        assertEquals("2026-01-10", PointsExpiryMath.formatDateUtc(r.lots.first().expiresTs))
+        assertEquals(500L, r.livePoints)
+    }
+
+    @Test
+    fun compute_fifo_consumesOldestFirst() {
+        // Earn 100 (Jan), earn 200 (Mar), redeem 150 -> oldest lot (100) fully gone, second lot -> 150 left.
+        val entries = listOf(
+            entry(utc(2025, 1, 1), 100L),
+            entry(utc(2025, 3, 1), 200L),
+            entry(utc(2025, 4, 1), -150L, type = "redeem"),
+        )
+        val r = PointsExpiryMath.computeExpiryFromHistory(entries, utc(2025, 5, 1))
+        assertEquals(1, r.lots.size)
+        assertEquals(150L, r.lots.first().pointsRemaining)
+        assertEquals(150L, r.livePoints)
+        // The surviving lot is the March earn -> expires 2026-03-01.
+        assertEquals("2026-03-01", PointsExpiryMath.formatDateUtc(r.lots.first().expiresTs))
+    }
+
+    @Test
+    fun compute_dropsAlreadyExpiredLots() {
+        // Earn Jan 2024 -> expires Jan 2025. As of Jun 2025 it is already expired and must be dropped.
+        val entries = listOf(
+            entry(utc(2024, 1, 1), 300L),
+            entry(utc(2025, 5, 1), 200L),
+        )
+        val r = PointsExpiryMath.computeExpiryFromHistory(entries, utc(2025, 6, 1))
+        assertEquals(1, r.lots.size)
+        assertEquals(200L, r.lots.first().pointsRemaining)
+    }
+
+    @Test
+    fun compute_expiringSoon_within60Days() {
+        // Earn on 2024-07-01 -> expires 2025-07-01. As of 2025-06-01 that is 30 days out -> expiring soon.
+        val soon = entry(utc(2024, 7, 1), 400L)
+        // Earn on 2024-10-01 -> expires 2025-10-01, ~120 days out -> NOT soon.
+        val later = entry(utc(2024, 10, 1), 600L)
+        val r = PointsExpiryMath.computeExpiryFromHistory(listOf(soon, later), utc(2025, 6, 1))
+        assertEquals(400L, r.expiringSoonPoints)
+        // Next expiry is the soonest (2025-07-01, 400 pts).
+        assertEquals(400L, r.nextExpiryPoints)
+        assertEquals("2025-07-01", PointsExpiryMath.formatDateUtc(r.nextExpiryTs))
+    }
+
+    @Test
+    fun compute_redeemBeyondEarns_leavesNothing() {
+        val entries = listOf(
+            entry(utc(2025, 1, 1), 100L),
+            entry(utc(2025, 2, 1), -500L, type = "redeem"),
+        )
+        val r = PointsExpiryMath.computeExpiryFromHistory(entries, utc(2025, 3, 1))
+        assertTrue(r.lots.isEmpty())
+        assertEquals(0L, r.livePoints)
+    }
+
+    @Test
+    fun compute_zeroPointEntry_isIgnored() {
+        val entries = listOf(
+            entry(utc(2025, 1, 1), 0L, desc = "informational"),
+            entry(utc(2025, 2, 1), 250L),
+        )
+        val r = PointsExpiryMath.computeExpiryFromHistory(entries, utc(2025, 3, 1))
+        assertEquals(1, r.lots.size)
+        assertEquals(250L, r.lots.first().pointsRemaining)
+    }
+
+    // ---- statementRows ----
+
+    @Test
+    fun statementRows_runningBalance_newestFirst() {
+        val entries = listOf(
+            entry(utc(2025, 1, 1), 100L),
+            entry(utc(2025, 2, 1), 50L),
+            entry(utc(2025, 3, 1), -30L),
+        )
+        val rows = PointsExpiryMath.statementRows(entries)
+        assertEquals(3, rows.size)
+        // Newest first.
+        assertEquals(utc(2025, 3, 1), rows[0].ts)
+        // Running balances: 100, 150, 120 chronologically; newest row shows 120.
+        assertEquals(120L, rows[0].runningBalance)
+        assertEquals(150L, rows[0].balanceBefore)
+        assertEquals(100L, rows[2].runningBalance)
+    }
+
+    @Test
+    fun statementRows_empty_isEmpty() {
+        assertTrue(PointsExpiryMath.statementRows(emptyList()).isEmpty())
+    }
+
+    // ---- period filter ----
+
+    @Test
+    fun filterByPeriod_thisYearAndMonth() {
+        val entries = listOf(
+            entry(utc(2024, 12, 1), 10L),
+            entry(utc(2025, 5, 1), 20L),
+            entry(utc(2025, 6, 15), 30L),
+        )
+        val rows = PointsExpiryMath.statementRows(entries)
+        val now = utc(2025, 6, 20)
+        assertEquals(3, PointsExpiryMath.filterByPeriod(rows, PointsExpiryMath.StatementPeriod.ALL, now).size)
+        assertEquals(2, PointsExpiryMath.filterByPeriod(rows, PointsExpiryMath.StatementPeriod.THIS_YEAR, now).size)
+        assertEquals(1, PointsExpiryMath.filterByPeriod(rows, PointsExpiryMath.StatementPeriod.THIS_MONTH, now).size)
+    }
+
+    // ---- CSV ----
+
+    @Test
+    fun expiryToCsv_headerAndRows_quotedFields() {
+        val entries = listOf(entry(utc(2025, 1, 5), 100L, type = "earn", desc = "Referral, bonus"))
+        val rows = PointsExpiryMath.statementRows(entries)
+        val csv = PointsExpiryMath.expiryToCsv(rows)
+        assertTrue(csv.startsWith("date,type,description,points,running_balance\n"))
+        assertTrue(csv.contains("2025-01-05"))
+        // Comma inside description must be quoted so columns are preserved.
+        assertTrue(csv.contains("\"Referral, bonus\""))
+        assertTrue(csv.contains("+100"))
+    }
+
+    @Test
+    fun expiryToCsv_empty_headerOnly() {
+        val csv = PointsExpiryMath.expiryToCsv(emptyList())
+        assertEquals("date,type,description,points,running_balance\n", csv)
+    }
+
+    // ---- formatting ----
+
+    @Test
+    fun signed_andSignedLabel() {
+        assertEquals("+250", PointsExpiryMath.signed(250L))
+        assertEquals("-100", PointsExpiryMath.signed(-100L))
+        assertEquals("0", PointsExpiryMath.signed(0L))
+        assertEquals("+1,250 pts", PointsExpiryMath.signedPointsLabel(1250L))
+        assertEquals("-100 pts", PointsExpiryMath.signedPointsLabel(-100L))
+    }
+
+    // ---- resolve (authoritative vs client) ----
+
+    @Test
+    fun resolve_prefersAuthoritativeWhenPresent() {
+        val client = PointsExpiryMath.computeExpiryFromHistory(
+            listOf(entry(utc(2024, 7, 1), 400L)), utc(2025, 6, 1),
+        )
+        val authoritative = PointsExpiry(
+            policyMonths = 12,
+            expiringSoonPoints = 999L,
+            nextExpiryTs = utc(2025, 12, 1),
+            nextExpiryPoints = 999L,
+            lots = listOf(PointsExpiryLot(earnedTs = utc(2024, 12, 1), pointsRemaining = 999L, expiresTs = utc(2025, 12, 1))),
+            available = true,
+        )
+        val resolved = PointsExpiryMath.resolve(authoritative, client)
+        assertFalse(resolved.estimated)
+        assertEquals(999L, resolved.expiringSoonPoints)
+    }
+
+    @Test
+    fun resolve_fallsBackToClientWhenUnavailable() {
+        val client = PointsExpiryMath.computeExpiryFromHistory(
+            listOf(entry(utc(2024, 7, 1), 400L)), utc(2025, 6, 1),
+        )
+        val resolved = PointsExpiryMath.resolve(PointsExpiry.unavailable(), client)
+        assertTrue(resolved.estimated)
+        assertEquals(400L, resolved.expiringSoonPoints)
+        assertEquals(1, resolved.lots.size)
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,6 +182,7 @@ const ReferralDashboard = lazy(() => import("@/pages/referrals/ReferralDashboard
 const RewardsPage = lazy(() => import("@/pages/rewards/RewardsPage"));
 const RewardsReferralsPage = lazy(() => import("@/pages/rewards/ReferralsPage"));
 const RewardsLeaderboardPage = lazy(() => import("@/pages/rewards/LeaderboardPage"));
+const RewardsStatementPage = lazy(() => import("@/pages/rewards/RewardsStatementPage"));
 const PromoCodesPage = lazy(() => import("@/pages/promo/PromoCodesPage"));
 const SchedulerPage = lazy(() => import("@/pages/scheduler/SchedulerPage"));
 const RefundRequestsPage = lazy(() => import("@/pages/billing/RefundRequestsPage"));
@@ -875,6 +876,7 @@ export default function App() {
           <Route path="rewards" element={<RewardsPage />} />
           <Route path="rewards/referrals" element={<RewardsReferralsPage />} />
           <Route path="rewards/leaderboard" element={<RewardsLeaderboardPage />} />
+          <Route path="rewards/statement" element={<RewardsStatementPage />} />
           <Route path="promo" element={<PromoCodesPage />} />
           <Route path="affiliates" element={<AffiliateDashboard />} />
           <Route path="achievements" element={<AchievementsPage />} />

--- a/frontend/src/api/endpoints/rewards.ts
+++ b/frontend/src/api/endpoints/rewards.ts
@@ -125,6 +125,35 @@ export interface ReferralLeaderboard {
 }
 
 
+
+
+// ── Rewards points expiry (optional authoritative — degrade on 404) ──
+
+/**
+ * One earn "lot" of points with its remaining balance and expiry date. Points
+ * expire `policy_months` after they were earned; lots are consumed FIFO
+ * (oldest-earned first) by redemptions/expirations.
+ */
+export interface RewardsExpiryLot {
+  earned_ts: number;
+  points_remaining: number;
+  expires_ts: number;
+}
+
+/**
+ * Authoritative points-EXPIRY read. Degrades on 404 -> the frontend computes
+ * the same view client-side (FIFO) from the rewards history (see
+ * `lib/pointsExpiry`). All timestamps are UNIX seconds; points are integers.
+ */
+export interface RewardsExpiry {
+  policy_months: number;
+  expiring_soon_points: number;
+  next_expiry_ts: number | null;
+  next_expiry_points: number;
+  lots: RewardsExpiryLot[];
+}
+
+
 // ── Trading rewards (points earned by trading volume — NEW) ──────
 
 /**
@@ -161,6 +190,9 @@ export const getRewardsCatalog = () =>
 
 export const getTradingRewards = () =>
   api.get<TradingRewards>("/me/rewards/trading");
+
+export const getRewardsExpiry = () =>
+  api.get<RewardsExpiry>("/me/rewards/expiry");
 
 export const getReferralLeaderboard = (period: LeaderboardPeriod = "all") =>
   api.get<ReferralLeaderboard>(`/me/referral/leaderboard?period=${period}`);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -199,6 +199,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Rewards", i18nKey: "nav.rewards", path: "/rewards", icon: <Award className="h-5 w-5" /> },
       { label: "Refer & Earn", i18nKey: "nav.referAndEarn", path: "/rewards/referrals", icon: <Users className="h-5 w-5" /> },
       { label: "Referral Leaderboard", i18nKey: "nav.referralLeaderboard", path: "/rewards/leaderboard", icon: <Trophy className="h-5 w-5" /> },
+      { label: "Points Statement", i18nKey: "nav.pointsStatement", path: "/rewards/statement", icon: <ScrollText className="h-5 w-5" /> },
       { label: "Promo Codes", i18nKey: "nav.promoCodes", path: "/promo", icon: <Tag className="h-5 w-5" /> },
       { label: "Affiliates", i18nKey: "nav.affiliates", path: "/affiliates", icon: <Link2 className="h-5 w-5" /> },
       { label: "Collaborations", i18nKey: "nav.collaborations", path: "/collaborations", icon: <Handshake className="h-5 w-5" /> },

--- a/frontend/src/lib/pointsExpiry.test.ts
+++ b/frontend/src/lib/pointsExpiry.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import type { RewardHistoryEntry } from "@/api/endpoints/rewards";
+import { toCsv } from "@/lib/exportReport";
+import {
+  EXPIRING_SOON_DAYS,
+  EXPIRY_MONTHS,
+  addMonths,
+  computeExpiryFromHistory,
+  daysUntil,
+  expiryToCsv,
+  formatExpiryDate,
+  statementRows,
+  tsToMs,
+} from "@/lib/pointsExpiry";
+
+const DAY = 86_400_000;
+
+/** UNIX seconds for a UTC date. */
+function secs(y: number, m: number, d: number): number {
+  return Math.floor(Date.UTC(y, m - 1, d) / 1000);
+}
+
+function entry(part: Partial<RewardHistoryEntry> & { ts: number; points: number }): RewardHistoryEntry {
+  return {
+    ts: part.ts,
+    type: part.type ?? "earn",
+    description: part.description ?? "",
+    points: part.points,
+    cash_cents: part.cash_cents ?? 0,
+    status: part.status ?? "posted",
+  };
+}
+
+describe("policy constants", () => {
+  it("matches the canonical shared-with-Android policy", () => {
+    expect(EXPIRY_MONTHS).toBe(12);
+    expect(EXPIRING_SOON_DAYS).toBe(60);
+  });
+});
+
+describe("tsToMs", () => {
+  it("scales seconds to ms and passes ms through", () => {
+    expect(tsToMs(1_700_000_000)).toBe(1_700_000_000_000);
+    expect(tsToMs(1_700_000_000_000)).toBe(1_700_000_000_000);
+  });
+  it("returns NaN for garbage", () => {
+    expect(Number.isNaN(tsToMs(null))).toBe(true);
+    expect(Number.isNaN(tsToMs(undefined))).toBe(true);
+  });
+});
+
+describe("addMonths", () => {
+  it("adds whole months", () => {
+    const jan = Date.UTC(2026, 0, 15);
+    expect(addMonths(jan, 12)).toBe(Date.UTC(2027, 0, 15));
+  });
+  it("clamps day-of-month at end-of-month (Jan 31 + 1mo -> Feb 28)", () => {
+    const jan31 = Date.UTC(2026, 0, 31);
+    expect(addMonths(jan31, 1)).toBe(Date.UTC(2026, 1, 28));
+  });
+  it("returns NaN for garbage input", () => {
+    expect(Number.isNaN(addMonths(Number.NaN, 12))).toBe(true);
+  });
+});
+
+describe("computeExpiryFromHistory", () => {
+  it("guards empty / garbage input", () => {
+    const now = Date.UTC(2026, 5, 1);
+    expect(computeExpiryFromHistory([], now)).toEqual({
+      lots: [],
+      expiringSoonPoints: 0,
+      nextExpiryTs: null,
+      nextExpiryPoints: 0,
+    });
+    expect(computeExpiryFromHistory(null, now).lots).toEqual([]);
+    expect(computeExpiryFromHistory([entry({ ts: secs(2026, 1, 1), points: 100 })], Number.NaN).lots).toEqual([]);
+  });
+
+  it("keeps a single un-touched earn lot with a +12mo expiry", () => {
+    const earned = secs(2026, 1, 10);
+    const now = Date.UTC(2026, 2, 1); // Mar 1 2026
+    const r = computeExpiryFromHistory([entry({ ts: earned, points: 500 })], now);
+    expect(r.lots).toHaveLength(1);
+    expect(r.lots[0]!.remaining).toBe(500);
+    expect(r.lots[0]!.expiresTs).toBe(addMonths(earned * 1000, EXPIRY_MONTHS));
+    expect(r.nextExpiryPoints).toBe(500);
+    expect(r.nextExpiryTs).toBe(r.lots[0]!.expiresTs);
+  });
+
+  it("consumes lots FIFO (oldest earned first)", () => {
+    const e1 = secs(2026, 1, 1);
+    const e2 = secs(2026, 3, 1);
+    const now = Date.UTC(2026, 3, 15);
+    const r = computeExpiryFromHistory(
+      [
+        entry({ ts: e1, points: 100 }),
+        entry({ ts: e2, points: 100 }),
+        entry({ ts: secs(2026, 3, 10), points: -120, type: "redeem" }),
+      ],
+      now,
+    );
+    // 120 consumed: all 100 from lot1, 20 from lot2 -> lot1 gone, lot2=80.
+    expect(r.lots).toHaveLength(1);
+    expect(r.lots[0]!.earnedTs).toBe(e2 * 1000);
+    expect(r.lots[0]!.remaining).toBe(80);
+  });
+
+  it("drops already-expired lots", () => {
+    const oldEarn = secs(2024, 1, 1); // expires Jan 2025
+    const now = Date.UTC(2026, 0, 1); // 2026 — past expiry
+    const r = computeExpiryFromHistory([entry({ ts: oldEarn, points: 300 })], now);
+    expect(r.lots).toEqual([]);
+    expect(r.nextExpiryTs).toBeNull();
+  });
+
+  it("flags points expiring within EXPIRING_SOON_DAYS", () => {
+    // earned so it expires ~30 days from now (within the 60-day window).
+    const now = Date.UTC(2026, 5, 1);
+    const expiresSoon = now + 30 * DAY;
+    const earnedForSoon = addMonths(expiresSoon, -EXPIRY_MONTHS);
+    const earnedForLater = addMonths(now + 200 * DAY, -EXPIRY_MONTHS);
+    const r = computeExpiryFromHistory(
+      [
+        entry({ ts: Math.floor(earnedForSoon / 1000), points: 40 }),
+        entry({ ts: Math.floor(earnedForLater / 1000), points: 90 }),
+      ],
+      now,
+    );
+    expect(r.expiringSoonPoints).toBe(40);
+    // soonest-first ordering
+    expect(r.lots[0]!.remaining).toBe(40);
+    expect(r.nextExpiryPoints).toBe(40);
+  });
+
+  it("ignores debits with nothing left to consume", () => {
+    const now = Date.UTC(2026, 5, 1);
+    const r = computeExpiryFromHistory(
+      [entry({ ts: secs(2026, 1, 1), points: -50, type: "redeem" })],
+      now,
+    );
+    expect(r.lots).toEqual([]);
+  });
+});
+
+describe("statementRows", () => {
+  it("returns [] for empty input", () => {
+    expect(statementRows([])).toEqual([]);
+    expect(statementRows(null)).toEqual([]);
+  });
+
+  it("orders ascending with a non-negative running balance", () => {
+    const rows = statementRows([
+      entry({ ts: secs(2026, 3, 1), points: -30, type: "redeem", description: "Redeem" }),
+      entry({ ts: secs(2026, 1, 1), points: 100, type: "earn", description: "Signup" }),
+      entry({ ts: secs(2026, 2, 1), points: 50, type: "earn" }),
+    ]);
+    expect(rows.map((r) => r.balanceAfter)).toEqual([100, 150, 120]);
+    expect(rows[0]!.description).toBe("Signup");
+  });
+
+  it("clamps the running balance at zero on over-redemption", () => {
+    const rows = statementRows([
+      entry({ ts: secs(2026, 1, 1), points: 10 }),
+      entry({ ts: secs(2026, 2, 1), points: -50, type: "redeem" }),
+    ]);
+    expect(rows[1]!.balanceAfter).toBe(0);
+  });
+});
+
+describe("expiryToCsv", () => {
+  it("emits a header + one row per statement row, with signed points", () => {
+    const rows = statementRows([
+      entry({ ts: secs(2026, 1, 1), points: 100, description: "Signup, welcome" }),
+      entry({ ts: secs(2026, 2, 1), points: -40, type: "redeem", cash_cents: 400 }),
+    ]);
+    const csv = expiryToCsv(rows, toCsv);
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("Date (ISO),Type,Description,Points,Cash,Status,Balance");
+    expect(lines).toHaveLength(3);
+    // signed points + running balance present
+    expect(lines[1]).toContain("+100");
+    expect(lines[1]).toContain("100"); // balance
+    expect(lines[2]).toContain("-40");
+    expect(lines[2]).toContain("4.00"); // cash dollars
+    // comma inside a description is RFC-4180 quoted
+    expect(lines[1]).toContain('"Signup, welcome"');
+  });
+
+  it("emits just a header for empty rows", () => {
+    expect(expiryToCsv([], toCsv)).toBe(
+      "Date (ISO),Type,Description,Points,Cash,Status,Balance",
+    );
+  });
+});
+
+describe("formatExpiryDate / daysUntil", () => {
+  it("formats null as an em dash", () => {
+    expect(formatExpiryDate(null)).toBe("—");
+    expect(formatExpiryDate(Number.NaN)).toBe("—");
+  });
+  it("formats a real date", () => {
+    expect(formatExpiryDate(Date.UTC(2026, 0, 5, 12))).toContain("2026");
+  });
+  it("computes whole days until, min zero", () => {
+    const now = Date.UTC(2026, 5, 1);
+    expect(daysUntil(now + 10 * DAY, now)).toBe(10);
+    expect(daysUntil(now - 5 * DAY, now)).toBe(0);
+  });
+});

--- a/frontend/src/lib/pointsExpiry.ts
+++ b/frontend/src/lib/pointsExpiry.ts
@@ -1,0 +1,246 @@
+// Pure helpers for the REWARDS POINTS EXPIRY + STATEMENT surface.
+// No React / no network — unit-testable in isolation (see pointsExpiry.test.ts).
+//
+// Points are whole integers. Timestamps are UNIX SECONDS on the wire (rewards
+// history + authoritative expiry), but this module works in MILLISECONDS
+// internally for date math; callers pass `nowMs` in ms and each entry's `ts`
+// (seconds) is normalized on the way in.
+//
+// CANONICAL POLICY (shared with Android):
+//   EXPIRY_MONTHS      = 12   points expire 12 months after they were earned
+//   EXPIRING_SOON_DAYS = 60   "expiring soon" = within 60 days from now
+
+import type { RewardHistoryEntry } from "@/api/endpoints/rewards";
+
+/** Points expire this many months after the date they were earned. */
+export const EXPIRY_MONTHS = 12;
+/** A lot counts as "expiring soon" when it expires within this many days. */
+export const EXPIRING_SOON_DAYS = 60;
+
+const DAY_MS = 86_400_000;
+/** Seconds-vs-ms heuristic: values below this are treated as seconds. */
+const MS_THRESHOLD = 1e12;
+
+/** Normalize a wire timestamp (seconds OR ms) to milliseconds. */
+export function tsToMs(ts: number | null | undefined): number {
+  if (ts == null || !Number.isFinite(ts)) return Number.NaN;
+  return ts < MS_THRESHOLD ? ts * 1000 : ts;
+}
+
+/**
+ * Add `n` calendar months to an epoch-ms timestamp. Clamps the day-of-month so
+ * e.g. Jan 31 + 1mo -> Feb 28/29 (never rolls into March). Pure, deterministic.
+ */
+export function addMonths(ms: number, n: number): number {
+  if (!Number.isFinite(ms)) return Number.NaN;
+  const d = new Date(ms);
+  const day = d.getUTCDate();
+  const base = new Date(
+    Date.UTC(
+      d.getUTCFullYear(),
+      d.getUTCMonth(),
+      1,
+      d.getUTCHours(),
+      d.getUTCMinutes(),
+      d.getUTCSeconds(),
+      d.getUTCMilliseconds(),
+    ),
+  );
+  base.setUTCMonth(base.getUTCMonth() + n);
+  // Clamp day to the last valid day of the target month.
+  const lastDay = new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth() + 1, 0)).getUTCDate();
+  base.setUTCDate(Math.min(day, lastDay));
+  return base.getTime();
+}
+
+/** True when an entry adds points to the balance (an EARN lot). */
+function isEarn(e: RewardHistoryEntry): boolean {
+  return Number.isFinite(e.points) && e.points > 0;
+}
+/** Magnitude of a debit (redeem/expire/reverse) in points, else 0. */
+function debitPoints(e: RewardHistoryEntry): number {
+  return Number.isFinite(e.points) && e.points < 0 ? -e.points : 0;
+}
+
+/** A remaining earn lot after FIFO consumption. */
+export interface ExpiryLot {
+  earnedTs: number; // ms
+  remaining: number; // whole points still live in this lot
+  expiresTs: number; // ms = earnedTs + policyMonths
+}
+
+export interface ExpiryComputation {
+  lots: ExpiryLot[];
+  expiringSoonPoints: number;
+  nextExpiryTs: number | null; // ms
+  nextExpiryPoints: number;
+}
+
+/**
+ * Compute remaining live earn-lots + expiry view from the rewards history,
+ * FIFO (oldest-earned consumed first by redeem/expire/reverse debits). Lots
+ * that have ALREADY expired (expiresTs <= nowMs) are dropped from the live view.
+ *
+ * `entries` are the raw history rows (ts in seconds); `nowMs` is the reference
+ * "now" in ms; `policyMonths` defaults to EXPIRY_MONTHS.
+ */
+export function computeExpiryFromHistory(
+  entries: RewardHistoryEntry[] | null | undefined,
+  nowMs: number,
+  policyMonths: number = EXPIRY_MONTHS,
+): ExpiryComputation {
+  const empty: ExpiryComputation = {
+    lots: [],
+    expiringSoonPoints: 0,
+    nextExpiryTs: null,
+    nextExpiryPoints: 0,
+  };
+  if (!Array.isArray(entries) || entries.length === 0 || !Number.isFinite(nowMs)) {
+    return empty;
+  }
+
+  // Chronological order (oldest first) so FIFO consumption is deterministic.
+  const ordered = [...entries]
+    .filter((e) => e && Number.isFinite(e.points) && Number.isFinite(tsToMs(e.ts)))
+    .sort((a, b) => tsToMs(a.ts) - tsToMs(b.ts));
+
+  // Build the queue of earn lots and apply debits FIFO across them.
+  const lots: { earnedTs: number; remaining: number }[] = [];
+  for (const e of ordered) {
+    if (isEarn(e)) {
+      lots.push({ earnedTs: tsToMs(e.ts), remaining: Math.trunc(e.points) });
+    } else {
+      let debit = Math.trunc(debitPoints(e));
+      // Consume oldest live lots first.
+      for (const lot of lots) {
+        if (debit <= 0) break;
+        if (lot.remaining <= 0) continue;
+        const take = Math.min(lot.remaining, debit);
+        lot.remaining -= take;
+        debit -= take;
+      }
+      // Any un-matched debit is simply ignored (nothing left to consume).
+    }
+  }
+
+  const soonCutoff = nowMs + EXPIRING_SOON_DAYS * DAY_MS;
+  const live: ExpiryLot[] = [];
+  for (const lot of lots) {
+    if (lot.remaining <= 0) continue;
+    const expiresTs = addMonths(lot.earnedTs, policyMonths);
+    if (expiresTs <= nowMs) continue; // already expired — not live
+    live.push({ earnedTs: lot.earnedTs, remaining: lot.remaining, expiresTs });
+  }
+  // Soonest expiry first.
+  live.sort((a, b) => a.expiresTs - b.expiresTs);
+
+  let expiringSoonPoints = 0;
+  for (const lot of live) {
+    if (lot.expiresTs <= soonCutoff) expiringSoonPoints += lot.remaining;
+  }
+
+  const next = live.length > 0 ? live[0] : null;
+  return {
+    lots: live,
+    expiringSoonPoints,
+    nextExpiryTs: next ? next.expiresTs : null,
+    nextExpiryPoints: next ? next.remaining : 0,
+  };
+}
+
+/** One statement row: a history entry with a running balance after it applies. */
+export interface StatementRow {
+  ts: number; // seconds (as delivered)
+  type: string;
+  description: string;
+  points: number; // signed delta
+  cashCents: number;
+  status: string;
+  balanceAfter: number; // running points balance after this row
+}
+
+/**
+ * Build statement rows in ASCENDING chronological order with a running
+ * `balanceAfter` (never below zero). Pure — safe on empty/garbage input.
+ */
+export function statementRows(
+  entries: RewardHistoryEntry[] | null | undefined,
+): StatementRow[] {
+  if (!Array.isArray(entries) || entries.length === 0) return [];
+  const ordered = [...entries]
+    .filter((e) => e && Number.isFinite(tsToMs(e.ts)))
+    .sort((a, b) => tsToMs(a.ts) - tsToMs(b.ts));
+  let balance = 0;
+  const rows: StatementRow[] = [];
+  for (const e of ordered) {
+    const delta = Number.isFinite(e.points) ? Math.trunc(e.points) : 0;
+    balance = Math.max(0, balance + delta);
+    rows.push({
+      ts: e.ts,
+      type: e.type ?? "",
+      description: e.description ?? "",
+      points: delta,
+      cashCents: Number.isFinite(e.cash_cents) ? e.cash_cents : 0,
+      status: e.status ?? "",
+      balanceAfter: balance,
+    });
+  }
+  return rows;
+}
+
+/** Format an epoch-ms (or null) as a short local date, e.g. "Jan 5, 2026". */
+export function formatExpiryDate(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) return "—";
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+
+/** Whole days from `nowMs` until `expiresTs` (min 0). */
+export function daysUntil(expiresTs: number, nowMs: number): number {
+  if (!Number.isFinite(expiresTs) || !Number.isFinite(nowMs)) return 0;
+  return Math.max(0, Math.ceil((expiresTs - nowMs) / DAY_MS));
+}
+
+// ── CSV export (reuses the shared RFC-4180 helpers) ──────────────────
+
+export const STATEMENT_CSV_HEADER = [
+  "Date (ISO)",
+  "Type",
+  "Description",
+  "Points",
+  "Cash",
+  "Status",
+  "Balance",
+];
+
+/** Format signed cents as a plain decimal dollar string (no locale commas). */
+function csvCents(cents: number): string {
+  if (!Number.isFinite(cents) || cents === 0) return "";
+  return (cents / 100).toFixed(2);
+}
+
+function csvIso(ts: number): string {
+  const ms = tsToMs(ts);
+  if (!Number.isFinite(ms)) return "";
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? "" : d.toISOString();
+}
+
+/** Build a statement CSV string from statement rows. Delegates escaping/joining
+ *  to the shared `toCsv`/`csvEscape` helpers so quoting stays RFC-4180 correct. */
+export function expiryToCsv(
+  rows: StatementRow[],
+  toCsv: (header: string[], rows: (string | number)[][]) => string,
+): string {
+  const body: (string | number)[][] = (rows ?? []).map((r) => [
+    csvIso(r.ts),
+    r.type,
+    r.description,
+    r.points > 0 ? `+${r.points}` : String(r.points),
+    csvCents(r.cashCents),
+    r.status,
+    r.balanceAfter,
+  ]);
+  return toCsv(STATEMENT_CSV_HEADER, body);
+}

--- a/frontend/src/pages/rewards/RewardsPage.tsx
+++ b/frontend/src/pages/rewards/RewardsPage.tsx
@@ -8,6 +8,7 @@ import {
   Sparkles,
   Gift,
   Users,
+  ScrollText,
   TrendingUp,
   ArrowRight,
   DollarSign,
@@ -228,11 +229,18 @@ export default function RewardsPage() {
             Earn points from referrals and activity, then redeem for cash or perks.
           </p>
         </div>
-        <Button asChild variant="outline" size="sm">
-          <Link to="/rewards/referrals">
-            <Users className="mr-1.5 h-4 w-4" /> Referrals
-          </Link>
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to="/rewards/statement">
+              <ScrollText className="mr-1.5 h-4 w-4" /> Statement
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/rewards/referrals">
+              <Users className="mr-1.5 h-4 w-4" /> Referrals
+            </Link>
+          </Button>
+        </div>
       </div>
 
       {/* Balances */}

--- a/frontend/src/pages/rewards/RewardsStatementPage.tsx
+++ b/frontend/src/pages/rewards/RewardsStatementPage.tsx
@@ -1,0 +1,380 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import {
+  Award,
+  CalendarX,
+  Coins,
+  Download,
+  ScrollText,
+  TriangleAlert,
+} from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { ApiError } from "@/api/client";
+import { getRewards, getRewardsHistory, getRewardsExpiry } from "@/api/endpoints/rewards";
+import type { RewardHistoryEntry } from "@/api/endpoints/rewards";
+import { toCsv, downloadCsv } from "@/lib/exportReport";
+import { formatPoints, formatCents } from "@/lib/rewards";
+import {
+  EXPIRY_MONTHS,
+  computeExpiryFromHistory,
+  daysUntil,
+  expiryToCsv,
+  formatExpiryDate,
+  statementRows,
+  tsToMs,
+} from "@/lib/pointsExpiry";
+import { PendingRewards } from "./PendingRewards";
+
+function is404(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+type Period = "all" | "year" | "month";
+
+const PERIODS: { id: Period; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "year", label: "This year" },
+  { id: "month", label: "This month" },
+];
+
+/** Keep only entries whose ts falls inside the chosen period (relative to now). */
+function filterByPeriod(entries: RewardHistoryEntry[], period: Period, now: Date): RewardHistoryEntry[] {
+  if (period === "all") return entries;
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  const start =
+    period === "year" ? new Date(y, 0, 1).getTime() : new Date(y, m, 1).getTime();
+  return entries.filter((e) => {
+    const ms = tsToMs(e.ts);
+    return Number.isFinite(ms) && ms >= start;
+  });
+}
+
+export default function RewardsStatementPage() {
+  const nowMs = Date.now();
+  const [period, setPeriod] = useState<Period>("all");
+
+  const rewardsQ = useQuery({
+    queryKey: ["me", "rewards", "summary"],
+    queryFn: getRewards,
+    retry: false,
+  });
+  const historyQ = useQuery({
+    queryKey: ["me", "rewards", "history"],
+    queryFn: getRewardsHistory,
+    retry: false,
+  });
+  const expiryQ = useQuery({
+    queryKey: ["me", "rewards", "expiry"],
+    queryFn: getRewardsExpiry,
+    retry: false,
+  });
+
+  const historyPending = is404(historyQ.error);
+
+  const entries: RewardHistoryEntry[] = historyQ.data?.entries ?? [];
+  const points = rewardsQ.data?.points ?? 0;
+
+  // Full statement (asc, running balance) then period-filtered for display/CSV.
+  const allRows = useMemo(() => statementRows(entries), [entries]);
+  const rows = useMemo(
+    () => filterByPeriod(entries, period, new Date(nowMs)),
+    [entries, period, nowMs],
+  );
+  const displayRows = useMemo(() => {
+    const keptTs = new Set(rows.map((e) => e.ts));
+    return allRows.filter((r) => keptTs.has(r.ts));
+  }, [allRows, rows]);
+
+  // Client-computed expiry (always available) + optional authoritative override.
+  const computed = useMemo(
+    () => computeExpiryFromHistory(entries, nowMs, EXPIRY_MONTHS),
+    [entries, nowMs],
+  );
+  const authoritative = expiryQ.data && !is404(expiryQ.error) ? expiryQ.data : null;
+
+  const expiringSoonPoints = authoritative
+    ? authoritative.expiring_soon_points
+    : computed.expiringSoonPoints;
+  const nextExpiryTs = authoritative
+    ? authoritative.next_expiry_ts != null
+      ? tsToMs(authoritative.next_expiry_ts)
+      : null
+    : computed.nextExpiryTs;
+  const nextExpiryPoints = authoritative
+    ? authoritative.next_expiry_points
+    : computed.nextExpiryPoints;
+  const policyMonths = authoritative?.policy_months ?? EXPIRY_MONTHS;
+  const isEstimated = !authoritative;
+
+  // Upcoming-expirations mini-list (soonest first, first 6).
+  const upcomingLots = useMemo(() => {
+    if (authoritative && Array.isArray(authoritative.lots)) {
+      return [...authoritative.lots]
+        .map((l) => ({
+          expiresTs: tsToMs(l.expires_ts),
+          remaining: l.points_remaining,
+        }))
+        .filter((l) => Number.isFinite(l.expiresTs) && l.remaining > 0)
+        .sort((a, b) => a.expiresTs - b.expiresTs)
+        .slice(0, 6);
+    }
+    return computed.lots
+      .map((l) => ({ expiresTs: l.expiresTs, remaining: l.remaining }))
+      .slice(0, 6);
+  }, [authoritative, computed]);
+
+  const onDownload = () => {
+    const csv = expiryToCsv(displayRows, toCsv);
+    const label = period === "all" ? "all" : period === "year" ? "this-year" : "this-month";
+    downloadCsv(`rewards-statement-${label}.csv`, csv);
+  };
+
+  const loading = rewardsQ.isLoading || historyQ.isLoading;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold">
+            <ScrollText className="h-6 w-6" /> Points statement
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Your running points ledger, upcoming expirations, and a downloadable statement.
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/rewards">
+            <Award className="mr-1.5 h-4 w-4" /> Rewards
+          </Link>
+        </Button>
+      </div>
+
+      {loading ? (
+        <Skeleton className="h-24 w-full" />
+      ) : historyPending ? (
+        <PendingRewards label="Your points statement" />
+      ) : (
+        <>
+          {/* Balance + expiring-soon warning */}
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Card>
+              <CardContent className="flex items-center gap-3 p-4">
+                <div className="rounded-lg bg-muted p-2 text-muted-foreground">
+                  <Coins className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Points balance</p>
+                  <p className="text-xl font-semibold tabular-nums">
+                    {formatPoints(points, false)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">available to redeem</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {expiringSoonPoints > 0 && nextExpiryTs != null ? (
+              <Card className="border-amber-500/40 bg-amber-500/5">
+                <CardContent className="flex items-start gap-3 p-4">
+                  <div className="rounded-lg bg-amber-500/15 p-2 text-amber-600 dark:text-amber-400">
+                    <TriangleAlert className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <p className="flex items-center gap-2 text-sm font-medium">
+                      {formatPoints(expiringSoonPoints)} expiring soon
+                      {isEstimated ? (
+                        <Badge variant="secondary" className="text-[10px]">
+                          Est
+                        </Badge>
+                      ) : null}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatPoints(nextExpiryPoints)} expire on {formatExpiryDate(nextExpiryTs)} (
+                      {daysUntil(nextExpiryTs, nowMs)} days). Redeem before then to keep them.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card>
+                <CardContent className="flex items-start gap-3 p-4">
+                  <div className="rounded-lg bg-muted p-2 text-muted-foreground">
+                    <CalendarX className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Nothing expiring soon</p>
+                    <p className="text-xs text-muted-foreground">
+                      {nextExpiryTs != null
+                        ? `Your next points expire on ${formatExpiryDate(nextExpiryTs)}.`
+                        : "You have no points scheduled to expire."}
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+
+          <p className="rounded-lg border border-dashed bg-muted/30 p-3 text-xs text-muted-foreground">
+            Points expire {policyMonths} months after they are earned. We warn you when points are
+            within 60 days of expiring.
+            {isEstimated
+              ? " Expiry dates below are estimated from your history (first-in, first-out)."
+              : ""}
+          </p>
+
+          {/* Upcoming expirations mini-list */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <CalendarX className="h-5 w-5" /> Upcoming expirations
+              </CardTitle>
+              <CardDescription>Points scheduled to expire, soonest first.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {upcomingLots.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  No points are scheduled to expire.
+                </p>
+              ) : (
+                <ul className="divide-y">
+                  {upcomingLots.map((l, i) => (
+                    <li key={`${l.expiresTs}-${i}`} className="flex items-center justify-between gap-3 py-2.5">
+                      <div>
+                        <p className="text-sm font-medium tabular-nums">
+                          {formatPoints(l.remaining)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          expires {formatExpiryDate(l.expiresTs)}
+                        </p>
+                      </div>
+                      <Badge variant="outline" className="tabular-nums">
+                        {daysUntil(l.expiresTs, nowMs)} days
+                      </Badge>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Statement table */}
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <CardTitle>Statement</CardTitle>
+                  <CardDescription>
+                    Every earn, redemption, and expiry with a running balance.
+                  </CardDescription>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="inline-flex rounded-md border p-0.5">
+                    {PERIODS.map((p) => (
+                      <button
+                        key={p.id}
+                        type="button"
+                        onClick={() => setPeriod(p.id)}
+                        className={
+                          "rounded px-2.5 py-1 text-xs font-medium transition-colors " +
+                          (period === p.id
+                            ? "bg-primary text-primary-foreground"
+                            : "text-muted-foreground hover:text-foreground")
+                        }
+                      >
+                        {p.label}
+                      </button>
+                    ))}
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={displayRows.length === 0}
+                    onClick={onDownload}
+                  >
+                    <Download className="mr-1.5 h-4 w-4" /> Download CSV
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {historyQ.isError && !historyPending ? (
+                <p className="text-sm text-destructive">Could not load your statement.</p>
+              ) : displayRows.length === 0 ? (
+                <p className="py-6 text-center text-sm text-muted-foreground">
+                  {entries.length === 0
+                    ? "No rewards activity yet."
+                    : "No activity in this period."}
+                </p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Date</TableHead>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Description</TableHead>
+                      <TableHead className="text-right">Points</TableHead>
+                      <TableHead className="text-right">Balance</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {displayRows.map((r, i) => (
+                      <TableRow key={`${r.ts}-${i}`}>
+                        <TableCell className="whitespace-nowrap text-muted-foreground">
+                          {Number.isFinite(tsToMs(r.ts))
+                            ? new Date(tsToMs(r.ts)).toLocaleDateString()
+                            : "—"}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline" className="capitalize">
+                            {r.type || "—"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{r.description || r.type || "—"}</TableCell>
+                        <TableCell
+                          className={
+                            "text-right tabular-nums " +
+                            (r.points > 0
+                              ? "text-emerald-600 dark:text-emerald-400"
+                              : r.points < 0
+                                ? "text-destructive"
+                                : "")
+                          }
+                        >
+                          {r.points > 0
+                            ? `+${formatPoints(r.points, false)}`
+                            : formatPoints(r.points, false)}
+                          {r.cashCents ? (
+                            <span className="ml-1 text-xs text-muted-foreground">
+                              ({formatCents(r.cashCents)})
+                            </span>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className="text-right font-medium tabular-nums">
+                          {formatPoints(r.balanceAfter, false)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Rewards points expiry + statement

A points **statement** (running-balance ledger of earn/redeem/expire entries) + **expiry** tracking (points expire 12 months after earned; warn when expiring soon). Works-now: FIFO expiry + statement computed **client-side** from the existing rewards history, with an optional authoritative override. Canonical policy both platforms: `EXPIRY_MONTHS=12`, expiring-soon within 60 days.

Optional authoritative `GET /me/rewards/expiry` → `{policy_months, expiring_soon_points, next_expiry_ts, next_expiry_points, lots[]}`; degrade-on-404 to client computation.

### Web (`/rewards/statement`)
`lib/pointsExpiry.ts` (+20 vitest) — `computeExpiryFromHistory` (FIFO lots), `statementRows` (running balance), `expiryToCsv`; `rewards.ts` `getRewardsExpiry`; `RewardsStatementPage` — balance + "N points expiring on DATE" banner, 12-month policy note, upcoming-expirations list, statement table (period filter) + Download CSV (reuses export helpers).

### Android (new statement screen in `feature/rewards`, registered in `MoreRoutes`)
`PointsExpiryMath.kt` (mirror; +18 JVM tests) + PointsStatement Screen/ViewModel/UiState + `PointsStatementShare` (CSV via ACTION_SEND); `RewardsApi/Domain/Repository` gain `GET me/rewards/expiry` (degrade-on-404); `MoreCatalog` + `MoreRoutes.REGISTERED` + `RewardsNavigation`.

No new deps. Gates: web tsc 0 · vite build · vitest 20/20; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (PointsExpiryMath 18/18, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
