### PR TITLE
FE-130: location message composer + map pin renderer (web + Android)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
          against platform users. Requested at RUNTIME behind an explicit "Find people you know"
          action; emails/phones are hashed on-device and NEVER uploaded (only hashes are sent). -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <!-- FE-130 (EPIC D) - coarse location for the "Use current location" chat-composer action (optional; manual entry is the fallback). -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <!-- AND-297: full-screen incoming-call notification (CATEGORY_CALL qualifies on API 34+). The
          notifier still degrades to a heads-up call notification when canUseFullScreenIntent() is false. -->

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
@@ -287,6 +287,18 @@ sealed interface MessageMedia {
         val innerMedia: MessageMedia,
         val innerText: String,
     ) : MessageMedia
+
+    /**
+     * FE-130 (EPIC D, <- BE-130 post / BE-133 reverse-geocode) - a shared location pin. Rides a normal
+     * text message whose body carries an encoded
+     * [com.testlogon.android.feature.messaging.LocationCardModel] payload behind the TLLOC1 sentinel;
+     * [MessageDto.toMedia] parses the body into [card]. The renderer shows a static-map thumbnail +
+     * label/place-name and opens native maps/directions. Degrades to a coords-only card on map/geocode
+     * failure (never crashes).
+     */
+    data class Location(
+        val card: com.testlogon.android.feature.messaging.LocationCardModel.LocationCard,
+    ) : MessageMedia
 }
 
 /** AND-137 — the kind of item a countdown is associated with (display/pass-through only). */
@@ -844,7 +856,11 @@ internal fun MessageDto.toMedia(): MessageMedia = when {
     // Parse it FIRST so it renders as a transfer card, not raw text; a non-card body falls through.
     // FE-150/FE-151 (EPIC F) - an ecom product/order card rides a normal text message behind its own
     // sentinel. Parse it FIRST so it renders as a card, not raw text; a non-card body falls through.
-    com.testlogon.android.feature.messaging.EcomCardModel.parse(text) is com.testlogon.android.feature.messaging.EcomCardModel.ProductCard ->
+    // FE-130 (EPIC D) - a location card rides a normal text message behind the TLLOC1 sentinel. Parse
+    // it FIRST so it renders as a map card, not raw text; a non-card body falls through.
+    com.testlogon.android.feature.messaging.LocationCardModel.parse(text) != null ->
+        MessageMedia.Location(com.testlogon.android.feature.messaging.LocationCardModel.parse(text)!!)
+        com.testlogon.android.feature.messaging.EcomCardModel.parse(text) is com.testlogon.android.feature.messaging.EcomCardModel.ProductCard ->
         MessageMedia.ProductCard(com.testlogon.android.feature.messaging.EcomCardModel.parse(text) as com.testlogon.android.feature.messaging.EcomCardModel.ProductCard)
     com.testlogon.android.feature.messaging.EcomCardModel.parse(text) is com.testlogon.android.feature.messaging.EcomCardModel.OrderCard ->
         MessageMedia.OrderCard(com.testlogon.android.feature.messaging.EcomCardModel.parse(text) as com.testlogon.android.feature.messaging.EcomCardModel.OrderCard)

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/geocode/GeocodeApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/geocode/GeocodeApi.kt
@@ -1,0 +1,66 @@
+package com.testlogon.android.data.messaging.geocode
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Query
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FE-130 (EPIC D, <- BE-133) - reverse-geocode read: resolve a lat/lng to a human place name.
+ *
+ * Matches the WEB contract (frontend/src/api/endpoints/messaging.ts reverseGeocode):
+ *   GET messaging/geocode/reverse?lat=&lng=  -> { place_name?, display_name? }
+ *
+ * Best-effort: the composer NEVER blocks a send on this. If the endpoint is missing (404), the backend
+ * has no key configured, or the call fails for any reason, [GeocodeRepository.reverse] returns null and
+ * the location card simply ships coords-only (degrade, no crash).
+ */
+interface GeocodeApi {
+    @GET("messaging/geocode/reverse")
+    suspend fun reverse(
+        @Query("lat") lat: Double,
+        @Query("lng") lng: Double,
+    ): ReverseGeocodeDto
+}
+
+/** BE-133 reverse-geocode response; either field may carry the place name. */
+@JsonClass(generateAdapter = true)
+data class ReverseGeocodeDto(
+    @Json(name = "place_name") val placeName: String? = null,
+    @Json(name = "display_name") val displayName: String? = null,
+)
+
+/** Best-effort reverse-geocode wrapper; returns null on any failure so a send is never blocked. */
+interface GeocodeRepository {
+    suspend fun reverse(lat: Double, lng: Double): String?
+}
+
+@Singleton
+class DefaultGeocodeRepository @Inject constructor(
+    private val api: GeocodeApi,
+) : GeocodeRepository {
+    override suspend fun reverse(lat: Double, lng: Double): String? =
+        runCatching {
+            val dto = api.reverse(lat, lng)
+            (dto.placeName ?: dto.displayName)?.trim()?.takeIf { it.isNotBlank() }
+        }.getOrNull()
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object GeocodeApiModule {
+    @Provides
+    @Singleton
+    fun provideGeocodeApi(retrofit: Retrofit): GeocodeApi = retrofit.create(GeocodeApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideGeocodeRepository(impl: DefaultGeocodeRepository): GeocodeRepository = impl
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/LocationCardModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/LocationCardModel.kt
@@ -1,0 +1,168 @@
+package com.testlogon.android.feature.messaging
+
+import java.util.Locale
+
+/**
+ * EPIC D (FE-130, BE-130 post / BE-133 reverse-geocode) - pure, dependency-free model for the
+ * location chat card. Kept Android-free so payload build/validate/encode/parse, coord formatting, the
+ * maps deep-links, the static-map thumbnail URL and the preview are all JVM-unit-testable in isolation
+ * (LocationCardModelTest).
+ *
+ * TRANSPORT (mirrors EcomCardModel / CryptoTransferModel / TradingCardModel - the 4th chat-card
+ * sentinel): the card rides on a NORMAL text message. The structured payload is encoded into the body
+ * behind the rare SENTINEL tag; MessageDto.toMedia parses it back to a card and renders it, falling
+ * through to a plain text bubble when the body is not a card (so an un-upgraded client just shows text).
+ *
+ * Encoding: SENTINEL + key=value pairs joined by ";". Reserved chars (";", "=", "%", newline) are
+ * percent-escaped so any user-facing value (labels/place names with ";" , "," , unicode) round-trips.
+ *
+ * Field names match the WEB contract (frontend/src/lib/locationCards.ts): lat/lng/label/place_name +
+ * the same maps URLs (keyless OpenStreetMap static map; Google Maps search/directions deep links).
+ */
+object LocationCardModel {
+
+    const val SENTINEL: String = "TLLOC1:"
+
+    /** A visible location pin marker used in previews (emoji, unicode-escaped for source safety). */
+    const val PIN: String = "📍"
+
+    data class LocationCard(
+        val lat: Double,
+        val lng: Double,
+        val label: String?,
+        val placeName: String?,
+    )
+
+    /** Valid WGS84 coordinate: finite, lat in [-90,90], lng in [-180,180]. */
+    fun isValidLatLng(lat: Double, lng: Double): Boolean =
+        lat.isFinite() && lng.isFinite() && lat >= -90.0 && lat <= 90.0 && lng >= -180.0 && lng <= 180.0
+
+    fun build(lat: Double, lng: Double, label: String?, placeName: String?): LocationCard =
+        LocationCard(
+            lat = lat,
+            lng = lng,
+            label = label?.trim()?.takeIf { it.isNotBlank() },
+            placeName = placeName?.trim()?.takeIf { it.isNotBlank() },
+        )
+
+    /** e.g. "37.77490, -122.41940" - fixed 5dp (~1.1m precision). */
+    fun formatCoords(lat: Double, lng: Double): String =
+        String.format(Locale.US, "%.5f, %.5f", lat, lng)
+
+    fun mapsOpenUrl(lat: Double, lng: Double, label: String? = null): String {
+        val coords = "$lat,$lng"
+        val q = label?.trim()?.takeIf { it.isNotEmpty() }?.let { "$it ($coords)" } ?: coords
+        return "https://www.google.com/maps/search/?api=1&query=" + urlEncode(q)
+    }
+
+    fun directionsUrl(lat: Double, lng: Double): String =
+        "https://www.google.com/maps/dir/?api=1&destination=" + urlEncode("$lat,$lng")
+
+    /** RFC 5870 geo: URI. */
+    fun geoUri(lat: Double, lng: Double): String = "geo:$lat,$lng"
+
+    /**
+     * Keyless static-map thumbnail URL (OpenStreetMap community service, no API key) with a red marker.
+     * The renderer falls back to a pin placeholder onError so an outage / 404 never breaks the card.
+     */
+    fun staticMapThumbUrl(lat: Double, lng: Double, w: Int = 320, h: Int = 160, zoom: Int = 15): String {
+        val center = "$lat,$lng"
+        return "https://staticmap.openstreetmap.de/staticmap.php" +
+            "?center=$center&zoom=$zoom&size=${w}x$h&markers=$center,red"
+    }
+
+    /** Conversation-list / reply preview: pin + label, else pin + "Location". */
+    fun locationPreview(label: String?, placeName: String?): String {
+        val name = (label?.trim()?.takeIf { it.isNotBlank() } ?: placeName?.trim()?.takeIf { it.isNotBlank() })
+        return if (name != null) "$PIN $name" else "$PIN Location"
+    }
+
+    fun preview(card: LocationCard): String = locationPreview(card.label, card.placeName)
+
+    fun previewForBody(body: String?): String? = parse(body)?.let { preview(it) }
+
+    fun isCard(body: String?): Boolean = body != null && body.startsWith(SENTINEL)
+
+    fun encode(card: LocationCard): String {
+        val sb = StringBuilder(SENTINEL)
+        sb.append(kv("lat", card.lat.toString()))
+        sb.append(SEP).append(kv("lng", card.lng.toString()))
+        card.label?.takeIf { it.isNotBlank() }?.let { sb.append(SEP).append(kv("label", it)) }
+        card.placeName?.takeIf { it.isNotBlank() }?.let { sb.append(SEP).append(kv("place", it)) }
+        return sb.toString()
+    }
+
+    /**
+     * Parse a message body into a LocationCard, or null when not a well-formed card. Out-of-range or
+     * unparsable coords are rejected (null) so a bad body degrades to a plain text bubble.
+     */
+    fun parse(body: String?): LocationCard? {
+        if (body == null || !body.startsWith(SENTINEL)) return null
+        val payload = body.substring(SENTINEL.length)
+        val map = HashMap<String, String>()
+        for (seg in payload.split(SEP)) {
+            val eq = seg.indexOf(EQ)
+            if (eq <= 0) continue
+            map[unescape(seg.substring(0, eq))] = unescape(seg.substring(eq + 1))
+        }
+        val lat = map["lat"]?.toDoubleOrNull() ?: return null
+        val lng = map["lng"]?.toDoubleOrNull() ?: return null
+        if (!isValidLatLng(lat, lng)) return null
+        return LocationCard(
+            lat = lat,
+            lng = lng,
+            label = map["label"]?.takeIf { it.isNotBlank() },
+            placeName = map["place"]?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private const val SEP: Char = ';'
+    private const val EQ: Char = '='
+
+    private fun kv(k: String, v: String): String = escape(k) + "=" + escape(v)
+
+    private fun escape(s: String): String {
+        val sb = StringBuilder(s.length)
+        for (c in s) {
+            when (c) {
+                '%' -> sb.append("%25")
+                ';' -> sb.append("%3B")
+                '=' -> sb.append("%3D")
+                '\n' -> sb.append("%0A")
+                '\r' -> sb.append("%0D")
+                else -> sb.append(c)
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun unescape(s: String): String {
+        if (s.indexOf('%') < 0) return s
+        val sb = StringBuilder(s.length)
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            if (c == '%' && i + 2 < s.length) {
+                val code = s.substring(i + 1, i + 3).toIntOrNull(16)
+                if (code != null) { sb.append(code.toChar()); i += 3; continue }
+            }
+            sb.append(c); i++
+        }
+        return sb.toString()
+    }
+
+    /** Minimal URL query-component encoder (pure; no android/java.net dependency needed). */
+    private fun urlEncode(s: String): String {
+        val sb = StringBuilder(s.length)
+        for (c in s) {
+            when {
+                c in 'A'..'Z' || c in 'a'..'z' || c in '0'..'9' || c == '-' || c == '_' || c == '.' || c == '~' ->
+                    sb.append(c)
+                else -> for (b in c.toString().toByteArray(Charsets.UTF_8)) {
+                    sb.append('%').append(String.format(Locale.US, "%02X", b.toInt() and 0xFF))
+                }
+            }
+        }
+        return sb.toString()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListUiState.kt
@@ -41,7 +41,10 @@ internal fun Conversation.toRow(): ConversationRow = ConversationRow(
     iconUrl = iconUrl,
     // FE-120 (EPIC C) — mask a reveal-wrapped last message so the raw TLRVL1 sentinel never
     // leaks into the inbox row; the inner content is never shown here (viewer-agnostic).
-    preview = com.testlogon.android.feature.messaging.RevealAtMath.previewForBody(lastMessagePreview)
+    // FE-130 (EPIC D) - mask a location-card last message so the raw TLLOC1 sentinel never leaks into
+    // the inbox row; falls through the reveal mask, then to the server text preview.
+    preview = com.testlogon.android.feature.messaging.LocationCardModel.previewForBody(lastMessagePreview)
+        ?: com.testlogon.android.feature.messaging.RevealAtMath.previewForBody(lastMessagePreview)
         ?: lastMessagePreview,
     lastActivityEpochSeconds = lastActivityEpochSeconds,
     unreadCount = unreadCount,

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LocationCardUi.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LocationCardUi.kt
@@ -1,0 +1,156 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.testlogon.android.feature.messaging.thread
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Directions
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import com.testlogon.android.feature.messaging.LocationCardModel
+
+object LocationCardTestTags {
+    const val CARD = "thread_location_card"
+    const val THUMB = "thread_location_card_thumb"
+    const val THUMB_FALLBACK = "thread_location_card_thumb_fallback"
+    const val OPEN = "thread_location_card_open"
+    const val DIRECTIONS = "thread_location_card_directions"
+}
+
+@Composable
+fun LocationCard(
+    card: LocationCardModel.LocationCard,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val coords = LocationCardModel.formatCoords(card.lat, card.lng)
+    val primary = card.label?.takeIf { it.isNotBlank() }
+        ?: card.placeName?.takeIf { it.isNotBlank() }
+        ?: "Shared location"
+    val secondary = when {
+        card.label != null && card.placeName != null -> card.placeName
+        else -> coords
+    }
+    val cd = "Location $primary, $secondary"
+
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = modifier
+            .widthIn(max = 260.dp)
+            .testTag(LocationCardTestTags.CARD)
+            .semantics { contentDescription = cd },
+    ) {
+        Column {
+            SubcomposeAsyncImage(
+                model = LocationCardModel.staticMapThumbUrl(card.lat, card.lng),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                loading = { MapThumbPlaceholder() },
+                error = { MapThumbPlaceholder() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(2f)
+                    .testTag(LocationCardTestTags.THUMB),
+            )
+            Column(Modifier.padding(12.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Filled.Place,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Text(
+                        primary,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(start = 6.dp),
+                    )
+                }
+                Text(
+                    secondary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 2.dp, start = 24.dp),
+                )
+                Row(
+                    Modifier.fillMaxWidth().padding(top = 10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { openMaps(context, card) },
+                        modifier = Modifier.weight(1f).testTag(LocationCardTestTags.OPEN),
+                    ) { Text("Open in Maps") }
+                    OutlinedButton(
+                        onClick = {
+                            openExternal(context, LocationCardModel.directionsUrl(card.lat, card.lng), fallback = null)
+                        },
+                        modifier = Modifier.testTag(LocationCardTestTags.DIRECTIONS),
+                    ) {
+                        Icon(Icons.Filled.Directions, contentDescription = "Directions", modifier = Modifier.size(18.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MapThumbPlaceholder() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .testTag(LocationCardTestTags.THUMB_FALLBACK),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Filled.Place,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(40.dp),
+        )
+    }
+}
+
+private fun openMaps(context: android.content.Context, card: LocationCardModel.LocationCard) {
+    val geo = LocationCardModel.geoUri(card.lat, card.lng)
+    val web = LocationCardModel.mapsOpenUrl(card.lat, card.lng, card.label)
+    openExternal(context, geo, fallback = web)
+}
+
+private fun openExternal(context: android.content.Context, url: String, fallback: String?) {
+    val ok = runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }.isSuccess
+    if (!ok && fallback != null) {
+        runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(fallback))) }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LocationComposer.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LocationComposer.kt
@@ -1,0 +1,193 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.testlogon.android.feature.messaging.thread
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.testlogon.android.feature.messaging.LocationCardModel
+import kotlinx.coroutines.launch
+
+object LocationComposerTestTags {
+    const val ATTACH = "thread_attach_location"
+    const val SHEET = "thread_location_composer"
+    const val USE_CURRENT = "thread_location_use_current"
+    const val LAT = "thread_location_lat"
+    const val LNG = "thread_location_lng"
+    const val LABEL = "thread_location_label"
+    const val SEND = "thread_location_send"
+}
+
+/**
+ * FE-130 (EPIC D) - Share location composer. Use-current-location is permission-gated (COARSE):
+ * deny / unsupported degrades to manual lat/lng entry (always present as the no-permission fallback).
+ * An optional label rides along. On send it best-effort reverse-geocodes via onReverseGeocode
+ * (degrade -> skip place name) and emits the encoded TLLOC1 body through onSend. Coord validation +
+ * encoding are the pure LocationCardModel; a geocode/location failure NEVER blocks the send.
+ */
+@Composable
+fun LocationComposerSheet(
+    onSend: (body: String) -> Unit,
+    onReverseGeocode: suspend (lat: Double, lng: Double) -> String?,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var latText by remember { mutableStateOf("") }
+    var lngText by remember { mutableStateOf("") }
+    var label by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf<String?>(null) }
+    var sending by remember { mutableStateOf(false) }
+
+    fun fillCurrentLocation() {
+        val lm = context.getSystemService(android.content.Context.LOCATION_SERVICE) as? LocationManager
+        if (lm == null) { note = "Location is unavailable. Enter coordinates manually."; return }
+        val loc = runCatching {
+            lm.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
+                ?: lm.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+                ?: lm.getLastKnownLocation(LocationManager.PASSIVE_PROVIDER)
+        }.getOrNull()
+        if (loc == null) {
+            note = "No recent location fix. Enter coordinates manually."
+        } else {
+            latText = loc.latitude.toString()
+            lngText = loc.longitude.toString()
+            note = null
+        }
+    }
+
+    val permLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) fillCurrentLocation() else note = "Location permission denied. Enter coordinates manually."
+    }
+
+    fun onUseCurrent() {
+        val coarse = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+        if (coarse == PackageManager.PERMISSION_GRANTED) fillCurrentLocation()
+        else permLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+    }
+
+    val lat = latText.trim().toDoubleOrNull()
+    val lng = lngText.trim().toDoubleOrNull()
+    val valid = lat != null && lng != null && LocationCardModel.isValidLatLng(lat, lng)
+
+    fun onSendClicked() {
+        val la = lat; val ln = lng
+        if (la == null || ln == null || !LocationCardModel.isValidLatLng(la, ln)) {
+            note = "Enter a valid latitude (-90..90) and longitude (-180..180)."
+            return
+        }
+        sending = true
+        scope.launch {
+            val place = runCatching { onReverseGeocode(la, ln) }.getOrNull()
+            val card = LocationCardModel.build(la, ln, label, place)
+            onSend(LocationCardModel.encode(card))
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag(LocationComposerTestTags.SHEET).semantics { testTagsAsResourceId = true },
+    ) {
+        Column(Modifier.fillMaxWidth().navigationBarsPadding().padding(16.dp).verticalScroll(rememberScrollState())) {
+            Text("Share location", style = MaterialTheme.typography.titleMedium)
+
+            OutlinedButton(
+                onClick = { onUseCurrent() },
+                enabled = !sending,
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp).testTag(LocationComposerTestTags.USE_CURRENT),
+            ) {
+                Icon(Icons.Filled.MyLocation, contentDescription = null, modifier = Modifier.size(18.dp))
+                Text("  Use current location")
+            }
+
+            Text(
+                "Or enter coordinates",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 14.dp),
+            )
+            Row(Modifier.fillMaxWidth().padding(top = 6.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = latText,
+                    onValueChange = { latText = it; note = null },
+                    modifier = Modifier.weight(1f).testTag(LocationComposerTestTags.LAT),
+                    label = { Text("Latitude") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                )
+                OutlinedTextField(
+                    value = lngText,
+                    onValueChange = { lngText = it; note = null },
+                    modifier = Modifier.weight(1f).testTag(LocationComposerTestTags.LNG),
+                    label = { Text("Longitude") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                )
+            }
+            OutlinedTextField(
+                value = label,
+                onValueChange = { label = it },
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp).testTag(LocationComposerTestTags.LABEL),
+                label = { Text("Label (optional)") },
+                placeholder = { Text("Home, The cafe") },
+                singleLine = true,
+            )
+            note?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+
+            Button(
+                onClick = { onSendClicked() },
+                enabled = valid && !sending,
+                modifier = Modifier.fillMaxWidth().padding(top = 16.dp).testTag(LocationComposerTestTags.SEND),
+            ) {
+                if (sending) CircularProgressIndicator(Modifier.size(18.dp)) else Text("Send location")
+            }
+            Box(Modifier.fillMaxWidth().heightIn(min = 16.dp))
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.CurrencyBitcoin
+import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.ReceiptLong
 import androidx.compose.material.icons.filled.ShoppingBag
 import androidx.compose.material.icons.filled.DeleteOutline
@@ -458,6 +459,10 @@ fun ThreadRoute(
         onAttachOrderCard = viewModel::onAttachOrderCard,
         onDismissOrderPicker = viewModel::onDismissOrderPicker,
         onSendOrderCard = viewModel::onSendOrderCard,
+        onAttachLocation = viewModel::onAttachLocation,
+        onDismissLocation = viewModel::onDismissLocation,
+        onReverseGeocode = viewModel::reverseGeocode,
+        onSendLocationCard = viewModel::onSendLocationCard,
         onOpenMessageOptions = viewModel::openMessageOptions,
         onClearMessageOptions = viewModel::clearMessageOptions,
         onRemoveStagedImage = viewModel::onRemoveStagedImage,
@@ -1115,6 +1120,10 @@ fun ThreadScreen(
     onAttachOrderCard: () -> Unit = {},
     onDismissOrderPicker: () -> Unit = {},
     onSendOrderCard: (OrderPick, com.testlogon.android.feature.messaging.EcomCardModel.OrderMode) -> Unit = { _, _ -> },
+    onAttachLocation: () -> Unit = {},
+    onDismissLocation: () -> Unit = {},
+    onReverseGeocode: suspend (Double, Double) -> String? = { _, _ -> null },
+    onSendLocationCard: (String) -> Unit = {},
     onCryptoSelectAsset: (String) -> Unit = {},
     onCryptoAmountChange: (String) -> Unit = {},
     onCryptoMax: () -> Unit = {},
@@ -1477,6 +1486,7 @@ fun ThreadScreen(
                         onAttachCryptoSend = onAttachCryptoSend,
                         onAttachProductCard = onAttachProductCard,
                         onAttachOrderCard = onAttachOrderCard,
+                        onAttachLocation = onAttachLocation,
                         onOpenMessageOptions = onOpenMessageOptions,
                         onClearMessageOptions = onClearMessageOptions,
                         onRemoveStagedImage = onRemoveStagedImage,
@@ -1703,6 +1713,13 @@ fun ThreadScreen(
             onDismiss = onDismissOrderPicker,
         )
     }
+    if (state.locationComposer.visible) {
+        LocationComposerSheet(
+            onSend = onSendLocationCard,
+            onReverseGeocode = onReverseGeocode,
+            onDismiss = onDismissLocation,
+        )
+    }
 
     if (state.tipSheet.messageId != null) {
         TipSheet(
@@ -1754,6 +1771,7 @@ private fun replyQuoteSnippet(m: ThreadMessageUi): String {
     (m.media as? MessageMedia.CryptoTransfer)?.let { return com.testlogon.android.feature.messaging.CryptoTransferModel.previewNeutral(it.card) }
     (m.media as? MessageMedia.ProductCard)?.let { return com.testlogon.android.feature.messaging.EcomCardModel.productPreview(it.card) }
     (m.media as? MessageMedia.OrderCard)?.let { return com.testlogon.android.feature.messaging.EcomCardModel.orderPreview(it.card) }
+    (m.media as? MessageMedia.Location)?.let { return com.testlogon.android.feature.messaging.LocationCardModel.preview(it.card) }
     val text = m.text.trim()
     if (text.isNotBlank()) return text
     return when (m.media) {
@@ -1773,6 +1791,7 @@ private fun replyQuoteSnippet(m: ThreadMessageUi): String {
         is MessageMedia.CryptoTransfer -> com.testlogon.android.feature.messaging.CryptoTransferModel.previewNeutral((m.media as MessageMedia.CryptoTransfer).card)
         is MessageMedia.ProductCard -> com.testlogon.android.feature.messaging.EcomCardModel.productPreview((m.media as MessageMedia.ProductCard).card)
         is MessageMedia.OrderCard -> com.testlogon.android.feature.messaging.EcomCardModel.orderPreview((m.media as MessageMedia.OrderCard).card)
+        is MessageMedia.Location -> com.testlogon.android.feature.messaging.LocationCardModel.preview((m.media as MessageMedia.Location).card)
         is MessageMedia.Countdown -> "[countdown]"
         is MessageMedia.CalendarEvent, is MessageMedia.CalendarShare -> "[calendar]"
         is MessageMedia.RevealLocked -> com.testlogon.android.feature.messaging.RevealAtMath.LOCKED_PREVIEW
@@ -2155,6 +2174,7 @@ private fun MessageBubble(
                     )
                     is MessageMedia.ProductCard -> ProductCard(card = inner.card, onBuy = onOpenProduct)
                     is MessageMedia.OrderCard -> OrderShareCard(card = inner.card)
+                    is MessageMedia.Location -> LocationCard(card = inner.card)
                     else -> Surface(
                         color = bubbleColor,
                         contentColor = if (message.isOwn) {
@@ -2265,6 +2285,7 @@ private fun MessageBubble(
                 onBuy = onOpenProduct,
             )
             is MessageMedia.OrderCard -> OrderShareCard(card = media.card)
+            is MessageMedia.Location -> LocationCard(card = media.card)
             is MessageMedia.Paid -> PaidMessageBubble(
                 monetization = media.monetization,
                 isOwn = message.isOwn,
@@ -2804,6 +2825,7 @@ private fun MessageComposer(
     onAttachCryptoSend: () -> Unit = {},
     onAttachProductCard: () -> Unit = {},
     onAttachOrderCard: () -> Unit = {},
+    onAttachLocation: () -> Unit = {},
     onOpenMessageOptions: () -> Unit = {},
     onClearMessageOptions: () -> Unit = {},
     onRemoveStagedImage: (Int) -> Unit = {},
@@ -2971,6 +2993,12 @@ private fun MessageComposer(
                         modifier = Modifier.size(44.dp).testTag(EcomComposerTestTags.ATTACH_ORDER),
                     ) {
                         Icon(Icons.Filled.ReceiptLong, contentDescription = "Share purchase", tint = MaterialTheme.colorScheme.primary)
+                    }
+                    IconButton(
+                        onClick = { actionsExpanded = false; onAttachLocation() },
+                        modifier = Modifier.size(44.dp).testTag(LocationComposerTestTags.ATTACH),
+                    ) {
+                        Icon(Icons.Filled.Place, contentDescription = "Share location", tint = MaterialTheme.colorScheme.primary)
                     }
                 }
             }

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
@@ -99,6 +99,8 @@ data class ThreadUiState(
     val productPicker: ProductPickerState = ProductPickerState(),
     /** FE-151 (EPIC F) — "Share purchase" order picker + mode-selector sheet (hidden until opened). */
     val orderPicker: OrderPickerState = OrderPickerState(),
+    /** FE-130 (EPIC D) — "Share location" composer sheet (map pin; hidden until opened). */
+    val locationComposer: LocationComposerState = LocationComposerState(),
     /** MSG — receiver passphrase-unlock dialog for an encrypted message (non-null key = open). */
     val encryptUnlock: EncryptUnlockState = EncryptUnlockState(),
     /** MSG — view-once viewer dialog (non-null key = open, showing the consumed content). */
@@ -318,6 +320,11 @@ data class OrderPick(
     val currency: String?,
     /** The caller's own display name; used only for gift/recommendation attribution (never in receipt). */
     val buyerName: String?,
+)
+
+/** FE-130 - "Share location" composer state. Just visibility; the sheet owns its transient input. */
+data class LocationComposerState(
+    val visible: Boolean = false,
 )
 
 /** FE-151 - "Share purchase" order-picker + mode-selector state. */

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
@@ -111,6 +111,7 @@ class ThreadViewModel @Inject constructor(
     private val custodyReader: com.testlogon.android.data.custody.CustodyReader,
     private val catalogRepository: com.testlogon.android.data.catalog.CatalogRepository,
     private val purchasesRepository: com.testlogon.android.data.purchases.PurchasesRepository,
+    private val geocodeRepository: com.testlogon.android.data.messaging.geocode.GeocodeRepository,
     private val groupRepository: com.testlogon.android.data.messaging.group.GroupRepository,
     private val muteStore: com.testlogon.android.data.messaging.mute.ConversationMuteStore,
 ) : ViewModel() {
@@ -2615,6 +2616,38 @@ class ThreadViewModel @Inject constructor(
     }
 
     fun onDismissOrderPicker() { _state.update { it.copy(orderPicker = OrderPickerState()) } }
+
+    // ---- FE-130 (EPIC D): share location in chat ----
+
+    /** FE-130 - open the "Share location" composer sheet. */
+    fun onAttachLocation() {
+        _state.update { it.copy(locationComposer = LocationComposerState(visible = true)) }
+    }
+
+    fun onDismissLocation() {
+        _state.update { it.copy(locationComposer = LocationComposerState()) }
+    }
+
+    /**
+     * FE-130 (<- BE-133) - best-effort reverse-geocode a coordinate to a place name for the composer.
+     * NEVER blocks or fails a send: any error / missing endpoint resolves to null (coords-only card).
+     */
+    suspend fun reverseGeocode(lat: Double, lng: Double): String? = geocodeRepository.reverse(lat, lng)
+
+    /**
+     * FE-130 - send a location card as a normal text message carrying the encoded [LocationCardModel]
+     * payload behind the TLLOC1 sentinel (degrade-safe transport; no dedicated endpoint). The composer
+     * has already validated coords + resolved the optional place name; [body] is the encoded payload.
+     */
+    fun onSendLocationCard(body: String) {
+        _state.update { it.copy(locationComposer = LocationComposerState()) }
+        val clientId = java.util.UUID.randomUUID().toString()
+        viewModelScope.launch {
+            repository.enqueueOptimistic(conversationId, clientId, body, clock())
+            repository.sendOutbox(conversationId, clientId, body)
+            _events.trySend(ThreadEvent.ScrollToBottom)
+        }
+    }
 
     /**
      * FE-151 - send an order_share card as a normal text message. The mode is passed to the model

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
@@ -1294,9 +1294,16 @@ fun newThreadViewModel(
         com.testlogon.android.feature.trading.FakeCustodyReader(),
         fakeCatalogRepository(),
         fakePurchasesRepository(),
+        fakeGeocodeRepository(),
         groupRepository,
         muteStore,
     )
+
+/** FE-130 (EPIC D) — no-op reverse-geocode repo for thread tests (always degrades to null). */
+private fun fakeGeocodeRepository(): com.testlogon.android.data.messaging.geocode.GeocodeRepository =
+    object : com.testlogon.android.data.messaging.geocode.GeocodeRepository {
+        override suspend fun reverse(lat: Double, lng: Double): String? = null
+    }
 
 /** EPIC F — minimal no-op catalog repo for thread tests (product-picker read returns empty). */
 private fun fakeCatalogRepository(): com.testlogon.android.data.catalog.CatalogRepository =

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/LocationCardModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/LocationCardModelTest.kt
@@ -1,0 +1,149 @@
+package com.testlogon.android.feature.messaging
+
+import com.testlogon.android.feature.messaging.LocationCardModel.LocationCard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** EPIC D (FE-130) - pure validate/build/encode/parse round-trip + URL builders + preview tests. */
+class LocationCardModelTest {
+
+    @Test
+    fun valid_lat_lng_bounds() {
+        assertTrue(LocationCardModel.isValidLatLng(0.0, 0.0))
+        assertTrue(LocationCardModel.isValidLatLng(-90.0, 180.0))
+        assertTrue(LocationCardModel.isValidLatLng(90.0, -180.0))
+        assertFalse(LocationCardModel.isValidLatLng(90.1, 0.0))
+        assertFalse(LocationCardModel.isValidLatLng(0.0, 180.1))
+        assertFalse(LocationCardModel.isValidLatLng(Double.NaN, 0.0))
+        assertFalse(LocationCardModel.isValidLatLng(0.0, Double.POSITIVE_INFINITY))
+    }
+
+    @Test
+    fun build_collapses_blank_label_and_place() {
+        val c = LocationCardModel.build(1.0, 2.0, "   ", "")
+        assertNull(c.label)
+        assertNull(c.placeName)
+        val d = LocationCardModel.build(1.0, 2.0, "  Home  ", "  1 Main St ")
+        assertEquals("Home", d.label)
+        assertEquals("1 Main St", d.placeName)
+    }
+
+    @Test
+    fun format_coords_5dp() {
+        assertEquals("37.77490, -122.41940", LocationCardModel.formatCoords(37.7749, -122.4194))
+        assertEquals("0.00000, 0.00000", LocationCardModel.formatCoords(0.0, 0.0))
+    }
+
+    @Test
+    fun encode_parse_round_trips_all_fields() {
+        val c = LocationCard(37.7749, -122.4194, "Home", "1 Market St, SF")
+        val body = LocationCardModel.encode(c)
+        assertTrue(body.startsWith(LocationCardModel.SENTINEL))
+        val back = LocationCardModel.parse(body)!!
+        assertEquals(c.lat, back.lat, 0.0)
+        assertEquals(c.lng, back.lng, 0.0)
+        assertEquals("Home", back.label)
+        assertEquals("1 Market St, SF", back.placeName)
+    }
+
+    @Test
+    fun encode_parse_round_trips_delimiter_hostile_label() {
+        // label + place with the reserved delimiters ; = % and a comma and unicode - must round-trip.
+        val c = LocationCard(1.5, -3.25, "a;b=c%d, e", "Cafe; \"El Nino\" = 100% ok")
+        val body = LocationCardModel.encode(c)
+        val back = LocationCardModel.parse(body)!!
+        assertEquals("a;b=c%d, e", back.label)
+        assertEquals("Cafe; \"El Nino\" = 100% ok", back.placeName)
+    }
+
+    @Test
+    fun encode_parse_round_trips_unicode_label() {
+        val c = LocationCard(48.8566, 2.3522, "Cafe de Flore", "Paris")
+        val back = LocationCardModel.parse(LocationCardModel.encode(c))!!
+        assertEquals("Cafe de Flore", back.label)
+    }
+
+    @Test
+    fun encode_omits_null_label_and_place() {
+        val c = LocationCard(10.0, 20.0, null, null)
+        val body = LocationCardModel.encode(c)
+        assertFalse(body.contains("label="))
+        assertFalse(body.contains("place="))
+        val back = LocationCardModel.parse(body)!!
+        assertNull(back.label)
+        assertNull(back.placeName)
+    }
+
+    @Test
+    fun parse_non_card_body_is_null() {
+        assertNull(LocationCardModel.parse(null))
+        assertNull(LocationCardModel.parse("hello world"))
+        assertNull(LocationCardModel.parse("TLSHOP1:product_card;item=x"))
+    }
+
+    @Test
+    fun parse_rejects_out_of_range_or_missing_coords() {
+        assertNull(LocationCardModel.parse(LocationCardModel.SENTINEL + "lat=99.0;lng=0.0"))
+        assertNull(LocationCardModel.parse(LocationCardModel.SENTINEL + "lat=abc;lng=0.0"))
+        assertNull(LocationCardModel.parse(LocationCardModel.SENTINEL + "lng=0.0"))
+    }
+
+    @Test
+    fun is_card_pre_check() {
+        assertTrue(LocationCardModel.isCard(LocationCardModel.SENTINEL + "lat=1.0;lng=2.0"))
+        assertFalse(LocationCardModel.isCard("nope"))
+        assertFalse(LocationCardModel.isCard(null))
+    }
+
+    @Test
+    fun maps_open_url_uses_coords_when_no_label() {
+        assertEquals(
+            "https://www.google.com/maps/search/?api=1&query=37.7749%2C-122.4194",
+            LocationCardModel.mapsOpenUrl(37.7749, -122.4194),
+        )
+    }
+
+    @Test
+    fun maps_open_url_encodes_label_and_coords() {
+        val url = LocationCardModel.mapsOpenUrl(1.0, 2.0, "The Cafe")
+        assertTrue(url.startsWith("https://www.google.com/maps/search/?api=1&query="))
+        assertTrue(url.contains("The%20Cafe"))
+        assertTrue(url.contains("1.0%2C2.0"))
+    }
+
+    @Test
+    fun directions_and_geo_uri() {
+        assertEquals(
+            "https://www.google.com/maps/dir/?api=1&destination=1.0%2C2.0",
+            LocationCardModel.directionsUrl(1.0, 2.0),
+        )
+        assertEquals("geo:1.0,2.0", LocationCardModel.geoUri(1.0, 2.0))
+    }
+
+    @Test
+    fun static_map_thumb_url_defaults_and_marker() {
+        val url = LocationCardModel.staticMapThumbUrl(1.5, 2.5)
+        assertTrue(url.startsWith("https://staticmap.openstreetmap.de/staticmap.php"))
+        assertTrue(url.contains("center=1.5,2.5"))
+        assertTrue(url.contains("zoom=15"))
+        assertTrue(url.contains("size=320x160"))
+        assertTrue(url.contains("markers=1.5,2.5,red"))
+    }
+
+    @Test
+    fun preview_prefers_label_then_place_then_generic() {
+        assertEquals("${LocationCardModel.PIN} Home", LocationCardModel.locationPreview("Home", "1 Main St"))
+        assertEquals("${LocationCardModel.PIN} 1 Main St", LocationCardModel.locationPreview(" ", "1 Main St"))
+        assertEquals("${LocationCardModel.PIN} Location", LocationCardModel.locationPreview(null, null))
+    }
+
+    @Test
+    fun preview_for_body_masks_sentinel() {
+        val body = LocationCardModel.encode(LocationCard(1.0, 2.0, "Office", null))
+        assertEquals("${LocationCardModel.PIN} Office", LocationCardModel.previewForBody(body))
+        assertNull(LocationCardModel.previewForBody("plain text"))
+    }
+}

--- a/frontend/src/api/endpoints/messaging.ts
+++ b/frontend/src/api/endpoints/messaging.ts
@@ -52,6 +52,7 @@ import { adaptConversation, adaptMessage } from "./messagingAdapter";
 import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
 import type { CryptoTransferPayload } from "@/lib/cryptoTransfer";
 import type { ProductCardPayload, OrderCardPayload } from "@/lib/ecomCards";
+import type { LocationCardPayload } from "@/lib/locationCards";
 import { isMessagingDmLotteryEnabled, isMessagingEncryptionEnabled } from "@/lib/featureFlags";
 import { encryptBytes } from "@/lib/messageEncryption";
 
@@ -896,7 +897,7 @@ export async function sendCountdownMessage(
 async function sendCardMessage(
   conversationId: string,
   cardEndpoint: string,
-  kind: "market_card" | "position_card" | "crypto_transfer" | "product_card" | "order_card",
+  kind: "market_card" | "position_card" | "crypto_transfer" | "product_card" | "order_card" | "location",
   payload: Record<string, unknown>,
   replyToMessageId?: string,
 ): Promise<Message> {
@@ -1000,6 +1001,47 @@ export async function sendOrderCardMessage(
     conversationId,
     "order",
     "order_card",
+    { ...payload },
+    replyToMessageId,
+  );
+}
+
+// ---- Location-in-chat card (EPIC D: FE-130) ----
+//
+// Preferred path is a dedicated /messaging/cards/location endpoint (BE-130). If
+// the backend has not shipped it yet (404), we degrade to a normal message
+// carrying kind "location" + the structured payload -- MessageBubble dispatches
+// on `kind` + payload so it renders identically either way.
+// BE-133 reverse-geocode read: resolve a lat/lng to a human place name. Best-
+// effort -- if the endpoint is missing (404) or the backend has no key
+// configured, we resolve undefined so the composer simply skips place_name
+// (coords-only card). Never throws for the not-configured / not-deployed case.
+export async function reverseGeocode(
+  lat: number,
+  lng: number,
+): Promise<string | undefined> {
+  try {
+    const res = await api.get<{ place_name?: string | null; display_name?: string | null }>(
+      `/messaging/geocode/reverse?lat=${lat}&lng=${lng}`,
+    );
+    const name = (res.place_name ?? res.display_name ?? "").trim();
+    return name || undefined;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return undefined;
+    // A geocode failure must never block sending the pin.
+    return undefined;
+  }
+}
+
+export async function sendLocationCard(
+  conversationId: string,
+  payload: LocationCardPayload,
+  replyToMessageId?: string,
+): Promise<Message> {
+  return sendCardMessage(
+    conversationId,
+    "location",
+    "location",
     { ...payload },
     replyToMessageId,
   );

--- a/frontend/src/api/endpoints/messagingAdapter.ts
+++ b/frontend/src/api/endpoints/messagingAdapter.ts
@@ -129,6 +129,11 @@ export function adaptMessage(raw: RawMessage): Message {
     target_datetime: raw.target_datetime,
     associated_event_type: raw.associated_event_type,
     associated_event_id: raw.associated_event_id,
+    // Location-in-chat card fields (EPIC D: FE-130)
+    lat: raw.lat,
+    lng: raw.lng,
+    label: raw.label,
+    place_name: raw.place_name,
     // Trading-in-chat card fields (EPIC A)
     symbol_id: raw.symbol_id,
     symbol: raw.symbol,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1307,7 +1307,7 @@ export interface Message {
   message_id: string;
   conversation_id: string;
   sender_id: string;
-  kind: "text" | "image" | "file" | "audio" | "video" | "gallery" | "file_share" | "calendar_share" | "calendar_event" | "meeting_poll" | "video_share" | "voice_message" | "voicemail" | "countdown" | "gif" | "sticker" | "find_datetime" | "market_card" | "position_card" | "crypto_transfer" | "product_card" | "order_card";
+  kind: "text" | "image" | "file" | "audio" | "video" | "gallery" | "file_share" | "calendar_share" | "calendar_event" | "meeting_poll" | "video_share" | "voice_message" | "voicemail" | "countdown" | "gif" | "sticker" | "find_datetime" | "market_card" | "position_card" | "crypto_transfer" | "product_card" | "order_card" | "location";
   created_at: number;
   text?: string;
   image?: MessageImage;
@@ -1417,6 +1417,13 @@ export interface Message {
   amount_cents?: number | null;
   item_count?: number | null;
   items?: { name: string; quantity: number }[] | null;
+  // Location-in-chat card fields (EPIC D: FE-130). `location` carries a lat/lng
+  // pin, an optional user label and an optional BE-133 reverse-geocoded
+  // place_name. These ride on a normal message keyed by `kind`.
+  lat?: number | null;
+  lng?: number | null;
+  label?: string | null;
+  place_name?: string | null;
   // B-COUNTDOWN #31: the stashed reveal payload, surfaced ONLY once the countdown
   // target has passed. Present on any message that carried countdown_reveal_* on
   // send (not just the dedicated "countdown" kind).

--- a/frontend/src/lib/locationCards.test.ts
+++ b/frontend/src/lib/locationCards.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  directionsUrl,
+  formatCoords,
+  geoUri,
+  isValidLatLng,
+  locationPreview,
+  mapsOpenUrl,
+  staticMapThumbUrl,
+} from "./locationCards";
+
+const SF = { lat: 37.7749, lng: -122.4194 };
+
+describe("isValidLatLng", () => {
+  it("accepts a normal coordinate", () => {
+    expect(isValidLatLng(SF.lat, SF.lng)).toBe(true);
+  });
+  it("accepts the boundary values", () => {
+    expect(isValidLatLng(-90, -180)).toBe(true);
+    expect(isValidLatLng(90, 180)).toBe(true);
+    expect(isValidLatLng(0, 0)).toBe(true);
+  });
+  it("rejects out-of-range latitude", () => {
+    expect(isValidLatLng(90.1, 0)).toBe(false);
+    expect(isValidLatLng(-91, 0)).toBe(false);
+  });
+  it("rejects out-of-range longitude", () => {
+    expect(isValidLatLng(0, 180.1)).toBe(false);
+    expect(isValidLatLng(0, -181)).toBe(false);
+  });
+  it("rejects non-finite values", () => {
+    expect(isValidLatLng(NaN, 0)).toBe(false);
+    expect(isValidLatLng(0, Infinity)).toBe(false);
+  });
+  it("rejects non-number values", () => {
+    expect(isValidLatLng("37", "-122")).toBe(false);
+    expect(isValidLatLng(undefined, null)).toBe(false);
+  });
+});
+
+describe("formatCoords", () => {
+  it("formats to fixed 5 decimals", () => {
+    expect(formatCoords(SF.lat, SF.lng)).toBe("37.77490, -122.41940");
+  });
+  it("rounds and pads", () => {
+    expect(formatCoords(1, -2)).toBe("1.00000, -2.00000");
+  });
+});
+
+describe("mapsOpenUrl", () => {
+  it("builds a universal search link with coords when no label", () => {
+    const url = mapsOpenUrl(SF.lat, SF.lng);
+    expect(url).toContain("https://www.google.com/maps/search/?api=1&query=");
+    expect(url).toContain(encodeURIComponent("37.7749,-122.4194"));
+  });
+  it("includes the label in the query when supplied", () => {
+    const url = mapsOpenUrl(SF.lat, SF.lng, "The Cafe");
+    expect(url).toContain(encodeURIComponent("The Cafe"));
+    expect(url).toContain(encodeURIComponent("37.7749,-122.4194"));
+  });
+  it("ignores a blank label", () => {
+    const url = mapsOpenUrl(SF.lat, SF.lng, "   ");
+    expect(url).toBe(mapsOpenUrl(SF.lat, SF.lng));
+  });
+});
+
+describe("directionsUrl", () => {
+  it("builds a directions link with the destination", () => {
+    const url = directionsUrl(SF.lat, SF.lng);
+    expect(url).toContain("https://www.google.com/maps/dir/?api=1&destination=");
+    expect(url).toContain(encodeURIComponent("37.7749,-122.4194"));
+  });
+});
+
+describe("geoUri", () => {
+  it("builds a geo: uri", () => {
+    expect(geoUri(SF.lat, SF.lng)).toBe("geo:37.7749,-122.4194");
+  });
+});
+
+describe("staticMapThumbUrl", () => {
+  it("uses keyless OSM static map with a marker and defaults", () => {
+    const url = staticMapThumbUrl(SF.lat, SF.lng);
+    expect(url).toContain("staticmap.openstreetmap.de/staticmap.php");
+    expect(url).toContain(`center=${SF.lat},${SF.lng}`);
+    expect(url).toContain(`markers=${SF.lat},${SF.lng},red`);
+    expect(url).toContain("size=320x160");
+    expect(url).toContain("zoom=15");
+  });
+  it("honours custom size and zoom", () => {
+    const url = staticMapThumbUrl(SF.lat, SF.lng, { w: 200, h: 100, zoom: 12 });
+    expect(url).toContain("size=200x100");
+    expect(url).toContain("zoom=12");
+  });
+  it("carries no api key", () => {
+    expect(staticMapThumbUrl(SF.lat, SF.lng).toLowerCase()).not.toContain("key=");
+  });
+});
+
+describe("locationPreview", () => {
+  it("uses the label when present", () => {
+    expect(locationPreview("Home")).toBe("📍 Home");
+  });
+  it("falls back to place name", () => {
+    expect(locationPreview(undefined, "1 Market St")).toBe("📍 1 Market St");
+  });
+  it("falls back to a generic label", () => {
+    expect(locationPreview()).toBe("📍 Location");
+    expect(locationPreview("   ", "  ")).toBe("📍 Location");
+  });
+});

--- a/frontend/src/lib/locationCards.ts
+++ b/frontend/src/lib/locationCards.ts
@@ -1,0 +1,92 @@
+// Pure helpers for the location-in-chat card (EPIC D: FE-130). Kept
+// dependency-light so payload building, coordinate validation, the maps deep
+// links and previews are unit-testable without React or the network.
+
+// The wire/payload carried on a `location` message. `label` is a user-supplied
+// title ("Home", "The cafe"); `place_name` is an optional reverse-geocoded
+// address from BE-133 (degrade-on-404 => absent). Coordinates are plain floats.
+export interface LocationCardPayload {
+  lat: number;
+  lng: number;
+  label?: string;
+  place_name?: string;
+}
+
+/** Valid WGS84 coordinate: finite, lat in [-90,90], lng in [-180,180]. */
+export function isValidLatLng(lat: unknown, lng: unknown): boolean {
+  return (
+    typeof lat === "number" &&
+    typeof lng === "number" &&
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+/** e.g. "37.77490, -122.41940" -- fixed 5dp (~1.1m precision). */
+export function formatCoords(lat: number, lng: number): string {
+  return `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+}
+
+/**
+ * A universal Google Maps "search" link. On mobile the Maps app intercepts
+ * this URL and opens natively (drops a pin); on desktop it opens maps in the
+ * browser. When a label is supplied it rides as the query so the pin is named,
+ * with the coords appended to disambiguate.
+ */
+export function mapsOpenUrl(lat: number, lng: number, label?: string): string {
+  const coords = `${lat},${lng}`;
+  const query = label && label.trim() ? `${label.trim()} (${coords})` : coords;
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+}
+
+/** A universal Google Maps "directions" link (destination = the pin). */
+export function directionsUrl(lat: number, lng: number): string {
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
+    `${lat},${lng}`,
+  )}`;
+}
+
+/** RFC 5870 geo: URI -- lets a native geo handler take the coords directly. */
+export function geoUri(lat: number, lng: number): string {
+  return `geo:${lat},${lng}`;
+}
+
+export interface StaticMapOpts {
+  w?: number;
+  h?: number;
+  zoom?: number;
+}
+
+/**
+ * A keyless static-map thumbnail URL. Uses the OpenStreetMap community static
+ * map service (no API key required) with a red marker on the point. The
+ * renderer falls back to a pin placeholder onError so a provider outage / 404
+ * never breaks the card.
+ */
+export function staticMapThumbUrl(
+  lat: number,
+  lng: number,
+  opts: StaticMapOpts = {},
+): string {
+  const w = opts.w ?? 320;
+  const h = opts.h ?? 160;
+  const zoom = opts.zoom ?? 15;
+  const center = `${lat},${lng}`;
+  return (
+    `https://staticmap.openstreetmap.de/staticmap.php` +
+    `?center=${center}&zoom=${zoom}&size=${w}x${h}&markers=${center},red`
+  );
+}
+
+/** Conversation-list / reply preview: "📍 Home" / "📍 Location". */
+export function locationPreview(
+  label?: string | null,
+  placeName?: string | null,
+): string {
+  const name = (label ?? placeName ?? "").trim();
+  return name ? `📍 ${name}` : "📍 Location";
+}

--- a/frontend/src/pages/messages/ComposeBar.tsx
+++ b/frontend/src/pages/messages/ComposeBar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Send, Paperclip, Loader2, Lock, Eye, EyeOff, EyeOff as EyeSlash, Headphones, X, ImageIcon, Clock, Reply, Globe, DollarSign, FileText, Images, FolderOpen, CalendarDays, CalendarCheck, Users, Dices, Video, Mic, Timer, Smile, Sticker as StickerIcon, Plus, Check, TrendingUp, Activity, Package, ShoppingBag } from "lucide-react";
+import { Send, Paperclip, Loader2, Lock, Eye, EyeOff, EyeOff as EyeSlash, Headphones, X, ImageIcon, Clock, Reply, Globe, DollarSign, FileText, Images, FolderOpen, CalendarDays, CalendarCheck, Users, Dices, Video, Mic, Timer, Smile, Sticker as StickerIcon, Plus, Check, TrendingUp, Activity, Package, ShoppingBag, MapPin } from "lucide-react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { GifPicker } from "@/components/shared/GifPicker";
@@ -30,6 +30,8 @@ import { PositionCardComposerDialog } from "./PositionCardComposerDialog";
 import { CryptoSendComposerDialog } from "./CryptoSendComposerDialog";
 import { ProductCardComposerDialog } from "./ProductCardComposerDialog";
 import { OrderShareComposerDialog } from "./OrderShareComposerDialog";
+import { LocationComposerDialog } from "./LocationComposerDialog";
+import type { LocationCardPayload } from "@/lib/locationCards";
 import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
 import type { CryptoTransferPayload } from "@/lib/cryptoTransfer";
 import type { ProductCardPayload, OrderCardPayload } from "@/lib/ecomCards";
@@ -79,6 +81,7 @@ interface ComposeBarProps {
   onSendCryptoTransfer?: (payload: CryptoTransferPayload) => void;
   onSendProductCard?: (payload: ProductCardPayload) => void;
   onSendOrderCard?: (payload: OrderCardPayload) => void;
+  onSendLocation?: (payload: LocationCardPayload) => void;
   /** DM partner display name for the send-crypto composer attribution. */
   recipientName?: string;
   currentUserName?: string;
@@ -120,6 +123,7 @@ export function ComposeBar({
   onSendCryptoTransfer,
   onSendProductCard,
   onSendOrderCard,
+  onSendLocation,
   recipientName,
   currentUserName,
   onSendLottery,
@@ -244,6 +248,7 @@ export function ComposeBar({
   const [cryptoSendOpen, setCryptoSendOpen] = React.useState(false);
   const [productCardOpen, setProductCardOpen] = React.useState(false);
   const [orderCardOpen, setOrderCardOpen] = React.useState(false);
+  const [locationOpen, setLocationOpen] = React.useState(false);
   const [activeDraftId, setActiveDraftId] = React.useState<string | null>(null);
   const [draftDirty, setDraftDirty] = React.useState(false);
   const [lastDraftSavedAt, setLastDraftSavedAt] = React.useState<number | null>(null);
@@ -1677,7 +1682,7 @@ export function ComposeBar({
       <div className="flex items-end gap-2">
         {(onSendVoiceMessage || onSendGallery || onSendLottery || onSendFileShare || onSendVideoShare ||
           onSendCalendarShare || onSendCalendarEvent || onSendMeetingPoll || onSendFindDateTime ||
-          onSendCountdown || onSendMarketCard || onSendPositionCard || onSendCryptoTransfer || onSendProductCard || onSendOrderCard || draftsEnabled || (onSendTtsVoice && ttsEnabled)) && (
+          onSendCountdown || onSendMarketCard || onSendPositionCard || onSendCryptoTransfer || onSendProductCard || onSendOrderCard || onSendLocation || draftsEnabled || (onSendTtsVoice && ttsEnabled)) && (
           <Popover open={moreOpen} onOpenChange={setMoreOpen}>
             <PopoverTrigger asChild>
               <Button
@@ -1903,6 +1908,13 @@ export function ComposeBar({
                     onClick={() => { setOrderCardOpen(true); setMoreOpen(false); }} aria-label="Share purchase"
                     data-testid="compose-share-purchase">
                     <ShoppingBag className="h-4 w-4" /> Share purchase
+                  </Button>
+                )}
+                {onSendLocation && (
+                  <Button variant="ghost" className="h-9 justify-start gap-2 px-2"
+                    onClick={() => { setLocationOpen(true); setMoreOpen(false); }} aria-label="Share location"
+                    data-testid="compose-share-location">
+                    <MapPin className="h-4 w-4" /> Share location
                   </Button>
                 )}
                 {draftsEnabled && (
@@ -2276,6 +2288,16 @@ export function ComposeBar({
           onSubmit={(payload) => {
             onSendOrderCard(payload);
             setOrderCardOpen(false);
+          }}
+        />
+      )}
+      {onSendLocation && (
+        <LocationComposerDialog
+          open={locationOpen}
+          onClose={() => setLocationOpen(false)}
+          onSubmit={(payload) => {
+            onSendLocation(payload);
+            setLocationOpen(false);
           }}
         />
       )}

--- a/frontend/src/pages/messages/ConversationList.tsx
+++ b/frontend/src/pages/messages/ConversationList.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { locationPreview } from "@/lib/locationCards";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Search, Plus, MessageSquare, Users, BellOff } from "lucide-react";
@@ -352,6 +353,8 @@ function getPreviewText(lastMsg: Message | undefined, convo: Conversation, curre
       { sender_id: lastMsg.sender_id, asset: lastMsg.asset, amount: lastMsg.amount },
       currentUserId,
     );
+  if (lastMsg.kind === "location")
+    return locationPreview(lastMsg.label ?? undefined, lastMsg.place_name ?? undefined);
   return lastMsg.text ?? convo.last_message_preview ?? "No messages yet";
 }
 

--- a/frontend/src/pages/messages/ConversationView.tsx
+++ b/frontend/src/pages/messages/ConversationView.tsx
@@ -24,6 +24,7 @@ import {
   sendCryptoTransferMessage,
   sendProductCardMessage,
   sendOrderCardMessage,
+  sendLocationCard,
   createLotteryMessage,
   sendVoiceMessage,
   markRead,
@@ -43,6 +44,7 @@ import type { Conversation, Message, SendTextMessageReq, SendFileShareReq, SendC
 import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
 import type { CryptoTransferPayload } from "@/lib/cryptoTransfer";
 import type { ProductCardPayload, OrderCardPayload } from "@/lib/ecomCards";
+import type { LocationCardPayload } from "@/lib/locationCards";
 import { MessageBubble } from "./MessageBubble";
 import { ComposeBar } from "./ComposeBar";
 import { PresenceDot } from "./PresenceDot";
@@ -673,6 +675,15 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
       queryClient.invalidateQueries({ queryKey: ["conversations"] });
     },
     onError: () => toast.error("Failed to share purchase"),
+  });
+
+  const sendLocation = useMutation({
+    mutationFn: (payload: LocationCardPayload) => sendLocationCard(convoId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["messages", convoId] });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+    onError: () => toast.error("Failed to share location"),
   });
 
   const sendLottery = useMutation({
@@ -1598,6 +1609,7 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         onSendCryptoTransfer={!isGroup ? (payload) => sendCryptoTransfer.mutate(payload) : undefined}
         onSendProductCard={(payload) => sendProductCard.mutate(payload)}
         onSendOrderCard={(payload) => sendOrderCard.mutate(payload)}
+        onSendLocation={(payload) => sendLocation.mutate(payload)}
         recipientName={dmPartner?.display_name}
         currentUserName={currentUserName}
         onSendLottery={!isGroup && dmLotteryEnabled ? (params) => sendLottery.mutate(params) : undefined}

--- a/frontend/src/pages/messages/LocationCard.tsx
+++ b/frontend/src/pages/messages/LocationCard.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { MapPin, Navigation, ExternalLink } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  directionsUrl,
+  formatCoords,
+  mapsOpenUrl,
+  staticMapThumbUrl,
+  type LocationCardPayload,
+} from "@/lib/locationCards";
+
+export interface LocationCardProps {
+  payload: LocationCardPayload;
+}
+
+/**
+ * FE-130: an in-chat location pin. A keyless static-map thumbnail (OpenStreetMap
+ * static service) with a red marker, falling back to a graceful pin placeholder
+ * onError (no key / provider 404 => coords-only card, never a crash). Shows the
+ * user label and the BE-133 reverse-geocoded place_name (or the raw coords), plus
+ * "Open in Maps" + "Directions" universal links that open native maps on mobile.
+ * Pure presentation -- URL/preview building lives in lib/locationCards.
+ */
+export function LocationCard({ payload }: LocationCardProps) {
+  const { lat, lng, label, place_name } = payload;
+  const [thumbFailed, setThumbFailed] = useState(false);
+
+  const coords = formatCoords(lat, lng);
+  const primary = (label ?? "").trim() || (place_name ?? "").trim() || "Shared location";
+  const secondary =
+    (label ?? "").trim() && (place_name ?? "").trim()
+      ? (place_name as string).trim()
+      : coords;
+
+  const thumb = staticMapThumbUrl(lat, lng, { w: 320, h: 160, zoom: 15 });
+
+  return (
+    <Card className="w-72 max-w-full overflow-hidden" data-testid="location-card">
+      <div className="h-32 w-full bg-muted">
+        {thumbFailed ? (
+          <div
+            className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground"
+            data-testid="location-card-placeholder"
+          >
+            <MapPin className="h-8 w-8" />
+          </div>
+        ) : (
+          <img
+            src={thumb}
+            alt={`Map of ${primary}`}
+            className="h-full w-full object-cover"
+            loading="lazy"
+            onError={() => setThumbFailed(true)}
+            data-testid="location-card-thumb"
+          />
+        )}
+      </div>
+
+      <CardContent className="pt-3">
+        <div className="flex items-start gap-2">
+          <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-rose-500" />
+          <div className="min-w-0 flex-1">
+            <div
+              className="line-clamp-2 text-sm font-semibold"
+              data-testid="location-card-label"
+            >
+              {primary}
+            </div>
+            <div
+              className="mt-0.5 truncate text-xs text-muted-foreground tabular-nums"
+              data-testid="location-card-sub"
+            >
+              {secondary}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <Button
+            asChild
+            size="sm"
+            variant="outline"
+            data-testid="location-card-open"
+          >
+            <a
+              href={mapsOpenUrl(lat, lng, label)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ExternalLink className="mr-1 h-3.5 w-3.5" />
+              Open in Maps
+            </a>
+          </Button>
+          <Button asChild size="sm" data-testid="location-card-directions">
+            <a
+              href={directionsUrl(lat, lng)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Navigation className="mr-1 h-3.5 w-3.5" />
+              Directions
+            </a>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default LocationCard;

--- a/frontend/src/pages/messages/LocationComposerDialog.tsx
+++ b/frontend/src/pages/messages/LocationComposerDialog.tsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { Crosshair, Loader2, MapPin } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { reverseGeocode } from "@/api/endpoints/messaging";
+import { isValidLatLng, type LocationCardPayload } from "@/lib/locationCards";
+import { LocationCard } from "./LocationCard";
+
+interface LocationComposerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: LocationCardPayload) => void;
+}
+
+/**
+ * FE-130: "Share location" composer. Offers a one-tap "Use current location"
+ * (navigator.geolocation.getCurrentPosition; on deny/timeout/unsupported it
+ * surfaces a hint and falls back to manual entry) plus manual lat/lng fields and
+ * an optional label. On confirm it best-effort reverse-geocodes (BE-133,
+ * degrade-on-404 => skip place_name) and emits a LocationCardPayload; the caller
+ * POSTs via sendLocationCard which degrades-on-404 to a normal `location` message.
+ */
+export function LocationComposerDialog({
+  open,
+  onClose,
+  onSubmit,
+}: LocationComposerDialogProps) {
+  const [latStr, setLatStr] = useState("");
+  const [lngStr, setLngStr] = useState("");
+  const [label, setLabel] = useState("");
+  const [locating, setLocating] = useState(false);
+  const [geoError, setGeoError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const lat = Number(latStr);
+  const lng = Number(lngStr);
+  const valid = latStr.trim() !== "" && lngStr.trim() !== "" && isValidLatLng(lat, lng);
+
+  function reset() {
+    setLatStr("");
+    setLngStr("");
+    setLabel("");
+    setLocating(false);
+    setGeoError(null);
+    setSubmitting(false);
+  }
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  function useCurrentLocation() {
+    setGeoError(null);
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      setGeoError("Location is not available on this device. Enter coordinates manually.");
+      return;
+    }
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setLatStr(String(pos.coords.latitude));
+        setLngStr(String(pos.coords.longitude));
+        setLocating(false);
+      },
+      (err) => {
+        setLocating(false);
+        setGeoError(
+          err.code === err.PERMISSION_DENIED
+            ? "Location permission denied. Enter coordinates manually."
+            : "Could not get your location. Enter coordinates manually.",
+        );
+      },
+      { enableHighAccuracy: true, timeout: 10_000, maximumAge: 60_000 },
+    );
+  }
+
+  async function handleSubmit() {
+    if (!valid || submitting) return;
+    setSubmitting(true);
+    let placeName: string | undefined;
+    try {
+      placeName = await reverseGeocode(lat, lng);
+    } catch {
+      placeName = undefined;
+    }
+    const payload: LocationCardPayload = {
+      lat,
+      lng,
+      label: label.trim() || undefined,
+      place_name: placeName,
+    };
+    onSubmit(payload);
+    reset();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (!o ? handleClose() : undefined)}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share location</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full justify-center gap-2"
+            onClick={useCurrentLocation}
+            disabled={locating}
+            data-testid="location-composer-current"
+          >
+            {locating ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Crosshair className="h-4 w-4" />
+            )}
+            {locating ? "Locating…" : "Use current location"}
+          </Button>
+
+          {geoError && (
+            <p className="text-xs text-amber-600" data-testid="location-composer-error">
+              {geoError}
+            </p>
+          )}
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="mb-1 block text-xs text-muted-foreground">Latitude</label>
+              <Input
+                inputMode="decimal"
+                placeholder="37.7749"
+                value={latStr}
+                onChange={(e) => setLatStr(e.target.value)}
+                aria-label="Latitude"
+                data-testid="location-composer-lat"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-muted-foreground">Longitude</label>
+              <Input
+                inputMode="decimal"
+                placeholder="-122.4194"
+                value={lngStr}
+                onChange={(e) => setLngStr(e.target.value)}
+                aria-label="Longitude"
+                data-testid="location-composer-lng"
+              />
+            </div>
+          </div>
+
+          {latStr.trim() !== "" && lngStr.trim() !== "" && !valid && (
+            <p className="text-xs text-red-500">
+              Enter a valid coordinate (lat -90…90, lng -180…180).
+            </p>
+          )}
+
+          <div>
+            <label className="mb-1 block text-xs text-muted-foreground">
+              Label (optional)
+            </label>
+            <Input
+              placeholder="Home, the cafe, …"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              aria-label="Location label"
+              data-testid="location-composer-label"
+            />
+          </div>
+
+          {valid ? (
+            <div className="flex justify-center pt-1">
+              <LocationCard
+                payload={{ lat, lng, label: label.trim() || undefined }}
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-center gap-2 rounded-md border border-dashed py-6 text-sm text-muted-foreground">
+              <MapPin className="h-4 w-4" />
+              Set a location to preview the pin.
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!valid || submitting}
+            data-testid="location-composer-send"
+          >
+            {submitting ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+            Share
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default LocationComposerDialog;

--- a/frontend/src/pages/messages/MessageBubble.tsx
+++ b/frontend/src/pages/messages/MessageBubble.tsx
@@ -62,7 +62,9 @@ import { PositionCard } from "./PositionCard";
 import { CryptoTransferCard } from "./CryptoTransferCard";
 import { ProductCard } from "./ProductCard";
 import { OrderShareCard } from "./OrderShareCard";
+import { LocationCard } from "./LocationCard";
 import { orderCardPreview, productCardPreview, type OrderCardPayload, type ProductCardPayload } from "@/lib/ecomCards";
+import { locationPreview, type LocationCardPayload } from "@/lib/locationCards";
 import type { PositionCardPayload } from "@/lib/tradingCards";
 import type { CryptoTransferPayload, TransferStatus } from "@/lib/cryptoTransfer";
 import { WaveformPlayer } from "./WaveformPlayer";
@@ -219,6 +221,8 @@ function replyPreviewText(msg: Message): string {
     });
   if (msg.kind === "crypto_transfer")
     return `[Crypto: ${[msg.amount, msg.asset].filter(Boolean).join(" ")}]`;
+  if (msg.kind === "location")
+    return locationPreview(msg.label ?? undefined, msg.place_name ?? undefined);
   if (msg.kind === "file") return msg.file?.name ? `[File: ${msg.file.name}]` : "[File]";
   if (msg.is_encrypted) return "[Encrypted message]";
   return (msg.text ?? "").slice(0, 80) || "[Message]";
@@ -2050,6 +2054,19 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
           )}
 
           {/* ── GIF message (MSG-008) ── */}
+          {message.kind === "location" &&
+            message.lat != null &&
+            message.lng != null && (
+              <LocationCard
+                payload={{
+                  lat: message.lat,
+                  lng: message.lng,
+                  label: message.label ?? undefined,
+                  place_name: message.place_name ?? undefined,
+                } satisfies LocationCardPayload}
+              />
+            )}
+
           {message.kind === "gif" && message.gif_url && (
             <div className="max-w-xs" data-testid="gif-message">
               <img


### PR DESCRIPTION
## FE-130 — location composer + map pin renderer (EPIC D)

A location chat card: **"Share location"** composer (current location or manual coords + optional label) → static **map thumbnail + label + Open-in-Maps/Directions**; place names via BE-133 reverse-geocode. Degrade-on-404 (no key / endpoint / permission → coords-only card, never a crash).

### Web (6th card kind)
- **NEW** `lib/locationCards.ts` (+19 vitest) — `isValidLatLng`, `formatCoords`, `mapsOpenUrl`/`directionsUrl`/`geoUri`, keyless OSM `staticMapThumbUrl`, `locationPreview`.
- **NEW** `LocationCard.tsx` (img thumbnail + `onError` pin placeholder) + `LocationComposerDialog.tsx` (geolocation → manual fallback on deny/timeout).
- `sendLocationCard` + `reverseGeocode` in `messaging.ts`; `"location"` on `Message.kind` + adapter; ComposeBar action + ConversationView mutation + list preview.

### Android (4th sentinel — TLCARD1/TLXFER1/TLSHOP1/TLRVL1 → **TLLOC1**)
- **NEW** `LocationCardModel.kt` (+16 JVM tests) — TLLOC1 encode/parse (percent-escaped delimiters round-trip labels with `;`/commas/unicode; same OSM+Google URLs as web).
- **NEW** `LocationCardUi.kt` (Coil thumbnail + placeholder + ACTION_VIEW `geo:`/maps intents), `LocationComposer.kt` (COARSE-gated current location + manual fallback), `GeocodeApi`/Repository (BE-133 best-effort).
- `MessagingDomain` `MessageMedia.Location`; thread wiring; inbox preview masks the sentinel. Added `ACCESS_COARSE_LOCATION` to the main manifest.

### Note
While wiring the web adapter I found a latent pre-existing bug: `adaptMessage` whitelists fields and does **not** map the ecom/crypto card payloads on non-optimistic messages (those cards can drop fields on round-trip). Out of scope here; flagging for a follow-up.

### Gates
- Web: `tsc` 0 · build green · 19/19 vitest
- Android: BUILD SUCCESSFUL · `LocationCardModelTest` 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
