### PR TITLE
FE-131: live-location UI (web + Android) — completes EPIC D

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
@@ -299,6 +299,19 @@ sealed interface MessageMedia {
     data class Location(
         val card: com.testlogon.android.feature.messaging.LocationCardModel.LocationCard,
     ) : MessageMedia
+
+    /**
+     * FE-131 (EPIC D, <- BE-131) - a LIVE (moving-pin) location share. Rides a normal text message
+     * whose body carries an encoded
+     * [com.testlogon.android.feature.messaging.LiveLocationModel] payload behind the TLLIVE1 sentinel;
+     * [MessageDto.toMedia] parses the body into [share]. The renderer shows a static-map thumbnail that
+     * refreshes as lat/lng change, a pulsing LIVE badge + live countdown to expiry, and (for the
+     * sharer) a Stop button. Recipient position refresh depends on BE-131 relaying updates; without it
+     * it degrades to the last-known pin + LIVE badge + countdown + auto-expiry. Never crashes.
+     */
+    data class LiveLocation(
+        val share: com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare,
+    ) : MessageMedia
 }
 
 /** AND-137 — the kind of item a countdown is associated with (display/pass-through only). */
@@ -858,6 +871,10 @@ internal fun MessageDto.toMedia(): MessageMedia = when {
     // sentinel. Parse it FIRST so it renders as a card, not raw text; a non-card body falls through.
     // FE-130 (EPIC D) - a location card rides a normal text message behind the TLLOC1 sentinel. Parse
     // it FIRST so it renders as a map card, not raw text; a non-card body falls through.
+    // FE-131 (EPIC D) - a LIVE location share rides a normal text message behind the TLLIVE1 sentinel.
+    // Parse it FIRST so it renders as a live map card, not raw text; a non-card body falls through.
+    com.testlogon.android.feature.messaging.LiveLocationModel.parse(text) != null ->
+        MessageMedia.LiveLocation(com.testlogon.android.feature.messaging.LiveLocationModel.parse(text)!!)
     com.testlogon.android.feature.messaging.LocationCardModel.parse(text) != null ->
         MessageMedia.Location(com.testlogon.android.feature.messaging.LocationCardModel.parse(text)!!)
         com.testlogon.android.feature.messaging.EcomCardModel.parse(text) is com.testlogon.android.feature.messaging.EcomCardModel.ProductCard ->

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/livelocation/LiveLocationApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/livelocation/LiveLocationApi.kt
@@ -1,0 +1,117 @@
+package com.testlogon.android.data.messaging.livelocation
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Path
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FE-131 (EPIC D, <- BE-131) - LIVE location relay: start a share, post periodic position updates,
+ * and stop it. Matches the assumed BE-131 wire contract:
+ *   POST messaging/conversations/{id}/live-location/start  { duration_sec }        -> { share_id, started_at, expires_at }
+ *   POST messaging/live-location/{share_id}/update         { lat, lng }            -> 200
+ *   POST messaging/live-location/{share_id}/stop                                    -> 200
+ *
+ * DEGRADE-ON-404: the moving-pin relay requires BE-131. When the endpoint is missing (404) or the
+ * call fails, [LiveLocationRepository] returns null / false and the caller falls back to the local
+ * TLLIVE1 optimistic card (last-known pin + LIVE badge + countdown + auto-expiry). Paths are relative
+ * (no leading slash) so they resolve against the shared Retrofit base URL.
+ */
+interface LiveLocationApi {
+    @POST("messaging/conversations/{conversation_id}/live-location/start")
+    suspend fun start(
+        @Path("conversation_id") conversationId: String,
+        @Body body: StartLiveLocationRequestDto,
+    ): StartLiveLocationResponseDto
+
+    @POST("messaging/live-location/{share_id}/update")
+    suspend fun update(
+        @Path("share_id") shareId: String,
+        @Body body: LiveLocationUpdateRequestDto,
+    )
+
+    @POST("messaging/live-location/{share_id}/stop")
+    suspend fun stop(
+        @Path("share_id") shareId: String,
+    )
+}
+
+@JsonClass(generateAdapter = true)
+data class StartLiveLocationRequestDto(
+    @Json(name = "duration_sec") val durationSec: Long,
+)
+
+@JsonClass(generateAdapter = true)
+data class StartLiveLocationResponseDto(
+    @Json(name = "share_id") val shareId: String,
+    @Json(name = "started_at") val startedAt: Long,
+    @Json(name = "expires_at") val expiresAt: Long,
+)
+
+@JsonClass(generateAdapter = true)
+data class LiveLocationUpdateRequestDto(
+    @Json(name = "lat") val lat: Double,
+    @Json(name = "lng") val lng: Double,
+)
+
+/** A started live share as resolved by the backend (server-authoritative share_id + window). */
+data class StartedLiveShare(
+    val shareId: String,
+    val startedAtSec: Long,
+    val expiresAtSec: Long,
+)
+
+/**
+ * Degrade-safe wrapper over [LiveLocationApi]. Every method swallows failures (incl. a 404 when
+ * BE-131 is undeployed) and returns null/false so the UI never crashes and can fall back to the
+ * local optimistic TLLIVE1 card.
+ */
+interface LiveLocationRepository {
+    /** Returns the server share window, or null when the relay is unavailable (degrade to local). */
+    suspend fun start(conversationId: String, durationSec: Long): StartedLiveShare?
+
+    /** Best-effort position relay; true when the update was accepted. */
+    suspend fun update(shareId: String, lat: Double, lng: Double): Boolean
+
+    /** Best-effort stop; true when the stop was accepted. */
+    suspend fun stop(shareId: String): Boolean
+}
+
+@Singleton
+class DefaultLiveLocationRepository @Inject constructor(
+    private val api: LiveLocationApi,
+) : LiveLocationRepository {
+
+    override suspend fun start(conversationId: String, durationSec: Long): StartedLiveShare? =
+        runCatching {
+            val dto = api.start(conversationId, StartLiveLocationRequestDto(durationSec))
+            StartedLiveShare(dto.shareId, dto.startedAt, dto.expiresAt)
+        }.getOrNull()
+
+    override suspend fun update(shareId: String, lat: Double, lng: Double): Boolean =
+        runCatching { api.update(shareId, LiveLocationUpdateRequestDto(lat, lng)) }.isSuccess
+
+    override suspend fun stop(shareId: String): Boolean =
+        runCatching { api.stop(shareId) }.isSuccess
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LiveLocationApiModule {
+    @Provides
+    @Singleton
+    fun provideLiveLocationApi(retrofit: Retrofit): LiveLocationApi =
+        retrofit.create(LiveLocationApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideLiveLocationRepository(impl: DefaultLiveLocationRepository): LiveLocationRepository = impl
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/LiveLocationModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/LiveLocationModel.kt
@@ -1,0 +1,176 @@
+package com.testlogon.android.feature.messaging
+
+/**
+ * EPIC D (FE-131, <- BE-131) - pure, dependency-free model for LIVE location sharing in chat.
+ *
+ * Kept Android-free so all of: the duration options, the active/expiry math, the remaining-time
+ * labels, the update cadence and the TLLIVE1 encode/parse round-trip are JVM-unit-testable in
+ * isolation (LiveLocationModelTest). `nowSec` is always injected (never reads a clock) so the math
+ * is deterministic and integer-only.
+ *
+ * TRANSPORT (mirrors [LocationCardModel] / the TLLOC1 static-pin card - the degrade-safe path): a
+ * live share rides a NORMAL text message whose body is encoded behind the TLLIVE1 sentinel. An
+ * un-upgraded client just shows the plain text; an upgraded client parses it back into a live card.
+ * When BE-131 is present the sharer's periodic `update`s relay a fresh lat/lng to recipients; without
+ * it the card degrades to the LAST-KNOWN pin + a LIVE badge + a live countdown + auto-expiry.
+ *
+ * The message body carries: share_id, lat, lng, started_at, expires_at (+ optional stopped_at when
+ * the sharer stops early / a label). Field names mirror the assumed BE-131 wire contract.
+ */
+object LiveLocationModel {
+
+    const val SENTINEL: String = "TLLIVE1:"
+
+    /** A visible pin marker used in previews (emoji, unicode-escaped for source safety). */
+    const val PIN: String = "📍"
+
+    /** How often the sharer posts a position update while the share is active AND foregrounded. */
+    const val UPDATE_INTERVAL_SEC: Long = 15L
+
+    /** Selectable share durations (seconds): 15 minutes, 1 hour, 8 hours. */
+    val LIVE_DURATION_OPTIONS: List<DurationOption> = listOf(
+        DurationOption(15 * 60L, "15 minutes"),
+        DurationOption(60 * 60L, "1 hour"),
+        DurationOption(8 * 60 * 60L, "8 hours"),
+    )
+
+    data class DurationOption(val seconds: Long, val label: String)
+
+    data class LiveShare(
+        val shareId: String,
+        val lat: Double,
+        val lng: Double,
+        val startedAtSec: Long,
+        val expiresAtSec: Long,
+        val stoppedAtSec: Long? = null,
+        val label: String? = null,
+    )
+
+    /** expires_at = started_at + duration (clamped so a non-positive duration yields started_at). */
+    fun computeExpiresAt(startedAtSec: Long, durationSec: Long): Long =
+        startedAtSec + (if (durationSec > 0L) durationSec else 0L)
+
+    /**
+     * A share is ACTIVE when it has neither been stopped nor expired at [nowSec]. A stop time in the
+     * future is ignored (treated as not-yet-stopped) so a clock skew never prematurely ends a share.
+     */
+    fun isLiveActive(expiresAtSec: Long, stoppedAtSec: Long?, nowSec: Long): Boolean {
+        if (stoppedAtSec != null && stoppedAtSec <= nowSec) return false
+        return nowSec < expiresAtSec
+    }
+
+    fun isLiveActive(share: LiveShare, nowSec: Long): Boolean =
+        isLiveActive(share.expiresAtSec, share.stoppedAtSec, nowSec)
+
+    /** Seconds until expiry, clamped to >= 0. */
+    fun liveSecondsRemaining(expiresAtSec: Long, nowSec: Long): Long {
+        val r = expiresAtSec - nowSec
+        return if (r > 0L) r else 0L
+    }
+
+    /**
+     * The sharer's periodic updater should auto-stop once the share is no longer active (expired OR
+     * stopped). Pure predicate so the coroutine loop's exit condition is unit-testable.
+     */
+    fun shouldAutoStop(expiresAtSec: Long, stoppedAtSec: Long?, nowSec: Long): Boolean =
+        !isLiveActive(expiresAtSec, stoppedAtSec, nowSec)
+
+    /** Compact remaining-time label, e.g. "8h 0m left", "14m left", "45s left", "Ended". */
+    fun liveRemainingLabel(expiresAtSec: Long, stoppedAtSec: Long?, nowSec: Long): String {
+        if (!isLiveActive(expiresAtSec, stoppedAtSec, nowSec)) return "Ended"
+        val rem = liveSecondsRemaining(expiresAtSec, nowSec)
+        val h = rem / 3600L
+        val m = (rem % 3600L) / 60L
+        val s = rem % 60L
+        return when {
+            h > 0L -> "${h}h ${m}m left"
+            m > 0L -> "${m}m left"
+            else -> "${s}s left"
+        }
+    }
+
+    fun preview(share: LiveShare?): String = "$PIN Live location"
+
+    /** Conversation-list / reply preview for a live-location body (masks the TLLIVE1 sentinel). */
+    fun previewForBody(body: String?): String? = if (isCard(body)) "$PIN Live location" else null
+
+    fun isCard(body: String?): Boolean = body != null && body.startsWith(SENTINEL)
+
+    fun encode(share: LiveShare): String {
+        val sb = StringBuilder(SENTINEL)
+        sb.append(kv("id", share.shareId))
+        sb.append(SEP).append(kv("lat", share.lat.toString()))
+        sb.append(SEP).append(kv("lng", share.lng.toString()))
+        sb.append(SEP).append(kv("start", share.startedAtSec.toString()))
+        sb.append(SEP).append(kv("exp", share.expiresAtSec.toString()))
+        share.stoppedAtSec?.let { sb.append(SEP).append(kv("stop", it.toString())) }
+        share.label?.takeIf { it.isNotBlank() }?.let { sb.append(SEP).append(kv("label", it)) }
+        return sb.toString()
+    }
+
+    /**
+     * Parse a body into a [LiveShare], or null when not a well-formed live-location card. Required
+     * fields: id, lat, lng, start, exp. Out-of-range coords or unparsable numbers reject to null so a
+     * malformed body degrades to a plain text bubble (never crashes).
+     */
+    fun parse(body: String?): LiveShare? {
+        if (body == null || !body.startsWith(SENTINEL)) return null
+        val payload = body.substring(SENTINEL.length)
+        val map = HashMap<String, String>()
+        for (seg in payload.split(SEP)) {
+            val eq = seg.indexOf(EQ)
+            if (eq <= 0) continue
+            map[unescape(seg.substring(0, eq))] = unescape(seg.substring(eq + 1))
+        }
+        val id = map["id"]?.takeIf { it.isNotBlank() } ?: return null
+        val lat = map["lat"]?.toDoubleOrNull() ?: return null
+        val lng = map["lng"]?.toDoubleOrNull() ?: return null
+        if (!LocationCardModel.isValidLatLng(lat, lng)) return null
+        val start = map["start"]?.toLongOrNull() ?: return null
+        val exp = map["exp"]?.toLongOrNull() ?: return null
+        return LiveShare(
+            shareId = id,
+            lat = lat,
+            lng = lng,
+            startedAtSec = start,
+            expiresAtSec = exp,
+            stoppedAtSec = map["stop"]?.toLongOrNull(),
+            label = map["label"]?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private const val SEP: Char = ';'
+    private const val EQ: Char = '='
+
+    private fun kv(k: String, v: String): String = escape(k) + "=" + escape(v)
+
+    private fun escape(s: String): String {
+        val sb = StringBuilder(s.length)
+        for (c in s) {
+            when (c) {
+                '%' -> sb.append("%25")
+                ';' -> sb.append("%3B")
+                '=' -> sb.append("%3D")
+                '\n' -> sb.append("%0A")
+                '\r' -> sb.append("%0D")
+                else -> sb.append(c)
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun unescape(s: String): String {
+        if (s.indexOf('%') < 0) return s
+        val sb = StringBuilder(s.length)
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            if (c == '%' && i + 2 < s.length) {
+                val code = s.substring(i + 1, i + 3).toIntOrNull(16)
+                if (code != null) { sb.append(code.toChar()); i += 3; continue }
+            }
+            sb.append(c); i++
+        }
+        return sb.toString()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/list/ConversationListUiState.kt
@@ -43,7 +43,8 @@ internal fun Conversation.toRow(): ConversationRow = ConversationRow(
     // leaks into the inbox row; the inner content is never shown here (viewer-agnostic).
     // FE-130 (EPIC D) - mask a location-card last message so the raw TLLOC1 sentinel never leaks into
     // the inbox row; falls through the reveal mask, then to the server text preview.
-    preview = com.testlogon.android.feature.messaging.LocationCardModel.previewForBody(lastMessagePreview)
+    preview = com.testlogon.android.feature.messaging.LiveLocationModel.previewForBody(lastMessagePreview)
+        ?: com.testlogon.android.feature.messaging.LocationCardModel.previewForBody(lastMessagePreview)
         ?: com.testlogon.android.feature.messaging.RevealAtMath.previewForBody(lastMessagePreview)
         ?: lastMessagePreview,
     lastActivityEpochSeconds = lastActivityEpochSeconds,

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LiveLocationCardUi.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LiveLocationCardUi.kt
@@ -1,0 +1,251 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.testlogon.android.feature.messaging.thread
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.SubcomposeAsyncImage
+import com.testlogon.android.feature.messaging.LiveLocationModel
+import com.testlogon.android.feature.messaging.LocationCardModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+
+object LiveLocationCardTestTags {
+    const val CARD = "thread_live_location_card"
+    const val THUMB = "thread_live_location_card_thumb"
+    const val THUMB_FALLBACK = "thread_live_location_card_thumb_fallback"
+    const val LIVE_BADGE = "thread_live_location_live_badge"
+    const val COUNTDOWN = "thread_live_location_countdown"
+    const val OPEN = "thread_live_location_open"
+    const val STOP = "thread_live_location_stop"
+    const val ENDED = "thread_live_location_ended"
+}
+
+/**
+ * FE-131 (EPIC D, BE-131) - the live-location chat card. Reuses the FE-130 static-map thumbnail
+ * (which re-composes as [LiveLocationModel.LiveShare.lat]/lng change, so a relayed position update
+ * moves the pin), a pulsing LIVE badge + a live 1s countdown to expiry, and "Open in Maps". The
+ * SHARER ([isOwn]) also sees a "Stop sharing" button while the share is active. When the share is
+ * stopped or expires the card flips to a static "Live location ended" state (auto-expiry needs no
+ * round-trip - the 1s ticker crossing [LiveLocationModel.LiveShare.expiresAtSec] flips it).
+ *
+ * The 1s ticker is lifecycle-scoped (collectAsStateWithLifecycle pauses it below STARTED) - the same
+ * no-leak idiom as [RevealLockedBubble] / the reveal countdown.
+ *
+ * @param onStop invoked when the sharer taps Stop (only rendered when [isOwn] AND active).
+ */
+@Composable
+fun LiveLocationCard(
+    share: LiveLocationModel.LiveShare,
+    isOwn: Boolean,
+    onStop: () -> Unit,
+    modifier: Modifier = Modifier,
+    nowProvider: () -> Long = { System.currentTimeMillis() / 1000L },
+) {
+    val context = LocalContext.current
+
+    val now by remember(share.expiresAtSec, share.stoppedAtSec) {
+        flow {
+            while (true) {
+                emit(nowProvider())
+                delay(1_000L)
+            }
+        }
+    }.collectAsStateWithLifecycle(initialValue = nowProvider())
+
+    val active = LiveLocationModel.isLiveActive(share.expiresAtSec, share.stoppedAtSec, now)
+    val remainingLabel = LiveLocationModel.liveRemainingLabel(share.expiresAtSec, share.stoppedAtSec, now)
+    val coords = LocationCardModel.formatCoords(share.lat, share.lng)
+    val primary = share.label?.takeIf { it.isNotBlank() } ?: "Live location"
+    val cd = if (active) {
+        "Live location, $remainingLabel, $coords"
+    } else {
+        "Live location ended, last seen $coords"
+    }
+
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = modifier
+            .widthIn(max = 260.dp)
+            .testTag(LiveLocationCardTestTags.CARD)
+            .semantics { contentDescription = cd },
+    ) {
+        Column {
+            Box {
+                SubcomposeAsyncImage(
+                    // Re-composes when lat/lng change -> the pin moves as updates arrive.
+                    model = LocationCardModel.staticMapThumbUrl(share.lat, share.lng),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    loading = { MapThumbPlaceholderLive() },
+                    error = { MapThumbPlaceholderLive() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(2f)
+                        .testTag(LiveLocationCardTestTags.THUMB),
+                )
+                if (active) {
+                    LivePulseBadge(
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(8.dp),
+                    )
+                }
+            }
+            Column(Modifier.padding(12.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Filled.Place,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Text(
+                        primary,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(start = 6.dp),
+                    )
+                }
+                Text(
+                    text = if (active) remainingLabel else "Live location ended",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (active) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    modifier = Modifier
+                        .padding(top = 2.dp, start = 24.dp)
+                        .testTag(if (active) LiveLocationCardTestTags.COUNTDOWN else LiveLocationCardTestTags.ENDED),
+                )
+                Row(
+                    Modifier.fillMaxWidth().padding(top = 10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { openLiveMaps(context, share) },
+                        modifier = Modifier.weight(1f).testTag(LiveLocationCardTestTags.OPEN),
+                    ) { Text("Open in Maps") }
+                    if (isOwn && active) {
+                        OutlinedButton(
+                            onClick = onStop,
+                            modifier = Modifier.testTag(LiveLocationCardTestTags.STOP),
+                        ) {
+                            Icon(Icons.Filled.Stop, contentDescription = "Stop sharing", modifier = Modifier.size(18.dp))
+                            Text("  Stop")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LivePulseBadge(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "live_pulse")
+    val alpha by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = 0.35f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(700),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "live_pulse_alpha",
+    )
+    Surface(
+        color = Color(0xFFD32F2F),
+        shape = RoundedCornerShape(8.dp),
+        modifier = modifier.testTag(LiveLocationCardTestTags.LIVE_BADGE),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        ) {
+            Box(
+                Modifier
+                    .size(8.dp)
+                    .alpha(alpha)
+                    .clip(CircleShape)
+                    .background(Color.White),
+            )
+            Text(
+                "LIVE",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                modifier = Modifier.padding(start = 6.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MapThumbPlaceholderLive() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .testTag(LiveLocationCardTestTags.THUMB_FALLBACK),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Filled.Place,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(40.dp),
+        )
+    }
+}
+
+private fun openLiveMaps(context: android.content.Context, share: LiveLocationModel.LiveShare) {
+    val geo = LocationCardModel.geoUri(share.lat, share.lng)
+    val web = LocationCardModel.mapsOpenUrl(share.lat, share.lng, share.label)
+    val ok = runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(geo))) }.isSuccess
+    if (!ok) runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(web))) }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LiveLocationComposer.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/LiveLocationComposer.kt
@@ -1,0 +1,161 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.testlogon.android.feature.messaging.thread
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.testlogon.android.feature.messaging.LiveLocationModel
+
+object LiveLocationComposerTestTags {
+    const val ATTACH = "thread_attach_live_location"
+    const val SHEET = "thread_live_location_composer"
+    const val DURATION_PREFIX = "thread_live_location_duration_"
+    const val START = "thread_live_location_start"
+}
+
+/**
+ * FE-131 (EPIC D, BE-131) - "Share live location" composer. The user picks a duration (15m/1h/8h),
+ * then Start captures a current location fix (COARSE-permission gated; deny/unsupported surfaces a
+ * clear error and blocks start - a moving pin needs a real fix). On start it hands the first fix +
+ * chosen duration to [onStart]; the ViewModel starts the (optionally BE-131-backed) session, emits
+ * the optimistic TLLIVE1 card, and drives periodic updates while foregrounded.
+ *
+ * @param onStart (lat, lng, durationSec) for the initial fix + chosen window.
+ */
+@Composable
+fun LiveLocationComposerSheet(
+    onStart: (lat: Double, lng: Double, durationSec: Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    var durationSec by remember { mutableStateOf(LiveLocationModel.LIVE_DURATION_OPTIONS.first().seconds) }
+    var note by remember { mutableStateOf<String?>(null) }
+    var starting by remember { mutableStateOf(false) }
+
+    fun currentFix(): android.location.Location? {
+        val lm = context.getSystemService(android.content.Context.LOCATION_SERVICE) as? LocationManager
+            ?: return null
+        return runCatching {
+            lm.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
+                ?: lm.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+                ?: lm.getLastKnownLocation(LocationManager.PASSIVE_PROVIDER)
+        }.getOrNull()
+    }
+
+    fun startWithFix() {
+        val loc = currentFix()
+        if (loc == null) {
+            note = "No recent location fix available. Try again once your location is known."
+            return
+        }
+        starting = true
+        onStart(loc.latitude, loc.longitude, durationSec)
+    }
+
+    val permLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) startWithFix() else note = "Location permission is required to share your live location."
+    }
+
+    fun onStartClicked() {
+        note = null
+        val coarse = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+        if (coarse == PackageManager.PERMISSION_GRANTED) startWithFix()
+        else permLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag(LiveLocationComposerTestTags.SHEET).semantics { testTagsAsResourceId = true },
+    ) {
+        Column(Modifier.fillMaxWidth().navigationBarsPadding().padding(16.dp)) {
+            Text("Share live location", style = MaterialTheme.typography.titleMedium)
+            Text(
+                "Recipients see your position update until it expires.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+
+            Text(
+                "Duration",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 14.dp),
+            )
+            LiveLocationModel.LIVE_DURATION_OPTIONS.forEach { opt ->
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = durationSec == opt.seconds,
+                            onClick = { durationSec = opt.seconds; note = null },
+                        )
+                        .padding(vertical = 6.dp)
+                        .testTag(LiveLocationComposerTestTags.DURATION_PREFIX + opt.seconds),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(selected = durationSec == opt.seconds, onClick = null)
+                    Text(opt.label, modifier = Modifier.padding(start = 8.dp))
+                }
+            }
+
+            note?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+
+            Button(
+                onClick = { onStartClicked() },
+                enabled = !starting,
+                modifier = Modifier.fillMaxWidth().padding(top = 16.dp).testTag(LiveLocationComposerTestTags.START),
+            ) {
+                if (starting) {
+                    CircularProgressIndicator(Modifier.size(18.dp))
+                } else {
+                    Icon(Icons.Filled.MyLocation, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Text("  Share live location")
+                }
+            }
+            Box(Modifier.fillMaxWidth().heightIn(min = 16.dp))
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.CurrencyBitcoin
+import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.ReceiptLong
 import androidx.compose.material.icons.filled.ShoppingBag
@@ -463,6 +464,10 @@ fun ThreadRoute(
         onDismissLocation = viewModel::onDismissLocation,
         onReverseGeocode = viewModel::reverseGeocode,
         onSendLocationCard = viewModel::onSendLocationCard,
+        onAttachLiveLocation = viewModel::onAttachLiveLocation,
+        onDismissLiveLocation = viewModel::onDismissLiveLocation,
+        onStartLiveLocation = viewModel::onStartLiveLocation,
+        onStopLiveLocation = viewModel::onStopLiveLocation,
         onOpenMessageOptions = viewModel::openMessageOptions,
         onClearMessageOptions = viewModel::clearMessageOptions,
         onRemoveStagedImage = viewModel::onRemoveStagedImage,
@@ -1124,6 +1129,10 @@ fun ThreadScreen(
     onDismissLocation: () -> Unit = {},
     onReverseGeocode: suspend (Double, Double) -> String? = { _, _ -> null },
     onSendLocationCard: (String) -> Unit = {},
+    onAttachLiveLocation: () -> Unit = {},
+    onDismissLiveLocation: () -> Unit = {},
+    onStartLiveLocation: (lat: Double, lng: Double, durationSec: Long) -> Unit = { _, _, _ -> },
+    onStopLiveLocation: (com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare) -> Unit = {},
     onCryptoSelectAsset: (String) -> Unit = {},
     onCryptoAmountChange: (String) -> Unit = {},
     onCryptoMax: () -> Unit = {},
@@ -1487,6 +1496,7 @@ fun ThreadScreen(
                         onAttachProductCard = onAttachProductCard,
                         onAttachOrderCard = onAttachOrderCard,
                         onAttachLocation = onAttachLocation,
+                        onAttachLiveLocation = onAttachLiveLocation,
                         onOpenMessageOptions = onOpenMessageOptions,
                         onClearMessageOptions = onClearMessageOptions,
                         onRemoveStagedImage = onRemoveStagedImage,
@@ -1565,6 +1575,7 @@ fun ThreadScreen(
                     pollVoter = pollVoter,
                     onOpenSymbol = onOpenSymbol,
                     onOpenProduct = onOpenProduct,
+                    onStopLiveLocation = onStopLiveLocation,
                     nowSeconds = nowSeconds,
                 )
             }
@@ -1720,6 +1731,12 @@ fun ThreadScreen(
             onDismiss = onDismissLocation,
         )
     }
+    if (state.liveLocationComposer.visible) {
+        LiveLocationComposerSheet(
+            onStart = onStartLiveLocation,
+            onDismiss = onDismissLiveLocation,
+        )
+    }
 
     if (state.tipSheet.messageId != null) {
         TipSheet(
@@ -1772,6 +1789,7 @@ private fun replyQuoteSnippet(m: ThreadMessageUi): String {
     (m.media as? MessageMedia.ProductCard)?.let { return com.testlogon.android.feature.messaging.EcomCardModel.productPreview(it.card) }
     (m.media as? MessageMedia.OrderCard)?.let { return com.testlogon.android.feature.messaging.EcomCardModel.orderPreview(it.card) }
     (m.media as? MessageMedia.Location)?.let { return com.testlogon.android.feature.messaging.LocationCardModel.preview(it.card) }
+    (m.media as? MessageMedia.LiveLocation)?.let { return com.testlogon.android.feature.messaging.LiveLocationModel.preview(it.share) }
     val text = m.text.trim()
     if (text.isNotBlank()) return text
     return when (m.media) {
@@ -1792,6 +1810,7 @@ private fun replyQuoteSnippet(m: ThreadMessageUi): String {
         is MessageMedia.ProductCard -> com.testlogon.android.feature.messaging.EcomCardModel.productPreview((m.media as MessageMedia.ProductCard).card)
         is MessageMedia.OrderCard -> com.testlogon.android.feature.messaging.EcomCardModel.orderPreview((m.media as MessageMedia.OrderCard).card)
         is MessageMedia.Location -> com.testlogon.android.feature.messaging.LocationCardModel.preview((m.media as MessageMedia.Location).card)
+        is MessageMedia.LiveLocation -> com.testlogon.android.feature.messaging.LiveLocationModel.preview((m.media as MessageMedia.LiveLocation).share)
         is MessageMedia.Countdown -> "[countdown]"
         is MessageMedia.CalendarEvent, is MessageMedia.CalendarShare -> "[calendar]"
         is MessageMedia.RevealLocked -> com.testlogon.android.feature.messaging.RevealAtMath.LOCKED_PREVIEW
@@ -1825,6 +1844,7 @@ private fun ThreadList(
     pollVoter: com.testlogon.android.data.poll.PollVoter? = null,
     onOpenSymbol: (Int) -> Unit = {},
     onOpenProduct: (categoryId: String, itemId: String) -> Unit = { _, _ -> },
+    onStopLiveLocation: (com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare) -> Unit = {},
     nowSeconds: Long,
 ) {
     // reverseLayout: index 0 is the newest message at the visual bottom.
@@ -1864,6 +1884,7 @@ private fun ThreadList(
                     marketCards = state.marketCards,
                     onOpenSymbol = onOpenSymbol,
                     onOpenProduct = onOpenProduct,
+                    onStopLiveLocation = onStopLiveLocation,
                     onRetry = { onRetrySend(message.key) },
                     onOpenImage = onOpenImage,
                     onOpenGalleryVideo = onOpenGalleryVideo,
@@ -1980,6 +2001,7 @@ private fun MessageBubble(
     marketCards: Map<Int, MarketCardLive> = emptyMap(),
     onOpenSymbol: (Int) -> Unit = {},
     onOpenProduct: (categoryId: String, itemId: String) -> Unit = { _, _ -> },
+    onStopLiveLocation: (com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare) -> Unit = {},
     onRetry: () -> Unit,
     onOpenImage: (String) -> Unit,
     onOpenGalleryVideo: (String) -> Unit = {},
@@ -2175,6 +2197,11 @@ private fun MessageBubble(
                     is MessageMedia.ProductCard -> ProductCard(card = inner.card, onBuy = onOpenProduct)
                     is MessageMedia.OrderCard -> OrderShareCard(card = inner.card)
                     is MessageMedia.Location -> LocationCard(card = inner.card)
+                    is MessageMedia.LiveLocation -> LiveLocationCard(
+                        share = inner.share,
+                        isOwn = message.isOwn,
+                        onStop = {},
+                    )
                     else -> Surface(
                         color = bubbleColor,
                         contentColor = if (message.isOwn) {
@@ -2286,6 +2313,11 @@ private fun MessageBubble(
             )
             is MessageMedia.OrderCard -> OrderShareCard(card = media.card)
             is MessageMedia.Location -> LocationCard(card = media.card)
+            is MessageMedia.LiveLocation -> LiveLocationCard(
+                share = media.share,
+                isOwn = message.isOwn,
+                onStop = { onStopLiveLocation(media.share) },
+            )
             is MessageMedia.Paid -> PaidMessageBubble(
                 monetization = media.monetization,
                 isOwn = message.isOwn,
@@ -2826,6 +2858,7 @@ private fun MessageComposer(
     onAttachProductCard: () -> Unit = {},
     onAttachOrderCard: () -> Unit = {},
     onAttachLocation: () -> Unit = {},
+    onAttachLiveLocation: () -> Unit = {},
     onOpenMessageOptions: () -> Unit = {},
     onClearMessageOptions: () -> Unit = {},
     onRemoveStagedImage: (Int) -> Unit = {},
@@ -2999,6 +3032,12 @@ private fun MessageComposer(
                         modifier = Modifier.size(44.dp).testTag(LocationComposerTestTags.ATTACH),
                     ) {
                         Icon(Icons.Filled.Place, contentDescription = "Share location", tint = MaterialTheme.colorScheme.primary)
+                    }
+                    IconButton(
+                        onClick = { actionsExpanded = false; onAttachLiveLocation() },
+                        modifier = Modifier.size(44.dp).testTag(LiveLocationComposerTestTags.ATTACH),
+                    ) {
+                        Icon(Icons.Filled.MyLocation, contentDescription = "Share live location", tint = MaterialTheme.colorScheme.primary)
                     }
                 }
             }

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
@@ -101,6 +101,8 @@ data class ThreadUiState(
     val orderPicker: OrderPickerState = OrderPickerState(),
     /** FE-130 (EPIC D) — "Share location" composer sheet (map pin; hidden until opened). */
     val locationComposer: LocationComposerState = LocationComposerState(),
+    /** FE-131 (EPIC D) — "Share live location" duration-picker sheet (hidden until opened). */
+    val liveLocationComposer: LiveLocationComposerState = LiveLocationComposerState(),
     /** MSG — receiver passphrase-unlock dialog for an encrypted message (non-null key = open). */
     val encryptUnlock: EncryptUnlockState = EncryptUnlockState(),
     /** MSG — view-once viewer dialog (non-null key = open, showing the consumed content). */
@@ -324,6 +326,11 @@ data class OrderPick(
 
 /** FE-130 - "Share location" composer state. Just visibility; the sheet owns its transient input. */
 data class LocationComposerState(
+    val visible: Boolean = false,
+)
+
+/** FE-131 - "Share live location" composer state. Just visibility; the sheet owns its transient input. */
+data class LiveLocationComposerState(
     val visible: Boolean = false,
 )
 

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
@@ -114,6 +114,7 @@ class ThreadViewModel @Inject constructor(
     private val geocodeRepository: com.testlogon.android.data.messaging.geocode.GeocodeRepository,
     private val groupRepository: com.testlogon.android.data.messaging.group.GroupRepository,
     private val muteStore: com.testlogon.android.data.messaging.mute.ConversationMuteStore,
+    private val liveLocationRepository: com.testlogon.android.data.messaging.livelocation.LiveLocationRepository,
 ) : ViewModel() {
 
     /**
@@ -139,6 +140,11 @@ class ThreadViewModel @Inject constructor(
         get() = voicePlayerOrNull ?: playerFactory.create().also { voicePlayerOrNull = it }
 
     private var recorderObserver: kotlinx.coroutines.Job? = null
+
+    /** FE-131 - the running live-location updater loop (per active share); cancelled on stop/expiry/onCleared. */
+    private var liveLocationJob: kotlinx.coroutines.Job? = null
+    /** FE-131 - the clientId of the outbox message carrying the active live-location card (for re-encode on stop). */
+    private var liveLocationClientId: String? = null
     private var capturedPeaks: List<Float> = emptyList()
 
     /** Epoch-seconds clock; overridable in tests for deterministic optimistic timestamps. */
@@ -2649,6 +2655,136 @@ class ThreadViewModel @Inject constructor(
         }
     }
 
+    // ---- FE-131 (EPIC D, <- BE-131): LIVE location sharing ----
+
+    /** FE-131 - open the "Share live location" duration-picker sheet. */
+    fun onAttachLiveLocation() {
+        _state.update { it.copy(liveLocationComposer = LiveLocationComposerState(visible = true)) }
+    }
+
+    fun onDismissLiveLocation() {
+        _state.update { it.copy(liveLocationComposer = LiveLocationComposerState()) }
+    }
+
+    /**
+     * FE-131 - start a live-location share. The composer has captured the first fix + chosen duration.
+     *
+     * Flow: try BE-131 [LiveLocationRepository.start] to get a server-authoritative share_id/window;
+     * degrade-on-404 to a locally-minted share_id + locally-computed expiry (optimistic). Emit the
+     * TLLIVE1 card as a normal outbox text message (degrade-safe transport - renders as a live card on
+     * upgraded clients, plain text otherwise), then launch a single updater loop that, WHILE the share
+     * is active, posts a fresh fix every [LiveLocationModel.UPDATE_INTERVAL_SEC] (BE-131 relay) and
+     * re-encodes/re-sends the card body so the local pin + last-known coords advance too. The loop
+     * AUTO-STOPS the instant the share is no longer active (expiry), and is cancelled on manual stop or
+     * onCleared - one structured-concurrency job, no leak.
+     *
+     * NOTE: true background tracking would need a foreground service (out of scope). Updates flow only
+     * while the thread is foregrounded; the card's own countdown + auto-expiry are clock-driven so the
+     * card still ends correctly even with no further updates.
+     */
+    fun onStartLiveLocation(lat: Double, lng: Double, durationSec: Long) {
+        _state.update { it.copy(liveLocationComposer = LiveLocationComposerState()) }
+        val startedLocal = clock()
+        viewModelScope.launch {
+            val started = liveLocationRepository.start(conversationId, durationSec)
+            val shareId = started?.shareId ?: ("live_" + java.util.UUID.randomUUID().toString())
+            val startedAt = started?.startedAtSec ?: startedLocal
+            val expiresAt = started?.expiresAtSec
+                ?: com.testlogon.android.feature.messaging.LiveLocationModel.computeExpiresAt(startedAt, durationSec)
+
+            val share = com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare(
+                shareId = shareId,
+                lat = lat,
+                lng = lng,
+                startedAtSec = startedAt,
+                expiresAtSec = expiresAt,
+                stoppedAtSec = null,
+            )
+            val clientId = java.util.UUID.randomUUID().toString()
+            liveLocationClientId = clientId
+            val body = com.testlogon.android.feature.messaging.LiveLocationModel.encode(share)
+            repository.enqueueOptimistic(conversationId, clientId, body, clock())
+            repository.sendOutbox(conversationId, clientId, body)
+            _events.trySend(ThreadEvent.ScrollToBottom)
+
+            // If the relay was unavailable AND the app can't relay updates, the card still degrades to
+            // the last-known pin + LIVE badge + countdown + auto-expiry (no crash). Surface a soft hint.
+            if (started == null) {
+                _state.update { it.copy(transientMessage = "Live location shared. Recipients will see your last-known pin until it expires.") }
+            }
+
+            // Single updater loop: cancel any prior one first (only one active share per thread).
+            liveLocationJob?.cancel()
+            liveLocationJob = viewModelScope.launch {
+                var current = share
+                while (com.testlogon.android.feature.messaging.LiveLocationModel.isLiveActive(
+                        current.expiresAtSec, current.stoppedAtSec, clock(),
+                    )
+                ) {
+                    delay(com.testlogon.android.feature.messaging.LiveLocationModel.UPDATE_INTERVAL_SEC * 1000L)
+                    if (!com.testlogon.android.feature.messaging.LiveLocationModel.isLiveActive(
+                            current.expiresAtSec, current.stoppedAtSec, clock(),
+                        )
+                    ) break
+                    val fix = latestFix() ?: continue
+                    current = current.copy(lat = fix.first, lng = fix.second)
+                    // BE-131 relay (best-effort; no-op degrade when undeployed).
+                    liveLocationRepository.update(shareId, fix.first, fix.second)
+                    // Advance the local card body so the pin moves for this client too.
+                    repository.enqueueOptimistic(
+                        conversationId, clientId,
+                        com.testlogon.android.feature.messaging.LiveLocationModel.encode(current), clock(),
+                    )
+                }
+                // AUTO-STOP at expiry: mark the card ended + best-effort backend stop.
+                finalizeLiveShare(current, clientId, shareId)
+            }
+        }
+    }
+
+    /** FE-131 - manual "Stop sharing" tap from the card. Cancels the updater + ends the share now. */
+    fun onStopLiveLocation(share: com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare) {
+        liveLocationJob?.cancel()
+        liveLocationJob = null
+        val clientId = liveLocationClientId ?: java.util.UUID.randomUUID().toString()
+        viewModelScope.launch {
+            val ended = share.copy(stoppedAtSec = clock())
+            finalizeLiveShare(ended, clientId, share.shareId)
+        }
+    }
+
+    /** FE-131 - re-encode the (stopped/expired) share so the card flips to the ended state + relay stop. */
+    private suspend fun finalizeLiveShare(
+        share: com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare,
+        clientId: String,
+        shareId: String,
+    ) {
+        val ended = if (share.stoppedAtSec == null) share.copy(stoppedAtSec = clock()) else share
+        repository.enqueueOptimistic(
+            conversationId, clientId,
+            com.testlogon.android.feature.messaging.LiveLocationModel.encode(ended), clock(),
+        )
+        liveLocationRepository.stop(shareId)
+        if (liveLocationClientId == clientId) {
+            liveLocationClientId = null
+            liveLocationJob = null
+        }
+    }
+
+    /** FE-131 - best-effort current fix (lat,lng) from the last-known providers; null when unavailable. */
+    @android.annotation.SuppressLint("MissingPermission")
+    private fun latestFix(): Pair<Double, Double>? {
+        val lm = appContext.getSystemService(android.content.Context.LOCATION_SERVICE) as? android.location.LocationManager
+            ?: return null
+        val loc = runCatching {
+            lm.getLastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER)
+                ?: lm.getLastKnownLocation(android.location.LocationManager.GPS_PROVIDER)
+                ?: lm.getLastKnownLocation(android.location.LocationManager.PASSIVE_PROVIDER)
+        }.getOrNull() ?: return null
+        return loc.latitude to loc.longitude
+    }
+
+
     /**
      * FE-151 - send an order_share card as a normal text message. The mode is passed to the model
      * choke point [EcomCardModel.buildOrderPayload], which STRIPS the buyer name in receipt mode (no
@@ -3364,6 +3500,9 @@ class ThreadViewModel @Inject constructor(
         super.onCleared()
         recorderOrNull?.release()
         voicePlayerOrNull?.release()
+        // FE-131 - stop the location updater so no coroutine leaks past the thread closing.
+        liveLocationJob?.cancel()
+        liveLocationJob = null
     }
 
     private fun reduceLoadFailure(message: String) {

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
@@ -1297,7 +1297,16 @@ fun newThreadViewModel(
         fakeGeocodeRepository(),
         groupRepository,
         muteStore,
+        fakeLiveLocationRepository(),
     )
+
+/** FE-131 (EPIC D) — no-op live-location relay for thread tests (always degrades to local/optimistic). */
+private fun fakeLiveLocationRepository(): com.testlogon.android.data.messaging.livelocation.LiveLocationRepository =
+    object : com.testlogon.android.data.messaging.livelocation.LiveLocationRepository {
+        override suspend fun start(conversationId: String, durationSec: Long): com.testlogon.android.data.messaging.livelocation.StartedLiveShare? = null
+        override suspend fun update(shareId: String, lat: Double, lng: Double): Boolean = false
+        override suspend fun stop(shareId: String): Boolean = false
+    }
 
 /** FE-130 (EPIC D) — no-op reverse-geocode repo for thread tests (always degrades to null). */
 private fun fakeGeocodeRepository(): com.testlogon.android.data.messaging.geocode.GeocodeRepository =

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/LiveLocationModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/LiveLocationModelTest.kt
@@ -1,0 +1,131 @@
+package com.testlogon.android.feature.messaging
+
+import com.testlogon.android.feature.messaging.LiveLocationModel.LiveShare
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** EPIC D (FE-131) - pure active/expiry math, remaining-label, and TLLIVE1 encode/parse round-trip. */
+class LiveLocationModelTest {
+
+    private fun share(
+        exp: Long,
+        start: Long = 1_000L,
+        stop: Long? = null,
+        lat: Double = 37.7749,
+        lng: Double = -122.4194,
+        label: String? = null,
+    ) = LiveShare("sh_1", lat, lng, start, exp, stop, label)
+
+    @Test
+    fun duration_options_are_15m_1h_8h() {
+        assertEquals(3, LiveLocationModel.LIVE_DURATION_OPTIONS.size)
+        assertEquals(900L, LiveLocationModel.LIVE_DURATION_OPTIONS[0].seconds)
+        assertEquals(3600L, LiveLocationModel.LIVE_DURATION_OPTIONS[1].seconds)
+        assertEquals(28800L, LiveLocationModel.LIVE_DURATION_OPTIONS[2].seconds)
+    }
+
+    @Test
+    fun compute_expires_at_adds_duration_and_clamps() {
+        assertEquals(1900L, LiveLocationModel.computeExpiresAt(1000L, 900L))
+        assertEquals(1000L, LiveLocationModel.computeExpiresAt(1000L, 0L))
+        assertEquals(1000L, LiveLocationModel.computeExpiresAt(1000L, -50L))
+    }
+
+    @Test
+    fun is_live_active_true_before_expiry() {
+        assertTrue(LiveLocationModel.isLiveActive(2000L, null, 1999L))
+    }
+
+    @Test
+    fun is_live_active_false_at_and_after_expiry() {
+        assertFalse(LiveLocationModel.isLiveActive(2000L, null, 2000L))
+        assertFalse(LiveLocationModel.isLiveActive(2000L, null, 2001L))
+    }
+
+    @Test
+    fun is_live_active_false_when_stopped_before_now() {
+        assertFalse(LiveLocationModel.isLiveActive(9999L, 1500L, 1600L))
+    }
+
+    @Test
+    fun is_live_active_ignores_future_stop_time() {
+        // stop in the future (clock skew) does not prematurely end an otherwise-active share.
+        assertTrue(LiveLocationModel.isLiveActive(9999L, 5000L, 1600L))
+    }
+
+    @Test
+    fun seconds_remaining_clamps_to_zero() {
+        assertEquals(400L, LiveLocationModel.liveSecondsRemaining(2000L, 1600L))
+        assertEquals(0L, LiveLocationModel.liveSecondsRemaining(2000L, 2000L))
+        assertEquals(0L, LiveLocationModel.liveSecondsRemaining(2000L, 5000L))
+    }
+
+    @Test
+    fun should_auto_stop_is_inverse_of_active() {
+        assertFalse(LiveLocationModel.shouldAutoStop(2000L, null, 1999L))
+        assertTrue(LiveLocationModel.shouldAutoStop(2000L, null, 2000L))
+        assertTrue(LiveLocationModel.shouldAutoStop(9999L, 1500L, 1600L))
+    }
+
+    @Test
+    fun remaining_label_formats_by_magnitude() {
+        val start = 0L
+        assertEquals("8h 0m left", LiveLocationModel.liveRemainingLabel(28800L, null, start))
+        assertEquals("14m left", LiveLocationModel.liveRemainingLabel(900L, null, 60L))
+        assertEquals("45s left", LiveLocationModel.liveRemainingLabel(45L, null, 0L))
+        assertEquals("Ended", LiveLocationModel.liveRemainingLabel(45L, null, 100L))
+        assertEquals("Ended", LiveLocationModel.liveRemainingLabel(9999L, 50L, 100L))
+    }
+
+    @Test
+    fun encode_parse_round_trip_all_fields() {
+        val s = share(exp = 2000L, start = 1000L, stop = 1500L, label = "On my way")
+        val body = LiveLocationModel.encode(s)
+        assertTrue(body.startsWith(LiveLocationModel.SENTINEL))
+        val back = LiveLocationModel.parse(body)!!
+        assertEquals(s.shareId, back.shareId)
+        assertEquals(s.lat, back.lat, 0.0)
+        assertEquals(s.lng, back.lng, 0.0)
+        assertEquals(s.startedAtSec, back.startedAtSec)
+        assertEquals(s.expiresAtSec, back.expiresAtSec)
+        assertEquals(s.stoppedAtSec, back.stoppedAtSec)
+        assertEquals(s.label, back.label)
+    }
+
+    @Test
+    fun encode_parse_round_trip_minimal() {
+        val s = share(exp = 2000L)
+        val back = LiveLocationModel.parse(LiveLocationModel.encode(s))!!
+        assertEquals("sh_1", back.shareId)
+        assertNull(back.stoppedAtSec)
+        assertNull(back.label)
+    }
+
+    @Test
+    fun label_with_delimiters_round_trips() {
+        val s = share(exp = 2000L, label = "a;b=c%d")
+        val back = LiveLocationModel.parse(LiveLocationModel.encode(s))!!
+        assertEquals("a;b=c%d", back.label)
+    }
+
+    @Test
+    fun parse_rejects_non_card_and_malformed() {
+        assertNull(LiveLocationModel.parse(null))
+        assertNull(LiveLocationModel.parse("hello"))
+        assertNull(LiveLocationModel.parse(LiveLocationModel.SENTINEL + "lat=1;lng=2")) // missing id/start/exp
+        assertNull(LiveLocationModel.parse(LiveLocationModel.SENTINEL + "id=x;lat=999;lng=2;start=1;exp=2")) // bad coord
+        assertNull(LiveLocationModel.parse(LiveLocationModel.SENTINEL + "id=x;lat=1;lng=2;start=xx;exp=2")) // bad start
+    }
+
+    @Test
+    fun is_card_and_preview_mask_the_sentinel() {
+        val body = LiveLocationModel.encode(share(exp = 2000L))
+        assertTrue(LiveLocationModel.isCard(body))
+        assertFalse(LiveLocationModel.isCard("plain"))
+        assertEquals("${LiveLocationModel.PIN} Live location", LiveLocationModel.previewForBody(body))
+        assertNull(LiveLocationModel.previewForBody("plain"))
+    }
+}

--- a/frontend/src/api/endpoints/messaging.ts
+++ b/frontend/src/api/endpoints/messaging.ts
@@ -1047,6 +1047,52 @@ export async function sendLocationCard(
   );
 }
 
+// ---- Live location (EPIC D: FE-131 <- BE-131) --------------------------------
+//
+// The moving-pin relay REQUIRES BE-131. There is no degrade-on-404 fabrication
+// of a live share: if the start endpoint is absent the action must fail clearly
+// (the caller surfaces a toast) and the chat falls back to the FE-130 static
+// pin. `startLiveLocation` creates the `live_location` message server-side;
+// `updateLiveLocation` pushes each new fix; `stopLiveLocation` ends the share.
+
+export interface StartLiveLocationResp {
+  share_id: string;
+  started_at: number;
+  expires_at: number;
+  message?: Message;
+}
+
+/**
+ * Begin a live-location share for `durationSec`. Throws on any error (including
+ * a 404 when BE-131 is not deployed) so the composer can degrade with a clear
+ * toast -- we never fabricate a share that cannot actually relay position.
+ */
+export async function startLiveLocation(
+  conversationId: string,
+  durationSec: number,
+  initial?: { lat: number; lng: number },
+): Promise<StartLiveLocationResp> {
+  const res = await api.post<StartLiveLocationResp>(
+    `/messaging/conversations/${conversationId}/live-location/start`,
+    { duration_sec: durationSec, ...(initial ? { lat: initial.lat, lng: initial.lng } : {}) },
+  );
+  return res;
+}
+
+/** Push a new position for an active share. Best-effort per tick. */
+export async function updateLiveLocation(
+  shareId: string,
+  lat: number,
+  lng: number,
+): Promise<void> {
+  await api.post<unknown>(`/messaging/live-location/${shareId}/update`, { lat, lng });
+}
+
+/** End a share early (manual "Stop sharing" or on unmount). */
+export async function stopLiveLocation(shareId: string): Promise<void> {
+  await api.post<unknown>(`/messaging/live-location/${shareId}/stop`, {});
+}
+
 export async function sendGifMessage(
   conversationId: string,
   params: {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1307,7 +1307,7 @@ export interface Message {
   message_id: string;
   conversation_id: string;
   sender_id: string;
-  kind: "text" | "image" | "file" | "audio" | "video" | "gallery" | "file_share" | "calendar_share" | "calendar_event" | "meeting_poll" | "video_share" | "voice_message" | "voicemail" | "countdown" | "gif" | "sticker" | "find_datetime" | "market_card" | "position_card" | "crypto_transfer" | "product_card" | "order_card" | "location";
+  kind: "text" | "image" | "file" | "audio" | "video" | "gallery" | "file_share" | "calendar_share" | "calendar_event" | "meeting_poll" | "video_share" | "voice_message" | "voicemail" | "countdown" | "gif" | "sticker" | "find_datetime" | "market_card" | "position_card" | "crypto_transfer" | "product_card" | "order_card" | "location" | "live_location";
   created_at: number;
   text?: string;
   image?: MessageImage;
@@ -1424,6 +1424,16 @@ export interface Message {
   lng?: number | null;
   label?: string | null;
   place_name?: string | null;
+  // Live-location fields (EPIC D: FE-131 <- BE-131). `live_location` reuses
+  // lat/lng (the last-known position, updated in place as the sharer moves) plus
+  // a share id and the lifecycle timestamps. `live_active` is a convenience
+  // projection; live-ness is derived from expires_at/stopped_at + now.
+  share_id?: string | null;
+  started_at?: number | null;
+  // NOTE: expires_at is already declared on Message (scheduled reveal / view-once
+  // reuse it); live_location shares reuse that same field for the share expiry.
+  stopped_at?: number | null;
+  live_active?: boolean | null;
   // B-COUNTDOWN #31: the stashed reveal payload, surfaced ONLY once the countdown
   // target has passed. Present on any message that carried countdown_reveal_* on
   // send (not just the dedicated "countdown" kind).

--- a/frontend/src/lib/liveLocation.test.ts
+++ b/frontend/src/lib/liveLocation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIVE_DURATION_OPTIONS,
+  UPDATE_INTERVAL_SEC,
+  computeExpiresAt,
+  isLiveActive,
+  liveRemainingLabel,
+  liveSecondsRemaining,
+  shouldAutoStop,
+} from "./liveLocation";
+
+const T0 = 1_000_000; // an arbitrary epoch-second base
+
+describe("LIVE_DURATION_OPTIONS", () => {
+  it("offers 15m / 1h / 8h", () => {
+    expect(LIVE_DURATION_OPTIONS.map((o) => o.seconds)).toEqual([900, 3600, 28800]);
+  });
+});
+
+describe("UPDATE_INTERVAL_SEC", () => {
+  it("is a small positive cadence", () => {
+    expect(UPDATE_INTERVAL_SEC).toBeGreaterThan(0);
+    expect(UPDATE_INTERVAL_SEC).toBeLessThanOrEqual(60);
+  });
+});
+
+describe("computeExpiresAt", () => {
+  it("adds the duration to the start", () => {
+    expect(computeExpiresAt(T0, 900)).toBe(T0 + 900);
+  });
+  it("floors fractional inputs and clamps negative duration to 0", () => {
+    expect(computeExpiresAt(T0 + 0.9, 900.9)).toBe(T0 + 900);
+    expect(computeExpiresAt(T0, -5)).toBe(T0);
+  });
+});
+
+describe("isLiveActive", () => {
+  it("is active before expiry with no stop", () => {
+    expect(isLiveActive(T0 + 900, null, T0)).toBe(true);
+  });
+  it("is inactive at/after expiry", () => {
+    expect(isLiveActive(T0 + 900, null, T0 + 900)).toBe(false);
+    expect(isLiveActive(T0 + 900, null, T0 + 901)).toBe(false);
+  });
+  it("is inactive once stopped, even before expiry", () => {
+    expect(isLiveActive(T0 + 900, T0 + 100, T0 + 200)).toBe(false);
+  });
+});
+
+describe("liveSecondsRemaining", () => {
+  it("returns whole seconds left", () => {
+    expect(liveSecondsRemaining(T0 + 900, T0)).toBe(900);
+    expect(liveSecondsRemaining(T0 + 900, T0 + 135)).toBe(765);
+  });
+  it("clamps to 0 once expired", () => {
+    expect(liveSecondsRemaining(T0, T0 + 50)).toBe(0);
+  });
+});
+
+describe("liveRemainingLabel", () => {
+  it("formats mm:ss under an hour", () => {
+    // 900 - 645 = 255s = 4:15
+    expect(liveRemainingLabel(T0 + 900, null, T0 + 645)).toBe("Live · 4:15 left");
+  });
+  it("formats h:mm:ss at/over an hour", () => {
+    expect(liveRemainingLabel(T0 + 3725, null, T0)).toBe("Live · 1:02:05 left");
+  });
+  it("reports ended when stopped", () => {
+    expect(liveRemainingLabel(T0 + 900, T0 + 10, T0 + 20)).toBe("Live location ended");
+  });
+  it("reports ended when expired", () => {
+    expect(liveRemainingLabel(T0 + 900, null, T0 + 900)).toBe("Live location ended");
+  });
+});
+
+describe("shouldAutoStop", () => {
+  it("is false before expiry", () => {
+    expect(shouldAutoStop(T0 + 900, T0 + 899)).toBe(false);
+  });
+  it("is true at and after expiry", () => {
+    expect(shouldAutoStop(T0 + 900, T0 + 900)).toBe(true);
+    expect(shouldAutoStop(T0 + 900, T0 + 901)).toBe(true);
+  });
+});

--- a/frontend/src/lib/liveLocation.ts
+++ b/frontend/src/lib/liveLocation.ts
@@ -1,0 +1,76 @@
+// Pure helpers for live-location sharing in chat (EPIC D: FE-131 ← BE-131).
+// Kept dependency-light (no React, no network, integer/second math with `nowSec`
+// injected) so the active/expiry/countdown logic is unit-testable in isolation.
+// The rendering (LiveLocationCard) and the watcher/session (useLiveLocationShare)
+// reuse these. Coordinate/maps helpers come from ./locationCards (FE-130).
+
+/** Duration choices offered by the "Share live location" picker, in seconds. */
+export const LIVE_DURATION_OPTIONS: ReadonlyArray<{ label: string; seconds: number }> = [
+  { label: "15 minutes", seconds: 15 * 60 },
+  { label: "1 hour", seconds: 60 * 60 },
+  { label: "8 hours", seconds: 8 * 60 * 60 },
+];
+
+/**
+ * How often the sharer pushes a position update (seconds). Used both as the
+ * setInterval fallback cadence and as the geolocation `maximumAge` ceiling so a
+ * watchPosition callback never relays a stale fix.
+ */
+export const UPDATE_INTERVAL_SEC = 15;
+
+/** expires_at (epoch sec) for a share started at `startedAt` lasting `durationSec`. */
+export function computeExpiresAt(startedAt: number, durationSec: number): number {
+  return Math.floor(startedAt) + Math.max(0, Math.floor(durationSec));
+}
+
+/**
+ * Is the share live right now? Live means not manually stopped AND not past
+ * expiry. `stoppedAt` (epoch sec) is undefined/null while running.
+ */
+export function isLiveActive(
+  expiresAt: number,
+  stoppedAt: number | null | undefined,
+  nowSec: number,
+): boolean {
+  if (stoppedAt != null) return false;
+  return nowSec < expiresAt;
+}
+
+/** Whole seconds until expiry, clamped to >= 0. */
+export function liveSecondsRemaining(expiresAt: number, nowSec: number): number {
+  const rem = Math.floor(expiresAt) - Math.floor(nowSec);
+  return rem > 0 ? rem : 0;
+}
+
+/** "42:15" for < 1h, "1:02:05" for >= 1h. */
+function formatDuration(totalSec: number): string {
+  const s = Math.max(0, Math.floor(totalSec));
+  const hours = Math.floor(s / 3600);
+  const mins = Math.floor((s % 3600) / 60);
+  const secs = s % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return hours > 0
+    ? `${hours}:${pad(mins)}:${pad(secs)}`
+    : `${mins}:${pad(secs)}`;
+}
+
+/**
+ * Badge/countdown label. Live: "Live · 42:15 left". Ended (stopped or expired):
+ * "Live location ended".
+ */
+export function liveRemainingLabel(
+  expiresAt: number,
+  stoppedAt: number | null | undefined,
+  nowSec: number,
+): string {
+  if (!isLiveActive(expiresAt, stoppedAt, nowSec)) return "Live location ended";
+  return `Live · ${formatDuration(liveSecondsRemaining(expiresAt, nowSec))} left`;
+}
+
+/**
+ * The sharers session should auto-stop once now has reached/passed expiry.
+ * (Manual stop and unmount are handled by the hook; this covers timeout.)
+ */
+export function shouldAutoStop(expiresAt: number, nowSec: number): boolean {
+  return Math.floor(nowSec) >= Math.floor(expiresAt);
+}

--- a/frontend/src/pages/messages/ComposeBar.tsx
+++ b/frontend/src/pages/messages/ComposeBar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Send, Paperclip, Loader2, Lock, Eye, EyeOff, EyeOff as EyeSlash, Headphones, X, ImageIcon, Clock, Reply, Globe, DollarSign, FileText, Images, FolderOpen, CalendarDays, CalendarCheck, Users, Dices, Video, Mic, Timer, Smile, Sticker as StickerIcon, Plus, Check, TrendingUp, Activity, Package, ShoppingBag, MapPin } from "lucide-react";
+import { Send, Paperclip, Loader2, Lock, Eye, EyeOff, EyeOff as EyeSlash, Headphones, X, ImageIcon, Clock, Reply, Globe, DollarSign, FileText, Images, FolderOpen, CalendarDays, CalendarCheck, Users, Dices, Video, Mic, Timer, Smile, Sticker as StickerIcon, Plus, Check, TrendingUp, Activity, Package, ShoppingBag, MapPin, Radio } from "lucide-react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { GifPicker } from "@/components/shared/GifPicker";
@@ -31,6 +31,7 @@ import { CryptoSendComposerDialog } from "./CryptoSendComposerDialog";
 import { ProductCardComposerDialog } from "./ProductCardComposerDialog";
 import { OrderShareComposerDialog } from "./OrderShareComposerDialog";
 import { LocationComposerDialog } from "./LocationComposerDialog";
+import { LiveLocationComposerDialog } from "./LiveLocationComposerDialog";
 import type { LocationCardPayload } from "@/lib/locationCards";
 import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
 import type { CryptoTransferPayload } from "@/lib/cryptoTransfer";
@@ -82,6 +83,10 @@ interface ComposeBarProps {
   onSendProductCard?: (payload: ProductCardPayload) => void;
   onSendOrderCard?: (payload: OrderCardPayload) => void;
   onSendLocation?: (payload: LocationCardPayload) => void;
+  /** FE-131: start a live-location share for the chosen duration (seconds). */
+  onSendLiveLocation?: (durationSec: number) => void;
+  /** FE-131: true while the live-location start request is in flight. */
+  liveLocationStarting?: boolean;
   /** DM partner display name for the send-crypto composer attribution. */
   recipientName?: string;
   currentUserName?: string;
@@ -124,6 +129,8 @@ export function ComposeBar({
   onSendProductCard,
   onSendOrderCard,
   onSendLocation,
+  onSendLiveLocation,
+  liveLocationStarting,
   recipientName,
   currentUserName,
   onSendLottery,
@@ -249,6 +256,7 @@ export function ComposeBar({
   const [productCardOpen, setProductCardOpen] = React.useState(false);
   const [orderCardOpen, setOrderCardOpen] = React.useState(false);
   const [locationOpen, setLocationOpen] = React.useState(false);
+  const [liveLocationOpen, setLiveLocationOpen] = React.useState(false);
   const [activeDraftId, setActiveDraftId] = React.useState<string | null>(null);
   const [draftDirty, setDraftDirty] = React.useState(false);
   const [lastDraftSavedAt, setLastDraftSavedAt] = React.useState<number | null>(null);
@@ -1682,7 +1690,7 @@ export function ComposeBar({
       <div className="flex items-end gap-2">
         {(onSendVoiceMessage || onSendGallery || onSendLottery || onSendFileShare || onSendVideoShare ||
           onSendCalendarShare || onSendCalendarEvent || onSendMeetingPoll || onSendFindDateTime ||
-          onSendCountdown || onSendMarketCard || onSendPositionCard || onSendCryptoTransfer || onSendProductCard || onSendOrderCard || onSendLocation || draftsEnabled || (onSendTtsVoice && ttsEnabled)) && (
+          onSendCountdown || onSendMarketCard || onSendPositionCard || onSendCryptoTransfer || onSendProductCard || onSendOrderCard || onSendLocation || onSendLiveLocation || draftsEnabled || (onSendTtsVoice && ttsEnabled)) && (
           <Popover open={moreOpen} onOpenChange={setMoreOpen}>
             <PopoverTrigger asChild>
               <Button
@@ -1915,6 +1923,13 @@ export function ComposeBar({
                     onClick={() => { setLocationOpen(true); setMoreOpen(false); }} aria-label="Share location"
                     data-testid="compose-share-location">
                     <MapPin className="h-4 w-4" /> Share location
+                  </Button>
+                )}
+                {onSendLiveLocation && (
+                  <Button variant="ghost" className="h-9 justify-start gap-2 px-2"
+                    onClick={() => { setLiveLocationOpen(true); setMoreOpen(false); }} aria-label="Share live location"
+                    data-testid="compose-share-live-location">
+                    <Radio className="h-4 w-4" /> Share live location
                   </Button>
                 )}
                 {draftsEnabled && (
@@ -2298,6 +2313,17 @@ export function ComposeBar({
           onSubmit={(payload) => {
             onSendLocation(payload);
             setLocationOpen(false);
+          }}
+        />
+      )}
+      {onSendLiveLocation && (
+        <LiveLocationComposerDialog
+          open={liveLocationOpen}
+          starting={liveLocationStarting}
+          onClose={() => setLiveLocationOpen(false)}
+          onSubmit={(durationSec) => {
+            onSendLiveLocation(durationSec);
+            setLiveLocationOpen(false);
           }}
         />
       )}

--- a/frontend/src/pages/messages/ConversationList.tsx
+++ b/frontend/src/pages/messages/ConversationList.tsx
@@ -355,6 +355,7 @@ function getPreviewText(lastMsg: Message | undefined, convo: Conversation, curre
     );
   if (lastMsg.kind === "location")
     return locationPreview(lastMsg.label ?? undefined, lastMsg.place_name ?? undefined);
+  if (lastMsg.kind === "live_location") return "📍 Live location";
   return lastMsg.text ?? convo.last_message_preview ?? "No messages yet";
 }
 

--- a/frontend/src/pages/messages/ConversationView.tsx
+++ b/frontend/src/pages/messages/ConversationView.tsx
@@ -39,6 +39,7 @@ import {
   type DirectCallMode,
 } from "@/api/endpoints/messaging";
 import { useAuthStore } from "@/stores/authStore";
+import { useLiveLocationShare } from "./useLiveLocationShare";
 import { useOfflineStore } from "@/stores/offlineStore";
 import type { Conversation, Message, SendTextMessageReq, SendFileShareReq, SendCalendarShareReq, SendCalendarEventReq, SendMeetingPollReq, SendFindDateTimeReq, CreateLotteryMessageReq } from "@/api/types";
 import type { MarketCardPayload, PositionCardPayload } from "@/lib/tradingCards";
@@ -91,6 +92,7 @@ interface ConversationViewProps {
 
 export function ConversationView({ conversation, onBack, onClaimSuccess }: ConversationViewProps) {
   const userId = useAuthStore((s) => s.userId);
+  const liveLocation = useLiveLocationShare();
   const queryClient = useQueryClient();
   const addToQueueWithId = useOfflineStore((s) => s.addToQueueWithId);
   const isOnline = useOfflineStore((s) => s.isOnline);
@@ -1504,6 +1506,12 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
                 viewedOnceIds={viewedOnceIds}
                 onViewOnce={handleViewOnce}
                 resolveSenderName={resolveSenderName}
+                onStopLiveLocation={
+                  msg.kind === "live_location" &&
+                  liveLocation.active?.shareId === (msg.share_id ?? undefined)
+                    ? () => { void liveLocation.stop(); }
+                    : undefined
+                }
               />
             </div>
           ))
@@ -1610,6 +1618,8 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         onSendProductCard={(payload) => sendProductCard.mutate(payload)}
         onSendOrderCard={(payload) => sendOrderCard.mutate(payload)}
         onSendLocation={(payload) => sendLocation.mutate(payload)}
+        onSendLiveLocation={(durationSec) => { void liveLocation.start(convoId, durationSec); }}
+        liveLocationStarting={liveLocation.starting}
         recipientName={dmPartner?.display_name}
         currentUserName={currentUserName}
         onSendLottery={!isGroup && dmLotteryEnabled ? (params) => sendLottery.mutate(params) : undefined}

--- a/frontend/src/pages/messages/LiveLocationCard.tsx
+++ b/frontend/src/pages/messages/LiveLocationCard.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { MapPin, ExternalLink, Square } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  formatCoords,
+  mapsOpenUrl,
+  staticMapThumbUrl,
+} from "@/lib/locationCards";
+import {
+  isLiveActive,
+  liveRemainingLabel,
+} from "@/lib/liveLocation";
+
+export interface LiveLocationCardPayload {
+  lat: number;
+  lng: number;
+  label?: string;
+  place_name?: string;
+  expires_at: number;
+  stopped_at?: number | null;
+}
+
+export interface LiveLocationCardProps {
+  payload: LiveLocationCardPayload;
+  /** True when the viewer is the sharer -> show "Stop sharing". */
+  isOwn?: boolean;
+  /** Called when the sharer taps "Stop sharing". */
+  onStop?: () => void;
+  stopping?: boolean;
+}
+
+/**
+ * FE-131: an in-chat LIVE location pin. Reuses the FE-130 keyless static-map
+ * thumbnail (which naturally refreshes as lat/lng update in place on the
+ * message), overlaid with a pulsing LIVE badge + a live countdown to expiry.
+ * The sharer sees a "Stop sharing" button. Once expired/stopped it collapses to
+ * a static "Live location ended" state showing the last-known pin. The moving-
+ * pin relay requires BE-131; without it the card still renders the last-known
+ * pin + badge/countdown but the pin will not move.
+ */
+export function LiveLocationCard({ payload, isOwn, onStop, stopping }: LiveLocationCardProps) {
+  const { lat, lng, label, place_name, expires_at, stopped_at } = payload;
+  const [thumbFailed, setThumbFailed] = useState(false);
+  // A local 1s tick drives the countdown + the live/ended transition. nowSec is
+  // passed into the pure helpers so the render stays deterministic.
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000));
+
+  const active = isLiveActive(expires_at, stopped_at, nowSec);
+
+  useEffect(() => {
+    if (!active) return;
+    const id = window.setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
+    return () => window.clearInterval(id);
+  }, [active]);
+
+  const coords = formatCoords(lat, lng);
+  const primary = (label ?? "").trim() || (place_name ?? "").trim() || "Live location";
+  const badge = liveRemainingLabel(expires_at, stopped_at, nowSec);
+  // The static-map URL is keyed by lat/lng so React remounts the <img> and the
+  // thumbnail refreshes whenever the sharer's position changes on the message.
+  const thumb = staticMapThumbUrl(lat, lng, { w: 320, h: 160, zoom: 15 });
+
+  return (
+    <Card
+      className="w-72 max-w-full overflow-hidden"
+      data-testid="live-location-card"
+      data-active={active ? "true" : "false"}
+    >
+      <div className="relative h-32 w-full bg-muted">
+        {thumbFailed ? (
+          <div
+            className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground"
+            data-testid="live-location-card-placeholder"
+          >
+            <MapPin className="h-8 w-8" />
+          </div>
+        ) : (
+          <img
+            key={thumb}
+            src={thumb}
+            alt={`Live map of ${primary}`}
+            className="h-full w-full object-cover"
+            loading="lazy"
+            onError={() => setThumbFailed(true)}
+            data-testid="live-location-card-thumb"
+          />
+        )}
+
+        <div
+          className="absolute left-2 top-2 flex items-center gap-1.5 rounded-full bg-black/70 px-2 py-1 text-xs font-medium text-white"
+          data-testid="live-location-badge"
+        >
+          {active && (
+            <span className="relative flex h-2 w-2" aria-hidden>
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-rose-500" />
+            </span>
+          )}
+          <span className="tabular-nums">{badge}</span>
+        </div>
+      </div>
+
+      <CardContent className="pt-3">
+        <div className="flex items-start gap-2">
+          <MapPin
+            className={`mt-0.5 h-4 w-4 shrink-0 ${active ? "text-rose-500" : "text-muted-foreground"}`}
+          />
+          <div className="min-w-0 flex-1">
+            <div className="line-clamp-2 text-sm font-semibold" data-testid="live-location-card-label">
+              {primary}
+            </div>
+            <div
+              className="mt-0.5 truncate text-xs text-muted-foreground tabular-nums"
+              data-testid="live-location-card-sub"
+            >
+              {active ? coords : "Live location ended"}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <Button asChild size="sm" variant="outline" data-testid="live-location-card-open">
+            <a href={mapsOpenUrl(lat, lng, label)} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="mr-1 h-3.5 w-3.5" />
+              Open in Maps
+            </a>
+          </Button>
+          {isOwn && active ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={onStop}
+              disabled={stopping}
+              data-testid="live-location-card-stop"
+            >
+              <Square className="mr-1 h-3.5 w-3.5" />
+              {stopping ? "Stopping…" : "Stop sharing"}
+            </Button>
+          ) : (
+            <div />
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default LiveLocationCard;

--- a/frontend/src/pages/messages/LiveLocationComposerDialog.tsx
+++ b/frontend/src/pages/messages/LiveLocationComposerDialog.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { Radio } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { LIVE_DURATION_OPTIONS } from "@/lib/liveLocation";
+
+interface LiveLocationComposerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Emit the chosen duration in seconds; the caller starts the share. */
+  onSubmit: (durationSec: number) => void;
+  starting?: boolean;
+}
+
+/**
+ * FE-131: "Share live location" duration picker. Pick 15m / 1h / 8h, then the
+ * caller starts the share (useLiveLocationShare) which begins relaying position
+ * until the chosen duration expires (auto-stop) or the sharer stops early.
+ */
+export function LiveLocationComposerDialog({
+  open,
+  onClose,
+  onSubmit,
+  starting,
+}: LiveLocationComposerDialogProps) {
+  const [seconds, setSeconds] = useState<number>(LIVE_DURATION_OPTIONS[0]?.seconds ?? 900);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (!o ? onClose() : undefined)}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Radio className="h-4 w-4 text-rose-500" />
+            Share live location
+          </DialogTitle>
+          <DialogDescription>
+            Your recipients will see your position update on a live map until it
+            expires. You can stop sharing at any time.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-2 py-1" role="radiogroup" aria-label="Share duration">
+          {LIVE_DURATION_OPTIONS.map((opt) => {
+            const selected = opt.seconds === seconds;
+            return (
+              <Button
+                key={opt.seconds}
+                type="button"
+                variant={selected ? "default" : "outline"}
+                className="justify-start"
+                role="radio"
+                aria-checked={selected}
+                onClick={() => setSeconds(opt.seconds)}
+                data-testid={`live-location-duration-${opt.seconds}`}
+              >
+                {opt.label}
+              </Button>
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={starting}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onSubmit(seconds)}
+            disabled={starting}
+            data-testid="live-location-start"
+          >
+            {starting ? "Starting…" : "Start sharing"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default LiveLocationComposerDialog;

--- a/frontend/src/pages/messages/MessageBubble.tsx
+++ b/frontend/src/pages/messages/MessageBubble.tsx
@@ -63,6 +63,7 @@ import { CryptoTransferCard } from "./CryptoTransferCard";
 import { ProductCard } from "./ProductCard";
 import { OrderShareCard } from "./OrderShareCard";
 import { LocationCard } from "./LocationCard";
+import { LiveLocationCard } from "./LiveLocationCard";
 import { orderCardPreview, productCardPreview, type OrderCardPayload, type ProductCardPayload } from "@/lib/ecomCards";
 import { locationPreview, type LocationCardPayload } from "@/lib/locationCards";
 import type { PositionCardPayload } from "@/lib/tradingCards";
@@ -115,6 +116,10 @@ interface MessageBubbleProps {
   onViewOnce?: (messageId: string) => void;
   /** Resolve a sender id (sub/email) to a friendly display name. */
   resolveSenderName?: (id: string) => string;
+  /** FE-131: stop the sharers own live-location share (from the card). */
+  onStopLiveLocation?: () => void;
+  /** FE-131: true while the stop request is in flight. */
+  liveLocationStopping?: boolean;
 }
 
 type LotteryRevealPhase = "idle" | "unlocking" | "revealing" | "revealed";
@@ -223,6 +228,7 @@ function replyPreviewText(msg: Message): string {
     return `[Crypto: ${[msg.amount, msg.asset].filter(Boolean).join(" ")}]`;
   if (msg.kind === "location")
     return locationPreview(msg.label ?? undefined, msg.place_name ?? undefined);
+  if (msg.kind === "live_location") return "📍 Live location";
   if (msg.kind === "file") return msg.file?.name ? `[File: ${msg.file.name}]` : "[File]";
   if (msg.is_encrypted) return "[Encrypted message]";
   return (msg.text ?? "").slice(0, 80) || "[Message]";
@@ -448,7 +454,7 @@ function OfflineStatusBadge({ offline, onRetry, onDiscard }: OfflineStatusBadgeP
   return null;
 }
 
-export function MessageBubble({ message, isOwn, showSender, conversationId, onReply, onViewThread, replyToMessage, viewedOnceIds, onViewOnce, resolveSenderName }: MessageBubbleProps) {
+export function MessageBubble({ message, isOwn, showSender, conversationId, onReply, onViewThread, replyToMessage, viewedOnceIds, onViewOnce, resolveSenderName, onStopLiveLocation, liveLocationStopping }: MessageBubbleProps) {
   const senderLabel = (id: string) => resolveSenderName?.(id) ?? id;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -2064,6 +2070,25 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                   label: message.label ?? undefined,
                   place_name: message.place_name ?? undefined,
                 } satisfies LocationCardPayload}
+              />
+            )}
+
+          {message.kind === "live_location" &&
+            message.lat != null &&
+            message.lng != null &&
+            message.expires_at != null && (
+              <LiveLocationCard
+                isOwn={isOwn}
+                stopping={liveLocationStopping}
+                onStop={onStopLiveLocation}
+                payload={{
+                  lat: message.lat,
+                  lng: message.lng,
+                  label: message.label ?? undefined,
+                  place_name: message.place_name ?? undefined,
+                  expires_at: message.expires_at,
+                  stopped_at: message.stopped_at ?? undefined,
+                }}
               />
             )}
 

--- a/frontend/src/pages/messages/useLiveLocationShare.ts
+++ b/frontend/src/pages/messages/useLiveLocationShare.ts
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+import {
+  startLiveLocation,
+  updateLiveLocation,
+  stopLiveLocation,
+} from "@/api/endpoints/messaging";
+import { UPDATE_INTERVAL_SEC, shouldAutoStop } from "@/lib/liveLocation";
+
+interface ActiveShare {
+  shareId: string;
+  conversationId: string;
+  expiresAt: number; // epoch sec
+}
+
+export interface UseLiveLocationShare {
+  active: ActiveShare | null;
+  starting: boolean;
+  start: (conversationId: string, durationSec: number) => Promise<void>;
+  stop: () => Promise<void>;
+}
+
+/**
+ * FE-131 active-share session manager. A single-active-share hook owned by the
+ * conversation view: it starts a live share, then relays the sharer position to
+ * BE-131 while the share is active AND the tab is foregrounded.
+ *
+ * Watcher/interval:
+ *   - navigator.geolocation.watchPosition is the primary source; each fix is
+ *     POSTed to /live-location/{id}/update. maximumAge is capped at
+ *     UPDATE_INTERVAL_SEC so a fix is never staler than the cadence.
+ *   - a belt-and-braces setInterval (UPDATE_INTERVAL_SEC) re-pushes the latest
+ *     cached fix even if watchPosition goes quiet (stationary device), and a
+ *     1s ticker checks shouldAutoStop.
+ *   - both relay timers are suspended while document.hidden (visibilitychange)
+ *     so a backgrounded tab stops draining GPS/battery, and resumed on
+ *     foreground. The auto-stop ticker runs regardless.
+ *
+ * Auto-stop: when shouldAutoStop(expiresAt, now) the session self-terminates
+ * (calls stop) exactly like the manual button. Cleanup: every timer/watcher/
+ * listener is torn down on unmount, manual stop, or expiry -- no leaks, and the
+ * geo watch id is always cleared.
+ *
+ * Degrade-on-404: start surfaces a clear toast and resolves without an active
+ * share if BE-131 is absent; it never throws into render and never fabricates a
+ * relay that cannot move the pin.
+ */
+export function useLiveLocationShare(): UseLiveLocationShare {
+  const queryClient = useQueryClient();
+  const [active, setActive] = useState<ActiveShare | null>(null);
+  const [starting, setStarting] = useState(false);
+
+  const watchIdRef = useRef<number | null>(null);
+  const intervalRef = useRef<number | null>(null);
+  const tickRef = useRef<number | null>(null);
+  const lastFixRef = useRef<{ lat: number; lng: number } | null>(null);
+  const activeRef = useRef<ActiveShare | null>(null);
+  const visibilityRemoverRef = useRef<(() => void) | null>(null);
+  const stopRef = useRef<() => Promise<void>>(async () => {});
+  activeRef.current = active;
+
+  const invalidate = useCallback(
+    (conversationId: string) => {
+      queryClient.invalidateQueries({ queryKey: ["messages", conversationId] });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+    [queryClient],
+  );
+
+  const stopWatching = useCallback(() => {
+    if (
+      watchIdRef.current != null &&
+      typeof navigator !== "undefined" &&
+      navigator.geolocation
+    ) {
+      navigator.geolocation.clearWatch(watchIdRef.current);
+    }
+    watchIdRef.current = null;
+  }, []);
+
+  const clearTimers = useCallback(() => {
+    stopWatching();
+    if (intervalRef.current != null) window.clearInterval(intervalRef.current);
+    intervalRef.current = null;
+    if (tickRef.current != null) window.clearInterval(tickRef.current);
+    tickRef.current = null;
+  }, [stopWatching]);
+
+  const pushFix = useCallback(
+    (lat: number, lng: number) => {
+      lastFixRef.current = { lat, lng };
+      const cur = activeRef.current;
+      if (!cur) return;
+      void updateLiveLocation(cur.shareId, lat, lng)
+        .then(() => invalidate(cur.conversationId))
+        .catch(() => {});
+    },
+    [invalidate],
+  );
+
+  const startWatching = useCallback(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+    if (watchIdRef.current != null) return;
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      (pos) => pushFix(pos.coords.latitude, pos.coords.longitude),
+      () => {},
+      { enableHighAccuracy: true, maximumAge: UPDATE_INTERVAL_SEC * 1000, timeout: 20_000 },
+    );
+  }, [pushFix]);
+
+  const resumeRelay = useCallback(() => {
+    startWatching();
+    if (intervalRef.current == null) {
+      intervalRef.current = window.setInterval(() => {
+        const fix = lastFixRef.current;
+        if (fix) pushFix(fix.lat, fix.lng);
+      }, UPDATE_INTERVAL_SEC * 1000);
+    }
+  }, [startWatching, pushFix]);
+
+  const suspendRelay = useCallback(() => {
+    stopWatching();
+    if (intervalRef.current != null) window.clearInterval(intervalRef.current);
+    intervalRef.current = null;
+  }, [stopWatching]);
+
+  const stop = useCallback(async () => {
+    const cur = activeRef.current;
+    clearTimers();
+    if (visibilityRemoverRef.current) {
+      visibilityRemoverRef.current();
+      visibilityRemoverRef.current = null;
+    }
+    lastFixRef.current = null;
+    setActive(null);
+    activeRef.current = null;
+    if (!cur) return;
+    try {
+      await stopLiveLocation(cur.shareId);
+    } catch {
+      // Ending is best-effort; the share also auto-expires server-side.
+    }
+    invalidate(cur.conversationId);
+  }, [clearTimers, invalidate]);
+  stopRef.current = stop;
+
+  const start = useCallback(
+    async (conversationId: string, durationSec: number) => {
+      if (starting || activeRef.current) return;
+      setStarting(true);
+      try {
+        const resp = await startLiveLocation(conversationId, durationSec);
+        const share: ActiveShare = {
+          shareId: resp.share_id,
+          conversationId,
+          expiresAt: resp.expires_at,
+        };
+        setActive(share);
+        activeRef.current = share;
+        invalidate(conversationId);
+
+        const onVisibility = () => {
+          if (typeof document !== "undefined" && document.hidden) suspendRelay();
+          else resumeRelay();
+        };
+        if (typeof document !== "undefined") {
+          document.addEventListener("visibilitychange", onVisibility);
+          visibilityRemoverRef.current = () =>
+            document.removeEventListener("visibilitychange", onVisibility);
+        }
+
+        tickRef.current = window.setInterval(() => {
+          const cur = activeRef.current;
+          if (!cur) return;
+          if (shouldAutoStop(cur.expiresAt, Math.floor(Date.now() / 1000))) {
+            void stopRef.current();
+          }
+        }, 1000);
+
+        if (typeof document === "undefined" || !document.hidden) resumeRelay();
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) {
+          toast.error("Live location is not available yet on this server.");
+        } else if (err instanceof ApiError) {
+          toast.error(err.detail || "Could not start live location.");
+        } else {
+          toast.error("Could not start live location.");
+        }
+      } finally {
+        setStarting(false);
+      }
+    },
+    [starting, invalidate, resumeRelay, suspendRelay],
+  );
+
+  // Unmount teardown: kill every timer/watcher/listener and fire-and-forget the
+  // server stop (unmount is synchronous; do not await).
+  useEffect(() => {
+    return () => {
+      const cur = activeRef.current;
+      clearTimers();
+      if (visibilityRemoverRef.current) {
+        visibilityRemoverRef.current();
+        visibilityRemoverRef.current = null;
+      }
+      if (cur) void stopLiveLocation(cur.shareId).catch(() => {});
+    };
+  }, [clearTimers]);
+
+  return { active, starting, start, stop };
+}
+
+export default useLiveLocationShare;


### PR DESCRIPTION
## FE-131 — live-location UI (completes EPIC D)

Start/stop **live location** with a duration picker (15m/1h/8h), a **live-updating map bubble** for active shares, and **auto-stop at expiry**. Builds on FE-130's location primitives. The moving-pin relay requires **BE-131** — **honest degrade-on-404**: no fabricated live shares; the card falls back to last-known pin + pulsing LIVE badge + countdown + auto-expiry, and starting surfaces a clear error if BE-131 is absent.

### Web
- NEW `lib/liveLocation.ts` (+15 vitest) — duration options, `isLiveActive`, `liveSecondsRemaining`, `liveRemainingLabel`, `computeExpiresAt`, `shouldAutoStop`, `UPDATE_INTERVAL_SEC`.
- NEW `LiveLocationCard.tsx` (refreshing thumbnail, LIVE badge, countdown, sharer Stop, ended state), `LiveLocationComposerDialog.tsx`, `useLiveLocationShare.ts` (watchPosition + interval relay, visibility-gated to save battery, 1s auto-stop ticker, leak-free teardown).
- start/update/stop endpoints; live_location on Message.kind; MessageBubble/ComposeBar/ConversationView/List wiring.

### Android
- NEW `LiveLocationModel.kt` (+14 JVM tests) — TLLIVE1 codec (mirrors TLLOC1) + active/expiry math.
- NEW `LiveLocationCardUi.kt`, `LiveLocationComposer.kt` (COARSE-gated duration sheet), `LiveLocationApi`/Repository (BE-131, degrade to local share).
- viewModelScope-child updater job (15s fixes, re-enqueues the moving card, auto-stops on not-active, cancelled in onCleared); MessagingDomain MessageMedia.LiveLocation; inbox preview masks the sentinel. Reuses the RevealLockedBubble 1s lifecycle-ticker.

**Scope note:** true background tracking needs a foreground service (out of scope); updates flow while the thread is foregrounded; clock-driven auto-expiry ends the share regardless.

### Gates
- Web: tsc 0 · build green · 15/15 vitest
- Android: BUILD SUCCESSFUL · LiveLocationModelTest 14/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
