### PR TITLE
FE-161: sponsored-slot rendering + labeling + tracking (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/ads/SponsoredSlotCard.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/ads/SponsoredSlotCard.kt
@@ -1,0 +1,147 @@
+package com.testlogon.android.feature.ads
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
+import com.testlogon.android.data.shopads.SponsoredProduct
+
+/** FE-161 — test tags for the reusable sponsored slot card. */
+object SponsoredSlotTestTags {
+    const val CARD = "sponsored_slot_card"
+    const val LABEL = "sponsored_slot_label"
+    fun card(unitId: String) = "sponsored_slot_card_$unitId"
+}
+
+/**
+ * FE-161 (EPIC G) — a REUSABLE sponsored slot card for interleaved list surfaces (market / token
+ * discovery). Renders the served creative (AsyncImage) + headline / CTA + an always-present, clear
+ * "Sponsored" disclosure chip alongside the server [SponsoredProduct.sponsorLabel]. Fires an
+ * IMPRESSION exactly once when first composed (keyed on the unit id) via [onImpression], and a CLICK
+ * on tap via [onClick] (the caller opens the cta_url through the shared ad-click path). Both beacons
+ * ride the one /ui/ads/track money-path through AdTrackRepository. Degrade-safe: a missing image just
+ * renders a placeholder box; a blank sponsor label still shows the fixed "Sponsored" chip.
+ */
+@Composable
+fun SponsoredSlotCard(
+    product: SponsoredProduct,
+    onImpression: () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Impression fires once when the slot first enters composition (i.e. becomes visible in the list).
+    LaunchedEffect(product.unitId) { onImpression() }
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(SponsoredSlotTestTags.CARD)
+            .testTag(SponsoredSlotTestTags.card(product.unitId))
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            SponsoredDisclosure(product.sponsorLabel)
+            Row(
+                Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    Modifier
+                        .size(72.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                ) {
+                    val image = product.imageUrl
+                    if (image != null) {
+                        SubcomposeAsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current).data(image).crossfade(true).build(),
+                            contentDescription = product.name,
+                            loading = { Box(Modifier.fillMaxSize()) },
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                }
+                Column(Modifier.weight(1f)) {
+                    val headline = product.tracking.headline?.takeIf { it.isNotBlank() } ?: product.name
+                    Text(
+                        text = headline,
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = product.ctaText,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The always-present "Sponsored" disclosure. The fixed chip is the legally-required mark; when the
+ * server carries a distinct [sponsorLabel] (e.g. the advertiser name) that is NOT just the word
+ * "Sponsored", it is shown alongside so the viewer sees who paid.
+ */
+@Composable
+private fun SponsoredDisclosure(sponsorLabel: String) {
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            shape = RoundedCornerShape(4.dp),
+            modifier = Modifier.testTag(SponsoredSlotTestTags.LABEL),
+        ) {
+            Text(
+                text = "Sponsored",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+            )
+        }
+        val extra = sponsorLabel.trim()
+        if (extra.isNotBlank() && !extra.equals("Sponsored", ignoreCase = true)) {
+            Text(
+                text = extra,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/ads/SponsoredSlotMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/ads/SponsoredSlotMath.kt
@@ -1,0 +1,95 @@
+package com.testlogon.android.feature.ads
+
+/**
+ * FE-161 (EPIC G, <- BE-161/BE-162) — PURE, framework-free math for interleaving served SPONSORED
+ * units into an organic list (market / token-discovery, catalog & search). No Android/Compose deps so
+ * it is fully JVM-unit-testable.
+ *
+ * A rendered list is an ordered sequence of [SlotEntry]: [SlotEntry.Organic] wraps a real list item,
+ * [SlotEntry.Sponsored] wraps a served ad with a stable de-dupe [SlotEntry.Sponsored.key]. Sponsored
+ * slots are inserted deterministically every N organic items, never adjacent to each other, never
+ * past the end of the organic list, capped at both the available served count and [max]. When no ads
+ * fill, the output is exactly the organic list (identity) — the organic rendering is unchanged.
+ */
+sealed interface SlotEntry<out T, out A> {
+    data class Organic<out T>(val item: T) : SlotEntry<T, Nothing>
+    data class Sponsored<out A>(val ad: A, val key: String) : SlotEntry<Nothing, A>
+}
+
+/**
+ * How many sponsored slots a list of [itemCount] organic items can hold at a cadence of one slot per
+ * [everyN] items, capped at [max]. A slot is placed AFTER each run of [everyN] organic items, and
+ * never after the final item (a slot must be followed by at least one organic item — "never past
+ * end"), so the count is `floor((itemCount) / everyN)` clamped so the last placement still has a
+ * trailing organic item, then capped at [max].
+ */
+fun sponsoredSlotCount(itemCount: Int, everyN: Int, max: Int): Int {
+    if (itemCount <= 0 || everyN <= 0 || max <= 0) return 0
+    // Slots go after positions everyN, 2*everyN, ... but the position must be strictly before the
+    // last item so a sponsored entry is never the terminal row and never sits past the end.
+    var slots = 0
+    var pos = everyN
+    while (pos < itemCount && slots < max) {
+        slots++
+        pos += everyN
+    }
+    return slots
+}
+
+/**
+ * Interleave [sponsored] ads into [items] every [everyN] organic items, beginning the cadence at
+ * [startAt] organic items in, capped at [max] and at the available [sponsored] count.
+ *
+ * Guarantees:
+ *  - deterministic ordering (organic order preserved; ads consumed in order);
+ *  - a sponsored slot is only ever placed AFTER an organic item and BEFORE another organic item, so
+ *    two sponsored slots are never adjacent and none is the last entry ("never past end");
+ *  - respects the available served count (stops when [sponsored] is exhausted) and [max];
+ *  - identity when [sponsored] is empty (returns exactly the organic list) — organic rendering is
+ *    unchanged when no ads fill.
+ *
+ * @param key stable per-ad key (used for de-dupe / LazyColumn keys). Defaults to the ad index.
+ */
+fun <T, A> interleaveSponsored(
+    items: List<T>,
+    sponsored: List<A>,
+    everyN: Int,
+    startAt: Int = everyN,
+    max: Int = Int.MAX_VALUE,
+    key: (index: Int, ad: A) -> String = { i, _ -> "sponsored_$i" },
+): List<SlotEntry<T, A>> {
+    val out = ArrayList<SlotEntry<T, A>>(items.size + minOf(sponsored.size, if (max > 0) max else 0))
+    // Degrade / guard: nothing to inject -> return the organic list verbatim.
+    if (sponsored.isEmpty() || everyN <= 0 || max <= 0 || items.isEmpty()) {
+        items.forEach { out.add(SlotEntry.Organic(it)) }
+        return out
+    }
+    val effectiveStart = if (startAt <= 0) everyN else startAt
+    var placed = 0
+    var adIndex = 0
+    for ((i, item) in items.withIndex()) {
+        out.add(SlotEntry.Organic(item))
+        val organicSoFar = i + 1
+        val isLast = organicSoFar == items.size
+        // Place a slot after this organic item when we've hit a cadence boundary, there is at least
+        // one more organic item to follow (never last / never past end), an ad is available, and we're
+        // under the cap.
+        val atBoundary = organicSoFar >= effectiveStart &&
+            (organicSoFar - effectiveStart) % everyN == 0
+        if (atBoundary && !isLast && adIndex < sponsored.size && placed < max) {
+            val ad = sponsored[adIndex]
+            out.add(SlotEntry.Sponsored(ad, key(adIndex, ad)))
+            adIndex++
+            placed++
+        }
+    }
+    return out
+}
+
+/**
+ * FE-161 — a served /ui/ads (shop) unit is a valid, renderable sponsored slot only when the serve was
+ * FILLED and carries a non-blank creative id (the money-path track call requires it). Degrade-on-404 /
+ * unfilled -> false -> no slot rendered.
+ */
+fun isValidServe(filled: Boolean, creativeId: String?): Boolean =
+    filled && !creativeId.isNullOrBlank()

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketScreen.kt
@@ -33,11 +33,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.testlogon.android.data.shopads.SponsoredProduct
+import com.testlogon.android.feature.ads.SlotEntry
+import com.testlogon.android.feature.ads.SponsoredSlotCard
 import com.testlogon.android.feature.onboarding.SurfaceIntro
 import com.testlogon.android.feature.onboarding.OnboardingModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -50,6 +54,11 @@ import com.testlogon.android.data.tokens.Token
  * Creator revenue-share TOKEN market/browse list. Two tabs: the LISTED market (browse) and the
  * caller's ISSUED tokens. A row taps through to detail; a FAB opens Mint. Every read degrades to an
  * honest empty state when the (not-yet-built) backend 404s.
+ *
+ * FE-161 (EPIC G) — the MARKET (token-discovery) tab additionally interleaves clearly-labeled
+ * SPONSORED slots (served best-effort) every ~5 organic rows; impression fires when a slot is shown,
+ * a tap fires the CLICK beacon + opens the ad cta_url. Degrade-on-404 -> no slots, organic list
+ * unchanged.
  */
 @Composable
 fun TokensMarketRoute(
@@ -59,6 +68,7 @@ fun TokensMarketRoute(
     viewModel: TokensMarketViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val uriHandler = LocalUriHandler.current
     Scaffold(
         topBar = {
             TopAppBar(
@@ -113,7 +123,17 @@ fun TokensMarketRoute(
                                 },
                             )
                         } else {
-                            TokenList(rows = state.rows, onOpenToken = onOpenToken)
+                            TokenList(
+                                slots = state.marketSlots,
+                                onOpenToken = onOpenToken,
+                                onSponsoredImpression = viewModel::onSponsoredImpression,
+                                onSponsoredClick = { product ->
+                                    viewModel.onSponsoredClick(product)
+                                    product.tracking.ctaUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                                        runCatching { uriHandler.openUri(url) }
+                                    }
+                                },
+                            )
                         }
                 }
             }
@@ -122,14 +142,36 @@ fun TokensMarketRoute(
 }
 
 @Composable
-private fun TokenList(rows: List<Token>, onOpenToken: (String) -> Unit) {
+private fun TokenList(
+    slots: List<SlotEntry<Token, SponsoredProduct>>,
+    onOpenToken: (String) -> Unit,
+    onSponsoredImpression: (SponsoredProduct) -> Unit,
+    onSponsoredClick: (SponsoredProduct) -> Unit,
+) {
     LazyColumn(
         modifier = Modifier.fillMaxSize().testTag("tokens_list"),
         contentPadding = PaddingValues(12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        items(rows, key = { it.tokenId }) { token ->
-            TokenRowCard(token = token, onClick = { onOpenToken(token.tokenId) })
+        items(
+            items = slots,
+            key = { slot ->
+                when (slot) {
+                    is SlotEntry.Organic -> "token_" + slot.item.tokenId
+                    is SlotEntry.Sponsored -> slot.key
+                }
+            },
+        ) { slot ->
+            when (slot) {
+                is SlotEntry.Organic ->
+                    TokenRowCard(token = slot.item, onClick = { onOpenToken(slot.item.tokenId) })
+                is SlotEntry.Sponsored ->
+                    SponsoredSlotCard(
+                        product = slot.ad,
+                        onImpression = { onSponsoredImpression(slot.ad) },
+                        onClick = { onSponsoredClick(slot.ad) },
+                    )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tokens/TokensMarketViewModel.kt
@@ -3,8 +3,15 @@ package com.testlogon.android.feature.tokens
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.ads.AdClickAttributionStore
+import com.testlogon.android.data.ads.AdEvent
+import com.testlogon.android.data.ads.AdTrackRepository
+import com.testlogon.android.data.shopads.ShopAdsRepository
+import com.testlogon.android.data.shopads.SponsoredProduct
 import com.testlogon.android.data.tokens.Token
 import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.feature.ads.SlotEntry
+import com.testlogon.android.feature.ads.interleaveSponsored
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,25 +28,66 @@ data class TokensMarketUiState(
     val tab: TokenListTab = TokenListTab.MARKET,
     val market: List<Token> = emptyList(),
     val issued: List<Token> = emptyList(),
+    /**
+     * FE-161 — served SPONSORED units interleaved into the MARKET tab's list. Empty when the serve
+     * 404s / is unfilled (degrade-on-404: the organic market list is unchanged).
+     */
+    val sponsored: List<SponsoredProduct> = emptyList(),
     val errorMessage: String? = null,
 ) {
     enum class Phase { Loading, Content, Error }
 
     val rows: List<Token> get() = if (tab == TokenListTab.MARKET) market else issued
+
+    /**
+     * FE-161 — the MARKET tab as an ordered list of organic token rows with SPONSORED slots
+     * interleaved every ~5 items (capped 2). The ISSUED tab never carries ads. When [sponsored] is
+     * empty the result is exactly the organic rows (organic rendering unchanged).
+     */
+    val marketSlots: List<SlotEntry<Token, SponsoredProduct>>
+        get() = if (tab == TokenListTab.MARKET) {
+            interleaveSponsored(
+                items = market,
+                sponsored = sponsored,
+                everyN = SPONSORED_EVERY_N,
+                startAt = SPONSORED_EVERY_N,
+                max = SPONSORED_MAX,
+                key = { _, ad -> "sponsored_" + ad.unitId },
+            )
+        } else {
+            issued.map { SlotEntry.Organic(it) }
+        }
+
+    companion object {
+        const val SPONSORED_EVERY_N = 5
+        const val SPONSORED_MAX = 2
+    }
 }
 
 /**
  * Drives the token market/browse list. Loads both the LISTED market (browse) and the caller's ISSUED
  * tokens; both degrade to empty on 404 so the screen shows an honest "pending backend" empty state
  * rather than an error when the endpoints are undeployed.
+ *
+ * FE-161 (EPIC G) — additionally serves STANDALONE product-linked SPONSORED units for the token
+ * DISCOVERY (market) surface and interleaves them into the organic market list as clearly-labeled
+ * sponsored slots. Impression fires when a slot is first shown; a tap fires the CLICK beacon + stashes
+ * the ad_click_id for CPA — all through the SHARED /ui/ads/track money-path (AdTrackRepository /
+ * AdClickAttributionStore). Best-effort: any serve/track failure never disturbs the organic list.
  */
 @HiltViewModel
 class TokensMarketViewModel @Inject constructor(
     private val repository: TokensRepository,
+    private val shopAdsRepository: ShopAdsRepository,
+    private val adTracker: AdTrackRepository,
+    private val adAttribution: AdClickAttributionStore,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TokensMarketUiState())
     val uiState: StateFlow<TokensMarketUiState> = _uiState.asStateFlow()
+
+    /** Impression dedupe — fire at most once per served unit per session. */
+    private val impressedUnits = java.util.Collections.synchronizedSet(mutableSetOf<String>())
 
     init {
         load()
@@ -74,6 +122,51 @@ class TokensMarketViewModel @Inject constructor(
                     errorMessage = null,
                 )
             }
+            loadSponsored()
         }
+    }
+
+    /**
+     * FE-161 — best-effort serve of sponsored units for the token-discovery surface. Re-labels the
+     * tracking surface to "token_discovery" so impression/click beacons record THIS surface. Any
+     * failure folds to an empty list inside the repository -> no slots -> organic list unchanged.
+     */
+    private fun loadSponsored() {
+        viewModelScope.launch {
+            val served = shopAdsRepository.serveShopSponsored(
+                surface = ShopAdsRepository.SURFACE_BROWSE,
+                limit = SPONSORED_LIMIT,
+            )
+            // Round-trip the client-facing discovery surface onto the track payload.
+            val relabeled = served.map { p ->
+                p.copy(tracking = p.tracking.copy(surface = SURFACE_TOKEN_DISCOVERY))
+            }
+            _uiState.update { it.copy(sponsored = relabeled) }
+        }
+    }
+
+    /**
+     * FE-161 — fire an IMPRESSION the first time a sponsored slot is shown (deduped per unit).
+     * Best-effort — a failed beacon never disturbs the list.
+     */
+    fun onSponsoredImpression(product: SponsoredProduct) {
+        val key = product.adClickId ?: product.unitId
+        if (!impressedUnits.add(key)) return
+        viewModelScope.launch { adTracker.track(AdEvent.IMPRESSION, product.tracking) }
+    }
+
+    /**
+     * FE-161 — on tap: fire the CLICK beacon (advertiser CPC, funds-guarded, idempotent, standalone ->
+     * platform 100%) AND stash the ad_click_id for CPA attribution. Best-effort; opening the cta_url is
+     * the screen's concern (LocalUriHandler).
+     */
+    fun onSponsoredClick(product: SponsoredProduct) {
+        adAttribution.record(product.adClickId)
+        viewModelScope.launch { adTracker.track(AdEvent.CLICK, product.tracking) }
+    }
+
+    companion object {
+        private const val SPONSORED_LIMIT = 3
+        const val SURFACE_TOKEN_DISCOVERY = "token_discovery"
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/ads/SponsoredSlotMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/ads/SponsoredSlotMathTest.kt
@@ -1,0 +1,153 @@
+package com.testlogon.android.feature.ads
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** FE-161 — pure-math unit tests for [interleaveSponsored] / [sponsoredSlotCount] / [isValidServe]. */
+class SponsoredSlotMathTest {
+
+    private fun organic(entry: SlotEntry<Int, String>): Int? =
+        (entry as? SlotEntry.Organic<Int>)?.item
+
+    private fun ad(entry: SlotEntry<Int, String>): String? =
+        (entry as? SlotEntry.Sponsored<String>)?.ad
+
+    private fun organicItems(list: List<SlotEntry<Int, String>>): List<Int> =
+        list.mapNotNull { organic(it) }
+
+    private fun sponsoredCount(list: List<SlotEntry<Int, String>>): Int =
+        list.count { it is SlotEntry.Sponsored<*> }
+
+    @Test
+    fun `no sponsored returns organic list verbatim`() {
+        val items = (1..7).toList()
+        val out = interleaveSponsored(items, emptyList<String>(), everyN = 3)
+        assertEquals(items, organicItems(out))
+        assertEquals(0, sponsoredCount(out))
+        assertEquals(items.size, out.size)
+    }
+
+    @Test
+    fun `empty items returns empty`() {
+        val out = interleaveSponsored(emptyList<Int>(), listOf("a"), everyN = 3)
+        assertTrue(out.isEmpty())
+    }
+
+    @Test
+    fun `inserts one slot every N after the boundary`() {
+        val items = (1..10).toList()
+        val out = interleaveSponsored(items, listOf("a", "b", "c"), everyN = 5, startAt = 5, max = 3)
+        // Organic order preserved.
+        assertEquals(items, organicItems(out))
+        // With 10 items and everyN=5: a slot after item#5 only (after #10 is the last -> suppressed).
+        assertEquals(1, sponsoredCount(out))
+        // Slot sits right after the 5th organic item.
+        val idx = out.indexOfFirst { it is SlotEntry.Sponsored<*> }
+        assertEquals(5, out.take(idx).count { it is SlotEntry.Organic<*> })
+    }
+
+    @Test
+    fun `never places two sponsored slots adjacent`() {
+        val items = (1..30).toList()
+        val out = interleaveSponsored(items, List(10) { "ad$it" }, everyN = 5, startAt = 5, max = 10)
+        for (i in 0 until out.size - 1) {
+            val bothSponsored = out[i] is SlotEntry.Sponsored<*> && out[i + 1] is SlotEntry.Sponsored<*>
+            assertFalse("adjacent sponsored at $i", bothSponsored)
+        }
+    }
+
+    @Test
+    fun `never ends with a sponsored slot (never past end)`() {
+        val items = (1..10).toList()
+        val out = interleaveSponsored(items, List(5) { "ad$it" }, everyN = 2, startAt = 2, max = 5)
+        assertTrue(out.last() is SlotEntry.Organic<*>)
+    }
+
+    @Test
+    fun `respects max cap`() {
+        val items = (1..100).toList()
+        val out = interleaveSponsored(items, List(20) { "ad$it" }, everyN = 5, startAt = 5, max = 2)
+        assertEquals(2, sponsoredCount(out))
+    }
+
+    @Test
+    fun `respects available served count`() {
+        val items = (1..100).toList()
+        val out = interleaveSponsored(items, listOf("a"), everyN = 5, startAt = 5, max = 10)
+        assertEquals(1, sponsoredCount(out))
+        assertEquals("a", ad(out.first { it is SlotEntry.Sponsored<*> }))
+    }
+
+    @Test
+    fun `ads consumed in order`() {
+        val items = (1..30).toList()
+        val out = interleaveSponsored(items, listOf("x", "y", "z"), everyN = 5, startAt = 5, max = 3)
+        val ads = out.mapNotNull { ad(it) }
+        assertEquals(listOf("x", "y", "z"), ads)
+    }
+
+    @Test
+    fun `keys are applied from the key function`() {
+        val items = (1..20).toList()
+        val out = interleaveSponsored(
+            items, listOf("a", "b"), everyN = 5, startAt = 5, max = 2,
+            key = { i, adv -> "k_${adv}_$i" },
+        )
+        val keys = out.filterIsInstance<SlotEntry.Sponsored<String>>().map { it.key }
+        assertEquals(listOf("k_a_0", "k_b_1"), keys)
+    }
+
+    @Test
+    fun `startAt shifts the first slot`() {
+        val items = (1..20).toList()
+        val out = interleaveSponsored(items, listOf("a"), everyN = 5, startAt = 3, max = 1)
+        val idx = out.indexOfFirst { it is SlotEntry.Sponsored<*> }
+        // First slot after the 3rd organic item.
+        assertEquals(3, out.take(idx).count { it is SlotEntry.Organic<*> })
+    }
+
+    @Test
+    fun `everyN zero degrades to organic`() {
+        val items = (1..5).toList()
+        val out = interleaveSponsored(items, listOf("a"), everyN = 0, max = 3)
+        assertEquals(items, organicItems(out))
+        assertEquals(0, sponsoredCount(out))
+    }
+
+    @Test
+    fun `all organic items preserved regardless of injection`() {
+        val items = (1..23).toList()
+        val out = interleaveSponsored(items, List(5) { "ad$it" }, everyN = 4, startAt = 4, max = 5)
+        assertEquals(items, organicItems(out))
+    }
+
+    @Test
+    fun `sponsoredSlotCount matches interleave placement`() {
+        val items = (1..17).toList()
+        val everyN = 5
+        val max = 10
+        val count = sponsoredSlotCount(items.size, everyN, max)
+        val out = interleaveSponsored(items, List(max) { "ad$it" }, everyN = everyN, startAt = everyN, max = max)
+        assertEquals(count, sponsoredCount(out))
+    }
+
+    @Test
+    fun `sponsoredSlotCount guards`() {
+        assertEquals(0, sponsoredSlotCount(0, 5, 3))
+        assertEquals(0, sponsoredSlotCount(10, 0, 3))
+        assertEquals(0, sponsoredSlotCount(10, 5, 0))
+        assertEquals(1, sponsoredSlotCount(10, 5, 3))
+        assertEquals(3, sponsoredSlotCount(100, 5, 3))
+    }
+
+    @Test
+    fun `isValidServe requires filled and creative id`() {
+        assertTrue(isValidServe(true, "cr_1"))
+        assertFalse(isValidServe(false, "cr_1"))
+        assertFalse(isValidServe(true, ""))
+        assertFalse(isValidServe(true, null))
+        assertFalse(isValidServe(false, null))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/tokens/TokensMarketViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/tokens/TokensMarketViewModelTest.kt
@@ -2,6 +2,13 @@ package com.testlogon.android.feature.tokens
 
 import com.testlogon.android.MainDispatcherRule
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.ads.AdClickAttributionStore
+import com.testlogon.android.data.ads.AdEvent
+import com.testlogon.android.data.ads.CtaAction
+import com.testlogon.android.data.ads.AdTrackRepository
+import com.testlogon.android.data.feed.SponsoredInfo
+import com.testlogon.android.data.shopads.ShopAdsRepository
+import com.testlogon.android.data.shopads.SponsoredProduct
 import com.testlogon.android.data.tokens.AuctionStatus
 import com.testlogon.android.data.tokens.Token
 import com.testlogon.android.data.tokens.TokenAck
@@ -12,6 +19,7 @@ import com.testlogon.android.data.tokens.TokenStatus
 import com.testlogon.android.data.tokens.TokenUpkeep
 import com.testlogon.android.data.tokens.TokensRepository
 import com.testlogon.android.data.tokens.UpkeepStatus
+import com.testlogon.android.feature.ads.SlotEntry
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -27,6 +35,32 @@ private fun sampleToken(id: String, ticker: String) = Token(
     totalSupply = 1_000_000L,
     revenueShareBps = 1_000,
     status = TokenStatus.LISTED,
+)
+
+private fun sampleSponsored(unitId: String) = SponsoredProduct(
+    unitId = unitId,
+    productId = "p_$unitId",
+    categoryId = "c1",
+    name = "Promoted $unitId",
+    priceCents = 999L,
+    currency = "USD",
+    imageUrl = null,
+    sponsorLabel = "AcmeCo",
+    ctaText = "Shop now",
+    tracking = SponsoredInfo(
+        label = "AcmeCo",
+        headline = "Promoted",
+        ctaText = "Shop now",
+        ctaUrl = "https://example.com/x",
+        adClickId = "ac_$unitId",
+        creativeId = "cr_$unitId",
+        campaignId = "camp_$unitId",
+        accountId = "acct_$unitId",
+        surface = "shop_browse",
+        slotType = "sponsored_post",
+        creatorId = "platform",
+        contentId = unitId,
+    ),
 )
 
 /** Fake honoring the repo contract: reads return the configured [ApiResult]; mutations are unused. */
@@ -56,27 +90,62 @@ private class FakeTokensRepo(
     override suspend fun payUpkeep(id: String) = ApiResult.Success(TokenAck(true))
 }
 
+/** FE-161 — fake shop-ads serve: returns [units] (degrades to empty like the real best-effort repo). */
+private class FakeShopAdsRepo(
+    var units: List<SponsoredProduct> = emptyList(),
+) : ShopAdsRepository {
+    override suspend fun serveShopSponsored(
+        surface: String,
+        query: String,
+        categoryId: String,
+        limit: Int,
+    ): List<SponsoredProduct> = units.take(limit)
+
+    override suspend fun boostListing(
+        itemId: String,
+        categoryId: String,
+        budgetCents: Int,
+        bidCpcCents: Int,
+    ) = throw UnsupportedOperationException()
+}
+
+/** FE-161 — records the ad events fired so impression/click wiring can be asserted. */
+private class RecordingAdTrackRepo : AdTrackRepository {
+    val events = mutableListOf<Pair<AdEvent, SponsoredInfo>>()
+    override suspend fun track(event: AdEvent, ad: SponsoredInfo): ApiResult<Unit> {
+        events.add(event to ad)
+        return ApiResult.Success(Unit)
+    }
+    override suspend fun clickCta(adClickId: String, action: CtaAction): ApiResult<Unit> =
+        ApiResult.Success(Unit)
+}
+
 /**
- * ViewModel-level coverage for [TokensMarketViewModel] (beyond the pure TokenMath tests): the
- * degrade-on-404 -> empty Content path (repo already folds 404 to empty Success) and the happy path
- * with a fake repo returning market + issued rows. A transport failure -> retryable Error is also
- * asserted so the "no connection" branch is exercised.
+ * ViewModel-level coverage for [TokensMarketViewModel]: the degrade-on-404 -> empty Content path, the
+ * happy path with market + issued rows, a transport-failure -> retryable Error, and (FE-161) the
+ * sponsored-slot interleave + impression/click tracking.
  */
 class TokensMarketViewModelTest {
 
     @get:Rule
     val mainRule = MainDispatcherRule()
 
+    private fun vm(
+        repo: FakeTokensRepo = FakeTokensRepo(),
+        shop: FakeShopAdsRepo = FakeShopAdsRepo(),
+        track: RecordingAdTrackRepo = RecordingAdTrackRepo(),
+    ) = TokensMarketViewModel(repo, shop, track, AdClickAttributionStore())
+
     @Test
     fun degrade_bothEmpty_toEmptyContent() = runTest(mainRule.dispatcher) {
-        // 404 already folded to empty Success inside the repo -> honest empty Content, no crash.
-        val vm = TokensMarketViewModel(FakeTokensRepo())
+        val vm = vm()
         advanceUntilIdle()
         val s = vm.uiState.value
         assertEquals(TokensMarketUiState.Phase.Content, s.phase)
         assertTrue(s.market.isEmpty())
         assertTrue(s.issued.isEmpty())
         assertTrue(s.rows.isEmpty())
+        assertTrue(s.sponsored.isEmpty())
         assertNull(s.errorMessage)
     }
 
@@ -86,13 +155,12 @@ class TokensMarketViewModelTest {
             marketResult = ApiResult.Success(listOf(sampleToken("t1", "AAA"), sampleToken("t2", "BBB"))),
             issuedResult = ApiResult.Success(listOf(sampleToken("t3", "CCC"))),
         )
-        val vm = TokensMarketViewModel(repo)
+        val vm = vm(repo)
         advanceUntilIdle()
         val s = vm.uiState.value
         assertEquals(TokensMarketUiState.Phase.Content, s.phase)
         assertEquals(2, s.market.size)
         assertEquals(1, s.issued.size)
-        // MARKET tab is the default -> rows mirror the market slice.
         assertEquals(2, s.rows.size)
         vm.selectTab(TokenListTab.ISSUED)
         assertEquals(1, vm.uiState.value.rows.size)
@@ -101,10 +169,42 @@ class TokensMarketViewModelTest {
     @Test
     fun transportFailure_toRetryableError() = runTest(mainRule.dispatcher) {
         val repo = FakeTokensRepo(marketResult = ApiResult.NetworkError(java.io.IOException(), isTimeout = false))
-        val vm = TokensMarketViewModel(repo)
+        val vm = vm(repo)
         advanceUntilIdle()
         val s = vm.uiState.value
         assertEquals(TokensMarketUiState.Phase.Error, s.phase)
         assertTrue(s.errorMessage != null)
+    }
+
+    @Test
+    fun sponsored_interleaved_and_relabeled_to_token_discovery() = runTest(mainRule.dispatcher) {
+        val market = (1..12).map { sampleToken("t$it", "T$it") }
+        val repo = FakeTokensRepo(marketResult = ApiResult.Success(market))
+        val shop = FakeShopAdsRepo(units = listOf(sampleSponsored("u1"), sampleSponsored("u2")))
+        val vm = vm(repo, shop)
+        advanceUntilIdle()
+        val s = vm.uiState.value
+        // Served units are re-labeled to the token-discovery track surface.
+        assertEquals(2, s.sponsored.size)
+        assertTrue(s.sponsored.all { it.tracking.surface == TokensMarketViewModel.SURFACE_TOKEN_DISCOVERY })
+        // Interleaved: 12 organic tokens + 2 sponsored slots, none adjacent / trailing.
+        val slots = s.marketSlots
+        assertEquals(12, slots.count { it is SlotEntry.Organic<*> })
+        assertEquals(2, slots.count { it is SlotEntry.Sponsored<*> })
+        assertTrue(slots.last() is SlotEntry.Organic<*>)
+    }
+
+    @Test
+    fun impression_and_click_fire_through_track_repo() = runTest(mainRule.dispatcher) {
+        val track = RecordingAdTrackRepo()
+        val vm = vm(track = track)
+        advanceUntilIdle()
+        val ad = sampleSponsored("u1")
+        vm.onSponsoredImpression(ad)
+        vm.onSponsoredImpression(ad) // deduped -> still one impression
+        vm.onSponsoredClick(ad)
+        advanceUntilIdle()
+        assertEquals(1, track.events.count { it.first == AdEvent.IMPRESSION })
+        assertEquals(1, track.events.count { it.first == AdEvent.CLICK })
     }
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -13810,6 +13810,13 @@ export interface AdServeResponse {
   reviewed_by?: string | null;
   promo_code_id?: string | null;
   affiliate_link_id?: string | null;
+  /** FE-161: sponsored-slot labeling + tracking fields (present when filled). */
+  campaign_id?: string | null;
+  account_id?: string | null;
+  creator_id?: string | null;
+  sponsor_label?: string | null;
+  impression_url?: string | null;
+  click_url?: string | null;
 }
 
 export interface AdTrackRequest {

--- a/frontend/src/lib/sponsoredSlots.test.ts
+++ b/frontend/src/lib/sponsoredSlots.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  interleaveSponsored,
+  sponsoredSlotCount,
+  isValidServeResponse,
+  type SponsoredEntry,
+} from "./sponsoredSlots";
+import type { AdServeResponse } from "@/api/types";
+
+/** Build a minimal valid served ad. */
+function ad(id: string): AdServeResponse {
+  return { filled: true, status: "filled", creative_id: id };
+}
+
+/** Extract a compact string representation for assertions. */
+function shape<T>(entries: SponsoredEntry<T>[]): string {
+  return entries
+    .map((e) => (e.type === "organic" ? "o" : "s"))
+    .join("");
+}
+
+const items = Array.from({ length: 12 }, (_, i) => `item-${i}`);
+
+describe("isValidServeResponse", () => {
+  it("accepts filled responses with a creative_id", () => {
+    expect(isValidServeResponse(ad("c1"))).toBe(true);
+  });
+
+  it("rejects null/undefined", () => {
+    expect(isValidServeResponse(null)).toBe(false);
+    expect(isValidServeResponse(undefined)).toBe(false);
+  });
+
+  it("rejects unfilled responses (degrade-on-unfilled)", () => {
+    expect(isValidServeResponse({ filled: false, status: "no_fill" })).toBe(false);
+  });
+
+  it("rejects filled-but-missing-creative", () => {
+    expect(isValidServeResponse({ filled: true, status: "filled" })).toBe(false);
+  });
+});
+
+describe("sponsoredSlotCount", () => {
+  it("is 0 for an empty list", () => {
+    expect(sponsoredSlotCount(0, { everyN: 5 })).toBe(0);
+  });
+
+  it("is 0 when fewer items than everyN", () => {
+    expect(sponsoredSlotCount(4, { everyN: 5 })).toBe(0);
+  });
+
+  it("inserts one slot per full block, never trailing on an exact multiple", () => {
+    // 10 items / everyN 5 => slots after item5 and item10; item10 is the end,
+    // so it is dropped -> 1 slot.
+    expect(sponsoredSlotCount(10, { everyN: 5 })).toBe(1);
+  });
+
+  it("counts a mid-list slot for non-multiple lengths", () => {
+    // 12 items / 5 => slots after 5 and 10 (11,12 follow) -> 2.
+    expect(sponsoredSlotCount(12, { everyN: 5 })).toBe(2);
+  });
+
+  it("respects max", () => {
+    expect(sponsoredSlotCount(100, { everyN: 5, max: 3 })).toBe(3);
+  });
+
+  it("defaults everyN to 5", () => {
+    expect(sponsoredSlotCount(12)).toBe(2);
+  });
+});
+
+describe("interleaveSponsored", () => {
+  it("returns all organic when no ads are supplied", () => {
+    const out = interleaveSponsored(items, [], { everyN: 5 });
+    expect(out).toHaveLength(items.length);
+    expect(out.every((e) => e.type === "organic")).toBe(true);
+    expect(shape(out)).toBe("oooooooooooo");
+  });
+
+  it("returns all organic when ads are all invalid (degrade-on-404)", () => {
+    const out = interleaveSponsored(
+      items,
+      [null, { filled: false, status: "no_fill" }, undefined],
+      { everyN: 5 },
+    );
+    expect(out.every((e) => e.type === "organic")).toBe(true);
+    expect(out).toHaveLength(items.length);
+  });
+
+  it("inserts a slot after every N organic items", () => {
+    const out = interleaveSponsored(items, [ad("a"), ad("b")], { everyN: 5 });
+    // 12 items: slot after 5th and after 10th.
+    expect(shape(out)).toBe("ooooosooooosoo");
+  });
+
+  it("never places two slots adjacent", () => {
+    const out = interleaveSponsored(items, [ad("a"), ad("b"), ad("c")], {
+      everyN: 1,
+      max: 3,
+    });
+    for (let i = 1; i < out.length; i++) {
+      if (out[i]!.type === "sponsored") {
+        expect(out[i - 1]!.type).toBe("organic");
+      }
+    }
+  });
+
+  it("never places a trailing slot past the end", () => {
+    const ten = items.slice(0, 10);
+    const out = interleaveSponsored(ten, [ad("a"), ad("b")], { everyN: 5 });
+    // slot after item5 only; item10 is the end -> no trailing slot.
+    expect(out[out.length - 1]!.type).toBe("organic");
+    expect(out.filter((e) => e.type === "sponsored")).toHaveLength(1);
+  });
+
+  it("respects max", () => {
+    const many = Array.from({ length: 30 }, (_, i) => i);
+    const out = interleaveSponsored(
+      many,
+      [ad("a"), ad("b"), ad("c"), ad("d"), ad("e")],
+      { everyN: 5, max: 2 },
+    );
+    expect(out.filter((e) => e.type === "sponsored")).toHaveLength(2);
+  });
+
+  it("is capped by the number of available ads", () => {
+    const many = Array.from({ length: 30 }, (_, i) => i);
+    const out = interleaveSponsored(many, [ad("a")], { everyN: 5, max: 5 });
+    expect(out.filter((e) => e.type === "sponsored")).toHaveLength(1);
+  });
+
+  it("filters invalid ads before consuming slots", () => {
+    const out = interleaveSponsored(
+      items,
+      [null, ad("a"), { filled: false, status: "x" }, ad("b")],
+      { everyN: 5 },
+    );
+    const slots = out.filter((e) => e.type === "sponsored");
+    expect(slots).toHaveLength(2);
+    expect(slots.map((s) => (s.type === "sponsored" ? s.ad.creative_id : ""))).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("honors startAt for the first insertion", () => {
+    const out = interleaveSponsored(items, [ad("a"), ad("b")], {
+      everyN: 5,
+      startAt: 3,
+    });
+    // first slot after item3, next after item8.
+    expect(shape(out)).toBe("ooosooooosoooo");
+  });
+
+  it("produces stable, unique keys", () => {
+    const out = interleaveSponsored(items, [ad("a"), ad("b")], { everyN: 5 });
+    const keys = out.map((e) => e.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("uses a custom keyOf for organic entries", () => {
+    const out = interleaveSponsored(
+      ["x", "y"],
+      [],
+      { everyN: 5 },
+      (item) => `k-${item}`,
+    );
+    expect(out.map((e) => e.key)).toEqual(["k-x", "k-y"]);
+  });
+
+  it("handles an empty item list", () => {
+    expect(interleaveSponsored([], [ad("a")], { everyN: 5 })).toEqual([]);
+  });
+});

--- a/frontend/src/lib/sponsoredSlots.ts
+++ b/frontend/src/lib/sponsoredSlots.ts
@@ -1,0 +1,110 @@
+// FE-161 (EPIC G): pure helpers for interleaving sponsored slots into a list.
+//
+// No network, no DOM — deterministic + unit-testable. The rendering layer
+// (useSponsoredSlot / SponsoredSlotCard) consumes the {type} discriminated
+// union this produces and handles beacons/tracking.
+
+import type { AdServeResponse } from "@/api/types";
+
+/** A rendered entry in an interleaved list: either an organic item or an ad. */
+export type SponsoredEntry<T> =
+  | { type: "organic"; item: T; key: string }
+  | { type: "sponsored"; ad: AdServeResponse; key: string };
+
+export interface InterleaveOpts {
+  /** Insert a sponsored slot after every N organic items. Default 5. */
+  everyN?: number;
+  /** Skip this many organic items before the first eligible insert. Default = everyN. */
+  startAt?: number;
+  /** Hard cap on the number of sponsored slots inserted. Default = ads.length. */
+  max?: number;
+}
+
+const DEFAULT_EVERY_N = 5;
+
+/**
+ * How many sponsored slots WOULD be inserted for a list of `itemCount`
+ * organic items, before the ad-availability + `max` cap is applied. Callers
+ * use this to decide how many ads to request.
+ */
+export function sponsoredSlotCount(
+  itemCount: number,
+  opts: { everyN?: number; max?: number } = {},
+): number {
+  const everyN = Math.max(1, Math.floor(opts.everyN ?? DEFAULT_EVERY_N));
+  if (itemCount <= 0) return 0;
+  // A slot goes after each full block of `everyN` items; never past the end
+  // (a trailing slot only makes sense if more organic items follow, which the
+  // interleave never does — so we place at most floor(itemCount / everyN),
+  // and never after the final item).
+  let slots = Math.floor(itemCount / everyN);
+  // If itemCount is an exact multiple, the last slot would land at the very end
+  // (after the last item) — drop it so slots are never trailing.
+  if (slots > 0 && itemCount % everyN === 0) slots -= 1;
+  if (opts.max != null) slots = Math.min(slots, Math.max(0, Math.floor(opts.max)));
+  return slots;
+}
+
+/**
+ * A serve response is renderable as a slot only if the server filled it and
+ * it carries a creative id.
+ */
+export function isValidServeResponse(
+  resp: AdServeResponse | null | undefined,
+): resp is AdServeResponse {
+  return !!resp && resp.filled === true && !!resp.creative_id;
+}
+
+/**
+ * Interleave `sponsored` ads into `items`, one slot after every `everyN`
+ * organic items, starting after `startAt` items. Slots are:
+ *  - never adjacent (there is always >=1 organic item between two slots),
+ *  - never past the end (no trailing slot after the final organic item),
+ *  - capped by `max` AND by the number of valid ads available.
+ * Invalid/unfilled ads are ignored. Deterministic.
+ */
+export function interleaveSponsored<T>(
+  items: readonly T[],
+  sponsored: readonly (AdServeResponse | null | undefined)[],
+  opts: InterleaveOpts = {},
+  keyOf?: (item: T, index: number) => string,
+): SponsoredEntry<T>[] {
+  const everyN = Math.max(1, Math.floor(opts.everyN ?? DEFAULT_EVERY_N));
+  const startAt = Math.max(0, Math.floor(opts.startAt ?? everyN));
+  const ads = sponsored.filter(isValidServeResponse);
+  const maxSlots = Math.min(
+    ads.length,
+    opts.max != null ? Math.max(0, Math.floor(opts.max)) : ads.length,
+  );
+
+  const out: SponsoredEntry<T>[] = [];
+  let adsUsed = 0;
+  const n = items.length;
+
+  for (let i = 0; i < n; i++) {
+    const item = items[i]!;
+    out.push({
+      type: "organic",
+      item,
+      key: keyOf ? keyOf(item, i) : `organic-${i}`,
+    });
+
+    const consumed = i + 1; // organic items emitted so far
+    const eligible =
+      consumed >= startAt &&
+      consumed < n && // never a trailing slot
+      (consumed - startAt) % everyN === 0;
+
+    if (eligible && adsUsed < maxSlots) {
+      const ad = ads[adsUsed]!;
+      out.push({
+        type: "sponsored",
+        ad,
+        key: `sponsored-${ad.creative_id ?? adsUsed}-${consumed}`,
+      });
+      adsUsed++;
+    }
+  }
+
+  return out;
+}

--- a/frontend/src/pages/ads/SponsoredSlotCard.tsx
+++ b/frontend/src/pages/ads/SponsoredSlotCard.tsx
@@ -1,0 +1,245 @@
+// FE-161 (EPIC G): generic sponsored-slot card for list/discovery surfaces.
+//
+// Adapted from feed/SponsoredPostCard.tsx (same IntersectionObserver impression
+// beacon + click-through idiom + "Sponsored"/sponsor-label badge + Why/Hide
+// overflow), but driven by an AdServeResponse (serveAd) instead of a FeedPost
+// and additionally reports structured events via trackAdEvent (POST
+// /ui/ads/track) so market/catalog slots reconcile in ad analytics.
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { Ref } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Tag, MoreHorizontal, ExternalLink } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { submitAdFeedback, trackAdEvent } from "@/api/endpoints/ads";
+import { WhyThisAdDialog } from "@/pages/feed/WhyThisAdDialog";
+import type { AdServeResponse } from "@/api/types";
+
+interface SponsoredSlotCardProps {
+  ad: AdServeResponse;
+  /** Surface + slot for tracking (e.g. "token_discovery" / "sponsored_post"). */
+  surface: string;
+  slotType: string;
+  /** Optional layout variant: "row" (table) vs "card" (grid). Default "card". */
+  variant?: "card" | "row";
+  /** Column span for the row variant (table cell). */
+  colSpan?: number;
+  onHide?: (creativeId: string) => void;
+}
+
+/** Fire a best-effort beacon to a server-provided tracking URL. */
+function fireBeacon(url: string | null | undefined) {
+  if (!url) return;
+  fetch(url, { method: "POST", credentials: "include" }).catch(() => {});
+}
+
+export function SponsoredSlotCard({
+  ad,
+  surface,
+  slotType,
+  variant = "card",
+  colSpan = 1,
+  onHide,
+}: SponsoredSlotCardProps) {
+  const [hidden, setHidden] = useState(false);
+  const [whyDialogOpen, setWhyDialogOpen] = useState(false);
+  const impressionFired = useRef(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const creativeId = ad.creative_id ?? "";
+  const campaignId = ad.campaign_id ?? "";
+
+  // Impression: fires once on first >=50% visibility. Beacon + structured track.
+  useEffect(() => {
+    if (impressionFired.current) return;
+    const el = rootRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !impressionFired.current) {
+          impressionFired.current = true;
+          fireBeacon(ad.impression_url);
+          if (creativeId) {
+            trackAdEvent({
+              event: "impression",
+              creative_id: creativeId,
+              campaign_id: campaignId,
+              account_id: ad.account_id ?? "",
+              surface,
+              slot_type: slotType,
+              content_id: creativeId,
+              creator_id: ad.creator_id ?? "",
+            }).catch(() => {});
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ad.impression_url, ad.account_id, ad.creator_id, campaignId, creativeId, surface, slotType]);
+
+  const hideMut = useMutation({
+    mutationFn: () =>
+      submitAdFeedback({
+        creative_id: creativeId,
+        campaign_id: campaignId || undefined,
+        feedback_type: "hide",
+      }),
+    onSuccess: () => {
+      setHidden(true);
+      onHide?.(creativeId);
+      toast.success("Ad hidden");
+    },
+  });
+
+  const handleCtaClick = useCallback(() => {
+    fireBeacon(ad.click_url);
+    if (creativeId) {
+      trackAdEvent({
+        event: "click",
+        creative_id: creativeId,
+        campaign_id: campaignId,
+        account_id: ad.account_id ?? "",
+        surface,
+        slot_type: slotType,
+        content_id: creativeId,
+        creator_id: ad.creator_id ?? "",
+      }).catch(() => {});
+    }
+    if (ad.cta_url) {
+      window.open(ad.cta_url, "_blank", "noopener,noreferrer");
+    }
+  }, [ad.click_url, ad.cta_url, ad.account_id, ad.creator_id, campaignId, creativeId, surface, slotType]);
+
+  if (hidden) return null;
+
+  const label = (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Tag className="h-3.5 w-3.5" />
+      <span className="font-medium">Sponsored</span>
+      {ad.sponsor_label && (
+        <>
+          <span className="mx-0.5">&middot;</span>
+          <span>{ad.sponsor_label}</span>
+        </>
+      )}
+    </div>
+  );
+
+  const overflow = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-7 w-7" data-testid="sponsored-slot-overflow">
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => hideMut.mutate()}>Hide this ad</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setWhyDialogOpen(true)}>Why this ad?</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => toast.info("Report submitted")}>Report ad</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const why = (
+    <WhyThisAdDialog
+      creativeId={creativeId}
+      open={whyDialogOpen}
+      onClose={() => setWhyDialogOpen(false)}
+    />
+  );
+
+  // Row variant: a single full-width table row that matches the market table.
+  if (variant === "row") {
+    return (
+      <tr data-testid="sponsored-slot" ref={rootRef as unknown as Ref<HTMLTableRowElement>}>
+        <td colSpan={colSpan} className="p-0">
+          <div
+            className="flex cursor-pointer items-center gap-3 border-l-2 border-primary/40 bg-muted/40 px-3 py-2.5 hover:bg-muted/60"
+            onClick={handleCtaClick}
+          >
+            {ad.image_url && (
+              <img
+                src={ad.image_url}
+                alt={ad.alt_text || ad.headline || "Sponsored"}
+                className="h-9 w-9 shrink-0 rounded object-cover"
+              />
+            )}
+            <div className="min-w-0 flex-1">
+              {label}
+              <div className="truncate text-sm font-medium">
+                {ad.headline || ad.title || "Sponsored"}
+              </div>
+              {ad.body_text && (
+                <div className="truncate text-xs text-muted-foreground">{ad.body_text}</div>
+              )}
+            </div>
+            {ad.cta_text && (
+              <Badge variant="secondary" className="shrink-0 text-xs">
+                {ad.cta_text}
+                <ExternalLink className="ml-1 h-3 w-3" />
+              </Badge>
+            )}
+            <div onClick={(e) => e.stopPropagation()}>{overflow}</div>
+          </div>
+          {why}
+        </td>
+      </tr>
+    );
+  }
+
+  // Card variant: matches the catalog product grid card footprint.
+  return (
+    <>
+      <Card
+        ref={rootRef}
+        data-testid="sponsored-slot"
+        className="cursor-pointer overflow-hidden border-primary/30 transition-shadow hover:shadow-md"
+        onClick={handleCtaClick}
+      >
+        <CardContent className="p-0">
+          <div className="relative flex h-36 items-center justify-center rounded-t-xl bg-muted">
+            {ad.image_url ? (
+              <img
+                src={ad.image_url}
+                alt={ad.alt_text || ad.headline || "Sponsored"}
+                className="h-full w-full rounded-t-xl object-cover"
+              />
+            ) : (
+              <Tag className="h-8 w-8 text-muted-foreground/50" />
+            )}
+            <div className="absolute right-1 top-1" onClick={(e) => e.stopPropagation()}>
+              {overflow}
+            </div>
+          </div>
+          <div className="space-y-1 p-3">
+            {label}
+            <h4 className="line-clamp-2 text-sm font-medium leading-tight">
+              {ad.headline || ad.title || "Sponsored"}
+            </h4>
+            {ad.body_text && (
+              <p className="line-clamp-2 text-xs text-muted-foreground">{ad.body_text}</p>
+            )}
+            {ad.cta_text && (
+              <Badge variant="secondary" className="mt-1 text-xs" data-testid="sponsored-slot-cta">
+                {ad.cta_text}
+                <ExternalLink className="ml-1 h-3 w-3" />
+              </Badge>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+      {why}
+    </>
+  );
+}

--- a/frontend/src/pages/ads/useSponsoredSlot.ts
+++ b/frontend/src/pages/ads/useSponsoredSlot.ts
@@ -1,0 +1,80 @@
+// FE-161 (EPIC G): fetch sponsored slot ad(s) for a surface, degrade-on-404.
+//
+// Wraps serveAd (POST /ui/ads/serve). A surface can request >1 slot; each is
+// an independent serve so an unfilled/errored slot never breaks the others.
+// Returns only VALID (filled + creative_id) responses, so callers can hand the
+// array straight to interleaveSponsored. Never throws.
+
+import { useQuery } from "@tanstack/react-query";
+import { serveAd } from "@/api/endpoints/ads";
+import type { AdServeRequest, AdServeResponse } from "@/api/types";
+import { isValidServeResponse } from "@/lib/sponsoredSlots";
+
+export interface SponsoredSlotOptions {
+  /** Surface identifier, e.g. "token_discovery" or "catalog". */
+  surface: string;
+  /** Slot type sent to the server + used in tracking. */
+  slotType?: string;
+  /** How many slots this surface wants. Default 2. */
+  count?: number;
+  /** Optional context passed through to the serve request. */
+  contentType?: string;
+  contentId?: string;
+  creatorId?: string;
+  /** Gate the fetch (e.g. only when the organic list is long enough). */
+  enabled?: boolean;
+}
+
+/**
+ * Serve up to `count` sponsored slots for a surface. Best-effort: any slot
+ * that 404s / errors / comes back unfilled is silently dropped. The organic
+ * experience is unaffected when this returns [].
+ */
+export function useSponsoredSlot(
+  opts: SponsoredSlotOptions,
+): { ads: AdServeResponse[]; isLoading: boolean } {
+  const {
+    surface,
+    slotType = "sponsored_post",
+    count = 2,
+    contentType,
+    contentId = "",
+    creatorId = "",
+    enabled = true,
+  } = opts;
+
+  const query = useQuery({
+    queryKey: ["sponsored-slot", surface, slotType, count],
+    enabled: enabled && count > 0,
+    staleTime: 60_000,
+    retry: false,
+    queryFn: async (): Promise<AdServeResponse[]> => {
+      const req: AdServeRequest = {
+        surface,
+        slot_type: slotType,
+        content_type: contentType,
+        content_id: contentId,
+        creator_id: creatorId,
+      };
+      // Independent serves; a rejected/unfilled slot must not fail the batch.
+      const settled = await Promise.allSettled(
+        Array.from({ length: count }, () => serveAd(req)),
+      );
+      const filled: AdServeResponse[] = [];
+      const seen = new Set<string>();
+      for (const r of settled) {
+        if (r.status !== "fulfilled") continue;
+        const resp = r.value;
+        if (!isValidServeResponse(resp)) continue;
+        // De-dupe: a surface should not show the same creative twice.
+        const id = resp.creative_id!;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        filled.push(resp);
+      }
+      return filled;
+    },
+  });
+
+  return { ads: query.data ?? [], isLoading: query.isLoading };
+}

--- a/frontend/src/pages/markets/MarketsPage.tsx
+++ b/frontend/src/pages/markets/MarketsPage.tsx
@@ -27,6 +27,9 @@ import {
   fundingIntervalOf,
 } from "@/hooks/useInstrumentClasses";
 import { impliedYes, type PmState } from "@/api/endpoints/trading";
+import { interleaveSponsored } from "@/lib/sponsoredSlots";
+import { useSponsoredSlot } from "@/pages/ads/useSponsoredSlot";
+import { SponsoredSlotCard } from "@/pages/ads/SponsoredSlotCard";
 
 // Fallback catalog if the symbols endpoint errors or returns empty.
 const FALLBACK_SYMBOLS: MarketSymbol[] = [
@@ -231,6 +234,22 @@ export default function MarketsPage() {
     [preClass, classTab, probe],
   );
 
+  // FE-161: sponsored slots for token discovery. Fetch is best-effort and
+  // gated on a list long enough to host a slot; degrades to [] on 404/unfilled.
+  const { ads: sponsoredAds } = useSponsoredSlot({
+    surface: "token_discovery",
+    slotType: "sponsored_post",
+    count: 2,
+    enabled: rows.length >= 5,
+  });
+  const interleavedRows = useMemo(
+    () =>
+      interleaveSponsored(rows, sponsoredAds, { everyN: 5, max: 2 }, (sym) =>
+        String(sym.symbol_id),
+      ),
+    [rows, sponsoredAds],
+  );
+
   const emptyWatchlist = watchTab === "watchlist" && watchlist.length === 0;
 
   // Column span for the "no rows" cell adapts to the extra columns.
@@ -325,19 +344,30 @@ export default function MarketsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {rows.map((sym) => (
-                  <MarketRow
-                    key={sym.symbol_id}
-                    sym={sym}
-                    fav={isFav(sym.symbol_id)}
-                    onToggleFav={toggleFav}
-                    activeClass={classTab}
-                    extras={{
-                      fundingRateBps: fundingRates.get(sym.symbol_id),
-                      pm: probe.pmById.get(sym.symbol_id),
-                    }}
-                  />
-                ))}
+                {interleavedRows.map((entry) =>
+                  entry.type === "sponsored" ? (
+                    <SponsoredSlotCard
+                      key={entry.key}
+                      ad={entry.ad}
+                      surface="token_discovery"
+                      slotType="sponsored_post"
+                      variant="row"
+                      colSpan={colSpan}
+                    />
+                  ) : (
+                    <MarketRow
+                      key={entry.key}
+                      sym={entry.item}
+                      fav={isFav(entry.item.symbol_id)}
+                      onToggleFav={toggleFav}
+                      activeClass={classTab}
+                      extras={{
+                        fundingRateBps: fundingRates.get(entry.item.symbol_id),
+                        pm: probe.pmById.get(entry.item.symbol_id),
+                      }}
+                    />
+                  ),
+                )}
                 {rows.length === 0 && (
                   <TableRow>
                     <TableCell colSpan={colSpan} className="py-4 text-center text-sm text-muted-foreground">

--- a/frontend/src/pages/shop/Catalog.tsx
+++ b/frontend/src/pages/shop/Catalog.tsx
@@ -16,6 +16,9 @@ import {
   searchCatalogItems,
 } from "@/api/endpoints/cart";
 import type { CatalogItem } from "@/api/types";
+import { interleaveSponsored } from "@/lib/sponsoredSlots";
+import { useSponsoredSlot } from "@/pages/ads/useSponsoredSlot";
+import { SponsoredSlotCard } from "@/pages/ads/SponsoredSlotCard";
 
 function formatPrice(cents: number, currency = "USD"): string {
   return new Intl.NumberFormat("en-US", {
@@ -52,6 +55,21 @@ export function Catalog() {
     ? (searchQuery.data?.items ?? [])
     : (itemsQuery.data?.items ?? []);
   const isLoadingItems = isSearching ? searchQuery.isLoading : itemsQuery.isLoading;
+
+  // FE-161: sponsored slots in the catalog/search grid. Best-effort; degrades
+  // to [] (organic grid unchanged) on 404/unfilled.
+  const { ads: sponsoredAds } = useSponsoredSlot({
+    surface: "catalog",
+    slotType: "sponsored_post",
+    count: 3,
+    enabled: items.length >= 5,
+  });
+  const gridEntries = interleaveSponsored(
+    items,
+    sponsoredAds,
+    { everyN: 5, max: 3 },
+    (item) => item.item_id,
+  );
 
   // Auto-select first category
   if (!selectedCategory && categories.length > 0 && !isSearching) {
@@ -149,21 +167,30 @@ export function Catalog() {
           />
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {items.map((item) => (
+            {gridEntries.map((entry) =>
+              entry.type === "sponsored" ? (
+                <SponsoredSlotCard
+                  key={entry.key}
+                  ad={entry.ad}
+                  surface="catalog"
+                  slotType="sponsored_post"
+                  variant="card"
+                />
+              ) : (
               <Card
-                key={item.item_id}
+                key={entry.key}
                 className="cursor-pointer transition-shadow hover:shadow-md"
                 onClick={() =>
-                  navigate(`/shop/${item.category_id}/${item.item_id}`)
+                  navigate(`/shop/${entry.item.category_id}/${entry.item.item_id}`)
                 }
               >
                 <CardContent className="p-0">
                   {/* Image placeholder */}
                   <div className="flex h-36 items-center justify-center rounded-t-xl bg-muted">
-                    {item.image_urls.length > 0 ? (
+                    {entry.item.image_urls.length > 0 ? (
                       <img
-                        src={item.image_urls[0]}
-                        alt={item.name}
+                        src={entry.item.image_urls[0]}
+                        alt={entry.item.name}
                         className="h-full w-full rounded-t-xl object-cover"
                       />
                     ) : (
@@ -172,28 +199,29 @@ export function Catalog() {
                   </div>
                   <div className="p-3">
                     <h4 className="text-sm font-medium leading-tight line-clamp-2">
-                      {item.name}
+                      {entry.item.name}
                     </h4>
                     <p className="mt-1 text-base font-semibold text-primary">
-                      {formatPrice(item.price_cents, item.currency)}
+                      {formatPrice(entry.item.price_cents, entry.item.currency)}
                     </p>
-                    {item.stock_status === "low_stock" && (
+                    {entry.item.stock_status === "low_stock" && (
                       <Badge variant="outline" className="mt-1 border-orange-500 text-orange-600 text-[10px]" data-testid="stock-badge">
-                        Only {item.stock_count} left
+                        Only {entry.item.stock_count} left
                       </Badge>
                     )}
-                    {item.stock_status === "out_of_stock" && (
+                    {entry.item.stock_status === "out_of_stock" && (
                       <Badge variant="destructive" className="mt-1 text-[10px]" data-testid="stock-badge">
                         Out of Stock
                       </Badge>
                     )}
-                    {item.stock_status !== "low_stock" && item.stock_status !== "out_of_stock" && (
+                    {entry.item.stock_status !== "low_stock" && entry.item.stock_status !== "out_of_stock" && (
                       <p className="mt-1 text-[10px] text-muted-foreground">No reviews yet</p>
                     )}
                   </div>
                 </CardContent>
               </Card>
-            ))}
+              ),
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## FE-161 — sponsored-slot rendering + labeling + tracking (EPIC G)

Injects clearly-labeled **"Sponsored"** slots into the **market list / token discovery** and **catalog & search**, with impression/click tracking. Degrade-on-404/unfilled → no slot, organic list unchanged, no crash.

### Web
- NEW `lib/sponsoredSlots.ts` (+22 vitest) — `interleaveSponsored` (deterministic, never adjacent/trailing, capped by max + available ads), `sponsoredSlotCount`, `isValidServeResponse`.
- NEW `useSponsoredSlot` hook (serveAd batch via allSettled; one unfilled slot never fails the batch; degrade → []) + generic `SponsoredSlotCard` (row + card variants) reusing the SponsoredPostCard IntersectionObserver impression beacon (≥50% visibility) + click-through + "Why this ad"/Hide.
- Injected into MarketsPage (token_discovery, everyN 5 / max 2) and Catalog (catalog surface, everyN 5 / max 3 — covers browse + search). Extended AdServeResponse with labeling/tracking fields.

### Android
- NEW `SponsoredSlotMath.kt` (+15 JVM tests) + `SponsoredSlotCard` composable (Coil creative, "Sponsored" chip + sponsor_label, impression via LaunchedEffect, click → track + open cta_url).
- Interleaved into the token-discovery market list (everyN 5 / max 2) reusing the existing `AdTrackRepository` (+ CPA `AdClickAttributionStore`) + the shop-serve degrade-on-404 path. Catalog & search already satisfied by the shipped shop-ads path — not regressed. +2 VM tests.

### Gates
- Web: tsc 0 · build green · 22/22 vitest
- Android: BUILD SUCCESSFUL · SponsoredSlotMathTest 15/15 · TokensMarketViewModelTest 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
