### PR TITLE
feat(admin): rewards catalog admin — operator CRUD (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/adminrewards/AdminRewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/adminrewards/AdminRewardsApi.kt
@@ -1,0 +1,177 @@
+package com.testlogon.android.data.adminrewards
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.json.LenientInt
+import com.testlogon.android.core.network.json.LenientLong
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.PUT
+import retrofit2.http.POST
+import retrofit2.http.Path
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Operator CRUD over the REDEEMABLE-REWARDS CATALOG that members see on the user Rewards surface. This is
+ * the ADMIN counterpart to [com.testlogon.android.data.rewards.RewardsApi] (whose me/rewards/catalog is a
+ * read-only member view). Paths are relative (no leading slash) so they resolve against the shared
+ * authenticated Retrofit base URL; session cookie + CSRF are attached by the core-network interceptor chain.
+ *
+ * The LIST read DEGRADES on 404 (undeployed backend) to an honest empty/unavailable state in the repository,
+ * while a backend 403 on any call surfaces as [ApiResult.Failure] so the ViewModel can show a role-gated
+ * "not authorised" state (the SAME server-side gate the other admin queues use). The MUTATIONS (create /
+ * update / delete / toggle) pass failures through as a CLEAR error and NEVER a silent success. Every DTO is
+ * codegen-only Moshi with numerics made lenient ([LenientLong]/[LenientInt]) and every field defaulted, so a
+ * partial or string-encoded-numeric shape still parses.
+ */
+interface AdminRewardsApi {
+
+    /** GET admin/rewards/catalog -> {rewards:[...]}. Read degrades on 404 (network errors surface). */
+    @GET("admin/rewards/catalog")
+    suspend fun list(): AdminCatalogListDto
+
+    /** POST admin/rewards/catalog {name,description,cost_points,value_cents,kind,active} -> item. Mutation: errors surface. */
+    @Headers("Content-Type: application/json")
+    @POST("admin/rewards/catalog")
+    suspend fun create(@Body body: AdminCatalogItemReq): AdminCatalogItemDto
+
+    /** PUT admin/rewards/catalog/{id} same body -> item. Mutation: errors surface. */
+    @Headers("Content-Type: application/json")
+    @PUT("admin/rewards/catalog/{id}")
+    suspend fun update(@Path("id") id: String, @Body body: AdminCatalogItemReq): AdminCatalogItemDto
+
+    /** DELETE admin/rewards/catalog/{id} -> {ok}. Mutation: errors surface. */
+    @DELETE("admin/rewards/catalog/{id}")
+    suspend fun delete(@Path("id") id: String): AdminCatalogDeleteDto
+}
+
+// ---- GET admin/rewards/catalog ----
+
+@JsonClass(generateAdapter = true)
+data class AdminCatalogListDto(
+    @Json(name = "rewards") val rewards: List<AdminCatalogItemDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class AdminCatalogItemDto(
+    @Json(name = "id") val id: String? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @LenientLong @Json(name = "cost_points") val costPoints: Long? = null,
+    @LenientLong @Json(name = "value_cents") val valueCents: Long? = null,
+    @Json(name = "kind") val kind: String? = null,
+    @Json(name = "active") val active: Boolean? = null,
+    @LenientInt @Json(name = "redeemed_count") val redeemedCount: Int? = null,
+)
+
+// ---- POST/PUT body ----
+
+@JsonClass(generateAdapter = true)
+data class AdminCatalogItemReq(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String,
+    @Json(name = "cost_points") val costPoints: Long,
+    @Json(name = "value_cents") val valueCents: Long,
+    @Json(name = "kind") val kind: String,
+    @Json(name = "active") val active: Boolean,
+)
+
+// ---- DELETE ----
+
+@JsonClass(generateAdapter = true)
+data class AdminCatalogDeleteDto(
+    @Json(name = "ok") val ok: Boolean = false,
+)
+
+// ---- Repository ----
+
+interface AdminRewardsRepository {
+    /** LIST read: 404/undeployed degrades to an honest empty list; 403 -> Failure; network -> NetworkError. */
+    suspend fun list(): ApiResult<AdminCatalogListDto>
+    suspend fun create(body: AdminCatalogItemReq): ApiResult<AdminCatalogItemDto>
+    suspend fun update(id: String, body: AdminCatalogItemReq): ApiResult<AdminCatalogItemDto>
+    suspend fun delete(id: String): ApiResult<AdminCatalogDeleteDto>
+}
+
+@Singleton
+class DefaultAdminRewardsRepository @Inject constructor(
+    private val api: AdminRewardsApi,
+    private val errorParser: ApiErrorParser,
+) : AdminRewardsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    /**
+     * LIST read. A 404 (undeployed backend) degrades to an honest EMPTY catalog so the screen shows a
+     * truthful empty state rather than an error. A 403 (not an operator) is passed through as Failure so
+     * the ViewModel renders the role-gated "not authorised" state. Real transport failures surface.
+     */
+    override suspend fun list(): ApiResult<AdminCatalogListDto> = withContext(io) {
+        try {
+            ApiResult.Success(api.list())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            if (e.code() == 404) ApiResult.Success(AdminCatalogListDto())
+            else ApiResult.Failure(errorParser.from(e))
+        } catch (e: com.squareup.moshi.JsonDataException) {
+            ApiResult.Success(AdminCatalogListDto())
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    override suspend fun create(body: AdminCatalogItemReq): ApiResult<AdminCatalogItemDto> =
+        withContext(io) { call { api.create(body) } }
+
+    override suspend fun update(id: String, body: AdminCatalogItemReq): ApiResult<AdminCatalogItemDto> =
+        withContext(io) { call { api.update(id, body) } }
+
+    override suspend fun delete(id: String): ApiResult<AdminCatalogDeleteDto> =
+        withContext(io) { call { api.delete(id) } }
+
+    /** Mutation wrapper: HTTP-error -> Failure (clear error, incl. 403/404), transport -> NetworkError. */
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AdminRewardsApiModule {
+    @Provides
+    @Singleton
+    fun provideAdminRewardsApi(retrofit: Retrofit): AdminRewardsApi =
+        retrofit.create(AdminRewardsApi::class.java)
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AdminRewardsDataModule {
+    @dagger.Binds
+    @Singleton
+    abstract fun bindAdminRewardsRepository(impl: DefaultAdminRewardsRepository): AdminRewardsRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminScreen.kt
@@ -1,0 +1,391 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.adminrewards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.CardGiftcard
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.adminrewards.AdminCatalogItemDto
+import com.testlogon.android.feature.adminmod.AdminOpsErrorType
+
+object CatalogAdminTestTags {
+    const val SCREEN = "reward_catalog_admin_screen"
+    const val LIST = "reward_catalog_admin_list"
+    const val EMPTY = "reward_catalog_admin_empty"
+    const val FORBIDDEN = "reward_catalog_admin_forbidden"
+    const val ERROR_RETRY = "reward_catalog_admin_error_retry"
+    const val CREATE = "reward_catalog_admin_create"
+    const val FORM_SUBMIT = "reward_catalog_admin_form_submit"
+    const val FORM_NAME = "reward_catalog_admin_form_name"
+    const val DELETE_CONFIRM = "reward_catalog_admin_delete_confirm"
+    fun row(id: String) = "reward_catalog_row_" + id
+    fun edit(id: String) = "reward_catalog_edit_" + id
+    fun delete(id: String) = "reward_catalog_delete_" + id
+    fun toggle(id: String) = "reward_catalog_toggle_" + id
+}
+
+@Composable
+fun CatalogAdminRoute(
+    onBack: () -> Unit,
+    viewModel: CatalogAdminViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    CatalogAdminScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onRetry = viewModel::retry,
+        onCreate = viewModel::create,
+        onUpdate = viewModel::update,
+        onDelete = viewModel::delete,
+        onToggleActive = viewModel::toggleActive,
+        onMessageShown = viewModel::clearMessage,
+    )
+}
+
+@Composable
+fun CatalogAdminScreen(
+    state: CatalogAdminUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onCreate: (CatalogDraft) -> Unit,
+    onUpdate: (String, CatalogDraft) -> Unit,
+    onDelete: (String) -> Unit,
+    onToggleActive: (AdminCatalogItemDto) -> Unit,
+    onMessageShown: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackbar = remember { SnackbarHostState() }
+    var editing by remember { mutableStateOf<EditTarget?>(null) }
+    var deleteTarget by remember { mutableStateOf<AdminCatalogItemDto?>(null) }
+    val content = state as? CatalogAdminUiState.Content
+
+    LaunchedEffect(content?.message, content?.transientError) {
+        val msg = content?.message ?: content?.transientError?.let { catalogAdminErrorMessage(it) }
+        if (msg != null) {
+            snackbar.showSnackbar(msg)
+            onMessageShown()
+        }
+    }
+
+    val canCreate = state is CatalogAdminUiState.Content || state is CatalogAdminUiState.Empty
+
+    Scaffold(
+        modifier = modifier.testTag(CatalogAdminTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbar) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Rewards catalog") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (canCreate) {
+                ExtendedFloatingActionButton(
+                    onClick = { editing = EditTarget(id = null, draft = emptyDraft()) },
+                    icon = { Icon(Icons.Outlined.Add, contentDescription = null) },
+                    text = { Text("New reward") },
+                    modifier = Modifier.testTag(CatalogAdminTestTags.CREATE),
+                )
+            }
+        },
+    ) { padding ->
+        val isRefreshing = content?.isRefreshing == true
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = onRefresh,
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            when (state) {
+                is CatalogAdminUiState.Loading -> LoadingState()
+                is CatalogAdminUiState.Empty -> EmptyState(
+                    modifier = Modifier.testTag(CatalogAdminTestTags.EMPTY),
+                    title = "No rewards yet",
+                    body = "Create the first redeemable reward members can spend points on.",
+                    imageVector = Icons.Outlined.CardGiftcard,
+                )
+                is CatalogAdminUiState.Forbidden -> EmptyState(
+                    modifier = Modifier.testTag(CatalogAdminTestTags.FORBIDDEN),
+                    title = "Not authorised",
+                    body = "You need operator access to manage the rewards catalog.",
+                    imageVector = Icons.Outlined.Lock,
+                    actionLabel = "Back",
+                    onAction = onBack,
+                )
+                is CatalogAdminUiState.Error -> ErrorState(
+                    modifier = Modifier.testTag(CatalogAdminTestTags.ERROR_RETRY),
+                    message = catalogAdminErrorMessage(state.type),
+                    onRetry = onRetry,
+                )
+                is CatalogAdminUiState.Content -> LazyColumn(
+                    modifier = Modifier.fillMaxSize().testTag(CatalogAdminTestTags.LIST),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(items = state.items, key = { it.id.orEmpty() }) { item ->
+                        CatalogRow(
+                            item = item,
+                            actionsEnabled = !state.actionInFlight,
+                            onEdit = { editing = EditTarget(id = item.id, draft = item.toDraft()) },
+                            onDelete = { deleteTarget = item },
+                            onToggle = { onToggleActive(item) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    editing?.let { target ->
+        CatalogFormDialog(
+            initial = target.draft,
+            isEdit = target.id != null,
+            onDismiss = { editing = null },
+            onSubmit = { draft ->
+                val id = target.id
+                if (id == null) onCreate(draft) else onUpdate(id, draft)
+                editing = null
+            },
+        )
+    }
+
+    deleteTarget?.let { item ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("Delete reward") },
+            text = { Text("Delete this reward? Members will no longer see it in the catalog.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        item.id?.let(onDelete)
+                        deleteTarget = null
+                    },
+                    modifier = Modifier.testTag(CatalogAdminTestTags.DELETE_CONFIRM),
+                ) { Text("Delete") }
+            },
+            dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("Cancel") } },
+        )
+    }
+}
+
+private data class EditTarget(val id: String?, val draft: CatalogDraft)
+
+@Composable
+private fun CatalogRow(
+    item: AdminCatalogItemDto,
+    actionsEnabled: Boolean,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onToggle: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(CatalogAdminTestTags.row(item.id.orEmpty()))) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    item.name.orEmpty().ifBlank { "Reward" },
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                AssistChip(
+                    onClick = {},
+                    enabled = false,
+                    label = { Text(item.kind ?: "perk") },
+                )
+            }
+            item.description?.takeIf { it.isNotBlank() }?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("" + (item.costPoints ?: 0L) + " pts", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
+                Text(formatCents(item.valueCents ?: 0L), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                item.redeemedCount?.let {
+                    Text("" + it + " redeemed", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+                    Switch(
+                        checked = item.active ?: false,
+                        onCheckedChange = { if (actionsEnabled) onToggle() },
+                        enabled = actionsEnabled,
+                        modifier = Modifier.testTag(CatalogAdminTestTags.toggle(item.id.orEmpty())),
+                    )
+                    Text(if (item.active == true) "Active" else "Inactive", style = MaterialTheme.typography.labelMedium)
+                }
+                OutlinedButton(
+                    onClick = onEdit,
+                    enabled = actionsEnabled,
+                    modifier = Modifier.testTag(CatalogAdminTestTags.edit(item.id.orEmpty())),
+                ) { Text("Edit") }
+                OutlinedButton(
+                    onClick = onDelete,
+                    enabled = actionsEnabled,
+                    modifier = Modifier.testTag(CatalogAdminTestTags.delete(item.id.orEmpty())),
+                ) { Text("Delete") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CatalogFormDialog(
+    initial: CatalogDraft,
+    isEdit: Boolean,
+    onDismiss: () -> Unit,
+    onSubmit: (CatalogDraft) -> Unit,
+) {
+    var name by remember { mutableStateOf(initial.name) }
+    var description by remember { mutableStateOf(initial.description) }
+    var costText by remember { mutableStateOf(if (initial.costPoints > 0) initial.costPoints.toString() else "") }
+    var valueText by remember { mutableStateOf(if (initial.valueCents > 0) initial.valueCents.toString() else "") }
+    var kind by remember { mutableStateOf(initial.kind) }
+    var active by remember { mutableStateOf(initial.active) }
+
+    val costPoints = costText.trim().toLongOrNull() ?: 0L
+    val valueCents = valueText.trim().toLongOrNull() ?: 0L
+    val validation = validateCatalogItem(name, costPoints, valueCents, kind)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (isEdit) "Edit reward" else "New reward") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    isError = validation.errorFor("name") != null,
+                    supportingText = { validation.errorFor("name")?.let { Text(it) } },
+                    modifier = Modifier.fillMaxWidth().testTag(CatalogAdminTestTags.FORM_NAME),
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Description") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = costText,
+                    onValueChange = { costText = it.filter(Char::isDigit) },
+                    label = { Text("Cost (points)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    isError = validation.errorFor("costPoints") != null,
+                    supportingText = { validation.errorFor("costPoints")?.let { Text(it) } },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = valueText,
+                    onValueChange = { valueText = it.filter(Char::isDigit) },
+                    label = { Text("Value (cents)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    isError = validation.errorFor("valueCents") != null,
+                    supportingText = { validation.errorFor("valueCents")?.let { Text(it) } },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    CATALOG_KINDS.forEach { k ->
+                        FilterChip(
+                            selected = kind == k,
+                            onClick = { kind = k },
+                            label = { Text(k) },
+                        )
+                    }
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Switch(checked = active, onCheckedChange = { active = it })
+                    Text(if (active) "Active" else "Inactive", style = MaterialTheme.typography.labelMedium)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onSubmit(
+                        CatalogDraft(
+                            name = name,
+                            description = description,
+                            costPoints = costPoints,
+                            valueCents = valueCents,
+                            kind = kind,
+                            active = active,
+                        )
+                    )
+                },
+                enabled = validation.ok,
+                modifier = Modifier.testTag(CatalogAdminTestTags.FORM_SUBMIT),
+            ) { Text(if (isEdit) "Save" else "Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+internal fun formatCents(cents: Long): String {
+    val dollars = cents / 100.0
+    return "$" + "%,.2f".format(dollars)
+}
+
+internal fun catalogAdminErrorMessage(type: AdminOpsErrorType): String = when (type) {
+    AdminOpsErrorType.AUTH -> "Your session expired. Please sign in again."
+    AdminOpsErrorType.SERVER -> "Something went wrong on the server. Try again."
+    AdminOpsErrorType.NETWORK -> "You appear to be offline. Check your connection."
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidation.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidation.kt
@@ -1,0 +1,75 @@
+package com.testlogon.android.feature.adminrewards
+
+/**
+ * PURE, framework-free validation for the rewards-catalog admin form. No Android deps, integer-only money
+ * (cents) + integer points, so it is fully exercisable by plain JVM unit tests and shared by the ViewModel
+ * to disable submit while the draft is invalid + surface per-field inline errors.
+ *
+ * A catalog item is {name, description, cost_points, value_cents, kind(cash|perk), active}. Rules:
+ *  - name        : non-empty (trimmed)
+ *  - cost_points : > 0 (a redeemable reward must cost some points)
+ *  - value_cents : >= 0 (never negative)
+ *  - kind        : one of cash | perk
+ *  - a CASH reward must carry a positive value_cents (otherwise it redeems to $0)
+ */
+
+/** The canonical reward kinds. */
+val CATALOG_KINDS: List<String> = listOf("cash", "perk")
+
+/** Per-field validation errors, keyed by field name; empty when the draft is valid. */
+data class CatalogValidationResult(
+    val errors: Map<String, String>,
+) {
+    val ok: Boolean get() = errors.isEmpty()
+    fun errorFor(field: String): String? = errors[field]
+}
+
+/** An editable catalog draft (integer money/points; kind kept as a raw string for the picker). */
+data class CatalogDraft(
+    val name: String = "",
+    val description: String = "",
+    val costPoints: Long = 0L,
+    val valueCents: Long = 0L,
+    val kind: String = "perk",
+    val active: Boolean = true,
+)
+
+/** A blank draft for the CREATE form (a sensible default kind + active). */
+fun emptyDraft(): CatalogDraft = CatalogDraft()
+
+/**
+ * Validate the four core inputs. Pure: takes primitives so it is trivially unit-testable and reusable from
+ * the ViewModel without constructing a draft.
+ */
+fun validateCatalogItem(
+    name: String,
+    costPoints: Long,
+    valueCents: Long,
+    kind: String,
+): CatalogValidationResult {
+    val errors = LinkedHashMap<String, String>()
+
+    if (name.trim().isEmpty()) {
+        errors["name"] = "Name is required"
+    }
+    if (costPoints <= 0L) {
+        errors["costPoints"] = "Cost must be greater than 0 points"
+    }
+    if (valueCents < 0L) {
+        errors["valueCents"] = "Value cannot be negative"
+    }
+
+    val normalizedKind = kind.trim().lowercase()
+    if (normalizedKind !in CATALOG_KINDS) {
+        errors["kind"] = "Kind must be cash or perk"
+    } else if (normalizedKind == "cash" && valueCents <= 0L) {
+        // A cash reward with no value would redeem to $0.
+        errors["valueCents"] = "Cash rewards need a value above $0"
+    }
+
+    return CatalogValidationResult(errors)
+}
+
+/** Convenience overload validating a whole [CatalogDraft]. */
+fun validateCatalogItem(draft: CatalogDraft): CatalogValidationResult =
+    validateCatalogItem(draft.name, draft.costPoints, draft.valueCents, draft.kind)

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminViewModel.kt
@@ -1,0 +1,171 @@
+package com.testlogon.android.feature.adminrewards
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.adminrewards.AdminCatalogItemDto
+import com.testlogon.android.data.adminrewards.AdminCatalogItemReq
+import com.testlogon.android.data.adminrewards.AdminRewardsRepository
+import com.testlogon.android.feature.adminmod.AdminOpsErrorType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Operator CRUD over the redeemable rewards catalog. List / create / edit / delete + active toggle. Role-gated
+ * exactly like the other admin queues (RefundAdminViewModel et al.): a backend 403 on the list -> [Forbidden]
+ * ("not authorised"); a 404 on the list DEGRADES (in the repo) to an honest empty catalog. Every mutation
+ * refreshes the list on success and surfaces a CLEAR error on failure (never a silent success).
+ */
+sealed interface CatalogAdminUiState {
+    data object Loading : CatalogAdminUiState
+    data class Content(
+        val items: List<AdminCatalogItemDto>,
+        val isRefreshing: Boolean = false,
+        val actionInFlight: Boolean = false,
+        val message: String? = null,
+        val transientError: AdminOpsErrorType? = null,
+    ) : CatalogAdminUiState
+    data object Empty : CatalogAdminUiState
+    data object Forbidden : CatalogAdminUiState
+    data class Error(val type: AdminOpsErrorType) : CatalogAdminUiState
+}
+
+@HiltViewModel
+class CatalogAdminViewModel @Inject constructor(
+    private val repo: AdminRewardsRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<CatalogAdminUiState>(CatalogAdminUiState.Loading)
+    val state: StateFlow<CatalogAdminUiState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun retry() = load()
+
+    fun refresh() {
+        val cur = _state.value
+        if (cur is CatalogAdminUiState.Content) _state.value = cur.copy(isRefreshing = true, transientError = null)
+        fetch(isRefresh = true)
+    }
+
+    private fun load() {
+        _state.value = CatalogAdminUiState.Loading
+        fetch(isRefresh = false)
+    }
+
+    private fun fetch(isRefresh: Boolean) {
+        viewModelScope.launch {
+            when (val r = repo.list()) {
+                is ApiResult.Success -> {
+                    val items = r.data.rewards
+                    _state.value = if (items.isEmpty()) CatalogAdminUiState.Empty
+                    else CatalogAdminUiState.Content(items = items)
+                }
+                is ApiResult.Failure -> reduceFailure(isRefresh, r.error.status)
+                is ApiResult.NetworkError -> reduceError(isRefresh, AdminOpsErrorType.NETWORK)
+            }
+        }
+    }
+
+    /** CREATE a catalog item, then refresh the list. */
+    fun create(draft: CatalogDraft) = runMutation("Reward created") { repo.create(draft.toReq()) }
+
+    /** EDIT an existing item, then refresh the list. */
+    fun update(id: String, draft: CatalogDraft) = runMutation("Reward updated") { repo.update(id, draft.toReq()) }
+
+    /** DELETE an item (after confirm), then refresh the list. */
+    fun delete(id: String) = runMutation("Reward deleted") { repo.delete(id) }
+
+    /** Flip active on/off in place, then refresh the list. */
+    fun toggleActive(item: AdminCatalogItemDto) {
+        val next = !(item.active ?: false)
+        runMutation(if (next) "Reward activated" else "Reward deactivated") {
+            repo.update(item.id.orEmpty(), item.toDraft().copy(active = next).toReq())
+        }
+    }
+
+    private fun <T> runMutation(successMsg: String, block: suspend () -> ApiResult<T>) {
+        val cur = _state.value
+        // Allow mutating from Content OR from an Empty catalog (the first CREATE).
+        if (cur is CatalogAdminUiState.Content && cur.actionInFlight) return
+        if (cur is CatalogAdminUiState.Content) {
+            _state.value = cur.copy(actionInFlight = true, transientError = null, message = null)
+        }
+        viewModelScope.launch {
+            when (val r = block()) {
+                is ApiResult.Success -> reloadAfterMutation(successMsg)
+                is ApiResult.Failure -> emitMutationError(r.error.status)
+                is ApiResult.NetworkError -> emitMutationError(null, AdminOpsErrorType.NETWORK)
+            }
+        }
+    }
+
+    private suspend fun reloadAfterMutation(successMsg: String) {
+        when (val r = repo.list()) {
+            is ApiResult.Success -> {
+                val items = r.data.rewards
+                _state.value = if (items.isEmpty()) CatalogAdminUiState.Empty
+                else CatalogAdminUiState.Content(items = items, message = successMsg)
+            }
+            is ApiResult.Failure -> reduceFailure(isRefresh = false, status = r.error.status)
+            is ApiResult.NetworkError -> reduceError(isRefresh = false, type = AdminOpsErrorType.NETWORK)
+        }
+    }
+
+    private fun emitMutationError(status: Int?, forced: AdminOpsErrorType? = null) {
+        val type = forced ?: when (status) {
+            403 -> AdminOpsErrorType.AUTH
+            401 -> AdminOpsErrorType.AUTH
+            else -> AdminOpsErrorType.SERVER
+        }
+        val cur = _state.value
+        if (cur is CatalogAdminUiState.Content) {
+            _state.value = cur.copy(actionInFlight = false, transientError = type)
+        } else {
+            _state.value = CatalogAdminUiState.Error(type)
+        }
+    }
+
+    fun clearMessage() {
+        val cur = _state.value
+        if (cur is CatalogAdminUiState.Content) _state.value = cur.copy(message = null, transientError = null)
+    }
+
+    private fun reduceFailure(isRefresh: Boolean, status: Int) = when (status) {
+        403 -> _state.value = CatalogAdminUiState.Forbidden
+        401 -> reduceError(isRefresh, AdminOpsErrorType.AUTH)
+        else -> reduceError(isRefresh, AdminOpsErrorType.SERVER)
+    }
+
+    private fun reduceError(isRefresh: Boolean, type: AdminOpsErrorType) {
+        val prior = _state.value as? CatalogAdminUiState.Content
+        _state.value = if (isRefresh && prior != null) prior.copy(isRefreshing = false, transientError = type)
+        else CatalogAdminUiState.Error(type)
+    }
+}
+
+/** Map an editable draft to the create/update request body. */
+internal fun CatalogDraft.toReq(): AdminCatalogItemReq = AdminCatalogItemReq(
+    name = name.trim(),
+    description = description.trim(),
+    costPoints = costPoints,
+    valueCents = valueCents,
+    kind = kind.trim().lowercase(),
+    active = active,
+)
+
+/** Seed an editable draft from an existing catalog item (for the EDIT form). */
+internal fun AdminCatalogItemDto.toDraft(): CatalogDraft = CatalogDraft(
+    name = name.orEmpty(),
+    description = description.orEmpty(),
+    costPoints = costPoints ?: 0L,
+    valueCents = valueCents ?: 0L,
+    kind = (kind ?: "perk").trim().lowercase().let { if (it in CATALOG_KINDS) it else "perk" },
+    active = active ?: false,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.CandlestickChart
 import androidx.compose.material.icons.outlined.SmartToy
 import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.CardGiftcard
 import androidx.compose.material.icons.outlined.ReceiptLong
 import androidx.compose.material.icons.outlined.ManageSearch
 import androidx.compose.material.icons.outlined.Inventory2
@@ -216,6 +217,15 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_refund_admin,
             icon = Icons.Outlined.ReceiptLong,
             route = MoreRoutes.ADMIN_REFUNDS,
+            hub = MoreHub.ADMIN,
+            section = MoreSection.SUPPORT,
+            operatorOnly = true,
+        ),
+        MoreEntry(
+            id = "rewards_catalog_admin",
+            labelRes = R.string.more_entry_rewards_catalog_admin,
+            icon = Icons.Outlined.CardGiftcard,
+            route = MoreRoutes.ADMIN_REWARDS_CATALOG,
             hub = MoreHub.ADMIN,
             section = MoreSection.SUPPORT,
             operatorOnly = true,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -345,6 +345,7 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         dmcaAdminDestination(navController)
         // B5 admin financial-ops queues (refunds + disputes + appeals + fraud + payment incidents).
         refundAdminDestination(navController)
+        catalogAdminDestination(navController)
         disputeAdminDestination(navController)
         appealAdminDestination(navController)
         fraudAdminDestination(navController)

--- a/android/app/src/main/java/com/testlogon/android/navigation/CatalogAdminNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CatalogAdminNavigation.kt
@@ -1,0 +1,21 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.adminrewards.CatalogAdminRoute
+
+/**
+ * Operator rewards-catalog admin (CRUD over the redeemable rewards members see), registered in the
+ * AUTHENTICATED graph. Role-gated the SAME way as the other admin queues (backend 403 -> Forbidden
+ * "not authorised"); the list read degrades on 404 to an honest empty state.
+ */
+data object CatalogAdminDest {
+    const val ROUTE = "admin/rewards/catalog"
+}
+
+fun NavGraphBuilder.catalogAdminDestination(navController: NavHostController) {
+    composable(CatalogAdminDest.ROUTE) {
+        CatalogAdminRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -499,6 +499,9 @@ object MoreRoutes {
     // B5: admin refund-requests queue (status filter + approve/reject).
     const val ADMIN_REFUNDS = RefundAdminDest.ROUTE
 
+    // Operator rewards-catalog CRUD (redeemable rewards members see). Role-gated (backend 403 -> Forbidden).
+    const val ADMIN_REWARDS_CATALOG = CatalogAdminDest.ROUTE
+
     // B5: admin billing-disputes queue (status filter + respond/resolve).
     const val ADMIN_DISPUTES = DisputeAdminDest.ROUTE
 
@@ -769,6 +772,7 @@ object MoreRoutes {
             ADMIN_VIDEO_REVIEW,
             ADMIN_DMCA,
             ADMIN_REFUNDS,
+            ADMIN_REWARDS_CATALOG,
             ADMIN_DISPUTES,
             ADMIN_APPEALS,
             ADMIN_FRAUD,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -939,6 +939,7 @@
     <string name="more_entry_video_review">Video review</string>
     <string name="more_entry_dmca_admin">DMCA claims</string>
     <string name="more_entry_refund_admin">Refund requests</string>
+    <string name="more_entry_rewards_catalog_admin">Rewards catalog</string>
     <string name="more_entry_dispute_admin">Disputes</string>
     <string name="more_entry_appeal_admin">Appeals review</string>
     <string name="more_entry_fraud_admin">Fraud review</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidationTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidationTest.kt
@@ -1,0 +1,100 @@
+package com.testlogon.android.feature.adminrewards
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CatalogAdminValidationTest {
+
+    @Test
+    fun validPerk_ok_noErrors() {
+        val r = validateCatalogItem(name = "Free sticker", costPoints = 500, valueCents = 0, kind = "perk")
+        assertTrue(r.ok)
+        assertTrue(r.errors.isEmpty())
+    }
+
+    @Test
+    fun validCash_withValue_ok() {
+        val r = validateCatalogItem(name = "\$5 credit", costPoints = 5000, valueCents = 500, kind = "cash")
+        assertTrue(r.ok)
+    }
+
+    @Test
+    fun blankName_isError() {
+        val r = validateCatalogItem(name = "   ", costPoints = 500, valueCents = 0, kind = "perk")
+        assertFalse(r.ok)
+        assertNotNullError(r, "name")
+    }
+
+    @Test
+    fun zeroCost_isError() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 0, valueCents = 0, kind = "perk")
+        assertFalse(r.ok)
+        assertNotNullError(r, "costPoints")
+    }
+
+    @Test
+    fun negativeCost_isError() {
+        val r = validateCatalogItem(name = "Perk", costPoints = -1, valueCents = 0, kind = "perk")
+        assertFalse(r.ok)
+        assertNotNullError(r, "costPoints")
+    }
+
+    @Test
+    fun negativeValue_isError() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = -1, kind = "perk")
+        assertFalse(r.ok)
+        assertNotNullError(r, "valueCents")
+    }
+
+    @Test
+    fun unknownKind_isError() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "swag")
+        assertFalse(r.ok)
+        assertNotNullError(r, "kind")
+    }
+
+    @Test
+    fun cashWithoutValue_isError() {
+        val r = validateCatalogItem(name = "Cash", costPoints = 100, valueCents = 0, kind = "cash")
+        assertFalse(r.ok)
+        assertNotNullError(r, "valueCents")
+    }
+
+    @Test
+    fun kindIsCaseInsensitiveAndTrimmed() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "  PERK ")
+        assertTrue(r.ok)
+    }
+
+    @Test
+    fun emptyDraft_defaultsAreSaneButInvalidCost() {
+        val d = emptyDraft()
+        assertEquals("perk", d.kind)
+        assertTrue(d.active)
+        // cost defaults to 0 -> not yet submittable, which is the intended "fill me in" state.
+        val r = validateCatalogItem(d)
+        assertFalse(r.ok)
+        assertNotNullError(r, "costPoints")
+    }
+
+    @Test
+    fun draftOverload_matchesPrimitiveOverload() {
+        val d = CatalogDraft(name = "X", costPoints = 10, valueCents = 0, kind = "perk", active = true)
+        assertTrue(validateCatalogItem(d).ok)
+    }
+
+    private fun assertNotNullError(r: CatalogValidationResult, field: String) {
+        assertTrue("expected error for \$field", r.errorFor(field) != null)
+    }
+
+    @Test
+    fun okDraft_hasNoFieldErrors() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk")
+        assertNull(r.errorFor("name"))
+        assertNull(r.errorFor("costPoints"))
+        assertNull(r.errorFor("kind"))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -221,6 +221,7 @@ const LicenseRevenuePage = lazy(() => import("@/pages/licenses/LicenseRevenuePag
 const RiskDashboardPage = lazy(() => import("@/pages/admin/RiskDashboardPage"));
 const SecurityDashboardPage = lazy(() => import("@/pages/admin/SecurityDashboardPage"));
 const SubscriptionTierManagerPage = lazy(() => import("@/pages/admin/SubscriptionTierManagerPage"));
+const RewardsCatalogAdminPage = lazy(() => import("@/pages/admin/RewardsCatalogAdminPage"));
 const BillingConfigPage = lazy(() => import("@/pages/admin/BillingConfigPage"));
 const CreatorDashboard = lazy(() => import("@/pages/dashboard/CreatorDashboard"));
 const OrgsPage = lazy(() => import("@/pages/orgs/OrgsPage"));
@@ -941,6 +942,7 @@ export default function App() {
           <Route path="admin/risk" element={<RiskDashboardPage />} />
           <Route path="admin/security" element={<SecurityDashboardPage />} />
           <Route path="admin/subscription-tiers" element={<SubscriptionTierManagerPage />} />
+          <Route path="admin/rewards-catalog" element={<RewardsCatalogAdminPage />} />
           <Route path="admin/billing-config" element={<BillingConfigPage />} />
           <Route path="licenses/requests" element={<LicenseRequestsPage />} />
           <Route path="kyc" element={<KycWizardPage />} />

--- a/frontend/src/api/endpoints/adminRewards.ts
+++ b/frontend/src/api/endpoints/adminRewards.ts
@@ -1,0 +1,59 @@
+import { api } from "@/api/client";
+import type { RewardKind } from "@/api/endpoints/rewards";
+
+/**
+ * REWARDS CATALOG ADMIN (`/admin/rewards/catalog*`).
+ *
+ * Operator/admin CRUD over the redeemable rewards catalog that users see on the
+ * Rewards surface (`GET /me/rewards/catalog`). The admin item is the user-facing
+ * catalog reward PLUS an `active` flag (deactivated items are hidden from users)
+ * and an optional `redeemed_count` metric.
+ *
+ * CONVENTIONS: every monetary amount is INTEGER CENTS; `cost_points` is a whole
+ * integer. These endpoints do NOT exist on the backend yet: the LIST read
+ * degrades on 404/absent to an honest "not available" empty state (callers use
+ * `retry:false`), and every mutation surfaces a clear error toast on failure —
+ * it never silently "succeeds".
+ */
+
+/** A catalog reward as seen by the operator (adds `active` + optional metric). */
+export interface AdminCatalogItem {
+  id: string;
+  name: string;
+  description: string;
+  cost_points: number;
+  value_cents: number;
+  kind: RewardKind;
+  active: boolean;
+  redeemed_count?: number;
+}
+
+export interface AdminCatalogList {
+  rewards: AdminCatalogItem[];
+}
+
+/** Write payload for create/update (server assigns the id + redeemed_count). */
+export interface AdminCatalogInput {
+  name: string;
+  description: string;
+  cost_points: number;
+  value_cents: number;
+  kind: RewardKind;
+  active: boolean;
+}
+
+// ── Read (degrade on 404 — caller uses retry:false) ──────────────────
+
+export const listAdminRewardsCatalog = () =>
+  api.get<AdminCatalogList>("/admin/rewards/catalog");
+
+// ── Mutations (clear error on failure — never silent) ────────────────
+
+export const createAdminRewardsCatalogItem = (input: AdminCatalogInput) =>
+  api.post<AdminCatalogItem>("/admin/rewards/catalog", input);
+
+export const updateAdminRewardsCatalogItem = (id: string, input: AdminCatalogInput) =>
+  api.put<AdminCatalogItem>(`/admin/rewards/catalog/${id}`, input);
+
+export const deleteAdminRewardsCatalogItem = (id: string) =>
+  api.del<{ ok: boolean }>(`/admin/rewards/catalog/${id}`);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -67,6 +67,7 @@ import {
   Lightbulb,
   Palette,
   Gauge,
+  Gift,
   Receipt,
   Terminal,
   Package,
@@ -303,6 +304,7 @@ const NAV_GROUPS: NavGroup[] = [
       { label: "Security Dashboard", i18nKey: "nav.securityDashboard", path: "/admin/security", icon: <ShieldAlert className="h-5 w-5" /> },
       { label: "Legal Holds", i18nKey: "nav.legalHolds", path: "/admin/legal-holds", icon: <Gavel className="h-5 w-5" /> },
       { label: "Subscription Tiers", i18nKey: "nav.subscriptionTiers", path: "/admin/subscription-tiers", icon: <Layers className="h-5 w-5" /> },
+      { label: "Rewards Catalog", path: "/admin/rewards-catalog", icon: <Gift className="h-5 w-5" /> },
       { label: "Compute", i18nKey: "nav.compute", path: "/admin/compute", icon: <Server className="h-5 w-5" /> },
       { label: "Inventory", i18nKey: "nav.inventory", path: "/admin/inventory", icon: <Boxes className="h-5 w-5" /> },
       { label: "Financials", i18nKey: "nav.financials", path: "/admin/financials", icon: <BarChart3 className="h-5 w-5" /> },
@@ -453,6 +455,7 @@ export default function Sidebar() {
   const showPaymentIncidents = canAccessPaymentIncidentQueue(accessToken);
   const showInventoryAdmin =
     isInventoryReservationsEnabled() && canAccessGeneralAdminControls(accessToken);
+  const showRewardsCatalogAdmin = canAccessGeneralAdminControls(accessToken);
 
   const { data: convoData } = useQuery({
     queryKey: ["conversations"],
@@ -517,6 +520,7 @@ export default function Sidebar() {
             if (item.path === "/admin/ads/fraud") return showModerationBoard;
             if (item.path === "/admin/ad-platform") return showModerationBoard;
             if (item.path === "/admin/bulk-payouts") return showRootRoleManagement;
+            if (item.path === "/admin/rewards-catalog") return showRewardsCatalogAdmin;
             if (item.path === "/admin/inventory") return showInventoryAdmin;
             return true;
           });

--- a/frontend/src/lib/rewardsCatalogAdmin.test.ts
+++ b/frontend/src/lib/rewardsCatalogAdmin.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  validateCatalogItem,
+  emptyDraft,
+  formatPoints,
+  formatCents,
+} from "./rewardsCatalogAdmin";
+
+describe("validateCatalogItem", () => {
+  const valid = {
+    name: "Gift Card",
+    cost_points: 1000,
+    value_cents: 500,
+    kind: "cash" as const,
+  };
+
+  it("accepts a valid cash item", () => {
+    const r = validateCatalogItem(valid);
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual({});
+  });
+
+  it("accepts a valid perk with zero value", () => {
+    const r = validateCatalogItem({ ...valid, kind: "perk", value_cents: 0 });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects an empty / whitespace name", () => {
+    expect(validateCatalogItem({ ...valid, name: "" }).errors.name).toBeDefined();
+    expect(validateCatalogItem({ ...valid, name: "   " }).errors.name).toBeDefined();
+    expect(validateCatalogItem({ ...valid, name: "   " }).ok).toBe(false);
+  });
+
+  it("rejects non-positive or non-integer cost_points", () => {
+    expect(validateCatalogItem({ ...valid, cost_points: 0 }).errors.cost_points).toBeDefined();
+    expect(validateCatalogItem({ ...valid, cost_points: -5 }).errors.cost_points).toBeDefined();
+    expect(validateCatalogItem({ ...valid, cost_points: 1.5 }).errors.cost_points).toBeDefined();
+  });
+
+  it("rejects negative or non-integer value_cents", () => {
+    expect(validateCatalogItem({ ...valid, value_cents: -1 }).errors.value_cents).toBeDefined();
+    expect(validateCatalogItem({ ...valid, kind: "perk", value_cents: 2.5 }).errors.value_cents).toBeDefined();
+  });
+
+  it("rejects an unknown kind", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = validateCatalogItem({ ...valid, kind: "gift" as any });
+    expect(r.errors.kind).toBeDefined();
+    expect(r.ok).toBe(false);
+  });
+
+  it("requires a cash reward to have value_cents > 0", () => {
+    const r = validateCatalogItem({ ...valid, kind: "cash", value_cents: 0 });
+    expect(r.ok).toBe(false);
+    expect(r.errors.value_cents).toBeDefined();
+  });
+
+  it("accumulates multiple errors at once", () => {
+    const r = validateCatalogItem({ name: "", cost_points: 0, value_cents: -1, kind: "cash" });
+    expect(r.ok).toBe(false);
+    expect(Object.keys(r.errors).sort()).toEqual(["cost_points", "name", "value_cents"]);
+  });
+});
+
+describe("emptyDraft", () => {
+  it("is an inactive-safe blank perk draft that FAILS validation until filled", () => {
+    const d = emptyDraft();
+    expect(d).toEqual({
+      name: "",
+      description: "",
+      cost_points: 0,
+      value_cents: 0,
+      kind: "perk",
+      active: true,
+    });
+    expect(validateCatalogItem(d).ok).toBe(false);
+  });
+
+  it("returns a fresh object each call (no shared mutation)", () => {
+    const a = emptyDraft();
+    const b = emptyDraft();
+    expect(a).not.toBe(b);
+    a.name = "changed";
+    expect(b.name).toBe("");
+  });
+});
+
+describe("re-exported formatters", () => {
+  it("formatPoints adds a unit and thousands separators", () => {
+    expect(formatPoints(12345)).toBe("12,345 pts");
+    expect(formatPoints(12345, false)).toBe("12,345");
+  });
+
+  it("formatCents renders integer cents as USD", () => {
+    expect(formatCents(500)).toBe("$5.00");
+    expect(formatCents(0)).toBe("$0.00");
+  });
+});

--- a/frontend/src/lib/rewardsCatalogAdmin.ts
+++ b/frontend/src/lib/rewardsCatalogAdmin.ts
@@ -1,0 +1,77 @@
+import type { RewardKind } from "@/api/endpoints/rewards";
+import type { AdminCatalogInput } from "@/api/endpoints/adminRewards";
+
+// Reuse the shared rewards formatters so the admin surface renders points/cents
+// identically to the user-facing Rewards page.
+export { formatPoints, formatCents } from "@/lib/rewards";
+
+/** The subset of an item we validate (create + edit share this shape). */
+export interface CatalogItemValidatable {
+  name: string;
+  cost_points: number;
+  value_cents: number;
+  kind: RewardKind;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: Partial<Record<"name" | "cost_points" | "value_cents" | "kind", string>>;
+}
+
+const REWARD_KINDS: readonly RewardKind[] = ["cash", "perk"];
+
+function isPositiveInt(n: number): boolean {
+  return Number.isInteger(n) && n > 0;
+}
+
+function isNonNegativeInt(n: number): boolean {
+  return Number.isInteger(n) && n >= 0;
+}
+
+/**
+ * Validate a catalog item draft. Pure — no I/O.
+ *
+ * Rules:
+ *  - name: required, non-empty (after trim)
+ *  - cost_points: integer > 0
+ *  - value_cents: integer >= 0
+ *  - kind: one of "cash" | "perk"
+ *  - a CASH reward must have value_cents > 0 (it credits the USD cash wallet)
+ */
+export function validateCatalogItem(item: CatalogItemValidatable): ValidationResult {
+  const errors: ValidationResult["errors"] = {};
+
+  if (!item.name || item.name.trim().length === 0) {
+    errors.name = "Name is required.";
+  }
+
+  if (!isPositiveInt(item.cost_points)) {
+    errors.cost_points = "Cost must be a whole number greater than 0.";
+  }
+
+  if (!isNonNegativeInt(item.value_cents)) {
+    errors.value_cents = "Value must be a whole number of cents (0 or more).";
+  }
+
+  if (!REWARD_KINDS.includes(item.kind)) {
+    errors.kind = "Kind must be cash or perk.";
+  } else if (item.kind === "cash" && !(item.value_cents > 0)) {
+    // Only meaningful once value_cents is otherwise valid; a cash reward with
+    // no cash value is nonsensical.
+    errors.value_cents = "A cash reward must have a value greater than $0.00.";
+  }
+
+  return { ok: Object.keys(errors).length === 0, errors };
+}
+
+/** A blank draft for the create form. */
+export function emptyDraft(): AdminCatalogInput {
+  return {
+    name: "",
+    description: "",
+    cost_points: 0,
+    value_cents: 0,
+    kind: "perk",
+    active: true,
+  };
+}

--- a/frontend/src/pages/admin/RewardsCatalogAdminPage.tsx
+++ b/frontend/src/pages/admin/RewardsCatalogAdminPage.tsx
@@ -1,0 +1,445 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Gift, Plus } from "lucide-react";
+
+import { PageHeader } from "@/components/shared/PageHeader";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { ApiError } from "@/api/client";
+import { useAuthStore } from "@/stores/authStore";
+import { canAccessGeneralAdminControls } from "@/lib/adminCapabilities";
+import type { RewardKind } from "@/api/endpoints/rewards";
+import {
+  listAdminRewardsCatalog,
+  createAdminRewardsCatalogItem,
+  updateAdminRewardsCatalogItem,
+  deleteAdminRewardsCatalogItem,
+  type AdminCatalogItem,
+  type AdminCatalogInput,
+} from "@/api/endpoints/adminRewards";
+import {
+  validateCatalogItem,
+  emptyDraft,
+  formatPoints,
+  formatCents,
+} from "@/lib/rewardsCatalogAdmin";
+
+function is404(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+// ─── Create / Edit form dialog ───────────────────────────────────
+
+function CatalogItemDialog({
+  open,
+  item,
+  onSave,
+  onCancel,
+  saving,
+}: {
+  open: boolean;
+  item: AdminCatalogItem | null; // null = create mode
+  onSave: (data: AdminCatalogInput) => void;
+  onCancel: () => void;
+  saving?: boolean;
+}) {
+  const [draft, setDraft] = useState<AdminCatalogInput>(emptyDraft());
+
+  useEffect(() => {
+    if (open) {
+      setDraft(
+        item
+          ? {
+              name: item.name,
+              description: item.description,
+              cost_points: item.cost_points,
+              value_cents: item.value_cents,
+              kind: item.kind,
+              active: item.active,
+            }
+          : emptyDraft(),
+      );
+    }
+  }, [open, item]);
+
+  const { ok, errors } = validateCatalogItem(draft);
+
+  const set = <K extends keyof AdminCatalogInput>(k: K, v: AdminCatalogInput[K]) =>
+    setDraft((prev) => ({ ...prev, [k]: v }));
+
+  const intFromInput = (raw: string): number => {
+    const n = parseInt(raw, 10);
+    return Number.isNaN(n) ? 0 : n;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (!o ? onCancel() : undefined)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{item ? "Edit reward" : "Create reward"}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="rc-name">Name</Label>
+            <Input
+              id="rc-name"
+              value={draft.name}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder="$5 cash credit"
+            />
+            {errors.name && <p className="text-sm text-destructive">{errors.name}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="rc-desc">Description</Label>
+            <Textarea
+              id="rc-desc"
+              value={draft.description}
+              onChange={(e) => set("description", e.target.value)}
+              placeholder="Redeem points for a credit to your USD cash wallet."
+              rows={3}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="rc-cost">Cost (points)</Label>
+              <Input
+                id="rc-cost"
+                type="number"
+                inputMode="numeric"
+                min={1}
+                step={1}
+                value={draft.cost_points === 0 ? "" : String(draft.cost_points)}
+                onChange={(e) => set("cost_points", intFromInput(e.target.value))}
+              />
+              {errors.cost_points && (
+                <p className="text-sm text-destructive">{errors.cost_points}</p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rc-value">Value (cents)</Label>
+              <Input
+                id="rc-value"
+                type="number"
+                inputMode="numeric"
+                min={0}
+                step={1}
+                value={draft.value_cents === 0 ? "" : String(draft.value_cents)}
+                onChange={(e) => set("value_cents", intFromInput(e.target.value))}
+              />
+              {errors.value_cents && (
+                <p className="text-sm text-destructive">{errors.value_cents}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 items-start gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="rc-kind">Kind</Label>
+              <Select
+                value={draft.kind}
+                onValueChange={(v) => set("kind", v as RewardKind)}
+              >
+                <SelectTrigger id="rc-kind">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="cash">Cash</SelectItem>
+                  <SelectItem value="perk">Perk</SelectItem>
+                </SelectContent>
+              </Select>
+              {errors.kind && <p className="text-sm text-destructive">{errors.kind}</p>}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rc-active">Active</Label>
+              <div className="flex h-10 items-center gap-2">
+                <Switch
+                  id="rc-active"
+                  checked={draft.active}
+                  onCheckedChange={(v) => set("active", v)}
+                />
+                <span className="text-sm text-muted-foreground">
+                  {draft.active ? "Visible to users" : "Hidden from users"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={() => onSave(draft)} disabled={!ok || saving}>
+            {saving ? "Saving…" : item ? "Save changes" : "Create reward"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────
+
+export default function RewardsCatalogAdminPage() {
+  const queryClient = useQueryClient();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const canAccess = canAccessGeneralAdminControls(accessToken);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [editItem, setEditItem] = useState<AdminCatalogItem | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AdminCatalogItem | null>(null);
+
+  const catalogQ = useQuery({
+    queryKey: ["admin", "rewards", "catalog"],
+    queryFn: listAdminRewardsCatalog,
+    retry: false,
+    enabled: canAccess,
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["admin", "rewards", "catalog"] });
+
+  const createMut = useMutation({
+    mutationFn: (data: AdminCatalogInput) => createAdminRewardsCatalogItem(data),
+    onSuccess: () => {
+      toast.success("Reward created");
+      setShowCreate(false);
+      invalidate();
+    },
+    onError: (e: unknown) =>
+      toast.error(e instanceof ApiError ? e.detail : "Create failed"),
+  });
+
+  const updateMut = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: AdminCatalogInput }) =>
+      updateAdminRewardsCatalogItem(id, data),
+    onSuccess: () => {
+      toast.success("Reward updated");
+      setEditItem(null);
+      invalidate();
+    },
+    onError: (e: unknown) =>
+      toast.error(e instanceof ApiError ? e.detail : "Update failed"),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteAdminRewardsCatalogItem(id),
+    onSuccess: () => {
+      toast.success("Reward deleted");
+      setDeleteTarget(null);
+      invalidate();
+    },
+    onError: (e: unknown) =>
+      toast.error(e instanceof ApiError ? e.detail : "Delete failed"),
+  });
+
+  const toggleActive = (item: AdminCatalogItem) =>
+    updateMut.mutate({
+      id: item.id,
+      data: {
+        name: item.name,
+        description: item.description,
+        cost_points: item.cost_points,
+        value_cents: item.value_cents,
+        kind: item.kind,
+        active: !item.active,
+      },
+    });
+
+  const handleSave = (data: AdminCatalogInput) => {
+    if (editItem) updateMut.mutate({ id: editItem.id, data });
+    else createMut.mutate(data);
+  };
+
+  const items = useMemo(() => catalogQ.data?.rewards ?? [], [catalogQ.data]);
+  const notAvailable = is404(catalogQ.error);
+
+  if (!canAccess) {
+    return (
+      <div className="mx-auto w-full max-w-5xl p-4 sm:p-6">
+        <PageHeader title="Rewards Catalog" />
+        <p className="text-muted-foreground">
+          You do not have permission to manage the rewards catalog.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 sm:p-6">
+      <PageHeader
+        title="Rewards Catalog"
+        description="Manage the redeemable rewards users see on their Rewards page. Deactivated rewards are hidden from users."
+        actions={
+          <Button
+            onClick={() => {
+              setEditItem(null);
+              setShowCreate(true);
+            }}
+          >
+            <Plus className="mr-2 h-4 w-4" /> Create reward
+          </Button>
+        }
+      />
+
+      {catalogQ.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading catalog…</p>
+      ) : notAvailable ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <Gift className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            The rewards catalog admin API is not available yet. This surface will
+            populate once the backend endpoints ship.
+          </p>
+        </div>
+      ) : catalogQ.isError ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Could not load the rewards catalog. Please try again.
+          </p>
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <Gift className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            No rewards in the catalog yet. Create the first redeemable reward.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Cost</TableHead>
+                <TableHead>Value</TableHead>
+                <TableHead>Kind</TableHead>
+                <TableHead className="text-right">Redeemed</TableHead>
+                <TableHead>Active</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.map((item) => (
+                <TableRow key={item.id} className={item.active ? "" : "opacity-60"}>
+                  <TableCell>
+                    <div className="font-medium">{item.name}</div>
+                    {item.description && (
+                      <div className="text-xs text-muted-foreground line-clamp-2">
+                        {item.description}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    {formatPoints(item.cost_points)}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    {formatCents(item.value_cents)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={item.kind === "cash" ? "default" : "secondary"}>
+                      {item.kind}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {item.redeemed_count ?? 0}
+                  </TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={item.active}
+                      onCheckedChange={() => toggleActive(item)}
+                      disabled={updateMut.isPending}
+                      aria-label={`Toggle ${item.name} active`}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setShowCreate(false);
+                          setEditItem(item);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive"
+                        onClick={() => setDeleteTarget(item)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <CatalogItemDialog
+        open={showCreate || !!editItem}
+        item={editItem}
+        onSave={handleSave}
+        onCancel={() => {
+          setShowCreate(false);
+          setEditItem(null);
+        }}
+        saving={createMut.isPending || updateMut.isPending}
+      />
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(o) => (!o ? setDeleteTarget(null) : undefined)}
+        title="Delete reward?"
+        description={
+          deleteTarget
+            ? `"${deleteTarget.name}" will be removed from the catalog. This cannot be undone.`
+            : undefined
+        }
+        variant="danger"
+        confirmLabel="Delete"
+        loading={deleteMut.isPending}
+        onConfirm={() => deleteTarget && deleteMut.mutate(deleteTarget.id)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Rewards catalog admin — operator CRUD

An operator surface to manage the rewards redeem catalog users see (`GET /me/rewards/catalog`). List / create / edit / delete / toggle-active, **role-gated** (reuses the app's existing admin gate), degrade-on-404.

New admin contract: `GET/POST /admin/rewards/catalog`, `PUT/DELETE /admin/rewards/catalog/{id}` (item = `{id,name,description,cost_points,value_cents,kind cash|perk,active,redeemed_count?}`).

### Web (`/admin/rewards-catalog`)
`lib/rewardsCatalogAdmin.ts` (+12 vitest) — `validateCatalogItem` (name / cost>0 / value≥0 / kind; cash needs value>0) + `emptyDraft`; `api/endpoints/adminRewards.ts`; `RewardsCatalogAdminPage` — table + Create/Edit dialog (validation, inline errors, disabled-until-valid) + Delete confirm + active toggle; gated via `canAccessGeneralAdminControls` (same lib as DMCA/moderation admin), Sidebar entry filtered by that capability.

### Android (new `feature/adminrewards` + `data/adminrewards`, registered in `MoreRoutes`)
`CatalogAdminValidation.kt` (mirror; +12 JVM tests) + CatalogAdmin Screen/ViewModel + typed `AdminRewardsApi`/repo (degrade-on-404); role-gated via the refund-admin server-403 → Forbidden pattern + `operatorOnly` MoreEntry.

No new deps. Gates: web tsc 0 · vite build · vitest 12/12; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (12/12, MoreCatalog 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
