### PR TITLE
feat(rewards): catalog stock / inventory limits (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/adminrewards/AdminRewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/adminrewards/AdminRewardsApi.kt
@@ -79,6 +79,7 @@ data class AdminCatalogItemDto(
     @Json(name = "kind") val kind: String? = null,
     @Json(name = "active") val active: Boolean? = null,
     @LenientInt @Json(name = "redeemed_count") val redeemedCount: Int? = null,
+    @LenientLong @Json(name = "stock_limit") val stockLimit: Long? = null,
 )
 
 // ---- POST/PUT body ----
@@ -91,6 +92,8 @@ data class AdminCatalogItemReq(
     @Json(name = "value_cents") val valueCents: Long,
     @Json(name = "kind") val kind: String,
     @Json(name = "active") val active: Boolean,
+    /** Optional inventory cap; null = UNLIMITED (omitted-as-null on the wire). */
+    @Json(name = "stock_limit") val stockLimit: Long? = null,
 )
 
 // ---- DELETE ----

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
@@ -220,6 +220,8 @@ data class CatalogRewardDto(
     @LenientLong @Json(name = "cost_points") val costPoints: Long? = null,
     @LenientLong @Json(name = "value_cents") val valueCents: Long? = null,
     @Json(name = "kind") val kind: String? = null,
+    @LenientLong @Json(name = "stock_limit") val stockLimit: Long? = null,
+    @LenientLong @Json(name = "redeemed_count") val redeemedCount: Long? = null,
 )
 
 // ---- POST me/rewards/redeem ----

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
@@ -150,6 +150,10 @@ data class CatalogReward(
     val costPoints: Long,
     val valueCents: Long,
     val kind: RewardKind,
+    /** Optional inventory cap; null = UNLIMITED (back-compat: absent field). */
+    val stockLimit: Long? = null,
+    /** How many have been redeemed so far (server-authoritative); defaults 0. */
+    val redeemedCount: Long = 0L,
 )
 
 /** Result of POST me/rewards/redeem (mutation). ok=true when the server accepted the redemption. */
@@ -277,6 +281,8 @@ internal fun CatalogRewardDto.toDomain(): CatalogReward? {
         costPoints = costPoints ?: 0L,
         valueCents = valueCents ?: 0L,
         kind = kind.toRewardKind(),
+        stockLimit = stockLimit?.coerceAtLeast(0L),
+        redeemedCount = (redeemedCount ?: 0L).coerceAtLeast(0L),
     )
 }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminScreen.kt
@@ -258,6 +258,13 @@ private fun CatalogRow(
                 item.redeemedCount?.let {
                     Text("" + it + " redeemed", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
+                val limit = item.stockLimit
+                if (limit == null) {
+                    Text("Unlimited stock", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                } else {
+                    val remaining = (limit - (item.redeemedCount ?: 0).toLong()).coerceAtLeast(0L)
+                    Text("" + remaining + " / " + limit + " left", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
             }
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -300,10 +307,13 @@ private fun CatalogFormDialog(
     var valueText by remember { mutableStateOf(if (initial.valueCents > 0) initial.valueCents.toString() else "") }
     var kind by remember { mutableStateOf(initial.kind) }
     var active by remember { mutableStateOf(initial.active) }
+    var stockText by remember { mutableStateOf(initial.stockLimit?.toString() ?: "") }
 
     val costPoints = costText.trim().toLongOrNull() ?: 0L
     val valueCents = valueText.trim().toLongOrNull() ?: 0L
-    val validation = validateCatalogItem(name, costPoints, valueCents, kind)
+    // Blank stock field = UNLIMITED (null); any digits = a concrete cap.
+    val stockLimit: Long? = stockText.trim().takeIf { it.isNotEmpty() }?.toLongOrNull()
+    val validation = validateCatalogItem(name, costPoints, valueCents, kind, stockLimit)
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -342,6 +352,18 @@ private fun CatalogFormDialog(
                     supportingText = { validation.errorFor("valueCents")?.let { Text(it) } },
                     modifier = Modifier.fillMaxWidth(),
                 )
+                OutlinedTextField(
+                    value = stockText,
+                    onValueChange = { stockText = it.filter(Char::isDigit) },
+                    label = { Text("Stock limit") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    isError = validation.errorFor("stockLimit") != null,
+                    supportingText = {
+                        val err = validation.errorFor("stockLimit")
+                        if (err != null) Text(err) else Text("Blank = unlimited")
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     CATALOG_KINDS.forEach { k ->
                         FilterChip(
@@ -368,6 +390,7 @@ private fun CatalogFormDialog(
                             valueCents = valueCents,
                             kind = kind,
                             active = active,
+                            stockLimit = stockLimit,
                         )
                     )
                 },

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidation.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidation.kt
@@ -32,6 +32,8 @@ data class CatalogDraft(
     val valueCents: Long = 0L,
     val kind: String = "perk",
     val active: Boolean = true,
+    /** Optional inventory cap; null = UNLIMITED (blank field). */
+    val stockLimit: Long? = null,
 )
 
 /** A blank draft for the CREATE form (a sensible default kind + active). */
@@ -46,6 +48,7 @@ fun validateCatalogItem(
     costPoints: Long,
     valueCents: Long,
     kind: String,
+    stockLimit: Long? = null,
 ): CatalogValidationResult {
     val errors = LinkedHashMap<String, String>()
 
@@ -57,6 +60,11 @@ fun validateCatalogItem(
     }
     if (valueCents < 0L) {
         errors["valueCents"] = "Value cannot be negative"
+    }
+
+    // Stock limit is OPTIONAL (null = unlimited); when present it must be a non-negative integer.
+    if (stockLimit != null && stockLimit < 0L) {
+        errors["stockLimit"] = "Stock limit cannot be negative"
     }
 
     val normalizedKind = kind.trim().lowercase()
@@ -72,4 +80,4 @@ fun validateCatalogItem(
 
 /** Convenience overload validating a whole [CatalogDraft]. */
 fun validateCatalogItem(draft: CatalogDraft): CatalogValidationResult =
-    validateCatalogItem(draft.name, draft.costPoints, draft.valueCents, draft.kind)
+    validateCatalogItem(draft.name, draft.costPoints, draft.valueCents, draft.kind, draft.stockLimit)

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminViewModel.kt
@@ -158,6 +158,7 @@ internal fun CatalogDraft.toReq(): AdminCatalogItemReq = AdminCatalogItemReq(
     valueCents = valueCents,
     kind = kind.trim().lowercase(),
     active = active,
+    stockLimit = stockLimit,
 )
 
 /** Seed an editable draft from an existing catalog item (for the EDIT form). */
@@ -168,4 +169,5 @@ internal fun AdminCatalogItemDto.toDraft(): CatalogDraft = CatalogDraft(
     valueCents = valueCents ?: 0L,
     kind = (kind ?: "perk").trim().lowercase().let { if (it in CATALOG_KINDS) it else "perk" },
     active = active ?: false,
+    stockLimit = stockLimit?.coerceAtLeast(0L),
 )

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsMath.kt
@@ -56,9 +56,29 @@ object RewardsMath {
     fun pointsAfterRedeem(points: Long, reward: CatalogReward): Long =
         (points - reward.costPoints).coerceAtLeast(0L)
 
-    /** The subset of [catalog] the user can currently afford, preserving order. */
+    // ---- Stock / inventory limits ----
+
+    /**
+     * Remaining stock for [reward]: null when UNLIMITED (no stock_limit set), otherwise
+     * max(0, stock_limit - redeemed_count) so it never shows negative.
+     */
+    fun remainingStock(reward: CatalogReward): Long? {
+        val limit = reward.stockLimit ?: return null
+        return (limit - reward.redeemedCount).coerceAtLeast(0L)
+    }
+
+    /** True only when the reward is stock-limited AND has zero remaining. Unlimited is never out of stock. */
+    fun isOutOfStock(reward: CatalogReward): Boolean = remainingStock(reward) == 0L
+
+    /** Stable stock label: "Unlimited" / "Out of stock" / "N left". */
+    fun stockLabel(reward: CatalogReward): String {
+        val remaining = remainingStock(reward) ?: return "Unlimited"
+        return if (remaining <= 0L) "Out of stock" else "$remaining left"
+    }
+
+    /** The subset of [catalog] the user can currently afford AND that is in stock, preserving order. */
     fun redeemableCatalog(catalog: List<CatalogReward>, points: Long): List<CatalogReward> =
-        catalog.filter { canRedeem(it, points) }
+        catalog.filter { canRedeem(it, points) && !isOutOfStock(it) }
 
     /** The subset of [catalog] the user CANNOT yet afford (locked), preserving order. */
     fun lockedCatalog(catalog: List<CatalogReward>, points: Long): List<CatalogReward> =

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
@@ -463,6 +463,8 @@ private fun CatalogCard(
             state.catalog.forEachIndexed { i, reward ->
                 if (i > 0) Divider()
                 val affordable = RewardsMath.canRedeem(reward, state.points)
+                val outOfStock = RewardsMath.isOutOfStock(reward)
+                val stockLimited = RewardsMath.remainingStock(reward) != null
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -473,6 +475,13 @@ private fun CatalogCard(
                             Text(reward.name, style = MaterialTheme.typography.bodyLarge)
                             if (RewardsMath.isCashReward(reward)) {
                                 AssistChip(onClick = {}, label = { Text("Cash") })
+                            }
+                            if (stockLimited) {
+                                AssistChip(
+                                    onClick = {},
+                                    enabled = false,
+                                    label = { Text(RewardsMath.stockLabel(reward)) },
+                                )
                             }
                         }
                         if (reward.description.isNotBlank()) {
@@ -493,10 +502,18 @@ private fun CatalogCard(
                         }
                     }
                     OutlinedButton(
-                        enabled = affordable && !state.redeeming,
+                        enabled = affordable && !outOfStock && !state.redeeming,
                         onClick = { onRedeemClick(reward) },
                         modifier = Modifier.testTag(RewardsTestTags.REDEEM_PREFIX + reward.id),
-                    ) { Text(if (affordable) "Redeem" else "Locked") }
+                    ) {
+                        Text(
+                            when {
+                                outOfStock -> "Out of stock"
+                                affordable -> "Redeem"
+                                else -> "Locked"
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/test/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidationTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidationTest.kt
@@ -86,6 +86,46 @@ class CatalogAdminValidationTest {
         assertTrue(validateCatalogItem(d).ok)
     }
 
+    @Test
+    fun stockLimit_absentIsUnlimited_ok() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", stockLimit = null)
+        assertTrue(r.ok)
+        assertNull(r.errorFor("stockLimit"))
+    }
+
+    @Test
+    fun stockLimit_zeroIsValid() {
+        // Zero is a valid (currently out-of-stock) cap, not an error.
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", stockLimit = 0)
+        assertTrue(r.ok)
+    }
+
+    @Test
+    fun stockLimit_positiveIsValid() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", stockLimit = 25)
+        assertTrue(r.ok)
+    }
+
+    @Test
+    fun stockLimit_negativeIsError() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", stockLimit = -1)
+        assertFalse(r.ok)
+        assertNotNullError(r, "stockLimit")
+    }
+
+    @Test
+    fun emptyDraft_stockLimitIsUnlimited() {
+        assertNull(emptyDraft().stockLimit)
+    }
+
+    @Test
+    fun draftOverload_carriesStockLimit() {
+        val d = CatalogDraft(name = "X", costPoints = 10, valueCents = 0, kind = "perk", active = true, stockLimit = -5)
+        val r = validateCatalogItem(d)
+        assertFalse(r.ok)
+        assertNotNullError(r, "stockLimit")
+    }
+
     private fun assertNotNullError(r: CatalogValidationResult, field: String) {
         assertTrue("expected error for \$field", r.errorFor(field) != null)
     }

--- a/android/app/src/test/java/com/testlogon/android/feature/rewards/RewardsMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/rewards/RewardsMathTest.kt
@@ -6,6 +6,7 @@ import com.testlogon.android.data.rewards.ReferredUser
 import com.testlogon.android.data.rewards.RewardKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -16,8 +17,23 @@ import org.junit.Test
  */
 class RewardsMathTest {
 
-    private fun reward(id: String, cost: Long, valueCents: Long = 0, kind: RewardKind = RewardKind.PERK) =
-        CatalogReward(id = id, name = id, description = "", costPoints = cost, valueCents = valueCents, kind = kind)
+    private fun reward(
+        id: String,
+        cost: Long,
+        valueCents: Long = 0,
+        kind: RewardKind = RewardKind.PERK,
+        stockLimit: Long? = null,
+        redeemedCount: Long = 0L,
+    ) = CatalogReward(
+        id = id,
+        name = id,
+        description = "",
+        costPoints = cost,
+        valueCents = valueCents,
+        kind = kind,
+        stockLimit = stockLimit,
+        redeemedCount = redeemedCount,
+    )
 
     private fun ref(id: String, status: ReferralStatus, rewardCents: Long) =
         ReferredUser(id = id, maskedName = "A**", joinedTs = 0L, status = status, rewardCents = rewardCents)
@@ -91,6 +107,53 @@ class RewardsMathTest {
     fun isCashReward_onlyForCashKind() {
         assertTrue(RewardsMath.isCashReward(reward("c", 500, 500, RewardKind.CASH)))
         assertFalse(RewardsMath.isCashReward(reward("p", 500, 0, RewardKind.PERK)))
+    }
+
+    // ---- stock / inventory limits ----
+
+    @Test
+    fun remainingStock_nullWhenUnlimited() {
+        assertNull(RewardsMath.remainingStock(reward("a", 100)))
+    }
+
+    @Test
+    fun remainingStock_limitMinusRedeemedFlooredAtZero() {
+        assertEquals(3L, RewardsMath.remainingStock(reward("a", 100, stockLimit = 5, redeemedCount = 2)))
+        assertEquals(0L, RewardsMath.remainingStock(reward("a", 100, stockLimit = 5, redeemedCount = 5)))
+        // Over-redeemed never goes negative.
+        assertEquals(0L, RewardsMath.remainingStock(reward("a", 100, stockLimit = 5, redeemedCount = 9)))
+    }
+
+    @Test
+    fun isOutOfStock_onlyWhenLimitedAndExhausted() {
+        assertFalse(RewardsMath.isOutOfStock(reward("a", 100)))
+        assertFalse(RewardsMath.isOutOfStock(reward("a", 100, stockLimit = 5, redeemedCount = 4)))
+        assertTrue(RewardsMath.isOutOfStock(reward("a", 100, stockLimit = 5, redeemedCount = 5)))
+    }
+
+    @Test
+    fun stockLabel_unlimitedLeftAndOut() {
+        assertEquals("Unlimited", RewardsMath.stockLabel(reward("a", 100)))
+        assertEquals("3 left", RewardsMath.stockLabel(reward("a", 100, stockLimit = 5, redeemedCount = 2)))
+        assertEquals("Out of stock", RewardsMath.stockLabel(reward("a", 100, stockLimit = 5, redeemedCount = 5)))
+    }
+
+    @Test
+    fun redeemableCatalog_requiresAffordableAndInStock() {
+        val catalog = listOf(
+            reward("aff_stock", 100),
+            reward("aff_out", 100, stockLimit = 1, redeemedCount = 1),
+            reward("expensive", 1000),
+        )
+        // 500 points: can afford aff_stock + aff_out, but aff_out is out of stock; expensive unaffordable.
+        val redeemable = RewardsMath.redeemableCatalog(catalog, 500)
+        assertEquals(listOf("aff_stock"), redeemable.map { it.id })
+    }
+
+    @Test
+    fun redeemableCatalog_keepsAffordableLimitedButInStock() {
+        val catalog = listOf(reward("a", 100, stockLimit = 5, redeemedCount = 4))
+        assertEquals(listOf("a"), RewardsMath.redeemableCatalog(catalog, 500).map { it.id })
     }
 
     // ---- referral counting ----

--- a/frontend/src/api/endpoints/adminRewards.ts
+++ b/frontend/src/api/endpoints/adminRewards.ts
@@ -26,6 +26,8 @@ export interface AdminCatalogItem {
   kind: RewardKind;
   active: boolean;
   redeemed_count?: number;
+  /** Optional inventory cap. null/absent = UNLIMITED (back-compat default). */
+  stock_limit?: number | null;
 }
 
 export interface AdminCatalogList {
@@ -40,6 +42,8 @@ export interface AdminCatalogInput {
   value_cents: number;
   kind: RewardKind;
   active: boolean;
+  /** Optional inventory cap. null = UNLIMITED (blank field in the form). */
+  stock_limit?: number | null;
 }
 
 // ── Read (degrade on 404 — caller uses retry:false) ──────────────────

--- a/frontend/src/api/endpoints/rewards.ts
+++ b/frontend/src/api/endpoints/rewards.ts
@@ -83,6 +83,10 @@ export interface CatalogReward {
   cost_points: number;
   value_cents: number;
   kind: RewardKind;
+  /** Optional inventory cap. null/absent = UNLIMITED (back-compat default). */
+  stock_limit?: number | null;
+  /** How many have been redeemed (drives remaining stock). Absent = 0. */
+  redeemed_count?: number;
 }
 
 export interface RewardsCatalog {

--- a/frontend/src/lib/rewards.test.ts
+++ b/frontend/src/lib/rewards.test.ts
@@ -5,12 +5,15 @@ import {
   canRedeem,
   formatCents,
   formatPoints,
+  isOutOfStock,
   pointsAfterRedeem,
   redeemableCatalog,
   referralEarnedCents,
   referralPendingCents,
   referralShareText,
   referralStatusCounts,
+  remainingStock,
+  stockLabel,
 } from "@/lib/rewards";
 
 function ref(partial: Partial<ReferralEntry>): ReferralEntry {
@@ -31,6 +34,8 @@ function reward(partial: Partial<CatalogReward>): CatalogReward {
     cost_points: partial.cost_points ?? 100,
     value_cents: partial.value_cents ?? 100,
     kind: partial.kind ?? "cash",
+    stock_limit: partial.stock_limit,
+    redeemed_count: partial.redeemed_count,
   };
 }
 
@@ -115,6 +120,57 @@ describe("redeemableCatalog", () => {
   });
   it("returns [] for bad input", () => {
     expect(redeemableCatalog(undefined as unknown as CatalogReward[], 100)).toEqual([]);
+  });
+});
+
+describe("remainingStock", () => {
+  it("returns null (unlimited) when no stock_limit is set", () => {
+    expect(remainingStock(reward({}))).toBeNull();
+    expect(remainingStock(reward({ stock_limit: null }))).toBeNull();
+  });
+  it("subtracts redeemed_count from the limit", () => {
+    expect(remainingStock(reward({ stock_limit: 10, redeemed_count: 3 }))).toBe(7);
+    expect(remainingStock(reward({ stock_limit: 5 }))).toBe(5);
+  });
+  it("clamps at zero when over-redeemed", () => {
+    expect(remainingStock(reward({ stock_limit: 2, redeemed_count: 9 }))).toBe(0);
+  });
+});
+
+describe("isOutOfStock", () => {
+  it("is false for unlimited items", () => {
+    expect(isOutOfStock(reward({}))).toBe(false);
+  });
+  it("is true only when a limited item has zero remaining", () => {
+    expect(isOutOfStock(reward({ stock_limit: 3, redeemed_count: 3 }))).toBe(true);
+    expect(isOutOfStock(reward({ stock_limit: 3, redeemed_count: 1 }))).toBe(false);
+  });
+});
+
+describe("stockLabel", () => {
+  it("labels unlimited, remaining, and sold-out", () => {
+    expect(stockLabel(reward({}))).toBe("Unlimited");
+    expect(stockLabel(reward({ stock_limit: 1200, redeemed_count: 200 }))).toBe("1,000 left");
+    expect(stockLabel(reward({ stock_limit: 4, redeemed_count: 4 }))).toBe("Out of stock");
+  });
+});
+
+describe("redeemableCatalog + stock", () => {
+  it("marks an out-of-stock but affordable item as NOT affordable", () => {
+    const catalog = [
+      reward({ id: "u", cost_points: 100 }), // unlimited, affordable
+      reward({ id: "s", cost_points: 100, stock_limit: 2, redeemed_count: 2 }), // sold out
+    ];
+    const out = redeemableCatalog(catalog, 1000);
+    expect(out.find((r) => r.id === "u")?.affordable).toBe(true);
+    expect(out.find((r) => r.id === "s")?.affordable).toBe(false);
+  });
+  it("keeps an in-stock affordable item redeemable", () => {
+    const out = redeemableCatalog(
+      [reward({ id: "k", cost_points: 100, stock_limit: 5, redeemed_count: 1 })],
+      500,
+    );
+    expect(out.find((r) => r.id === "k")?.affordable).toBe(true);
   });
 });
 

--- a/frontend/src/lib/rewards.ts
+++ b/frontend/src/lib/rewards.ts
@@ -62,13 +62,51 @@ export function referralStatusCounts(
   return counts;
 }
 
+/**
+ * Remaining redeemable stock for a catalog item.
+ *  - null  -> UNLIMITED (no `stock_limit` set / null / not a finite number)
+ *  - number -> max(0, stock_limit - redeemed_count) (clamped at zero)
+ */
+export function remainingStock(item: {
+  stock_limit?: number | null;
+  redeemed_count?: number;
+}): number | null {
+  const limit = item?.stock_limit;
+  if (limit === null || limit === undefined || !Number.isFinite(limit)) return null;
+  const redeemed = Number.isFinite(item?.redeemed_count) ? (item.redeemed_count as number) : 0;
+  return Math.max(0, Math.trunc(limit) - Math.max(0, Math.trunc(redeemed)));
+}
+
+/** True only when the item is stock-limited AND has zero remaining. */
+export function isOutOfStock(item: {
+  stock_limit?: number | null;
+  redeemed_count?: number;
+}): boolean {
+  return remainingStock(item) === 0;
+}
+
+/** Human stock label: "Unlimited", "N left", or "Out of stock". */
+export function stockLabel(item: {
+  stock_limit?: number | null;
+  redeemed_count?: number;
+}): string {
+  const remaining = remainingStock(item);
+  if (remaining === null) return "Unlimited";
+  if (remaining === 0) return "Out of stock";
+  const n = new Intl.NumberFormat("en-US").format(remaining);
+  return `${n} left`;
+}
+
 /** Annotate each catalog reward with an `affordable` flag for the given points. */
 export function redeemableCatalog(
   catalog: CatalogReward[],
   points: number,
 ): RedeemableReward[] {
   if (!Array.isArray(catalog)) return [];
-  return catalog.map((r) => ({ ...r, affordable: canRedeem(points, r.cost_points) }));
+  return catalog.map((r) => ({
+    ...r,
+    affordable: canRedeem(points, r.cost_points) && !isOutOfStock(r),
+  }));
 }
 
 /** Format whole points with thousands separators, e.g. 12345 -> "12,345 pts". */

--- a/frontend/src/lib/rewardsCatalogAdmin.test.ts
+++ b/frontend/src/lib/rewardsCatalogAdmin.test.ts
@@ -61,7 +61,25 @@ describe("validateCatalogItem", () => {
     expect(r.ok).toBe(false);
     expect(Object.keys(r.errors).sort()).toEqual(["cost_points", "name", "value_cents"]);
   });
+
+  it("treats a blank/undefined stock_limit as valid (unlimited)", () => {
+    expect(validateCatalogItem({ ...valid }).ok).toBe(true);
+    expect(validateCatalogItem({ ...valid, stock_limit: undefined }).ok).toBe(true);
+    expect(validateCatalogItem({ ...valid, stock_limit: null }).ok).toBe(true);
+  });
+
+  it("accepts a whole-number stock_limit >= 0", () => {
+    expect(validateCatalogItem({ ...valid, stock_limit: 0 }).ok).toBe(true);
+    expect(validateCatalogItem({ ...valid, stock_limit: 250 }).ok).toBe(true);
+  });
+
+  it("rejects a negative or non-integer stock_limit", () => {
+    expect(validateCatalogItem({ ...valid, stock_limit: -1 }).errors.stock_limit).toBeDefined();
+    expect(validateCatalogItem({ ...valid, stock_limit: 3.5 }).errors.stock_limit).toBeDefined();
+    expect(validateCatalogItem({ ...valid, stock_limit: NaN }).ok).toBe(false);
+  });
 });
+
 
 describe("emptyDraft", () => {
   it("is an inactive-safe blank perk draft that FAILS validation until filled", () => {
@@ -73,6 +91,7 @@ describe("emptyDraft", () => {
       value_cents: 0,
       kind: "perk",
       active: true,
+      stock_limit: null,
     });
     expect(validateCatalogItem(d).ok).toBe(false);
   });

--- a/frontend/src/lib/rewardsCatalogAdmin.ts
+++ b/frontend/src/lib/rewardsCatalogAdmin.ts
@@ -11,11 +11,13 @@ export interface CatalogItemValidatable {
   cost_points: number;
   value_cents: number;
   kind: RewardKind;
+  /** Optional inventory cap. null/undefined = unlimited (valid). */
+  stock_limit?: number | null;
 }
 
 export interface ValidationResult {
   ok: boolean;
-  errors: Partial<Record<"name" | "cost_points" | "value_cents" | "kind", string>>;
+  errors: Partial<Record<"name" | "cost_points" | "value_cents" | "kind" | "stock_limit", string>>;
 }
 
 const REWARD_KINDS: readonly RewardKind[] = ["cash", "perk"];
@@ -61,6 +63,14 @@ export function validateCatalogItem(item: CatalogItemValidatable): ValidationRes
     errors.value_cents = "A cash reward must have a value greater than $0.00.";
   }
 
+  // stock_limit is OPTIONAL: null/undefined = unlimited (valid). When present it
+  // must be a whole number >= 0. NaN (e.g. a half-typed field) is invalid.
+  if (item.stock_limit !== null && item.stock_limit !== undefined) {
+    if (!isNonNegativeInt(item.stock_limit)) {
+      errors.stock_limit = "Stock limit must be a whole number (0 or more), or blank for unlimited.";
+    }
+  }
+
   return { ok: Object.keys(errors).length === 0, errors };
 }
 
@@ -73,5 +83,6 @@ export function emptyDraft(): AdminCatalogInput {
     value_cents: 0,
     kind: "perk",
     active: true,
+    stock_limit: null,
   };
 }

--- a/frontend/src/pages/admin/RewardsCatalogAdminPage.tsx
+++ b/frontend/src/pages/admin/RewardsCatalogAdminPage.tsx
@@ -52,6 +52,7 @@ import {
   formatPoints,
   formatCents,
 } from "@/lib/rewardsCatalogAdmin";
+import { remainingStock } from "@/lib/rewards";
 
 function is404(err: unknown): boolean {
   return err instanceof ApiError && err.status === 404;
@@ -85,6 +86,7 @@ function CatalogItemDialog({
               value_cents: item.value_cents,
               kind: item.kind,
               active: item.active,
+              stock_limit: item.stock_limit ?? null,
             }
           : emptyDraft(),
       );
@@ -197,6 +199,34 @@ function CatalogItemDialog({
               </div>
             </div>
           </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="rc-stock">Stock limit</Label>
+            <Input
+              id="rc-stock"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={1}
+              placeholder="Blank = unlimited"
+              value={
+                draft.stock_limit === null || draft.stock_limit === undefined
+                  ? ""
+                  : String(draft.stock_limit)
+              }
+              onChange={(e) =>
+                set(
+                  "stock_limit",
+                  e.target.value.trim() === "" ? null : intFromInput(e.target.value),
+                )
+              }
+            />
+            <p className="text-xs text-muted-foreground">
+              Leave blank for unlimited inventory.
+            </p>
+            {errors.stock_limit && (
+              <p className="text-sm text-destructive">{errors.stock_limit}</p>
+            )}
+          </div>
         </div>
 
         <DialogFooter>
@@ -277,6 +307,7 @@ export default function RewardsCatalogAdminPage() {
         value_cents: item.value_cents,
         kind: item.kind,
         active: !item.active,
+        stock_limit: item.stock_limit ?? null,
       },
     });
 
@@ -348,6 +379,7 @@ export default function RewardsCatalogAdminPage() {
                 <TableHead>Cost</TableHead>
                 <TableHead>Value</TableHead>
                 <TableHead>Kind</TableHead>
+                <TableHead className="text-right">Stock</TableHead>
                 <TableHead className="text-right">Redeemed</TableHead>
                 <TableHead>Active</TableHead>
                 <TableHead className="text-right">Actions</TableHead>
@@ -374,6 +406,15 @@ export default function RewardsCatalogAdminPage() {
                     <Badge variant={item.kind === "cash" ? "default" : "secondary"}>
                       {item.kind}
                     </Badge>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {item.stock_limit === null || item.stock_limit === undefined ? (
+                      <span className="text-muted-foreground">∞</span>
+                    ) : (
+                      <span className={remainingStock(item) === 0 ? "text-destructive" : ""}>
+                        {remainingStock(item)}/{item.stock_limit}
+                      </span>
+                    )}
                   </TableCell>
                   <TableCell className="text-right tabular-nums">
                     {item.redeemed_count ?? 0}

--- a/frontend/src/pages/rewards/RewardsPage.tsx
+++ b/frontend/src/pages/rewards/RewardsPage.tsx
@@ -44,8 +44,11 @@ import type { CatalogReward, RewardHistoryEntry } from "@/api/endpoints/rewards"
 import {
   formatCents,
   formatPoints,
+  isOutOfStock,
   pointsAfterRedeem,
   redeemableCatalog,
+  remainingStock,
+  stockLabel,
 } from "@/lib/rewards";
 import {
   CENTS_PER_POINT,
@@ -518,7 +521,10 @@ export default function RewardsPage() {
             </p>
           ) : (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {catalog.map((r) => (
+              {catalog.map((r) => {
+                const remaining = remainingStock(r);
+                const outOfStock = isOutOfStock(r);
+                return (
                 <div
                   key={r.id}
                   className="flex flex-col justify-between gap-3 rounded-lg border p-4"
@@ -531,6 +537,14 @@ export default function RewardsPage() {
                       </Badge>
                     </div>
                     <p className="mt-1 text-sm text-muted-foreground">{r.description}</p>
+                    {remaining !== null ? (
+                      <Badge
+                        variant={outOfStock ? "destructive" : "secondary"}
+                        className="mt-2 tabular-nums"
+                      >
+                        {stockLabel(r)}
+                      </Badge>
+                    ) : null}
                   </div>
                   <div className="flex items-center justify-between gap-2">
                     <div className="text-sm">
@@ -549,11 +563,12 @@ export default function RewardsPage() {
                       disabled={!r.affordable || redeemMut.isPending}
                       onClick={() => setPending(r)}
                     >
-                      {r.affordable ? "Redeem" : "Locked"}
+                      {outOfStock ? "Out of stock" : r.affordable ? "Redeem" : "Locked"}
                     </Button>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
## Rewards catalog stock / inventory limits

Each rewards catalog item gets an optional `stock_limit` (integer; **null/absent = unlimited**). Remaining = `max(0, stock_limit − redeemed_count)`. Admins set it; users see "N left"/"Out of stock" and can't redeem a sold-out item. **Fully back-compat** — absent = unlimited, no behavior change.

**Pure helpers (both platforms, +tests):** `remainingStock` (null=unlimited), `isOutOfStock`, `stockLabel`; `redeemableCatalog` now requires affordable **AND** in-stock. Admin `validateCatalogItem` validates `stock_limit` (integer ≥ 0) when present.

### Web
`rewards.ts`/`adminRewards.ts` types gain `stock_limit?` + `redeemed_count?`; `lib/rewards.ts` + `lib/rewardsCatalogAdmin.ts` helpers/validation (+15 vitest → 42/42); RewardsPage per-item stock badge + disabled "Out of stock" redeem; RewardsCatalogAdminPage Stock-limit field ("blank = unlimited") + Stock column threaded through create/update.

### Android
`data/rewards` + `data/adminrewards` DTOs/domain gain `stock_limit: Long?`; `RewardsMath` + `CatalogAdminValidation` mirror the helpers/validation (+ tests); RewardsScreen stock badge + disabled redeem; CatalogAdminScreen stock field + display.

No new deps, no route changes. Gates: web tsc 0 · vite build · vitest 42/42; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
