### PR TITLE
feat(rewards): catalog featured flag + sort ordering (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/adminrewards/AdminRewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/adminrewards/AdminRewardsApi.kt
@@ -80,6 +80,8 @@ data class AdminCatalogItemDto(
     @Json(name = "active") val active: Boolean? = null,
     @LenientInt @Json(name = "redeemed_count") val redeemedCount: Int? = null,
     @LenientLong @Json(name = "stock_limit") val stockLimit: Long? = null,
+    @Json(name = "featured") val featured: Boolean? = null,
+    @LenientLong @Json(name = "sort_order") val sortOrder: Long? = null,
 )
 
 // ---- POST/PUT body ----
@@ -94,6 +96,10 @@ data class AdminCatalogItemReq(
     @Json(name = "active") val active: Boolean,
     /** Optional inventory cap; null = UNLIMITED (omitted-as-null on the wire). */
     @Json(name = "stock_limit") val stockLimit: Long? = null,
+    /** Optional "featured" flag; featured items sort first + get a badge. Default false. */
+    @Json(name = "featured") val featured: Boolean = false,
+    /** Optional sort weight; lower sorts first. Default 0. */
+    @Json(name = "sort_order") val sortOrder: Long = 0L,
 )
 
 // ---- DELETE ----

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsApi.kt
@@ -222,6 +222,8 @@ data class CatalogRewardDto(
     @Json(name = "kind") val kind: String? = null,
     @LenientLong @Json(name = "stock_limit") val stockLimit: Long? = null,
     @LenientLong @Json(name = "redeemed_count") val redeemedCount: Long? = null,
+    @Json(name = "featured") val featured: Boolean? = null,
+    @LenientLong @Json(name = "sort_order") val sortOrder: Long? = null,
 )
 
 // ---- POST me/rewards/redeem ----

--- a/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/rewards/RewardsDomain.kt
@@ -154,6 +154,10 @@ data class CatalogReward(
     val stockLimit: Long? = null,
     /** How many have been redeemed so far (server-authoritative); defaults 0. */
     val redeemedCount: Long = 0L,
+    /** Optional operator "featured" flag; featured items sort first + get a badge. Default false. */
+    val featured: Boolean = false,
+    /** Optional operator sort weight; lower sorts first (missing/absent = 0). Default 0. */
+    val sortOrder: Long = 0L,
 )
 
 /** Result of POST me/rewards/redeem (mutation). ok=true when the server accepted the redemption. */
@@ -283,6 +287,8 @@ internal fun CatalogRewardDto.toDomain(): CatalogReward? {
         kind = kind.toRewardKind(),
         stockLimit = stockLimit?.coerceAtLeast(0L),
         redeemedCount = (redeemedCount ?: 0L).coerceAtLeast(0L),
+        featured = featured == true,
+        sortOrder = sortOrder ?: 0L,
     )
 }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminScreen.kt
@@ -64,11 +64,14 @@ object CatalogAdminTestTags {
     const val CREATE = "reward_catalog_admin_create"
     const val FORM_SUBMIT = "reward_catalog_admin_form_submit"
     const val FORM_NAME = "reward_catalog_admin_form_name"
+    const val FORM_SORT = "reward_catalog_admin_form_sort"
+    const val FORM_FEATURED = "reward_catalog_admin_form_featured"
     const val DELETE_CONFIRM = "reward_catalog_admin_delete_confirm"
     fun row(id: String) = "reward_catalog_row_" + id
     fun edit(id: String) = "reward_catalog_edit_" + id
     fun delete(id: String) = "reward_catalog_delete_" + id
     fun toggle(id: String) = "reward_catalog_toggle_" + id
+    fun featured(id: String) = "reward_catalog_featured_" + id
 }
 
 @Composable
@@ -243,11 +246,21 @@ private fun CatalogRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                AssistChip(
-                    onClick = {},
-                    enabled = false,
-                    label = { Text(item.kind ?: "perk") },
-                )
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    if (item.featured == true) {
+                        AssistChip(
+                            onClick = {},
+                            enabled = false,
+                            label = { Text("Featured") },
+                            modifier = Modifier.testTag(CatalogAdminTestTags.featured(item.id.orEmpty())),
+                        )
+                    }
+                    AssistChip(
+                        onClick = {},
+                        enabled = false,
+                        label = { Text(item.kind ?: "perk") },
+                    )
+                }
             }
             item.description?.takeIf { it.isNotBlank() }?.let {
                 Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 2, overflow = TextOverflow.Ellipsis)
@@ -258,6 +271,7 @@ private fun CatalogRow(
                 item.redeemedCount?.let {
                     Text("" + it + " redeemed", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
+                Text("order " + (item.sortOrder ?: 0L), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 val limit = item.stockLimit
                 if (limit == null) {
                     Text("Unlimited stock", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -307,13 +321,17 @@ private fun CatalogFormDialog(
     var valueText by remember { mutableStateOf(if (initial.valueCents > 0) initial.valueCents.toString() else "") }
     var kind by remember { mutableStateOf(initial.kind) }
     var active by remember { mutableStateOf(initial.active) }
+    var featured by remember { mutableStateOf(initial.featured) }
     var stockText by remember { mutableStateOf(initial.stockLimit?.toString() ?: "") }
+    var sortText by remember { mutableStateOf(if (initial.sortOrder != 0L) initial.sortOrder.toString() else "") }
 
     val costPoints = costText.trim().toLongOrNull() ?: 0L
     val valueCents = valueText.trim().toLongOrNull() ?: 0L
     // Blank stock field = UNLIMITED (null); any digits = a concrete cap.
     val stockLimit: Long? = stockText.trim().takeIf { it.isNotEmpty() }?.toLongOrNull()
-    val validation = validateCatalogItem(name, costPoints, valueCents, kind, stockLimit)
+    // Blank sort field = 0 (default weight); any digits = an explicit weight.
+    val sortOrder: Long = sortText.trim().toLongOrNull() ?: 0L
+    val validation = validateCatalogItem(name, costPoints, valueCents, kind, stockLimit, sortOrder)
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -364,6 +382,18 @@ private fun CatalogFormDialog(
                     },
                     modifier = Modifier.fillMaxWidth(),
                 )
+                OutlinedTextField(
+                    value = sortText,
+                    onValueChange = { sortText = it.filter(Char::isDigit) },
+                    label = { Text("Sort order") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    isError = validation.errorFor("sortOrder") != null,
+                    supportingText = {
+                        val err = validation.errorFor("sortOrder")
+                        if (err != null) Text(err) else Text("Lower shows first; blank = 0")
+                    },
+                    modifier = Modifier.fillMaxWidth().testTag(CatalogAdminTestTags.FORM_SORT),
+                )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     CATALOG_KINDS.forEach { k ->
                         FilterChip(
@@ -376,6 +406,14 @@ private fun CatalogFormDialog(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Switch(checked = active, onCheckedChange = { active = it })
                     Text(if (active) "Active" else "Inactive", style = MaterialTheme.typography.labelMedium)
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Switch(
+                        checked = featured,
+                        onCheckedChange = { featured = it },
+                        modifier = Modifier.testTag(CatalogAdminTestTags.FORM_FEATURED),
+                    )
+                    Text(if (featured) "Featured" else "Not featured", style = MaterialTheme.typography.labelMedium)
                 }
             }
         },
@@ -391,6 +429,8 @@ private fun CatalogFormDialog(
                             kind = kind,
                             active = active,
                             stockLimit = stockLimit,
+                            featured = featured,
+                            sortOrder = sortOrder,
                         )
                     )
                 },

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidation.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidation.kt
@@ -34,6 +34,10 @@ data class CatalogDraft(
     val active: Boolean = true,
     /** Optional inventory cap; null = UNLIMITED (blank field). */
     val stockLimit: Long? = null,
+    /** Featured flag; featured items sort first + get a badge. Default false. */
+    val featured: Boolean = false,
+    /** Optional sort weight; lower sorts first (integer >= 0). Default 0. */
+    val sortOrder: Long = 0L,
 )
 
 /** A blank draft for the CREATE form (a sensible default kind + active). */
@@ -49,6 +53,7 @@ fun validateCatalogItem(
     valueCents: Long,
     kind: String,
     stockLimit: Long? = null,
+    sortOrder: Long? = null,
 ): CatalogValidationResult {
     val errors = LinkedHashMap<String, String>()
 
@@ -67,6 +72,11 @@ fun validateCatalogItem(
         errors["stockLimit"] = "Stock limit cannot be negative"
     }
 
+    // Sort order is OPTIONAL (absent -> 0); when present it must be a non-negative integer.
+    if (sortOrder != null && sortOrder < 0L) {
+        errors["sortOrder"] = "Sort order cannot be negative"
+    }
+
     val normalizedKind = kind.trim().lowercase()
     if (normalizedKind !in CATALOG_KINDS) {
         errors["kind"] = "Kind must be cash or perk"
@@ -80,4 +90,4 @@ fun validateCatalogItem(
 
 /** Convenience overload validating a whole [CatalogDraft]. */
 fun validateCatalogItem(draft: CatalogDraft): CatalogValidationResult =
-    validateCatalogItem(draft.name, draft.costPoints, draft.valueCents, draft.kind, draft.stockLimit)
+    validateCatalogItem(draft.name, draft.costPoints, draft.valueCents, draft.kind, draft.stockLimit, draft.sortOrder)

--- a/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminrewards/CatalogAdminViewModel.kt
@@ -63,7 +63,7 @@ class CatalogAdminViewModel @Inject constructor(
         viewModelScope.launch {
             when (val r = repo.list()) {
                 is ApiResult.Success -> {
-                    val items = r.data.rewards
+                    val items = sortAdminCatalog(r.data.rewards)
                     _state.value = if (items.isEmpty()) CatalogAdminUiState.Empty
                     else CatalogAdminUiState.Content(items = items)
                 }
@@ -109,7 +109,7 @@ class CatalogAdminViewModel @Inject constructor(
     private suspend fun reloadAfterMutation(successMsg: String) {
         when (val r = repo.list()) {
             is ApiResult.Success -> {
-                val items = r.data.rewards
+                val items = sortAdminCatalog(r.data.rewards)
                 _state.value = if (items.isEmpty()) CatalogAdminUiState.Empty
                 else CatalogAdminUiState.Content(items = items, message = successMsg)
             }
@@ -150,6 +150,17 @@ class CatalogAdminViewModel @Inject constructor(
     }
 }
 
+/**
+ * Order the ADMIN catalog list the SAME way members see it (RewardsMath.sortCatalog): FEATURED first,
+ * then sort_order ascending (missing = 0), then name (case-insensitive) ascending. Pure + stable.
+ */
+internal fun sortAdminCatalog(items: List<AdminCatalogItemDto>): List<AdminCatalogItemDto> =
+    items.sortedWith(
+        compareByDescending<AdminCatalogItemDto> { it.featured == true }
+            .thenBy { it.sortOrder ?: 0L }
+            .thenBy { (it.name ?: "").trim().lowercase() },
+    )
+
 /** Map an editable draft to the create/update request body. */
 internal fun CatalogDraft.toReq(): AdminCatalogItemReq = AdminCatalogItemReq(
     name = name.trim(),
@@ -159,6 +170,8 @@ internal fun CatalogDraft.toReq(): AdminCatalogItemReq = AdminCatalogItemReq(
     kind = kind.trim().lowercase(),
     active = active,
     stockLimit = stockLimit,
+    featured = featured,
+    sortOrder = sortOrder.coerceAtLeast(0L),
 )
 
 /** Seed an editable draft from an existing catalog item (for the EDIT form). */
@@ -170,4 +183,6 @@ internal fun AdminCatalogItemDto.toDraft(): CatalogDraft = CatalogDraft(
     kind = (kind ?: "perk").trim().lowercase().let { if (it in CATALOG_KINDS) it else "perk" },
     active = active ?: false,
     stockLimit = stockLimit?.coerceAtLeast(0L),
+    featured = featured == true,
+    sortOrder = (sortOrder ?: 0L).coerceAtLeast(0L),
 )

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsMath.kt
@@ -84,6 +84,21 @@ object RewardsMath {
     fun lockedCatalog(catalog: List<CatalogReward>, points: Long): List<CatalogReward> =
         catalog.filter { !canRedeem(it, points) }
 
+    // ---- Catalog ordering (featured-first) ----
+
+    /**
+     * Canonical display order for the redeemable catalog: FEATURED items first, then by [CatalogReward.sortOrder]
+     * ascending (missing = 0), then by name (case-insensitive) ascending. STABLE + PURE (returns a new list,
+     * never mutates the input). Back-compat: when nothing is featured and all sort_orders are 0 this degrades to
+     * a plain name sort, which is a harmless re-order of the existing catalog.
+     */
+    fun sortCatalog(catalog: List<CatalogReward>): List<CatalogReward> =
+        catalog.sortedWith(
+            compareByDescending<CatalogReward> { it.featured }
+                .thenBy { it.sortOrder }
+                .thenBy { it.name.trim().lowercase() },
+        )
+
     /** Points still needed to afford [reward] (0 when already affordable). */
     fun pointsNeeded(reward: CatalogReward, points: Long): Long =
         (reward.costPoints - points).coerceAtLeast(0L)

--- a/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/rewards/RewardsScreen.kt
@@ -62,6 +62,7 @@ object RewardsTestTags {
     const val ERROR = "rewards_error"
     const val COMING_SOON = "rewards_coming_soon"
     const val REDEEM_PREFIX = "rewards_redeem_"
+    const val FEATURED_PREFIX = "rewards_featured_"
     const val REDEEM_CONFIRM = "rewards_redeem_confirm"
     const val TRADING = "rewards_trading_card"
     const val TRADING_CTA = "rewards_trading_cta"
@@ -460,7 +461,7 @@ private fun CatalogCard(
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Text("Redeem points", style = MaterialTheme.typography.titleMedium)
-            state.catalog.forEachIndexed { i, reward ->
+            RewardsMath.sortCatalog(state.catalog).forEachIndexed { i, reward ->
                 if (i > 0) Divider()
                 val affordable = RewardsMath.canRedeem(reward, state.points)
                 val outOfStock = RewardsMath.isOutOfStock(reward)
@@ -473,6 +474,14 @@ private fun CatalogCard(
                     Column(modifier = Modifier.weight(1f)) {
                         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             Text(reward.name, style = MaterialTheme.typography.bodyLarge)
+                            if (reward.featured) {
+                                AssistChip(
+                                    onClick = {},
+                                    enabled = false,
+                                    label = { Text("Featured") },
+                                    modifier = Modifier.testTag(RewardsTestTags.FEATURED_PREFIX + reward.id),
+                                )
+                            }
                             if (RewardsMath.isCashReward(reward)) {
                                 AssistChip(onClick = {}, label = { Text("Cash") })
                             }

--- a/android/app/src/test/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidationTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/adminrewards/CatalogAdminValidationTest.kt
@@ -126,6 +126,54 @@ class CatalogAdminValidationTest {
         assertNotNullError(r, "stockLimit")
     }
 
+    @Test
+    fun sortOrder_absentDefaultsOk() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", sortOrder = null)
+        assertTrue(r.ok)
+        assertNull(r.errorFor("sortOrder"))
+    }
+
+    @Test
+    fun sortOrder_zeroIsValid() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", sortOrder = 0)
+        assertTrue(r.ok)
+    }
+
+    @Test
+    fun sortOrder_positiveIsValid() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", sortOrder = 42)
+        assertTrue(r.ok)
+    }
+
+    @Test
+    fun sortOrder_negativeIsError() {
+        val r = validateCatalogItem(name = "Perk", costPoints = 100, valueCents = 0, kind = "perk", sortOrder = -1)
+        assertFalse(r.ok)
+        assertNotNullError(r, "sortOrder")
+    }
+
+    @Test
+    fun emptyDraft_featuredFalseAndSortZero() {
+        val d = emptyDraft()
+        assertFalse(d.featured)
+        assertEquals(0L, d.sortOrder)
+    }
+
+    @Test
+    fun draftOverload_carriesSortOrder_negativeIsError() {
+        val d = CatalogDraft(name = "X", costPoints = 10, valueCents = 0, kind = "perk", active = true, sortOrder = -3)
+        val r = validateCatalogItem(d)
+        assertFalse(r.ok)
+        assertNotNullError(r, "sortOrder")
+    }
+
+    @Test
+    fun draftOverload_featuredDraftWithValidSortIsOk() {
+        val d = CatalogDraft(name = "X", costPoints = 10, valueCents = 0, kind = "perk", active = true, featured = true, sortOrder = 5)
+        assertTrue(validateCatalogItem(d).ok)
+        assertTrue(d.featured)
+    }
+
     private fun assertNotNullError(r: CatalogValidationResult, field: String) {
         assertTrue("expected error for \$field", r.errorFor(field) != null)
     }

--- a/android/app/src/test/java/com/testlogon/android/feature/rewards/RewardsMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/rewards/RewardsMathTest.kt
@@ -24,15 +24,20 @@ class RewardsMathTest {
         kind: RewardKind = RewardKind.PERK,
         stockLimit: Long? = null,
         redeemedCount: Long = 0L,
+        featured: Boolean = false,
+        sortOrder: Long = 0L,
+        name: String = id,
     ) = CatalogReward(
         id = id,
-        name = id,
+        name = name,
         description = "",
         costPoints = cost,
         valueCents = valueCents,
         kind = kind,
         stockLimit = stockLimit,
         redeemedCount = redeemedCount,
+        featured = featured,
+        sortOrder = sortOrder,
     )
 
     private fun ref(id: String, status: ReferralStatus, rewardCents: Long) =
@@ -154,6 +159,72 @@ class RewardsMathTest {
     fun redeemableCatalog_keepsAffordableLimitedButInStock() {
         val catalog = listOf(reward("a", 100, stockLimit = 5, redeemedCount = 4))
         assertEquals(listOf("a"), RewardsMath.redeemableCatalog(catalog, 500).map { it.id })
+    }
+
+    // ---- catalog ordering (featured-first) ----
+
+    @Test
+    fun sortCatalog_featuredComeFirst() {
+        val catalog = listOf(
+            reward("plain", 100),
+            reward("star", 100, featured = true),
+        )
+        assertEquals(listOf("star", "plain"), RewardsMath.sortCatalog(catalog).map { it.id })
+    }
+
+    @Test
+    fun sortCatalog_withinGroupBySortOrderAsc() {
+        val catalog = listOf(
+            reward("c", 100, sortOrder = 30),
+            reward("a", 100, sortOrder = 10),
+            reward("b", 100, sortOrder = 20),
+        )
+        assertEquals(listOf("a", "b", "c"), RewardsMath.sortCatalog(catalog).map { it.id })
+    }
+
+    @Test
+    fun sortCatalog_missingSortOrderTreatedAsZeroThenName() {
+        // Both default to sort_order 0, so they fall back to case-insensitive name order.
+        val catalog = listOf(
+            reward("z", 100, name = "Zephyr"),
+            reward("a", 100, name = "apple"),
+        )
+        assertEquals(listOf("a", "z"), RewardsMath.sortCatalog(catalog).map { it.id })
+    }
+
+    @Test
+    fun sortCatalog_featuredBeatsLowerSortOrder() {
+        val catalog = listOf(
+            reward("cheapOrder", 100, sortOrder = 0),
+            reward("featuredHighOrder", 100, sortOrder = 999, featured = true),
+        )
+        assertEquals(
+            listOf("featuredHighOrder", "cheapOrder"),
+            RewardsMath.sortCatalog(catalog).map { it.id },
+        )
+    }
+
+    @Test
+    fun sortCatalog_featuredGroupOrderedBySortThenName() {
+        val catalog = listOf(
+            reward("f2", 100, featured = true, sortOrder = 5, name = "Bravo"),
+            reward("f1", 100, featured = true, sortOrder = 5, name = "Alpha"),
+            reward("f0", 100, featured = true, sortOrder = 1, name = "Zulu"),
+        )
+        assertEquals(listOf("f0", "f1", "f2"), RewardsMath.sortCatalog(catalog).map { it.id })
+    }
+
+    @Test
+    fun sortCatalog_isPureDoesNotMutateInput() {
+        val original = listOf(reward("plain", 100), reward("star", 100, featured = true))
+        val snapshot = original.map { it.id }
+        RewardsMath.sortCatalog(original)
+        assertEquals(snapshot, original.map { it.id })
+    }
+
+    @Test
+    fun sortCatalog_emptyIsEmpty() {
+        assertTrue(RewardsMath.sortCatalog(emptyList()).isEmpty())
     }
 
     // ---- referral counting ----

--- a/frontend/src/api/endpoints/adminRewards.ts
+++ b/frontend/src/api/endpoints/adminRewards.ts
@@ -28,6 +28,10 @@ export interface AdminCatalogItem {
   redeemed_count?: number;
   /** Optional inventory cap. null/absent = UNLIMITED (back-compat default). */
   stock_limit?: number | null;
+  /** Featured items sort first + get a badge for users. Absent/false = no. */
+  featured?: boolean;
+  /** Sort weight (asc) after featured, before name. Absent = 0. */
+  sort_order?: number;
 }
 
 export interface AdminCatalogList {
@@ -44,6 +48,10 @@ export interface AdminCatalogInput {
   active: boolean;
   /** Optional inventory cap. null = UNLIMITED (blank field in the form). */
   stock_limit?: number | null;
+  /** Featured items sort first + get a badge for users. Default false. */
+  featured?: boolean;
+  /** Sort weight (asc) after featured, before name. Default 0. */
+  sort_order?: number;
 }
 
 // ── Read (degrade on 404 — caller uses retry:false) ──────────────────

--- a/frontend/src/api/endpoints/rewards.ts
+++ b/frontend/src/api/endpoints/rewards.ts
@@ -87,6 +87,10 @@ export interface CatalogReward {
   stock_limit?: number | null;
   /** How many have been redeemed (drives remaining stock). Absent = 0. */
   redeemed_count?: number;
+  /** Featured items sort first and get a badge. Absent/false = not featured. */
+  featured?: boolean;
+  /** Sort weight (asc) after featured, before name. Absent = 0. */
+  sort_order?: number;
 }
 
 export interface RewardsCatalog {

--- a/frontend/src/lib/rewards.test.ts
+++ b/frontend/src/lib/rewards.test.ts
@@ -13,6 +13,7 @@ import {
   referralShareText,
   referralStatusCounts,
   remainingStock,
+  sortCatalog,
   stockLabel,
 } from "@/lib/rewards";
 
@@ -36,6 +37,8 @@ function reward(partial: Partial<CatalogReward>): CatalogReward {
     kind: partial.kind ?? "cash",
     stock_limit: partial.stock_limit,
     redeemed_count: partial.redeemed_count,
+    featured: partial.featured,
+    sort_order: partial.sort_order,
   };
 }
 
@@ -203,5 +206,76 @@ describe("referralShareText", () => {
     expect(referralShareText("", "https://x.test")).toContain("https://x.test");
     expect(referralShareText("ABC", "")).toContain("ABC");
     expect(referralShareText("", "")).toBe("Join me here!");
+  });
+});
+
+
+describe("sortCatalog", () => {
+  it("puts featured items before non-featured", () => {
+    const a = reward({ id: "a", name: "Zed", featured: false });
+    const b = reward({ id: "b", name: "Apple", featured: true });
+    const out = sortCatalog([a, b]);
+    expect(out.map((r) => r.id)).toEqual(["b", "a"]);
+  });
+
+  it("orders by sort_order ascending within the same featured group", () => {
+    const a = reward({ id: "a", name: "A", sort_order: 5 });
+    const b = reward({ id: "b", name: "B", sort_order: 1 });
+    const c = reward({ id: "c", name: "C", sort_order: 3 });
+    expect(sortCatalog([a, b, c]).map((r) => r.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("treats missing/non-finite sort_order as 0", () => {
+    const a = reward({ id: "a", name: "A", sort_order: 2 });
+    const b = reward({ id: "b", name: "B" }); // undefined -> 0
+    expect(sortCatalog([a, b]).map((r) => r.id)).toEqual(["b", "a"]);
+  });
+
+  it("breaks sort_order ties by name ascending (case-insensitive)", () => {
+    const a = reward({ id: "a", name: "banana", sort_order: 0 });
+    const b = reward({ id: "b", name: "Apple", sort_order: 0 });
+    expect(sortCatalog([a, b]).map((r) => r.id)).toEqual(["b", "a"]);
+  });
+
+  it("is STABLE for fully-equal keys (preserves input order)", () => {
+    const a = reward({ id: "a", name: "Same" });
+    const b = reward({ id: "b", name: "Same" });
+    const c = reward({ id: "c", name: "Same" });
+    expect(sortCatalog([a, b, c]).map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("applies the full precedence: featured, then sort_order, then name", () => {
+    const items = [
+      reward({ id: "n1", name: "Beta", featured: false, sort_order: 1 }),
+      reward({ id: "f2", name: "Zeta", featured: true, sort_order: 2 }),
+      reward({ id: "f1", name: "Alpha", featured: true, sort_order: 2 }),
+      reward({ id: "n2", name: "Alpha", featured: false, sort_order: 0 }),
+    ];
+    // featured group (sort_order 2 tie -> name): f1(Alpha), f2(Zeta);
+    // then non-featured by sort_order: n2(0), n1(1)
+    expect(sortCatalog(items).map((r) => r.id)).toEqual(["f1", "f2", "n2", "n1"]);
+  });
+
+  it("is PURE — does not mutate the input array", () => {
+    const items = [
+      reward({ id: "a", name: "Z", featured: false }),
+      reward({ id: "b", name: "A", featured: true }),
+    ];
+    const copy = [...items];
+    const out = sortCatalog(items);
+    expect(items).toEqual(copy); // input order untouched
+    expect(out).not.toBe(items); // new array
+  });
+
+  it("returns [] for a non-array input", () => {
+    // @ts-expect-error exercising the defensive guard
+    expect(sortCatalog(undefined)).toEqual([]);
+  });
+
+  it("preserves current order for back-compat (all flags absent)", () => {
+    const a = reward({ id: "a", name: "B" });
+    const b = reward({ id: "b", name: "A" });
+    // no featured/sort_order -> tie broken by name (A before B)
+    expect(sortCatalog([a, b]).map((r) => r.id)).toEqual(["b", "a"]);
   });
 });

--- a/frontend/src/lib/rewards.ts
+++ b/frontend/src/lib/rewards.ts
@@ -97,6 +97,38 @@ export function stockLabel(item: {
   return `${n} left`;
 }
 
+/**
+ * Order a catalog for display: FEATURED first (true before false), then
+ * `sort_order` ascending (missing/non-finite = 0), then `name` ascending
+ * (case-insensitive). STABLE and PURE — returns a NEW array, never mutates the
+ * input; equal keys preserve original relative order (so absent featured/
+ * sort_order preserves the current order for ties).
+ */
+export function sortCatalog<T extends {
+  name?: string;
+  featured?: boolean;
+  sort_order?: number;
+}>(items: T[]): T[] {
+  if (!Array.isArray(items)) return [];
+  const weight = (n: unknown): number => (Number.isFinite(n) ? (n as number) : 0);
+  return items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => {
+      const fa = a.item?.featured ? 1 : 0;
+      const fb = b.item?.featured ? 1 : 0;
+      if (fa !== fb) return fb - fa; // featured (1) before non-featured (0)
+      const sa = weight(a.item?.sort_order);
+      const sb = weight(b.item?.sort_order);
+      if (sa !== sb) return sa - sb; // sort_order ascending
+      const na = (a.item?.name ?? "").toString();
+      const nb = (b.item?.name ?? "").toString();
+      const byName = na.localeCompare(nb, undefined, { sensitivity: "base" });
+      if (byName !== 0) return byName; // name ascending
+      return a.index - b.index; // STABLE fallback
+    })
+    .map((w) => w.item);
+}
+
 /** Annotate each catalog reward with an `affordable` flag for the given points. */
 export function redeemableCatalog(
   catalog: CatalogReward[],

--- a/frontend/src/lib/rewardsCatalogAdmin.test.ts
+++ b/frontend/src/lib/rewardsCatalogAdmin.test.ts
@@ -78,6 +78,22 @@ describe("validateCatalogItem", () => {
     expect(validateCatalogItem({ ...valid, stock_limit: 3.5 }).errors.stock_limit).toBeDefined();
     expect(validateCatalogItem({ ...valid, stock_limit: NaN }).ok).toBe(false);
   });
+
+  it("treats a blank/undefined sort_order as valid (default 0)", () => {
+    expect(validateCatalogItem({ ...valid }).ok).toBe(true);
+    expect(validateCatalogItem({ ...valid, sort_order: undefined }).ok).toBe(true);
+  });
+
+  it("accepts a whole-number sort_order >= 0", () => {
+    expect(validateCatalogItem({ ...valid, sort_order: 0 }).ok).toBe(true);
+    expect(validateCatalogItem({ ...valid, sort_order: 42 }).ok).toBe(true);
+  });
+
+  it("rejects a negative or non-integer sort_order", () => {
+    expect(validateCatalogItem({ ...valid, sort_order: -1 }).errors.sort_order).toBeDefined();
+    expect(validateCatalogItem({ ...valid, sort_order: 2.5 }).errors.sort_order).toBeDefined();
+    expect(validateCatalogItem({ ...valid, sort_order: NaN }).ok).toBe(false);
+  });
 });
 
 
@@ -92,6 +108,8 @@ describe("emptyDraft", () => {
       kind: "perk",
       active: true,
       stock_limit: null,
+      featured: false,
+      sort_order: 0,
     });
     expect(validateCatalogItem(d).ok).toBe(false);
   });

--- a/frontend/src/lib/rewardsCatalogAdmin.ts
+++ b/frontend/src/lib/rewardsCatalogAdmin.ts
@@ -13,11 +13,13 @@ export interface CatalogItemValidatable {
   kind: RewardKind;
   /** Optional inventory cap. null/undefined = unlimited (valid). */
   stock_limit?: number | null;
+  /** Optional display order (>= 0). undefined = default 0 (valid). */
+  sort_order?: number;
 }
 
 export interface ValidationResult {
   ok: boolean;
-  errors: Partial<Record<"name" | "cost_points" | "value_cents" | "kind" | "stock_limit", string>>;
+  errors: Partial<Record<"name" | "cost_points" | "value_cents" | "kind" | "stock_limit" | "sort_order", string>>;
 }
 
 const REWARD_KINDS: readonly RewardKind[] = ["cash", "perk"];
@@ -71,6 +73,14 @@ export function validateCatalogItem(item: CatalogItemValidatable): ValidationRes
     }
   }
 
+  // sort_order is OPTIONAL: undefined = default 0 (valid). When present it must
+  // be a whole number >= 0.
+  if (item.sort_order !== undefined && item.sort_order !== null) {
+    if (!isNonNegativeInt(item.sort_order)) {
+      errors.sort_order = "Sort order must be a whole number (0 or more).";
+    }
+  }
+
   return { ok: Object.keys(errors).length === 0, errors };
 }
 
@@ -84,5 +94,7 @@ export function emptyDraft(): AdminCatalogInput {
     kind: "perk",
     active: true,
     stock_limit: null,
+    featured: false,
+    sort_order: 0,
   };
 }

--- a/frontend/src/pages/admin/RewardsCatalogAdminPage.tsx
+++ b/frontend/src/pages/admin/RewardsCatalogAdminPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Gift, Plus } from "lucide-react";
+import { Gift, Plus, Star } from "lucide-react";
 
 import { PageHeader } from "@/components/shared/PageHeader";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
@@ -52,7 +52,7 @@ import {
   formatPoints,
   formatCents,
 } from "@/lib/rewardsCatalogAdmin";
-import { remainingStock } from "@/lib/rewards";
+import { remainingStock, sortCatalog } from "@/lib/rewards";
 
 function is404(err: unknown): boolean {
   return err instanceof ApiError && err.status === 404;
@@ -87,6 +87,8 @@ function CatalogItemDialog({
               kind: item.kind,
               active: item.active,
               stock_limit: item.stock_limit ?? null,
+              featured: item.featured ?? false,
+              sort_order: item.sort_order ?? 0,
             }
           : emptyDraft(),
       );
@@ -227,6 +229,42 @@ function CatalogItemDialog({
               <p className="text-sm text-destructive">{errors.stock_limit}</p>
             )}
           </div>
+
+          <div className="grid grid-cols-2 items-start gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="rc-sort">Sort order</Label>
+              <Input
+                id="rc-sort"
+                type="number"
+                inputMode="numeric"
+                min={0}
+                step={1}
+                value={draft.sort_order ? String(draft.sort_order) : ""}
+                onChange={(e) => set("sort_order", intFromInput(e.target.value))}
+                placeholder="0"
+              />
+              <p className="text-xs text-muted-foreground">
+                Lower shows first (after featured).
+              </p>
+              {errors.sort_order && (
+                <p className="text-sm text-destructive">{errors.sort_order}</p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rc-featured">Featured</Label>
+              <div className="flex h-10 items-center gap-2">
+                <Switch
+                  id="rc-featured"
+                  checked={!!draft.featured}
+                  onCheckedChange={(v) => set("featured", v)}
+                />
+                <span className="text-sm text-muted-foreground">
+                  {draft.featured ? "Shown first with a badge" : "Not featured"}
+                </span>
+              </div>
+            </div>
+          </div>
         </div>
 
         <DialogFooter>
@@ -308,6 +346,8 @@ export default function RewardsCatalogAdminPage() {
         kind: item.kind,
         active: !item.active,
         stock_limit: item.stock_limit ?? null,
+        featured: item.featured ?? false,
+        sort_order: item.sort_order ?? 0,
       },
     });
 
@@ -316,7 +356,10 @@ export default function RewardsCatalogAdminPage() {
     else createMut.mutate(data);
   };
 
-  const items = useMemo(() => catalogQ.data?.rewards ?? [], [catalogQ.data]);
+  const items = useMemo(
+    () => sortCatalog(catalogQ.data?.rewards ?? []),
+    [catalogQ.data],
+  );
   const notAvailable = is404(catalogQ.error);
 
   if (!canAccess) {
@@ -376,6 +419,7 @@ export default function RewardsCatalogAdminPage() {
             <TableHeader>
               <TableRow>
                 <TableHead>Name</TableHead>
+                <TableHead className="text-right">Order</TableHead>
                 <TableHead>Cost</TableHead>
                 <TableHead>Value</TableHead>
                 <TableHead>Kind</TableHead>
@@ -389,12 +433,22 @@ export default function RewardsCatalogAdminPage() {
               {items.map((item) => (
                 <TableRow key={item.id} className={item.active ? "" : "opacity-60"}>
                   <TableCell>
-                    <div className="font-medium">{item.name}</div>
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-medium">{item.name}</span>
+                      {item.featured ? (
+                        <Badge className="gap-1 px-1.5 py-0">
+                          <Star className="h-3 w-3 fill-current" /> Featured
+                        </Badge>
+                      ) : null}
+                    </div>
                     {item.description && (
                       <div className="text-xs text-muted-foreground line-clamp-2">
                         {item.description}
                       </div>
                     )}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {item.sort_order ?? 0}
                   </TableCell>
                   <TableCell className="whitespace-nowrap">
                     {formatPoints(item.cost_points)}

--- a/frontend/src/pages/rewards/RewardsPage.tsx
+++ b/frontend/src/pages/rewards/RewardsPage.tsx
@@ -13,6 +13,7 @@ import {
   TrendingUp,
   ArrowRight,
   DollarSign,
+  Star,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -48,6 +49,7 @@ import {
   pointsAfterRedeem,
   redeemableCatalog,
   remainingStock,
+  sortCatalog,
   stockLabel,
 } from "@/lib/rewards";
 import {
@@ -125,7 +127,7 @@ export default function RewardsPage() {
   const rewards = rewardsQ.data;
   const points = rewards?.points ?? 0;
   const history: RewardHistoryEntry[] = historyQ.data?.entries ?? [];
-  const catalog = redeemableCatalog(catalogQ.data?.rewards ?? [], points);
+  const catalog = redeemableCatalog(sortCatalog(catalogQ.data?.rewards ?? []), points);
 
   // Prefer the authoritative /me/rewards/trading read; else estimate from
   // the caller’s own 30-day trade volume. Never throws, degrades gracefully.
@@ -527,7 +529,9 @@ export default function RewardsPage() {
                 return (
                 <div
                   key={r.id}
-                  className="flex flex-col justify-between gap-3 rounded-lg border p-4"
+                  className={`flex flex-col justify-between gap-3 rounded-lg border p-4${
+                    r.featured ? " border-primary/50 bg-primary/5" : ""
+                  }`}
                 >
                   <div>
                     <div className="flex items-center justify-between gap-2">
@@ -536,6 +540,11 @@ export default function RewardsPage() {
                         {r.kind === "cash" ? "Cash" : "Perk"}
                       </Badge>
                     </div>
+                    {r.featured ? (
+                      <Badge className="mt-1 gap-1">
+                        <Star className="h-3 w-3 fill-current" /> Featured
+                      </Badge>
+                    ) : null}
                     <p className="mt-1 text-sm text-muted-foreground">{r.description}</p>
                     {remaining !== null ? (
                       <Badge


### PR DESCRIPTION
## Rewards catalog featured flag + sort ordering

Each item gets optional `featured` (bool, default false) + `sort_order` (int, default 0). Admins set them; the user catalog is ordered **featured-first → sort_order asc → name asc** (stable), and featured items get a "Featured" badge. **Back-compat**: absent = false/0, existing catalogs fall back to name order.

**Pure `sortCatalog(items)` (both platforms, +tests):** featured-first → sort_order asc (missing=0) → case-insensitive name asc; stable, non-mutating. Admin `validateCatalogItem` validates `sort_order` (integer ≥0) when present.

### Web
types gain `featured?`/`sort_order?`; `lib/rewards.ts` `sortCatalog` + `lib/rewardsCatalogAdmin.ts` validation/draft (+11 vitest → 54/54); RewardsPage renders `redeemableCatalog(sortCatalog(...))` with Featured badge + highlight; admin form Featured toggle + Sort-order field, table sorted the same.

### Android
`data/rewards` + `data/adminrewards` DTOs/domain gain `featured`/`sortOrder`; `RewardsMath.sortCatalog` + `CatalogAdminValidation` (+14 JVM cases); RewardsScreen Featured badge + sorted; CatalogAdminScreen Featured toggle + Sort-order field + `sortAdminCatalog`.

No new deps, no route changes. Gates: web tsc 0 · vite build · vitest 54/54; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
