### PR TITLE
FE-160: fund ad budget with crypto (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/adsbilling/data/AdsBillingRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adsbilling/data/AdsBillingRepository.kt
@@ -88,6 +88,8 @@ interface AdsBillingRepository {
         accountId: String,
         amountCents: Long,
         paymentMethodId: String? = null,
+        payWith: String? = null,
+        quoteToken: String? = null,
     ): ApiResult<DepositResult>
 }
 
@@ -160,11 +162,18 @@ class AdsBillingRepositoryImpl @Inject constructor(
         accountId: String,
         amountCents: Long,
         paymentMethodId: String?,
+        payWith: String?,
+        quoteToken: String?,
     ): ApiResult<DepositResult> = withContext(Dispatchers.IO) {
         call {
             api.deposit(
                 accountId,
-                AdDepositIn(amountCents = amountCents, paymentMethodId = paymentMethodId),
+                AdDepositIn(
+                    amountCents = amountCents,
+                    paymentMethodId = paymentMethodId,
+                    payWith = payWith,
+                    quoteToken = quoteToken,
+                ),
             ).toDomain()
         }
     }

--- a/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdDepositMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdDepositMath.kt
@@ -1,0 +1,76 @@
+package com.testlogon.android.feature.adsbilling.ui
+
+/**
+ * FE-160 - pure, framework-free money math for the ad-account "Add funds" (deposit / top-up) surface,
+ * including the "Fund with crypto balance" path. Every function is deterministic and side-effect free
+ * (no clock, no I/O): amounts are integer USD cents (Long) so there is no binary-float drift. The FX /
+ * rate-lock math for the crypto path lives in the shipped
+ * [com.testlogon.android.feature.checkout.CheckoutCryptoMath] (reused as-is); this object only owns the
+ * top-up amount presets + validation + balance projection for the ad account.
+ *
+ * Mirrors the deposit bounds already enforced by the ads-billing ViewModel/server (min $50, max $100k)
+ * but with a lower validation floor for the "is this text even a sane top-up" check requested by FE-160
+ * (min $1); the ViewModel keeps its own server-authoritative 5000..10000000 gate for the actual charge.
+ */
+object AdDepositMath {
+
+    /** USD sign kept as a constant so string building never trips Kotlin's dollar interpolation. */
+    private const val USD = "$"
+
+    /** Quick top-up presets shown as chips, in integer USD cents ($25 / $50 / $100 / $250). */
+    val PRESET_TOPUPS_CENTS: List<Long> = listOf(2_500L, 5_000L, 10_000L, 25_000L)
+
+    /** The lowest a top-up may be (FE-160: min $1) in integer cents. */
+    const val MIN_TOPUP_CENTS: Long = 100L
+
+    /** A sane upper bound so a fat-fingered entry can't request an absurd charge ($100k) in cents. */
+    const val MAX_TOPUP_CENTS: Long = 10_000_000L
+
+    /**
+     * True when [cents] is a valid top-up: a positive integer number of cents within
+     * [MIN_TOPUP_CENTS]..[MAX_TOPUP_CENTS]. Cents are already integral (Long), so "integer" here means
+     * simply in-range and non-fractional-by-construction.
+     */
+    fun isValidTopUpCents(cents: Long): Boolean = cents in MIN_TOPUP_CENTS..MAX_TOPUP_CENTS
+
+    /** Human label for a top-up amount, e.g. 2500 -> "$25". Whole dollars drop the ".00". */
+    fun topUpLabel(cents: Long): String = USD + formatCents(cents)
+
+    /**
+     * The account balance after crediting [addedCents] to [currentCents]. Negative operands are treated
+     * as 0 (a balance never goes below zero from a top-up; a negative add is a no-op). Saturates at
+     * [Long.MAX_VALUE] rather than overflowing.
+     */
+    fun newBalanceCents(currentCents: Long, addedCents: Long): Long {
+        val cur = if (currentCents < 0L) 0L else currentCents
+        val add = if (addedCents < 0L) 0L else addedCents
+        val sum = cur + add
+        // Overflow guard: if adding wrapped to negative, saturate.
+        return if (sum < cur) Long.MAX_VALUE else sum
+    }
+
+    /** dollars (Double) -> integer cents, half-up, clamped to >= 0. */
+    fun dollarsToCents(dollars: Double): Long {
+        val safe = if (dollars.isNaN() || dollars.isInfinite() || dollars < 0.0) 0.0 else dollars
+        return Math.round(safe * 100.0)
+    }
+
+    /** integer cents -> dollars (Double). */
+    fun centsToDollars(cents: Long): Double = cents / 100.0
+
+    /**
+     * Formats integer [cents] as a plain dollar-and-cent string WITHOUT the currency symbol: whole
+     * dollars render with no decimals ("25"), otherwise two decimals ("25.50"). No locale coupling.
+     */
+    fun formatCents(cents: Long): String {
+        val abs = if (cents < 0L) -cents else cents
+        val dollars = abs / 100L
+        val rem = abs % 100L
+        val sign = if (cents < 0L) "-" else ""
+        return if (rem == 0L) {
+            sign + dollars.toString()
+        } else {
+            sign + dollars.toString() + "." + rem.toString().padStart(2, '0')
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdsBillingScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdsBillingScreen.kt
@@ -52,6 +52,12 @@ import com.testlogon.android.core.ui.state.ErrorState
 import com.testlogon.android.core.ui.state.LoadingState
 import com.testlogon.android.core.ui.state.StaleBanner
 import com.testlogon.android.data.billing.PaymentMethod
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Tab
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import com.testlogon.android.feature.checkout.CheckoutCryptoMath
 
 /** AND-367 - stable testTags for the ads-account billing screen + deposit sheet. */
 object AdsBillingTestTags {
@@ -64,6 +70,14 @@ object AdsBillingTestTags {
     const val DEPOSIT_CONFIRM = "ads_deposit_confirm"
     const val DEPOSIT_SUCCESS = "ads_deposit_success"
     const val DEPOSIT_DONE = "ads_deposit_done"
+    const val FUND_TAB_CARD = "ads_fund_tab_card"
+    const val FUND_TAB_CRYPTO = "ads_fund_tab_crypto"
+    const val CRYPTO_ASSET_PICKER = "ads_crypto_asset_picker"
+    const val CRYPTO_RATE = "ads_crypto_rate"
+    const val CRYPTO_COUNTDOWN = "ads_crypto_countdown"
+    const val CRYPTO_INSUFFICIENT = "ads_crypto_insufficient"
+    const val CRYPTO_FUND_CONFIRM = "ads_crypto_fund_confirm"
+    const val CRYPTO_UNAVAILABLE = "ads_crypto_unavailable"
     const val ERROR_RETRY = "ads_error_retry"
 
     /** Per-row ledger tag (suffix is the row index). */
@@ -86,6 +100,8 @@ fun AdsBillingRoute(
     val amountText by viewModel.amountText.collectAsStateWithLifecycle()
     val paymentMethods by viewModel.paymentMethods.collectAsStateWithLifecycle()
     val selectedPaymentMethodId by viewModel.selectedPaymentMethodId.collectAsStateWithLifecycle()
+    val crypto by viewModel.crypto.collectAsStateWithLifecycle()
+    val cryptoFundingMode by viewModel.cryptoFundingMode.collectAsStateWithLifecycle()
     AdsBillingScreen(
         state = state,
         depositState = depositState,
@@ -94,6 +110,8 @@ fun AdsBillingRoute(
         paymentMethods = paymentMethods,
         selectedPaymentMethodId = selectedPaymentMethodId,
         canSubmitDeposit = viewModel.canSubmitDeposit,
+        crypto = crypto,
+        cryptoFundingMode = cryptoFundingMode,
         onBack = onBack,
         onRetry = viewModel::onRetry,
         onOpenDeposit = viewModel::openDeposit,
@@ -101,6 +119,10 @@ fun AdsBillingRoute(
         onAmountChanged = viewModel::onAmountChanged,
         onPaymentMethodSelected = viewModel::onPaymentMethodSelected,
         onConfirmDeposit = { viewModel.deposit() },
+        onPresetSelected = viewModel::onPresetSelected,
+        onCryptoModeChanged = viewModel::setCryptoFundingMode,
+        onCryptoAssetSelected = viewModel::onCryptoAssetSelected,
+        onConfirmCryptoFund = { viewModel.fundWithCrypto() },
     )
 }
 
@@ -114,6 +136,8 @@ fun AdsBillingScreen(
     paymentMethods: List<PaymentMethod>,
     selectedPaymentMethodId: String?,
     canSubmitDeposit: Boolean,
+    crypto: CryptoFundUiState,
+    cryptoFundingMode: Boolean,
     onBack: () -> Unit,
     onRetry: () -> Unit,
     onOpenDeposit: () -> Unit,
@@ -121,6 +145,10 @@ fun AdsBillingScreen(
     onAmountChanged: (String) -> Unit,
     onPaymentMethodSelected: (String) -> Unit,
     onConfirmDeposit: () -> Unit,
+    onPresetSelected: (Long) -> Unit,
+    onCryptoModeChanged: (Boolean) -> Unit,
+    onCryptoAssetSelected: (String) -> Unit,
+    onConfirmCryptoFund: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -167,10 +195,16 @@ fun AdsBillingScreen(
             paymentMethods = paymentMethods,
             selectedPaymentMethodId = selectedPaymentMethodId,
             canSubmitDeposit = canSubmitDeposit,
+            crypto = crypto,
+            cryptoFundingMode = cryptoFundingMode,
             onDismiss = onDismissDeposit,
             onAmountChanged = onAmountChanged,
             onPaymentMethodSelected = onPaymentMethodSelected,
             onConfirm = onConfirmDeposit,
+            onPresetSelected = onPresetSelected,
+            onCryptoModeChanged = onCryptoModeChanged,
+            onCryptoAssetSelected = onCryptoAssetSelected,
+            onConfirmCryptoFund = onConfirmCryptoFund,
         )
     }
 }
@@ -348,10 +382,16 @@ private fun DepositSheet(
     paymentMethods: List<PaymentMethod>,
     selectedPaymentMethodId: String?,
     canSubmitDeposit: Boolean,
+    crypto: CryptoFundUiState,
+    cryptoFundingMode: Boolean,
     onDismiss: () -> Unit,
     onAmountChanged: (String) -> Unit,
     onPaymentMethodSelected: (String) -> Unit,
     onConfirm: () -> Unit,
+    onPresetSelected: (Long) -> Unit,
+    onCryptoModeChanged: (Boolean) -> Unit,
+    onCryptoAssetSelected: (String) -> Unit,
+    onConfirmCryptoFund: () -> Unit,
 ) {
     // The sheet is open whenever a deposit interaction is in progress (Idle once opened, Submitting,
     // Success, or Error). When fully dismissed the VM sets Idle + empties the amount, and we render nothing.
@@ -377,6 +417,27 @@ private fun DepositSheet(
             )
 
             val submitting = depositState is DepositState.Submitting
+            val terminal = depositState is DepositState.Success
+
+            // FE-160: Card/wallet vs. Fund-with-crypto selector.
+            if (!terminal) {
+                TabRow(selectedTabIndex = if (cryptoFundingMode) 1 else 0) {
+                    Tab(
+                        selected = !cryptoFundingMode,
+                        onClick = { if (!submitting) onCryptoModeChanged(false) },
+                        text = { Text(stringResource(R.string.fund_tab_card)) },
+                        modifier = Modifier.testTag(AdsBillingTestTags.FUND_TAB_CARD),
+                    )
+                    Tab(
+                        selected = cryptoFundingMode,
+                        onClick = { if (!submitting) onCryptoModeChanged(true) },
+                        text = { Text(stringResource(R.string.fund_tab_crypto)) },
+                        modifier = Modifier.testTag(AdsBillingTestTags.FUND_TAB_CRYPTO),
+                    )
+                }
+                PresetTopUps(enabled = !submitting, onPresetSelected = onPresetSelected)
+            }
+
             val showInvalid = amountText.isNotBlank() && !canSubmitDeposit
             TlTextField(
                 value = amountText,
@@ -390,12 +451,20 @@ private fun DepositSheet(
                 modifier = Modifier.testTag(AdsBillingTestTags.DEPOSIT_AMOUNT),
             )
 
-            PaymentMethodPicker(
-                paymentMethods = paymentMethods,
-                selectedPaymentMethodId = selectedPaymentMethodId,
-                enabled = !submitting,
-                onSelect = onPaymentMethodSelected,
-            )
+            if (cryptoFundingMode) {
+                CryptoFundSection(
+                    crypto = crypto,
+                    enabled = !submitting,
+                    onCryptoAssetSelected = onCryptoAssetSelected,
+                )
+            } else {
+                PaymentMethodPicker(
+                    paymentMethods = paymentMethods,
+                    selectedPaymentMethodId = selectedPaymentMethodId,
+                    enabled = !submitting,
+                    onSelect = onPaymentMethodSelected,
+                )
+            }
 
             when (depositState) {
                 is DepositState.Error -> Text(
@@ -423,6 +492,16 @@ private fun DepositSheet(
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(AdsBillingTestTags.DEPOSIT_DONE),
+                )
+            } else if (cryptoFundingMode) {
+                TlButton(
+                    text = stringResource(R.string.fund_crypto_confirm),
+                    onClick = onConfirmCryptoFund,
+                    enabled = canSubmitDeposit && crypto.canFund && !submitting,
+                    loading = submitting,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(AdsBillingTestTags.CRYPTO_FUND_CONFIRM),
                 )
             } else {
                 TlButton(
@@ -515,5 +594,153 @@ private fun LabeledRow(label: String, value: String, valueModifier: Modifier = M
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Text(text = value, style = MaterialTheme.typography.bodyMedium, modifier = valueModifier)
+    }
+}
+
+
+/**
+ * FE-160 - quick top-up preset chips ($25 / $50 / $100 / $250). Tapping one fills the amount field
+ * (which drives both the card deposit and the crypto quote).
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PresetTopUps(enabled: Boolean, onPresetSelected: (Long) -> Unit) {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        AdDepositMath.PRESET_TOPUPS_CENTS.forEach { cents ->
+            FilterChip(
+                selected = false,
+                enabled = enabled,
+                onClick = { onPresetSelected(cents) },
+                label = { Text(AdDepositMath.topUpLabel(cents)) },
+            )
+        }
+    }
+}
+
+/**
+ * FE-160 - the "Fund with crypto balance" section of the deposit sheet: asset picker from custody
+ * balances, the rate-lock display (rate + total coin + conversion fee + live "locked for Ns" countdown),
+ * and insufficient / unavailable handling. Mirrors the FE-152 checkout crypto section (CheckoutCryptoMath
+ * reused verbatim for the display lines + countdown).
+ */
+@Composable
+private fun CryptoFundSection(
+    crypto: CryptoFundUiState,
+    enabled: Boolean,
+    onCryptoAssetSelected: (String) -> Unit,
+) {
+    if (!crypto.enabled) {
+        Text(
+            text = stringResource(R.string.fund_crypto_unavailable),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag(AdsBillingTestTags.CRYPTO_UNAVAILABLE),
+        )
+        return
+    }
+    if (crypto.assets.isEmpty()) {
+        Text(
+            text = stringResource(R.string.fund_crypto_no_balance),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return
+    }
+
+    CryptoAssetPicker(
+        assets = crypto.assets,
+        selectedSymbol = crypto.selectedSymbol,
+        enabled = enabled,
+        onSelect = onCryptoAssetSelected,
+    )
+
+    val quote = crypto.quote
+    when {
+        crypto.quoting -> Text(
+            text = stringResource(R.string.fund_crypto_quoting),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        quote != null -> {
+            LabeledRow(
+                label = stringResource(R.string.fund_crypto_rate),
+                value = CheckoutCryptoMath.rateLine(quote),
+                valueModifier = Modifier.testTag(AdsBillingTestTags.CRYPTO_RATE),
+            )
+            LabeledRow(
+                label = stringResource(R.string.fund_crypto_fee),
+                value = CheckoutCryptoMath.feeLine(quote),
+            )
+            LabeledRow(
+                label = stringResource(R.string.fund_crypto_total),
+                value = CheckoutCryptoMath.totalLine(quote),
+            )
+            Text(
+                text = CheckoutCryptoMath.lockedForLabel(crypto.secondsRemaining),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.testTag(AdsBillingTestTags.CRYPTO_COUNTDOWN),
+            )
+            if (crypto.insufficient) {
+                Text(
+                    text = stringResource(R.string.fund_crypto_insufficient),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag(AdsBillingTestTags.CRYPTO_INSUFFICIENT),
+                )
+            }
+        }
+    }
+    if (crypto.error != null) {
+        Text(
+            text = crypto.error,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+/** FE-160 - the custody-balance asset dropdown for crypto funding. */
+@Composable
+private fun CryptoAssetPicker(
+    assets: List<AdCryptoAssetOption>,
+    selectedSymbol: String?,
+    enabled: Boolean,
+    onSelect: (String) -> Unit,
+) {
+    val selected = assets.firstOrNull { it.symbol == selectedSymbol }
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { if (enabled) expanded = it },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        OutlinedTextField(
+            value = selected?.let { "${it.symbol} - ${it.balanceText} available" }
+                ?: stringResource(R.string.fund_crypto_pick_asset),
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(stringResource(R.string.fund_crypto_asset_label)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            enabled = enabled,
+            modifier = Modifier
+                .menuAnchor()
+                .fillMaxWidth()
+                .testTag(AdsBillingTestTags.CRYPTO_ASSET_PICKER),
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            assets.forEach { asset ->
+                DropdownMenuItem(
+                    text = { Text("${asset.symbol} (${asset.name}) - ${asset.balanceText}") },
+                    onClick = {
+                        onSelect(asset.symbol)
+                        expanded = false
+                    },
+                )
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdsBillingUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdsBillingUiState.kt
@@ -4,6 +4,7 @@ import com.testlogon.android.core.model.ApiError
 import com.testlogon.android.core.model.ads.AdAccountSummary
 import com.testlogon.android.core.model.ads.AdBillingEntry
 import com.testlogon.android.core.model.ads.AdInvoice
+import com.testlogon.android.data.fees.FeeQuote
 
 /**
  * AND-367 - hoisted UI state for the ads-account billing screen (the READ view).
@@ -51,4 +52,48 @@ sealed interface DepositState {
     data class Success(val newBalanceCents: Long?) : DepositState
 
     data class Error(val message: String) : DepositState
+}
+
+
+/**
+ * FE-160 - one selectable crypto asset row in the "Fund with crypto balance" picker: symbol, human name
+ * and the custody balance in BOTH whole units (display) and integer base units (the insufficient compare
+ * against a quote total_native). Mirrors the FE-152 checkout CryptoAssetOption.
+ */
+data class AdCryptoAssetOption(
+    val symbol: String,
+    val name: String,
+    val decimals: Int,
+    val balanceWhole: Double,
+    val balanceBaseUnits: Long,
+) {
+    val balanceText: String
+        get() = if (balanceWhole == balanceWhole.toLong().toDouble()) balanceWhole.toLong().toString()
+        else balanceWhole.toString()
+}
+
+/**
+ * FE-160 - the "Fund with crypto balance" sub-state layered onto the ads deposit sheet. Additive: the
+ * existing card/wallet deposit path is untouched. [enabled] flips false once the fee-quote endpoint 404s
+ * (degrade-on-404 -> "Crypto funding unavailable"). [assets] is the fundable custody balance set; [quote]
+ * is the live rate-locked quote for [selectedSymbol]; [secondsRemaining] drives the countdown chip;
+ * [insufficient] disables funding with a message; [error] carries a quote/pay error. [enabledForFunding]
+ * mirrors the checkout canPay gate.
+ */
+data class CryptoFundUiState(
+    val enabled: Boolean = true,
+    val assets: List<AdCryptoAssetOption> = emptyList(),
+    val selectedSymbol: String? = null,
+    val quoting: Boolean = false,
+    val quote: FeeQuote? = null,
+    val secondsRemaining: Long = 0L,
+    val insufficient: Boolean = false,
+    val error: String? = null,
+) {
+    val selectedAsset: AdCryptoAssetOption?
+        get() = assets.firstOrNull { it.symbol == selectedSymbol }
+
+    /** True only when a live, non-expired, affordable quote is ready to fund with. */
+    val canFund: Boolean
+        get() = enabled && quote != null && secondsRemaining > 0L && !insufficient && !quoting
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdsBillingViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adsbilling/ui/AdsBillingViewModel.kt
@@ -10,6 +10,16 @@ import com.testlogon.android.core.network.error.ApiErrorParser
 import com.testlogon.android.data.billing.BillingRepository
 import com.testlogon.android.data.billing.PaymentMethod
 import com.testlogon.android.feature.adsbilling.data.AdsBillingRepository
+import com.testlogon.android.data.custody.CustodyAssets
+import com.testlogon.android.data.custody.CustodyReader
+import com.testlogon.android.data.fees.FeeQuote
+import com.testlogon.android.data.fees.FeesRepository
+import com.testlogon.android.feature.checkout.CheckoutCryptoMath
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlin.math.roundToLong
 import com.testlogon.android.navigation.AdsBillingDest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,6 +48,8 @@ import javax.inject.Inject
 class AdsBillingViewModel @Inject constructor(
     private val repository: AdsBillingRepository,
     private val billingRepository: BillingRepository,
+    private val feesRepository: FeesRepository,
+    private val custodyReader: CustodyReader,
     private val errorParser: ApiErrorParser,
     savedState: SavedStateHandle,
 ) : ViewModel() {
@@ -67,6 +79,17 @@ class AdsBillingViewModel @Inject constructor(
     /** ADV-306 - the card selected to fund the deposit (null until methods load / when the wallet is empty). */
     private val _selectedPaymentMethodId = MutableStateFlow<String?>(null)
     val selectedPaymentMethodId: StateFlow<String?> = _selectedPaymentMethodId.asStateFlow()
+
+    /** FE-160 - the "Fund with crypto balance" sub-state (asset picker + rate-locked quote + countdown). */
+    private val _crypto = MutableStateFlow(CryptoFundUiState())
+    val crypto: StateFlow<CryptoFundUiState> = _crypto.asStateFlow()
+
+    /** FE-160 - true when the user has switched the deposit sheet to the crypto-funding tab. */
+    private val _cryptoFundingMode = MutableStateFlow(false)
+    val cryptoFundingMode: StateFlow<Boolean> = _cryptoFundingMode.asStateFlow()
+
+    /** Drives the 1s rate-lock countdown; cancelled on re-quote / clear / onCleared. */
+    private var countdownJob: Job? = null
 
     init {
         load()
@@ -130,7 +153,10 @@ class AdsBillingViewModel @Inject constructor(
         _amountText.value = ""
         _depositState.value = DepositState.Idle
         _depositSheetVisible.value = true
+        _cryptoFundingMode.value = false
+        _crypto.value = CryptoFundUiState()
         loadPaymentMethods()
+        loadCryptoBalances()
     }
 
     /** ADV-306 - the user picked a card in the deposit sheet. */
@@ -172,9 +198,12 @@ class AdsBillingViewModel @Inject constructor(
     /** Dismisses the deposit sheet (only when not submitting) -> Idle. */
     fun dismissDeposit() {
         if (_depositState.value is DepositState.Submitting) return
+        countdownJob?.cancel()
         _amountText.value = ""
         _depositState.value = DepositState.Idle
         _depositSheetVisible.value = false
+        _cryptoFundingMode.value = false
+        _crypto.value = CryptoFundUiState()
     }
 
     /** True only when the current amount text parses to a valid in-range cents amount (5000..10000000). */
@@ -212,6 +241,167 @@ class AdsBillingViewModel @Inject constructor(
             }
         }
     }
+
+    // ---- FE-160: fund with crypto balance ----
+
+    /** Switches the deposit sheet between the card/wallet path and the crypto-funding path. */
+    fun setCryptoFundingMode(enabled: Boolean) {
+        if (enabled == _cryptoFundingMode.value) return
+        _cryptoFundingMode.value = enabled
+        if (!enabled) {
+            countdownJob?.cancel()
+            _crypto.update {
+                it.copy(selectedSymbol = null, quote = null, error = null, insufficient = false, secondsRemaining = 0L)
+            }
+        } else {
+            _crypto.value.selectedSymbol?.let { requestQuote(it) }
+        }
+    }
+
+    /** Applies a preset top-up (integer cents) into the amount field (validated by [AdDepositMath]). */
+    fun onPresetSelected(cents: Long) {
+        onAmountChanged(AdDepositMath.formatCents(cents))
+        if (_cryptoFundingMode.value) _crypto.value.selectedSymbol?.let { requestQuote(it) }
+    }
+
+    /** Loads the fundable custody balances (known assets with a positive balance) for the picker. */
+    private fun loadCryptoBalances() {
+        viewModelScope.launch {
+            val balances = (custodyReader.getBalance() as? ApiResult.Success)?.data ?: return@launch
+            val options = balances.rows
+                .filter { it.known && it.amount > 0.0 }
+                .mapNotNull { row ->
+                    val asset = CustodyAssets.findAsset(row.symbol) ?: return@mapNotNull null
+                    AdCryptoAssetOption(
+                        symbol = asset.symbol,
+                        name = asset.name,
+                        decimals = asset.decimals,
+                        balanceWhole = row.amount,
+                        balanceBaseUnits = wholeToBaseUnits(row.amount, asset.decimals),
+                    )
+                }
+            _crypto.update { it.copy(assets = options) }
+        }
+    }
+
+    /** The user picked a coin: reset the prior quote and request a fresh rate-locked quote. */
+    fun onCryptoAssetSelected(symbol: String) {
+        if (symbol == _crypto.value.selectedSymbol && _crypto.value.quote != null) return
+        _crypto.update { it.copy(selectedSymbol = symbol, quote = null, error = null, insufficient = false) }
+        requestQuote(symbol)
+    }
+
+    /**
+     * Requests a rate-locked fee quote for the CURRENT top-up amount + [symbol]. Ignored when the amount
+     * is not yet a valid top-up. A 404 -> Success(null) flips the crypto path off (degrade-on-404).
+     */
+    private fun requestQuote(symbol: String) {
+        countdownJob?.cancel()
+        val cents = parsedAmountCents()
+        if (cents == null || !AdDepositMath.isValidTopUpCents(cents)) {
+            _crypto.update { it.copy(quoting = false, quote = null, secondsRemaining = 0L) }
+            return
+        }
+        _crypto.update { it.copy(quoting = true, error = null) }
+        viewModelScope.launch {
+            when (val r = feesRepository.quoteFee(amountCents = cents, payWith = symbol)) {
+                is ApiResult.Success -> {
+                    val q = r.data
+                    if (q == null) {
+                        _crypto.update { it.copy(quoting = false, enabled = false, quote = null) }
+                    } else {
+                        applyQuote(symbol, q)
+                    }
+                }
+                is ApiResult.Failure ->
+                    _crypto.update { it.copy(quoting = false, quote = null, error = r.error.message) }
+                is ApiResult.NetworkError ->
+                    _crypto.update { it.copy(quoting = false, quote = null, error = OFFLINE_FALLBACK) }
+            }
+        }
+    }
+
+    private fun applyQuote(symbol: String, quote: FeeQuote) {
+        val bal = _crypto.value.assets.firstOrNull { it.symbol == symbol }?.balanceBaseUnits ?: 0L
+        val insufficient = CheckoutCryptoMath.insufficientForQuote(bal, quote.totalNative)
+        _crypto.update {
+            it.copy(
+                quoting = false,
+                enabled = true,
+                quote = quote,
+                insufficient = insufficient,
+                secondsRemaining = CheckoutCryptoMath.quoteExpirySeconds(quote.expiresAt, nowMs()),
+                error = null,
+            )
+        }
+        startCountdown(symbol, quote)
+    }
+
+    private fun startCountdown(symbol: String, quote: FeeQuote) {
+        countdownJob?.cancel()
+        countdownJob = viewModelScope.launch {
+            while (isActive) {
+                val remaining = CheckoutCryptoMath.quoteExpirySeconds(quote.expiresAt, nowMs())
+                _crypto.update { it.copy(secondsRemaining = remaining) }
+                if (remaining <= 0L) {
+                    requestQuote(symbol)
+                    return@launch
+                }
+                delay(1000L)
+            }
+        }
+    }
+
+    /**
+     * Funds the ad account from the selected crypto balance at the LOCKED rate. Ignored unless a live,
+     * affordable quote is ready. On success: reflect the new balance + refresh the ledger (same as the
+     * card path). A 409 quote_expired re-quotes; other failures surface a friendly deposit error.
+     */
+    fun fundWithCrypto() {
+        if (_depositState.value is DepositState.Submitting) return
+        val cState = _crypto.value
+        val quote = cState.quote ?: return
+        if (!cState.canFund) return
+        val cents = parsedAmountCents() ?: return
+        _depositState.value = DepositState.Submitting
+        viewModelScope.launch {
+            when (
+                val r = repository.deposit(
+                    accountId = accountId,
+                    amountCents = cents,
+                    paymentMethodId = null,
+                    payWith = quote.payWith,
+                    quoteToken = quote.quoteToken,
+                )
+            ) {
+                is ApiResult.Success -> {
+                    applyNewBalance(r.data.newBalanceCents)
+                    refreshLedger()
+                    countdownJob?.cancel()
+                    _amountText.value = ""
+                    _crypto.update { it.copy(quote = null, secondsRemaining = 0L) }
+                    _depositState.value = DepositState.Success(r.data.newBalanceCents)
+                }
+                is ApiResult.Failure -> {
+                    if (r.error.status == 409 || r.error.code == "quote_expired") {
+                        _depositState.value = DepositState.Idle
+                        requestQuote(quote.payWith)
+                    } else {
+                        _depositState.value = DepositState.Error(friendlyDepositError(r.error))
+                    }
+                }
+                is ApiResult.NetworkError ->
+                    _depositState.value = DepositState.Error(OFFLINE_FALLBACK)
+            }
+        }
+    }
+
+    override fun onCleared() {
+        countdownJob?.cancel()
+        super.onCleared()
+    }
+
+    private fun nowMs(): Long = System.currentTimeMillis()
 
     // ---- internals ----
 
@@ -274,6 +464,15 @@ class AdsBillingViewModel @Inject constructor(
          * Parses a USD entry ("50", "50.00", "$50.00", "1,000.00") into integer cents, or null when
          * unparseable / negative. Caps at two decimal places. Mirrors the AND-364 / AND-366 helpers.
          */
+        /** whole-coin Double -> integer native base units (half-up, clamped >= 0). Mirrors FE-152. */
+        internal fun wholeToBaseUnits(whole: Double, decimals: Int): Long {
+            if (whole <= 0.0) return 0L
+            var scale = 1.0
+            repeat(if (decimals < 0) 0 else decimals) { scale *= 10.0 }
+            val v = (whole * scale).roundToLong()
+            return if (v < 0L) 0L else v
+        }
+
         internal fun parseUsdToCents(text: String): Long? {
             val cleaned = text.trim().removePrefix("$").replace(",", "")
             if (cleaned.isEmpty()) return null

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4020,6 +4020,19 @@
     <string name="deposit_success">Deposit successful.</string>
     <string name="deposit_done">Done</string>
     <string name="deposit_success_with_balance">Deposit successful. New balance: %1$s</string>
+    <!-- FE-160: fund ad account with crypto balance -->
+    <string name="fund_tab_card">Card / wallet</string>
+    <string name="fund_tab_crypto">Crypto balance</string>
+    <string name="fund_crypto_asset_label">Pay with</string>
+    <string name="fund_crypto_pick_asset">Choose a crypto balance</string>
+    <string name="fund_crypto_no_balance">No crypto balance available to fund with.</string>
+    <string name="fund_crypto_unavailable">Crypto funding unavailable.</string>
+    <string name="fund_crypto_quoting">Fetching rate…</string>
+    <string name="fund_crypto_rate">Rate</string>
+    <string name="fund_crypto_fee">Conversion fee</string>
+    <string name="fund_crypto_total">Total</string>
+    <string name="fund_crypto_insufficient">Insufficient balance for this amount.</string>
+    <string name="fund_crypto_confirm">Fund with crypto</string>
 
     <!-- AND-368: READ-ONLY ad-analytics dashboard -->
     <string name="more_entry_ad_analytics">Ad analytics</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/ads/accounts/AdsAccountsViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/ads/accounts/AdsAccountsViewModelTest.kt
@@ -72,6 +72,8 @@ class AdsAccountsViewModelTest {
             accountId: String,
             amountCents: Long,
             paymentMethodId: String?,
+            payWith: String?,
+            quoteToken: String?,
         ): ApiResult<DepositResult> = ApiResult.Success(DepositResult())
     }
 

--- a/android/app/src/test/java/com/testlogon/android/feature/ads/analytics/AdAnalyticsViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/ads/analytics/AdAnalyticsViewModelTest.kt
@@ -114,6 +114,8 @@ class AdAnalyticsViewModelTest {
             accountId: String,
             amountCents: Long,
             paymentMethodId: String?,
+            payWith: String?,
+            quoteToken: String?,
         ): ApiResult<DepositResult> = throw NotImplementedError()
     }
 

--- a/android/app/src/test/java/com/testlogon/android/feature/ads/campaigns/AdsCampaignsViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/ads/campaigns/AdsCampaignsViewModelTest.kt
@@ -77,6 +77,8 @@ class AdsCampaignsViewModelTest {
             accountId: String,
             amountCents: Long,
             paymentMethodId: String?,
+            payWith: String?,
+            quoteToken: String?,
         ): ApiResult<DepositResult> = ApiResult.Success(DepositResult())
     }
 

--- a/android/app/src/test/java/com/testlogon/android/feature/adsbilling/AdDepositMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/adsbilling/AdDepositMathTest.kt
@@ -1,0 +1,96 @@
+package com.testlogon.android.feature.adsbilling.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * FE-160 - correctness for the ad-account top-up amount presets + validation + balance projection.
+ * Pure integer math (cents), no clock or I/O. The crypto rate-lock math is covered separately by
+ * CheckoutCryptoMathTest (reused as-is).
+ */
+class AdDepositMathTest {
+
+    @Test
+    fun presets_are_the_expected_usd_amounts_in_cents() {
+        assertEquals(listOf(2_500L, 5_000L, 10_000L, 25_000L), AdDepositMath.PRESET_TOPUPS_CENTS)
+    }
+
+    @Test
+    fun every_preset_is_valid() {
+        AdDepositMath.PRESET_TOPUPS_CENTS.forEach {
+            assertTrue("preset $it should be valid", AdDepositMath.isValidTopUpCents(it))
+        }
+    }
+
+    @Test
+    fun min_topup_is_one_dollar_inclusive() {
+        assertTrue(AdDepositMath.isValidTopUpCents(100L))
+        assertFalse(AdDepositMath.isValidTopUpCents(99L))
+    }
+
+    @Test
+    fun zero_and_negative_are_invalid() {
+        assertFalse(AdDepositMath.isValidTopUpCents(0L))
+        assertFalse(AdDepositMath.isValidTopUpCents(-500L))
+    }
+
+    @Test
+    fun max_topup_is_inclusive_and_above_is_invalid() {
+        assertTrue(AdDepositMath.isValidTopUpCents(10_000_000L))
+        assertFalse(AdDepositMath.isValidTopUpCents(10_000_001L))
+    }
+
+    @Test
+    fun topUpLabel_whole_dollars_have_no_decimals() {
+        assertEquals("$25", AdDepositMath.topUpLabel(2_500L))
+        assertEquals("$100", AdDepositMath.topUpLabel(10_000L))
+    }
+
+    @Test
+    fun topUpLabel_fractional_dollars_show_two_decimals() {
+        assertEquals("$25.50", AdDepositMath.topUpLabel(2_550L))
+        assertEquals("$0.05", AdDepositMath.topUpLabel(5L))
+    }
+
+    @Test
+    fun newBalance_adds_credit() {
+        assertEquals(15_000L, AdDepositMath.newBalanceCents(5_000L, 10_000L))
+    }
+
+    @Test
+    fun newBalance_treats_negatives_as_zero() {
+        assertEquals(10_000L, AdDepositMath.newBalanceCents(-1L, 10_000L))
+        assertEquals(5_000L, AdDepositMath.newBalanceCents(5_000L, -10_000L))
+        assertEquals(0L, AdDepositMath.newBalanceCents(-1L, -1L))
+    }
+
+    @Test
+    fun newBalance_saturates_on_overflow() {
+        assertEquals(Long.MAX_VALUE, AdDepositMath.newBalanceCents(Long.MAX_VALUE, 1L))
+    }
+
+    @Test
+    fun dollars_to_cents_rounds_half_up_and_clamps() {
+        assertEquals(2_500L, AdDepositMath.dollarsToCents(25.0))
+        assertEquals(2_555L, AdDepositMath.dollarsToCents(25.554))
+        assertEquals(2_556L, AdDepositMath.dollarsToCents(25.555))
+        assertEquals(0L, AdDepositMath.dollarsToCents(-5.0))
+        assertEquals(0L, AdDepositMath.dollarsToCents(Double.NaN))
+    }
+
+    @Test
+    fun cents_to_dollars_roundtrips() {
+        assertEquals(25.0, AdDepositMath.centsToDollars(2_500L), 0.0001)
+        assertEquals(0.05, AdDepositMath.centsToDollars(5L), 0.0001)
+    }
+
+    @Test
+    fun formatCents_handles_whole_fractional_and_negative() {
+        assertEquals("25", AdDepositMath.formatCents(2_500L))
+        assertEquals("25.50", AdDepositMath.formatCents(2_550L))
+        assertEquals("0.05", AdDepositMath.formatCents(5L))
+        assertEquals("-25.50", AdDepositMath.formatCents(-2_550L))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/adsbilling/AdsBillingViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/adsbilling/AdsBillingViewModelTest.kt
@@ -22,6 +22,11 @@ import com.testlogon.android.data.billing.Subscription
 import com.testlogon.android.data.billing.WalletBalance
 import com.testlogon.android.core.testing.MainDispatcherRule
 import com.testlogon.android.feature.adsbilling.data.AdsBillingRepository
+import com.testlogon.android.data.custody.CustodyBalances
+import com.testlogon.android.data.custody.CustodyReader
+import com.testlogon.android.data.fees.CheckoutPayResult
+import com.testlogon.android.data.fees.FeeQuote
+import com.testlogon.android.data.fees.FeesRepository
 import com.testlogon.android.feature.adsbilling.ui.AdsBillingUiState
 import com.testlogon.android.feature.adsbilling.ui.AdsBillingViewModel
 import com.testlogon.android.feature.adsbilling.ui.DepositState
@@ -92,16 +97,40 @@ class AdsBillingViewModelTest {
         ) = error("updateCampaign not used in this test")
         override suspend fun getInvoice(accountId: String, month: String) = invoiceOutcome
 
+        var lastDepositPayWith: String? = null
+
         override suspend fun deposit(
             accountId: String,
             amountCents: Long,
             paymentMethodId: String?,
+            payWith: String?,
+            quoteToken: String?,
         ): ApiResult<DepositResult> {
             depositCount++
             lastDepositCents = amountCents
+            lastDepositPayWith = payWith
             depositGate?.await()
             return depositOutcome
         }
+    }
+
+    /** FE-160 - fees fake: quote/pay outcomes for the crypto-funding path. */
+    private class FakeFeesRepo(
+        var quoteOutcome: ApiResult<FeeQuote?> = ApiResult.Success(null),
+    ) : FeesRepository {
+        override suspend fun quoteFee(amountCents: Long, payWith: String): ApiResult<FeeQuote?> = quoteOutcome
+        override suspend fun payCheckoutOrder(orderId: String, quote: FeeQuote): ApiResult<CheckoutPayResult> =
+            ApiResult.Success(CheckoutPayResult(status = null, orderId = orderId, txnId = null, coinNativeDebited = null))
+    }
+
+    /** FE-160 - custody fake: canned balances for the asset picker. */
+    private class FakeCustodyReader(
+        var balances: ApiResult<CustodyBalances> =
+            ApiResult.Success(CustodyBalances(vault = "v", tier = "t", rows = emptyList())),
+    ) : CustodyReader {
+        override suspend fun getBalance(): ApiResult<CustodyBalances> = balances
+        override suspend fun getStaking(): ApiResult<com.testlogon.android.data.custody.StakingDashboard> =
+            ApiResult.Failure(ApiError(status = 404, message = "n/a"))
     }
 
     /** ADV-306 - minimal general-billing fake backing the deposit card picker ([pms] = saved cards). */
@@ -127,10 +156,14 @@ class AdsBillingViewModelTest {
     private fun vm(
         repo: AdsBillingRepository = FakeBillingRepo(),
         billing: BillingRepository = FakeGeneralBilling(),
+        fees: FeesRepository = FakeFeesRepo(),
+        custody: CustodyReader = FakeCustodyReader(),
         accountId: String = ACCOUNT_ID,
     ): AdsBillingViewModel = AdsBillingViewModel(
         repository = repo,
         billingRepository = billing,
+        feesRepository = fees,
+        custodyReader = custody,
         errorParser = ApiErrorParser(Moshi.Builder().build()),
         savedState = SavedStateHandle(mapOf(AdsBillingViewModel.ARG_ACCOUNT_ID to accountId)),
     )

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/ads/AdsDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/ads/AdsDtos.kt
@@ -131,6 +131,11 @@ data class AdInvoiceCampaignLineDto(
 data class AdDepositIn(
     @Json(name = "amount_cents") val amountCents: Long,
     @Json(name = "payment_method_id") val paymentMethodId: String? = null,
+    // FE-160: optional crypto-funding fields. When both are present the server funds the deposit from the
+    // caller custody balance at the LOCKED rate carried by `quote_token`; when both are null the existing
+    // card/wallet path is unchanged. Additive - omitting them keeps the AND-367 wire contract.
+    @Json(name = "pay_with") val payWith: String? = null,
+    @Json(name = "quote_token") val quoteToken: String? = null,
 )
 
 /**

--- a/frontend/src/api/endpoints/ads.ts
+++ b/frontend/src/api/endpoints/ads.ts
@@ -310,10 +310,20 @@ export const whyThisAd = (
 
 // ─── Ad Billing (ADS-007) ────────────────────────────────────────────────
 
-/** Deposit funds into ad account */
+/**
+ * Deposit funds into an ad account.
+ *
+ * Card/default path: omit pay_with/quote_token (unchanged behaviour).
+ * Pay-with-crypto (FE-160 / BE-160): pass a locked FeeQuote pay_with +
+ * quote_token to fund the budget from a crypto balance at the shown rate —
+ * the same pay-any-coin contract as checkout (see api/endpoints/fees.ts).
+ * Server returns 409 quote_expired (re-quote) / 402 insufficient_<coin>.
+ */
 export const depositAdFunds = (accountId: string, data: {
   amount_cents: number;
   payment_method_id?: string;
+  pay_with?: string;
+  quote_token?: string;
 }) =>
   api.post<{ ok: boolean; entry_id: string; new_balance_cents: number }>(
     `/ui/ads/accounts/${accountId}/deposit`,

--- a/frontend/src/lib/adDeposit.test.ts
+++ b/frontend/src/lib/adDeposit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PRESET_TOPUPS_CENTS,
+  MIN_TOPUP_CENTS,
+  MAX_TOPUP_CENTS,
+  isValidTopUpCents,
+  topUpLabel,
+  newBalanceCents,
+  dollarsToCents,
+  centsToDollars,
+} from "@/lib/adDeposit";
+
+describe("adDeposit presets", () => {
+  it("exposes ascending USD-cent presets", () => {
+    expect(PRESET_TOPUPS_CENTS).toEqual([2500, 5000, 10000, 25000]);
+    const sorted = [...PRESET_TOPUPS_CENTS].sort((a, b) => a - b);
+    expect(PRESET_TOPUPS_CENTS).toEqual(sorted);
+  });
+
+  it("every preset is itself a valid top-up", () => {
+    for (const c of PRESET_TOPUPS_CENTS) {
+      expect(isValidTopUpCents(c)).toBe(true);
+    }
+  });
+});
+
+describe("isValidTopUpCents", () => {
+  it("accepts the minimum and a mid value", () => {
+    expect(isValidTopUpCents(MIN_TOPUP_CENTS)).toBe(true);
+    expect(isValidTopUpCents(5000)).toBe(true);
+    expect(isValidTopUpCents(MAX_TOPUP_CENTS)).toBe(true);
+  });
+
+  it("rejects below the $1 minimum", () => {
+    expect(isValidTopUpCents(99)).toBe(false);
+    expect(isValidTopUpCents(0)).toBe(false);
+    expect(isValidTopUpCents(-100)).toBe(false);
+  });
+
+  it("rejects above the sane maximum", () => {
+    expect(isValidTopUpCents(MAX_TOPUP_CENTS + 1)).toBe(false);
+  });
+
+  it("rejects non-integer and non-finite cents", () => {
+    expect(isValidTopUpCents(100.5)).toBe(false);
+    expect(isValidTopUpCents(NaN)).toBe(false);
+    expect(isValidTopUpCents(Infinity)).toBe(false);
+  });
+});
+
+describe("topUpLabel", () => {
+  it("drops decimals for whole dollars", () => {
+    expect(topUpLabel(2500)).toBe("$25");
+    expect(topUpLabel(10000)).toBe("$100");
+  });
+
+  it("shows cents for fractional dollars", () => {
+    expect(topUpLabel(12345)).toBe("$123.45");
+    expect(topUpLabel(150)).toBe("$1.50");
+  });
+
+  it("thousands separators for large amounts", () => {
+    expect(topUpLabel(1000000)).toBe("$10,000");
+  });
+
+  it("is safe for non-finite input", () => {
+    expect(topUpLabel(NaN)).toBe("$0");
+  });
+});
+
+describe("newBalanceCents", () => {
+  it("adds current + top-up in cents", () => {
+    expect(newBalanceCents(5000, 2500)).toBe(7500);
+    expect(newBalanceCents(0, 10000)).toBe(10000);
+  });
+
+  it("treats non-finite inputs as 0", () => {
+    expect(newBalanceCents(NaN, 2500)).toBe(2500);
+    expect(newBalanceCents(5000, NaN)).toBe(5000);
+    expect(newBalanceCents(NaN, NaN)).toBe(0);
+  });
+
+  it("rounds fractional cents defensively", () => {
+    expect(newBalanceCents(100.4, 200.4)).toBe(300);
+  });
+});
+
+describe("dollarsToCents / centsToDollars", () => {
+  it("parses dollar strings to whole cents", () => {
+    expect(dollarsToCents("25")).toBe(2500);
+    expect(dollarsToCents("1.50")).toBe(150);
+  });
+
+  it("returns NaN for invalid dollar input", () => {
+    expect(Number.isNaN(dollarsToCents("abc"))).toBe(true);
+    expect(Number.isNaN(dollarsToCents(""))).toBe(true);
+  });
+
+  it("centsToDollars is the inverse for whole cents", () => {
+    expect(centsToDollars(2500)).toBe(25);
+    expect(centsToDollars(150)).toBe(1.5);
+  });
+
+  it("centsToDollars is safe for non-finite input", () => {
+    expect(centsToDollars(NaN)).toBe(0);
+  });
+});

--- a/frontend/src/lib/adDeposit.ts
+++ b/frontend/src/lib/adDeposit.ts
@@ -1,0 +1,62 @@
+// Pure helpers for funding an ad-account / campaign budget (FE-160, EPIC G).
+//
+// The ad-billing deposit surface tops up an advertiser account balance in
+// integer USD cents. This module holds the small amount of pure, integer-safe
+// math the top-up UI needs (preset amounts, validation, labels, new-balance
+// projection) so it is unit-testable in isolation. No React / no network.
+//
+// Money math reuses the shared cents model in lib/cashMath.ts.
+
+import { dollarsToCents as _dollarsToCents } from "@/lib/cashMath";
+
+/** Re-export the shared parser so callers can import one place. */
+export const dollarsToCents = _dollarsToCents;
+
+/** Whole USD cents -> a plain dollars number (2dp). */
+export function centsToDollars(cents: number): number {
+  if (!isFinite(cents)) return 0;
+  return Math.round(cents) / 100;
+}
+
+/** Minimum top-up: $1.00 (matches the cash wallet floor). */
+export const MIN_TOPUP_CENTS = 100;
+
+/** A sane upper bound on a single top-up ($100,000) to catch fat-finger input. */
+export const MAX_TOPUP_CENTS = 10_000_000;
+
+/** Quick top-up presets shown as buttons (USD cents): $25 / $50 / $100 / $250. */
+export const PRESET_TOPUPS_CENTS: number[] = [2500, 5000, 10000, 25000];
+
+/**
+ * True when `cents` is a fundable top-up: a whole (integer) number of cents,
+ * finite, at least the $1 minimum, and no more than the sane maximum.
+ */
+export function isValidTopUpCents(cents: number): boolean {
+  if (!isFinite(cents)) return false;
+  if (!Number.isInteger(cents)) return false;
+  if (cents < MIN_TOPUP_CENTS) return false;
+  if (cents > MAX_TOPUP_CENTS) return false;
+  return true;
+}
+
+/** e.g. 2500 -> "$25", 12345 -> "$123.45". Whole dollars drop the ".00". */
+export function topUpLabel(cents: number): string {
+  const safe = isFinite(cents) ? Math.round(cents) : 0;
+  const dollars = safe / 100;
+  const whole = safe % 100 === 0;
+  return `$${dollars.toLocaleString("en-US", {
+    minimumFractionDigits: whole ? 0 : 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/**
+ * Project the new account balance after adding a top-up. Both args and the
+ * result are integer USD cents; non-finite inputs are treated as 0 so the
+ * projection never renders NaN.
+ */
+export function newBalanceCents(currentCents: number, addedCents: number): number {
+  const cur = isFinite(currentCents) ? Math.round(currentCents) : 0;
+  const add = isFinite(addedCents) ? Math.round(addedCents) : 0;
+  return cur + add;
+}

--- a/frontend/src/pages/ads/AdBillingPage.tsx
+++ b/frontend/src/pages/ads/AdBillingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   listMyAdAccounts,
@@ -8,6 +8,25 @@ import {
   listCampaigns,
 } from "@/api/endpoints/ads";
 import type { AdAccount, AdBillingEntry, Campaign, AdInvoice } from "@/api/types";
+import { quoteFee, type FeeQuote } from "@/api/endpoints/fees";
+import { getBalance, mergeBalances } from "@/api/endpoints/custody";
+import { ApiError } from "@/api/client";
+import {
+  quoteExpirySeconds,
+  insufficientForCents,
+  rateLine,
+  totalLine,
+  feeLine,
+  formatCoin,
+  formatCountdown,
+} from "@/lib/checkoutCrypto";
+import {
+  PRESET_TOPUPS_CENTS,
+  isValidTopUpCents,
+  topUpLabel,
+  newBalanceCents,
+  dollarsToCents,
+} from "@/lib/adDeposit";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -18,8 +37,20 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { Badge } from "@/components/ui/badge";
-import { DollarSign, Plus, Receipt, TrendingUp } from "lucide-react";
+import { toast } from "sonner";
+import {
+  DollarSign,
+  Plus,
+  Receipt,
+  TrendingUp,
+  Bitcoin,
+  CreditCard,
+  Loader2,
+  RefreshCw,
+  AlertTriangle,
+} from "lucide-react";
 
 function formatCents(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
@@ -41,6 +72,16 @@ export default function AdBillingPage() {
   const [invoiceMonth, setInvoiceMonth] = useState(
     new Date().toISOString().slice(0, 7),
   );
+
+  // Fund-with-crypto state (FE-160) — mirrors Checkout.tsx pay-with-crypto (FE-152).
+  const [payCrypto, setPayCrypto] = useState(false);
+  const [cryptoAsset, setCryptoAsset] = useState<string | null>(null);
+  const [quote, setQuote] = useState<FeeQuote | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+  const [quoteError, setQuoteError] = useState("");
+  const [cryptoUnavailable, setCryptoUnavailable] = useState(false);
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000));
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   // Fetch accounts
   const { data: accounts = [] } = useQuery<AdAccount[]>({
@@ -71,19 +112,147 @@ export default function AdBillingPage() {
     enabled: !!accountId && !!invoiceMonth,
   });
 
-  // Deposit mutation
-  const depositMut = useMutation({
-    mutationFn: (amount: number) =>
-      depositAdFunds(accountId, { amount_cents: amount }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["ad-billing", accountId] });
-      queryClient.invalidateQueries({ queryKey: ["ad-accounts"] });
-      setDepositOpen(false);
-      setDepositAmount("");
-    },
+  // Crypto balances (custody). Degrade on 404 -> hide the crypto option.
+  const balanceQuery = useQuery({
+    queryKey: ["custody", "balance"],
+    queryFn: getBalance,
+    retry: false,
   });
 
   const currentAccount = accounts.find((a) => a.account_id === accountId);
+
+  // --- Fund-with-crypto derived state -------------------------------------
+  const cryptoAvailable = balanceQuery.isSuccess && !!balanceQuery.data;
+  const balanceRows = useMemo(
+    () => mergeBalances(balanceQuery.data?.balances),
+    [balanceQuery.data],
+  );
+  const selectedRow = useMemo(
+    () => balanceRows.find((r) => r.symbol === cryptoAsset) ?? null,
+    [balanceRows, cryptoAsset],
+  );
+  const selectedBalance = selectedRow ? Number(selectedRow.balance) : 0;
+  const secondsLeft = quote ? quoteExpirySeconds(quote.expires_at, nowSec) : 0;
+  const quoteStale = !!quote && secondsLeft <= 0;
+  const insufficient =
+    !!quote && !quoteStale && insufficientForCents(selectedBalance, quote);
+
+  // Parsed top-up amount (cents) + validity from the pure lib.
+  const topUpCents = dollarsToCents(depositAmount);
+  const validTopUp = isValidTopUpCents(topUpCents);
+
+  // --- Quote lifecycle (mirror of Checkout.tsx) ---------------------------
+  const fetchQuote = async (asset: string, amountCents: number) => {
+    if (!asset || amountCents <= 0) return;
+    setQuoteLoading(true);
+    setQuoteError("");
+    try {
+      const q = await quoteFee({ amount_cents: amountCents, pay_with: asset });
+      setQuote(q);
+      setNowSec(Math.floor(Date.now() / 1000));
+    } catch (err) {
+      const status = err instanceof ApiError ? err.status : 0;
+      if (status === 404) {
+        setCryptoUnavailable(true);
+        setPayCrypto(false);
+        setQuote(null);
+      } else {
+        setQuote(null);
+        setQuoteError(
+          err instanceof ApiError ? err.detail : "Could not get a rate. Try again.",
+        );
+      }
+    } finally {
+      setQuoteLoading(false);
+    }
+  };
+
+  const handleSelectCryptoAsset = (asset: string) => {
+    setPayCrypto(true);
+    setCryptoAsset(asset);
+    setQuote(null);
+    if (validTopUp) void fetchQuote(asset, topUpCents);
+  };
+
+  const handleRequote = () => {
+    if (cryptoAsset && validTopUp) void fetchQuote(cryptoAsset, topUpCents);
+  };
+
+  // Re-quote when the amount changes while a coin is chosen.
+  useEffect(() => {
+    if (!payCrypto || !cryptoAsset) return;
+    if (!validTopUp) {
+      setQuote(null);
+      return;
+    }
+    void fetchQuote(cryptoAsset, topUpCents);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topUpCents, cryptoAsset, payCrypto]);
+
+  // Live 1Hz countdown for the rate lock while a crypto quote is shown.
+  useEffect(() => {
+    if (!payCrypto || !quote) return;
+    const id = setInterval(
+      () => setNowSec(Math.floor(Date.now() / 1000)),
+      1000,
+    );
+    return () => clearInterval(id);
+  }, [payCrypto, quote]);
+
+  const resetDeposit = () => {
+    setDepositOpen(false);
+    setDepositAmount("");
+    setPayCrypto(false);
+    setCryptoAsset(null);
+    setQuote(null);
+    setQuoteError("");
+  };
+
+  // Deposit mutation (card/default OR crypto).
+  const depositMut = useMutation({
+    mutationFn: () => {
+      const body: {
+        amount_cents: number;
+        pay_with?: string;
+        quote_token?: string;
+      } = { amount_cents: topUpCents };
+      if (payCrypto && quote) {
+        body.pay_with = quote.pay_with;
+        body.quote_token = quote.quote_token;
+      }
+      return depositAdFunds(accountId, body);
+    },
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ["ad-billing", accountId] });
+      queryClient.invalidateQueries({ queryKey: ["ad-accounts"] });
+      queryClient.invalidateQueries({ queryKey: ["custody", "balance"] });
+      setConfirmOpen(false);
+      toast.success(
+        `Funded — new balance ${formatCents(Number(res.new_balance_cents))}`,
+      );
+      resetDeposit();
+    },
+    onError: (err: unknown) => {
+      const detail = err instanceof ApiError ? err.detail : undefined;
+      const status = err instanceof ApiError ? err.status : 0;
+      if (status === 409 && payCrypto) {
+        toast.error("Rate expired — refreshing the quote.");
+        handleRequote();
+      } else if (status === 402 && payCrypto) {
+        toast.error(detail || "Insufficient crypto balance.");
+        setQuoteError(detail || "Insufficient crypto balance.");
+      } else {
+        toast.error(detail || "Deposit failed");
+      }
+    },
+  });
+
+  // Enablement for the primary deposit button.
+  const canSubmit =
+    validTopUp &&
+    (payCrypto
+      ? !!quote && !quoteStale && !insufficient && !quoteLoading
+      : true);
 
   return (
     <div className="space-y-6 p-6" data-testid="ad-billing-page">
@@ -284,7 +453,10 @@ export default function AdBillingPage() {
       )}
 
       {/* Deposit Dialog */}
-      <Dialog open={depositOpen} onOpenChange={setDepositOpen}>
+      <Dialog
+        open={depositOpen}
+        onOpenChange={(o) => (o ? setDepositOpen(true) : resetDeposit())}
+      >
         <DialogContent data-testid="deposit-dialog">
           <DialogHeader>
             <DialogTitle>Deposit Funds</DialogTitle>
@@ -294,48 +466,203 @@ export default function AdBillingPage() {
               <label className="text-sm text-muted-foreground">Amount (USD)</label>
               <Input
                 type="number"
-                min={50}
+                min={1}
                 step={1}
                 value={depositAmount}
                 onChange={(e) => setDepositAmount(e.target.value)}
-                placeholder="50.00"
+                placeholder="25.00"
                 data-testid="deposit-amount-input"
               />
+              {depositAmount && !validTopUp && (
+                <p className="mt-1 text-xs text-destructive" data-testid="topup-invalid">
+                  Enter a whole-cent amount of at least {topUpLabel(100)}.
+                </p>
+              )}
             </div>
-            <div className="flex gap-2">
-              {[50, 100, 250, 500].map((amt) => (
+            <div className="flex flex-wrap gap-2">
+              {PRESET_TOPUPS_CENTS.map((cents) => (
                 <Button
-                  key={amt}
+                  key={cents}
                   variant="outline"
                   size="sm"
-                  onClick={() => setDepositAmount(String(amt))}
+                  onClick={() => setDepositAmount(String(cents / 100))}
+                  data-testid={`topup-preset-${cents}`}
                 >
-                  ${amt}
+                  {topUpLabel(cents)}
                 </Button>
               ))}
             </div>
+
+            {/* Funding method: card/default vs crypto balance (FE-160) */}
+            <div className="space-y-2 pt-1">
+              <p className="text-xs font-medium text-muted-foreground">
+                Funding method
+              </p>
+              <button
+                type="button"
+                className={`flex w-full items-center gap-3 rounded-lg border px-4 py-2.5 text-left transition-colors ${
+                  !payCrypto ? "border-primary bg-primary/5" : "hover:bg-accent"
+                }`}
+                onClick={() => setPayCrypto(false)}
+                data-testid="fund-card-option"
+              >
+                <CreditCard className="h-5 w-5 shrink-0 text-muted-foreground" />
+                <span className="text-sm font-medium">Card / default method</span>
+              </button>
+
+              {cryptoAvailable && !cryptoUnavailable && (
+                <button
+                  type="button"
+                  className={`flex w-full items-center gap-3 rounded-lg border px-4 py-2.5 text-left transition-colors ${
+                    payCrypto ? "border-primary bg-primary/5" : "hover:bg-accent"
+                  }`}
+                  onClick={() => setPayCrypto(true)}
+                  data-testid="fund-crypto-option"
+                >
+                  <Bitcoin className="h-5 w-5 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <span className="text-sm font-medium">
+                      Fund with crypto balance
+                    </span>
+                    <span className="ml-2 text-sm text-muted-foreground">
+                      any supported coin
+                    </span>
+                  </div>
+                </button>
+              )}
+
+              {cryptoUnavailable && (
+                <p className="text-xs text-muted-foreground" data-testid="crypto-unavailable">
+                  Crypto funding unavailable.
+                </p>
+              )}
+
+              {payCrypto && cryptoAvailable && !cryptoUnavailable && (
+                <div className="space-y-3 rounded-lg border border-dashed p-3">
+                  {/* Asset picker */}
+                  <div>
+                    <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                      Choose a coin
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {balanceRows.map((row) => (
+                        <button
+                          key={row.symbol}
+                          type="button"
+                          className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                            cryptoAsset === row.symbol
+                              ? "border-primary bg-primary/10 font-medium"
+                              : "hover:bg-accent"
+                          }`}
+                          onClick={() => handleSelectCryptoAsset(row.symbol)}
+                          data-testid={`crypto-asset-${row.symbol}`}
+                        >
+                          {row.symbol}
+                          <span className="ml-1.5 text-xs text-muted-foreground">
+                            {formatCoin(Number(row.balance))}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {!validTopUp && (
+                    <p className="text-xs text-muted-foreground">
+                      Enter an amount to get a locked rate.
+                    </p>
+                  )}
+
+                  {quoteLoading && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Fetching rate…
+                    </div>
+                  )}
+
+                  {quoteError && !quoteLoading && (
+                    <p className="text-sm text-destructive" data-testid="crypto-quote-error">
+                      {quoteError}
+                    </p>
+                  )}
+
+                  {quote && !quoteLoading && (
+                    <div className="space-y-1.5 rounded-md bg-muted/50 p-3 text-sm" data-testid="crypto-rate-lock">
+                      <div className="flex items-center justify-between">
+                        <span className="text-muted-foreground">{rateLine(quote)}</span>
+                        {quoteStale ? (
+                          <Badge variant="destructive" className="text-[10px]">
+                            Rate expired
+                          </Badge>
+                        ) : (
+                          <Badge variant="secondary" className="text-[10px]" data-testid="crypto-countdown">
+                            Locked {formatCountdown(secondsLeft)}
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="flex items-center justify-between font-medium">
+                        <span>{totalLine(quote)}</span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {feeLine(quote)} · balance {formatCoin(selectedBalance)}{" "}
+                        {quote.pay_with}
+                      </div>
+
+                      {insufficient && (
+                        <p className="flex items-center gap-1.5 text-xs text-destructive" data-testid="crypto-insufficient">
+                          <AlertTriangle className="h-3.5 w-3.5" />
+                          Insufficient {quote.pay_with} balance for this top-up.
+                        </p>
+                      )}
+
+                      {(quoteStale || !insufficient) && (
+                        <button
+                          type="button"
+                          className="mt-1 flex items-center gap-1 text-xs text-primary hover:underline"
+                          onClick={handleRequote}
+                          data-testid="crypto-requote"
+                        >
+                          <RefreshCw className="h-3 w-3" />
+                          {quoteStale ? "Refresh rate" : "Re-quote"}
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDepositOpen(false)}>
+            <Button variant="outline" onClick={resetDeposit}>
               Cancel
             </Button>
             <Button
-              onClick={() => {
-                const cents = Math.round(parseFloat(depositAmount) * 100);
-                if (cents >= 5000) depositMut.mutate(cents);
-              }}
-              disabled={
-                !depositAmount ||
-                parseFloat(depositAmount) < 50 ||
-                depositMut.isPending
-              }
+              onClick={() => setConfirmOpen(true)}
+              disabled={!canSubmit || depositMut.isPending}
               data-testid="deposit-submit"
             >
-              {depositMut.isPending ? "Processing..." : "Deposit"}
+              {depositMut.isPending
+                ? "Processing..."
+                : payCrypto && quote && !quoteStale
+                  ? `Fund ${formatCoin(quote.total_native)} ${quote.pay_with}`
+                  : "Deposit"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Confirm Deposit"
+        description={
+          payCrypto && quote
+            ? `${totalLine(quote)} (${rateLine(quote)}) to add ${topUpLabel(topUpCents)} — new balance ${formatCents(newBalanceCents(Number(currentAccount?.balance_cents ?? 0), topUpCents))}?`
+            : `Add ${topUpLabel(topUpCents)} to your ad balance — new balance ${formatCents(newBalanceCents(Number(currentAccount?.balance_cents ?? 0), topUpCents))}?`
+        }
+        confirmLabel="Deposit"
+        onConfirm={() => depositMut.mutate()}
+        loading={depositMut.isPending}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## FE-160 — fund ad budget with crypto (EPIC G)

Adds **"Fund with crypto balance"** to the ad-account budget deposit: an asset picker + **rate-lock display** + top-up flow + insufficient handling, extending the FE-152 pay-with-crypto flow. Degrade-on-404 → "Crypto funding unavailable"; the existing card/wallet deposit path is untouched.

### Web
- NEW `lib/adDeposit.ts` (+17 vitest) — `PRESET_TOPUPS_CENTS` (25/50/100/250), `isValidTopUpCents` (min $1 / max $100k), `topUpLabel`, `newBalanceCents`, dollars↔cents.
- `AdBillingPage` deposit dialog gains a Card/Crypto funding-method toggle, custody-balance asset picker, rate-lock panel (rateLine/totalLine/feeLine + 1s countdown + re-quote), confirm w/ projected new balance; `depositAdFunds` additively carries `pay_with`+`quote_token`; 409 auto-re-quote, 402 insufficient. Reuses `checkoutCrypto` + `quoteFee` verbatim.

### Android
- NEW `AdDepositMath.kt` (+13 JVM tests); `AdDepositIn` DTO + `AdsBillingRepository.deposit` extended additively; `AdsBillingScreen` deposit sheet gains a Card/Crypto TabRow + preset chips + CryptoFundSection (asset dropdown, rate/fee/total + live countdown, insufficient/unavailable, confirm); `AdsBillingViewModel` injects FeesRepository + CustodyReader (quote lifecycle + auto-re-quote). Reuses `CheckoutCryptoMath` + `FeesRepository` verbatim. Test fakes updated for the widened signature.

### Gates
- Web: tsc 0 · build green · 17/17 vitest
- Android: BUILD SUCCESSFUL · AdDepositMathTest 13/13 (+ existing AdsBillingViewModelTest 9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
