### PR TITLE
FE-170: Trading Documents in the file manager (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsApi.kt
@@ -1,0 +1,69 @@
+package com.testlogon.android.data.tradingdocs
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * FE-170 (EPIC H) — Retrofit interface + Moshi DTOs for the "Trading Documents" surface (broker
+ * statements, 1099s, trade confirmations, fills, pnl) exposed in the file manager.
+ *
+ * Backend contract (BE-171 list / BE-172 download) — built against the assumed contract, DEGRADES ON
+ * 404 (the backend may not be deployed yet):
+ *   - GET ui/trading-documents?type=<statement|1099|confirmation|fills|pnl>
+ *       -> { documents: [ { doc_id, type, title, period_start?, period_end?, tax_year?,
+ *                           format:"pdf"|"csv", size_bytes?, status:"ready"|"generating",
+ *                           created_at, download_url? } ] }
+ *       `type` is OPTIONAL (omitted => all types). Idempotent GET.
+ *   - GET ui/trading-documents/{doc_id}/download -> { download_url } (presigned) OR streamed bytes.
+ *
+ * Mirrors the AND-246 TaxDocsApi idiom (envelope DTO + all-but-id server-defaulted fields). Money/size
+ * are integers; timestamps are epoch seconds. Download is opened in a Custom Tab via the presigned
+ * download_url (reusing the AND-243 InvoicePdfLauncher pattern), so session cookies ride along.
+ */
+interface TradingDocsApi {
+
+    /** List the user's trading documents, optionally filtered by [type]. Idempotent GET. */
+    @GET("ui/trading-documents")
+    suspend fun listTradingDocuments(
+        @Query("type") type: String? = null,
+    ): TradingDocListDto
+
+    /** Resolve a presigned download URL for [docId] (used when the list row carried no download_url). */
+    @GET("ui/trading-documents/{doc_id}/download")
+    suspend fun getDownload(
+        @Path("doc_id") docId: String,
+    ): TradingDocDownloadDto
+}
+
+// ---- DTOs ----
+
+/** List envelope; documents under the `documents` key (mirrors TaxDocumentListDto). */
+@JsonClass(generateAdapter = true)
+data class TradingDocListDto(
+    @Json(name = "documents") val documents: List<TradingDocDto> = emptyList(),
+)
+
+/** A single trading document. Only doc_id is required; every other field server-defaults. */
+@JsonClass(generateAdapter = true)
+data class TradingDocDto(
+    @Json(name = "doc_id") val docId: String,
+    @Json(name = "type") val type: String = "statement",
+    @Json(name = "title") val title: String? = null,
+    @Json(name = "period_start") val periodStart: Long? = null,
+    @Json(name = "period_end") val periodEnd: Long? = null,
+    @Json(name = "tax_year") val taxYear: Int? = null,
+    @Json(name = "format") val format: String = "pdf",
+    @Json(name = "size_bytes") val sizeBytes: Long? = null,
+    @Json(name = "status") val status: String = "ready",
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "download_url") val downloadUrl: String? = null,
+)
+
+/** Download resolution response (presigned URL). */
+@JsonClass(generateAdapter = true)
+data class TradingDocDownloadDto(
+    @Json(name = "download_url") val downloadUrl: String? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsDataModule.kt
@@ -1,0 +1,30 @@
+package com.testlogon.android.data.tradingdocs
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** FE-170 — provides the [TradingDocsApi] on the shared (authenticated) Retrofit. */
+@Module
+@InstallIn(SingletonComponent::class)
+object TradingDocsApiModule {
+
+    @Provides
+    @Singleton
+    fun provideTradingDocsApi(retrofit: Retrofit): TradingDocsApi =
+        retrofit.create(TradingDocsApi::class.java)
+}
+
+/** FE-170 — binds the trading-documents repository over [TradingDocsApi]. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TradingDocsDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTradingDocsRepository(impl: TradingDocsRepositoryImpl): TradingDocsRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsDomain.kt
@@ -1,0 +1,43 @@
+package com.testlogon.android.data.tradingdocs
+
+/**
+ * FE-170 — framework-free trading-document domain models + DTO -> domain mappers.
+ *
+ * Conventions (matching data/taxdocs):
+ *  - Timestamps are epoch-seconds Longs (NOT java.time); 0/absent -> null.
+ *  - size in bytes is nullable (server may omit it, e.g. while generating).
+ *  - Mapping is TOTAL: no exceptions thrown.
+ */
+
+/** A single trading document (statement / 1099 / trade confirmation / fills / pnl). */
+data class TradingDocument(
+    val docId: String,
+    val type: String,
+    val rawTitle: String?,
+    val periodStartEpochSeconds: Long?,
+    val periodEndEpochSeconds: Long?,
+    val taxYear: Int?,
+    val format: String,
+    val sizeBytes: Long?,
+    val status: String,
+    val createdAtEpochSeconds: Long?,
+    val downloadUrl: String?,
+)
+
+// ---- Mappers (DTO -> domain) ----
+
+private fun Long.epochSecondsOrNull(): Long? = takeIf { it > 0 }
+
+internal fun TradingDocDto.toDomain(): TradingDocument = TradingDocument(
+    docId = docId,
+    type = type,
+    rawTitle = title?.takeIf { it.isNotBlank() },
+    periodStartEpochSeconds = periodStart?.epochSecondsOrNull(),
+    periodEndEpochSeconds = periodEnd?.epochSecondsOrNull(),
+    taxYear = taxYear,
+    format = format,
+    sizeBytes = sizeBytes?.takeIf { it > 0 },
+    status = status,
+    createdAtEpochSeconds = createdAt.epochSecondsOrNull(),
+    downloadUrl = downloadUrl?.takeIf { it.isNotBlank() },
+)

--- a/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsRepository.kt
@@ -1,0 +1,63 @@
+package com.testlogon.android.data.tradingdocs
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FE-170 — trading-documents data layer over [TradingDocsApi].
+ *
+ * DEGRADE-ON-404 (per the FE-170 acceptance criteria — the backend BE-171/172 may be undeployed):
+ * every call is wrapped so that an HttpException (incl. 404) or any transport IOException folds to a
+ * SAFE EMPTY result — [listTradingDocuments] returns an empty list and [getDownloadUrl] returns null —
+ * so the screen shows the honest "No trading documents yet" empty state and never crashes.
+ * CancellationException is always re-thrown (structured concurrency).
+ *
+ * The list is sorted newest-first (created_at desc). The download flow prefers the row's inline
+ * download_url and only calls [getDownloadUrl] as a fallback.
+ */
+interface TradingDocsRepository {
+
+    /** All trading documents, optionally filtered by [type]. Empty list on any error (degrade-on-404). */
+    suspend fun listTradingDocuments(type: String? = null): List<TradingDocument>
+
+    /** Resolve a presigned download URL for [docId]; null on any error (degrade-on-404). */
+    suspend fun getDownloadUrl(docId: String): String?
+}
+
+@Singleton
+class TradingDocsRepositoryImpl @Inject constructor(
+    private val api: TradingDocsApi,
+) : TradingDocsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun listTradingDocuments(type: String?): List<TradingDocument> = withContext(io) {
+        callOr(emptyList()) {
+            api.listTradingDocuments(type)
+                .documents
+                .map { it.toDomain() }
+                .sortedByDescending { it.createdAtEpochSeconds ?: 0L }
+        }
+    }
+
+    override suspend fun getDownloadUrl(docId: String): String? = withContext(io) {
+        callOr(null) { api.getDownload(docId).downloadUrl?.takeIf { it.isNotBlank() } }
+    }
+
+    /** Runs [block], returning [fallback] on HTTP (incl. 404) / transport errors. Re-throws cancellation. */
+    private inline fun <T> callOr(fallback: T, block: () -> T): T = try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: HttpException) {
+        fallback
+    } catch (_: IOException) {
+        fallback
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/files/ui/FilesScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/files/ui/FilesScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.outlined.ReceiptLong
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Folder
@@ -132,6 +133,9 @@ object FilesTestTags {
     const val APPEND_FOOTER = "files_append_footer"
     const val APPEND_RETRY = "files_append_retry"
 
+    /** FE-170 - the Trading Documents entry-point tile at the file-manager root. */
+    const val TRADING_DOCS_TILE = "files_trading_docs_tile"
+
     /** FM1 - the floating chip shown while a row is being dragged to a folder. */
     const val DRAG_CHIP = "files_drag_chip"
 
@@ -225,6 +229,9 @@ fun FilesRoute(
     // AND-336 - "Import from Google Drive" affordance: opens the backend-mediated Drive picker for the
     // folder currently on screen (defaults to no-op so existing call sites/tests are unaffected).
     onImportFromDrive: (String) -> Unit = {},
+    // FE-170 - open the Trading Documents area (statements/1099s/confirmations). Defaults no-op so
+    // existing call sites / tests are unaffected.
+    onOpenTradingDocuments: () -> Unit = {},
     viewModel: FilesViewModel = hiltViewModel(),
     uploadViewModel: com.testlogon.android.feature.files.upload.FilesUploadViewModel = hiltViewModel(),
     downloadViewModel: com.testlogon.android.feature.files.download.FileActionsViewModel = hiltViewModel(),
@@ -318,6 +325,8 @@ fun FilesRoute(
         onShareFile = { node -> onShareFile(node.path) },
         // AND-336 - the Drive-import action carries the folder on screen as the import target.
         onImportFromDrive = { onImportFromDrive(state.currentPath) },
+        // FE-170 - the Trading Documents entry point (a tile at the files root).
+        onOpenTradingDocuments = onOpenTradingDocuments,
         // F13 - long-press CRUD context-menu actions wired to the existing FilesViewModel ops.
         onRename = { node, newName -> viewModel.rename(node.path, newName, node.type == FileNodeType.FOLDER) },
         onDelete = { node -> viewModel.delete(node.path, node.type == FileNodeType.FOLDER) },
@@ -389,6 +398,9 @@ fun FilesScreen(
     // AND-336 - "Import from Google Drive" action (null -> the affordance is hidden, so existing AND-332
     // FilesScreen callers / tests are unaffected).
     onImportFromDrive: (() -> Unit)? = null,
+    // FE-170 - Trading Documents entry point (null -> the tile is hidden, so existing FilesScreen
+    // callers / tests are unaffected).
+    onOpenTradingDocuments: (() -> Unit)? = null,
     // F13 - long-press context-menu CRUD actions (defaulted no-op so existing callers / tests are
     // unaffected). Rename/Delete/New-folder are fully wired; Move targets a destination folder path.
     onRename: (FileNode, String) -> Unit = { _, _ -> },
@@ -479,6 +491,13 @@ fun FilesScreen(
                 onToggleMode = onToggleSearchMode,
             )
             HorizontalDivider()
+            // FE-170 - Trading Documents entry point: a tile at the file-manager root that navigates to
+            // the statements / 1099s / trade-confirmations area. Shown only at the root and only when the
+            // host wired the callback (defaulted-off so existing FilesScreen callers / tests are unaffected).
+            if (onOpenTradingDocuments != null && !state.isSearching && state.currentPath == FilePath.ROOT) {
+                TradingDocsTile(onClick = onOpenTradingDocuments)
+                HorizontalDivider()
+            }
             // FM6/FM3 - destination-picker banner: while a transfer is active the user navigates into the
             // target folder (folder taps drill in, breadcrumbs jump) then taps Move/Copy here. Cancel exits.
             transfer?.let { t ->
@@ -1503,4 +1522,50 @@ private fun thumbnailUrl(node: FileNode): String {
     node.posterUrl?.takeIf { it.isNotBlank() }?.let { return it }
     val encoded = java.net.URLEncoder.encode(node.path, "UTF-8")
     return "/v1/fs/preview?path=$encoded"
+}
+
+
+/**
+ * FE-170 - a tappable "Trading Documents" tile at the file-manager root that opens the statements /
+ * 1099s / trade-confirmations area. Mirrors the list-row idiom used elsewhere on this screen.
+ */
+@Composable
+private fun TradingDocsTile(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag(FilesTestTags.TRADING_DOCS_TILE),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            Icons.Outlined.ReceiptLong,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp),
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.trading_docs_title),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = stringResource(R.string.trading_docs_tile_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            Icons.Filled.ChevronRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/TradingDocsMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/TradingDocsMath.kt
@@ -1,0 +1,119 @@
+package com.testlogon.android.feature.tradingdocs
+
+import com.testlogon.android.data.tradingdocs.TradingDocument
+import java.util.Locale
+
+/**
+ * FE-170 — PURE (no Android deps), JVM-testable helpers for the Trading Documents screen: type
+ * ordering, grouping, titles, safe filenames, downloadability + human meta. Kept framework-free so the
+ * grouping/labelling logic is unit-tested without Robolectric (mirrors the AND-246 TaxDocsFormat idiom).
+ */
+
+/** Canonical, display-ordered trading-document type codes (BE-171 `type` values). */
+val TRADING_DOC_TYPES: List<String> = listOf(
+    "statement",
+    "1099",
+    "confirmation",
+    "fills",
+    "pnl",
+)
+
+private const val STATUS_GENERATING = "generating"
+
+/** A group of documents sharing one [type], with the type kept for headers. Newest-first within a group. */
+data class TradingDocGroup(
+    val type: String,
+    val documents: List<TradingDocument>,
+)
+
+/** Human label for a document [type] code; unknown codes fall back to a title-cased raw code. */
+fun docTypeLabel(type: String): String = when (type.lowercase(Locale.ROOT)) {
+    "statement" -> "Statements"
+    "1099" -> "1099 Tax Forms"
+    "confirmation" -> "Trade Confirmations"
+    "fills" -> "Fills"
+    "pnl" -> "Profit & Loss"
+    else -> type.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
+}
+
+/**
+ * Group [docs] by type, newest-first WITHIN each group (created_at desc), with GROUPS themselves ordered
+ * by [TRADING_DOC_TYPES] (known types first, in canonical order; any unknown types appended
+ * alphabetically). Empty groups are omitted.
+ */
+fun groupDocuments(docs: List<TradingDocument>): List<TradingDocGroup> {
+    if (docs.isEmpty()) return emptyList()
+    val byType: Map<String, List<TradingDocument>> = docs.groupBy { it.type.lowercase(Locale.ROOT) }
+    val known = TRADING_DOC_TYPES.mapNotNull { type ->
+        byType[type]?.let { TradingDocGroup(type, it.sortedByDescending { d -> d.createdAtEpochSeconds ?: 0L }) }
+    }
+    val unknown = byType.keys
+        .filter { it !in TRADING_DOC_TYPES }
+        .sorted()
+        .map { type ->
+            TradingDocGroup(type, byType.getValue(type).sortedByDescending { d -> d.createdAtEpochSeconds ?: 0L })
+        }
+    return known + unknown
+}
+
+/** Best display title for a [doc]: the server title if present, else a derived "<Type> <year|period>". */
+fun docTitle(doc: TradingDocument): String {
+    doc.rawTitle?.let { return it }
+    val label = docTypeLabel(doc.type).removeSuffix("s")
+    val period = when {
+        doc.taxYear != null -> doc.taxYear.toString()
+        doc.periodStartEpochSeconds != null -> "period"
+        else -> null
+    }
+    return if (period != null) "$label $period" else label
+}
+
+/** File extension implied by the document [format] (defaults to pdf). */
+private fun docExtension(doc: TradingDocument): String = when (doc.format.lowercase(Locale.ROOT)) {
+    "csv" -> "csv"
+    "pdf" -> "pdf"
+    else -> "pdf"
+}
+
+private val UNSAFE_FILENAME = Regex("[^A-Za-z0-9._-]+")
+
+/**
+ * A SAFE, portable download filename for [doc]: derived from the title (or type + id), stripped of
+ * filesystem-unsafe characters, collapsed underscores, with the correct extension for its format.
+ */
+fun docFilename(doc: TradingDocument): String {
+    val base = (doc.rawTitle ?: "${doc.type}_${doc.docId}")
+        .trim()
+        .replace(UNSAFE_FILENAME, "_")
+        .trim('_')
+        .ifBlank { "trading_document" }
+    return "$base.${docExtension(doc)}"
+}
+
+/** A document is downloadable only when it is READY (not still generating). */
+fun isDownloadable(doc: TradingDocument): Boolean =
+    !doc.status.equals(STATUS_GENERATING, ignoreCase = true)
+
+/**
+ * Compact human meta line for a row: uppercased format + optional size (KB/MB) + a "Generating…" tag
+ * while pending. E.g. "PDF · 1.2 MB" or "CSV · Generating…".
+ */
+fun formatDocMeta(doc: TradingDocument): String {
+    val parts = mutableListOf(doc.format.uppercase(Locale.ROOT))
+    doc.sizeBytes?.let { parts += formatSize(it) }
+    if (!isDownloadable(doc)) parts += "Generating…"
+    return parts.joinToString(" · ")
+}
+
+/** Bytes -> a compact "B / KB / MB / GB" string (1024-based, one decimal for KB+). */
+internal fun formatSize(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val units = listOf("KB", "MB", "GB", "TB")
+    var value = bytes.toDouble() / 1024.0
+    var unitIndex = 0
+    while (value >= 1024.0 && unitIndex < units.size - 1) {
+        value /= 1024.0
+        unitIndex++
+    }
+    return String.format(Locale.US, "%.1f %s", value, units[unitIndex])
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/TradingDocsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/TradingDocsScreen.kt
@@ -1,0 +1,236 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.tradingdocs
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.R
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.tradingdocs.TradingDocument
+import com.testlogon.android.feature.invoices.CustomTabsInvoicePdfLauncher
+import com.testlogon.android.feature.invoices.InvoicePdfLauncher
+import kotlinx.coroutines.flow.collectLatest
+
+/** FE-170 stable testTags for the Trading Documents screen. */
+object TradingDocsTestTags {
+    const val SCREEN = "trading_docs_screen"
+    const val LIST = "trading_docs_list"
+    const val EMPTY = "trading_docs_empty"
+    const val ROW = "trading_doc_row"
+    const val DOWNLOAD = "trading_doc_download"
+    const val SHARE = "trading_doc_share"
+    const val GROUP_HEADER = "trading_docs_group_header"
+}
+
+/**
+ * FE-170 route-level Trading Documents list, reachable from the file manager. Download opens the
+ * presigned URL in a Custom Tab (reusing the AND-243 [InvoicePdfLauncher]); Share fires ACTION_SEND with
+ * the link (or the title when no URL is resolvable). Degrades to the honest empty state on a 404.
+ */
+@Composable
+fun TradingDocsRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TradingDocsViewModel = hiltViewModel(),
+    pdfLauncher: InvoicePdfLauncher = remember { CustomTabsInvoicePdfLauncher() },
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    val noViewerMessage = stringResource(R.string.trading_docs_no_viewer)
+    val unavailableMessage = stringResource(R.string.trading_docs_download_unavailable)
+    val shareChooserTitle = stringResource(R.string.trading_docs_share_chooser)
+
+    LaunchedEffect(viewModel) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                is TradingDocsEvent.OpenDownload -> {
+                    val launched = pdfLauncher.launch(context, event.url)
+                    if (!launched) snackbarHostState.showSnackbar(noViewerMessage)
+                }
+                is TradingDocsEvent.Share ->
+                    shareDocument(context, event.title, event.url, shareChooserTitle)
+                TradingDocsEvent.DownloadUnavailable ->
+                    snackbarHostState.showSnackbar(unavailableMessage)
+            }
+        }
+    }
+
+    TradingDocsScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onDownloadClick = viewModel::onDownloadClicked,
+        onShareClick = viewModel::onShareClicked,
+        onRefresh = viewModel::refresh,
+        onBack = onBack,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun TradingDocsScreen(
+    state: TradingDocsUiState,
+    snackbarHostState: SnackbarHostState,
+    onDownloadClick: (TradingDocument) -> Unit,
+    onShareClick: (TradingDocument) -> Unit,
+    onRefresh: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(TradingDocsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.trading_docs_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading && state.isEmpty ->
+                    LoadingState(message = stringResource(R.string.trading_docs_loading))
+
+                state.isEmpty ->
+                    EmptyState(
+                        title = stringResource(R.string.trading_docs_empty),
+                        modifier = Modifier.testTag(TradingDocsTestTags.EMPTY),
+                    )
+
+                else -> PullToRefreshBox(
+                    isRefreshing = state.isRefreshing,
+                    onRefresh = onRefresh,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    LazyColumn(modifier = Modifier.fillMaxSize().testTag(TradingDocsTestTags.LIST)) {
+                        state.groups.forEach { group ->
+                            item(key = "header_${group.type}") {
+                                Text(
+                                    text = docTypeLabel(group.type),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                                        .testTag(TradingDocsTestTags.GROUP_HEADER),
+                                )
+                            }
+                            items(items = group.documents, key = { it.docId }) { doc ->
+                                TradingDocRow(
+                                    doc = doc,
+                                    onDownloadClick = { onDownloadClick(doc) },
+                                    onShareClick = { onShareClick(doc) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TradingDocRow(
+    doc: TradingDocument,
+    onDownloadClick: () -> Unit,
+    onShareClick: () -> Unit,
+) {
+    val downloadable = isDownloadable(doc)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag(TradingDocsTestTags.ROW),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(text = docTitle(doc), style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = formatDocMeta(doc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(
+            onClick = onShareClick,
+            modifier = Modifier.testTag(TradingDocsTestTags.SHARE),
+        ) {
+            Icon(
+                Icons.Outlined.Share,
+                contentDescription = stringResource(R.string.trading_docs_share_cd, docTitle(doc)),
+                modifier = Modifier.size(24.dp),
+            )
+        }
+        IconButton(
+            onClick = onDownloadClick,
+            enabled = downloadable,
+            modifier = Modifier.testTag(TradingDocsTestTags.DOWNLOAD),
+        ) {
+            Icon(
+                Icons.Outlined.Download,
+                contentDescription = stringResource(R.string.trading_docs_download_cd, docTitle(doc)),
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+/** FE-170 — share a document as a link (ACTION_SEND text/plain); falls back to the title alone. */
+private fun shareDocument(context: Context, title: String, url: String?, chooserTitle: String) {
+    val text = if (url != null) "$title\n$url" else title
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_SUBJECT, title)
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    val chooser = Intent.createChooser(send, chooserTitle).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(chooser)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/TradingDocsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/TradingDocsViewModel.kt
@@ -1,0 +1,102 @@
+package com.testlogon.android.feature.tradingdocs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.data.tradingdocs.TradingDocsRepository
+import com.testlogon.android.data.tradingdocs.TradingDocument
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * FE-170 — Trading Documents screen state. The list is ALWAYS resolvable to a grouped view; a fetch
+ * failure (incl. BE-171 404) degrades to an empty list, surfaced as the honest empty state — no error
+ * surface, no crash (per the acceptance criteria).
+ */
+data class TradingDocsUiState(
+    val groups: List<TradingDocGroup> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+) {
+    val isEmpty: Boolean get() = groups.isEmpty()
+}
+
+/** FE-170 — one-shot effects: open a download in a Custom Tab, or share a link. */
+sealed interface TradingDocsEvent {
+    /** Open a resolved (presigned) download URL in a Custom Tab. */
+    data class OpenDownload(val url: String) : TradingDocsEvent
+
+    /** Share a document via ACTION_SEND (a link when a URL is resolvable, else the title). */
+    data class Share(val title: String, val url: String?) : TradingDocsEvent
+
+    /** The document could not be downloaded (no URL resolvable). */
+    data object DownloadUnavailable : TradingDocsEvent
+}
+
+/**
+ * FE-170 — presentation logic for the Trading Documents area. Loads the (unfiltered) list on
+ * construction; [refresh] re-fetches. Download prefers the row's inline download_url, falling back to
+ * [TradingDocsRepository.getDownloadUrl]; a "generating" doc is never downloadable. Share emits a link
+ * (or the title if none resolvable). Everything degrades gracefully — a failed fetch just yields the
+ * empty state.
+ */
+@HiltViewModel
+class TradingDocsViewModel @Inject constructor(
+    private val repository: TradingDocsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TradingDocsUiState(isLoading = true))
+    val uiState: StateFlow<TradingDocsUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<TradingDocsEvent>(Channel.BUFFERED)
+    val events: Flow<TradingDocsEvent> = _events.receiveAsFlow()
+
+    init {
+        load(isRefresh = false)
+    }
+
+    fun refresh() = load(isRefresh = true)
+
+    /** Download [doc]: no-op while generating; open the inline URL or resolve one, else signal unavailable. */
+    fun onDownloadClicked(doc: TradingDocument) {
+        if (!isDownloadable(doc)) return
+        viewModelScope.launch {
+            val url = doc.downloadUrl ?: repository.getDownloadUrl(doc.docId)
+            if (url != null) {
+                _events.send(TradingDocsEvent.OpenDownload(url))
+            } else {
+                _events.send(TradingDocsEvent.DownloadUnavailable)
+            }
+        }
+    }
+
+    /** Share [doc]: emits a link when one is inline/resolvable, else shares the title text. */
+    fun onShareClicked(doc: TradingDocument) {
+        viewModelScope.launch {
+            val url = doc.downloadUrl ?: if (isDownloadable(doc)) repository.getDownloadUrl(doc.docId) else null
+            _events.send(TradingDocsEvent.Share(title = docTitle(doc), url = url))
+        }
+    }
+
+    private fun load(isRefresh: Boolean) {
+        val hadData = _uiState.value.groups.isNotEmpty()
+        _uiState.update { it.copy(isLoading = !isRefresh && !hadData, isRefreshing = isRefresh) }
+        viewModelScope.launch {
+            val docs = repository.listTradingDocuments()
+            _uiState.update {
+                it.copy(
+                    groups = groupDocuments(docs),
+                    isLoading = false,
+                    isRefreshing = false,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -212,6 +212,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         videoUploadDestination(navController)
         // AND-332: read-only file-manager browse (path nav + breadcrumbs + search + sort + paged listing).
         filesDestination(navController)
+        // FE-170: Trading Documents area (statements/1099s/confirmations) reached from the file manager.
+        tradingDocsDestination(navController)
         // Trading Blotter: native orders/fills/positions blotter (web parity; sample data + ticker).
         blotterDestination(navController)
         // Active Algos monitor: client-side TWAP / Iceberg algo progress + pause/cancel.

--- a/android/app/src/main/java/com/testlogon/android/navigation/FilesNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/FilesNavigation.kt
@@ -31,6 +31,11 @@ fun NavGraphBuilder.filesDestination(navController: NavHostController) {
             onImportFromDrive = { targetFolderPath ->
                 navController.navigate(DriveImportDest.build(targetFolderPath)) { launchSingleTop = true }
             },
+            // FE-170 - Trading Documents area (statements/1099s/trade confirmations) reachable from the
+            // file manager. Navigates to the trading-docs list route (files feature graph).
+            onOpenTradingDocuments = {
+                navController.navigate(TradingDocsDest.ROUTE) { launchSingleTop = true }
+            },
         )
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/navigation/TradingDocsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/TradingDocsNavigation.kt
@@ -1,0 +1,23 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.tradingdocs.TradingDocsRoute
+
+/**
+ * FE-170 — the Trading Documents list route (statements / 1099s / trade confirmations), reached from the
+ * file-manager entry point. Downloads open in a Custom Tab; degrades to an empty state on a 404. This
+ * route lives in the files feature graph (NOT the More catalog), so it does not touch MoreCatalog /
+ * RouteRegistry.
+ */
+data object TradingDocsDest {
+    const val ROUTE = "files/trading-documents"
+}
+
+/** FE-170 — registers the Trading Documents list destination. */
+fun NavGraphBuilder.tradingDocsDestination(navController: NavHostController) {
+    composable(TradingDocsDest.ROUTE) {
+        TradingDocsRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1988,6 +1988,16 @@
     <string name="tax_docs_row_subtitle">%1$s · %2$d transactions</string>
     <string name="tax_docs_download_cd">Download %1$s tax statement</string>
     <string name="tax_docs_no_viewer">No app available to open this file.</string>
+    <!-- FE-170 Trading Documents (statements / 1099s / trade confirmations) in the file manager -->
+    <string name="trading_docs_title">Trading Documents</string>
+    <string name="trading_docs_tile_subtitle">Statements, 1099s, trade confirmations</string>
+    <string name="trading_docs_loading">Loading trading documents\u2026</string>
+    <string name="trading_docs_empty">No trading documents yet</string>
+    <string name="trading_docs_no_viewer">No app available to open this document.</string>
+    <string name="trading_docs_download_unavailable">This document isn\'t available to download yet.</string>
+    <string name="trading_docs_share_chooser">Share document</string>
+    <string name="trading_docs_download_cd">Download %1$s</string>
+    <string name="trading_docs_share_cd">Share %1$s</string>
     <!-- PAR-24 earnings summary card -->
     <string name="tax_docs_summary_title">Earnings summary</string>
     <string name="tax_docs_summary_year">%1$d</string>

--- a/android/app/src/test/java/com/testlogon/android/data/tradingdocs/TradingDocsRepositoryContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/tradingdocs/TradingDocsRepositoryContractTest.kt
@@ -1,0 +1,91 @@
+package com.testlogon.android.data.tradingdocs
+
+import com.squareup.moshi.Moshi
+import com.testlogon.android.core.testing.net.Fixtures
+import com.testlogon.android.core.testing.net.MockBackendRule
+import com.testlogon.android.core.testing.net.retrofit
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * FE-170 — contract tests for [TradingDocsRepositoryImpl] against MockWebServer. Covers the list path +
+ * type query param + newest-first sort, download-URL resolution, and the DEGRADE-ON-404 tolerance
+ * (404 / 500 -> empty list / null, never an exception).
+ */
+class TradingDocsRepositoryContractTest {
+
+    @get:Rule
+    val backend = MockBackendRule()
+
+    private val moshi: Moshi = Moshi.Builder().build()
+
+    private fun repo(): TradingDocsRepositoryImpl {
+        val api = backend.retrofit(moshi).create(TradingDocsApi::class.java)
+        return TradingDocsRepositoryImpl(api = api)
+    }
+
+    @Test
+    fun listTradingDocuments_sortsNewestFirst_andSendsTypeQuery() = runTest {
+        backend.enqueue(
+            Fixtures.okBody(
+                """{"documents":[
+                   {"doc_id":"old","type":"statement","created_at":10},
+                   {"doc_id":"new","type":"statement","created_at":99},
+                   {"doc_id":"mid","type":"statement","created_at":50}
+                ]}""",
+            ),
+        )
+        val list = repo().listTradingDocuments("statement")
+        assertEquals(listOf("new", "mid", "old"), list.map { it.docId })
+
+        val req = backend.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/ui/trading-documents", req.requestUrl?.encodedPath)
+        assertEquals("statement", req.requestUrl?.queryParameter("type"))
+    }
+
+    @Test
+    fun listTradingDocuments_noType_omitsQuery() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"documents":[]}"""))
+        val list = repo().listTradingDocuments(null)
+        assertTrue(list.isEmpty())
+        val req = backend.takeRequest()
+        assertNull(req.requestUrl?.query)
+    }
+
+    @Test
+    fun listTradingDocuments_404_degradesToEmpty() = runTest {
+        backend.enqueue(Fixtures.error("\"not found\"", 404))
+        assertTrue(repo().listTradingDocuments().isEmpty())
+    }
+
+    @Test
+    fun listTradingDocuments_500_degradesToEmpty() = runTest {
+        backend.enqueue(Fixtures.error("\"boom\"", 500))
+        assertTrue(repo().listTradingDocuments("1099").isEmpty())
+    }
+
+    @Test
+    fun getDownloadUrl_resolvesPresignedUrl() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"download_url":"https://s3.example/x.pdf?sig=1"}"""))
+        assertEquals("https://s3.example/x.pdf?sig=1", repo().getDownloadUrl("doc-1"))
+        val req = backend.takeRequest()
+        assertEquals("/ui/trading-documents/doc-1/download", req.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun getDownloadUrl_404_degradesToNull() = runTest {
+        backend.enqueue(Fixtures.error("\"nope\"", 404))
+        assertNull(repo().getDownloadUrl("doc-1"))
+    }
+
+    @Test
+    fun getDownloadUrl_blankUrl_isNull() = runTest {
+        backend.enqueue(Fixtures.okBody("""{"download_url":""}"""))
+        assertNull(repo().getDownloadUrl("doc-1"))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/tradingdocs/TradingDocsMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/tradingdocs/TradingDocsMathTest.kt
@@ -1,0 +1,155 @@
+package com.testlogon.android.feature.tradingdocs
+
+import com.testlogon.android.data.tradingdocs.TradingDocument
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** FE-170 — pure JVM tests for the trading-documents grouping/labelling/filename helpers. */
+class TradingDocsMathTest {
+
+    private fun doc(
+        docId: String = "d1",
+        type: String = "statement",
+        title: String? = null,
+        taxYear: Int? = null,
+        periodStart: Long? = null,
+        format: String = "pdf",
+        sizeBytes: Long? = null,
+        status: String = "ready",
+        createdAt: Long? = 100L,
+        downloadUrl: String? = null,
+    ) = TradingDocument(
+        docId = docId,
+        type = type,
+        rawTitle = title,
+        periodStartEpochSeconds = periodStart,
+        periodEndEpochSeconds = null,
+        taxYear = taxYear,
+        format = format,
+        sizeBytes = sizeBytes,
+        status = status,
+        createdAtEpochSeconds = createdAt,
+        downloadUrl = downloadUrl,
+    )
+
+    @Test
+    fun tradingDocTypes_areCanonicalOrder() {
+        assertEquals(listOf("statement", "1099", "confirmation", "fills", "pnl"), TRADING_DOC_TYPES)
+    }
+
+    @Test
+    fun docTypeLabel_knownCodes() {
+        assertEquals("Statements", docTypeLabel("statement"))
+        assertEquals("1099 Tax Forms", docTypeLabel("1099"))
+        assertEquals("Trade Confirmations", docTypeLabel("confirmation"))
+        assertEquals("Fills", docTypeLabel("fills"))
+        assertEquals("Profit & Loss", docTypeLabel("pnl"))
+    }
+
+    @Test
+    fun docTypeLabel_unknownCode_titleCasesRaw() {
+        assertEquals("Margin", docTypeLabel("margin"))
+    }
+
+    @Test
+    fun groupDocuments_empty_isEmpty() {
+        assertTrue(groupDocuments(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun groupDocuments_ordersGroupsByCanonicalTypeOrder() {
+        val docs = listOf(
+            doc(docId = "p", type = "pnl"),
+            doc(docId = "s", type = "statement"),
+            doc(docId = "t", type = "1099"),
+        )
+        val groups = groupDocuments(docs)
+        assertEquals(listOf("statement", "1099", "pnl"), groups.map { it.type })
+    }
+
+    @Test
+    fun groupDocuments_newestFirstWithinGroup() {
+        val docs = listOf(
+            doc(docId = "old", type = "statement", createdAt = 10L),
+            doc(docId = "new", type = "statement", createdAt = 99L),
+            doc(docId = "mid", type = "statement", createdAt = 50L),
+        )
+        val group = groupDocuments(docs).single()
+        assertEquals(listOf("new", "mid", "old"), group.documents.map { it.docId })
+    }
+
+    @Test
+    fun groupDocuments_unknownTypesAppendedAlphabetically() {
+        val docs = listOf(
+            doc(docId = "z", type = "zeta"),
+            doc(docId = "a", type = "alpha"),
+            doc(docId = "s", type = "statement"),
+        )
+        val groups = groupDocuments(docs)
+        assertEquals(listOf("statement", "alpha", "zeta"), groups.map { it.type })
+    }
+
+    @Test
+    fun docTitle_prefersServerTitle() {
+        assertEquals("Q1 2025 Statement", docTitle(doc(title = "Q1 2025 Statement")))
+    }
+
+    @Test
+    fun docTitle_derivesFromTypeAndTaxYear_whenNoTitle() {
+        assertEquals("1099 Tax Form 2024", docTitle(doc(type = "1099", taxYear = 2024)))
+    }
+
+    @Test
+    fun docTitle_fallsBackToTypeLabel_singular() {
+        assertEquals("Statement", docTitle(doc(type = "statement")))
+    }
+
+    @Test
+    fun docFilename_safeAndCorrectExtension_pdf() {
+        val name = docFilename(doc(title = "Q1/2025: Statement*!", format = "pdf"))
+        assertEquals("Q1_2025_Statement.pdf", name)
+    }
+
+    @Test
+    fun docFilename_csvExtension() {
+        val name = docFilename(doc(title = "fills report", format = "csv"))
+        assertEquals("fills_report.csv", name)
+    }
+
+    @Test
+    fun docFilename_blankTitle_fallsBackToTypeAndId() {
+        val name = docFilename(doc(docId = "abc", type = "pnl", title = null, format = "pdf"))
+        assertEquals("pnl_abc.pdf", name)
+    }
+
+    @Test
+    fun docFilename_unknownFormat_defaultsToPdf() {
+        assertEquals("report.pdf", docFilename(doc(title = "report", format = "xyz")))
+    }
+
+    @Test
+    fun isDownloadable_falseWhenGenerating() {
+        assertFalse(isDownloadable(doc(status = "generating")))
+        assertTrue(isDownloadable(doc(status = "ready")))
+    }
+
+    @Test
+    fun formatDocMeta_readyWithSize() {
+        assertEquals("PDF · 1.0 KB", formatDocMeta(doc(format = "pdf", sizeBytes = 1024L)))
+    }
+
+    @Test
+    fun formatDocMeta_generatingTag() {
+        val meta = formatDocMeta(doc(format = "csv", sizeBytes = null, status = "generating"))
+        assertEquals("CSV · Generating…", meta)
+    }
+
+    @Test
+    fun formatSize_units() {
+        assertEquals("512 B", formatSize(512L))
+        assertEquals("1.0 KB", formatSize(1024L))
+        assertEquals("1.5 MB", formatSize((1024L * 1024L * 3L) / 2L))
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ const AdminLicenseCompliancePage = lazy(
   () => import("@/pages/licenses/AdminLicenseCompliancePage"),
 );
 const FilesPage = lazy(() => import("@/pages/files/FilesPage"));
+const TradingDocumentsPage = lazy(() => import("@/pages/files/TradingDocumentsPage"));
 const KycWorkloadPage = lazy(() => import("@/pages/admin/KycWorkloadPage"));
 const KycDocumentTemplatesPage = lazy(() => import("@/pages/admin/KycDocumentTemplatesPage"));
 const KycTranslationsPage = lazy(() => import("@/pages/admin/KycTranslationsPage"));
@@ -549,6 +550,7 @@ export default function App() {
           <Route path="contacts" element={<ContactsPage />} />
           <Route path="helpdesk" element={<HelpdeskPage />} />
           <Route path="files" element={<FilesPage />} />
+          <Route path="files/trading-documents" element={<TradingDocumentsPage />} />
           <Route path="files/share-links" element={<ShareLinksPage />} />
           <Route path="signing" element={<SigningPage />} />
           <Route path="signing/new" element={<CreateSignatureRequestPage />} />

--- a/frontend/src/api/endpoints/tradingDocuments.ts
+++ b/frontend/src/api/endpoints/tradingDocuments.ts
@@ -1,0 +1,79 @@
+// FE-170 (EPIC H) — Trading Documents feed for the file manager.
+// Mirrors the tax-docs / 1099 pattern (list endpoint + a download that is EITHER
+// a presigned {download_url} OR streamed bytes). Both calls DEGRADE-ON-404 so the
+// UI shows an honest empty state on backends where BE-171/172 are not deployed.
+import { api, ApiError } from "@/api/client";
+
+// ── contract (assumed BE-171/172) ────────────────────────────────────
+
+export type TradingDocType = "statement" | "1099" | "confirmation" | "fills" | "pnl";
+export type TradingDocFormat = "pdf" | "csv";
+export type TradingDocStatus = "ready" | "generating";
+
+export interface TradingDocument {
+  doc_id: string;
+  type: TradingDocType;
+  title?: string;
+  period_start?: string;
+  period_end?: string;
+  tax_year?: number;
+  format?: TradingDocFormat;
+  size_bytes?: number;
+  status?: TradingDocStatus;
+  created_at?: string;
+  download_url?: string;
+}
+
+export interface TradingDocumentList {
+  documents: TradingDocument[];
+}
+
+export interface TradingDocumentDownload {
+  download_url: string;
+}
+
+const EMPTY: TradingDocumentList = { documents: [] };
+
+/** Absent-backend statuses that DEGRADE to an honest empty feed. */
+function isAbsent(err: unknown): boolean {
+  return err instanceof ApiError && (err.status === 404 || err.status === 501 || err.status === 0);
+}
+
+/**
+ * List the caller trading documents, optionally filtered by `type`.
+ * DEGRADES-ON-404 (endpoint absent) to `{documents:[]}` so the UI renders the
+ * empty state rather than crashing. Other errors propagate.
+ */
+export async function listTradingDocuments(type?: TradingDocType): Promise<TradingDocumentList> {
+  try {
+    return await api.get<TradingDocumentList>(
+      "/ui/trading-documents",
+      type ? { type } : undefined,
+    );
+  } catch (err) {
+    if (isAbsent(err)) return EMPTY;
+    throw err;
+  }
+}
+
+/**
+ * Resolve a presigned download URL for one document. When the backend streams
+ * bytes instead of returning a URL, callers fall back to fetching the download
+ * path directly (see the page performDownload path). DEGRADES-ON-404 to null.
+ */
+export async function getTradingDocumentDownloadUrl(docId: string): Promise<string | null> {
+  try {
+    const res = await api.get<TradingDocumentDownload>(
+      `/ui/trading-documents/${encodeURIComponent(docId)}/download`,
+    );
+    return res?.download_url ?? null;
+  } catch (err) {
+    if (isAbsent(err)) return null;
+    throw err;
+  }
+}
+
+/** The raw streamed-bytes download path (used when no presigned URL is returned). */
+export function tradingDocumentDownloadPath(docId: string): string {
+  return `/ui/trading-documents/${encodeURIComponent(docId)}/download`;
+}

--- a/frontend/src/lib/tradingDocuments.test.ts
+++ b/frontend/src/lib/tradingDocuments.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import type { TradingDocument } from "@/api/endpoints/tradingDocuments";
+import {
+  TRADING_DOC_TYPES,
+  TRADING_DOC_ICONS,
+  docTypeLabel,
+  groupDocuments,
+  docTitle,
+  docFilename,
+  isDownloadable,
+  formatBytes,
+  formatDocMeta,
+} from "./tradingDocuments";
+
+function doc(over: Partial<TradingDocument>): TradingDocument {
+  return { doc_id: "d1", type: "statement", ...over };
+}
+
+describe("catalog", () => {
+  it("has a label + icon key for every type", () => {
+    for (const t of TRADING_DOC_TYPES) {
+      expect(docTypeLabel(t)).toBeTruthy();
+      expect(TRADING_DOC_ICONS[t]).toBeTruthy();
+    }
+  });
+
+  it("titleises unknown types", () => {
+    expect(docTypeLabel("trade_confirmation")).toBe("Trade Confirmation");
+  });
+});
+
+describe("docTitle", () => {
+  it("prefers an explicit title", () => {
+    expect(docTitle(doc({ title: "Custom Name" }))).toBe("Custom Name");
+  });
+
+  it("builds a statement title from tax_year", () => {
+    expect(docTitle(doc({ type: "statement", tax_year: 2024 }))).toBe("2024 Account Statement");
+  });
+
+  it("builds a 1099 title", () => {
+    expect(docTitle(doc({ type: "1099", tax_year: 2024 }))).toBe("1099-B 2024");
+  });
+
+  it("builds a confirmation title from period_start", () => {
+    expect(docTitle(doc({ type: "confirmation", period_start: "2024-06-01" }))).toBe(
+      "Trade Confirmation — 2024-06-01",
+    );
+  });
+
+  it("derives the year from period_start when no tax_year", () => {
+    expect(docTitle(doc({ type: "pnl", period_start: "2023-01-01" }))).toBe("2023 P&L Statement");
+  });
+});
+
+describe("docFilename", () => {
+  it("uses the csv extension for csv docs", () => {
+    expect(docFilename(doc({ type: "fills", tax_year: 2024, format: "csv" }))).toBe(
+      "2024-fills-report.csv",
+    );
+  });
+
+  it("defaults to pdf and is filesystem-safe", () => {
+    const name = docFilename(doc({ type: "confirmation", period_start: "2024-06-01" }));
+    expect(name).toBe("trade-confirmation-2024-06-01.pdf");
+    expect(name).not.toMatch(/[^a-z0-9.\-]/);
+  });
+});
+
+describe("isDownloadable", () => {
+  it("false while generating", () => {
+    expect(isDownloadable(doc({ status: "generating", download_url: "x" }))).toBe(false);
+  });
+
+  it("true when ready with a doc_id", () => {
+    expect(isDownloadable(doc({ status: "ready" }))).toBe(true);
+  });
+
+  it("true when a download_url is present", () => {
+    expect(isDownloadable(doc({ download_url: "https://x/y.pdf" }))).toBe(true);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats small + large sizes", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5 MB");
+  });
+
+  it("returns empty for missing/invalid", () => {
+    expect(formatBytes(undefined)).toBe("");
+    expect(formatBytes(-1)).toBe("");
+  });
+});
+
+describe("formatDocMeta", () => {
+  it("joins period, size and format without dangling separators", () => {
+    const meta = formatDocMeta(
+      doc({ period_start: "2024-01-01", period_end: "2024-12-31", size_bytes: 2048, format: "pdf" }),
+    );
+    expect(meta).toBe("2024-01-01 – 2024-12-31 · 2 KB · PDF");
+  });
+
+  it("falls back to created_at when no period", () => {
+    expect(formatDocMeta(doc({ created_at: "2024-06-01" }))).toBe("2024-06-01");
+  });
+
+  it("is empty when nothing is known", () => {
+    expect(formatDocMeta(doc({}))).toBe("");
+  });
+});
+
+describe("groupDocuments", () => {
+  it("groups by type in catalog order, newest-first within a group", () => {
+    const docs: TradingDocument[] = [
+      doc({ doc_id: "a", type: "1099", created_at: "2024-01-01" }),
+      doc({ doc_id: "b", type: "statement", created_at: "2023-01-01" }),
+      doc({ doc_id: "c", type: "statement", created_at: "2024-01-01" }),
+    ];
+    const groups = groupDocuments(docs);
+    expect(groups.map((g) => g.type)).toEqual(["statement", "1099"]);
+    expect(groups[0]?.documents.map((d) => d.doc_id)).toEqual(["c", "b"]);
+  });
+
+  it("places unknown types after known ones and omits empty groups", () => {
+    const docs: TradingDocument[] = [
+      doc({ doc_id: "x", type: "custom" as TradingDocument["type"] }),
+      doc({ doc_id: "y", type: "pnl" }),
+    ];
+    const groups = groupDocuments(docs);
+    expect(groups.map((g) => g.type)).toEqual(["pnl", "custom"]);
+  });
+
+  it("returns [] for no docs", () => {
+    expect(groupDocuments([])).toEqual([]);
+  });
+});

--- a/frontend/src/lib/tradingDocuments.ts
+++ b/frontend/src/lib/tradingDocuments.ts
@@ -1,0 +1,212 @@
+// FE-170 (EPIC H) — pure, DOM-free helpers for the Trading Documents area.
+// Every function here is a pure transform over a TradingDocument so they are
+// trivially unit-testable (see tradingDocuments.test.ts). No I/O, no React.
+import type {
+  TradingDocument,
+  TradingDocType,
+  TradingDocFormat,
+} from "@/api/endpoints/tradingDocuments";
+
+// ── type catalog ─────────────────────────────────────────────────────
+
+export const TRADING_DOC_TYPES: TradingDocType[] = [
+  "statement",
+  "1099",
+  "confirmation",
+  "fills",
+  "pnl",
+];
+
+/** Human labels per document type. */
+const TYPE_LABELS: Record<TradingDocType, string> = {
+  statement: "Account Statements",
+  "1099": "Tax Forms (1099)",
+  confirmation: "Trade Confirmations",
+  fills: "Fills Reports",
+  pnl: "P&L Statements",
+};
+
+/** lucide icon KEY per type (the UI maps these to actual components). */
+export const TRADING_DOC_ICONS: Record<TradingDocType, string> = {
+  statement: "FileText",
+  "1099": "Receipt",
+  confirmation: "FileCheck",
+  fills: "FileSpreadsheet",
+  pnl: "TrendingUp",
+};
+
+/** Label for a document type (falls back to a titleised raw type). */
+export function docTypeLabel(type: string): string {
+  const known = (TYPE_LABELS as Record<string, string | undefined>)[type];
+  if (known) return known;
+  return type
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+// ── time helpers (pure) ──────────────────────────────────────────────
+
+const MS_THRESHOLD = 1e12;
+
+/** Parse a doc timestamp (ISO string, or epoch seconds/ms) to ms, or null. */
+function toMs(value: string | number | undefined | null): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    return value < MS_THRESHOLD ? value * 1000 : value;
+  }
+  const asNum = Number(value);
+  if (value.trim() !== "" && Number.isFinite(asNum) && /^\d+$/.test(value.trim())) {
+    return asNum < MS_THRESHOLD ? asNum * 1000 : asNum;
+  }
+  const t = Date.parse(value);
+  return Number.isNaN(t) ? null : t;
+}
+
+/** Sort key for "newest first" — docs without a date sort last. */
+function createdMs(doc: TradingDocument): number {
+  const ms = toMs(doc.created_at);
+  return ms == null ? -Infinity : ms;
+}
+
+/** Best-effort year from a doc (tax_year, else period_start, else created_at). */
+function docYear(doc: TradingDocument): number | null {
+  if (doc.tax_year != null && Number.isFinite(doc.tax_year)) return doc.tax_year;
+  const ms = toMs(doc.period_start) ?? toMs(doc.created_at);
+  return ms == null ? null : new Date(ms).getUTCFullYear();
+}
+
+/** ISO date (YYYY-MM-DD) for a timestamp value, or "". */
+function isoDate(value: string | number | undefined | null): string {
+  const ms = toMs(value);
+  if (ms == null) return "";
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? "" : d.toISOString().slice(0, 10);
+}
+
+// ── grouping ─────────────────────────────────────────────────────────
+
+export interface TradingDocGroup {
+  type: TradingDocType;
+  label: string;
+  documents: TradingDocument[];
+}
+
+/**
+ * Group documents by type (in TRADING_DOC_TYPES order, unknown types after),
+ * each group sorted newest-first. Empty groups are omitted.
+ */
+export function groupDocuments(docs: TradingDocument[]): TradingDocGroup[] {
+  const byType = new Map<string, TradingDocument[]>();
+  for (const doc of docs) {
+    const key = doc.type;
+    const arr = byType.get(key);
+    if (arr) arr.push(doc);
+    else byType.set(key, [doc]);
+  }
+
+  const orderedKeys: string[] = [
+    ...TRADING_DOC_TYPES.filter((t) => byType.has(t)),
+    ...[...byType.keys()].filter((k) => !TRADING_DOC_TYPES.includes(k as TradingDocType)),
+  ];
+
+  return orderedKeys.map((key) => {
+    const documents = [...(byType.get(key) ?? [])].sort((a, b) => createdMs(b) - createdMs(a));
+    return {
+      type: key as TradingDocType,
+      label: docTypeLabel(key),
+      documents,
+    };
+  });
+}
+
+// ── titles / filenames ───────────────────────────────────────────────
+
+/** Human-readable title for a document (uses the explicit title when present). */
+export function docTitle(doc: TradingDocument): string {
+  if (doc.title && doc.title.trim()) return doc.title.trim();
+  const year = docYear(doc);
+  switch (doc.type) {
+    case "statement":
+      return year != null ? `${year} Account Statement` : "Account Statement";
+    case "1099":
+      return year != null ? `1099-B ${year}` : "1099-B";
+    case "confirmation": {
+      const day = isoDate(doc.period_start) || isoDate(doc.created_at);
+      return day ? `Trade Confirmation — ${day}` : "Trade Confirmation";
+    }
+    case "fills":
+      return year != null ? `${year} Fills Report` : "Fills Report";
+    case "pnl":
+      return year != null ? `${year} P&L Statement` : "P&L Statement";
+    default:
+      return docTypeLabel(doc.type);
+  }
+}
+
+const EXT_BY_FORMAT: Record<TradingDocFormat, string> = { pdf: "pdf", csv: "csv" };
+
+/** Slugify a title into a filesystem-safe base name. */
+function slug(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-") || "document";
+}
+
+/** Safe download filename with the correct extension for the doc format. */
+export function docFilename(doc: TradingDocument): string {
+  const ext = doc.format && EXT_BY_FORMAT[doc.format] ? EXT_BY_FORMAT[doc.format] : "pdf";
+  return `${slug(docTitle(doc))}.${ext}`;
+}
+
+// ── status / metadata ────────────────────────────────────────────────
+
+/** True when a doc is ready AND has something to download (url or id). */
+export function isDownloadable(doc: TradingDocument): boolean {
+  if (doc.status === "generating") return false;
+  const hasSource = Boolean(doc.download_url) || Boolean(doc.doc_id);
+  return hasSource;
+}
+
+/** Format bytes into a compact human size (e.g. "1.2 MB"), or "". */
+export function formatBytes(bytes: number | undefined | null): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let val = bytes / 1024;
+  let i = 0;
+  while (val >= 1024 && i < units.length - 1) {
+    val /= 1024;
+    i += 1;
+  }
+  const rounded = val >= 10 || Number.isInteger(val) ? Math.round(val) : Math.round(val * 10) / 10;
+  return `${rounded} ${units[i]}`;
+}
+
+/**
+ * One-line metadata: period (or date), file size, and format — joined with " · ".
+ * Empty parts are dropped so there are never dangling separators.
+ */
+export function formatDocMeta(doc: TradingDocument): string {
+  const parts: string[] = [];
+
+  const start = isoDate(doc.period_start);
+  const end = isoDate(doc.period_end);
+  if (start && end) parts.push(`${start} – ${end}`);
+  else if (start) parts.push(start);
+  else {
+    const created = isoDate(doc.created_at);
+    if (created) parts.push(created);
+  }
+
+  const size = formatBytes(doc.size_bytes);
+  if (size) parts.push(size);
+
+  if (doc.format) parts.push(doc.format.toUpperCase());
+
+  return parts.join(" · ");
+}

--- a/frontend/src/pages/files/FilesPage.tsx
+++ b/frontend/src/pages/files/FilesPage.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheck,
   Cloud,
   HardDrive,
+  Receipt,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -1039,6 +1040,13 @@ export default function FilesPage() {
       <PageHeader
         title="Files"
         description="Manage your files and folders"
+        actions={
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/files/trading-documents">
+              <Receipt className="mr-1.5 h-4 w-4" /> Trading Documents
+            </Link>
+          </Button>
+        }
       />
       <ImpersonationRouteIndicator area="files" />
 

--- a/frontend/src/pages/files/TradingDocumentsPage.tsx
+++ b/frontend/src/pages/files/TradingDocumentsPage.tsx
@@ -1,0 +1,234 @@
+// FE-170 (EPIC H) — Trading Documents area of the file manager.
+// Lists statements / 1099s / trade confirmations (BE-171), grouped by type, and
+// downloads each (BE-172) either via a presigned {download_url} (anchor navigate)
+// or streamed bytes (fetch → blob → anchor — the FilesPage performDownload idiom).
+// Share reuses the copy-link idiom. Everything DEGRADES-ON-404 to an honest
+// "No trading documents yet" empty state — no crash.
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import {
+  FileText,
+  FileCheck,
+  FileSpreadsheet,
+  Receipt,
+  TrendingUp,
+  Download,
+  Share,
+  ArrowLeft,
+  Clock,
+  Files as FilesIcon,
+} from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { EmptyState } from "@/components/shared/EmptyState";
+
+import {
+  listTradingDocuments,
+  getTradingDocumentDownloadUrl,
+  tradingDocumentDownloadPath,
+  type TradingDocument,
+} from "@/api/endpoints/tradingDocuments";
+import {
+  groupDocuments,
+  docTitle,
+  docFilename,
+  formatDocMeta,
+  isDownloadable,
+  TRADING_DOC_ICONS,
+} from "@/lib/tradingDocuments";
+
+// lucide component per icon KEY produced by the pure lib.
+const ICON_BY_KEY: Record<string, typeof FileText> = {
+  FileText,
+  FileCheck,
+  FileSpreadsheet,
+  Receipt,
+  TrendingUp,
+};
+
+/** Trigger a client-side file download from an in-memory blob (FilesPage idiom). */
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** Navigate the browser to a presigned URL to start a download. */
+function navigateDownload(url: string) {
+  const a = document.createElement("a");
+  a.href = url;
+  a.rel = "noopener";
+  a.target = "_blank";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+async function handleDownload(doc: TradingDocument) {
+  const filename = docFilename(doc);
+  const toastId = toast.loading(`Preparing ${filename}...`);
+  try {
+    // Prefer an inline presigned URL, else resolve one from BE-172.
+    let url = doc.download_url ?? null;
+    if (!url) url = await getTradingDocumentDownloadUrl(doc.doc_id);
+
+    if (url) {
+      navigateDownload(url);
+      toast.success(`Downloading ${filename}`, { id: toastId });
+      return;
+    }
+
+    // No presigned URL → the endpoint streams bytes. Fetch → blob → anchor.
+    const res = await fetch(tradingDocumentDownloadPath(doc.doc_id), { credentials: "include" });
+    if (!res.ok) throw new Error(`download failed (${res.status})`);
+    const blob = await res.blob();
+    triggerDownload(blob, filename);
+    toast.success(`Downloaded ${filename}`, { id: toastId });
+  } catch {
+    toast.error(`Could not download ${filename}`, { id: toastId });
+  }
+}
+
+async function handleShare(doc: TradingDocument) {
+  try {
+    // Reuse the file-manager share idiom: resolve a shareable link and copy it.
+    const url = doc.download_url ?? (await getTradingDocumentDownloadUrl(doc.doc_id));
+    if (!url) {
+      toast.error("No shareable link available for this document yet.");
+      return;
+    }
+    const absolute = /^https?:\/\//.test(url) ? url : new URL(url, window.location.origin).href;
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(absolute);
+      toast.success("Link copied to clipboard");
+    } else {
+      toast.success(absolute);
+    }
+  } catch {
+    toast.error("Could not create a share link.");
+  }
+}
+
+function DocRow({ doc }: { doc: TradingDocument }) {
+  const iconKey = TRADING_DOC_ICONS[doc.type] ?? "FileText";
+  const Icon = ICON_BY_KEY[iconKey] ?? FileText;
+  const meta = formatDocMeta(doc);
+  const generating = doc.status === "generating";
+  const downloadable = isDownloadable(doc);
+
+  return (
+    <div
+      className="flex items-center gap-3 rounded-md border px-3 py-2.5 hover:bg-accent/40 transition-colors"
+      data-testid="trading-doc-row"
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <Icon className="h-4.5 w-4.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-medium">{docTitle(doc)}</span>
+          {generating && (
+            <Badge variant="secondary" className="gap-1 text-[10px]">
+              <Clock className="h-3 w-3" /> Generating
+            </Badge>
+          )}
+        </div>
+        {meta && <p className="truncate text-xs text-muted-foreground">{meta}</p>}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={!downloadable}
+          onClick={() => handleShare(doc)}
+          title="Copy share link"
+        >
+          <Share className="h-4 w-4" />
+          <span className="sr-only">Share</span>
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={!downloadable}
+          onClick={() => handleDownload(doc)}
+        >
+          <Download className="mr-1.5 h-4 w-4" /> Download
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function TradingDocumentsPage() {
+  const query = useQuery({
+    queryKey: ["trading-documents"],
+    queryFn: () => listTradingDocuments(),
+    retry: false,
+  });
+
+  const groups = useMemo(
+    () => groupDocuments(query.data?.documents ?? []),
+    [query.data],
+  );
+
+  return (
+    <div className="p-4 md:p-6 lg:p-8 space-y-4">
+      <PageHeader
+        title="Trading Documents"
+        description="Statements, tax forms and trade confirmations"
+        actions={
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/files">
+              <ArrowLeft className="mr-1.5 h-4 w-4" /> Back to Files
+            </Link>
+          </Button>
+        }
+      />
+
+      {query.isLoading && (
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      )}
+
+      {!query.isLoading && groups.length === 0 && (
+        <Card>
+          <CardContent className="pt-6">
+            <EmptyState
+              icon={<FilesIcon className="h-8 w-8" />}
+              title="No trading documents yet"
+              description="Account statements, 1099s and trade confirmations will appear here once they are generated."
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {!query.isLoading &&
+        groups.map((group) => (
+          <Card key={group.type}>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">{group.label}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {group.documents.map((doc) => (
+                <DocRow key={doc.doc_id} doc={doc} />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## FE-170 — Trading Documents in the file manager (EPIC H)

A **"Trading Documents"** area (statements, 1099s, trade confirmations) in the file manager: **list / download / share**. Built against BE-171 (list) + BE-172 (download: presigned URL or streamed bytes), mirroring the shipped tax-documents/1099 pattern. Degrade-on-404 → honest "No trading documents yet" empty state, no crash.

### Web
- NEW `api/endpoints/tradingDocuments.ts` (`listTradingDocuments`/`getTradingDocumentDownloadUrl`, degrade-on-404) + pure `lib/tradingDocuments.ts` (`TRADING_DOC_TYPES`, `groupDocuments`, `docTitle`, `docFilename`, `isDownloadable`, `formatDocMeta`) + 20 vitest.
- NEW `TradingDocumentsPage` (grouped cards, Download via presigned-anchor/blob, Share via copy-link, generating→pending badge) at route `files/trading-documents`, reached from a Files-page header button. Reuses `FilesPage` download + TaxReport/RewardsStatement page structure.

### Android
- NEW `TradingDocsApi`/Domain/Repository (+ Hilt module, degrade-on-404 → empty) + pure `TradingDocsMath.kt` (+18 JVM tests) + repository contract tests (7) + `TradingDocsScreen`/ViewModel.
- A "Trading Documents" tile at the file-manager root → grouped list (Download via Custom Tabs for presigned URL, Share via ACTION_SEND, generating→disabled). Route lives in the files feature graph (MoreCatalogTest unaffected — verified). Mirrors AND-246 TaxDocs + AND-243 Custom Tabs launcher.

### Gates
- Web: tsc 0 · build green · 20/20 vitest
- Android: BUILD SUCCESSFUL · TradingDocsMathTest 18/18 · TradingDocsRepositoryContractTest 7/7 · MoreCatalogTest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
