### PR TITLE
FE-162: promote-entity picker + behavioral targeting UI (web + Android) — completes EPIC G

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/ads/create/campaign/CreateCampaignScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/ads/create/campaign/CreateCampaignScreen.kt
@@ -1,12 +1,15 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 
 package com.testlogon.android.feature.ads.create.campaign
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -22,6 +25,8 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +52,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.R
 import com.testlogon.android.core.model.ads.AdAccountSummary
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.PromoteEntityKind
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.SelectedSegments
 
 /** ADV-108 - stable testTags for the create-campaign screen. */
 object CreateCampaignTestTags {
@@ -68,6 +75,12 @@ object CreateCampaignTestTags {
     const val SUCCESS = "create_campaign_success"
     const val REVIEW = "create_campaign_review"
     const val CONTINUE = "create_campaign_continue"
+    // FE-162
+    const val PROMOTE_KIND = "create_campaign_promote_kind"
+    const val PROMOTE_SEARCH = "create_campaign_promote_search"
+    const val PROMOTE_ENTITY = "create_campaign_promote_entity"
+    const val TARGETING = "create_campaign_targeting"
+    const val ESTIMATE = "create_campaign_estimate"
 }
 
 /** ADV-108 - route-level create-campaign entry. [onCreated] carries the new campaign id to continue into creative creation. */
@@ -93,6 +106,13 @@ fun CreateCampaignRoute(
     val endDate by viewModel.endDateMillis.collectAsStateWithLifecycle()
     val submit by viewModel.submitState.collectAsStateWithLifecycle()
     val review by viewModel.reviewState.collectAsStateWithLifecycle()
+    // FE-162
+    val promoteKind by viewModel.promoteKind.collectAsStateWithLifecycle()
+    val promoteQuery by viewModel.promoteQuery.collectAsStateWithLifecycle()
+    val promoteEntities by viewModel.promoteEntities.collectAsStateWithLifecycle()
+    val selectedEntity by viewModel.selectedEntity.collectAsStateWithLifecycle()
+    val segments by viewModel.segments.collectAsStateWithLifecycle()
+    val estimate by viewModel.estimate.collectAsStateWithLifecycle()
 
     CreateCampaignScreen(
         accounts = accounts,
@@ -109,6 +129,22 @@ fun CreateCampaignRoute(
         submitState = submit,
         reviewState = review,
         canSubmit = viewModel.canSubmit,
+        promoteKind = promoteKind,
+        promoteQuery = promoteQuery,
+        promoteEntities = promoteEntities,
+        selectedEntity = selectedEntity,
+        segments = segments,
+        estimate = estimate,
+        targetingSummary = viewModel.targetingSummary,
+        onPromoteKind = viewModel::onPromoteKind,
+        onPromoteQuery = viewModel::onPromoteQuery,
+        onPromoteEntity = viewModel::onPromoteEntitySelected,
+        onToggleAge = viewModel::onToggleAgeRange,
+        onToggleGender = viewModel::onToggleGender,
+        onToggleCountry = viewModel::onToggleCountry,
+        onToggleDevice = viewModel::onToggleDevice,
+        onToggleContentCategory = viewModel::onToggleContentCategory,
+        onNewUserOnly = viewModel::onNewUserOnly,
         onAccount = viewModel::onAccountSelected,
         onName = viewModel::onName,
         onObjective = viewModel::onObjective,
@@ -148,6 +184,22 @@ fun CreateCampaignScreen(
     submitState: CreateCampaignViewModel.SubmitState,
     reviewState: CreateCampaignViewModel.ReviewState,
     canSubmit: Boolean,
+    promoteKind: PromoteEntityKind?,
+    promoteQuery: String,
+    promoteEntities: CreateCampaignViewModel.PromoteEntitiesState,
+    selectedEntity: CreateCampaignViewModel.PromoteEntity?,
+    segments: SelectedSegments,
+    estimate: CreateCampaignViewModel.EstimateState,
+    targetingSummary: String,
+    onPromoteKind: (PromoteEntityKind?) -> Unit,
+    onPromoteQuery: (String) -> Unit,
+    onPromoteEntity: (CreateCampaignViewModel.PromoteEntity) -> Unit,
+    onToggleAge: (String) -> Unit,
+    onToggleGender: (String) -> Unit,
+    onToggleCountry: (String) -> Unit,
+    onToggleDevice: (String) -> Unit,
+    onToggleContentCategory: (String) -> Unit,
+    onNewUserOnly: (Boolean) -> Unit,
     onAccount: (String) -> Unit,
     onName: (String) -> Unit,
     onObjective: (String) -> Unit,
@@ -234,6 +286,31 @@ fun CreateCampaignScreen(
                 singleLine = true,
                 enabled = !submitting,
                 modifier = Modifier.fillMaxWidth().testTag(CreateCampaignTestTags.NAME),
+            )
+
+            // FE-162 (EPIC G) — promote-entity picker (choose what to promote) + behavioral targeting panel.
+            PromoteEntitySection(
+                promoteKind = promoteKind,
+                query = promoteQuery,
+                entities = promoteEntities,
+                selected = selectedEntity,
+                enabled = !submitting,
+                onPromoteKind = onPromoteKind,
+                onQuery = onPromoteQuery,
+                onEntity = onPromoteEntity,
+            )
+
+            TargetingSegmentsSection(
+                segments = segments,
+                summary = targetingSummary,
+                estimate = estimate,
+                enabled = !submitting,
+                onToggleAge = onToggleAge,
+                onToggleGender = onToggleGender,
+                onToggleCountry = onToggleCountry,
+                onToggleDevice = onToggleDevice,
+                onToggleContentCategory = onToggleContentCategory,
+                onNewUserOnly = onNewUserOnly,
             )
 
             // ADV2-306 (F3) — free "promote my content" self-advertising toggle. When on, the money fields
@@ -385,6 +462,213 @@ fun CreateCampaignScreen(
     }
 }
 
+/**
+ * FE-162 — the promote-entity picker: a KIND chooser (market / creator-token / product; "none" clears it)
+ * plus a searchable candidate list from the existing tokens/catalog reads. Degrades to an honest empty
+ * state when the entity read 404s (no crash, no scary error). Entirely optional — leaving the kind unset
+ * keeps the plain create path.
+ */
+@Composable
+private fun PromoteEntitySection(
+    promoteKind: PromoteEntityKind?,
+    query: String,
+    entities: CreateCampaignViewModel.PromoteEntitiesState,
+    selected: CreateCampaignViewModel.PromoteEntity?,
+    enabled: Boolean,
+    onPromoteKind: (PromoteEntityKind?) -> Unit,
+    onQuery: (String) -> Unit,
+    onEntity: (CreateCampaignViewModel.PromoteEntity) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(CreateCampaignTestTags.PROMOTE_KIND)) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text("Promote", style = MaterialTheme.typography.titleMedium)
+            Text(
+                "Optionally pick a market, creator token, or product to promote with this campaign.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                FilterChip(
+                    selected = promoteKind == null,
+                    onClick = { if (enabled) onPromoteKind(null) },
+                    label = { Text("None") },
+                    enabled = enabled,
+                )
+                PromoteEntityKind.entries.forEach { kind ->
+                    FilterChip(
+                        selected = promoteKind == kind,
+                        onClick = { if (enabled) onPromoteKind(kind) },
+                        label = { Text(kind.label) },
+                        enabled = enabled,
+                    )
+                }
+            }
+
+            if (promoteKind != null) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = onQuery,
+                    label = { Text("Search ${promoteKind.label.lowercase()}") },
+                    singleLine = true,
+                    enabled = enabled,
+                    modifier = Modifier.fillMaxWidth().testTag(CreateCampaignTestTags.PROMOTE_SEARCH),
+                )
+                when (entities) {
+                    is CreateCampaignViewModel.PromoteEntitiesState.Loading ->
+                        CircularProgressIndicator(modifier = Modifier.padding(8.dp))
+                    is CreateCampaignViewModel.PromoteEntitiesState.Empty ->
+                        Text(
+                            "Nothing to promote here yet.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    is CreateCampaignViewModel.PromoteEntitiesState.Error ->
+                        Text(
+                            entities.message,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    is CreateCampaignViewModel.PromoteEntitiesState.Content ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 220.dp)
+                                .verticalScroll(rememberScrollState()),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            entities.entities.forEach { entity ->
+                                FilterChip(
+                                    selected = selected?.id == entity.id,
+                                    onClick = { if (enabled) onEntity(entity) },
+                                    label = {
+                                        Text(
+                                            entity.subtitle?.let { "${entity.title} · $it" } ?: entity.title,
+                                        )
+                                    },
+                                    enabled = enabled,
+                                    modifier = Modifier.testTag(CreateCampaignTestTags.PROMOTE_ENTITY),
+                                )
+                            }
+                        }
+                    CreateCampaignViewModel.PromoteEntitiesState.Idle -> Unit
+                }
+                selected?.let {
+                    Text(
+                        "Promoting: ${it.title}",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * FE-162 — behavioral targeting segments (age / gender / country / device / content-category multi-selects +
+ * new-user-only) with an explicit OPT-IN-RESPECTING disclosure and a live audience estimate. Targeting is
+ * additive: leaving everything unset reaches everyone. The estimate hides when the endpoint 404s.
+ */
+@Composable
+private fun TargetingSegmentsSection(
+    segments: SelectedSegments,
+    summary: String,
+    estimate: CreateCampaignViewModel.EstimateState,
+    enabled: Boolean,
+    onToggleAge: (String) -> Unit,
+    onToggleGender: (String) -> Unit,
+    onToggleCountry: (String) -> Unit,
+    onToggleDevice: (String) -> Unit,
+    onToggleContentCategory: (String) -> Unit,
+    onNewUserOnly: (Boolean) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(CreateCampaignTestTags.TARGETING)) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text("Audience targeting", style = MaterialTheme.typography.titleMedium)
+
+            // Opt-in disclosure — a product invariant, always shown.
+            Text(
+                PromoteTargetingMath.RESPECTS_OPT_IN_NOTE,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            ChipMultiSelect("Age", PromoteTargetingMath.SEGMENT_AGE_RANGES, segments.ageRanges, enabled, onToggleAge)
+            ChipMultiSelect("Gender", PromoteTargetingMath.SEGMENT_GENDERS, segments.genders, enabled, onToggleGender)
+            ChipMultiSelect(
+                label = "Country",
+                options = PromoteTargetingMath.SEGMENT_COUNTRIES.map { it.code },
+                selected = segments.countryCodes,
+                enabled = enabled,
+                onToggle = onToggleCountry,
+            )
+            ChipMultiSelect("Device", PromoteTargetingMath.SEGMENT_DEVICE_TYPES, segments.deviceTypes, enabled, onToggleDevice)
+            ChipMultiSelect(
+                label = "Content category",
+                options = PromoteTargetingMath.SEGMENT_CONTENT_CATEGORIES,
+                selected = segments.contentCategories,
+                enabled = enabled,
+                onToggle = onToggleContentCategory,
+            )
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("New users only", modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+                Switch(checked = segments.newUserOnly, onCheckedChange = onNewUserOnly, enabled = enabled)
+            }
+
+            HorizontalDivider()
+            Text(summary, style = MaterialTheme.typography.bodyMedium)
+
+            when (estimate) {
+                is CreateCampaignViewModel.EstimateState.Loading ->
+                    Text(
+                        "Estimating reach…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag(CreateCampaignTestTags.ESTIMATE),
+                    )
+                is CreateCampaignViewModel.EstimateState.Ready ->
+                    Text(
+                        "Estimated reach: ~${estimate.display}",
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.testTag(CreateCampaignTestTags.ESTIMATE),
+                    )
+                // Idle (pre-create) / Unavailable (404) — no numeric estimate shown.
+                else -> Unit
+            }
+        }
+    }
+}
+
+/** A labeled row of FilterChips backing a multi-select segment. */
+@Composable
+private fun ChipMultiSelect(
+    label: String,
+    options: List<String>,
+    selected: List<String>,
+    enabled: Boolean,
+    onToggle: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(label, style = MaterialTheme.typography.titleSmall)
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            options.forEach { opt ->
+                FilterChip(
+                    selected = opt in selected,
+                    onClick = { if (enabled) onToggle(opt) },
+                    label = { Text(opt) },
+                    enabled = enabled,
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun CampaignCreatedCard(
     reviewState: CreateCampaignViewModel.ReviewState,
@@ -514,7 +798,7 @@ private fun FlightDateField(
 @Composable
 private fun selfPromoModeLabel(mode: String): String = stringResource(
     if (mode == "always_win") R.string.create_campaign_fill_mode_always_win
-    else R.string.create_campaign_fill_mode_fill_only,
+    else R.string.create_campaign_fill_mode_fill_only
 )
 
 /** A labeled exposed-dropdown picker over [options] (value to label). */

--- a/android/app/src/main/java/com/testlogon/android/feature/ads/create/campaign/CreateCampaignViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/ads/create/campaign/CreateCampaignViewModel.kt
@@ -6,9 +6,17 @@ import com.testlogon.android.core.model.ApiError
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.core.model.ads.AdAccountSummary
 import com.testlogon.android.core.model.ads.AdCampaign
+import com.testlogon.android.core.network.ads.AdTargetingCreateIn
+import com.testlogon.android.data.catalog.CatalogRepository
+import com.testlogon.android.data.tokens.TokensRepository
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.PromoteEntityKind
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.SelectedSegments
 import com.testlogon.android.feature.ads.create.data.AdsCreateRepository
 import com.testlogon.android.feature.ads.create.data.AdsStudioSelection
+import com.testlogon.android.feature.ads.targeting.data.AdTargetingRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -22,6 +30,16 @@ import javax.inject.Inject
  * auto-resolve: a REAL account PICKER chooses which account the campaign lives under, and the created
  * campaign is recorded as the studio [AdsStudioSelection] so targeting/scheduling/optimization open against it.
  *
+ * FE-162 (EPIC G, <- BE-161/BE-162/BE-163) - additionally drives the PROMOTE-ENTITY picker (choose to promote
+ * a market / creator-token / product, searchable from the existing tokens + catalog reads) and a BEHAVIORAL
+ * TARGETING SEGMENTS panel (age/gender/country/device/content-category multi-selects + new-user-only) that is
+ * OPT-IN-RESPECTING (a disclosure the UI shows). A LIVE audience ESTIMATE is requested (debounced) as segments
+ * change. On submit the campaign is created WITH the promote descriptor, then a targeting set is created from
+ * the selected segments ([PromoteTargetingMath.buildTargetingPayload] + entity ids). Everything ADDITIVE:
+ * with no kind/segments chosen the plain create path is unchanged. All FE-162 network is DEGRADE-ON-404:
+ * a 404 (undeployed backend) is swallowed - the estimate hides, targeting-create failure never blocks the
+ * campaign that already succeeded.
+ *
  * The account list is loaded on init ([accountsState]); the form pre-selects the studio-selected account (or
  * the first active one). Create is NON-idempotent (in-flight guard, no auto-retry). Budget/bid are entered in
  * USD and parsed to integer cents (budget >= $1; bid $0.50..$200, default $5.00).
@@ -30,6 +48,9 @@ import javax.inject.Inject
 class CreateCampaignViewModel @Inject constructor(
     private val repository: AdsCreateRepository,
     private val selection: AdsStudioSelection,
+    private val tokensRepository: TokensRepository,
+    private val catalogRepository: CatalogRepository,
+    private val targetingRepository: AdTargetingRepository,
 ) : ViewModel() {
 
     sealed interface AccountsState {
@@ -51,6 +72,26 @@ class CreateCampaignViewModel @Inject constructor(
         data object Submitting : ReviewState
         data class Done(val status: String) : ReviewState
         data class Error(val message: String) : ReviewState
+    }
+
+    /** FE-162 - one searchable promote-entity candidate (market / token / product). */
+    data class PromoteEntity(val id: String, val title: String, val subtitle: String? = null)
+
+    /** FE-162 - the promote-entity picker's load state for the selected kind. */
+    sealed interface PromoteEntitiesState {
+        data object Idle : PromoteEntitiesState
+        data object Loading : PromoteEntitiesState
+        data class Content(val entities: List<PromoteEntity>) : PromoteEntitiesState
+        data object Empty : PromoteEntitiesState
+        data class Error(val message: String) : PromoteEntitiesState
+    }
+
+    /** FE-162 - the live audience-estimate state. [Unavailable] = degrade-on-404 (hide the estimate). */
+    sealed interface EstimateState {
+        data object Idle : EstimateState
+        data object Loading : EstimateState
+        data class Ready(val reach: Long, val display: String) : EstimateState
+        data object Unavailable : EstimateState
     }
 
     private val _accountsState = MutableStateFlow<AccountsState>(AccountsState.Loading)
@@ -98,11 +139,43 @@ class CreateCampaignViewModel @Inject constructor(
     private val _endDateMillis = MutableStateFlow<Long?>(null)
     val endDateMillis: StateFlow<Long?> = _endDateMillis.asStateFlow()
 
+    // ---- FE-162: promote-entity picker state ----
+
+    /** The chosen promote-entity KIND (null = plain create path, no entity promoted). */
+    private val _promoteKind = MutableStateFlow<PromoteEntityKind?>(null)
+    val promoteKind: StateFlow<PromoteEntityKind?> = _promoteKind.asStateFlow()
+
+    /** The picker query for filtering candidates. */
+    private val _promoteQuery = MutableStateFlow("")
+    val promoteQuery: StateFlow<String> = _promoteQuery.asStateFlow()
+
+    /** The loaded candidate list for the current kind (already filtered). */
+    private val _promoteEntities = MutableStateFlow<PromoteEntitiesState>(PromoteEntitiesState.Idle)
+    val promoteEntities: StateFlow<PromoteEntitiesState> = _promoteEntities.asStateFlow()
+
+    /** The selected entity to promote (id + label for display). */
+    private val _selectedEntity = MutableStateFlow<PromoteEntity?>(null)
+    val selectedEntity: StateFlow<PromoteEntity?> = _selectedEntity.asStateFlow()
+
+    // Raw (unfiltered) candidates cached per kind so client-side filtering never re-hits the network.
+    private var loadedEntities: List<PromoteEntity> = emptyList()
+    private var entitiesLoadJob: Job? = null
+
+    // ---- FE-162: behavioral targeting segments state ----
+
+    private val _segments = MutableStateFlow(SelectedSegments())
+    val segments: StateFlow<SelectedSegments> = _segments.asStateFlow()
+
+    private val _estimate = MutableStateFlow<EstimateState>(EstimateState.Idle)
+    val estimate: StateFlow<EstimateState> = _estimate.asStateFlow()
+
     private val _submitState = MutableStateFlow<SubmitState>(SubmitState.Idle)
     val submitState: StateFlow<SubmitState> = _submitState.asStateFlow()
 
     private val _reviewState = MutableStateFlow<ReviewState>(ReviewState.Idle)
     val reviewState: StateFlow<ReviewState> = _reviewState.asStateFlow()
+
+    private var estimateJob: Job? = null
 
     init {
         loadAccounts()
@@ -140,6 +213,157 @@ class CreateCampaignViewModel @Inject constructor(
     fun onStartDate(millis: Long?) { _startDateMillis.value = millis }
     fun onEndDate(millis: Long?) { _endDateMillis.value = millis }
 
+    // ---- FE-162: promote-entity picker actions ----
+
+    /** Choose (or clear) what to promote; loads the candidate list for the kind and resets the selection. */
+    fun onPromoteKind(kind: PromoteEntityKind?) {
+        if (_promoteKind.value == kind) return
+        _promoteKind.value = kind
+        _selectedEntity.value = null
+        _promoteQuery.value = ""
+        loadedEntities = emptyList()
+        clearError()
+        if (kind == null) {
+            entitiesLoadJob?.cancel()
+            _promoteEntities.value = PromoteEntitiesState.Idle
+        } else {
+            loadPromoteEntities(kind)
+        }
+    }
+
+    /** Update the picker filter query and re-filter the cached candidates client-side. */
+    fun onPromoteQuery(text: String) {
+        _promoteQuery.value = text
+        if (_promoteEntities.value is PromoteEntitiesState.Content ||
+            _promoteEntities.value is PromoteEntitiesState.Empty
+        ) {
+            applyEntityFilter()
+        }
+    }
+
+    /** Select a candidate to promote. */
+    fun onPromoteEntitySelected(entity: PromoteEntity) {
+        _selectedEntity.value = entity
+        clearError()
+    }
+
+    private fun loadPromoteEntities(kind: PromoteEntityKind) {
+        entitiesLoadJob?.cancel()
+        _promoteEntities.value = PromoteEntitiesState.Loading
+        entitiesLoadJob = viewModelScope.launch {
+            val result: ApiResult<List<PromoteEntity>> = when (kind) {
+                // Markets = LISTED creator tokens (the tradeable market view).
+                PromoteEntityKind.MARKET -> tokensRepository.market().mapEntities { t ->
+                    PromoteEntity(id = t.symbolId ?: t.tokenId, title = t.name, subtitle = t.ticker)
+                }
+                // Creator tokens = all tokens the caller has ISSUED (mint output).
+                PromoteEntityKind.CREATOR_TOKEN -> tokensRepository.issued().mapEntities { t ->
+                    PromoteEntity(id = t.tokenId, title = t.name, subtitle = t.ticker)
+                }
+                // Products = catalog items (empty query = a first page of the catalog).
+                PromoteEntityKind.PRODUCT -> catalogRepository.search(query = "", cursor = null)
+                    .let { r ->
+                        when (r) {
+                            is ApiResult.Success -> ApiResult.Success(
+                                r.data.items.map { item ->
+                                    PromoteEntity(id = item.itemId, title = item.name, subtitle = null)
+                                },
+                            )
+                            is ApiResult.Failure -> r
+                            is ApiResult.NetworkError -> r
+                        }
+                    }
+            }
+            when (result) {
+                is ApiResult.Success -> {
+                    loadedEntities = result.data
+                    applyEntityFilter()
+                }
+                // DEGRADE-ON-404: an undeployed entity read surfaces as Empty (no scary error).
+                is ApiResult.Failure ->
+                    _promoteEntities.value = if (result.error.status == HTTP_NOT_FOUND) {
+                        PromoteEntitiesState.Empty
+                    } else {
+                        PromoteEntitiesState.Error(result.error.message)
+                    }
+                is ApiResult.NetworkError -> _promoteEntities.value = PromoteEntitiesState.Error(OFFLINE)
+            }
+        }
+    }
+
+    private fun applyEntityFilter() {
+        val q = _promoteQuery.value.trim().lowercase()
+        val filtered = if (q.isEmpty()) {
+            loadedEntities
+        } else {
+            loadedEntities.filter {
+                it.title.lowercase().contains(q) || (it.subtitle?.lowercase()?.contains(q) == true)
+            }
+        }
+        _promoteEntities.value =
+            if (filtered.isEmpty()) PromoteEntitiesState.Empty else PromoteEntitiesState.Content(filtered)
+    }
+
+    // ---- FE-162: behavioral targeting segments actions ----
+
+    /** Toggle one value in a multi-select segment; recomputes the live estimate (debounced). */
+    fun onToggleAgeRange(value: String) = updateSegments { it.copy(ageRanges = it.ageRanges.toggled(value)) }
+    fun onToggleGender(value: String) = updateSegments { it.copy(genders = it.genders.toggled(value)) }
+    fun onToggleCountry(code: String) = updateSegments { it.copy(countryCodes = it.countryCodes.toggled(code)) }
+    fun onToggleDevice(value: String) = updateSegments { it.copy(deviceTypes = it.deviceTypes.toggled(value)) }
+    fun onToggleContentCategory(value: String) =
+        updateSegments { it.copy(contentCategories = it.contentCategories.toggled(value)) }
+    fun onNewUserOnly(on: Boolean) = updateSegments { it.copy(newUserOnly = on) }
+
+    private inline fun updateSegments(transform: (SelectedSegments) -> SelectedSegments) {
+        _segments.value = transform(_segments.value)
+        requestEstimateDebounced()
+    }
+
+    private fun List<String>.toggled(value: String): List<String> =
+        if (contains(value)) this - value else this + value
+
+    /**
+     * FE-162 - request a live audience estimate for the current segments, DEBOUNCED. Needs a
+     * campaign context; before the campaign exists we estimate against the just-created campaign only after
+     * submit, so pre-submit we surface a client-side "Everyone/segmented" preview via the summary and mark
+     * the numeric estimate Idle. DEGRADE-ON-404 -> Unavailable (hidden).
+     */
+    private fun requestEstimateDebounced() {
+        val campaignId = (_submitState.value as? SubmitState.Success)?.campaign?.campaignId
+        if (campaignId == null) {
+            // No campaign yet: the numeric estimate is only meaningful post-create; keep it Idle.
+            _estimate.value = EstimateState.Idle
+            return
+        }
+        estimateJob?.cancel()
+        estimateJob = viewModelScope.launch {
+            delay(ESTIMATE_DEBOUNCE_MS)
+            _estimate.value = EstimateState.Loading
+            val body = currentTargetingBody()
+            when (val r = targetingRepository.estimateAudience(campaignId, body)) {
+                is ApiResult.Success ->
+                    _estimate.value = EstimateState.Ready(r.data, PromoteTargetingMath.formatEstimatedReach(r.data))
+                // DEGRADE-ON-404: undeployed estimate endpoint -> hide.
+                is ApiResult.Failure ->
+                    _estimate.value =
+                        if (r.error.status == HTTP_NOT_FOUND) EstimateState.Unavailable else EstimateState.Unavailable
+                is ApiResult.NetworkError -> _estimate.value = EstimateState.Unavailable
+            }
+        }
+    }
+
+    /** The targeting body for the current segments + selected promote entity (entity ids attached). */
+    private fun currentTargetingBody(): AdTargetingCreateIn = PromoteTargetingMath.withPromoteEntity(
+        body = PromoteTargetingMath.buildTargetingPayload(_segments.value.copy(name = _name.value.trim())),
+        kind = _promoteKind.value,
+        entityId = _selectedEntity.value?.id,
+    )
+
+    /** A client-side summary of the current segments (opt-in suffix always appended). */
+    val targetingSummary: String
+        get() = PromoteTargetingMath.summarizeTargeting(currentTargetingBody())
+
     /** True when an account is selected, a name is present, and budget/bid parse into their valid ranges. */
     val canSubmit: Boolean
         get() = _selectedAccountId.value != null &&
@@ -173,6 +397,10 @@ class CreateCampaignViewModel @Inject constructor(
             cpa = parseCents(_bidCpaUsd.value)?.takeIf { it in MIN_CPA_CENTS..MAX_CPA_CENTS }?.toInt() ?: return
         }
 
+        // FE-162 - the promote-entity descriptor (null when nothing is being promoted).
+        val kind = _promoteKind.value
+        val entityId = _selectedEntity.value?.id
+
         _submitState.value = SubmitState.Submitting
         viewModelScope.launch {
             val result = repository.createCampaign(
@@ -190,16 +418,40 @@ class CreateCampaignViewModel @Inject constructor(
                 endDate = if (selfPromo) null else _endDateMillis.value?.let { it / 1000 },
                 isSelfPromo = selfPromo,
                 selfPromoMode = if (selfPromo) _selfPromoMode.value else null,
+                // FE-162 - persist WHAT is being promoted on the campaign (additive; ignored if undeployed).
+                promoteKind = if (entityId != null) kind?.wire else null,
+                promoteEntityId = entityId,
             )
             when (result) {
                 is ApiResult.Success -> {
                     selection.selectCampaign(result.data.campaignId, accountId)
+                    // FE-162 - create the targeting set (segments + entity ids) against the new campaign.
+                    // DEGRADE-ON-404: a targeting-create failure NEVER undoes the campaign that succeeded.
+                    persistTargeting(result.data.campaignId)
                     _submitState.value = SubmitState.Success(result.data)
+                    // Now that a campaign exists, a live estimate is meaningful.
+                    requestEstimateDebounced()
                 }
                 is ApiResult.Failure -> _submitState.value = SubmitState.Error(result.error.friendly())
                 is ApiResult.NetworkError -> _submitState.value = SubmitState.Error(OFFLINE)
             }
         }
+    }
+
+    /**
+     * FE-162 - create the behavioral-targeting set for the just-created [campaignId] from the selected
+     * segments + promote-entity ids. Best-effort: only sent when segments or a promote entity are present;
+     * any failure (incl. 404) is swallowed so it never blocks the created campaign.
+     */
+    private suspend fun persistTargeting(campaignId: String) {
+        val hasSegments = _segments.value.let {
+            it.ageRanges.isNotEmpty() || it.genders.isNotEmpty() || it.countryCodes.isNotEmpty() ||
+                it.deviceTypes.isNotEmpty() || it.contentCategories.isNotEmpty() || it.newUserOnly
+        }
+        val hasEntity = _selectedEntity.value != null && _promoteKind.value != null
+        if (!hasSegments && !hasEntity) return
+        // Ignore the result: degrade-on-404 / any failure is non-fatal to the campaign.
+        targetingRepository.createTargeting(campaignId, currentTargetingBody())
     }
 
     /** ADV-108 - submit the just-created draft campaign for admin review. */
@@ -236,6 +488,15 @@ class CreateCampaignViewModel @Inject constructor(
         else -> message
     }
 
+    /** Maps an entity read to promote candidates, preserving Failure/NetworkError variants. */
+    private inline fun <T> ApiResult<List<T>>.mapEntities(
+        transform: (T) -> PromoteEntity,
+    ): ApiResult<List<PromoteEntity>> = when (this) {
+        is ApiResult.Success -> ApiResult.Success(data.map(transform))
+        is ApiResult.Failure -> this
+        is ApiResult.NetworkError -> this
+    }
+
     companion object {
         val OBJECTIVES = listOf("awareness", "traffic", "conversions")
         val BUDGET_TYPES = listOf("lifetime", "daily")
@@ -256,7 +517,9 @@ class CreateCampaignViewModel @Inject constructor(
         const val DEFAULT_CPA_USD = "5.00"
 
         private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_NOT_FOUND = 404
         private const val OFFLINE = "Couldn't reach the server. Try again."
+        private const val ESTIMATE_DEBOUNCE_MS = 400L
 
         /** Parses a USD entry into integer cents, or null when unparseable/negative. */
         internal fun parseCents(text: String): Long? {

--- a/android/app/src/main/java/com/testlogon/android/feature/ads/create/campaign/PromoteTargetingMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/ads/create/campaign/PromoteTargetingMath.kt
@@ -1,0 +1,190 @@
+package com.testlogon.android.feature.ads.create.campaign
+
+import com.testlogon.android.core.network.ads.AdTargetingCreateIn
+
+/**
+ * FE-162 (EPIC G, <- BE-161/BE-162/BE-163) - PURE helpers for the promote-entity picker + behavioral
+ * targeting UI. Mirrors the web `promoteTargeting.ts` 1:1 so the two clients build identical create-campaign
+ * / create-targeting request bodies.
+ *
+ * No Android / network / coroutine deps - deterministic + unit-testable (see PromoteTargetingMathTest). The
+ * presentation layer (CreateCampaignViewModel / CreateCampaignScreen) consumes these to build the request
+ * bodies and to render summaries + the audience estimate.
+ *
+ * OPT-IN INVARIANT: behavioral targeting only applies to users who opted into personalization; everyone else
+ * falls into the untargeted pool. This is a product invariant surfaced in the UI ([RESPECTS_OPT_IN_NOTE]).
+ */
+object PromoteTargetingMath {
+
+    /** What a campaign can promote. Wire values mirror the web PromoteEntityKind. */
+    enum class PromoteEntityKind(val wire: String, val label: String) {
+        MARKET("market", "Market"),
+        CREATOR_TOKEN("creator_token", "Creator token"),
+        PRODUCT("product", "Product");
+
+        companion object {
+            fun fromWire(value: String?): PromoteEntityKind? =
+                entries.firstOrNull { it.wire == value }
+        }
+    }
+
+    /** Ordered list of the three promote-entity kinds (web PROMOTE_ENTITY_KINDS parity). */
+    val PROMOTE_ENTITY_KINDS: List<PromoteEntityKind> = PromoteEntityKind.entries.toList()
+
+    /** The promote-entity descriptor persisted onto the campaign. */
+    data class PromotePayload(val promoteKind: String, val promoteEntityId: String)
+
+    /**
+     * UI-side selected targeting segments. Every field is optional and defaults to "no constraint". Flat +
+     * serialisable so it maps 1:1 onto [AdTargetingCreateIn]. Mirrors the web SelectedSegments.
+     */
+    data class SelectedSegments(
+        val name: String? = null,
+        val ageRanges: List<String> = emptyList(),
+        val genders: List<String> = emptyList(),
+        val countryCodes: List<String> = emptyList(),
+        val deviceTypes: List<String> = emptyList(),
+        val contentCategories: List<String> = emptyList(),
+        val newUserOnly: Boolean = false,
+    )
+
+    /** A country preset: ISO [code] + human [label]. */
+    data class CountryOption(val code: String, val label: String)
+
+    /** Preset option lists for the segment multi-selects (web SEGMENT_OPTIONS parity). */
+    val SEGMENT_AGE_RANGES: List<String> = listOf("18-24", "25-34", "35-44", "45-54", "55+")
+    val SEGMENT_GENDERS: List<String> = listOf("male", "female", "other")
+    val SEGMENT_DEVICE_TYPES: List<String> = listOf("mobile", "desktop", "tablet")
+    val SEGMENT_CONTENT_CATEGORIES: List<String> = listOf(
+        "gaming", "finance", "sports", "music", "tech", "lifestyle", "news", "education",
+    )
+    val SEGMENT_COUNTRIES: List<CountryOption> = listOf(
+        CountryOption("US", "United States"),
+        CountryOption("CA", "Canada"),
+        CountryOption("GB", "United Kingdom"),
+        CountryOption("DE", "Germany"),
+        CountryOption("FR", "France"),
+        CountryOption("AU", "Australia"),
+        CountryOption("JP", "Japan"),
+        CountryOption("BR", "Brazil"),
+        CountryOption("IN", "India"),
+        CountryOption("MX", "Mexico"),
+    )
+
+    /** Constant disclosure copy: targeting respects the user's opt-in choice. */
+    const val RESPECTS_OPT_IN_NOTE: String =
+        "Targeting only applies to users who opted into personalization. " +
+            "Everyone else is reached without behavioral segments."
+
+    /** Default targeting-set name (matches the server/web default). */
+    const val DEFAULT_TARGETING_NAME: String = "Default"
+
+    /** Minimum campaign budget in cents ($1.00). */
+    const val MIN_BUDGET_CENTS: Long = 100L
+
+    /**
+     * Map the selected UI [segments] onto an [AdTargetingCreateIn] body, DROPPING empty arrays / unset
+     * fields so the server never receives noise. [SelectedSegments.newUserOnly] is only carried when true.
+     * Always carries a name (defaults to [DEFAULT_TARGETING_NAME]). Web buildTargetingPayload parity.
+     */
+    fun buildTargetingPayload(segments: SelectedSegments): AdTargetingCreateIn = AdTargetingCreateIn(
+        name = segments.name?.trim().takeUnless { it.isNullOrEmpty() } ?: DEFAULT_TARGETING_NAME,
+        ageRanges = segments.ageRanges.takeIf { it.isNotEmpty() },
+        genders = segments.genders.takeIf { it.isNotEmpty() },
+        countryCodes = segments.countryCodes.takeIf { it.isNotEmpty() },
+        contentCategories = segments.contentCategories.takeIf { it.isNotEmpty() },
+        deviceTypes = segments.deviceTypes.takeIf { it.isNotEmpty() },
+        newUserOnly = segments.newUserOnly,
+    )
+
+    /**
+     * Attach the promote-entity ids to a targeting body onto the matching additive list
+     * (market_ids / token_ids / product_ids) so entity-scoped targeting rides along the segment body.
+     * A null/blank id leaves the body unchanged.
+     */
+    fun withPromoteEntity(
+        body: AdTargetingCreateIn,
+        kind: PromoteEntityKind?,
+        entityId: String?,
+    ): AdTargetingCreateIn {
+        val id = entityId?.trim().orEmpty()
+        if (kind == null || id.isEmpty()) return body
+        return when (kind) {
+            PromoteEntityKind.MARKET -> body.copy(marketIds = listOf(id))
+            PromoteEntityKind.CREATOR_TOKEN -> body.copy(tokenIds = listOf(id))
+            PromoteEntityKind.PRODUCT -> body.copy(productIds = listOf(id))
+        }
+    }
+
+    /** Build the promote-entity descriptor for a campaign (web buildPromotePayload parity). */
+    fun buildPromotePayload(kind: PromoteEntityKind, entityId: String): PromotePayload =
+        PromotePayload(promoteKind = kind.wire, promoteEntityId = entityId.trim())
+
+    /** A promote-campaign draft to validate before submit. */
+    data class PromoteCampaignDraft(
+        val name: String,
+        val budgetCents: Long,
+        val kind: PromoteEntityKind?,
+        val entityId: String?,
+    )
+
+    /**
+     * Validate a promote-campaign [draft]; returns a (possibly empty) list of human error strings. Web
+     * validatePromoteCampaign parity: name required, budget >= $1.00, a kind chosen, an entity selected.
+     */
+    fun validatePromoteCampaign(draft: PromoteCampaignDraft): List<String> {
+        val errors = mutableListOf<String>()
+        if (draft.name.isBlank()) {
+            errors.add("Campaign name is required.")
+        }
+        if (draft.budgetCents < MIN_BUDGET_CENTS) {
+            errors.add("Minimum budget is \$1.00.")
+        }
+        if (draft.kind == null) {
+            errors.add("Choose what to promote (a market, creator token, or product).")
+        }
+        if (draft.entityId.isNullOrBlank()) {
+            errors.add("Select an item to promote.")
+        }
+        return errors
+    }
+
+    /**
+     * A compact human summary of a targeting body, e.g. "US, 18-24, 25-34, mobile - opt-in only". Segments
+     * are joined with ", "; the opt-in suffix is ALWAYS appended (the invariant). "Everyone" when no
+     * segments set. Web summarizeTargeting parity.
+     */
+    fun summarizeTargeting(targeting: AdTargetingCreateIn?): String {
+        val parts = mutableListOf<String>()
+        if (targeting != null) {
+            targeting.countryCodes?.takeIf { it.isNotEmpty() }?.let { parts.add(it.joinToString("/")) }
+            targeting.ageRanges?.takeIf { it.isNotEmpty() }?.let { parts.add(it.joinToString(", ")) }
+            targeting.genders?.takeIf { it.isNotEmpty() }?.let { parts.add(it.joinToString("/")) }
+            targeting.deviceTypes?.takeIf { it.isNotEmpty() }?.let { parts.add(it.joinToString("/")) }
+            targeting.contentCategories?.takeIf { it.isNotEmpty() }?.let { parts.add(it.joinToString("/")) }
+            if (targeting.newUserOnly) parts.add("new users")
+        }
+        val lead = if (parts.isNotEmpty()) parts.joinToString(", ") else "Everyone"
+        return "$lead - opt-in only"
+    }
+
+    /** Compact reach formatter: 1234 -> "1.2K", 2_500_000 -> "2.5M". Web formatEstimatedReach parity. */
+    fun formatEstimatedReach(n: Long): String {
+        if (n < 0) return "0"
+        if (n < 1_000) return n.toString()
+        if (n < 1_000_000) {
+            val k = n / 1000.0
+            val rounded = if (k >= 100) Math.round(k).toDouble() else Math.round(k * 10) / 10.0
+            return trimTrailingZero(rounded) + "K"
+        }
+        val m = n / 1_000_000.0
+        val rounded = if (m >= 100) Math.round(m).toDouble() else Math.round(m * 10) / 10.0
+        return trimTrailingZero(rounded) + "M"
+    }
+
+    /** "1.0" -> "1", "1.2" -> "1.2" (drops a trailing .0 so "1K" not "1.0K"). */
+    private fun trimTrailingZero(v: Double): String {
+        val asLong = v.toLong()
+        return if (v == asLong.toDouble()) asLong.toString() else v.toString()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/ads/create/data/AdsCreateRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/ads/create/data/AdsCreateRepository.kt
@@ -66,6 +66,9 @@ interface AdsCreateRepository {
         endDate: Long?,
         isSelfPromo: Boolean = false,
         selfPromoMode: String? = null,
+        // FE-162 - optional promote-entity descriptor persisted onto the campaign (null on the plain path).
+        promoteKind: String? = null,
+        promoteEntityId: String? = null,
     ): ApiResult<AdCampaign>
 
     /** ADV-108 - submit a draft campaign for admin review. */
@@ -131,6 +134,8 @@ class AdsCreateRepositoryImpl @Inject constructor(
         endDate: Long?,
         isSelfPromo: Boolean,
         selfPromoMode: String?,
+        promoteKind: String?,
+        promoteEntityId: String?,
     ): ApiResult<AdCampaign> = withContext(Dispatchers.IO) {
         call {
             api.createCampaign(
@@ -148,6 +153,8 @@ class AdsCreateRepositoryImpl @Inject constructor(
                     endDate = endDate,
                     isSelfPromo = isSelfPromo,
                     selfPromoMode = selfPromoMode,
+                    promoteKind = promoteKind,
+                    promoteEntityId = promoteEntityId,
                 ),
             ).toDomain()
         }

--- a/android/app/src/test/java/com/testlogon/android/feature/ads/create/campaign/PromoteTargetingMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/ads/create/campaign/PromoteTargetingMathTest.kt
@@ -1,0 +1,175 @@
+package com.testlogon.android.feature.ads.create.campaign
+
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.PromoteCampaignDraft
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.PromoteEntityKind
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.SelectedSegments
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.buildPromotePayload
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.buildTargetingPayload
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.formatEstimatedReach
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.summarizeTargeting
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.validatePromoteCampaign
+import com.testlogon.android.feature.ads.create.campaign.PromoteTargetingMath.withPromoteEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * FE-162 - pure unit tests for [PromoteTargetingMath], mirroring the web promoteTargeting.test.ts cases
+ * (entity kinds, segment presets, opt-in note, payload build + drop-empties, promote descriptor, validation,
+ * summary opt-in suffix, reach formatting) plus the Android-only entity-id attach helper.
+ */
+class PromoteTargetingMathTest {
+
+    @Test
+    fun `entity kinds are the three expected with labels`() {
+        assertEquals(
+            listOf(PromoteEntityKind.MARKET, PromoteEntityKind.CREATOR_TOKEN, PromoteEntityKind.PRODUCT),
+            PromoteTargetingMath.PROMOTE_ENTITY_KINDS,
+        )
+        PromoteTargetingMath.PROMOTE_ENTITY_KINDS.forEach { assertTrue(it.label.isNotBlank()) }
+        assertEquals(PromoteEntityKind.MARKET, PromoteEntityKind.fromWire("market"))
+        assertEquals(PromoteEntityKind.CREATOR_TOKEN, PromoteEntityKind.fromWire("creator_token"))
+        assertNull(PromoteEntityKind.fromWire("nope"))
+    }
+
+    @Test
+    fun `segment preset lists are non-empty and countries carry code plus label`() {
+        assertTrue(PromoteTargetingMath.SEGMENT_AGE_RANGES.isNotEmpty())
+        assertTrue(PromoteTargetingMath.SEGMENT_GENDERS.isNotEmpty())
+        assertTrue(PromoteTargetingMath.SEGMENT_DEVICE_TYPES.isNotEmpty())
+        assertTrue(PromoteTargetingMath.SEGMENT_CONTENT_CATEGORIES.isNotEmpty())
+        assertTrue(PromoteTargetingMath.SEGMENT_COUNTRIES.isNotEmpty())
+        val us = PromoteTargetingMath.SEGMENT_COUNTRIES.first { it.code == "US" }
+        assertEquals("United States", us.label)
+    }
+
+    @Test
+    fun `opt-in note mentions personalization`() {
+        assertTrue(PromoteTargetingMath.RESPECTS_OPT_IN_NOTE.lowercase().contains("opted into personalization"))
+    }
+
+    @Test
+    fun `buildTargetingPayload drops empty arrays and unset fields`() {
+        val body = buildTargetingPayload(
+            SelectedSegments(ageRanges = emptyList(), genders = emptyList(), countryCodes = emptyList()),
+        )
+        assertEquals("Default", body.name)
+        assertNull(body.ageRanges)
+        assertNull(body.genders)
+        assertNull(body.countryCodes)
+        assertNull(body.deviceTypes)
+        assertNull(body.contentCategories)
+        assertEquals(false, body.newUserOnly)
+    }
+
+    @Test
+    fun `buildTargetingPayload keeps non-empty segments and trims name`() {
+        val body = buildTargetingPayload(
+            SelectedSegments(
+                name = "  Q3 push  ",
+                countryCodes = listOf("US", "CA"),
+                ageRanges = listOf("18-24"),
+                deviceTypes = emptyList(),
+                newUserOnly = true,
+            ),
+        )
+        assertEquals("Q3 push", body.name)
+        assertEquals(listOf("US", "CA"), body.countryCodes)
+        assertEquals(listOf("18-24"), body.ageRanges)
+        assertNull(body.deviceTypes)
+        assertEquals(true, body.newUserOnly)
+    }
+
+    @Test
+    fun `buildTargetingPayload omits new_user_only when false and defaults blank name`() {
+        val body = buildTargetingPayload(SelectedSegments(name = "   ", newUserOnly = false))
+        assertEquals("Default", body.name)
+        assertEquals(false, body.newUserOnly)
+    }
+
+    @Test
+    fun `buildPromotePayload builds descriptor and trims id`() {
+        val payload = buildPromotePayload(PromoteEntityKind.MARKET, "  sym-42 ")
+        assertEquals("market", payload.promoteKind)
+        assertEquals("sym-42", payload.promoteEntityId)
+    }
+
+    @Test
+    fun `withPromoteEntity attaches id to the matching list`() {
+        val base = buildTargetingPayload(SelectedSegments())
+        val market = withPromoteEntity(base, PromoteEntityKind.MARKET, " m1 ")
+        assertEquals(listOf("m1"), market.marketIds)
+        assertNull(market.tokenIds)
+
+        val token = withPromoteEntity(base, PromoteEntityKind.CREATOR_TOKEN, "t1")
+        assertEquals(listOf("t1"), token.tokenIds)
+
+        val product = withPromoteEntity(base, PromoteEntityKind.PRODUCT, "p1")
+        assertEquals(listOf("p1"), product.productIds)
+    }
+
+    @Test
+    fun `withPromoteEntity leaves body unchanged for null kind or blank id`() {
+        val base = buildTargetingPayload(SelectedSegments())
+        assertEquals(base, withPromoteEntity(base, null, "m1"))
+        assertEquals(base, withPromoteEntity(base, PromoteEntityKind.MARKET, "   "))
+    }
+
+    @Test
+    fun `validatePromoteCampaign passes a complete draft`() {
+        val errs = validatePromoteCampaign(
+            PromoteCampaignDraft(name = "Launch", budgetCents = 5000L, kind = PromoteEntityKind.PRODUCT, entityId = "item-1"),
+        )
+        assertTrue(errs.isEmpty())
+    }
+
+    @Test
+    fun `validatePromoteCampaign collects every missing or invalid field`() {
+        val errs = validatePromoteCampaign(
+            PromoteCampaignDraft(name = "  ", budgetCents = 50L, kind = null, entityId = ""),
+        )
+        assertEquals(4, errs.size)
+        assertTrue(errs.any { it.contains("name", ignoreCase = true) })
+        assertTrue(errs.any { it.contains("budget", ignoreCase = true) })
+        assertTrue(errs.any { it.contains("promote", ignoreCase = true) })
+        assertTrue(errs.any { it.contains("item", ignoreCase = true) })
+    }
+
+    @Test
+    fun `summarizeTargeting always appends opt-in suffix`() {
+        assertEquals("Everyone - opt-in only", summarizeTargeting(null))
+        assertEquals("Everyone - opt-in only", summarizeTargeting(buildTargetingPayload(SelectedSegments())))
+    }
+
+    @Test
+    fun `summarizeTargeting joins the set segments`() {
+        val body = buildTargetingPayload(
+            SelectedSegments(
+                countryCodes = listOf("US"),
+                ageRanges = listOf("18-24", "25-34"),
+                deviceTypes = listOf("mobile"),
+            ),
+        )
+        assertEquals("US, 18-24, 25-34, mobile - opt-in only", summarizeTargeting(body))
+    }
+
+    @Test
+    fun `summarizeTargeting includes new users flag`() {
+        val body = buildTargetingPayload(SelectedSegments(newUserOnly = true))
+        assertEquals("new users - opt-in only", summarizeTargeting(body))
+    }
+
+    @Test
+    fun `formatEstimatedReach formats small thousands millions`() {
+        assertEquals("0", formatEstimatedReach(0))
+        assertEquals("999", formatEstimatedReach(999))
+        assertEquals("1.2K", formatEstimatedReach(1234))
+        assertEquals("2.5M", formatEstimatedReach(2_500_000))
+    }
+
+    @Test
+    fun `formatEstimatedReach guards against negatives`() {
+        assertEquals("0", formatEstimatedReach(-5))
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/ads/AdTargetingDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/ads/AdTargetingDtos.kt
@@ -29,6 +29,10 @@ data class AdTargetingDto(
     @Json(name = "content_types") val contentTypes: List<String>? = null,
     @Json(name = "exclude_creator_ids") val excludeCreatorIds: List<String>? = null,
     @Json(name = "exclude_categories") val excludeCategories: List<String>? = null,
+    // FE-162 (EPIC G, <- BE-162) - entity-scoped targeting (additive, tolerated on read).
+    @Json(name = "market_ids") val marketIds: List<String>? = null,
+    @Json(name = "token_ids") val tokenIds: List<String>? = null,
+    @Json(name = "product_ids") val productIds: List<String>? = null,
     @Json(name = "created_at") val createdAt: Long? = null,
     @Json(name = "updated_at") val updatedAt: Long? = null,
 )
@@ -46,6 +50,12 @@ data class AdTargetingCreateIn(
     @Json(name = "active_hours") val activeHours: List<Int>? = null,
     @Json(name = "device_types") val deviceTypes: List<String>? = null,
     @Json(name = "new_user_only") val newUserOnly: Boolean = false,
+    // FE-162 (EPIC G, <- BE-162) - entity-scoped targeting. Additive + OPTIONAL: promote a specific
+    // market / creator-token / product to the segmented audience. A backend that ignores these keys still
+    // applies the demographic/behavioral segments (degrade-gracefully).
+    @Json(name = "market_ids") val marketIds: List<String>? = null,
+    @Json(name = "token_ids") val tokenIds: List<String>? = null,
+    @Json(name = "product_ids") val productIds: List<String>? = null,
 )
 
 /** Audience estimate returned by POST .../targeting/estimate. */

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/ads/AdsCreateDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/ads/AdsCreateDtos.kt
@@ -58,6 +58,11 @@ data class AdCampaignCreateIn(
     // fill_only (serve only when no paying ad is eligible) vs always_win (always win the own-content slot).
     @Json(name = "is_self_promo") val isSelfPromo: Boolean = false,
     @Json(name = "self_promo_mode") val selfPromoMode: String? = null,
+    // FE-162 (EPIC G, <- BE-161) - promote-entity descriptor. Additive + OPTIONAL: the market / creator-token /
+    // product this campaign promotes. A backend that does not persist these simply ignores the extra keys
+    // (ignore-unknown). Null when the plain create path is used (nothing promoted).
+    @Json(name = "promote_kind") val promoteKind: String? = null,
+    @Json(name = "promote_entity_id") val promoteEntityId: String? = null,
 )
 
 /**

--- a/frontend/src/api/endpoints/ads.ts
+++ b/frontend/src/api/endpoints/ads.ts
@@ -116,6 +116,10 @@ export const createCampaign = (accountId: string, data: {
   budget_type: string;
   start_date?: number;
   end_date?: number;
+  // FE-162 (<- BE-161): promote-entity descriptor. Additive + optional; a
+  // backend that does not persist it ignores the extra keys.
+  promote_kind?: string;
+  promote_entity_id?: string;
 }) =>
   api.post<Campaign>(`/ui/ads/accounts/${accountId}/campaigns`, data);
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -6425,6 +6425,10 @@ export interface Campaign {
   status: string;
   created_at: number;
   updated_at: number;
+  // FE-162 (<- BE-161): what this campaign promotes. Additive + optional;
+  // absent on backends that do not yet persist the promote descriptor.
+  promote_kind?: string | null;
+  promote_entity_id?: string | null;
 }
 
 // ─── Ad Billing (ADS-007) ───────────────────────────────────────────
@@ -13754,6 +13758,10 @@ export interface AdTargeting {
   content_types?: string[] | null;
   exclude_creator_ids?: string[] | null;
   exclude_categories?: string[] | null;
+  // FE-162 (<- BE-162): entity-scoped targeting. Additive + optional.
+  market_ids?: string[] | null;
+  token_ids?: string[] | null;
+  product_ids?: string[] | null;
   created_at: number;
   updated_at: number;
 }

--- a/frontend/src/lib/promoteTargeting.test.ts
+++ b/frontend/src/lib/promoteTargeting.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROMOTE_ENTITY_KINDS,
+  PROMOTE_ENTITY_LABELS,
+  SEGMENT_OPTIONS,
+  respectsOptInNote,
+  buildTargetingPayload,
+  buildPromotePayload,
+  validatePromoteCampaign,
+  summarizeTargeting,
+  formatEstimatedReach,
+} from "@/lib/promoteTargeting";
+
+describe("PROMOTE_ENTITY_KINDS", () => {
+  it("has the three entity kinds with labels", () => {
+    expect(PROMOTE_ENTITY_KINDS).toEqual(["market", "creator_token", "product"]);
+    for (const k of PROMOTE_ENTITY_KINDS) {
+      expect(PROMOTE_ENTITY_LABELS[k]).toBeTruthy();
+    }
+  });
+});
+
+describe("SEGMENT_OPTIONS + opt-in note", () => {
+  it("exposes non-empty preset lists", () => {
+    expect(SEGMENT_OPTIONS.age_ranges.length).toBeGreaterThan(0);
+    expect(SEGMENT_OPTIONS.genders.length).toBeGreaterThan(0);
+    expect(SEGMENT_OPTIONS.countries.length).toBeGreaterThan(0);
+    expect(SEGMENT_OPTIONS.device_types.length).toBeGreaterThan(0);
+    expect(SEGMENT_OPTIONS.content_categories.length).toBeGreaterThan(0);
+  });
+  it("countries carry code+label", () => {
+    const us = SEGMENT_OPTIONS.countries.find((c) => c.code === "US");
+    expect(us?.label).toBe("United States");
+  });
+  it("opt-in note mentions personalization", () => {
+    expect(respectsOptInNote.toLowerCase()).toContain("opted into personalization");
+  });
+});
+
+describe("buildTargetingPayload", () => {
+  it("drops empty arrays and unset fields", () => {
+    const body = buildTargetingPayload({
+      age_ranges: [],
+      genders: [],
+      country_codes: [],
+    });
+    expect(body).toEqual({ name: "Default" });
+  });
+  it("keeps only non-empty segments and trims name", () => {
+    const body = buildTargetingPayload({
+      name: "  Q3 push  ",
+      country_codes: ["US", "CA"],
+      age_ranges: ["18-24"],
+      device_types: [],
+      new_user_only: true,
+    });
+    expect(body).toEqual({
+      name: "Q3 push",
+      country_codes: ["US", "CA"],
+      age_ranges: ["18-24"],
+      new_user_only: true,
+    });
+  });
+  it("omits new_user_only when false", () => {
+    const body = buildTargetingPayload({ new_user_only: false });
+    expect(body.new_user_only).toBeUndefined();
+  });
+  it("defaults name to Default when blank", () => {
+    expect(buildTargetingPayload({ name: "   " }).name).toBe("Default");
+  });
+});
+
+describe("buildPromotePayload", () => {
+  it("builds a descriptor and trims the id", () => {
+    expect(buildPromotePayload("market", "  sym-42 ")).toEqual({
+      promote_kind: "market",
+      promote_entity_id: "sym-42",
+    });
+  });
+});
+
+describe("validatePromoteCampaign", () => {
+  it("passes a complete draft", () => {
+    expect(
+      validatePromoteCampaign({
+        name: "Launch",
+        budgetCents: 5000,
+        kind: "product",
+        entityId: "item-1",
+      }),
+    ).toEqual([]);
+  });
+  it("collects every missing/invalid field", () => {
+    const errs = validatePromoteCampaign({
+      name: "  ",
+      budgetCents: 50,
+      kind: null,
+      entityId: "",
+    });
+    expect(errs.length).toBe(4);
+    expect(errs.some((e) => /name/i.test(e))).toBe(true);
+    expect(errs.some((e) => /budget/i.test(e))).toBe(true);
+    expect(errs.some((e) => /promote/i.test(e))).toBe(true);
+    expect(errs.some((e) => /item/i.test(e))).toBe(true);
+  });
+  it("rejects NaN budget", () => {
+    const errs = validatePromoteCampaign({
+      name: "x",
+      budgetCents: Number.NaN,
+      kind: "market",
+      entityId: "m1",
+    });
+    expect(errs.some((e) => /budget/i.test(e))).toBe(true);
+  });
+});
+
+describe("summarizeTargeting", () => {
+  it("appends the opt-in suffix always", () => {
+    expect(summarizeTargeting(null)).toBe("Everyone - opt-in only");
+    expect(summarizeTargeting({})).toBe("Everyone - opt-in only");
+  });
+  it("joins the set segments", () => {
+    const s = summarizeTargeting({
+      country_codes: ["US"],
+      age_ranges: ["18-24", "25-34"],
+      device_types: ["mobile"],
+    });
+    expect(s).toBe("US, 18-24, 25-34, mobile - opt-in only");
+  });
+  it("includes new users flag", () => {
+    expect(summarizeTargeting({ new_user_only: true })).toBe(
+      "new users - opt-in only",
+    );
+  });
+});
+
+describe("formatEstimatedReach", () => {
+  it("formats small, thousands, millions", () => {
+    expect(formatEstimatedReach(0)).toBe("0");
+    expect(formatEstimatedReach(999)).toBe("999");
+    expect(formatEstimatedReach(1234)).toBe("1.2K");
+    expect(formatEstimatedReach(2_500_000)).toBe("2.5M");
+  });
+  it("guards against negatives/NaN", () => {
+    expect(formatEstimatedReach(-5)).toBe("0");
+    expect(formatEstimatedReach(Number.NaN)).toBe("0");
+  });
+});

--- a/frontend/src/lib/promoteTargeting.ts
+++ b/frontend/src/lib/promoteTargeting.ts
@@ -1,0 +1,174 @@
+// FE-162 (EPIC G, <- BE-161/BE-162/BE-163): pure helpers for the
+// promote-entity picker + behavioral-targeting UI.
+//
+// No network, no DOM - deterministic + unit-testable. The rendering layer
+// (PromoteTargetingStep / CampaignEditor) consumes these to build the
+// createCampaign / createTargeting request bodies and to render summaries.
+//
+// OPT-IN NOTE: behavioral targeting only applies to users who opted into
+// personalization; everyone else falls into the untargeted pool. This is a
+// product invariant surfaced in the UI (see respectsOptInNote).
+
+import type { AdTargeting } from "@/api/types";
+
+/** What a campaign can promote. */
+export type PromoteEntityKind = "market" | "creator_token" | "product";
+
+export const PROMOTE_ENTITY_KINDS: readonly PromoteEntityKind[] = [
+  "market",
+  "creator_token",
+  "product",
+] as const;
+
+/** Human labels for each promote-entity kind. */
+export const PROMOTE_ENTITY_LABELS: Record<PromoteEntityKind, string> = {
+  market: "Market",
+  creator_token: "Creator token",
+  product: "Product",
+};
+
+/** The promote-entity descriptor persisted onto the campaign/creative. */
+export interface PromotePayload {
+  promote_kind: PromoteEntityKind;
+  promote_entity_id: string;
+}
+
+/**
+ * The UI-side selected targeting segments. Every field is optional and defaults
+ * to "no constraint". Kept flat + serialisable so it maps 1:1 onto AdTargeting.
+ */
+export interface SelectedSegments {
+  name?: string;
+  age_ranges?: string[];
+  genders?: string[];
+  country_codes?: string[];
+  device_types?: string[];
+  content_categories?: string[];
+  new_user_only?: boolean;
+}
+
+/** Preset option lists for the segment multi-selects. */
+export const SEGMENT_OPTIONS = {
+  age_ranges: ["18-24", "25-34", "35-44", "45-54", "55+"],
+  genders: ["male", "female", "other"],
+  countries: [
+    { code: "US", label: "United States" },
+    { code: "CA", label: "Canada" },
+    { code: "GB", label: "United Kingdom" },
+    { code: "DE", label: "Germany" },
+    { code: "FR", label: "France" },
+    { code: "AU", label: "Australia" },
+    { code: "JP", label: "Japan" },
+    { code: "BR", label: "Brazil" },
+    { code: "IN", label: "India" },
+    { code: "MX", label: "Mexico" },
+  ],
+  device_types: ["mobile", "desktop", "tablet"],
+  content_categories: [
+    "gaming",
+    "finance",
+    "sports",
+    "music",
+    "tech",
+    "lifestyle",
+    "news",
+    "education",
+  ],
+} as const;
+
+/** Constant disclosure copy: targeting respects the users opt-in choice. */
+export const respectsOptInNote =
+  "Targeting only applies to users who opted into personalization. " +
+  "Everyone else is reached without behavioral segments.";
+
+/**
+ * Map the selected UI segments onto an AdTargeting request body, DROPPING empty
+ * arrays / unset fields so the server never receives noise. `new_user_only` is
+ * only sent when true. Always carries a name (defaults to "Default").
+ */
+export function buildTargetingPayload(
+  segments: SelectedSegments,
+): Partial<AdTargeting> {
+  const body: Partial<AdTargeting> = {
+    name: segments.name?.trim() || "Default",
+  };
+  const put = (k: keyof AdTargeting, v?: string[]) => {
+    if (v && v.length) (body as Record<string, unknown>)[k] = v;
+  };
+  put("age_ranges", segments.age_ranges);
+  put("genders", segments.genders);
+  put("country_codes", segments.country_codes);
+  put("device_types", segments.device_types);
+  put("content_categories", segments.content_categories);
+  if (segments.new_user_only) body.new_user_only = true;
+  return body;
+}
+
+/** Build the promote-entity descriptor for a campaign/creative. */
+export function buildPromotePayload(
+  kind: PromoteEntityKind,
+  entityId: string,
+): PromotePayload {
+  return { promote_kind: kind, promote_entity_id: entityId.trim() };
+}
+
+export interface PromoteCampaignDraft {
+  name: string;
+  budgetCents: number;
+  kind: PromoteEntityKind | null;
+  entityId: string | null;
+}
+
+/** Validate a promote-campaign draft; returns a (possibly empty) error list. */
+export function validatePromoteCampaign(
+  draft: PromoteCampaignDraft,
+): string[] {
+  const errors: string[] = [];
+  if (!draft.name || !draft.name.trim()) {
+    errors.push("Campaign name is required.");
+  }
+  if (!Number.isFinite(draft.budgetCents) || draft.budgetCents < 100) {
+    errors.push("Minimum budget is $1.00.");
+  }
+  if (!draft.kind || !PROMOTE_ENTITY_KINDS.includes(draft.kind)) {
+    errors.push("Choose what to promote (a market, creator token, or product).");
+  }
+  if (!draft.entityId || !draft.entityId.trim()) {
+    errors.push("Select an item to promote.");
+  }
+  return errors;
+}
+
+/**
+ * A compact human summary of a targeting body, e.g.
+ * "US, 18-34, mobile - opt-in only". Segments are joined with ", "; the opt-in
+ * suffix is always appended (the invariant). "Everyone" when no segments set.
+ */
+export function summarizeTargeting(
+  targeting: Partial<AdTargeting> | null | undefined,
+): string {
+  const parts: string[] = [];
+  if (targeting) {
+    if (targeting.country_codes?.length) parts.push(targeting.country_codes.join("/"));
+    if (targeting.age_ranges?.length) parts.push(targeting.age_ranges.join(", "));
+    if (targeting.genders?.length) parts.push(targeting.genders.join("/"));
+    if (targeting.device_types?.length) parts.push(targeting.device_types.join("/"));
+    if (targeting.content_categories?.length)
+      parts.push(targeting.content_categories.join("/"));
+    if (targeting.new_user_only) parts.push("new users");
+  }
+  const lead = parts.length ? parts.join(", ") : "Everyone";
+  return lead + " - opt-in only";
+}
+
+/** Compact reach formatter: 1234 -> "1.2K", 2_500_000 -> "2.5M". */
+export function formatEstimatedReach(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return "0";
+  if (n < 1000) return String(Math.floor(n));
+  if (n < 1_000_000) {
+    const k = n / 1000;
+    return (k >= 100 ? Math.round(k) : Math.round(k * 10) / 10) + "K";
+  }
+  const m = n / 1_000_000;
+  return (m >= 100 ? Math.round(m) : Math.round(m * 10) / 10) + "M";
+}

--- a/frontend/src/pages/ads/CampaignList.tsx
+++ b/frontend/src/pages/ads/CampaignList.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Megaphone, Plus, Pause, Play, Send, Archive } from "lucide-react";
+import { Megaphone, Plus, Pause, Play, Send, Archive, Sparkles } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -13,6 +13,7 @@ import {
 } from "@/api/endpoints/ads";
 import type { Campaign } from "@/api/types";
 import CampaignEditor from "./CampaignEditor";
+import PromoteCampaignDialog from "./PromoteCampaignDialog";
 
 const statusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   draft: "outline",
@@ -29,6 +30,7 @@ export default function CampaignList() {
   const accountId = params.get("account") ?? "";
   const queryClient = useQueryClient();
   const [editorOpen, setEditorOpen] = useState(false);
+  const [promoteOpen, setPromoteOpen] = useState(false);
 
   const { data: campaigns = [], isLoading } = useQuery({
     queryKey: ["ad-campaigns", accountId],
@@ -81,10 +83,16 @@ export default function CampaignList() {
             <Megaphone className="h-6 w-6" />
             <CardTitle>Campaigns</CardTitle>
           </div>
-          <Button onClick={() => setEditorOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Create Campaign
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => setPromoteOpen(true)}>
+              <Sparkles className="mr-2 h-4 w-4" />
+              Promote
+            </Button>
+            <Button onClick={() => setEditorOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create Campaign
+            </Button>
+          </div>
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -179,6 +187,15 @@ export default function CampaignList() {
         onOpenChange={setEditorOpen}
         onSubmit={(data) => createMut.mutate(data)}
         isPending={createMut.isPending}
+      />
+
+      <PromoteCampaignDialog
+        open={promoteOpen}
+        onOpenChange={setPromoteOpen}
+        accountId={accountId}
+        onCreated={() =>
+          queryClient.invalidateQueries({ queryKey: ["ad-campaigns", accountId] })
+        }
       />
     </div>
   );

--- a/frontend/src/pages/ads/PromoteCampaignDialog.tsx
+++ b/frontend/src/pages/ads/PromoteCampaignDialog.tsx
@@ -1,0 +1,496 @@
+// FE-162 (EPIC G, <- BE-161/BE-162/BE-163): "promote an entity" campaign flow.
+//
+// Pick WHAT to promote (a market / creator-token / product) via a searchable
+// picker populated from the existing entity reads, choose behavioral targeting
+// segments (opt-in-respecting), see a live debounced audience estimate, and on
+// submit create the campaign + its targeting set. Every network read/write
+// degrades on 404 (no crash; the estimate simply hides).
+import { useMemo, useState, useEffect, useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Search, Users, ShieldCheck } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { createCampaign, createTargeting, estimateAudience } from "@/api/endpoints/ads";
+import { getSymbols } from "@/api/endpoints/marketData";
+import { getTokenMarket } from "@/api/endpoints/tokens";
+import { searchCatalogItems } from "@/api/endpoints/cart";
+import type { AudienceEstimate } from "@/api/types";
+import {
+  PROMOTE_ENTITY_KINDS,
+  PROMOTE_ENTITY_LABELS,
+  SEGMENT_OPTIONS,
+  respectsOptInNote,
+  buildTargetingPayload,
+  buildPromotePayload,
+  validatePromoteCampaign,
+  summarizeTargeting,
+  formatEstimatedReach,
+  type PromoteEntityKind,
+  type SelectedSegments,
+} from "@/lib/promoteTargeting";
+
+interface PickerOption {
+  id: string;
+  label: string;
+  sub?: string;
+}
+
+interface PromoteCampaignDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accountId: string;
+  onCreated?: () => void;
+}
+
+export default function PromoteCampaignDialog({
+  open,
+  onOpenChange,
+  accountId,
+  onCreated,
+}: PromoteCampaignDialogProps) {
+  const [name, setName] = useState("");
+  const [budgetDollars, setBudgetDollars] = useState("10");
+  const [kind, setKind] = useState<PromoteEntityKind>("market");
+  const [entityId, setEntityId] = useState<string | null>(null);
+  const [entityLabel, setEntityLabel] = useState<string>("");
+  const [search, setSearch] = useState("");
+  const [segments, setSegments] = useState<SelectedSegments>({});
+  const [estimate, setEstimate] = useState<AudienceEstimate | null>(null);
+  const [submitErrors, setSubmitErrors] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const resetAll = () => {
+    setName("");
+    setBudgetDollars("10");
+    setKind("market");
+    setEntityId(null);
+    setEntityLabel("");
+    setSearch("");
+    setSegments({});
+    setEstimate(null);
+    setSubmitErrors([]);
+    setServerError(null);
+  };
+
+  // Entity reads (reuse existing endpoints), degrade on 404 -> []
+  const marketsQ = useQuery({
+    queryKey: ["promote", "markets"],
+    queryFn: getSymbols,
+    enabled: open && kind === "market",
+    retry: false,
+    staleTime: 60_000,
+  });
+  const tokensQ = useQuery({
+    queryKey: ["promote", "tokens"],
+    queryFn: getTokenMarket,
+    enabled: open && kind === "creator_token",
+    retry: false,
+    staleTime: 60_000,
+  });
+  const productsQ = useQuery({
+    queryKey: ["promote", "products", search],
+    queryFn: () => searchCatalogItems(search.trim() || "a"),
+    enabled: open && kind === "product",
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  const options: PickerOption[] = useMemo(() => {
+    if (kind === "market") {
+      return (marketsQ.data?.symbols ?? []).map((s) => ({
+        id: String(s.symbol_id),
+        label: s.symbol,
+        sub: s.is_perpetual ? "perpetual" : "spot",
+      }));
+    }
+    if (kind === "creator_token") {
+      return (tokensQ.data?.tokens ?? []).map((t) => ({
+        id: t.token_id,
+        label: t.ticker + " - " + t.name,
+        sub: t.status,
+      }));
+    }
+    return (productsQ.data?.items ?? []).map((i) => ({
+      id: i.item_id,
+      label: i.name,
+      sub: "$" + (i.price_cents / 100).toFixed(2),
+    }));
+  }, [kind, marketsQ.data, tokensQ.data, productsQ.data]);
+
+  const filteredOptions = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q || kind === "product") return options; // product search is server-side
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [options, search, kind]);
+
+  const budgetCents = Math.round((parseFloat(budgetDollars) || 0) * 100);
+
+  // Debounced audience estimate (degrade on 404 -> hide)
+  const targetingBody = useMemo(
+    () => buildTargetingPayload({ ...segments, name: name || "Promote" }),
+    [segments, name],
+  );
+
+  const fetchEstimate = useCallback(async () => {
+    try {
+      const est = await estimateAudience("preview", targetingBody);
+      setEstimate(est);
+    } catch {
+      setEstimate(null); // degrade-on-404: hide the estimate
+    }
+  }, [targetingBody]);
+
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(fetchEstimate, 500);
+    return () => clearTimeout(t);
+  }, [open, fetchEstimate]);
+
+  const toggle = (field: keyof SelectedSegments, value: string) => {
+    setSegments((prev) => {
+      const arr = (prev[field] as string[] | undefined) ?? [];
+      const next = arr.includes(value)
+        ? arr.filter((v) => v !== value)
+        : [...arr, value];
+      return { ...prev, [field]: next };
+    });
+  };
+  const isOn = (field: keyof SelectedSegments, value: string) =>
+    ((segments[field] as string[] | undefined) ?? []).includes(value);
+
+  const handleSubmit = async () => {
+    setServerError(null);
+    const errs = validatePromoteCampaign({ name, budgetCents, kind, entityId });
+    setSubmitErrors(errs);
+    if (errs.length) return;
+
+    setSubmitting(true);
+    try {
+      const promote = buildPromotePayload(kind, entityId!);
+      const campaign = await createCampaign(accountId, {
+        name: name.trim(),
+        objective: "conversions",
+        budget_cents: budgetCents,
+        budget_type: "lifetime",
+        promote_kind: promote.promote_kind,
+        promote_entity_id: promote.promote_entity_id,
+      });
+      // Best-effort targeting set; degrade-on-404 (older backend) without
+      // failing the whole flow - the campaign is already created.
+      try {
+        await createTargeting(campaign.campaign_id, {
+          ...buildTargetingPayload({ ...segments, name: name || "Promote" }),
+          ...(kind === "market" ? { market_ids: [promote.promote_entity_id] } : {}),
+          ...(kind === "creator_token" ? { token_ids: [promote.promote_entity_id] } : {}),
+          ...(kind === "product" ? { product_ids: [promote.promote_entity_id] } : {}),
+        });
+      } catch {
+        /* targeting is optional; campaign already exists */
+      }
+      resetAll();
+      onOpenChange(false);
+      onCreated?.();
+    } catch {
+      setServerError(
+        "Could not create the campaign. The promote-campaign API may be unavailable.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) resetAll();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Promote an entity</DialogTitle>
+          <DialogDescription>
+            Create a campaign that promotes a market, creator token, or product.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[70vh] pr-3">
+          <div className="space-y-6 py-1">
+            {/* Basics */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="col-span-2">
+                <Label htmlFor="promo-name">Campaign name</Label>
+                <Input
+                  id="promo-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Promote BTC-PERP"
+                  data-testid="promote-name"
+                />
+              </div>
+              <div>
+                <Label htmlFor="promo-budget">Lifetime budget ($)</Label>
+                <Input
+                  id="promo-budget"
+                  type="number"
+                  min={1}
+                  step="0.01"
+                  value={budgetDollars}
+                  onChange={(e) => setBudgetDollars(e.target.value)}
+                  data-testid="promote-budget"
+                />
+              </div>
+            </div>
+
+            {/* What to promote */}
+            <div>
+              <h3 className="mb-2 font-semibold">What do you want to promote?</h3>
+              <div className="flex gap-2">
+                {PROMOTE_ENTITY_KINDS.map((k) => (
+                  <Button
+                    key={k}
+                    type="button"
+                    size="sm"
+                    variant={kind === k ? "default" : "outline"}
+                    onClick={() => {
+                      setKind(k);
+                      setEntityId(null);
+                      setEntityLabel("");
+                      setSearch("");
+                    }}
+                    data-testid={"promote-kind-" + k}
+                  >
+                    {PROMOTE_ENTITY_LABELS[k]}
+                  </Button>
+                ))}
+              </div>
+
+              <div className="relative mt-3">
+                <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  className="pl-8"
+                  placeholder={"Search " + PROMOTE_ENTITY_LABELS[kind].toLowerCase() + "s..."}
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  data-testid="promote-search"
+                />
+              </div>
+
+              <div className="mt-2 rounded border">
+                <ScrollArea className="h-40">
+                  <div className="divide-y">
+                    {filteredOptions.length === 0 ? (
+                      <p className="p-3 text-sm text-muted-foreground">
+                        No items found.
+                      </p>
+                    ) : (
+                      filteredOptions.map((o) => (
+                        <button
+                          key={o.id}
+                          type="button"
+                          onClick={() => {
+                            setEntityId(o.id);
+                            setEntityLabel(o.label);
+                          }}
+                          className={
+                            "flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent " +
+                            (entityId === o.id ? "bg-accent" : "")
+                          }
+                          data-testid={"promote-option-" + o.id}
+                        >
+                          <span className="font-medium">{o.label}</span>
+                          {o.sub && (
+                            <span className="text-xs text-muted-foreground">
+                              {o.sub}
+                            </span>
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </ScrollArea>
+              </div>
+              {entityId && (
+                <p className="mt-2 text-sm" data-testid="promote-selected">
+                  Promoting:{" "}
+                  <Badge variant="secondary">{entityLabel || entityId}</Badge>
+                </p>
+              )}
+            </div>
+
+            {/* Behavioral targeting */}
+            <div>
+              <h3 className="mb-1 font-semibold">Behavioral targeting</h3>
+              <div
+                className="mb-3 flex items-start gap-2 rounded-md bg-muted/50 p-2 text-xs text-muted-foreground"
+                data-testid="opt-in-disclosure"
+              >
+                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{respectsOptInNote}</span>
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <Label>Age ranges</Label>
+                  <div className="mt-1 flex flex-wrap gap-3">
+                    {SEGMENT_OPTIONS.age_ranges.map((r) => (
+                      <label key={r} className="flex items-center gap-1.5">
+                        <Checkbox
+                          checked={isOn("age_ranges", r)}
+                          onCheckedChange={() => toggle("age_ranges", r)}
+                          data-testid={"seg-age-" + r}
+                        />
+                        <span className="text-sm">{r}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <Label>Gender</Label>
+                  <div className="mt-1 flex flex-wrap gap-3">
+                    {SEGMENT_OPTIONS.genders.map((g) => (
+                      <label key={g} className="flex items-center gap-1.5">
+                        <Checkbox
+                          checked={isOn("genders", g)}
+                          onCheckedChange={() => toggle("genders", g)}
+                        />
+                        <span className="text-sm capitalize">{g}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <Label>Countries</Label>
+                  <div className="mt-1 flex flex-wrap gap-2">
+                    {SEGMENT_OPTIONS.countries.map((c) => (
+                      <Button
+                        key={c.code}
+                        type="button"
+                        size="sm"
+                        variant={isOn("country_codes", c.code) ? "default" : "outline"}
+                        onClick={() => toggle("country_codes", c.code)}
+                        data-testid={"seg-country-" + c.code}
+                      >
+                        {c.code}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <Label>Devices</Label>
+                  <div className="mt-1 flex flex-wrap gap-3">
+                    {SEGMENT_OPTIONS.device_types.map((d) => (
+                      <label key={d} className="flex items-center gap-1.5">
+                        <Checkbox
+                          checked={isOn("device_types", d)}
+                          onCheckedChange={() => toggle("device_types", d)}
+                        />
+                        <span className="text-sm capitalize">{d}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <Label>Content categories</Label>
+                  <div className="mt-1 flex flex-wrap gap-2">
+                    {SEGMENT_OPTIONS.content_categories.map((c) => (
+                      <Button
+                        key={c}
+                        type="button"
+                        size="sm"
+                        variant={isOn("content_categories", c) ? "default" : "outline"}
+                        onClick={() => toggle("content_categories", c)}
+                      >
+                        {c}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={segments.new_user_only ?? false}
+                    onCheckedChange={(v) =>
+                      setSegments((p) => ({ ...p, new_user_only: v }))
+                    }
+                    data-testid="seg-new-user-only"
+                  />
+                  <Label>New users only</Label>
+                </div>
+              </div>
+
+              <p className="mt-3 text-sm text-muted-foreground">
+                {summarizeTargeting(targetingBody)}
+              </p>
+
+              {estimate && (
+                <div
+                  className="mt-3 flex items-center gap-3 rounded-md border p-3"
+                  data-testid="promote-estimate"
+                >
+                  <Users className="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <div className="text-lg font-semibold">
+                      {formatEstimatedReach(estimate.estimated_reach)}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Estimated reach
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {submitErrors.length > 0 && (
+              <ul className="list-disc space-y-1 pl-5 text-sm text-destructive">
+                {submitErrors.map((e) => (
+                  <li key={e}>{e}</li>
+                ))}
+              </ul>
+            )}
+            {serverError && (
+              <p className="text-sm text-destructive">{serverError}</p>
+            )}
+          </div>
+        </ScrollArea>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+            data-testid="promote-submit"
+          >
+            {submitting ? "Creating..." : "Create campaign"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## FE-162 — promote-entity picker + behavioral targeting UI (completes EPIC G)

Campaign creation can now **pick what to promote** (market / creator-token / product) and attach **opt-in-respecting behavioral targeting** segments with a live audience estimate. Degrade-on-404 throughout; the plain campaign-create path is preserved.

### Web
- NEW `lib/promoteTargeting.ts` (+17 vitest) — `PROMOTE_ENTITY_KINDS`, `SEGMENT_OPTIONS` (age/gender/country/device/content-category), `buildTargetingPayload` (drops empties), `buildPromotePayload`, `validatePromoteCampaign`, `summarizeTargeting`, `formatEstimatedReach`, opt-in disclosure.
- NEW `PromoteCampaignDialog` (kind selector → searchable entity picker from existing reads `getSymbols`/`getTokenMarket`/`searchCatalogItems` → opt-in segment panel → debounced `estimateAudience`) + a Promote button on `CampaignList`. `createCampaign` extended additively with `promote_kind`/`promote_entity_id`; `AdTargeting` gains `market_ids`/`token_ids`/`product_ids`.

### Android
- NEW `PromoteTargetingMath.kt` (+16 JVM tests); `CreateCampaign` Screen/ViewModel gain the promote-entity picker (market via `TokensRepository.market`, creator-token via `issued`, product via `CatalogRepository.search`) + opt-in segments panel + debounced estimate; `AdsCreateRepository.createCampaign` + `AdCampaignCreateIn` extended with `promote_kind`/`promote_entity_id`; AdTargeting DTOs gain market/token/product ids. Reused the existing campaign-create + targeting (`createTargeting`/`estimateAudience`) APIs — no new endpoints.

On submit: create campaign (with promote descriptor) → best-effort create targeting (segments + entity-scoped ids); targeting failure never undoes the campaign. Opt-in disclosure always shown; estimate hides on 404.

### Gates
- Web: tsc 0 · build green · 17/17 vitest
- Android: BUILD SUCCESSFUL · PromoteTargetingMathTest 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
