### PR TITLE
feat(messaging): EPIC A — trading-in-chat cards (market + position)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
@@ -227,6 +227,23 @@ sealed interface MessageMedia {
     data class Paid(
         val monetization: MessageMonetization,
     ) : MessageMedia
+
+    /**
+     * FE-101 — a shared market reference (ticker + live price/change fetched at render time). Rides a
+     * normal text message whose body is a [com.testlogon.android.feature.messaging.TradingCardModel]
+     * payload; [MessageDto.toMedia] parses it. [card] is the parsed payload.
+     */
+    data class MarketCard(
+        val card: com.testlogon.android.feature.messaging.TradingCardModel.MarketCard,
+    ) : MessageMedia
+
+    /**
+     * FE-102 — a shared position P&L card carrying ONLY the fields permitted by its disclosure. Rides
+     * a normal text message; [MessageDto.toMedia] parses the body into [card].
+     */
+    data class PositionCard(
+        val card: com.testlogon.android.feature.messaging.TradingCardModel.PositionCard,
+    ) : MessageMedia
 }
 
 /** AND-137 — the kind of item a countdown is associated with (display/pass-through only). */
@@ -765,6 +782,16 @@ internal fun List<EditHistoryEntryDto>.toMessageEdits(): List<MessageEdit> =
 
 /** Maps the wire media object to the domain [MessageMedia] (pure; no Android types). */
 internal fun MessageDto.toMedia(): MessageMedia = when {
+    // FE-101/FE-102 — a trading card rides a normal text message; the body carries the encoded
+    // TradingCardModel payload behind a sentinel. Parse it FIRST so it renders as a card, not raw text.
+    // A non-card body falls through (parse == null) to the normal media resolution below.
+    com.testlogon.android.feature.messaging.TradingCardModel.parse(text) != null -> {
+        when (val c = com.testlogon.android.feature.messaging.TradingCardModel.parse(text)) {
+            is com.testlogon.android.feature.messaging.TradingCardModel.MarketCard -> MessageMedia.MarketCard(c)
+            is com.testlogon.android.feature.messaging.TradingCardModel.PositionCard -> MessageMedia.PositionCard(c)
+            else -> MessageMedia.None
+        }
+    }
     // C6 — gallery (multi-image) message. Sender + unlocked recipients get free_images here.
     kind == "gallery" && !freeImages.isNullOrEmpty() -> MessageMedia.Gallery(
         images = freeImages.map { gi ->

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/TradingCardModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/TradingCardModel.kt
@@ -1,0 +1,259 @@
+package com.testlogon.android.feature.messaging
+
+/**
+ * FE-101 / FE-102 — pure, dependency-free model for the two "trading-in-chat" card kinds
+ * (market_card, position_card). Kept Android-free so the payload encode/parse + the disclosure
+ * field-selection logic can be JVM-unit-tested in isolation (see TradingCardModelTest).
+ *
+ * TRANSPORT (works-now, no backend change, degrade-on-404): a trading card rides on a NORMAL text
+ * message. The structured payload is encoded into the message body behind a rare sentinel tag; the
+ * message dispatch parses the body back to a [TradingCard] and renders the card, and falls through
+ * to a plain text bubble when the body is not a card (so an un-upgraded client just shows text).
+ *
+ * The encoding is a single line: SENTINEL + "market_card" | "position_card" + ";" + key=value pairs
+ * joined by ";". Reserved chars (";", "=", "%", newline) are percent-escaped so values round-trip.
+ */
+object TradingCardModel {
+
+    /** Sentinel prefix on the message body that marks a trading-card payload. */
+    const val SENTINEL: String = "TLCARD1:"
+
+    enum class Kind(val wire: String) {
+        MARKET("market_card"),
+        POSITION("position_card"),
+    }
+
+    /**
+     * FE-102 disclosure selector. The sender chooses how much of their position to reveal:
+     *  - [FULL]: side, qty, entry, mark, liquidation, uPnL AND the derived percentages.
+     *  - [PNL_PCT]: uPnL% only (no absolute cash amounts, no qty/entry/liq).
+     *  - [ROI]: return-on-margin % only (no absolute cash amounts, no qty/entry/liq).
+     */
+    enum class Disclosure(val wire: String) {
+        FULL("full"),
+        PNL_PCT("pnl_pct"),
+        ROI("roi"),
+        ;
+
+        companion object {
+            fun fromWire(w: String?): Disclosure = entries.firstOrNull { it.wire == w } ?: FULL
+        }
+    }
+
+    /** The permitted field set for a disclosure. A field absent here MUST NOT be sent/rendered. */
+    enum class PositionField { SIDE, QTY, ENTRY_PRICE, MARK_PRICE, LIQUIDATION_PRICE, UPNL_ABS, PNL_PCT, ROI_PCT }
+
+    /**
+     * FE-102 — the single source of truth for "what a disclosure permits". FULL reveals everything;
+     * PNL_PCT reveals ONLY the P&L percentage; ROI reveals ONLY the ROI percentage. Directional color
+     * needs the SIDE, but SIDE is an identity (not a dollar amount), so it is permitted in every mode.
+     */
+    fun permittedFields(disclosure: Disclosure): Set<PositionField> = when (disclosure) {
+        Disclosure.FULL -> setOf(
+            PositionField.SIDE,
+            PositionField.QTY,
+            PositionField.ENTRY_PRICE,
+            PositionField.MARK_PRICE,
+            PositionField.LIQUIDATION_PRICE,
+            PositionField.UPNL_ABS,
+            PositionField.PNL_PCT,
+            PositionField.ROI_PCT,
+        )
+        Disclosure.PNL_PCT -> setOf(PositionField.SIDE, PositionField.PNL_PCT)
+        Disclosure.ROI -> setOf(PositionField.SIDE, PositionField.ROI_PCT)
+    }
+
+    // ---- parsed card shapes ----
+
+    sealed interface TradingCard {
+        val symbolId: Int
+        val symbol: String
+    }
+
+    /** FE-101 — a shared market reference. Live price/change/sparkline are fetched at render time. */
+    data class MarketCard(
+        override val symbolId: Int,
+        override val symbol: String,
+    ) : TradingCard
+
+    /**
+     * FE-102 — a shared position. Carries ONLY the fields permitted by [disclosure]; every optional
+     * field is null when the disclosure withholds it (so the payload itself never leaks a hidden
+     * dollar amount). [owner] is the display attribution ("shared by <owner>").
+     */
+    data class PositionCard(
+        override val symbolId: Int,
+        override val symbol: String,
+        val disclosure: Disclosure,
+        val owner: String,
+        val side: String?,          // "buy" | "sell" | null
+        val qty: Long?,
+        val entryPrice: Long?,
+        val markPrice: Long?,
+        val liquidationPrice: Long?,
+        val unrealizedPnl: Long?,   // minor units (raw)
+        val pnlPct: Double?,        // uPnL as % of notional
+        val roiPct: Double?,        // uPnL as % of margin/ROI
+    ) : TradingCard {
+        val isLong: Boolean? get() = when (side) { "buy" -> true; "sell" -> false; else -> null }
+    }
+
+    // ---- projection: build a permitted position payload from the FULL raw values ----
+
+    /** Raw (FULL) position values known to the sender before disclosure filtering. */
+    data class RawPosition(
+        val symbolId: Int,
+        val symbol: String,
+        val owner: String,
+        val side: String?,
+        val qty: Long,
+        val entryPrice: Long,
+        val markPrice: Long,
+        val liquidationPrice: Long,
+        val unrealizedPnl: Long,
+        val pnlPct: Double?,
+        val roiPct: Double?,
+    )
+
+    /**
+     * FE-102 — project a raw position down to EXACTLY the fields permitted by [disclosure]. Fields the
+     * disclosure withholds are nulled out here (never transmitted), so a PNL_PCT/ROI share can never
+     * leak entry/qty/liq/absolute-uPnL even if the wire is inspected.
+     */
+    fun project(raw: RawPosition, disclosure: Disclosure): PositionCard {
+        val f = permittedFields(disclosure)
+        return PositionCard(
+            symbolId = raw.symbolId,
+            symbol = raw.symbol,
+            disclosure = disclosure,
+            owner = raw.owner,
+            side = if (PositionField.SIDE in f) raw.side else null,
+            qty = if (PositionField.QTY in f) raw.qty else null,
+            entryPrice = if (PositionField.ENTRY_PRICE in f) raw.entryPrice else null,
+            markPrice = if (PositionField.MARK_PRICE in f) raw.markPrice else null,
+            liquidationPrice = if (PositionField.LIQUIDATION_PRICE in f) raw.liquidationPrice else null,
+            unrealizedPnl = if (PositionField.UPNL_ABS in f) raw.unrealizedPnl else null,
+            pnlPct = if (PositionField.PNL_PCT in f) raw.pnlPct else null,
+            roiPct = if (PositionField.ROI_PCT in f) raw.roiPct else null,
+        )
+    }
+
+    // ---- conversation / reply preview strings ----
+
+    fun marketPreview(symbol: String): String = "[Market: $symbol]"
+    fun positionPreview(symbol: String): String = "[Position: $symbol]"
+
+    /**
+     * Preview for a message body that MAY be a trading card; null when the body is not a card (so the
+     * caller keeps the server-provided text preview). Used by the conversation list + reply preview.
+     */
+    fun previewForBody(body: String?): String? {
+        val card = parse(body) ?: return null
+        return when (card) {
+            is MarketCard -> marketPreview(card.symbol)
+            is PositionCard -> positionPreview(card.symbol)
+        }
+    }
+
+    // ---- encode / parse ----
+
+    /** True when [body] begins with the trading-card sentinel (fast pre-check before a full parse). */
+    fun isCard(body: String?): Boolean = body != null && body.startsWith(SENTINEL)
+
+    fun encode(card: TradingCard): String {
+        val sb = StringBuilder(SENTINEL)
+        when (card) {
+            is MarketCard -> {
+                sb.append(Kind.MARKET.wire)
+                sb.append(';').append(kv("sid", card.symbolId.toString()))
+                sb.append(';').append(kv("sym", card.symbol))
+            }
+            is PositionCard -> {
+                sb.append(Kind.POSITION.wire)
+                sb.append(';').append(kv("sid", card.symbolId.toString()))
+                sb.append(';').append(kv("sym", card.symbol))
+                sb.append(';').append(kv("disc", card.disclosure.wire))
+                sb.append(';').append(kv("owner", card.owner))
+                card.side?.let { sb.append(';').append(kv("side", it)) }
+                card.qty?.let { sb.append(';').append(kv("qty", it.toString())) }
+                card.entryPrice?.let { sb.append(';').append(kv("entry", it.toString())) }
+                card.markPrice?.let { sb.append(';').append(kv("mark", it.toString())) }
+                card.liquidationPrice?.let { sb.append(';').append(kv("liq", it.toString())) }
+                card.unrealizedPnl?.let { sb.append(';').append(kv("upnl", it.toString())) }
+                card.pnlPct?.let { sb.append(';').append(kv("pnlpct", it.toString())) }
+                card.roiPct?.let { sb.append(';').append(kv("roipct", it.toString())) }
+            }
+        }
+        return sb.toString()
+    }
+
+    /** Parse a message body into a [TradingCard], or null when it is not a (well-formed) card. */
+    fun parse(body: String?): TradingCard? {
+        if (body == null || !body.startsWith(SENTINEL)) return null
+        val payload = body.substring(SENTINEL.length)
+        val parts = payload.split(';')
+        if (parts.isEmpty()) return null
+        val wireKind = parts[0]
+        val map = HashMap<String, String>()
+        for (i in 1 until parts.size) {
+            val seg = parts[i]
+            val eq = seg.indexOf('=')
+            if (eq <= 0) continue
+            map[unescape(seg.substring(0, eq))] = unescape(seg.substring(eq + 1))
+        }
+        val sid = map["sid"]?.toIntOrNull() ?: return null
+        val sym = map["sym"] ?: return null
+        return when (wireKind) {
+            Kind.MARKET.wire -> MarketCard(symbolId = sid, symbol = sym)
+            Kind.POSITION.wire -> PositionCard(
+                symbolId = sid,
+                symbol = sym,
+                disclosure = Disclosure.fromWire(map["disc"]),
+                owner = map["owner"] ?: "",
+                side = map["side"],
+                qty = map["qty"]?.toLongOrNull(),
+                entryPrice = map["entry"]?.toLongOrNull(),
+                markPrice = map["mark"]?.toLongOrNull(),
+                liquidationPrice = map["liq"]?.toLongOrNull(),
+                unrealizedPnl = map["upnl"]?.toLongOrNull(),
+                pnlPct = map["pnlpct"]?.toDoubleOrNull(),
+                roiPct = map["roipct"]?.toDoubleOrNull(),
+            )
+            else -> null
+        }
+    }
+
+    private fun kv(k: String, v: String): String = escape(k) + "=" + escape(v)
+
+    /** Percent-escape the reserved delimiters so any user-facing value round-trips through [parse]. */
+    private fun escape(s: String): String {
+        val sb = StringBuilder(s.length)
+        for (c in s) {
+            when (c) {
+                '%' -> sb.append("%25")
+                ';' -> sb.append("%3B")
+                '=' -> sb.append("%3D")
+                '\n' -> sb.append("%0A")
+                '\r' -> sb.append("%0D")
+                else -> sb.append(c)
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun unescape(s: String): String {
+        if (s.indexOf('%') < 0) return s
+        val sb = StringBuilder(s.length)
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            if (c == '%' && i + 2 < s.length) {
+                val hex = s.substring(i + 1, i + 3)
+                val code = hex.toIntOrNull(16)
+                if (code != null) { sb.append(code.toChar()); i += 3; continue }
+            }
+            sb.append(c); i++
+        }
+        return sb.toString()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
@@ -62,6 +62,8 @@ import androidx.compose.material.icons.filled.EditCalendar
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.FolderShared
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ShowChart
+import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.EmojiEmotions
@@ -194,6 +196,7 @@ fun ThreadRoute(
     onBack: () -> Unit,
     onPlaceCall: (String) -> Unit = {},
     onViewContact: (userId: String) -> Unit = {},
+    onOpenSymbol: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
     onOpenGroupDetails: () -> Unit = {},
     viewModel: ThreadViewModel = hiltViewModel(),
@@ -346,6 +349,7 @@ fun ThreadRoute(
         onBack = onBack,
         onPlaceCall = onPlaceCall,
         onViewContact = onViewContact,
+        onOpenSymbol = onOpenSymbol,
         onOpenGroupDetails = onOpenGroupDetails,
         onRetry = viewModel::retry,
         onDraftChange = viewModel::onDraftChange,
@@ -420,6 +424,13 @@ fun ThreadRoute(
         onAttachFileShare = viewModel::onAttachFileShare,
         onDismissFileShare = viewModel::onDismissFileShareComposer,
         onSendFileShare = viewModel::onSendFileShare,
+        onAttachMarketCard = viewModel::onAttachMarketCard,
+        onMarketPickerQuery = viewModel::onMarketPickerQuery,
+        onDismissMarketPicker = viewModel::onDismissMarketPicker,
+        onSendMarketCard = viewModel::onSendMarketCard,
+        onAttachPositionCard = viewModel::onAttachPositionCard,
+        onDismissPositionPicker = viewModel::onDismissPositionPicker,
+        onSendPositionCard = viewModel::onSendPositionCard,
         onOpenMessageOptions = viewModel::openMessageOptions,
         onClearMessageOptions = viewModel::clearMessageOptions,
         onRemoveStagedImage = viewModel::onRemoveStagedImage,
@@ -1030,6 +1041,13 @@ fun ThreadScreen(
     onAttachFileShare: () -> Unit = {},
     onDismissFileShare: () -> Unit = {},
     onSendFileShare: (String) -> Unit = {},
+    onAttachMarketCard: () -> Unit = {},
+    onMarketPickerQuery: (String) -> Unit = {},
+    onDismissMarketPicker: () -> Unit = {},
+    onSendMarketCard: (SymbolPick) -> Unit = {},
+    onAttachPositionCard: () -> Unit = {},
+    onDismissPositionPicker: () -> Unit = {},
+    onSendPositionCard: (OpenPositionPick, com.testlogon.android.feature.messaging.TradingCardModel.Disclosure) -> Unit = { _, _ -> },
     onOpenMessageOptions: () -> Unit = {},
     onClearMessageOptions: () -> Unit = {},
     onRemoveStagedFile: () -> Unit = {},
@@ -1055,6 +1073,7 @@ fun ThreadScreen(
     onOpenScheduled: () -> Unit = {},
     onPlaceCall: (String) -> Unit = {},
     onViewContact: (userId: String) -> Unit = {},
+    onOpenSymbol: (Int) -> Unit = {},
     searchBar: @Composable () -> Unit = {},
     // FULL-PARITY (delegate) — an optional banner slot rendered directly under the top app bar. The
     // ThreadRoute passes the "Managing @creator" DelegationBannerHost here so the reused thread makes it
@@ -1306,6 +1325,8 @@ fun ThreadScreen(
                         onAttachCalendarEvent = onAttachCalendarEvent,
                         onAttachCalendarShare = onAttachCalendarShare,
                         onAttachFileShare = onAttachFileShare,
+                        onAttachMarketCard = onAttachMarketCard,
+                        onAttachPositionCard = onAttachPositionCard,
                         onOpenMessageOptions = onOpenMessageOptions,
                         onClearMessageOptions = onClearMessageOptions,
                         onRemoveStagedImage = onRemoveStagedImage,
@@ -1382,6 +1403,7 @@ fun ThreadScreen(
                     onMessageLongPress = { actionTarget = it },
                     onJumpToMessage = onJumpToMessage,
                     pollVoter = pollVoter,
+                    onOpenSymbol = onOpenSymbol,
                     nowSeconds = nowSeconds,
                 )
             }
@@ -1488,6 +1510,21 @@ fun ThreadScreen(
             onDismiss = onDismissFileShare,
         )
     }
+    if (state.marketPicker.visible) {
+        MarketPickerSheet(
+            state = state.marketPicker,
+            onQuery = onMarketPickerQuery,
+            onPick = onSendMarketCard,
+            onDismiss = onDismissMarketPicker,
+        )
+    }
+    if (state.positionPicker.visible) {
+        PositionPickerSheet(
+            state = state.positionPicker,
+            onSend = onSendPositionCard,
+            onDismiss = onDismissPositionPicker,
+        )
+    }
 
     if (state.tipSheet.messageId != null) {
         TipSheet(
@@ -1532,6 +1569,10 @@ private fun defaultPollSlots(): List<com.testlogon.android.data.messaging.Meetin
  * present, else a media-kind placeholder ([image]/[file]/etc.) so non-text originals still read sensibly.
  */
 private fun replyQuoteSnippet(m: ThreadMessageUi): String {
+    // FE-101/FE-102 — a trading-card message's text IS the encoded payload; use the card label, never
+    // the raw body. Checked before the text fallback so the sentinel string never leaks into a quote.
+    (m.media as? MessageMedia.MarketCard)?.let { return com.testlogon.android.feature.messaging.TradingCardModel.marketPreview(it.card.symbol) }
+    (m.media as? MessageMedia.PositionCard)?.let { return com.testlogon.android.feature.messaging.TradingCardModel.positionPreview(it.card.symbol) }
     val text = m.text.trim()
     if (text.isNotBlank()) return text
     return when (m.media) {
@@ -1546,6 +1587,8 @@ private fun replyQuoteSnippet(m: ThreadMessageUi): String {
         is MessageMedia.Sticker -> "[sticker]"
         is MessageMedia.Poll -> "[poll]"
         is MessageMedia.MeetingPoll, is MessageMedia.FindDateTime -> "[poll]"
+        is MessageMedia.MarketCard -> com.testlogon.android.feature.messaging.TradingCardModel.marketPreview((m.media as MessageMedia.MarketCard).card.symbol)
+        is MessageMedia.PositionCard -> com.testlogon.android.feature.messaging.TradingCardModel.positionPreview((m.media as MessageMedia.PositionCard).card.symbol)
         is MessageMedia.Countdown -> "[countdown]"
         is MessageMedia.CalendarEvent, is MessageMedia.CalendarShare -> "[calendar]"
         is MessageMedia.Paid -> "[locked]"
@@ -1576,6 +1619,7 @@ private fun ThreadList(
     onMessageLongPress: (ThreadMessageUi) -> Unit,
     onJumpToMessage: (String) -> Unit = {},
     pollVoter: com.testlogon.android.data.poll.PollVoter? = null,
+    onOpenSymbol: (Int) -> Unit = {},
     nowSeconds: Long,
 ) {
     // reverseLayout: index 0 is the newest message at the visual bottom.
@@ -1612,6 +1656,8 @@ private fun ThreadList(
                     voicePlayback = voicePlayback,
                     polls = state.polls,
                     unlock = state.unlocks[message.key] ?: UnlockUiState(),
+                    marketCards = state.marketCards,
+                    onOpenSymbol = onOpenSymbol,
                     onRetry = { onRetrySend(message.key) },
                     onOpenImage = onOpenImage,
                     onOpenGalleryVideo = onOpenGalleryVideo,
@@ -1725,6 +1771,8 @@ private fun MessageBubble(
     polls: Map<String, MeetingPollCardUiState>,
     unlock: UnlockUiState,
     pollVoter: com.testlogon.android.data.poll.PollVoter? = null,
+    marketCards: Map<Int, MarketCardLive> = emptyMap(),
+    onOpenSymbol: (Int) -> Unit = {},
     onRetry: () -> Unit,
     onOpenImage: (String) -> Unit,
     onOpenGalleryVideo: (String) -> Unit = {},
@@ -1968,6 +2016,15 @@ private fun MessageBubble(
             )
             is MessageMedia.CalendarShare -> CalendarShareBubble(media = media, isOwn = message.isOwn)
             is MessageMedia.FindDateTime -> FindDateTimeCard(media = media)
+            is MessageMedia.MarketCard -> MarketCard(
+                card = media.card,
+                live = marketCards[media.card.symbolId] ?: MarketCardLive(),
+                onTrade = onOpenSymbol,
+            )
+            is MessageMedia.PositionCard -> PositionCard(
+                card = media.card,
+                onTrade = onOpenSymbol,
+            )
             is MessageMedia.Paid -> PaidMessageBubble(
                 monetization = media.monetization,
                 isOwn = message.isOwn,
@@ -2502,6 +2559,8 @@ private fun MessageComposer(
     onAttachCalendarEvent: () -> Unit = {},
     onAttachCalendarShare: () -> Unit = {},
     onAttachFileShare: () -> Unit = {},
+    onAttachMarketCard: () -> Unit = {},
+    onAttachPositionCard: () -> Unit = {},
     onOpenMessageOptions: () -> Unit = {},
     onClearMessageOptions: () -> Unit = {},
     onRemoveStagedImage: (Int) -> Unit = {},
@@ -2639,6 +2698,18 @@ private fun MessageComposer(
                         modifier = Modifier.size(44.dp).testTag(RichMessageTestTags.ATTACH_FILE_SHARE),
                     ) {
                         Icon(Icons.Filled.FolderShared, contentDescription = "Share a file", tint = MaterialTheme.colorScheme.primary)
+                    }
+                    IconButton(
+                        onClick = { actionsExpanded = false; onAttachMarketCard() },
+                        modifier = Modifier.size(44.dp).testTag(TradingComposerTestTags.ATTACH_MARKET),
+                    ) {
+                        Icon(Icons.Filled.ShowChart, contentDescription = "Share market", tint = MaterialTheme.colorScheme.primary)
+                    }
+                    IconButton(
+                        onClick = { actionsExpanded = false; onAttachPositionCard() },
+                        modifier = Modifier.size(44.dp).testTag(TradingComposerTestTags.ATTACH_POSITION),
+                    ) {
+                        Icon(Icons.Filled.Insights, contentDescription = "Share position", tint = MaterialTheme.colorScheme.primary)
                     }
                 }
             }

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
@@ -81,6 +81,13 @@ data class ThreadUiState(
     val calendarShareComposer: CalendarPickerState = CalendarPickerState(),
     /** File-manager share composer (pick a file). */
     val fileShareComposer: FilePickerState = FilePickerState(),
+    // ---- FE-101 / FE-102: trading-in-chat cards ----
+    /** FE-101 — live market data (price/change/spark) per shared market card, keyed by symbolId. */
+    val marketCards: Map<Int, MarketCardLive> = emptyMap(),
+    /** FE-101 — "Share market" symbol-picker sheet (hidden until opened). */
+    val marketPicker: MarketPickerState = MarketPickerState(),
+    /** FE-102 — "Share position" picker + disclosure sheet (hidden until opened). */
+    val positionPicker: PositionPickerState = PositionPickerState(),
     /** MSG — receiver passphrase-unlock dialog for an encrypted message (non-null key = open). */
     val encryptUnlock: EncryptUnlockState = EncryptUnlockState(),
     /** MSG — view-once viewer dialog (non-null key = open, showing the consumed content). */
@@ -198,6 +205,45 @@ data class FilePickerState(
     val visible: Boolean = false,
     val loading: Boolean = false,
     val files: List<com.testlogon.android.data.messaging.FileEntryUi> = emptyList(),
+    val error: String? = null,
+)
+
+/** FE-101 — one selectable symbol in the "Share market" picker. */
+data class SymbolPick(val symbolId: Int, val symbol: String)
+
+/** FE-101 — "Share market" symbol-picker state (searchable). */
+data class MarketPickerState(
+    val visible: Boolean = false,
+    val loading: Boolean = false,
+    val query: String = "",
+    val symbols: List<SymbolPick> = emptyList(),
+    val error: String? = null,
+) {
+    /** Case-insensitive filter over the loaded symbol list. */
+    val filtered: List<SymbolPick>
+        get() = if (query.isBlank()) symbols
+        else symbols.filter { it.symbol.contains(query.trim(), ignoreCase = true) }
+}
+
+/** FE-102 — one of the caller's open positions offered in the "Share position" picker. */
+data class OpenPositionPick(
+    val symbolId: Int,
+    val symbol: String,
+    val side: String?,
+    val qty: Long,
+    val entryPrice: Long,
+    val markPrice: Long,
+    val liquidationPrice: Long,
+    val unrealizedPnl: Long,
+    val pnlPct: Double?,
+    val roiPct: Double?,
+)
+
+/** FE-102 — "Share position" picker + disclosure-selector state. */
+data class PositionPickerState(
+    val visible: Boolean = false,
+    val loading: Boolean = false,
+    val positions: List<OpenPositionPick> = emptyList(),
     val error: String? = null,
 )
 

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
@@ -106,6 +106,8 @@ class ThreadViewModel @Inject constructor(
     private val displayNames: com.testlogon.android.data.profile.DisplayNameResolver,
     // TIP-405 — decode the 402 tip_required detail body (min_tip_cents/recipient) off a failed send.
     private val apiErrorParser: com.testlogon.android.core.network.error.ApiErrorParser,
+    private val exchangeRepository: com.testlogon.android.data.exchange.ExchangeRepository,
+    private val tradingRepository: com.testlogon.android.data.exchange.TradingRepository,
 ) : ViewModel() {
 
     /**
@@ -370,7 +372,9 @@ class ThreadViewModel @Inject constructor(
                             ?: if (visible.isEmpty()) prior.isDm else otherSenders.size <= 1,
                     )
                 }
-                // AND-152 — once the deep-link target message is loaded, scroll to it (once).
+                // FE-101 — refresh live price/change/spark for any market cards now on screen.
+                refreshMarketCards()
+                                // AND-152 — once the deep-link target message is loaded, scroll to it (once).
                 val target = focusMessageId
                 if (target != null && visible.any { it.id == target || it.clientId == target }) {
                     focusMessageId = null
@@ -2205,6 +2209,149 @@ class ThreadViewModel @Inject constructor(
         viewModelScope.launch {
             repository.shareFile(conversationId, filePath, permission = "read", text = null)
             _events.trySend(ThreadEvent.ScrollToBottom)
+        }
+    }
+
+    // ---- FE-101 / FE-102: trading-in-chat cards ----
+
+    /** FE-101 — open the "Share market" symbol picker + load the symbol list. */
+    fun onAttachMarketCard() {
+        _state.update { it.copy(marketPicker = MarketPickerState(visible = true, loading = true)) }
+        viewModelScope.launch {
+            when (val r = exchangeRepository.symbols()) {
+                is ApiResult.Success -> _state.update {
+                    it.copy(marketPicker = it.marketPicker.copy(
+                        loading = false,
+                        symbols = r.data.map { s -> SymbolPick(s.symbolId, s.symbol) },
+                    ))
+                }
+                else -> _state.update {
+                    it.copy(marketPicker = it.marketPicker.copy(loading = false, error = "Couldn't load symbols"))
+                }
+            }
+        }
+    }
+
+    fun onMarketPickerQuery(q: String) {
+        _state.update { it.copy(marketPicker = it.marketPicker.copy(query = q)) }
+    }
+
+    fun onDismissMarketPicker() { _state.update { it.copy(marketPicker = MarketPickerState()) } }
+
+    /** FE-101 — send a market_card as a normal text message carrying the encoded card payload. */
+    fun onSendMarketCard(pick: SymbolPick) {
+        _state.update { it.copy(marketPicker = MarketPickerState()) }
+        val body = com.testlogon.android.feature.messaging.TradingCardModel.encode(
+            com.testlogon.android.feature.messaging.TradingCardModel.MarketCard(pick.symbolId, pick.symbol),
+        )
+        val clientId = java.util.UUID.randomUUID().toString()
+        viewModelScope.launch {
+            repository.enqueueOptimistic(conversationId, clientId, body, clock())
+            repository.sendOutbox(conversationId, clientId, body)
+            _events.trySend(ThreadEvent.ScrollToBottom)
+        }
+    }
+
+    /** FE-102 — open the "Share position" picker + load the caller's open position(s). */
+    fun onAttachPositionCard() {
+        _state.update { it.copy(positionPicker = PositionPickerState(visible = true, loading = true)) }
+        viewModelScope.launch {
+            val symbolsById = (exchangeRepository.symbols() as? ApiResult.Success)?.data
+                ?.associateBy { it.symbolId } ?: emptyMap()
+            when (val r = tradingRepository.marginAccount()) {
+                is ApiResult.Success -> {
+                    val pos = r.data.position
+                    val picks = if (pos != null && pos.qty != 0L) {
+                        val inst = symbolsById[pos.symbolId]
+                        val sym = inst?.symbol ?: "Symbol ${pos.symbolId}"
+                        // Derive % figures for the disclosure headline: P&L% vs entry-notional and a
+                        // simple ROI% (uPnL over |entry notional|). Null-safe when entry is 0.
+                        val entryNotional = kotlin.math.abs(pos.entryPrice * pos.qty).toDouble()
+                        val pnlPct = if (entryNotional > 0) pos.unrealizedPnl / entryNotional * 100.0 else null
+                        val roiPct = pnlPct  // one-position demo: ROI over entry notional mirrors P&L%.
+                        listOf(
+                            OpenPositionPick(
+                                symbolId = pos.symbolId,
+                                symbol = sym,
+                                side = pos.side?.name?.lowercase(),
+                                qty = pos.qty,
+                                entryPrice = pos.entryPrice,
+                                markPrice = pos.entryPrice + (if (pos.qty != 0L) pos.unrealizedPnl / pos.qty else 0L),
+                                liquidationPrice = pos.liquidationPrice,
+                                unrealizedPnl = pos.unrealizedPnl,
+                                pnlPct = pnlPct,
+                                roiPct = roiPct,
+                            ),
+                        )
+                    } else {
+                        emptyList()
+                    }
+                    _state.update { it.copy(positionPicker = it.positionPicker.copy(loading = false, positions = picks)) }
+                }
+                else -> _state.update {
+                    it.copy(positionPicker = it.positionPicker.copy(loading = false, error = "Couldn't load your positions"))
+                }
+            }
+        }
+    }
+
+    fun onDismissPositionPicker() { _state.update { it.copy(positionPicker = PositionPickerState()) } }
+
+    /** FE-102 — project the position to the permitted fields, encode, and send as a text message. */
+    fun onSendPositionCard(
+        pick: OpenPositionPick,
+        disclosure: com.testlogon.android.feature.messaging.TradingCardModel.Disclosure,
+    ) {
+        _state.update { it.copy(positionPicker = PositionPickerState()) }
+        val ownerName = selfSub()?.let { displayNames.resolve(it) } ?: "You"
+        val raw = com.testlogon.android.feature.messaging.TradingCardModel.RawPosition(
+            symbolId = pick.symbolId,
+            symbol = pick.symbol,
+            owner = ownerName,
+            side = pick.side,
+            qty = pick.qty,
+            entryPrice = pick.entryPrice,
+            markPrice = pick.markPrice,
+            liquidationPrice = pick.liquidationPrice,
+            unrealizedPnl = pick.unrealizedPnl,
+            pnlPct = pick.pnlPct,
+            roiPct = pick.roiPct,
+        )
+        val card = com.testlogon.android.feature.messaging.TradingCardModel.project(raw, disclosure)
+        val body = com.testlogon.android.feature.messaging.TradingCardModel.encode(card)
+        val clientId = java.util.UUID.randomUUID().toString()
+        viewModelScope.launch {
+            repository.enqueueOptimistic(conversationId, clientId, body, clock())
+            repository.sendOutbox(conversationId, clientId, body)
+            _events.trySend(ThreadEvent.ScrollToBottom)
+        }
+    }
+
+    /** FE-101 — refresh live price/change/spark for the market cards currently in the thread. */
+    private fun refreshMarketCards() {
+        val symbolIds = _state.value.messages
+            .mapNotNull { (it.media as? MessageMedia.MarketCard)?.card?.symbolId }
+            .distinct()
+        if (symbolIds.isEmpty()) return
+        viewModelScope.launch {
+            val symbolsById = (exchangeRepository.symbols() as? ApiResult.Success)?.data
+                ?.associateBy { it.symbolId } ?: emptyMap()
+            val live = HashMap<Int, MarketCardLive>(_state.value.marketCards)
+            for (sid in symbolIds) {
+                val inst = symbolsById[sid] ?: continue
+                val lastRaw = (exchangeRepository.trades(sid) as? ApiResult.Success)?.data?.firstOrNull()?.price
+                val closes = (exchangeRepository.candles(sid, 60) as? ApiResult.Success)?.data
+                    ?.map { inst.display(it.close) } ?: emptyList()
+                val spark = com.testlogon.android.feature.markets.MarketSummaryMath.spark(closes, 30)
+                val change = com.testlogon.android.feature.markets.MarketSummaryMath.changePctOf(closes, 30)
+                val lastDisplay = lastRaw?.let { inst.display(it) } ?: closes.lastOrNull()
+                live[sid] = MarketCardLive(
+                    lastPriceDisplay = lastDisplay,
+                    changePct = change,
+                    spark = spark,
+                )
+            }
+            _state.update { it.copy(marketCards = live) }
         }
     }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/TradingCardComposers.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/TradingCardComposers.kt
@@ -1,0 +1,161 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.testlogon.android.feature.messaging.thread
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.testlogon.android.feature.messaging.TradingCardModel
+
+object TradingComposerTestTags {
+    const val ATTACH_MARKET = "thread_attach_market"
+    const val ATTACH_POSITION = "thread_attach_position"
+    const val MARKET_PICKER = "thread_market_picker"
+    const val MARKET_PICKER_SEARCH = "thread_market_picker_search"
+    const val MARKET_PICKER_ROW = "thread_market_picker_row_"
+    const val POSITION_PICKER = "thread_position_picker"
+    const val POSITION_PICKER_ROW = "thread_position_picker_row_"
+    const val DISCLOSURE_CHIP = "thread_position_disclosure_"
+    const val POSITION_SEND = "thread_position_send"
+}
+
+/** FE-101 — "Share market": searchable symbol picker; selecting a row sends a market_card message. */
+@Composable
+fun MarketPickerSheet(
+    state: MarketPickerState,
+    onQuery: (String) -> Unit,
+    onPick: (SymbolPick) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss, modifier = Modifier.testTag(TradingComposerTestTags.MARKET_PICKER).semantics { testTagsAsResourceId = true }) {
+        Column(Modifier.fillMaxWidth().navigationBarsPadding().padding(16.dp).verticalScroll(rememberScrollState())) {
+            Text("Share market", style = MaterialTheme.typography.titleMedium)
+            OutlinedTextField(
+                value = state.query,
+                onValueChange = onQuery,
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp).testTag(TradingComposerTestTags.MARKET_PICKER_SEARCH),
+                placeholder = { Text("Search symbol (e.g. BTC)") },
+                singleLine = true,
+            )
+            when {
+                state.loading -> CircularProgressIndicator(Modifier.padding(16.dp))
+                state.filtered.isEmpty() -> Text(
+                    state.error ?: "No symbols found.",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+                else -> state.filtered.forEach { sym ->
+                    OutlinedButton(
+                        onClick = { onPick(sym) },
+                        modifier = Modifier.fillMaxWidth().padding(top = 6.dp).testTag(TradingComposerTestTags.MARKET_PICKER_ROW + sym.symbolId),
+                    ) { Text(sym.symbol, style = MaterialTheme.typography.bodyLarge) }
+                }
+            }
+            Box(Modifier.fillMaxWidth().heightIn(min = 16.dp))
+        }
+    }
+}
+
+/**
+ * FE-102 — "Share position": pick one open position + a disclosure (full / P&L% / ROI), then send a
+ * position_card carrying ONLY the permitted fields (the projection is done in the ViewModel/model).
+ */
+@Composable
+fun PositionPickerSheet(
+    state: PositionPickerState,
+    onSend: (OpenPositionPick, TradingCardModel.Disclosure) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selectedId by remember { mutableStateOf<Int?>(null) }
+    var disclosure by remember { mutableStateOf(TradingCardModel.Disclosure.FULL) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, modifier = Modifier.testTag(TradingComposerTestTags.POSITION_PICKER).semantics { testTagsAsResourceId = true }) {
+        Column(Modifier.fillMaxWidth().navigationBarsPadding().padding(16.dp).verticalScroll(rememberScrollState())) {
+            Text("Share position", style = MaterialTheme.typography.titleMedium)
+            when {
+                state.loading -> CircularProgressIndicator(Modifier.padding(16.dp))
+                state.positions.isEmpty() -> Text(
+                    state.error ?: "You have no open positions to share.",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+                else -> {
+                    Text("Position", style = MaterialTheme.typography.labelMedium, modifier = Modifier.padding(top = 8.dp))
+                    state.positions.forEach { pos ->
+                        val sideLabel = when (pos.side) { "buy" -> "LONG"; "sell" -> "SHORT"; else -> "" }
+                        FilterChip(
+                            selected = selectedId == pos.symbolId,
+                            onClick = { selectedId = pos.symbolId },
+                            label = { Text("${pos.symbol}  $sideLabel") },
+                            modifier = Modifier.padding(top = 4.dp).testTag(TradingComposerTestTags.POSITION_PICKER_ROW + pos.symbolId),
+                        )
+                    }
+                    Text("Disclosure", style = MaterialTheme.typography.labelMedium, modifier = Modifier.padding(top = 12.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        DisclosureChip(TradingCardModel.Disclosure.FULL, "Full", disclosure) { disclosure = it }
+                        DisclosureChip(TradingCardModel.Disclosure.PNL_PCT, "P&L %", disclosure) { disclosure = it }
+                        DisclosureChip(TradingCardModel.Disclosure.ROI, "ROI %", disclosure) { disclosure = it }
+                    }
+                    Text(
+                        when (disclosure) {
+                            TradingCardModel.Disclosure.FULL -> "Shares size, entry, mark, liquidation and uPnL."
+                            TradingCardModel.Disclosure.PNL_PCT -> "Shares only your P&L percentage (no cash amounts)."
+                            TradingCardModel.Disclosure.ROI -> "Shares only your ROI percentage (no cash amounts)."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                    val selected = state.positions.firstOrNull { it.symbolId == selectedId }
+                    Button(
+                        onClick = { selected?.let { onSend(it, disclosure) } },
+                        enabled = selected != null,
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp).testTag(TradingComposerTestTags.POSITION_SEND),
+                    ) { Text("Share position") }
+                }
+            }
+            Box(Modifier.fillMaxWidth().heightIn(min = 16.dp))
+        }
+    }
+}
+
+@Composable
+private fun DisclosureChip(
+    value: TradingCardModel.Disclosure,
+    label: String,
+    selected: TradingCardModel.Disclosure,
+    onSelect: (TradingCardModel.Disclosure) -> Unit,
+) {
+    FilterChip(
+        selected = selected == value,
+        onClick = { onSelect(value) },
+        label = { Text(label, fontWeight = if (selected == value) FontWeight.SemiBold else FontWeight.Normal) },
+        modifier = Modifier.testTag(TradingComposerTestTags.DISCLOSURE_CHIP + value.wire),
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/TradingCardUi.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/TradingCardUi.kt
@@ -1,0 +1,206 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.testlogon.android.feature.messaging.thread
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.testlogon.android.feature.markets.ui.MarketColors
+import com.testlogon.android.feature.messaging.TradingCardModel
+import java.util.Locale
+
+/** FE-101 test tags. */
+object TradingCardTestTags {
+    const val MARKET_CARD = "thread_market_card"
+    const val MARKET_TRADE = "thread_market_card_trade"
+    const val POSITION_CARD = "thread_position_card"
+}
+
+/**
+ * FE-101 — live market data resolved at render time for a shared market card (price/change/spark are
+ * NOT carried on the wire; the ViewModel refreshes them into [ThreadUiState.marketCards]). All fields
+ * null while loading, so the card shows the ticker immediately and fills price/change/spark when ready.
+ */
+data class MarketCardLive(
+    val lastPriceDisplay: Double? = null,
+    val changePct: Double? = null,
+    val spark: List<Float> = emptyList(),
+    val priceLabel: String? = null,
+)
+
+/**
+ * FE-101 — Market card: ticker + live price + change % + a mini sparkline + a Trade button that opens
+ * the order-ticket (Symbol detail) screen for the symbol. Mirrors the Markets-list row treatment.
+ */
+@Composable
+fun MarketCard(
+    card: TradingCardModel.MarketCard,
+    live: MarketCardLive,
+    onTrade: (symbolId: Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val up = (live.changePct ?: 0.0) >= 0.0
+    val cd = "Market ${card.symbol}" + (live.changePct?.let { ", ${pct(it)}" } ?: "")
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = modifier
+            .widthIn(max = 300.dp)
+            .testTag(TradingCardTestTags.MARKET_CARD)
+            .semantics { contentDescription = cd },
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Market", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(card.symbol, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                MiniSparkline(points = live.spark, up = up, modifier = Modifier.width(72.dp).height(28.dp))
+            }
+            Row(Modifier.fillMaxWidth().padding(top = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    live.priceLabel ?: live.lastPriceDisplay?.let { fmtPrice(it) } ?: "—",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    live.changePct?.let { pct(it) } ?: "--",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (live.changePct == null) MaterialTheme.colorScheme.onSurfaceVariant else if (up) MarketColors.Up else MarketColors.Down,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Button(
+                onClick = { onTrade(card.symbolId) },
+                modifier = Modifier.fillMaxWidth().padding(top = 10.dp).testTag(TradingCardTestTags.MARKET_TRADE),
+            ) { Text("Trade") }
+        }
+    }
+}
+
+/**
+ * FE-102 — Position card: renders ONLY the fields the sender's disclosure permitted (the withheld
+ * ones arrive null and are simply not shown), plus "shared by <owner>" attribution and directional
+ * color. The disclosure logic itself lives in the pure TradingCardModel; this only renders.
+ */
+@Composable
+fun PositionCard(
+    card: TradingCardModel.PositionCard,
+    onTrade: (symbolId: Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val long = card.isLong
+    val directional = when (long) { true -> MarketColors.Up; false -> MarketColors.Down; else -> MaterialTheme.colorScheme.onSurfaceVariant }
+    val sideLabel = when (long) { true -> "LONG"; false -> "SHORT"; else -> null }
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = modifier
+            .widthIn(max = 300.dp)
+            .testTag(TradingCardTestTags.POSITION_CARD)
+            .semantics { contentDescription = "Position ${card.symbol}" },
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Position", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(card.symbol, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                sideLabel?.let {
+                    Text(it, style = MaterialTheme.typography.labelLarge, color = directional, fontWeight = FontWeight.Bold)
+                }
+            }
+            // The headline P&L figure: the percentage the disclosure exposes (uPnL% or ROI%).
+            val headlinePct = card.pnlPct ?: card.roiPct
+            headlinePct?.let {
+                Text(
+                    (if (card.pnlPct != null) "P&L " else "ROI ") + pct(it),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = if (it >= 0) MarketColors.Up else MarketColors.Down,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+            // FULL-disclosure detail rows (each present only when the field was permitted/sent).
+            card.qty?.let { DetailRow("Size", it.toString()) }
+            card.entryPrice?.let { DetailRow("Entry", it.toString()) }
+            card.markPrice?.let { DetailRow("Mark", it.toString()) }
+            card.liquidationPrice?.let { DetailRow("Liq.", it.toString()) }
+            card.unrealizedPnl?.let { DetailRow("uPnL", it.toString(), if (it >= 0) MarketColors.Up else MarketColors.Down) }
+            Text(
+                "Shared by ${card.owner.ifBlank { "a trader" }}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            Button(
+                onClick = { onTrade(card.symbolId) },
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            ) { Text("View market") }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String, valueColor: Color? = null) {
+    Row(Modifier.fillMaxWidth().padding(top = 2.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodySmall, color = valueColor ?: MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Medium)
+    }
+}
+
+/** A compact filled-area sparkline (mirrors the Markets-list Sparkline; self-contained Canvas). */
+@Composable
+private fun MiniSparkline(points: List<Float>, up: Boolean, modifier: Modifier = Modifier) {
+    val color = if (up) MarketColors.Up else MarketColors.Down
+    Canvas(modifier = modifier) {
+        val n = points.size
+        if (n < 2) {
+            val y = size.height / 2f
+            drawLine(MarketColors.Border, Offset(0f, y), Offset(size.width, y), strokeWidth = 1.5f)
+            return@Canvas
+        }
+        val min = points.min()
+        val max = points.max()
+        val range = (max - min).let { if (it == 0f) 1f else it }
+        val dx = size.width / (n - 1)
+        fun px(i: Int) = dx * i
+        fun py(v: Float) = size.height * (1f - (v - min) / range)
+        val line = Path().apply {
+            moveTo(px(0), py(points[0]))
+            for (i in 1 until n) lineTo(px(i), py(points[i]))
+        }
+        val fill = Path().apply {
+            addPath(line)
+            lineTo(px(n - 1), size.height)
+            lineTo(px(0), size.height)
+            close()
+        }
+        drawPath(fill, Brush.verticalGradient(listOf(color.copy(alpha = 0.22f), Color.Transparent)))
+        drawPath(line, color = color, style = Stroke(width = 2f, cap = StrokeCap.Round))
+    }
+}
+
+private fun pct(v: Double): String = String.format(Locale.US, "%+.2f%%", v)
+private fun fmtPrice(v: Double): String = String.format(Locale.US, "%,.2f", v)

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
@@ -1285,4 +1285,6 @@ fun newThreadViewModel(
         typingRepository,
         fakeDisplayNameResolver(),
         fakeApiErrorParser(),
+        com.testlogon.android.feature.trading.FakeExchangeRepository(),
+        com.testlogon.android.feature.trading.FakeTradingRepository(),
     )

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/TradingCardModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/TradingCardModelTest.kt
@@ -1,0 +1,158 @@
+package com.testlogon.android.feature.messaging
+
+import com.testlogon.android.feature.messaging.TradingCardModel.Disclosure
+import com.testlogon.android.feature.messaging.TradingCardModel.PositionField
+import com.testlogon.android.feature.messaging.TradingCardModel.RawPosition
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** FE-101 / FE-102 — pure disclosure + preview + payload-parse tests (no Android runtime). */
+class TradingCardModelTest {
+
+    private fun raw() = RawPosition(
+        symbolId = 1,
+        symbol = "BTCUSDC",
+        owner = "Ada",
+        side = "buy",
+        qty = 5,
+        entryPrice = 60_000,
+        markPrice = 61_000,
+        liquidationPrice = 45_000,
+        unrealizedPnl = 5_000,
+        pnlPct = 1.67,
+        roiPct = 12.5,
+    )
+
+    @Test
+    fun full_disclosure_permits_every_field() {
+        val f = TradingCardModel.permittedFields(Disclosure.FULL)
+        assertEquals(PositionField.values().toSet(), f)
+    }
+
+    @Test
+    fun pnlPct_disclosure_permits_only_side_and_pnlPct() {
+        val f = TradingCardModel.permittedFields(Disclosure.PNL_PCT)
+        assertEquals(setOf(PositionField.SIDE, PositionField.PNL_PCT), f)
+    }
+
+    @Test
+    fun roi_disclosure_permits_only_side_and_roiPct() {
+        val f = TradingCardModel.permittedFields(Disclosure.ROI)
+        assertEquals(setOf(PositionField.SIDE, PositionField.ROI_PCT), f)
+    }
+
+    @Test
+    fun project_full_keeps_all_values() {
+        val c = TradingCardModel.project(raw(), Disclosure.FULL)
+        assertEquals("buy", c.side)
+        assertEquals(5L, c.qty)
+        assertEquals(60_000L, c.entryPrice)
+        assertEquals(61_000L, c.markPrice)
+        assertEquals(45_000L, c.liquidationPrice)
+        assertEquals(5_000L, c.unrealizedPnl)
+        assertEquals(1.67, c.pnlPct!!, 1e-9)
+        assertEquals(12.5, c.roiPct!!, 1e-9)
+        assertTrue(c.isLong == true)
+    }
+
+    @Test
+    fun project_pnlPct_withholds_absolute_amounts() {
+        val c = TradingCardModel.project(raw(), Disclosure.PNL_PCT)
+        // permitted
+        assertEquals("buy", c.side)
+        assertEquals(1.67, c.pnlPct!!, 1e-9)
+        // withheld — must never leak
+        assertNull(c.qty)
+        assertNull(c.entryPrice)
+        assertNull(c.markPrice)
+        assertNull(c.liquidationPrice)
+        assertNull(c.unrealizedPnl)
+        assertNull(c.roiPct)
+    }
+
+    @Test
+    fun project_roi_withholds_everything_except_side_and_roi() {
+        val c = TradingCardModel.project(raw(), Disclosure.ROI)
+        assertEquals("buy", c.side)
+        assertEquals(12.5, c.roiPct!!, 1e-9)
+        assertNull(c.pnlPct)
+        assertNull(c.qty)
+        assertNull(c.entryPrice)
+        assertNull(c.markPrice)
+        assertNull(c.liquidationPrice)
+        assertNull(c.unrealizedPnl)
+    }
+
+    @Test
+    fun withheld_fields_are_absent_from_the_encoded_payload() {
+        // A ROI share encoded to the wire must not contain entry/qty/liq/upnl keys at all.
+        val wire = TradingCardModel.encode(TradingCardModel.project(raw(), Disclosure.ROI))
+        assertFalse(wire.contains("entry="))
+        assertFalse(wire.contains("qty="))
+        assertFalse(wire.contains("liq="))
+        assertFalse(wire.contains("upnl="))
+        assertFalse(wire.contains("pnlpct="))
+        assertTrue(wire.contains("roipct="))
+    }
+
+    @Test
+    fun market_preview_strings() {
+        assertEquals("[Market: BTCUSDC]", TradingCardModel.marketPreview("BTCUSDC"))
+        assertEquals("[Position: ETHUSDC]", TradingCardModel.positionPreview("ETHUSDC"))
+    }
+
+    @Test
+    fun market_card_round_trips_through_encode_parse() {
+        val original = TradingCardModel.MarketCard(symbolId = 3, symbol = "SOLUSDC")
+        val wire = TradingCardModel.encode(original)
+        assertTrue(TradingCardModel.isCard(wire))
+        val parsed = TradingCardModel.parse(wire)
+        assertEquals(original, parsed)
+        assertEquals("[Market: SOLUSDC]", TradingCardModel.previewForBody(wire))
+    }
+
+    @Test
+    fun position_card_round_trips_and_preserves_disclosure() {
+        val original = TradingCardModel.project(raw(), Disclosure.PNL_PCT)
+        val wire = TradingCardModel.encode(original)
+        val parsed = TradingCardModel.parse(wire) as TradingCardModel.PositionCard
+        assertEquals(Disclosure.PNL_PCT, parsed.disclosure)
+        assertEquals("Ada", parsed.owner)
+        assertEquals("buy", parsed.side)
+        assertEquals(1.67, parsed.pnlPct!!, 1e-9)
+        assertNull(parsed.entryPrice)
+        assertEquals("[Position: BTCUSDC]", TradingCardModel.previewForBody(wire))
+    }
+
+    @Test
+    fun plain_text_body_is_not_a_card_and_has_no_preview() {
+        assertFalse(TradingCardModel.isCard("hello world"))
+        assertNull(TradingCardModel.parse("hello world"))
+        assertNull(TradingCardModel.previewForBody("hello world"))
+        assertNull(TradingCardModel.parse(null))
+    }
+
+    @Test
+    fun owner_with_reserved_chars_round_trips() {
+        // A ; or = in a name must not corrupt the key/value framing.
+        val original = TradingCardModel.project(raw().copy(owner = "a;b=c%d"), Disclosure.FULL)
+        val parsed = TradingCardModel.parse(TradingCardModel.encode(original)) as TradingCardModel.PositionCard
+        assertEquals("a;b=c%d", parsed.owner)
+    }
+
+    @Test
+    fun malformed_card_body_parses_to_null() {
+        assertNull(TradingCardModel.parse(TradingCardModel.SENTINEL + "market_card;sym=BTC")) // no sid
+        assertNull(TradingCardModel.parse(TradingCardModel.SENTINEL + "bogus_kind;sid=1;sym=BTC"))
+    }
+
+    @Test
+    fun disclosure_fromWire_defaults_to_full() {
+        assertEquals(Disclosure.FULL, Disclosure.fromWire(null))
+        assertEquals(Disclosure.FULL, Disclosure.fromWire("nonsense"))
+        assertEquals(Disclosure.ROI, Disclosure.fromWire("roi"))
+    }
+}

--- a/frontend/src/api/endpoints/messaging.ts
+++ b/frontend/src/api/endpoints/messaging.ts
@@ -1,4 +1,4 @@
-import { api } from "@/api/client";
+import { api, ApiError } from "@/api/client";
 import type {
   Conversation,
   Message,
@@ -49,6 +49,7 @@ import type {
   GalleryImageItem,
 } from "@/api/types";
 import { adaptConversation, adaptMessage } from "./messagingAdapter";
+import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
 import { isMessagingDmLotteryEnabled, isMessagingEncryptionEnabled } from "@/lib/featureFlags";
 import { encryptBytes } from "@/lib/messageEncryption";
 
@@ -881,6 +882,67 @@ export async function sendCountdownMessage(
     params,
   );
   return adaptMessage(res);
+}
+
+// ---- Trading-in-chat cards (EPIC A: FE-101 market, FE-102 position) ----
+//
+// Preferred path is a dedicated /messaging/cards/* endpoint (BE-101/BE-102).
+// If the backend has not shipped it yet (404), we degrade to a normal message
+// carrying a new `kind` + structured payload -- the works-now path that renders
+// identically because MessageBubble dispatches purely on `kind` + payload.
+
+async function sendCardMessage(
+  conversationId: string,
+  cardEndpoint: string,
+  kind: "market_card" | "position_card",
+  payload: Record<string, unknown>,
+  replyToMessageId?: string,
+): Promise<Message> {
+  try {
+    const res = await api.post<Message>(
+      `/messaging/conversations/${conversationId}/cards/${cardEndpoint}`,
+      { ...payload, reply_to_message_id: replyToMessageId },
+    );
+    return adaptMessage(res);
+  } catch (err) {
+    // Degrade-on-404 (endpoint not deployed) to the normal kind+payload send.
+    if (err instanceof ApiError && err.status === 404) {
+      const res = await api.post<Message>(
+        `/messaging/conversations/${conversationId}/messages`,
+        { kind, ...payload, reply_to_message_id: replyToMessageId },
+      );
+      return adaptMessage(res);
+    }
+    throw err;
+  }
+}
+
+export async function sendMarketCardMessage(
+  conversationId: string,
+  payload: MarketCardPayload,
+  replyToMessageId?: string,
+): Promise<Message> {
+  return sendCardMessage(
+    conversationId,
+    "market",
+    "market_card",
+    { ...payload },
+    replyToMessageId,
+  );
+}
+
+export async function sendPositionCardMessage(
+  conversationId: string,
+  payload: PositionCardPayload,
+  replyToMessageId?: string,
+): Promise<Message> {
+  return sendCardMessage(
+    conversationId,
+    "position",
+    "position_card",
+    { ...payload },
+    replyToMessageId,
+  );
 }
 
 export async function sendGifMessage(

--- a/frontend/src/api/endpoints/messagingAdapter.ts
+++ b/frontend/src/api/endpoints/messagingAdapter.ts
@@ -126,6 +126,16 @@ export function adaptMessage(raw: RawMessage): Message {
     target_datetime: raw.target_datetime,
     associated_event_type: raw.associated_event_type,
     associated_event_id: raw.associated_event_id,
+    // Trading-in-chat card fields (EPIC A)
+    symbol_id: raw.symbol_id,
+    symbol: raw.symbol,
+    price_scaler: raw.price_scaler,
+    side: raw.side,
+    disclosure: raw.disclosure,
+    roi_pct: raw.roi_pct,
+    entry: raw.entry,
+    mark: raw.mark,
+    size: raw.size,
     // GIF & Sticker fields (MSG-008)
     gif_url: raw.gif_url,
     gif_alt_text: raw.gif_alt_text,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1307,7 +1307,7 @@ export interface Message {
   message_id: string;
   conversation_id: string;
   sender_id: string;
-  kind: "text" | "image" | "file" | "audio" | "video" | "gallery" | "file_share" | "calendar_share" | "calendar_event" | "meeting_poll" | "video_share" | "voice_message" | "voicemail" | "countdown" | "gif" | "sticker" | "find_datetime";
+  kind: "text" | "image" | "file" | "audio" | "video" | "gallery" | "file_share" | "calendar_share" | "calendar_event" | "meeting_poll" | "video_share" | "voice_message" | "voicemail" | "countdown" | "gif" | "sticker" | "find_datetime" | "market_card" | "position_card";
   created_at: number;
   text?: string;
   image?: MessageImage;
@@ -1377,6 +1377,18 @@ export interface Message {
   target_datetime?: number | null;
   associated_event_type?: "broadcast" | "call" | "calendar" | "custom" | null;
   associated_event_id?: string | null;
+  // Trading-in-chat card fields (EPIC A). market_card carries symbol_id+symbol;
+  // position_card additionally carries side/disclosure/roi_pct and, at "full"
+  // disclosure, entry/mark/size. These ride on a normal message keyed by `kind`.
+  symbol_id?: number | null;
+  symbol?: string | null;
+  price_scaler?: number | null;
+  side?: "Long" | "Short" | null;
+  disclosure?: "full" | "pnl_pct" | "roi" | null;
+  roi_pct?: number | null;
+  entry?: number | null;
+  mark?: number | null;
+  size?: number | null;
   // B-COUNTDOWN #31: the stashed reveal payload, surfaced ONLY once the countdown
   // target has passed. Present on any message that carried countdown_reveal_* on
   // send (not just the dedicated "countdown" kind).

--- a/frontend/src/lib/tradingCards.test.ts
+++ b/frontend/src/lib/tradingCards.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMarketCardPayload,
+  buildPositionCardPayload,
+  changePctFromCloses,
+  type PositionSource,
+} from "./tradingCards";
+
+const src: PositionSource = {
+  symbol_id: 1,
+  symbol: "BTCUSDC",
+  side: "Long",
+  roi_pct: 12.5,
+  entry: 100000,
+  mark: 112500,
+  size: 3,
+  price_scaler: 1,
+};
+
+describe("buildPositionCardPayload disclosure gating", () => {
+  it("full disclosure carries entry, mark and (absolute) size", () => {
+    const p = buildPositionCardPayload(src, "full");
+    expect(p.disclosure).toBe("full");
+    expect(p.symbol).toBe("BTCUSDC");
+    expect(p.side).toBe("Long");
+    expect(p.roi_pct).toBe(12.5);
+    expect(p.entry).toBe(100000);
+    expect(p.mark).toBe(112500);
+    expect(p.size).toBe(3);
+  });
+
+  it("size is normalised to its absolute value at full disclosure", () => {
+    const short = buildPositionCardPayload({ ...src, side: "Short", size: -4 }, "full");
+    expect(short.size).toBe(4);
+  });
+
+  it("pnl_pct disclosure reveals ONLY symbol/side/roi -- never notionals", () => {
+    const p = buildPositionCardPayload(src, "pnl_pct");
+    expect(p.disclosure).toBe("pnl_pct");
+    expect(p.symbol).toBe("BTCUSDC");
+    expect(p.side).toBe("Long");
+    expect(p.roi_pct).toBe(12.5);
+    expect(p.entry).toBeUndefined();
+    expect(p.mark).toBeUndefined();
+    expect(p.size).toBeUndefined();
+  });
+
+  it("roi disclosure reveals ONLY symbol/side/roi -- never notionals", () => {
+    const p = buildPositionCardPayload(src, "roi");
+    expect(p.entry).toBeUndefined();
+    expect(p.mark).toBeUndefined();
+    expect(p.size).toBeUndefined();
+    expect(p.roi_pct).toBe(12.5);
+  });
+});
+
+describe("buildMarketCardPayload", () => {
+  it("carries just symbol_id + symbol", () => {
+    expect(buildMarketCardPayload(2, "ETHUSDC")).toEqual({ symbol_id: 2, symbol: "ETHUSDC" });
+  });
+});
+
+describe("changePctFromCloses", () => {
+  it("computes first->last percent change", () => {
+    expect(changePctFromCloses([100, 110])).toBeCloseTo(10);
+  });
+  it("returns undefined for an empty window or zero base", () => {
+    expect(changePctFromCloses([])).toBeUndefined();
+    expect(changePctFromCloses([0, 5])).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/tradingCards.ts
+++ b/frontend/src/lib/tradingCards.ts
@@ -1,0 +1,87 @@
+// Pure helpers for the trading-in-chat cards (EPIC A: FE-101 market card,
+// FE-102 position card). Kept dependency-light so the disclosure-field
+// selection is unit-testable without React.
+
+export type PositionDisclosure = "full" | "pnl_pct" | "roi";
+
+export interface PositionSource {
+  symbol_id: number;
+  symbol: string;
+  side: "Long" | "Short";
+  /** Return-on-investment percent (signed). Always shareable. */
+  roi_pct: number;
+  /** Average entry price in display units. Full disclosure only. */
+  entry?: number;
+  /** Current mark price in display units. Full disclosure only. */
+  mark?: number;
+  /** Absolute (unsigned) net position size. Full disclosure only. */
+  size?: number;
+  /** Price scaler for the symbol (display formatting). */
+  price_scaler?: number;
+}
+
+// The wire/payload shape carried on a position_card message. Only the fields
+// permitted by the chosen disclosure level are populated -- the composer must
+// never leak entry/mark/size at a reduced disclosure level.
+export interface PositionCardPayload {
+  symbol_id: number;
+  symbol: string;
+  side: "Long" | "Short";
+  disclosure: PositionDisclosure;
+  roi_pct: number;
+  entry?: number;
+  mark?: number;
+  size?: number;
+  price_scaler?: number;
+}
+
+export interface MarketCardPayload {
+  symbol_id: number;
+  symbol: string;
+}
+
+/**
+ * Project a caller-owned position into the payload permitted by `disclosure`.
+ * Contract (per FE-102): symbol + side + roi% are ALWAYS included; entry, mark
+ * and size are included ONLY at "full". "pnl_pct" and "roi" reveal just the
+ * percentage -- never the notionals. This is the single choke point that
+ * enforces the privacy selector, so it is unit-tested directly.
+ */
+export function buildPositionCardPayload(
+  src: PositionSource,
+  disclosure: PositionDisclosure,
+): PositionCardPayload {
+  const base: PositionCardPayload = {
+    symbol_id: src.symbol_id,
+    symbol: src.symbol,
+    side: src.side,
+    disclosure,
+    roi_pct: src.roi_pct,
+    price_scaler: src.price_scaler,
+  };
+  if (disclosure === "full") {
+    base.entry = src.entry;
+    base.mark = src.mark;
+    base.size = src.size != null ? Math.abs(src.size) : undefined;
+  }
+  return base;
+}
+
+export function buildMarketCardPayload(symbolId: number, symbol: string): MarketCardPayload {
+  return { symbol_id: symbolId, symbol };
+}
+
+export const DISCLOSURE_LABEL: Record<PositionDisclosure, string> = {
+  full: "Full (entry, mark, size & ROI)",
+  pnl_pct: "P&L % only",
+  roi: "ROI % only",
+};
+
+/** Compute % change between the first and last close of a candle window. */
+export function changePctFromCloses(closes: number[]): number | undefined {
+  if (closes.length < 1) return undefined;
+  const first = closes[0];
+  const last = closes[closes.length - 1];
+  if (first == null || last == null || first === 0) return undefined;
+  return ((last - first) / first) * 100;
+}

--- a/frontend/src/pages/messages/ComposeBar.tsx
+++ b/frontend/src/pages/messages/ComposeBar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Send, Paperclip, Loader2, Lock, Eye, EyeOff, EyeOff as EyeSlash, Headphones, X, ImageIcon, Clock, Reply, Globe, DollarSign, FileText, Images, FolderOpen, CalendarDays, CalendarCheck, Users, Dices, Video, Mic, Timer, Smile, Sticker as StickerIcon, Plus, Check } from "lucide-react";
+import { Send, Paperclip, Loader2, Lock, Eye, EyeOff, EyeOff as EyeSlash, Headphones, X, ImageIcon, Clock, Reply, Globe, DollarSign, FileText, Images, FolderOpen, CalendarDays, CalendarCheck, Users, Dices, Video, Mic, Timer, Smile, Sticker as StickerIcon, Plus, Check, TrendingUp, Activity } from "lucide-react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { GifPicker } from "@/components/shared/GifPicker";
@@ -25,6 +25,9 @@ import { EventPickerDialog } from "./EventPickerDialog";
 import { MeetingPollComposer } from "./MeetingPollComposer";
 import { FindDateTimeComposer } from "./FindDateTimeComposer";
 import { CountdownComposerDialog, type CountdownSubmitData } from "./CountdownComposerDialog";
+import { MarketCardComposerDialog } from "./MarketCardComposerDialog";
+import { PositionCardComposerDialog } from "./PositionCardComposerDialog";
+import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
 import { getPaymentMethods } from "@/api/endpoints/billing";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { FilePickerDialog } from "./FilePickerDialog";
@@ -66,6 +69,9 @@ interface ComposeBarProps {
   onSendMeetingPoll?: (params: SendMeetingPollReq) => void;
   onSendFindDateTime?: (params: SendFindDateTimeReq) => void;
   onSendCountdown?: (params: CountdownSubmitData) => void;
+  onSendMarketCard?: (payload: MarketCardPayload) => void;
+  onSendPositionCard?: (payload: PositionCardPayload) => void;
+  currentUserName?: string;
   onSendLottery?: (params: Omit<CreateLotteryMessageReq, "conversation_id">) => void;
   onSendVoiceMessage?: (blob: Blob, meta: { duration: number; waveform: number[]; contentType: string; consumption_policy?: "none" | "listen_once"; reply_to_message_id?: string | null; send_at?: number | null }) => void;
   // MVA-010: synthesize the current draft text into a TTS voice message.
@@ -99,6 +105,9 @@ export function ComposeBar({
   onSendMeetingPoll,
   onSendFindDateTime,
   onSendCountdown,
+  onSendMarketCard,
+  onSendPositionCard,
+  currentUserName,
   onSendLottery,
   onSendVoiceMessage,
   onSendTtsVoice,
@@ -212,6 +221,8 @@ export function ComposeBar({
   const [meetingPollOpen, setMeetingPollOpen] = React.useState(false);
   const [findDateTimeOpen, setFindDateTimeOpen] = React.useState(false);
   const [countdownOpen, setCountdownOpen] = React.useState(false);
+  const [marketCardOpen, setMarketCardOpen] = React.useState(false);
+  const [positionCardOpen, setPositionCardOpen] = React.useState(false);
   const [activeDraftId, setActiveDraftId] = React.useState<string | null>(null);
   const [draftDirty, setDraftDirty] = React.useState(false);
   const [lastDraftSavedAt, setLastDraftSavedAt] = React.useState<number | null>(null);
@@ -1603,7 +1614,7 @@ export function ComposeBar({
       <div className="flex items-end gap-2">
         {(onSendVoiceMessage || onSendGallery || onSendLottery || onSendFileShare || onSendVideoShare ||
           onSendCalendarShare || onSendCalendarEvent || onSendMeetingPoll || onSendFindDateTime ||
-          onSendCountdown || draftsEnabled || (onSendTtsVoice && ttsEnabled)) && (
+          onSendCountdown || onSendMarketCard || onSendPositionCard || draftsEnabled || (onSendTtsVoice && ttsEnabled)) && (
           <Popover open={moreOpen} onOpenChange={setMoreOpen}>
             <PopoverTrigger asChild>
               <Button
@@ -1785,6 +1796,18 @@ export function ComposeBar({
                   <Button variant="ghost" className="h-9 justify-start gap-2 px-2"
                     onClick={() => { setCountdownOpen(true); setMoreOpen(false); }} aria-label="Create a countdown">
                     <Timer className="h-4 w-4" /> Create a countdown
+                  </Button>
+                )}
+                {onSendMarketCard && (
+                  <Button variant="ghost" className="h-9 justify-start gap-2 px-2"
+                    onClick={() => { setMarketCardOpen(true); setMoreOpen(false); }} aria-label="Share market">
+                    <TrendingUp className="h-4 w-4" /> Share market
+                  </Button>
+                )}
+                {onSendPositionCard && (
+                  <Button variant="ghost" className="h-9 justify-start gap-2 px-2"
+                    onClick={() => { setPositionCardOpen(true); setMoreOpen(false); }} aria-label="Share position">
+                    <Activity className="h-4 w-4" /> Share position
                   </Button>
                 )}
                 {draftsEnabled && (
@@ -2098,6 +2121,27 @@ export function ComposeBar({
         />
       )}
 
+      {onSendMarketCard && (
+        <MarketCardComposerDialog
+          open={marketCardOpen}
+          onClose={() => setMarketCardOpen(false)}
+          onSubmit={(payload) => {
+            onSendMarketCard(payload);
+            setMarketCardOpen(false);
+          }}
+        />
+      )}
+      {onSendPositionCard && (
+        <PositionCardComposerDialog
+          open={positionCardOpen}
+          onClose={() => setPositionCardOpen(false)}
+          ownerName={currentUserName}
+          onSubmit={(payload) => {
+            onSendPositionCard(payload);
+            setPositionCardOpen(false);
+          }}
+        />
+      )}
       {onSendCountdown && (
         <CountdownComposerDialog
           open={countdownOpen}

--- a/frontend/src/pages/messages/ConversationView.tsx
+++ b/frontend/src/pages/messages/ConversationView.tsx
@@ -19,6 +19,8 @@ import {
   sendMeetingPollMessage,
   sendFindDateTimeMessage,
   sendCountdownMessage,
+  sendMarketCardMessage,
+  sendPositionCardMessage,
   createLotteryMessage,
   sendVoiceMessage,
   markRead,
@@ -34,6 +36,7 @@ import {
 import { useAuthStore } from "@/stores/authStore";
 import { useOfflineStore } from "@/stores/offlineStore";
 import type { Conversation, Message, SendTextMessageReq, SendFileShareReq, SendCalendarShareReq, SendCalendarEventReq, SendMeetingPollReq, SendFindDateTimeReq, CreateLotteryMessageReq } from "@/api/types";
+import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
 import { MessageBubble } from "./MessageBubble";
 import { ComposeBar } from "./ComposeBar";
 import { PresenceDot } from "./PresenceDot";
@@ -598,6 +601,24 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
     onError: () => toast.error("Failed to create countdown"),
   });
 
+  const sendMarketCard = useMutation({
+    mutationFn: (payload: MarketCardPayload) => sendMarketCardMessage(convoId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["messages", convoId] });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+    onError: () => toast.error("Failed to share market"),
+  });
+
+  const sendPositionCard = useMutation({
+    mutationFn: (payload: PositionCardPayload) => sendPositionCardMessage(convoId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["messages", convoId] });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+    onError: () => toast.error("Failed to share position"),
+  });
+
   const sendLottery = useMutation({
     mutationFn: (params: Omit<CreateLotteryMessageReq, "conversation_id">) =>
       createLotteryMessage({ ...params, conversation_id: convoId }),
@@ -719,6 +740,10 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         .join(", ") || "Conversation");
 
   const participantCount = conversation.participants.length;
+
+  // Owner attribution for the shared position card (falls back to "You").
+  const currentUserName =
+    conversation.participants.find((p) => p.user_id === userId)?.display_name ?? "You";
 
   // Resolve a sender id to a friendly display name for message/reply labels
   // (falls back to the raw id when a participant isn't found).
@@ -1474,6 +1499,9 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         onSendMeetingPoll={(params) => sendMeetingPoll.mutate(params)}
         onSendFindDateTime={(params) => sendFindDateTime.mutate(params)}
         onSendCountdown={(params) => sendCountdown.mutate(params)}
+        onSendMarketCard={(payload) => sendMarketCard.mutate(payload)}
+        onSendPositionCard={(payload) => sendPositionCard.mutate(payload)}
+        currentUserName={currentUserName}
         onSendLottery={!isGroup && dmLotteryEnabled ? (params) => sendLottery.mutate(params) : undefined}
         onSendVoiceMessage={(blob, meta) => sendVoice.mutate({ blob, meta })}
         onSendTtsVoice={(ttsText, opts) =>

--- a/frontend/src/pages/messages/MarketCard.tsx
+++ b/frontend/src/pages/messages/MarketCard.tsx
@@ -1,0 +1,115 @@
+import { useNavigate } from "react-router-dom";
+import { TrendingUp } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useCandles, useSymbols } from "@/hooks/useMarketData";
+import { formatPrice } from "@/pages/markets/format";
+import { changePctFromCloses } from "@/lib/tradingCards";
+
+/** Tiny inline SVG sparkline of recent closes (mirrors MarketsPage). */
+function Sparkline({ closes, up }: { closes: number[]; up: boolean }) {
+  const width = 96;
+  const height = 30;
+  if (closes.length < 2) {
+    return <svg width={width} height={height} aria-hidden data-testid="market-card-sparkline" />;
+  }
+  const min = Math.min(...closes);
+  const max = Math.max(...closes);
+  const range = max - min || 1;
+  const step = width / (closes.length - 1);
+  const points = closes
+    .map((c, i) => {
+      const x = i * step;
+      const y = height - 2 - ((c - min) / range) * (height - 4);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="overflow-visible"
+      aria-hidden
+      data-testid="market-card-sparkline"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        className={up ? "stroke-emerald-500" : "stroke-rose-500"}
+      />
+    </svg>
+  );
+}
+
+export interface MarketCardProps {
+  symbolId: number;
+  symbol: string;
+}
+
+/**
+ * FE-101: an in-chat market card. Ticker + live price + change% + mini
+ * sparkline + a Trade button that opens the order ticket pre-filled. Live data
+ * reuses the same md hooks (useCandles / useSymbols) the markets surfaces poll.
+ */
+export function MarketCard({ symbolId, symbol }: MarketCardProps) {
+  const navigate = useNavigate();
+  const symbolsQ = useSymbols();
+  const scaler =
+    symbolsQ.data?.symbols?.find((s) => s.symbol_id === symbolId)?.price_scaler || 1;
+
+  // 60s candles, most-recent window; oldest -> newest. Same feed as MarketsPage.
+  const candles = useCandles(symbolId, 60, symbolId > 0, 60);
+  const bars = candles.data?.bars ?? [];
+  const closes = bars.map((b) => b.close);
+  const last = closes.length ? closes[closes.length - 1]! : undefined;
+  const changePct = changePctFromCloses(closes);
+  const up = (changePct ?? 0) >= 0;
+
+  return (
+    <Card className="w-72 max-w-full" data-testid="market-card">
+      <CardContent className="pt-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5 text-sm font-semibold">
+              <TrendingUp className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate" data-testid="market-card-ticker">
+                {symbol}
+              </span>
+            </div>
+            <div className="mt-1 text-xl font-bold tabular-nums" data-testid="market-card-price">
+              {last != null ? formatPrice(last, scaler) : "—"}
+            </div>
+            <div
+              className={
+                "text-xs font-medium tabular-nums " +
+                (changePct == null
+                  ? "text-muted-foreground"
+                  : up
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-rose-600 dark:text-rose-400")
+              }
+              data-testid="market-card-change"
+            >
+              {changePct == null ? "—" : `${up ? "+" : ""}${changePct.toFixed(2)}%`}
+            </div>
+          </div>
+          <Sparkline closes={closes} up={up} />
+        </div>
+        <Button
+          size="sm"
+          className="mt-3 w-full"
+          onClick={() => navigate(`/markets/${symbolId}`)}
+          data-testid="market-card-trade"
+        >
+          Trade
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default MarketCard;

--- a/frontend/src/pages/messages/MarketCardComposerDialog.tsx
+++ b/frontend/src/pages/messages/MarketCardComposerDialog.tsx
@@ -1,0 +1,117 @@
+import { useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useSymbols } from "@/hooks/useMarketData";
+import { MarketCard } from "./MarketCard";
+import type { MarketCardPayload } from "@/lib/tradingCards";
+import { buildMarketCardPayload } from "@/lib/tradingCards";
+
+interface MarketCardComposerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: MarketCardPayload) => void;
+}
+
+export function MarketCardComposerDialog({
+  open,
+  onClose,
+  onSubmit,
+}: MarketCardComposerDialogProps) {
+  const symbolsQ = useSymbols();
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<{ symbol_id: number; symbol: string } | null>(null);
+
+  const results = useMemo(() => {
+    const all = symbolsQ.data?.symbols ?? [];
+    const q = query.trim().toUpperCase();
+    const filtered = q ? all.filter((s) => s.symbol.toUpperCase().includes(q)) : all;
+    return filtered.slice(0, 40);
+  }, [symbolsQ.data, query]);
+
+  function reset() {
+    setQuery("");
+    setSelected(null);
+  }
+  function handleClose() {
+    reset();
+    onClose();
+  }
+  function handleSubmit() {
+    if (!selected) return;
+    onSubmit(buildMarketCardPayload(selected.symbol_id, selected.symbol));
+    reset();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (!o ? handleClose() : undefined)}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share market</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              className="pl-8"
+              placeholder="Search by ticker (e.g. BTC)"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search symbols"
+              data-testid="market-composer-search"
+            />
+          </div>
+
+          <div className="max-h-56 overflow-y-auto rounded-md border">
+            {symbolsQ.isLoading ? (
+              <p className="p-3 text-sm text-muted-foreground">Loading symbols…</p>
+            ) : results.length === 0 ? (
+              <p className="p-3 text-sm text-muted-foreground">No matching symbols.</p>
+            ) : (
+              results.map((s) => (
+                <button
+                  key={s.symbol_id}
+                  type="button"
+                  onClick={() => setSelected({ symbol_id: s.symbol_id, symbol: s.symbol })}
+                  className={
+                    "flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent " +
+                    (selected?.symbol_id === s.symbol_id ? "bg-accent" : "")
+                  }
+                  data-testid={`market-composer-option-${s.symbol_id}`}
+                >
+                  <span className="font-medium">{s.symbol}</span>
+                  <span className="text-xs text-muted-foreground">#{s.symbol_id}</span>
+                </button>
+              ))
+            )}
+          </div>
+
+          {selected && (
+            <div className="flex justify-center pt-1">
+              <MarketCard symbolId={selected.symbol_id} symbol={selected.symbol} />
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!selected} data-testid="market-composer-send">
+            Share
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default MarketCardComposerDialog;

--- a/frontend/src/pages/messages/MessageBubble.tradingcards.test.tsx
+++ b/frontend/src/pages/messages/MessageBubble.tradingcards.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageBubble } from "./MessageBubble";
+import type { Message } from "@/api/types";
+
+// MessageBubble pulls in a large messaging surface; stub the API + side modules.
+vi.mock("@/api/endpoints/messaging", () => ({
+  deleteMessage: vi.fn(),
+  editMessage: vi.fn(),
+  reactToMessage: vi.fn(),
+  hideMessage: vi.fn(),
+  reportMessage: vi.fn(),
+  createOnceMediaAttachmentGrant: vi.fn(),
+  consumeOnceMediaAttachment: vi.fn(),
+  buildAttachmentDownloadUrl: vi.fn(),
+  sendMessageTip: vi.fn(),
+  sendTextMessage: vi.fn(),
+  unlockMessage: vi.fn(),
+  unlockLotteryMessage: vi.fn(),
+  getMeetingPoll: vi.fn(),
+  voteMeetingPoll: vi.fn(),
+  confirmMeetingPoll: vi.fn(),
+  markViewed: vi.fn(),
+}));
+vi.mock("@/api/endpoints/messagingAi", () => ({ translateMessage: vi.fn() }));
+vi.mock("@/api/endpoints/calendar", () => ({ createEvent: vi.fn() }));
+vi.mock("@/api/endpoints/billing", () => ({ getPaymentMethods: vi.fn(async () => []) }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("./ReadReceipts", () => ({ ReadReceipts: () => null, ViewTracker: () => null }));
+vi.mock("./ForwardDialog", () => ({ ForwardDialog: () => null }));
+vi.mock("./MessageDetailsSheet", () => ({ MessageDetailsSheet: () => null }));
+
+// MarketCard reads live md via these hooks -- return a stable candle window.
+vi.mock("@/hooks/useMarketData", () => ({
+  useSymbols: () => ({
+    data: { symbols: [{ symbol_id: 1, symbol: "BTCUSDC", price_scaler: 1 }] },
+    isLoading: false,
+  }),
+  useCandles: () => ({
+    data: {
+      bars: [
+        { open: 100, high: 105, low: 99, close: 100, volume: 1, trades: 1, ts_start_ns: 1 },
+        { open: 100, high: 115, low: 100, close: 110, volume: 1, trades: 1, ts_start_ns: 2 },
+      ],
+    },
+    isLoading: false,
+  }),
+}));
+
+function renderBubble(message: Message) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <MessageBubble conversationId="c1" isOwn={false} message={message} />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+const base = {
+  message_id: "m1",
+  conversation_id: "c1",
+  sender_id: "u-sender",
+  created_at: 1,
+  reactions_counts: {},
+};
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe("MessageBubble trading cards", () => {
+  it("renders a market_card with ticker, live price, change% and a Trade button", () => {
+    renderBubble({
+      ...base,
+      kind: "market_card",
+      symbol_id: 1,
+      symbol: "BTCUSDC",
+    } as Message);
+
+    expect(screen.getByTestId("market-card")).toBeInTheDocument();
+    expect(screen.getByTestId("market-card-ticker")).toHaveTextContent("BTCUSDC");
+    // last close = 110
+    expect(screen.getByTestId("market-card-price")).toHaveTextContent("110");
+    // change = (110-100)/100 = +10%
+    expect(screen.getByTestId("market-card-change")).toHaveTextContent("+10.00%");
+    expect(screen.getByTestId("market-card-trade")).toBeInTheDocument();
+  });
+
+  it("renders a full-disclosure position_card with ROI, side and notionals", () => {
+    renderBubble({
+      ...base,
+      kind: "position_card",
+      symbol_id: 1,
+      symbol: "BTCUSDC",
+      side: "Long",
+      disclosure: "full",
+      roi_pct: 12.5,
+      entry: 100000,
+      mark: 112500,
+      size: 3,
+      price_scaler: 1,
+    } as Message);
+
+    expect(screen.getByTestId("position-card")).toBeInTheDocument();
+    expect(screen.getByTestId("position-card-ticker")).toHaveTextContent("BTCUSDC");
+    expect(screen.getByTestId("position-card-side")).toHaveTextContent("Long");
+    expect(screen.getByTestId("position-card-roi")).toHaveTextContent("+12.50%");
+    expect(screen.getByTestId("position-card-full-metrics")).toBeInTheDocument();
+  });
+
+  it("renders a reduced-disclosure position_card WITHOUT notionals", () => {
+    renderBubble({
+      ...base,
+      kind: "position_card",
+      symbol_id: 1,
+      symbol: "BTCUSDC",
+      side: "Short",
+      disclosure: "roi",
+      roi_pct: -4.2,
+    } as Message);
+
+    expect(screen.getByTestId("position-card-roi")).toHaveTextContent("-4.20%");
+    expect(screen.queryByTestId("position-card-full-metrics")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/messages/MessageBubble.tsx
+++ b/frontend/src/pages/messages/MessageBubble.tsx
@@ -57,6 +57,9 @@ import { ApiError } from "@/api/client";
 import type { GalleryImageItem, Message, MeetingPollAttachment, FindDateTimeAttachment, PaymentMethod } from "@/api/types";
 import { getPaymentMethods } from "@/api/endpoints/billing";
 import { FileMessageCard } from "./FileMessageCard";
+import { MarketCard } from "./MarketCard";
+import { PositionCard } from "./PositionCard";
+import type { PositionCardPayload } from "@/lib/tradingCards";
 import { WaveformPlayer } from "./WaveformPlayer";
 import { VoicemailBubble } from "./VoicemailBubble";
 import { TranscriptControl } from "./TranscriptControl";
@@ -196,6 +199,8 @@ function replyPreviewText(msg: Message): string {
   if (msg.kind === "gif") return "[GIF]";
   if (msg.kind === "sticker") return "[Sticker]";
   if (msg.kind === "find_datetime") return "[Find a Time]";
+  if (msg.kind === "market_card") return `[Market: ${msg.symbol ?? ""}]`;
+  if (msg.kind === "position_card") return `[Position: ${msg.symbol ?? ""}]`;
   if (msg.kind === "file") return msg.file?.name ? `[File: ${msg.file.name}]` : "[File]";
   if (msg.is_encrypted) return "[Encrypted message]";
   return (msg.text ?? "").slice(0, 80) || "[Message]";
@@ -1918,6 +1923,32 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                 associatedEventId={message.associated_event_id}
               />
             )}
+
+          {/* ── Market card (FE-101) ── */}
+          {message.kind === "market_card" && message.symbol_id != null && (
+            <MarketCard
+              symbolId={message.symbol_id}
+              symbol={message.symbol ?? `#${message.symbol_id}`}
+            />
+          )}
+
+          {/* ── Position card (FE-102) ── */}
+          {message.kind === "position_card" && message.symbol_id != null && (
+            <PositionCard
+              payload={{
+                symbol_id: message.symbol_id,
+                symbol: message.symbol ?? `#${message.symbol_id}`,
+                side: message.side ?? "Long",
+                disclosure: message.disclosure ?? "roi",
+                roi_pct: message.roi_pct ?? 0,
+                entry: message.entry ?? undefined,
+                mark: message.mark ?? undefined,
+                size: message.size ?? undefined,
+                price_scaler: message.price_scaler ?? undefined,
+              } satisfies PositionCardPayload}
+              ownerName={isOwn ? "You" : senderLabel(message.sender_id)}
+            />
+          )}
 
           {/* ── GIF message (MSG-008) ── */}
           {message.kind === "gif" && message.gif_url && (

--- a/frontend/src/pages/messages/PositionCard.tsx
+++ b/frontend/src/pages/messages/PositionCard.tsx
@@ -1,0 +1,118 @@
+import { useNavigate } from "react-router-dom";
+import { Activity, ArrowUpRight, ArrowDownRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { formatPrice } from "@/pages/markets/format";
+import type { PositionCardPayload } from "@/lib/tradingCards";
+
+export interface PositionCardProps {
+  payload: PositionCardPayload;
+  /** Display name of the position owner (attribution). */
+  ownerName?: string;
+}
+
+/**
+ * FE-102: an in-chat position/P&L card. Renders EXACTLY the fields permitted by
+ * the payload's disclosure level (the composer already stripped the rest via
+ * buildPositionCardPayload). Directional P&L color + "shared by <owner>".
+ */
+export function PositionCard({ payload, ownerName }: PositionCardProps) {
+  const navigate = useNavigate();
+  const scaler = payload.price_scaler || 1;
+  const roi = payload.roi_pct;
+  const up = roi >= 0;
+  const isFull = payload.disclosure === "full";
+  const isLong = payload.side === "Long";
+
+  const metricLabel = payload.disclosure === "roi" ? "ROI" : "P&L";
+
+  return (
+    <Card className="w-72 max-w-full" data-testid="position-card">
+      <CardContent className="pt-4">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5 text-sm font-semibold">
+            <Activity className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate" data-testid="position-card-ticker">
+              {payload.symbol}
+            </span>
+          </div>
+          <span
+            className={
+              "inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium " +
+              (isLong
+                ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400"
+                : "bg-rose-500/15 text-rose-700 dark:text-rose-400")
+            }
+            data-testid="position-card-side"
+          >
+            {isLong ? <ArrowUpRight className="h-3 w-3" /> : <ArrowDownRight className="h-3 w-3" />}
+            {payload.side}
+          </span>
+        </div>
+
+        <div className="mt-2 flex items-baseline gap-2">
+          <span className="text-xs text-muted-foreground">{metricLabel}</span>
+          <span
+            className={
+              "text-2xl font-bold tabular-nums " +
+              (up
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-rose-600 dark:text-rose-400")
+            }
+            data-testid="position-card-roi"
+          >
+            {up ? "+" : ""}
+            {roi.toFixed(2)}%
+          </span>
+        </div>
+
+        {isFull && (
+          <div
+            className="mt-2 grid grid-cols-3 gap-2 text-xs"
+            data-testid="position-card-full-metrics"
+          >
+            <div>
+              <div className="text-muted-foreground">Entry</div>
+              <div className="tabular-nums font-medium">
+                {payload.entry != null ? formatPrice(payload.entry, scaler) : "—"}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Mark</div>
+              <div className="tabular-nums font-medium">
+                {payload.mark != null ? formatPrice(payload.mark, scaler) : "—"}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Size</div>
+              <div className="tabular-nums font-medium">
+                {payload.size != null ? payload.size : "—"}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {ownerName && (
+          <p
+            className="mt-2 text-[11px] text-muted-foreground"
+            data-testid="position-card-owner"
+          >
+            Shared by {ownerName}
+          </p>
+        )}
+
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3 w-full"
+          onClick={() => navigate(`/markets/${payload.symbol_id}`)}
+          data-testid="position-card-trade"
+        >
+          View market
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default PositionCard;

--- a/frontend/src/pages/messages/PositionCardComposerDialog.tsx
+++ b/frontend/src/pages/messages/PositionCardComposerDialog.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useSymbols } from "@/hooks/useMarketData";
+import { usePaperAccount, usePaperMarks } from "@/hooks/usePaperMarks";
+import { usePaperMode } from "@/lib/paperMode";
+import { paperPositionsToBlotter } from "@/lib/paperBlotter";
+import { PositionCard } from "./PositionCard";
+import {
+  buildPositionCardPayload,
+  DISCLOSURE_LABEL,
+  type PositionCardPayload,
+  type PositionDisclosure,
+  type PositionSource,
+} from "@/lib/tradingCards";
+
+interface PositionCardComposerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: PositionCardPayload) => void;
+  /** Owner display name for the preview attribution. */
+  ownerName?: string;
+}
+
+const DISCLOSURES: PositionDisclosure[] = ["full", "pnl_pct", "roi"];
+
+/**
+ * FE-102 composer: pick one of the caller's open positions + a disclosure
+ * level, then send a position_card. The caller's open positions are read from
+ * the same PAPER account the Portfolio/PnL surfaces use (usePaperMarks); ROI is
+ * uPnL / notional-at-entry. The disclosure selector routes through
+ * buildPositionCardPayload so reduced levels never carry entry/mark/size.
+ */
+export function PositionCardComposerDialog({
+  open,
+  onClose,
+  onSubmit,
+  ownerName,
+}: PositionCardComposerDialogProps) {
+  const { enabled: paper } = usePaperMode();
+  const acct = usePaperAccount(open || paper);
+  const { marks, symName } = usePaperMarks(acct, open);
+  const symbolsQ = useSymbols();
+
+  const scalerFor = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const s of symbolsQ.data?.symbols ?? []) map.set(s.symbol_id, s.price_scaler || 1);
+    return (id: number) => map.get(id) || 1;
+  }, [symbolsQ.data]);
+
+  const sources = useMemo<PositionSource[]>(() => {
+    const rows = paperPositionsToBlotter(acct, marks, symName);
+    return rows.map((r) => {
+      const notional = Math.abs(r.avgCost * r.netQty);
+      const roi = notional !== 0 ? (r.unrealized / notional) * 100 : 0;
+      return {
+        symbol_id: r.symbolId,
+        symbol: r.sym,
+        side: r.side,
+        roi_pct: roi,
+        entry: r.avgCost,
+        mark: r.markPx,
+        size: Math.abs(r.netQty),
+        price_scaler: scalerFor(r.symbolId),
+      };
+    });
+  }, [acct, marks, symName, scalerFor]);
+
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [disclosure, setDisclosure] = useState<PositionDisclosure>("full");
+
+  const selected = sources.find((s) => s.symbol_id === selectedId) ?? null;
+  const previewPayload = selected ? buildPositionCardPayload(selected, disclosure) : null;
+
+  function reset() {
+    setSelectedId(null);
+    setDisclosure("full");
+  }
+  function handleClose() {
+    reset();
+    onClose();
+  }
+  function handleSubmit() {
+    if (!selected) return;
+    onSubmit(buildPositionCardPayload(selected, disclosure));
+    reset();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (!o ? handleClose() : undefined)}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share position</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Open position</Label>
+            <div className="max-h-48 overflow-y-auto rounded-md border">
+              {sources.length === 0 ? (
+                <p className="p-3 text-sm text-muted-foreground" data-testid="position-composer-empty">
+                  No open positions to share.
+                </p>
+              ) : (
+                sources.map((s) => (
+                  <button
+                    key={s.symbol_id}
+                    type="button"
+                    onClick={() => setSelectedId(s.symbol_id)}
+                    className={
+                      "flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent " +
+                      (selectedId === s.symbol_id ? "bg-accent" : "")
+                    }
+                    data-testid={`position-composer-option-${s.symbol_id}`}
+                  >
+                    <span className="font-medium">
+                      {s.symbol} · {s.side}
+                    </span>
+                    <span
+                      className={
+                        "tabular-nums " +
+                        (s.roi_pct >= 0 ? "text-emerald-600" : "text-rose-600")
+                      }
+                    >
+                      {s.roi_pct >= 0 ? "+" : ""}
+                      {s.roi_pct.toFixed(2)}%
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Disclosure</Label>
+            <RadioGroup
+              value={disclosure}
+              onValueChange={(v) => setDisclosure(v as PositionDisclosure)}
+            >
+              {DISCLOSURES.map((d) => (
+                <div key={d} className="flex items-center gap-2">
+                  <RadioGroupItem value={d} id={`position-disclosure-${d}`} />
+                  <Label htmlFor={`position-disclosure-${d}`} className="font-normal cursor-pointer">
+                    {DISCLOSURE_LABEL[d]}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          </div>
+
+          {previewPayload && (
+            <div className="flex justify-center pt-1">
+              <PositionCard payload={previewPayload} ownerName={ownerName} />
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!selected} data-testid="position-composer-send">
+            Share
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default PositionCardComposerDialog;


### PR DESCRIPTION
## EPIC A — trading-in-chat cards (FE-101 Market card + FE-102 Position card)

First epic of the messaging platform-integration program (`MESSAGING_FRONTEND_TICKETS.md`). Reuses the existing rich-message card pattern (countdown/find_datetime/video) + the shipped trading infra (symbol picker, market-data, order ticket, positions).

- **FE-101 Market card** — "Share market" composer (searchable symbol picker) → card with ticker + live price + change % + mini sparkline + a **Trade** button opening the pre-filled order ticket (`/markets/{symbol_id}`).
- **FE-102 Position card** — "Share position" with a disclosure selector (full / P&L% / ROI) → a P&L card that carries **and** renders only the permitted fields per disclosure (pure model nulls out withheld entry/mark/size), with "shared by owner" attribution.

**Transport (degrade-on-404 / works-now):** web POSTs `/messaging/.../cards/{market|position}` (BE-101/102), degrading to a normal message with a new kind + payload; Android encodes the card as a sentinel-tagged text body over the existing send (backend `sendMessage` takes only text/encryption today), degrading to plain text on old clients. Both share one card model + renderer and converge once the backend adds a real card-message kind.

Web: `lib/tradingCards.ts` (+7 vitest) + MarketCard/PositionCard + composer dialogs + MessageBubble dispatch + RTL test (3) → 10/10. Android: `TradingCardModel.kt` (+14 JVM) + TradingCardUi (Canvas sparkline) + composers + Thread VM/Screen dispatch.

No new deps. Gates: web tsc 0 · vite build · vitest 10/10; android assembleDebug + testDebugUnitTest BUILD SUCCESSFUL (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
