### PR TITLE
FE-171: request/download statements + exports + 1099 (web + Android) — completes EPIC H

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsApi.kt
@@ -2,7 +2,9 @@ package com.testlogon.android.data.tradingdocs
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -36,6 +38,16 @@ interface TradingDocsApi {
     suspend fun getDownload(
         @Path("doc_id") docId: String,
     ): TradingDocDownloadDto
+
+    /**
+     * FE-171 (BE-170) — request generation of a new trading document (statement / pnl / fills / 1099).
+     * Body: { type, period_start?, period_end?, tax_year? }. The generated file lands in the FE-170
+     * list once ready. Returns the (possibly still-generating) document descriptor.
+     */
+    @POST("ui/trading-documents/request")
+    suspend fun requestTradingDocument(
+        @Body body: TradingDocRequestDto,
+    ): TradingDocRequestResultDto
 }
 
 // ---- DTOs ----
@@ -66,4 +78,20 @@ data class TradingDocDto(
 @JsonClass(generateAdapter = true)
 data class TradingDocDownloadDto(
     @Json(name = "download_url") val downloadUrl: String? = null,
+)
+
+/** FE-171 (BE-170) — request-generate body. Only params relevant to the type are populated. */
+@JsonClass(generateAdapter = true)
+data class TradingDocRequestDto(
+    @Json(name = "type") val type: String,
+    @Json(name = "period_start") val periodStart: Long? = null,
+    @Json(name = "period_end") val periodEnd: Long? = null,
+    @Json(name = "tax_year") val taxYear: Int? = null,
+)
+
+/** FE-171 (BE-170) — request-generate result; the (possibly generating) document descriptor. */
+@JsonClass(generateAdapter = true)
+data class TradingDocRequestResultDto(
+    @Json(name = "doc_id") val docId: String? = null,
+    @Json(name = "status") val status: String = "generating",
 )

--- a/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/tradingdocs/TradingDocsRepository.kt
@@ -28,6 +28,18 @@ interface TradingDocsRepository {
 
     /** Resolve a presigned download URL for [docId]; null on any error (degrade-on-404). */
     suspend fun getDownloadUrl(docId: String): String?
+
+    /**
+     * FE-171 (BE-170) — request generation of a trading document. Returns true when the backend
+     * ACCEPTED the request; false on any error (incl. a 404 when BE-170 is undeployed) — degrade-on-404,
+     * the caller then shows the honest "not available yet" message.
+     */
+    suspend fun requestTradingDocument(
+        type: String,
+        periodStart: Long? = null,
+        periodEnd: Long? = null,
+        taxYear: Int? = null,
+    ): Boolean
 }
 
 @Singleton
@@ -48,6 +60,25 @@ class TradingDocsRepositoryImpl @Inject constructor(
 
     override suspend fun getDownloadUrl(docId: String): String? = withContext(io) {
         callOr(null) { api.getDownload(docId).downloadUrl?.takeIf { it.isNotBlank() } }
+    }
+
+    override suspend fun requestTradingDocument(
+        type: String,
+        periodStart: Long?,
+        periodEnd: Long?,
+        taxYear: Int?,
+    ): Boolean = withContext(io) {
+        callOr(false) {
+            api.requestTradingDocument(
+                TradingDocRequestDto(
+                    type = type,
+                    periodStart = periodStart,
+                    periodEnd = periodEnd,
+                    taxYear = taxYear,
+                ),
+            )
+            true
+        }
     }
 
     /** Runs [block], returning [fallback] on HTTP (incl. 404) / transport errors. Re-throws cancellation. */

--- a/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/portfolio/PortfolioScreen.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.feature.tradingdocs.ReportRequestSection
+import com.testlogon.android.feature.tradingdocs.ReportRequestViewModel
+import com.testlogon.android.feature.tradingdocs.ReportSubmissionState
 
 /** Green/red for uPnL, independent of the app theme (matches the markets convention). */
 private val PnlUp = Color(0xFF16A34A)
@@ -48,14 +51,23 @@ private val PnlDown = Color(0xFFDC2626)
 @Composable
 fun PortfolioRoute(
     onBack: () -> Unit,
+    onOpenTradingDocs: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PortfolioViewModel = hiltViewModel(),
+    reportViewModel: ReportRequestViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val submission by reportViewModel.submission.collectAsStateWithLifecycle()
     PortfolioScreen(
         state = state,
+        submission = submission,
         onBack = onBack,
         onRefresh = viewModel::refresh,
+        onGenerateReport = reportViewModel::generate,
+        onOpenTradingDocs = {
+            reportViewModel.reset()
+            onOpenTradingDocs()
+        },
         modifier = modifier,
     )
 }
@@ -63,8 +75,11 @@ fun PortfolioRoute(
 @Composable
 fun PortfolioScreen(
     state: PortfolioUiState,
+    submission: ReportSubmissionState,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
+    onGenerateReport: (type: String, periodStart: Long?, periodEnd: Long?, taxYear: Int?) -> Unit,
+    onOpenTradingDocs: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -101,6 +116,14 @@ fun PortfolioScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item { TotalEquityHeader(state) }
+
+            item {
+                ReportRequestSection(
+                    submission = submission,
+                    onGenerate = onGenerateReport,
+                    onViewDocuments = onOpenTradingDocs,
+                )
+            }
 
             if (state.anyLoading && state.cards.all { it.loading }) {
                 item { LoadingBlock() }

--- a/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/ReportRequestMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/ReportRequestMath.kt
@@ -1,0 +1,133 @@
+package com.testlogon.android.feature.tradingdocs
+
+import java.util.Locale
+
+/**
+ * FE-171 (EPIC H) — PURE (no Android deps), JVM-testable helpers for REQUESTING a trading document
+ * (account statement / P&L report / fills CSV / 1099). Kept framework-free so the report-type catalog,
+ * request validation, request-payload shaping and filename derivation are unit-tested without
+ * Robolectric (mirrors the FE-170 [TradingDocsMath] idiom).
+ *
+ * Backend contract (BE-170 request/generate): POST ui/trading-documents/request
+ *   { type, period_start?, period_end?, tax_year? }
+ * where period_start/period_end are epoch-SECONDS Longs and tax_year is an Int. The generated file
+ * then lands in the FE-170 "Trading Documents" list once ready (degrade-on-404 everywhere).
+ */
+
+/** Report output format. */
+enum class ReportFormat { PDF, CSV }
+
+/**
+ * A requestable report type. [needsPeriod] => a start+end date range is required; [needsTaxYear] => a
+ * tax year is required (mutually exclusive by product rule: statement/pnl/fills need a period, 1099
+ * needs a tax year).
+ */
+data class ReportType(
+    /** BE-170 `type` code (also the FE-170 list `type`). */
+    val code: String,
+    val label: String,
+    val format: ReportFormat,
+    val needsPeriod: Boolean,
+    val needsTaxYear: Boolean,
+)
+
+/** Canonical, display-ordered catalog of requestable report types. */
+val REPORT_TYPES: List<ReportType> = listOf(
+    ReportType("statement", "Account statement", ReportFormat.PDF, needsPeriod = true, needsTaxYear = false),
+    ReportType("pnl", "Profit & Loss report", ReportFormat.PDF, needsPeriod = true, needsTaxYear = false),
+    ReportType("fills", "Fills (CSV)", ReportFormat.CSV, needsPeriod = true, needsTaxYear = false),
+    ReportType("1099", "1099 tax form", ReportFormat.PDF, needsPeriod = false, needsTaxYear = true),
+)
+
+/** Look up a [ReportType] by its BE-170 `type` code (case-insensitive); null if unknown. */
+fun reportTypeOf(code: String): ReportType? =
+    REPORT_TYPES.firstOrNull { it.code.equals(code, ignoreCase = true) }
+
+/**
+ * Validate a report request. Returns a (possibly empty) list of human-readable errors; an EMPTY list
+ * means the request is well-formed and may be submitted.
+ *
+ * Rules:
+ *  - Unknown [type] -> a single "unknown report type" error.
+ *  - Period-based types (statement / pnl / fills) need BOTH [periodStart] and [periodEnd], and start
+ *    must be strictly before end.
+ *  - 1099 needs a plausible [taxYear] (>= 1900).
+ */
+fun validateReportRequest(
+    type: String,
+    periodStart: Long? = null,
+    periodEnd: Long? = null,
+    taxYear: Int? = null,
+): List<String> {
+    val rt = reportTypeOf(type) ?: return listOf("Unknown report type.")
+    val errors = mutableListOf<String>()
+    if (rt.needsPeriod) {
+        if (periodStart == null || periodEnd == null) {
+            errors += "Select a start and end date."
+        } else if (periodStart >= periodEnd) {
+            errors += "Start date must be before end date."
+        }
+    }
+    if (rt.needsTaxYear) {
+        if (taxYear == null) {
+            errors += "Select a tax year."
+        } else if (taxYear < 1900) {
+            errors += "Select a valid tax year."
+        }
+    }
+    return errors
+}
+
+/**
+ * Shape the BE-170 request payload for [type]. Only the parameters RELEVANT to the type are included
+ * (period-based types carry period_start/period_end; 1099 carries tax_year); irrelevant params are
+ * dropped. Assumes the request already passed [validateReportRequest].
+ */
+fun requestPayload(
+    type: String,
+    periodStart: Long? = null,
+    periodEnd: Long? = null,
+    taxYear: Int? = null,
+): Map<String, Any> {
+    val rt = reportTypeOf(type)
+    val payload = linkedMapOf<String, Any>("type" to (rt?.code ?: type))
+    if (rt?.needsPeriod == true) {
+        periodStart?.let { payload["period_start"] = it }
+        periodEnd?.let { payload["period_end"] = it }
+    }
+    if (rt?.needsTaxYear == true) {
+        taxYear?.let { payload["tax_year"] = it }
+    }
+    return payload
+}
+
+private val UNSAFE_FILENAME = Regex("[^A-Za-z0-9._-]+")
+
+/**
+ * A SAFE, portable filename for a report request (used for a client-side export or as a display hint):
+ * "<type>_<period|year>.<ext>", stripped of filesystem-unsafe characters.
+ */
+fun reportFilename(
+    type: String,
+    periodStart: Long? = null,
+    periodEnd: Long? = null,
+    taxYear: Int? = null,
+): String {
+    val rt = reportTypeOf(type)
+    val ext = when (rt?.format) {
+        ReportFormat.CSV -> "csv"
+        else -> "pdf"
+    }
+    val code = rt?.code ?: type
+    val suffix = when {
+        rt?.needsTaxYear == true && taxYear != null -> taxYear.toString()
+        rt?.needsPeriod == true && periodStart != null && periodEnd != null -> "${periodStart}_$periodEnd"
+        else -> null
+    }
+    val base = (if (suffix != null) "${code}_$suffix" else code)
+        .lowercase(Locale.ROOT)
+        .replace(UNSAFE_FILENAME, "_")
+        .trim('_')
+        .ifBlank { "report" }
+    return "$base.$ext"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/ReportRequestSection.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/ReportRequestSection.kt
@@ -1,0 +1,303 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.tradingdocs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+/** FE-171 stable testTags for the "Statements & reports" request section. */
+object ReportRequestTestTags {
+    const val SECTION = "report_request_section"
+    const val TYPE_DROPDOWN = "report_request_type"
+    const val YEAR_DROPDOWN = "report_request_year"
+    const val START_DATE = "report_request_start"
+    const val END_DATE = "report_request_end"
+    const val GENERATE = "report_request_generate"
+    const val MESSAGE = "report_request_message"
+}
+
+/** UI-side selection state for the report request form. Days are UTC-midnight millis (DatePicker native). */
+private data class ReportRequestForm(
+    val type: ReportType = REPORT_TYPES.first(),
+    val startMillis: Long? = null,
+    val endMillis: Long? = null,
+    val taxYear: Int? = null,
+)
+
+/** Recent tax years offered for a 1099 (current year back 5), newest first. */
+private fun recentTaxYears(): List<Int> {
+    val now = Calendar.getInstance().get(Calendar.YEAR)
+    return (0..5).map { now - it }
+}
+
+private fun fmtDay(millis: Long?): String =
+    millis?.let {
+        SimpleDateFormat("MMM d, yyyy", Locale.getDefault()).format(Date(it))
+    } ?: "Select"
+
+/** UTC-midnight day-millis -> epoch SECONDS (BE-170 period_* are epoch-seconds). */
+private fun daySeconds(millis: Long): Long = millis / 1000L
+
+/**
+ * FE-171 — "Statements & reports" request section for the account/portfolio screen. Pick a report type,
+ * the required params (a start/end date range, or a tax year for 1099), then Generate. On submit the
+ * request is validated via [validateReportRequest] and sent through [onGenerate]; the outcome
+ * ([submission]) is surfaced as an inline honest message with a link to the Trading Documents area.
+ *
+ * Reuses the FE-170 trading-documents request/download flow: a successful request points the user to
+ * the rendered file in Trading Documents ([onViewDocuments]); degrade-on-404 shows "not available yet".
+ */
+@Composable
+fun ReportRequestSection(
+    submission: ReportSubmissionState,
+    onGenerate: (type: String, periodStart: Long?, periodEnd: Long?, taxYear: Int?) -> Unit,
+    onViewDocuments: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var form by remember { mutableStateOf(ReportRequestForm()) }
+    var localErrors by remember { mutableStateOf<List<String>>(emptyList()) }
+
+    Card(modifier = modifier.fillMaxWidth().testTag(ReportRequestTestTags.SECTION)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(
+                "Statements & reports",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                "Request an account statement, P&L report, fills export, or 1099. It will appear in " +
+                    "Trading Documents when ready.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            ReportTypeDropdown(
+                selected = form.type,
+                onSelected = { form = form.copy(type = it) },
+            )
+
+            if (form.type.needsPeriod) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    DateField(
+                        label = "Start",
+                        millis = form.startMillis,
+                        onPicked = { form = form.copy(startMillis = it) },
+                        testTag = ReportRequestTestTags.START_DATE,
+                        modifier = Modifier.weight(1f),
+                    )
+                    DateField(
+                        label = "End",
+                        millis = form.endMillis,
+                        onPicked = { form = form.copy(endMillis = it) },
+                        testTag = ReportRequestTestTags.END_DATE,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            if (form.type.needsTaxYear) {
+                TaxYearDropdown(
+                    selected = form.taxYear,
+                    onSelected = { form = form.copy(taxYear = it) },
+                )
+            }
+
+            val startSec = form.startMillis?.let(::daySeconds)
+            val endSec = form.endMillis?.let(::daySeconds)
+
+            Button(
+                onClick = {
+                    val errs = validateReportRequest(form.type.code, startSec, endSec, form.taxYear)
+                    localErrors = errs
+                    if (errs.isEmpty()) {
+                        onGenerate(form.type.code, startSec, endSec, form.taxYear)
+                    }
+                },
+                enabled = submission !is ReportSubmissionState.Submitting,
+                modifier = Modifier.fillMaxWidth().testTag(ReportRequestTestTags.GENERATE),
+            ) {
+                Text(
+                    if (submission is ReportSubmissionState.Submitting) "Generating…" else "Generate",
+                )
+            }
+
+            localErrors.forEach { err ->
+                Text(
+                    err,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag(ReportRequestTestTags.MESSAGE),
+                )
+            }
+
+            when (submission) {
+                ReportSubmissionState.Idle, ReportSubmissionState.Submitting -> Unit
+                is ReportSubmissionState.Success -> {
+                    Text(
+                        "Generating your report — it will appear in Trading Documents when ready.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.testTag(ReportRequestTestTags.MESSAGE),
+                    )
+                    TextButton(onClick = onViewDocuments) { Text("View Trading Documents") }
+                }
+                is ReportSubmissionState.Unavailable -> {
+                    Text(
+                        "Reports aren’t available yet. Trading Documents will list them once the " +
+                            "service is enabled.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag(ReportRequestTestTags.MESSAGE),
+                    )
+                    TextButton(onClick = onViewDocuments) { Text("Open Trading Documents") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReportTypeDropdown(
+    selected: ReportType,
+    onSelected: (ReportType) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = selected.label,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Report type") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+                .testTag(ReportRequestTestTags.TYPE_DROPDOWN),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            REPORT_TYPES.forEach { rt ->
+                DropdownMenuItem(
+                    text = { Text(rt.label) },
+                    onClick = {
+                        onSelected(rt)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaxYearDropdown(
+    selected: Int?,
+    onSelected: (Int) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = selected?.toString() ?: "Select a year",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Tax year") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+                .testTag(ReportRequestTestTags.YEAR_DROPDOWN),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            recentTaxYears().forEach { year ->
+                DropdownMenuItem(
+                    text = { Text(year.toString()) },
+                    onClick = {
+                        onSelected(year)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DateField(
+    label: String,
+    millis: Long?,
+    onPicked: (Long) -> Unit,
+    testTag: String,
+    modifier: Modifier = Modifier,
+) {
+    var show by remember { mutableStateOf(false) }
+    Box(modifier) {
+        OutlinedButton(
+            onClick = { show = true },
+            modifier = Modifier.fillMaxWidth().testTag(testTag),
+        ) {
+            Text("$label: ${fmtDay(millis)}")
+        }
+    }
+    if (show) {
+        val dateState = rememberDatePickerState(
+            initialSelectedDateMillis = millis ?: System.currentTimeMillis(),
+        )
+        DatePickerDialog(
+            onDismissRequest = { show = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    dateState.selectedDateMillis?.let(onPicked)
+                    show = false
+                }) { Text("OK") }
+            },
+            dismissButton = { TextButton(onClick = { show = false }) { Text("Cancel") } },
+        ) {
+            DatePicker(state = dateState)
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/ReportRequestViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tradingdocs/ReportRequestViewModel.kt
@@ -1,0 +1,57 @@
+package com.testlogon.android.feature.tradingdocs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.data.tradingdocs.TradingDocsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * FE-171 — outcome of a report-generation request, surfaced inline by [ReportRequestSection]:
+ *  - [Idle]        : no request in flight.
+ *  - [Submitting]  : POST in flight (button disabled).
+ *  - [Success]     : backend accepted — point the user at Trading Documents.
+ *  - [Unavailable] : degrade-on-404 — the backend rejected/absent; honest "not available yet".
+ */
+sealed interface ReportSubmissionState {
+    data object Idle : ReportSubmissionState
+    data object Submitting : ReportSubmissionState
+    data object Success : ReportSubmissionState
+    data object Unavailable : ReportSubmissionState
+}
+
+/**
+ * FE-171 — drives the "Statements & reports" request flow over [TradingDocsRepository]. Validation is
+ * done in the composable via the PURE [validateReportRequest]; this VM just performs the (already
+ * validated) request and maps repo success/failure to [ReportSubmissionState]. The repo degrades on 404
+ * to `false`, which we surface as [ReportSubmissionState.Unavailable] — never a crash.
+ */
+@HiltViewModel
+class ReportRequestViewModel @Inject constructor(
+    private val repository: TradingDocsRepository,
+) : ViewModel() {
+
+    private val _submission = MutableStateFlow<ReportSubmissionState>(ReportSubmissionState.Idle)
+    val submission: StateFlow<ReportSubmissionState> = _submission.asStateFlow()
+
+    /** Submit an already-validated report request; maps the degrade-on-404 repo result to the UI state. */
+    fun generate(type: String, periodStart: Long?, periodEnd: Long?, taxYear: Int?) {
+        _submission.update { ReportSubmissionState.Submitting }
+        viewModelScope.launch {
+            val ok = repository.requestTradingDocument(type, periodStart, periodEnd, taxYear)
+            _submission.update {
+                if (ok) ReportSubmissionState.Success else ReportSubmissionState.Unavailable
+            }
+        }
+    }
+
+    /** Reset back to idle (e.g. after navigating away to Trading Documents). */
+    fun reset() {
+        _submission.update { ReportSubmissionState.Idle }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/PortfolioNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/PortfolioNavigation.kt
@@ -19,6 +19,11 @@ fun NavGraphBuilder.portfolioDestination(navController: NavHostController) {
     composable(PortfolioDest.ROUTE) {
         PortfolioRoute(
             onBack = { navController.popBackStack() },
+            // FE-171 — after a report request, jump to the FE-170 Trading Documents route (existing
+            // destination in the files graph; NO new route literal, so MoreCatalog is unaffected).
+            onOpenTradingDocs = {
+                navController.navigate(TradingDocsDest.ROUTE) { launchSingleTop = true }
+            },
         )
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/tradingdocs/ReportRequestMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/tradingdocs/ReportRequestMathTest.kt
@@ -1,0 +1,129 @@
+package com.testlogon.android.feature.tradingdocs
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** FE-171 — pure JVM tests for the report-request catalog, validation, payload shaping and filenames. */
+class ReportRequestMathTest {
+
+    @Test
+    fun reportTypes_catalogCodesAndOrder() {
+        assertEquals(listOf("statement", "pnl", "fills", "1099"), REPORT_TYPES.map { it.code })
+    }
+
+    @Test
+    fun reportTypes_formatsAndParamNeeds() {
+        val fills = reportTypeOf("fills")!!
+        assertEquals(ReportFormat.CSV, fills.format)
+        assertTrue(fills.needsPeriod)
+        assertFalse(fills.needsTaxYear)
+
+        val form1099 = reportTypeOf("1099")!!
+        assertEquals(ReportFormat.PDF, form1099.format)
+        assertFalse(form1099.needsPeriod)
+        assertTrue(form1099.needsTaxYear)
+    }
+
+    @Test
+    fun reportTypeOf_isCaseInsensitive_andNullForUnknown() {
+        assertEquals("statement", reportTypeOf("STATEMENT")?.code)
+        assertNull(reportTypeOf("nope"))
+    }
+
+    @Test
+    fun validate_unknownType_singleError() {
+        assertEquals(listOf("Unknown report type."), validateReportRequest("bogus"))
+    }
+
+    @Test
+    fun validate_statement_needsPeriod() {
+        val errs = validateReportRequest("statement", periodStart = null, periodEnd = null)
+        assertEquals(1, errs.size)
+        assertTrue(errs.single().contains("start", ignoreCase = true))
+    }
+
+    @Test
+    fun validate_pnl_needsPeriod() {
+        assertFalse(validateReportRequest("pnl", periodStart = 100, periodEnd = 200).isNotEmpty())
+    }
+
+    @Test
+    fun validate_fills_startBeforeEnd() {
+        val errs = validateReportRequest("fills", periodStart = 500, periodEnd = 100)
+        assertEquals(1, errs.size)
+        assertTrue(errs.single().contains("before", ignoreCase = true))
+    }
+
+    @Test
+    fun validate_fills_equalDates_isError() {
+        assertTrue(validateReportRequest("fills", periodStart = 100, periodEnd = 100).isNotEmpty())
+    }
+
+    @Test
+    fun validate_period_ok_isEmpty() {
+        assertTrue(validateReportRequest("statement", periodStart = 100, periodEnd = 200).isEmpty())
+    }
+
+    @Test
+    fun validate_1099_needsTaxYear() {
+        val errs = validateReportRequest("1099", taxYear = null)
+        assertEquals(1, errs.size)
+        assertTrue(errs.single().contains("tax year", ignoreCase = true))
+    }
+
+    @Test
+    fun validate_1099_implausibleYear_isError() {
+        assertTrue(validateReportRequest("1099", taxYear = 1800).isNotEmpty())
+    }
+
+    @Test
+    fun validate_1099_ok_isEmpty() {
+        assertTrue(validateReportRequest("1099", taxYear = 2024).isEmpty())
+    }
+
+    @Test
+    fun payload_period_onlyIncludesPeriodParams() {
+        val p = requestPayload("statement", periodStart = 100, periodEnd = 200, taxYear = 2024)
+        assertEquals("statement", p["type"])
+        assertEquals(100L, p["period_start"])
+        assertEquals(200L, p["period_end"])
+        assertFalse(p.containsKey("tax_year"))
+    }
+
+    @Test
+    fun payload_1099_onlyIncludesTaxYear() {
+        val p = requestPayload("1099", periodStart = 100, periodEnd = 200, taxYear = 2024)
+        assertEquals("1099", p["type"])
+        assertEquals(2024, p["tax_year"])
+        assertFalse(p.containsKey("period_start"))
+        assertFalse(p.containsKey("period_end"))
+    }
+
+    @Test
+    fun payload_alwaysCarriesType() {
+        assertEquals("pnl", requestPayload("pnl").getValue("type"))
+    }
+
+    @Test
+    fun filename_period_pdf() {
+        assertEquals("statement_100_200.pdf", reportFilename("statement", periodStart = 100, periodEnd = 200))
+    }
+
+    @Test
+    fun filename_fills_csv() {
+        assertEquals("fills_100_200.csv", reportFilename("fills", periodStart = 100, periodEnd = 200))
+    }
+
+    @Test
+    fun filename_1099_year_pdf() {
+        assertEquals("1099_2024.pdf", reportFilename("1099", taxYear = 2024))
+    }
+
+    @Test
+    fun filename_unknownType_defaultsPdf() {
+        assertEquals("weird.pdf", reportFilename("weird"))
+    }
+}

--- a/frontend/src/api/endpoints/tradingDocuments.ts
+++ b/frontend/src/api/endpoints/tradingDocuments.ts
@@ -77,3 +77,42 @@ export async function getTradingDocumentDownloadUrl(docId: string): Promise<stri
 export function tradingDocumentDownloadPath(docId: string): string {
   return `/ui/trading-documents/${encodeURIComponent(docId)}/download`;
 }
+
+// ── request generation (BE-170) ──────────────────────────────────────
+
+/** Params accepted by the request endpoint (only what a given type needs). */
+export interface TradingDocumentRequest {
+  type: TradingDocType;
+  period_start?: string;
+  period_end?: string;
+  tax_year?: number;
+}
+
+export interface TradingDocumentRequestResult {
+  /** True when the backend accepted the request (queued/generated). */
+  accepted: boolean;
+  /** Present when the backend created/queued a document. */
+  doc_id?: string;
+  status?: TradingDocStatus;
+}
+
+/**
+ * Ask the backend to GENERATE a trading document (BE-170). Returns
+ * `{accepted:true, ...}` on success. DEGRADES-ON-404/501/offline to
+ * `{accepted:false}` so the caller can show an honest "not available yet"
+ * message instead of crashing. Other errors propagate.
+ */
+export async function requestTradingDocument(
+  req: TradingDocumentRequest,
+): Promise<TradingDocumentRequestResult> {
+  try {
+    const res = await api.post<Partial<TradingDocumentRequestResult>>(
+      "/ui/trading-documents/request",
+      req,
+    );
+    return { accepted: true, doc_id: res?.doc_id, status: res?.status };
+  } catch (err) {
+    if (isAbsent(err)) return { accepted: false };
+    throw err;
+  }
+}

--- a/frontend/src/lib/reportRequest.test.ts
+++ b/frontend/src/lib/reportRequest.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REPORT_TYPES,
+  REPORT_TYPE_META,
+  reportTypeLabel,
+  reportFormat,
+  isClientSideCsv,
+  validateReportRequest,
+  isValidReportRequest,
+  requestPayload,
+  reportFilename,
+  currentYear,
+  type ReportRequest,
+} from "./reportRequest";
+
+// A fixed "now" (2024-06-15) so tax-year bounds are deterministic.
+const NOW = Date.parse("2024-06-15T12:00:00Z");
+
+describe("catalog", () => {
+  it("exposes exactly the four report types", () => {
+    expect(REPORT_TYPES).toEqual(["statement", "pnl", "fills", "1099"]);
+  });
+  it("has meta (label/format/paramsNeeded) for every type", () => {
+    for (const t of REPORT_TYPES) {
+      const m = REPORT_TYPE_META[t];
+      expect(m.type).toBe(t);
+      expect(m.label.length).toBeGreaterThan(0);
+      expect(["pdf", "csv"]).toContain(m.format);
+      expect(Array.isArray(m.paramsNeeded)).toBe(true);
+    }
+  });
+  it("labels the types", () => {
+    expect(reportTypeLabel("statement")).toBe("Account statement");
+    expect(reportTypeLabel("1099")).toBe("Tax form (1099)");
+  });
+  it("maps formats: statement/1099 = pdf, fills/pnl = csv", () => {
+    expect(reportFormat("statement")).toBe("pdf");
+    expect(reportFormat("1099")).toBe("pdf");
+    expect(reportFormat("fills")).toBe("csv");
+    expect(reportFormat("pnl")).toBe("csv");
+  });
+  it("marks only fills & pnl as client-side CSV", () => {
+    expect(isClientSideCsv("fills")).toBe(true);
+    expect(isClientSideCsv("pnl")).toBe(true);
+    expect(isClientSideCsv("statement")).toBe(false);
+    expect(isClientSideCsv("1099")).toBe(false);
+  });
+});
+
+describe("validateReportRequest — period types", () => {
+  it("statement needs both dates", () => {
+    const errs = validateReportRequest({ type: "statement" }, NOW);
+    expect(errs.length).toBe(2);
+  });
+  it("fills accepts a valid period", () => {
+    const req: ReportRequest = { type: "fills", periodStart: "2024-01-01", periodEnd: "2024-03-31" };
+    expect(validateReportRequest(req, NOW)).toEqual([]);
+    expect(isValidReportRequest(req, NOW)).toBe(true);
+  });
+  it("pnl rejects start > end", () => {
+    const errs = validateReportRequest(
+      { type: "pnl", periodStart: "2024-04-01", periodEnd: "2024-01-01" },
+      NOW,
+    );
+    expect(errs.some((e) => /on or before/.test(e))).toBe(true);
+  });
+  it("rejects malformed dates", () => {
+    const errs = validateReportRequest(
+      { type: "fills", periodStart: "not-a-date", periodEnd: "2024-01-01" },
+      NOW,
+    );
+    expect(errs.some((e) => /start date/i.test(e))).toBe(true);
+  });
+});
+
+describe("validateReportRequest — 1099", () => {
+  it("needs a tax year", () => {
+    expect(validateReportRequest({ type: "1099" }, NOW).length).toBe(1);
+  });
+  it("accepts a plausible year", () => {
+    expect(validateReportRequest({ type: "1099", taxYear: 2023 }, NOW)).toEqual([]);
+  });
+  it("rejects a future year", () => {
+    expect(validateReportRequest({ type: "1099", taxYear: 2030 }, NOW).length).toBe(1);
+  });
+  it("rejects a non-integer year", () => {
+    expect(validateReportRequest({ type: "1099", taxYear: 2023.5 }, NOW).length).toBe(1);
+  });
+  it("does not require a period for 1099", () => {
+    expect(isValidReportRequest({ type: "1099", taxYear: 2022 }, NOW)).toBe(true);
+  });
+});
+
+describe("requestPayload", () => {
+  it("statement sends only the period", () => {
+    const p = requestPayload({ type: "statement", periodStart: "2024-01-01", periodEnd: "2024-02-01", taxYear: 2024 });
+    expect(p).toEqual({ type: "statement", period_start: "2024-01-01", period_end: "2024-02-01" });
+    expect(p).not.toHaveProperty("tax_year");
+  });
+  it("1099 sends only the tax_year (never a period)", () => {
+    const p = requestPayload({ type: "1099", taxYear: 2023, periodStart: "2024-01-01" });
+    expect(p).toEqual({ type: "1099", tax_year: 2023 });
+    expect(p).not.toHaveProperty("period_start");
+  });
+});
+
+describe("reportFilename", () => {
+  it("1099 uses the tax year + pdf ext", () => {
+    expect(reportFilename({ type: "1099", taxYear: 2023 })).toBe("testlogon-1099-2023.pdf");
+  });
+  it("period csv reports use start_end + csv ext", () => {
+    expect(reportFilename({ type: "fills", periodStart: "2024-01-01", periodEnd: "2024-03-31" })).toBe(
+      "testlogon-fills-2024-01-01_2024-03-31.csv",
+    );
+  });
+  it("statement is a pdf", () => {
+    expect(reportFilename({ type: "statement", periodStart: "2024-01-01", periodEnd: "2024-03-31" })).toBe(
+      "testlogon-statement-2024-01-01_2024-03-31.pdf",
+    );
+  });
+});
+
+describe("currentYear", () => {
+  it("returns the UTC year of the given instant", () => {
+    expect(currentYear(NOW)).toBe(2024);
+  });
+});

--- a/frontend/src/lib/reportRequest.ts
+++ b/frontend/src/lib/reportRequest.ts
@@ -1,0 +1,191 @@
+// FE-171 (EPIC H) — pure, DOM-free helpers for the "Statements & reports"
+// request/download flow on the trading/reporting screen. Given a chosen report
+// type + params it VALIDATES the request, decides whether it is served as an
+// immediate CLIENT-SIDE CSV (fills / pnl, built from live fills) or a
+// backend-generated PDF (statement / 1099, requested via BE-170 then downloaded
+// from Trading Documents / BE-172), and produces the request payload + a safe
+// download filename. No I/O, no React — trivially unit-testable
+// (see reportRequest.test.ts).
+import type { TradingDocType, TradingDocFormat } from "@/api/endpoints/tradingDocuments";
+
+// ── catalog ──────────────────────────────────────────────────────────
+
+/** The report types offered by the request UI (subset of TradingDocType). */
+export type ReportType = "statement" | "pnl" | "fills" | "1099";
+
+export const REPORT_TYPES: ReportType[] = ["statement", "pnl", "fills", "1099"];
+
+/** What params a report type needs before it can be requested. */
+export type ParamNeed = "period" | "taxYear";
+
+export interface ReportTypeMeta {
+  type: ReportType;
+  label: string;
+  /** Rendered file format. */
+  format: TradingDocFormat;
+  /** Which params must be supplied (empty = none). */
+  paramsNeeded: ParamNeed[];
+  /** One-line helper describing the report. */
+  description: string;
+}
+
+export const REPORT_TYPE_META: Record<ReportType, ReportTypeMeta> = {
+  statement: {
+    type: "statement",
+    label: "Account statement",
+    format: "pdf",
+    paramsNeeded: ["period"],
+    description: "A point-in-time balance & position statement for a chosen period (PDF).",
+  },
+  pnl: {
+    type: "pnl",
+    label: "P&L report",
+    format: "csv",
+    paramsNeeded: ["period"],
+    description: "Per-symbol realized P&L over a period, built from your fills (CSV).",
+  },
+  fills: {
+    type: "fills",
+    label: "Fills / trade history",
+    format: "csv",
+    paramsNeeded: ["period"],
+    description: "Every executed fill over a period, built from your fills (CSV).",
+  },
+  "1099": {
+    type: "1099",
+    label: "Tax form (1099)",
+    format: "pdf",
+    paramsNeeded: ["taxYear"],
+    description: "Consolidated 1099 for a tax year (PDF).",
+  },
+};
+
+/** Human label for a report type (falls back to the raw type). */
+export function reportTypeLabel(type: ReportType): string {
+  return REPORT_TYPE_META[type]?.label ?? String(type);
+}
+
+/** The rendered format (pdf|csv) for a report type. */
+export function reportFormat(type: ReportType): TradingDocFormat {
+  return REPORT_TYPE_META[type]?.format ?? "pdf";
+}
+
+/**
+ * True for report types built + downloaded ENTIRELY client-side from live fills
+ * (a guaranteed real download, no backend). PDF types (statement / 1099) are
+ * server-generated and go through the BE-170 request → Trading Documents path.
+ */
+export function isClientSideCsv(type: ReportType): boolean {
+  return type === "fills" || type === "pnl";
+}
+
+// ── request shape ────────────────────────────────────────────────────
+
+export interface ReportRequest {
+  type: ReportType;
+  /** ISO date (YYYY-MM-DD) — required for period reports. */
+  periodStart?: string;
+  /** ISO date (YYYY-MM-DD) — required for period reports. */
+  periodEnd?: string;
+  /** Four-digit tax year — required for 1099. */
+  taxYear?: number;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse an ISO YYYY-MM-DD to epoch ms (UTC midnight), or null if malformed. */
+function isoToMs(s: string | undefined): number | null {
+  if (!s || !ISO_DATE.test(s)) return null;
+  const ms = Date.parse(s + "T00:00:00Z");
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** Current year (kept as a param for deterministic tests). */
+export function currentYear(now = Date.now()): number {
+  return new Date(now).getUTCFullYear();
+}
+
+/**
+ * Validate a report request, returning a list of human-readable error strings
+ * (empty = valid). Rules:
+ *  - period reports (statement / fills / pnl) need BOTH a start and end date,
+ *    with start <= end;
+ *  - 1099 needs a plausible four-digit tax year (2000..currentYear).
+ */
+export function validateReportRequest(req: ReportRequest, now = Date.now()): string[] {
+  const errors: string[] = [];
+  const meta = REPORT_TYPE_META[req.type];
+  if (!meta) {
+    errors.push(`Unknown report type "${String(req.type)}".`);
+    return errors;
+  }
+
+  if (meta.paramsNeeded.includes("period")) {
+    const start = isoToMs(req.periodStart);
+    const end = isoToMs(req.periodEnd);
+    if (start == null) errors.push("A valid start date is required.");
+    if (end == null) errors.push("A valid end date is required.");
+    if (start != null && end != null && start > end) {
+      errors.push("The start date must be on or before the end date.");
+    }
+  }
+
+  if (meta.paramsNeeded.includes("taxYear")) {
+    const y = req.taxYear;
+    const max = currentYear(now);
+    if (y == null || !Number.isInteger(y) || y < 2000 || y > max) {
+      errors.push(`A tax year between 2000 and ${max} is required.`);
+    }
+  }
+
+  return errors;
+}
+
+/** True when a request passes validation. */
+export function isValidReportRequest(req: ReportRequest, now = Date.now()): boolean {
+  return validateReportRequest(req, now).length === 0;
+}
+
+// ── request payload (BE-170 POST /ui/trading-documents/request) ──────
+
+export interface ReportRequestPayload {
+  type: TradingDocType;
+  period_start?: string;
+  period_end?: string;
+  tax_year?: number;
+}
+
+/**
+ * Build the POST body for BE-170. Only the params the type needs are included
+ * (so a 1099 never sends a period, and a statement never sends a tax_year).
+ */
+export function requestPayload(req: ReportRequest): ReportRequestPayload {
+  const meta = REPORT_TYPE_META[req.type];
+  const payload: ReportRequestPayload = { type: req.type };
+  if (meta?.paramsNeeded.includes("period")) {
+    if (req.periodStart) payload.period_start = req.periodStart;
+    if (req.periodEnd) payload.period_end = req.periodEnd;
+  }
+  if (meta?.paramsNeeded.includes("taxYear") && req.taxYear != null) {
+    payload.tax_year = req.taxYear;
+  }
+  return payload;
+}
+
+// ── filenames ────────────────────────────────────────────────────────
+
+/** Filename-safe download name for a report request (correct extension). */
+export function reportFilename(req: ReportRequest): string {
+  const ext = reportFormat(req.type) === "csv" ? "csv" : "pdf";
+  let scope = "";
+  if (req.type === "1099") {
+    scope = req.taxYear != null ? String(req.taxYear) : "unknown-year";
+  } else if (req.periodStart && req.periodEnd) {
+    scope = `${req.periodStart}_${req.periodEnd}`;
+  } else if (req.periodStart) {
+    scope = req.periodStart;
+  } else {
+    scope = "all";
+  }
+  return `testlogon-${req.type}-${scope}.${ext}`;
+}

--- a/frontend/src/pages/reports/ReportsPage.tsx
+++ b/frontend/src/pages/reports/ReportsPage.tsx
@@ -65,6 +65,7 @@ import {
   type PeriodPreset,
   type PeriodRange,
 } from "@/lib/reportPeriod";
+import StatementsReportsCard from "./StatementsReportsCard";
 
 // --- helpers ----------------------------------------------------
 
@@ -365,6 +366,16 @@ export default function ReportsPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Statements & reports (FE-171) — request PDF docs + download CSVs */}
+      <div className="print:hidden">
+        <StatementsReportsCard
+          fills={allFills}
+          resolve={resolve}
+          quoteScaler={quoteScaler}
+          fillsUnavailable={fillsUnavailable}
+        />
+      </div>
 
       {/* Print-only report heading */}
       <div className="hidden print:block">

--- a/frontend/src/pages/reports/StatementsReportsCard.tsx
+++ b/frontend/src/pages/reports/StatementsReportsCard.tsx
@@ -1,0 +1,316 @@
+// FE-171 (EPIC H) — "Statements & reports" request/download section for the
+// Export & reporting screen. Pick a report type + the params it needs, then
+// Generate/Download:
+//   - fills / pnl (CSV): built ENTIRELY client-side from the live fills the
+//     parent already loaded (a guaranteed real download) via exportReport.ts.
+//   - statement / 1099 (PDF): requested from the backend (BE-170); on success we
+//     point the user at Trading Documents; on 404 we degrade to an honest
+//     "not available yet" message. No crash either way.
+// All validation is done by the pure reportRequest.ts lib before submit.
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { FileText, Download, Loader2, Info } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { requestTradingDocument } from "@/api/endpoints/tradingDocuments";
+import {
+  buildTradeHistoryCsv,
+  buildPnlSummaryCsv,
+  downloadCsv,
+  type ReportFill,
+  type SymbolResolver,
+} from "@/lib/exportReport";
+import type { PnlSummary } from "@/lib/pnl";
+import {
+  REPORT_TYPES,
+  REPORT_TYPE_META,
+  isClientSideCsv,
+  validateReportRequest,
+  requestPayload,
+  reportFilename,
+  reportTypeLabel,
+  currentYear,
+  type ReportType,
+  type ReportRequest,
+} from "@/lib/reportRequest";
+
+export interface StatementsReportsCardProps {
+  /** ALL fills (unscoped) — the section filters them to the chosen period. */
+  fills: ReportFill[];
+  /** symbolid -> {name, scaler}. */
+  resolve: SymbolResolver;
+  /** Quote-asset scaler for the aggregate P&L TOTAL row. */
+  quoteScaler: number;
+  /** True when the fills feed is unavailable (CSV reports cannot be built). */
+  fillsUnavailable?: boolean;
+}
+
+const MS_THRESHOLD = 1e12;
+const toMs = (ts: number): number => (ts < MS_THRESHOLD ? ts * 1000 : ts);
+
+/** Inclusive [start,end] filter over fills by ISO date (end = end-of-day). */
+function scopeFills(fills: ReportFill[], startIso: string, endIso: string): ReportFill[] {
+  const start = Date.parse(startIso + "T00:00:00Z");
+  const end = Date.parse(endIso + "T23:59:59Z");
+  if (Number.isNaN(start) || Number.isNaN(end)) return fills;
+  return fills.filter((f) => {
+    const ms = toMs(f.ts);
+    return ms >= start && ms <= end;
+  });
+}
+
+// Default period: start of this year -> today.
+function defaultStart(): string {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-01-01`;
+}
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default function StatementsReportsCard({
+  fills,
+  resolve,
+  quoteScaler,
+  fillsUnavailable,
+}: StatementsReportsCardProps) {
+  const [type, setType] = useState<ReportType>("statement");
+  const [periodStart, setPeriodStart] = useState<string>(defaultStart());
+  const [periodEnd, setPeriodEnd] = useState<string>(today());
+  const [taxYear, setTaxYear] = useState<number>(currentYear() - 1);
+  const [submitting, setSubmitting] = useState(false);
+  const [unavailableMsg, setUnavailableMsg] = useState<string | null>(null);
+
+  const meta = REPORT_TYPE_META[type];
+  const needsPeriod = meta.paramsNeeded.includes("period");
+  const needsTaxYear = meta.paramsNeeded.includes("taxYear");
+  const clientSide = isClientSideCsv(type);
+
+  const req: ReportRequest = useMemo(
+    () => ({
+      type,
+      periodStart: needsPeriod ? periodStart : undefined,
+      periodEnd: needsPeriod ? periodEnd : undefined,
+      taxYear: needsTaxYear ? taxYear : undefined,
+    }),
+    [type, needsPeriod, periodStart, periodEnd, needsTaxYear, taxYear],
+  );
+
+  const errors = useMemo(() => validateReportRequest(req), [req]);
+  const valid = errors.length === 0;
+
+  // Tax-year options: last 6 years up to current.
+  const taxYears = useMemo(() => {
+    const cur = currentYear();
+    return Array.from({ length: 6 }, (_, i) => cur - i);
+  }, []);
+
+  const clientSideUnavailable = clientSide && fillsUnavailable;
+
+  async function onGenerate() {
+    setUnavailableMsg(null);
+    if (!valid) {
+      toast.error(errors[0]);
+      return;
+    }
+
+    // fills / pnl -> build the CSV client-side from the scoped live fills.
+    if (clientSide) {
+      if (fillsUnavailable) {
+        toast.error("Trade history is not available on this backend yet.");
+        return;
+      }
+      const scoped = scopeFills(fills, periodStart, periodEnd);
+      if (scoped.length === 0) {
+        toast.error("No trades in the selected period. Pick a wider range.");
+        return;
+      }
+      const filename = reportFilename(req);
+      if (type === "fills") {
+        downloadCsv(filename, buildTradeHistoryCsv(scoped, resolve));
+      } else {
+        // pnl - compute a summary over the scoped fills only.
+        const { computePnl } = await import("@/lib/pnl");
+        const summary: PnlSummary = computePnl(
+          scoped.map((f) => ({
+            symbolid: f.symbolid,
+            price: f.price,
+            qty: f.qty,
+            side: f.side === "sell" ? "sell" : "buy",
+            fee: f.fee,
+            ts: f.ts,
+          })),
+          [],
+          [],
+        );
+        downloadCsv(filename, buildPnlSummaryCsv(summary.perSymbol, summary, resolve, quoteScaler));
+      }
+      toast.success(`Downloaded ${filename}`);
+      return;
+    }
+
+    // statement / 1099 (PDF) -> request backend generation (BE-170).
+    setSubmitting(true);
+    try {
+      const result = await requestTradingDocument(requestPayload(req));
+      if (result.accepted) {
+        toast.success(
+          `${reportTypeLabel(type)} is generating — it will appear in Trading Documents when ready.`,
+        );
+      } else {
+        setUnavailableMsg(
+          `${reportTypeLabel(type)} generation is not available on this backend yet. It will appear in Trading Documents once the reporting service is deployed.`,
+        );
+      }
+    } catch {
+      toast.error(`Could not request your ${reportTypeLabel(type).toLowerCase()}. Please try again.`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <FileText className="h-4 w-4 text-muted-foreground" />
+          Statements &amp; reports
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-xs text-muted-foreground">{meta.description}</p>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {/* type */}
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs" htmlFor="report-type">
+              Report
+            </Label>
+            <Select value={type} onValueChange={(v) => setType(v as ReportType)}>
+              <SelectTrigger id="report-type" className="h-9" aria-label="Report type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REPORT_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {reportTypeLabel(t)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* period */}
+          {needsPeriod && (
+            <>
+              <div className="flex flex-col gap-1.5">
+                <Label className="text-xs" htmlFor="report-from">
+                  From
+                </Label>
+                <Input
+                  id="report-from"
+                  type="date"
+                  value={periodStart}
+                  max={periodEnd || undefined}
+                  onChange={(e) => setPeriodStart(e.target.value)}
+                  className="h-9"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label className="text-xs" htmlFor="report-to">
+                  To
+                </Label>
+                <Input
+                  id="report-to"
+                  type="date"
+                  value={periodEnd}
+                  min={periodStart || undefined}
+                  onChange={(e) => setPeriodEnd(e.target.value)}
+                  className="h-9"
+                />
+              </div>
+            </>
+          )}
+
+          {/* tax year */}
+          {needsTaxYear && (
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs" htmlFor="report-year">
+                Tax year
+              </Label>
+              <Select value={String(taxYear)} onValueChange={(v) => setTaxYear(Number(v))}>
+                <SelectTrigger id="report-year" className="h-9" aria-label="Tax year">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {taxYears.map((y) => (
+                    <SelectItem key={y} value={String(y)}>
+                      {y}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* action */}
+          <div className="flex items-end">
+            <Button
+              type="button"
+              className="h-9 w-full gap-1.5"
+              onClick={onGenerate}
+              disabled={submitting || !valid || clientSideUnavailable}
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4" />
+              )}
+              {clientSide ? "Download CSV" : "Generate"}
+            </Button>
+          </div>
+        </div>
+
+        {!valid && <p className="text-xs text-destructive">{errors[0]}</p>}
+
+        {clientSideUnavailable && (
+          <Alert>
+            <Info className="h-4 w-4" />
+            <AlertDescription className="text-xs">
+              Trade history is not available on this backend yet, so this CSV cannot be built.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {unavailableMsg && (
+          <Alert>
+            <Info className="h-4 w-4" />
+            <AlertDescription className="text-xs">{unavailableMsg}</AlertDescription>
+          </Alert>
+        )}
+
+        <p className="text-[11px] text-muted-foreground">
+          CSV reports (fills &amp; P&amp;L) download immediately. PDF documents (statements &amp;
+          1099) are generated in the background and appear in{" "}
+          <Link to="/files/trading-documents" className="underline">
+            Trading Documents
+          </Link>
+          .
+        </p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## FE-171 — request/download statements + exports + 1099 (completes EPIC H)

From the account/trading screen: **request** an account statement / P&L report / fills CSV / 1099 and **download** the rendered file. Builds on FE-170's trading-documents API (adds BE-170 request/generate). Degrade-on-404 → clear "will appear in Trading Documents when ready" / honest error, no crash.

### Web
- NEW pure `lib/reportRequest.ts` (+20 vitest) — `REPORT_TYPES` + meta, `validateReportRequest` (period types need start≤end; 1099 needs a valid tax year), `requestPayload`, `reportFilename`, `isClientSideCsv`.
- NEW `StatementsReportsCard` on the Reports page — **fills/pnl build a REAL CSV client-side** via `exportReport.ts` from live `/me/fills/fees` (immediate download); statement/1099 (PDF) call `requestTradingDocument` → toast + link to `files/trading-documents` (404 → inline "not available yet"). `requestTradingDocument` added to `tradingDocuments.ts`.

### Android
- NEW pure `ReportRequestMath.kt` (+19 JVM tests) + `ReportRequestViewModel` + `ReportRequestSection` (report-type dropdown, Material3 date range for period types, tax-year dropdown for 1099, Generate → success/unavailable) on the Portfolio screen.
- `TradingDocsApi`/`Repository` extended with `requestTradingDocument` (BE-170, `callOr` degrade-on-404); request→generate routes to FE-170's Trading Documents screen for the Custom Tabs download. No new route literal (reuses `TradingDocsDest.ROUTE`); MoreCatalogTest green.

### Gates
- Web: tsc 0 · build green · 20/20 vitest
- Android: BUILD SUCCESSFUL · ReportRequestMathTest 19/19 · MoreCatalogTest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
