### PR TITLE
FE-140: per-conversation mute + client-side mute respect (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDataModule.kt
@@ -4,6 +4,8 @@ import com.testlogon.android.data.messaging.group.GroupApi
 import com.testlogon.android.data.messaging.group.GroupRepository
 import com.testlogon.android.data.messaging.group.GroupRepositoryImpl
 import com.testlogon.android.data.messaging.helpdesk.HelpdeskApi
+import com.testlogon.android.data.messaging.mute.ConversationMuteStore
+import com.testlogon.android.data.messaging.mute.DataStoreConversationMuteStore
 import com.testlogon.android.data.messaging.helpdesk.HelpdeskRepository
 import com.testlogon.android.data.messaging.helpdesk.HelpdeskRepositoryImpl
 import com.testlogon.android.data.messaging.mass.MassMessageApi
@@ -97,4 +99,11 @@ abstract class MessagingDataModule {
     @Binds
     @Singleton
     abstract fun bindBillingAuthorizer(impl: RealBillingAuthorizer): BillingAuthorizer
+
+    /** FE-140 — binds the per-conversation mute mirror (DataStore-backed muted_until map). */
+    @Binds
+    @Singleton
+    abstract fun bindConversationMuteStore(
+        impl: DataStoreConversationMuteStore,
+    ): ConversationMuteStore
 }

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingRepository.kt
@@ -924,6 +924,7 @@ class MessagingRepositoryImpl @Inject constructor(
     private val storageClient: com.testlogon.android.data.upload.StorageUploadClient,
     private val attachmentDownloader: AttachmentDownloader,
     private val moshi: com.squareup.moshi.Moshi,
+    private val muteStore: com.testlogon.android.data.messaging.mute.ConversationMuteStore,
 ) : MessagingRepository {
 
     private val io: CoroutineDispatcher = Dispatchers.IO
@@ -937,6 +938,9 @@ class MessagingRepositoryImpl @Inject constructor(
                 is ApiResult.Success -> {
                     val domain = result.data.map(ConversationDto::toDomain).sortedNewestFirst()
                     conversationDao.upsertAll(domain.map(Conversation::toEntity))
+                    // FE-140 — mirror each conversation's authoritative muted_until so the
+                    // notification path + list/thread mute indicators have a durable local source.
+                    muteStore.syncFromList(result.data.map { it.conversationId to it.mutedUntil })
                     ApiResult.Success(domain)
                 }
                 is ApiResult.Failure -> result

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/mute/ConversationMuteStore.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/mute/ConversationMuteStore.kt
@@ -1,0 +1,101 @@
+package com.testlogon.android.data.messaging.mute
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.conversationMuteDataStore by preferencesDataStore(name = "conversation_mute")
+
+/**
+ * FE-140 — a small, durable client-side cache of per-conversation `muted_until` (epoch SECONDS),
+ * keyed by conversation id. This is the ONE mute source that is readable from the notification
+ * presentation path (which may run after a process restart, with no ViewModel alive), and it also
+ * feeds the conversation-list / thread mute indicators.
+ *
+ * It is a client-side MIRROR of the server's authoritative `muted_until`, refreshed whenever
+ * conversations are fetched ([syncFromList]) and updated the moment the user mutes/unmutes
+ * ([setMuted]). It is intentionally advisory: an unknown conversation reads back as 0 (not muted),
+ * so the notification path fails OPEN (posts as today) when state is unknown.
+ *
+ * Interface seam so JVM tests can inject an in-memory fake (no DataStore I/O off-device).
+ */
+interface ConversationMuteStore {
+    /** `muted_until` epoch seconds for [conversationId]; 0 when unknown / not muted. */
+    suspend fun mutedUntil(conversationId: String): Long
+
+    /** Reactive `muted_until` for one conversation (emits 0 when unknown / cleared). */
+    fun observeMutedUntil(conversationId: String): Flow<Long>
+
+    /** Whole mute map (conversationId -> mutedUntil). Used by the list screen. */
+    fun observeAll(): Flow<Map<String, Long>>
+
+    /** Record a single conversation's mute state (0 clears it). */
+    suspend fun setMuted(conversationId: String, mutedUntil: Long)
+
+    /**
+     * Reconcile from an authoritative fetch: upserts every (id -> mutedUntil) pair. Entries not in
+     * [pairs] are left untouched (a partial page must not wipe others). A 0 in [pairs] clears that id.
+     */
+    suspend fun syncFromList(pairs: List<Pair<String, Long>>)
+
+    suspend fun clear()
+}
+
+@Singleton
+class DataStoreConversationMuteStore @Inject constructor(
+    @ApplicationContext context: Context,
+) : ConversationMuteStore {
+
+    private val dataStore = context.conversationMuteDataStore
+
+    private fun key(conversationId: String) = longPreferencesKey("mute_$conversationId")
+
+    override suspend fun mutedUntil(conversationId: String): Long =
+        dataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .first()[key(conversationId)] ?: 0L
+
+    override fun observeMutedUntil(conversationId: String): Flow<Long> =
+        dataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .map { it[key(conversationId)] ?: 0L }
+
+    override fun observeAll(): Flow<Map<String, Long>> =
+        dataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .map { prefs ->
+                prefs.asMap().entries
+                    .filter { it.key.name.startsWith("mute_") && it.value is Long }
+                    .associate { it.key.name.removePrefix("mute_") to (it.value as Long) }
+            }
+
+    override suspend fun setMuted(conversationId: String, mutedUntil: Long) {
+        dataStore.edit { prefs ->
+            if (mutedUntil > 0L) prefs[key(conversationId)] = mutedUntil
+            else prefs.remove(key(conversationId))
+        }
+    }
+
+    override suspend fun syncFromList(pairs: List<Pair<String, Long>>) {
+        if (pairs.isEmpty()) return
+        dataStore.edit { prefs ->
+            for ((id, until) in pairs) {
+                if (until > 0L) prefs[key(id)] = until else prefs.remove(key(id))
+            }
+        }
+    }
+
+    override suspend fun clear() {
+        dataStore.edit { it.clear() }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.GroupAdd
+import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.Contacts
@@ -63,6 +64,7 @@ object ConversationListTestTags {
     const val LIST = "conv_list"
     const val ROW = "conv_row"
     const val UNREAD_BADGE = "conv_unread_badge"
+    const val MUTE_BADGE = "conv_mute_badge"
     const val STALE_BANNER = "conv_stale_banner"
 
     /** AND-152 — global message-search entry icon. */
@@ -245,7 +247,12 @@ internal fun ConversationRowItem(row: ConversationRow, onClick: () -> Unit) {
     }
     val previewText = row.preview ?: stringResource(R.string.conv_list_no_messages)
     val unreadLabel = if (row.isUnread) "${row.unreadCount} unread, " else ""
-    val cd = "${row.title}, $unreadLabel$relative, $previewText"
+    // FE-140 - muted indicator (bell-off). Display-only now-read is fine for an indicator.
+    val muted = com.testlogon.android.feature.messaging.mute.MuteMath.isMuted(
+        row.mutedUntil, System.currentTimeMillis() / 1000L,
+    )
+    val mutedLabel = if (muted) "muted, " else ""
+    val cd = "${row.title}, $unreadLabel${mutedLabel}$relative, $previewText"
 
     Row(
         modifier = Modifier
@@ -297,6 +304,16 @@ internal fun ConversationRowItem(row: ConversationRow, onClick: () -> Unit) {
                     text = relative,
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (muted) {
+                Icon(
+                    imageVector = Icons.Filled.NotificationsOff,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .size(16.dp)
+                        .testTag(ConversationListTestTags.MUTE_BADGE),
                 )
             }
             if (row.isUnread) {

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListUiState.kt
@@ -16,6 +16,8 @@ data class ConversationRow(
     /** Epoch SECONDS, formatted relative-to-now at render time. */
     val lastActivityEpochSeconds: Long,
     val unreadCount: Int,
+    /** FE-140 - muted_until epoch SECONDS (0 = not muted); rendered as a bell-off on the row. */
+    val mutedUntil: Long = 0L,
 ) {
     val isUnread: Boolean get() = unreadCount > 0
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -36,6 +37,7 @@ sealed interface ConversationListEvent {
 class ConversationListViewModel @Inject constructor(
     private val repository: MessagingRepository,
     private val eventStream: MessagingEventStream,
+    private val muteStore: com.testlogon.android.data.messaging.mute.ConversationMuteStore,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<ConversationListUiState>(ConversationListUiState.Loading)
@@ -76,8 +78,15 @@ class ConversationListViewModel @Inject constructor(
 
     private fun observeCache() {
         viewModelScope.launch {
-            repository.observeConversations().collect { conversations ->
-                cached = conversations.map(Conversation::toRow)
+            // FE-140 - join the conversation cache with the local mute mirror so each row can show a
+            // bell-off indicator. Unknown ids default to 0 (not muted).
+            combine(
+                repository.observeConversations(),
+                muteStore.observeAll(),
+            ) { conversations, muteMap ->
+                conversations.map { c -> c.toRow().copy(mutedUntil = muteMap[c.id] ?: 0L) }
+            }.collect { rows ->
+                cached = rows
                 renderCache()
             }
         }

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/mute/MuteMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/mute/MuteMath.kt
@@ -1,0 +1,83 @@
+package com.testlogon.android.feature.messaging.mute
+
+/**
+ * FE-140 - pure, integer-only math for per-conversation mute. No android.*, no clock reads: the
+ * caller passes nowSec (epoch SECONDS) in, keeping every function JVM-unit-testable and
+ * deterministic.
+ *
+ * Wire contract (matches the web muteConversation + AND-159 Android group mute):
+ *  - muted_until is an epoch-SECONDS Long; 0 (or any value <= now) means NOT muted.
+ *  - "Until I turn it back on" is represented by [FOREVER_SENTINEL], a far-future epoch so the
+ *    same isMuted(mutedUntil, now) comparison works without a special case.
+ */
+object MuteMath {
+
+    /** Far-future sentinel (seconds) for "mute until turned off". ~ year 5138; safely > any real now. */
+    const val FOREVER_SENTINEL: Long = 100_000_000_000L
+
+    const val OPT_1_HOUR = "1h"
+    const val OPT_8_HOURS = "8h"
+    const val OPT_1_WEEK = "1w"
+    const val OPT_UNTIL_OFF = "until_off"
+
+    private const val HOUR_SECONDS = 60L * 60L
+    private const val DAY_SECONDS = 24L * HOUR_SECONDS
+    private const val WEEK_SECONDS = 7L * DAY_SECONDS
+
+    /** The selectable mute durations, in display order. */
+    fun muteOptions(): List<String> = listOf(OPT_1_HOUR, OPT_8_HOURS, OPT_1_WEEK, OPT_UNTIL_OFF)
+
+    /**
+     * Resolve a chosen [optionId] to the absolute muted_until epoch seconds given [nowSec].
+     * "until off" maps to [FOREVER_SENTINEL]; an unknown id falls back to 1 hour (fail-short, never
+     * an accidental forever).
+     */
+    fun computeMutedUntil(optionId: String, nowSec: Long): Long = when (optionId) {
+        OPT_1_HOUR -> nowSec + HOUR_SECONDS
+        OPT_8_HOURS -> nowSec + 8L * HOUR_SECONDS
+        OPT_1_WEEK -> nowSec + WEEK_SECONDS
+        OPT_UNTIL_OFF -> FOREVER_SENTINEL
+        else -> nowSec + HOUR_SECONDS
+    }
+
+    /** True when [mutedUntil] is strictly in the future relative to [nowSec]. 0/past => not muted. */
+    fun isMuted(mutedUntil: Long, nowSec: Long): Boolean = mutedUntil > nowSec
+
+    /** True when this mute has no practical end (the "until off" sentinel or beyond). */
+    fun isForever(mutedUntil: Long): Boolean = mutedUntil >= FOREVER_SENTINEL
+
+    /**
+     * A short human label for the current mute state. Empty when not muted. "Muted" for the forever
+     * sentinel; otherwise "Muted for <n> <unit>" rounded UP to the coarsest whole unit remaining.
+     */
+    fun mutedLabel(mutedUntil: Long, nowSec: Long): String {
+        if (!isMuted(mutedUntil, nowSec)) return ""
+        if (isForever(mutedUntil)) return "Muted"
+        val remaining = mutedUntil - nowSec
+        return when {
+            remaining >= DAY_SECONDS -> {
+                val days = ceilDiv(remaining, DAY_SECONDS)
+                "Muted for " + days + (if (days == 1L) " day" else " days")
+            }
+            remaining >= HOUR_SECONDS -> {
+                val hours = ceilDiv(remaining, HOUR_SECONDS)
+                "Muted for " + hours + (if (hours == 1L) " hour" else " hours")
+            }
+            else -> {
+                val mins = ceilDiv(remaining, 60L).coerceAtLeast(1L)
+                "Muted for " + mins + (if (mins == 1L) " minute" else " minutes")
+            }
+        }
+    }
+
+    /** Human label for a duration [optionId] as shown in the picker. */
+    fun formatMuteOption(optionId: String): String = when (optionId) {
+        OPT_1_HOUR -> "1 hour"
+        OPT_8_HOURS -> "8 hours"
+        OPT_1_WEEK -> "1 week"
+        OPT_UNTIL_OFF -> "Until I turn it back on"
+        else -> optionId
+    }
+
+    private fun ceilDiv(a: Long, b: Long): Long = (a + b - 1L) / b
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -188,6 +190,9 @@ object ThreadTestTags {
 
     /** AND-158/159 — open group details/settings. */
     const val OPEN_GROUP_DETAILS = "thread_open_group_details"
+    // FE-140 - mute controls.
+    const val MUTE_MENU_ITEM = "thread_mute_menu_item"
+    const val MUTE_BADGE = "thread_mute_badge"
 
     /** #19 — the single "+" that opens the conversation-actions dropdown menu. */
     const val TOPBAR_MENU = "thread_topbar_menu"
@@ -355,6 +360,8 @@ fun ThreadRoute(
         onViewContact = onViewContact,
         onOpenSymbol = onOpenSymbol,
         onOpenGroupDetails = onOpenGroupDetails,
+        onMute = viewModel::onMute,
+        onUnmute = viewModel::onUnmute,
         onRetry = viewModel::retry,
         onDraftChange = viewModel::onDraftChange,
         onSend = viewModel::onSend,
@@ -995,6 +1002,9 @@ fun ThreadScreen(
     onBack: () -> Unit,
     // AND-158/159 — open the group details/settings surface from the thread top bar.
     onOpenGroupDetails: () -> Unit = {},
+    // FE-140 — per-conversation mute: onMute(optionId) / onUnmute, wired to the mute repo call.
+    onMute: (String) -> Unit = {},
+    onUnmute: () -> Unit = {},
     onRetry: () -> Unit,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
@@ -1123,6 +1133,9 @@ fun ThreadScreen(
     var actionTarget by remember { mutableStateOf<ThreadMessageUi?>(null) }
     // #25/#27 — the gallery VIDEO item currently open in the full-screen player (null = closed).
     var galleryVideoUrl by remember { mutableStateOf<String?>(null) }
+    // FE-140 - per-conversation mute options bottom sheet.
+    var showMuteSheet by remember { mutableStateOf(false) }
+    val isConversationMuted = com.testlogon.android.feature.messaging.mute.MuteMath.isMuted(state.mutedUntil, nowSeconds)
     // #3 KEYBOARD DISMISS — clear the composer's focus + hide the IME without leaving the thread.
     val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
     val keyboardController = androidx.compose.ui.platform.LocalSoftwareKeyboardController.current
@@ -1152,6 +1165,37 @@ fun ThreadScreen(
             onConfirm = blockVm::onBlockConfirmed,
             onDismiss = blockVm::onBlockDismissed,
         )
+    }
+    // FE-140 - mute-duration chooser. Picks an option, computes muted_until locally, and hands the
+    // option id to onMute (the VM does the repo call + optimistic store write).
+    if (showMuteSheet) {
+        androidx.compose.material3.ModalBottomSheet(onDismissRequest = { showMuteSheet = false }) {
+            androidx.compose.foundation.layout.Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 24.dp),
+            ) {
+                Text(
+                    text = "Mute notifications",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                )
+                com.testlogon.android.feature.messaging.mute.MuteMath.muteOptions().forEach { opt ->
+                    Text(
+                        text = com.testlogon.android.feature.messaging.mute.MuteMath.formatMuteOption(opt),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                showMuteSheet = false
+                                onMute(opt)
+                            }
+                            .padding(horizontal = 24.dp, vertical = 16.dp)
+                            .testTag("thread_mute_option_" + opt),
+                    )
+                }
+            }
+        }
     }
     Scaffold(
         modifier = modifier.testTag(ThreadTestTags.SCREEN),
@@ -1194,6 +1238,18 @@ fun ThreadScreen(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )
+                        // FE-140 - a bell-off badge next to the title when this
+                        // conversation is muted (reads state.mutedUntil vs nowSeconds).
+                        if (isConversationMuted) {
+                            Icon(
+                                imageVector = Icons.Filled.NotificationsOff,
+                                contentDescription = "Muted",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .size(18.dp)
+                                    .testTag(ThreadTestTags.MUTE_BADGE),
+                            )
+                        }
                     }
                 },
                 navigationIcon = {
@@ -1281,6 +1337,33 @@ fun ThreadScreen(
                             leadingIcon = { Icon(Icons.Outlined.Info, contentDescription = null) },
                             onClick = { menuOpen = false; onOpenGroupDetails() },
                             modifier = Modifier.testTag(ThreadTestTags.OPEN_GROUP_DETAILS),
+                        )
+                        // FE-140 - per-conversation mute / unmute.
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = {
+                                Text(
+                                    if (isConversationMuted) {
+                                        val lbl = com.testlogon.android.feature.messaging.mute.MuteMath
+                                            .mutedLabel(state.mutedUntil, nowSeconds)
+                                        if (lbl.isNotEmpty()) "Unmute (" + lbl + ")" else "Unmute"
+                                    } else {
+                                        "Mute notifications"
+                                    },
+                                )
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    if (isConversationMuted) Icons.Filled.Notifications
+                                    else Icons.Filled.NotificationsOff,
+                                    contentDescription = null,
+                                )
+                            },
+                            enabled = !state.muteActionInFlight,
+                            onClick = {
+                                menuOpen = false
+                                if (isConversationMuted) onUnmute() else showMuteSheet = true
+                            },
+                            modifier = Modifier.testTag(ThreadTestTags.MUTE_MENU_ITEM),
                         )
                         // AND-140 — pinned messages.
                         androidx.compose.material3.DropdownMenuItem(

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
@@ -61,6 +61,11 @@ data class ThreadUiState(
     // ---- AND-141: drafts ----
     /** True when a non-blank draft exists for this conversation (gates "Discard draft"). */
     val hasDraft: Boolean = false,
+    /** FE-140 - per-conversation mute: muted_until epoch SECONDS (0 = not muted). Mirrored from the
+     *  ConversationMuteStore, which is synced from the conversation fetch + updated on mute/unmute. */
+    val mutedUntil: Long = 0L,
+    /** FE-140 - true while a mute/unmute network call is in flight (disables the menu item). */
+    val muteActionInFlight: Boolean = false,
     /** Last draft sync outcome (non-blocking UX only). */
     val draftSyncState: DraftSyncState = DraftSyncState.Idle,
     // ---- AND-147: read receipts / views ----

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
@@ -111,6 +111,8 @@ class ThreadViewModel @Inject constructor(
     private val custodyReader: com.testlogon.android.data.custody.CustodyReader,
     private val catalogRepository: com.testlogon.android.data.catalog.CatalogRepository,
     private val purchasesRepository: com.testlogon.android.data.purchases.PurchasesRepository,
+    private val groupRepository: com.testlogon.android.data.messaging.group.GroupRepository,
+    private val muteStore: com.testlogon.android.data.messaging.mute.ConversationMuteStore,
 ) : ViewModel() {
 
     /**
@@ -250,6 +252,66 @@ class ThreadViewModel @Inject constructor(
         startTyping()
         observePeerPhoto()
         resolvePeerFromParticipants()
+        observeMute()
+    }
+
+    /**
+     * FE-140 - reflect the per-conversation mute state (from the locally-mirrored ConversationMuteStore)
+     * in the top bar. The store is refreshed on every conversation fetch and updated immediately on
+     * mute/unmute, so the header bell + label stay in sync without a bespoke network round-trip here.
+     */
+    private fun observeMute() {
+        viewModelScope.launch {
+            muteStore.observeMutedUntil(conversationId).collect { until ->
+                _state.update { it.copy(mutedUntil = until) }
+            }
+        }
+    }
+
+    /**
+     * FE-140 - mute this conversation for the chosen [optionId] (see [MuteMath.muteOptions]). Calls the
+     * shared conversation-level mute endpoint (AND-159 GroupRepository.setMute, which works for any
+     * conversation type). Optimistically writes the local store so the notification-suppress path + UI
+     * update at once; reverts on failure. until_off sends muted_until=null (server persists a
+     * sentinel) and stores the far-future sentinel locally.
+     */
+    fun onMute(optionId: String) {
+        if (_state.value.muteActionInFlight) return
+        val nowSec = clock()
+        val untilForever = optionId == com.testlogon.android.feature.messaging.mute.MuteMath.OPT_UNTIL_OFF
+        val localUntil = com.testlogon.android.feature.messaging.mute.MuteMath.computeMutedUntil(optionId, nowSec)
+        val serverUntil: Long? = if (untilForever) null else localUntil
+        val prior = _state.value.mutedUntil
+        _state.update { it.copy(muteActionInFlight = true) }
+        viewModelScope.launch {
+            muteStore.setMuted(conversationId, localUntil) // optimistic (drives observeMute + suppress)
+            when (val r = groupRepository.setMute(conversationId, muted = true, mutedUntilEpochSeconds = serverUntil)) {
+                is ApiResult.Success -> _state.update { it.copy(muteActionInFlight = false) }
+                is ApiResult.Failure -> revertMute(prior, r.error.message)
+                is ApiResult.NetworkError -> revertMute(prior, OFFLINE_MESSAGE)
+            }
+        }
+    }
+
+    /** FE-140 - unmute this conversation (muted=false, muted_until=0). Optimistic + reverts on failure. */
+    fun onUnmute() {
+        if (_state.value.muteActionInFlight) return
+        val prior = _state.value.mutedUntil
+        _state.update { it.copy(muteActionInFlight = true) }
+        viewModelScope.launch {
+            muteStore.setMuted(conversationId, 0L)
+            when (val r = groupRepository.setMute(conversationId, muted = false, mutedUntilEpochSeconds = null)) {
+                is ApiResult.Success -> _state.update { it.copy(muteActionInFlight = false) }
+                is ApiResult.Failure -> revertMute(prior, r.error.message)
+                is ApiResult.NetworkError -> revertMute(prior, OFFLINE_MESSAGE)
+            }
+        }
+    }
+
+    private suspend fun revertMute(priorUntil: Long, message: String) {
+        muteStore.setMuted(conversationId, priorUntil)
+        _state.update { it.copy(muteActionInFlight = false) }
+        _events.send(ThreadEvent.Toast(message))
     }
 
     /**

--- a/android/app/src/main/java/com/testlogon/android/notifications/NotificationPresenter.kt
+++ b/android/app/src/main/java/com/testlogon/android/notifications/NotificationPresenter.kt
@@ -86,6 +86,7 @@ class NotificationDisplaySink @Inject constructor(
     private val parser: PushPayloadParser,
     private val presenter: NotificationPresenter,
     private val callPushHandler: com.testlogon.android.feature.call.incoming.CallPushHandler,
+    private val muteStore: com.testlogon.android.data.messaging.mute.ConversationMuteStore,
 ) : com.testlogon.android.push.PushMessageSink {
 
     override fun onMessage(message: com.testlogon.android.push.PushMessage) {
@@ -97,6 +98,22 @@ class NotificationDisplaySink @Inject constructor(
             com.testlogon.android.push.PushLog.d("notif dropped reason=invalid_payload")
             return
         }
+
+        // FE-140 - client-side per-conversation mute respect. For a MESSAGE notification, entityId is
+        // the conversation id: if the user muted that conversation (muted_until in the future per the
+        // locally-mirrored ConversationMuteStore) skip posting. Fails OPEN when state is unknown
+        // (mutedUntil defaults to 0 -> not muted -> post as today). Non-message + call kinds unaffected.
+        if (payload.kind == NotificationKind.MESSAGE) {
+            val nowSec = System.currentTimeMillis() / 1000L
+            val mutedUntil = kotlinx.coroutines.runBlocking { muteStore.mutedUntil(payload.entityId) }
+            if (com.testlogon.android.feature.messaging.mute.MuteMath.isMuted(mutedUntil, nowSec)) {
+                com.testlogon.android.push.PushLog.d(
+                    "notif dropped reason=conversation_muted entityId=" + payload.entityId,
+                )
+                return
+            }
+        }
+
         presenter.show(payload)
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/data/messaging/MessagingRepositoryTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/messaging/MessagingRepositoryTest.kt
@@ -558,6 +558,7 @@ class MessagingRepositoryTest {
         storageClient = storageClient,
         attachmentDownloader = attachmentDownloader,
         moshi = Moshi.Builder().build(),
+        muteStore = com.testlogon.android.feature.messaging.FakeConversationMuteStore(),
     )
 
     private fun convEntity(id: String, unread: Int) = ConversationEntity(

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
@@ -25,6 +25,7 @@ import com.testlogon.android.data.messaging.realtime.MessagingStreamEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import java.io.IOException
 
@@ -1269,6 +1270,9 @@ fun newThreadViewModel(
     billing: com.testlogon.android.data.messaging.BillingAuthorizer,
     draftRepository: com.testlogon.android.data.messaging.DraftRepository = FakeDraftRepository(),
     typingRepository: com.testlogon.android.data.messaging.typing.TypingRepository = FakeTypingRepository(),
+    groupRepository: com.testlogon.android.data.messaging.group.GroupRepository =
+        com.testlogon.android.data.messaging.group.FakeGroupRepository(),
+    muteStore: com.testlogon.android.data.messaging.mute.ConversationMuteStore = FakeConversationMuteStore(),
 ): com.testlogon.android.feature.messaging.thread.ThreadViewModel =
     com.testlogon.android.feature.messaging.thread.ThreadViewModel(
         handle,
@@ -1290,6 +1294,8 @@ fun newThreadViewModel(
         com.testlogon.android.feature.trading.FakeCustodyReader(),
         fakeCatalogRepository(),
         fakePurchasesRepository(),
+        groupRepository,
+        muteStore,
     )
 
 /** EPIC F — minimal no-op catalog repo for thread tests (product-picker read returns empty). */
@@ -1339,3 +1345,24 @@ private fun fakePurchasesRepository(): com.testlogon.android.data.purchases.Purc
                 com.testlogon.android.core.model.ApiError(status = 404, message = "nf"),
             )
     }
+
+
+/** FE-140 - in-memory mute store for thread/list tests (no DataStore I/O off-device). */
+class FakeConversationMuteStore : com.testlogon.android.data.messaging.mute.ConversationMuteStore {
+    private val flow = kotlinx.coroutines.flow.MutableStateFlow<Map<String, Long>>(emptyMap())
+    override suspend fun mutedUntil(conversationId: String): Long = flow.value[conversationId] ?: 0L
+    override fun observeMutedUntil(conversationId: String): kotlinx.coroutines.flow.Flow<Long> =
+        flow.map { m -> m[conversationId] ?: 0L }
+    override fun observeAll(): kotlinx.coroutines.flow.Flow<Map<String, Long>> = flow
+    override suspend fun setMuted(conversationId: String, mutedUntil: Long) {
+        flow.value = flow.value.toMutableMap().apply {
+            if (mutedUntil > 0L) put(conversationId, mutedUntil) else remove(conversationId)
+        }
+    }
+    override suspend fun syncFromList(pairs: List<Pair<String, Long>>) {
+        flow.value = flow.value.toMutableMap().apply {
+            for ((id, until) in pairs) if (until > 0L) put(id, until) else remove(id)
+        }
+    }
+    override suspend fun clear() { flow.value = emptyMap() }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/list/ConversationListViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/list/ConversationListViewModelTest.kt
@@ -24,7 +24,7 @@ class ConversationListViewModelTest {
     private val repo = FakeMessagingRepository()
     private val stream = FakeMessagingEventStream()
 
-    private fun vm() = ConversationListViewModel(repo, stream)
+    private fun vm() = ConversationListViewModel(repo, stream, com.testlogon.android.feature.messaging.FakeConversationMuteStore())
 
     private fun conv(id: String, unread: Int = 0, activity: Long = 100) = Conversation(
         id = id, title = id, iconUrl = null, lastMessagePreview = "p",

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/mute/MuteMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/mute/MuteMathTest.kt
@@ -1,0 +1,84 @@
+package com.testlogon.android.feature.messaging.mute
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * FE-140 — pure unit tests for [MuteMath]. All times are epoch SECONDS; a fixed [NOW] is passed in
+ * (no clock reads inside the SUT).
+ */
+class MuteMathTest {
+
+    private companion object {
+        const val NOW = 1_700_000_000L
+        const val HOUR = 3_600L
+        const val DAY = 86_400L
+        const val WEEK = 7L * DAY
+    }
+
+    @Test fun muteOptions_hasFourInOrder() {
+        assertEquals(
+            listOf(MuteMath.OPT_1_HOUR, MuteMath.OPT_8_HOURS, MuteMath.OPT_1_WEEK, MuteMath.OPT_UNTIL_OFF),
+            MuteMath.muteOptions(),
+        )
+    }
+
+    @Test fun computeMutedUntil_oneHour() =
+        assertEquals(NOW + HOUR, MuteMath.computeMutedUntil(MuteMath.OPT_1_HOUR, NOW))
+
+    @Test fun computeMutedUntil_eightHours() =
+        assertEquals(NOW + 8 * HOUR, MuteMath.computeMutedUntil(MuteMath.OPT_8_HOURS, NOW))
+
+    @Test fun computeMutedUntil_oneWeek() =
+        assertEquals(NOW + WEEK, MuteMath.computeMutedUntil(MuteMath.OPT_1_WEEK, NOW))
+
+    @Test fun computeMutedUntil_untilOff_isSentinel() =
+        assertEquals(MuteMath.FOREVER_SENTINEL, MuteMath.computeMutedUntil(MuteMath.OPT_UNTIL_OFF, NOW))
+
+    @Test fun computeMutedUntil_unknown_failsShortToOneHour() =
+        assertEquals(NOW + HOUR, MuteMath.computeMutedUntil("bogus", NOW))
+
+    @Test fun isMuted_futureIsTrue() = assertTrue(MuteMath.isMuted(NOW + 1, NOW))
+
+    @Test fun isMuted_zeroIsFalse() = assertFalse(MuteMath.isMuted(0L, NOW))
+
+    @Test fun isMuted_pastIsFalse() = assertFalse(MuteMath.isMuted(NOW - 1, NOW))
+
+    @Test fun isMuted_exactlyNowIsFalse() = assertFalse(MuteMath.isMuted(NOW, NOW))
+
+    @Test fun isMuted_sentinelIsTrue() = assertTrue(MuteMath.isMuted(MuteMath.FOREVER_SENTINEL, NOW))
+
+    @Test fun isForever_sentinelTrue_realDateFalse() {
+        assertTrue(MuteMath.isForever(MuteMath.FOREVER_SENTINEL))
+        assertFalse(MuteMath.isForever(NOW + WEEK))
+    }
+
+    @Test fun mutedLabel_notMutedIsEmpty() = assertEquals("", MuteMath.mutedLabel(0L, NOW))
+
+    @Test fun mutedLabel_foreverIsMuted() =
+        assertEquals("Muted", MuteMath.mutedLabel(MuteMath.FOREVER_SENTINEL, NOW))
+
+    @Test fun mutedLabel_daysRoundUp() =
+        assertEquals("Muted for 7 days", MuteMath.mutedLabel(NOW + WEEK, NOW))
+
+    @Test fun mutedLabel_singularDay() =
+        assertEquals("Muted for 1 day", MuteMath.mutedLabel(NOW + DAY, NOW))
+
+    @Test fun mutedLabel_hours() =
+        assertEquals("Muted for 8 hours", MuteMath.mutedLabel(NOW + 8 * HOUR, NOW))
+
+    @Test fun mutedLabel_singularHour() =
+        assertEquals("Muted for 1 hour", MuteMath.mutedLabel(NOW + HOUR, NOW))
+
+    @Test fun mutedLabel_minutesFallback() =
+        assertEquals("Muted for 30 minutes", MuteMath.mutedLabel(NOW + 30 * 60, NOW))
+
+    @Test fun formatMuteOption_labels() {
+        assertEquals("1 hour", MuteMath.formatMuteOption(MuteMath.OPT_1_HOUR))
+        assertEquals("8 hours", MuteMath.formatMuteOption(MuteMath.OPT_8_HOURS))
+        assertEquals("1 week", MuteMath.formatMuteOption(MuteMath.OPT_1_WEEK))
+        assertEquals("Until I turn it back on", MuteMath.formatMuteOption(MuteMath.OPT_UNTIL_OFF))
+    }
+}

--- a/frontend/src/lib/conversationMute.test.ts
+++ b/frontend/src/lib/conversationMute.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MUTE_OPTIONS,
+  MUTE_FOREVER,
+  computeMutedUntil,
+  isMuted,
+  isMutedForever,
+  mutedLabel,
+  formatMuteOption,
+} from "./conversationMute";
+
+// A fixed "now": 2026-06-17 10:00:00 local time. Building via the local
+// Date ctor keeps these assertions timezone-agnostic.
+const NOW = new Date(2026, 5, 17, 10, 0, 0);
+const NOW_SEC = Math.floor(NOW.getTime() / 1000);
+
+describe("MUTE_OPTIONS", () => {
+  it("exposes the expected option ids", () => {
+    expect(MUTE_OPTIONS.map((o) => o.id)).toEqual(["1h", "8h", "1w", "off"]);
+  });
+
+  it("has exactly one indefinite (durationSec=null) option", () => {
+    expect(MUTE_OPTIONS.filter((o) => o.durationSec === null)).toHaveLength(1);
+  });
+
+  it("formatMuteOption returns the option label", () => {
+    const first = MUTE_OPTIONS[0]!;
+    expect(formatMuteOption(first)).toBe("For 1 hour");
+  });
+});
+
+describe("computeMutedUntil", () => {
+  it("adds the duration for a timed option", () => {
+    expect(computeMutedUntil("1h", NOW_SEC)).toBe(NOW_SEC + 3600);
+    expect(computeMutedUntil("8h", NOW_SEC)).toBe(NOW_SEC + 8 * 3600);
+    expect(computeMutedUntil("1w", NOW_SEC)).toBe(NOW_SEC + 7 * 24 * 3600);
+  });
+
+  it("returns the far-future sentinel for the indefinite option", () => {
+    expect(computeMutedUntil("off", NOW_SEC)).toBe(MUTE_FOREVER);
+  });
+
+  it("returns 0 (no-op) for an unknown option id", () => {
+    expect(computeMutedUntil("nope", NOW_SEC)).toBe(0);
+  });
+
+  it("floors a fractional nowSec", () => {
+    expect(computeMutedUntil("1h", NOW_SEC + 0.9)).toBe(NOW_SEC + 3600);
+  });
+});
+
+describe("isMuted", () => {
+  it("is false for 0 / undefined / null", () => {
+    expect(isMuted(0, NOW_SEC)).toBe(false);
+    expect(isMuted(undefined, NOW_SEC)).toBe(false);
+    expect(isMuted(null, NOW_SEC)).toBe(false);
+  });
+
+  it("is false when the mute has expired", () => {
+    expect(isMuted(NOW_SEC - 1, NOW_SEC)).toBe(false);
+    expect(isMuted(NOW_SEC, NOW_SEC)).toBe(false);
+  });
+
+  it("is true when muted_until is in the future", () => {
+    expect(isMuted(NOW_SEC + 1, NOW_SEC)).toBe(true);
+    expect(isMuted(computeMutedUntil("1h", NOW_SEC), NOW_SEC)).toBe(true);
+    expect(isMuted(MUTE_FOREVER, NOW_SEC)).toBe(true);
+  });
+});
+
+describe("isMutedForever", () => {
+  it("is true only at/above the sentinel", () => {
+    expect(isMutedForever(MUTE_FOREVER)).toBe(true);
+    expect(isMutedForever(MUTE_FOREVER + 100)).toBe(true);
+    expect(isMutedForever(NOW_SEC + 3600)).toBe(false);
+    expect(isMutedForever(0)).toBe(false);
+    expect(isMutedForever(undefined)).toBe(false);
+  });
+});
+
+describe("mutedLabel", () => {
+  it("is empty when not muted", () => {
+    expect(mutedLabel(0, NOW_SEC)).toBe("");
+    expect(mutedLabel(NOW_SEC - 10, NOW_SEC)).toBe("");
+  });
+
+  it("is plain \"Muted\" for indefinite", () => {
+    expect(mutedLabel(MUTE_FOREVER, NOW_SEC)).toBe("Muted");
+  });
+
+  it("shows a same-day clock time", () => {
+    // 2 hours later is still the same calendar day.
+    const until = NOW_SEC + 2 * 3600;
+    expect(mutedLabel(until, NOW_SEC)).toBe("Muted until 12:00 PM");
+  });
+
+  it("shows a weekday for a later day", () => {
+    // +2 days from Wed 2026-06-17 -> Fri.
+    const until = NOW_SEC + 2 * 24 * 3600;
+    expect(mutedLabel(until, NOW_SEC)).toBe("Muted until Fri");
+  });
+});

--- a/frontend/src/lib/conversationMute.ts
+++ b/frontend/src/lib/conversationMute.ts
@@ -1,0 +1,84 @@
+// FE-140: per-conversation mute — pure helpers.
+// All functions are pure and integer-based; callers pass `nowSec` (epoch
+// seconds) so nothing here reads the clock directly (keeps them testable).
+
+/** Sentinel used for "until I turn it off" — a far-future epoch second value. */
+export const MUTE_FOREVER = 4102444800; // 2100-01-01T00:00:00Z
+
+export interface MuteOption {
+  id: string;
+  label: string;
+  /** Duration to add to `nowSec`, in seconds. `null` = mute forever. */
+  durationSec: number | null;
+}
+
+export const MUTE_OPTIONS: readonly MuteOption[] = [
+  { id: "1h", label: "For 1 hour", durationSec: 60 * 60 },
+  { id: "8h", label: "For 8 hours", durationSec: 8 * 60 * 60 },
+  { id: "1w", label: "For 1 week", durationSec: 7 * 24 * 60 * 60 },
+  { id: "off", label: "Until I turn it back on", durationSec: null },
+] as const;
+
+/** Human label for a mute option (used by the menu). */
+export function formatMuteOption(option: MuteOption): string {
+  return option.label;
+}
+
+/**
+ * Resolve the `muted_until` epoch-second value for a chosen option.
+ * "Until off" resolves to the far-future sentinel. Unknown id -> 0 (no-op).
+ */
+export function computeMutedUntil(optionId: string, nowSec: number): number {
+  const opt = MUTE_OPTIONS.find((o) => o.id === optionId);
+  if (!opt) return 0;
+  if (opt.durationSec === null) return MUTE_FOREVER;
+  return Math.floor(nowSec) + opt.durationSec;
+}
+
+/** True when the conversation is muted at `nowSec`. 0/undefined = not muted. */
+export function isMuted(mutedUntil: number | undefined | null, nowSec: number): boolean {
+  if (!mutedUntil || mutedUntil <= 0) return false;
+  return mutedUntil > Math.floor(nowSec);
+}
+
+/** True when this represents an indefinite ("until off") mute. */
+export function isMutedForever(mutedUntil: number | undefined | null): boolean {
+  return !!mutedUntil && mutedUntil >= MUTE_FOREVER;
+}
+
+function two(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function clockLabel(d: Date): string {
+  let h = d.getHours();
+  const m = d.getMinutes();
+  const ampm = h >= 12 ? "PM" : "AM";
+  h = h % 12;
+  if (h === 0) h = 12;
+  return `${h}:${two(m)} ${ampm}`;
+}
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/**
+ * Label describing mute state for display next to a conversation.
+ * - not muted -> ""
+ * - forever    -> "Muted"
+ * - same day   -> "Muted until 3:00 PM"
+ * - later day  -> "Muted until Tue"
+ */
+export function mutedLabel(mutedUntil: number | undefined | null, nowSec: number): string {
+  if (!isMuted(mutedUntil, nowSec)) return "";
+  if (isMutedForever(mutedUntil)) return "Muted";
+
+  const until = new Date((mutedUntil as number) * 1000);
+  const now = new Date(Math.floor(nowSec) * 1000);
+  const sameDay =
+    until.getFullYear() === now.getFullYear() &&
+    until.getMonth() === now.getMonth() &&
+    until.getDate() === now.getDate();
+
+  if (sameDay) return `Muted until ${clockLabel(until)}`;
+  return `Muted until ${WEEKDAYS[until.getDay()]}`;
+}

--- a/frontend/src/pages/messages/ConversationList.tsx
+++ b/frontend/src/pages/messages/ConversationList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Search, Plus, MessageSquare, Users } from "lucide-react";
+import { Search, Plus, MessageSquare, Users, BellOff } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -23,6 +23,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { transferPreview } from "@/lib/cryptoTransfer";
 import { resolveCanonicalProfilePath } from "@/components/shared/UserProfileLink";
 import { StalenessIndicator } from "@/components/shared/StalenessIndicator";
+import { isMuted } from "@/lib/conversationMute";
 
 interface ConversationListProps {
   activeId?: string;
@@ -204,6 +205,12 @@ export function ConversationList({ activeId, onSelect }: ConversationListProps) 
                       >
                         {name}
                       </span>
+                      {isMuted(convo.muted_until, Math.floor(Date.now() / 1000)) && (
+                        <BellOff
+                          className="h-3 w-3 shrink-0 text-muted-foreground"
+                          aria-label="Muted"
+                        />
+                      )}
                       {lastMsg && (
                         <span className="shrink-0 text-[10px] text-muted-foreground">
                           {formatTimestamp(lastMsg.created_at)}

--- a/frontend/src/pages/messages/ConversationView.tsx
+++ b/frontend/src/pages/messages/ConversationView.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useMutation, useQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import { ArrowLeft, Images, Users, Clock, MoreHorizontal, EyeOff, Pin, Phone, Video, Upload } from "lucide-react";
+import { ArrowLeft, Images, Users, Clock, MoreHorizontal, EyeOff, Pin, Phone, Video, Upload, Bell, BellOff } from "lucide-react";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import { Button } from "@/components/ui/button";
@@ -27,6 +27,7 @@ import {
   createLotteryMessage,
   sendVoiceMessage,
   markRead,
+  muteConversation,
   claimHelpdeskConversation,
   transferHelpdeskConversation,
   listHelpdeskGroupAgents,
@@ -71,8 +72,13 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import { GroupCallButton } from "./GroupCallOverlay";
+import { MUTE_OPTIONS, computeMutedUntil, isMuted as isConversationMuted, mutedLabel } from "@/lib/conversationMute";
 
 interface ConversationViewProps {
   conversation: Conversation;
@@ -343,6 +349,23 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
       document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [convoId, queryClient]);
+
+  // ── Per-conversation mute (FE-140) ─────────────────────────────
+  const nowSec = Math.floor(Date.now() / 1000);
+  const conversationMuted = isConversationMuted(conversation.muted_until, nowSec);
+  const mutedText = mutedLabel(conversation.muted_until, nowSec);
+
+  const muteMutation = useMutation({
+    mutationFn: (mutedUntil: number) => muteConversation(convoId, mutedUntil),
+    onSuccess: (_data, mutedUntil) => {
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["conversation", convoId] });
+      toast.success(mutedUntil > 0 ? "Conversation muted" : "Conversation unmuted");
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to update mute setting");
+    },
+  });
 
   // ── Send mutations ─────────────────────────────────────────────
 
@@ -1225,6 +1248,12 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
               {participantCount} participant{participantCount !== 1 && "s"}
             </p>
           )}
+          {conversationMuted && (
+            <p className="flex items-center gap-1 text-xs text-muted-foreground" aria-label={mutedText}>
+              <BellOff className="h-3 w-3" />
+              {mutedText}
+            </p>
+          )}
         </div>
         {galleryEnabled && (
           <Button
@@ -1294,6 +1323,38 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
               <EyeOff className="mr-2 h-4 w-4" />
               Hidden messages
             </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {conversationMuted ? (
+              <DropdownMenuItem
+                onClick={() => muteMutation.mutate(0)}
+                disabled={muteMutation.isPending}
+              >
+                <Bell className="mr-2 h-4 w-4" />
+                Unmute
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <BellOff className="mr-2 h-4 w-4" />
+                  Mute notifications
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {MUTE_OPTIONS.map((opt) => (
+                    <DropdownMenuItem
+                      key={opt.id}
+                      onClick={() =>
+                        muteMutation.mutate(
+                          computeMutedUntil(opt.id, Math.floor(Date.now() / 1000)),
+                        )
+                      }
+                      disabled={muteMutation.isPending}
+                    >
+                      {opt.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            )}
             {callRecordingEnabled && (
               <DropdownMenuItem onClick={() => setRecordingsOpen(true)}>
                 <Video className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## FE-140 — Push notifications (per-conversation mute slice)

Recon confirmed the push stack is ~built on both platforms (VAPID/service-worker + FCM subscription, permission prompts, deep-link into thread/call). The one missing client piece for the acceptance — *"...deep-links correctly, respecting per-convo mute"* — was **per-conversation mute**: the backend `muted_until` field + mute endpoint existed with no client control, display, or respect. This ships exactly that; all other push infra is reused untouched.

### Web
- **NEW** `lib/conversationMute.ts` (+15 vitest) — pure/integer mute math (options 1h/8h/1w/until-off, `computeMutedUntil`, `isMuted`, `mutedLabel`).
- `ConversationView.tsx` — overflow **Mute notifications** submenu / **Unmute**, wired to the existing `muteConversation` (unmute = `muted_until: 0`); `BellOff` + label in header.
- `ConversationList.tsx` — `BellOff` on muted rows. (`muted_until` already on the type.)

### Android
- Reuses **existing** `GroupRepository.setMute` (conversation-level `POST messaging/conversations/{id}/mute`) + `ConversationDto.mutedUntil`.
- **NEW** `MuteMath.kt` (+20 JVM tests) — pure math.
- **NEW** `ConversationMuteStore` — DataStore muted-map synced from `refreshConversations`; lets `NotificationDisplaySink` **suppress a MESSAGE notification for a muted conversation** (fails open on unknown id; never touches `call.*`).
- Thread overflow Mute/Unmute duration sheet + bell-off in top bar and list rows (optimistic, reverts on failure).

### Gates
- Web: `tsc` 0 · build green · 15/15 vitest
- Android: BUILD SUCCESSFUL · `MuteMathTest` 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
