### PR TITLE
FE-141: media from CDN + upload progress + retry (web + Android)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,6 +39,12 @@ android {
         // client hashes stop matching server hashes. Non-secret (see that module's docstring).
         buildConfigField("String", "CONTACT_MATCH_SALT", "\"tl_contact_match_v1\"")
         buildConfigField("boolean", "WEBRTC_FORCE_RELAY", "false")
+        // FE-141 (EPIC E) - optional media CDN origin. EMPTY by default so media urls fall
+        // back to the existing dev/mock server-relative path (RelativeUrlMapper resolves it
+        // against API_BASE_URL). Set to an absolute https origin to derive prod CDN object
+        // urls for DTOs that omit an absolute url. Prod DTOs already carry an absolute url,
+        // which resolveMediaUrl always prefers; this is a hardening fallback.
+        buildConfigField("String", "MEDIA_CDN_BASE", "\"\"")
     }
 
     buildTypes {

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/MessagingDomain.kt
@@ -1,5 +1,6 @@
 package com.testlogon.android.data.messaging
 import com.testlogon.android.data.poll.toDomain
+import com.testlogon.android.feature.messaging.media.MediaCdnMath
 
 /**
  * AND-120..AND-124 — domain models for the messaging feature (no Moshi/Room leakage past the
@@ -898,15 +899,21 @@ internal fun MessageDto.toMedia(): MessageMedia = when {
             val isVideo = gi.mediaKind?.equals("video", ignoreCase = true)
                 ?: gi.contentType?.startsWith("video/") == true
             MessageMedia.GalleryImage(
-                url = gi.url?.takeIf { it.isNotBlank() } ?: deriveS3Url(gi.bucket, gi.key),
+                url = MediaCdnMath.resolveMediaUrl(gi.url, gi.bucket, gi.key, mediaCdnBase()),
                 isVideo = isVideo,
                 posterUrl = deriveS3Url(gi.previewBucket, gi.previewKey),
             )
         },
     )
     image != null -> MessageMedia.Image(
-        url = image.url?.takeIf { it.isNotBlank() }
-            ?: deriveS3Url(image.bucket, image.key),
+        // FE-141 — prefer the API-provided absolute CDN url; else derive from a configured CDN
+        // base, else the mock-relative gateway path (dev/mock unchanged).
+        url = MediaCdnMath.resolveMediaUrl(
+            url = image.url,
+            bucket = image.bucket,
+            key = image.key,
+            cdnBase = mediaCdnBase(),
+        ),
         width = image.width,
         height = image.height,
     )
@@ -1065,13 +1072,15 @@ internal fun MessageFileDto.toFileMedia(policy: String, isShare: Boolean): Messa
  */
 internal fun deriveS3Url(bucket: String?, key: String?): String? {
     if (bucket.isNullOrBlank() || key.isNullOrBlank()) return null
-    // The backend serves uploaded objects through its storage gateway at /mock/s3/<bucket>/<key> --
-    // the same server-relative path the list/get endpoints return as image.url and that presign hands
-    // out for upload. The image-CREATE response omits url, so the sender's just-sent bubble must
-    // derive it here; Coil's RelativeUrlMapper resolves the leading-"/" path against the API origin.
-    // (Without this the sender saw a broken/blank thumbnail until a thread refresh re-fetched url.)
-    return "/mock/s3/$bucket/$key"
+    // FE-141 — the image-CREATE response omits url, so the sender's just-sent bubble derives one
+    // here. resolveMediaUrl builds a CDN object url when MEDIA_CDN_BASE is configured, else the
+    // server-relative /mock/s3/<bucket>/<key> path (Coil's RelativeUrlMapper resolves the leading
+    // "/" against the API origin). Dev/mock behavior is unchanged when MEDIA_CDN_BASE is empty.
+    return MediaCdnMath.resolveMediaUrl(url = null, bucket = bucket, key = key, cdnBase = mediaCdnBase())
 }
+
+/** FE-141 — configured media CDN origin (empty in dev/mock -> resolver uses the mock-relative path). */
+private fun mediaCdnBase(): String = com.testlogon.android.BuildConfig.MEDIA_CDN_BASE
 
 /**
  * #13 — resolve a lottery outcome's media_asset_id to a server-relative object url. The backend

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/media/MediaCdnMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/media/MediaCdnMath.kt
@@ -1,0 +1,106 @@
+package com.testlogon.android.feature.messaging.media
+
+import java.net.URLEncoder
+
+/**
+ * FE-141 (EPIC E, <- BE-141) — pure, JVM-testable media-CDN + upload-retry decisions. No Android
+ * types here so every rule is unit-tested; the runtime render/upload code calls into this.
+ *
+ * The backend serves uploaded objects one of two ways depending on the environment:
+ *  - dev/mock: the list/get endpoints return a server-RELATIVE object url (e.g. "/mock/s3/<bucket>/<key>")
+ *    which Coil's RelativeUrlMapper resolves against the API origin.
+ *  - prod: the endpoints return an ABSOLUTE CDN url in the DTO's `url` field.
+ *
+ * [resolveMediaUrl] therefore ALWAYS prefers the API-provided absolute `url`; only when it is blank
+ * does it derive one — from a configured CDN base if available, else the mock-relative path so
+ * dev/mock behavior is unchanged.
+ */
+object MediaCdnMath {
+
+    /** Manual retry ceiling for a failed media upload (see [isRetryableUploadStatus]). */
+    const val MAX_UPLOAD_RETRIES: Int = 5
+
+    private const val BACKOFF_BASE_MS: Long = 1_000L
+    private const val BACKOFF_CAP_MS: Long = 30_000L
+
+    /**
+     * Resolves the display/playback url for a media message, mirroring the web client's precedence:
+     *  1. a non-blank absolute API [url] wins (prod CDN url, or a signed url);
+     *  2. else, if [cdnBase] is a non-blank absolute origin AND we have [bucket]+[key], build
+     *     "<cdnBase>/<bucket>/<encoded key>";
+     *  3. else fall back to the mock-relative "/mock/s3/<bucket>/<key>" path (bucket-less: "/mock/s3/<key>")
+     *     which RelativeUrlMapper absolutizes against the API origin (dev/mock unchanged);
+     *  4. null when nothing is derivable.
+     *
+     * A blank [url] is treated as absent so a prod-blank never shadows the fallback.
+     */
+    fun resolveMediaUrl(
+        url: String?,
+        bucket: String?,
+        key: String?,
+        cdnBase: String?,
+    ): String? {
+        val absolute = url?.trim().orEmpty()
+        if (absolute.isNotEmpty()) return absolute
+
+        val k = key?.trim().orEmpty()
+        if (k.isEmpty()) return null
+        val b = bucket?.trim().orEmpty()
+
+        val base = cdnBase?.trim().orEmpty()
+        if (base.isNotEmpty() && isAbsoluteUrl(base) && b.isNotEmpty()) {
+            return base.trimEnd('/') + "/" + b + "/" + encodeMediaKey(k)
+        }
+
+        // Mock-relative fallback (dev/mock). The path segments are already gateway-safe.
+        return if (b.isEmpty()) "/mock/s3/$k" else "/mock/s3/$b/$k"
+    }
+
+    /**
+     * Percent-encodes an object key per path segment, keeping the slashes (mirrors the web
+     * buildS3ObjectUrl / the upload-side s3ObjectUrl). Spaces become "%20" (not "+").
+     */
+    fun encodeMediaKey(key: String): String =
+        key.split("/").joinToString("/") { segment ->
+            URLEncoder.encode(segment, Charsets.UTF_8.name()).replace("+", "%20")
+        }
+
+    /**
+     * Whether a failed storage PUT / presign / confirm with HTTP [code] is worth retrying:
+     * transport failure (0 == no response), 408 request timeout, 429 too-many-requests, or any 5xx.
+     * 4xx (except 408/429) are permanent (bad request / auth / expired-presign) and NOT retried here.
+     */
+    fun isRetryableUploadStatus(code: Int): Boolean = when {
+        code == 0 -> true
+        code == 408 -> true
+        code == 429 -> true
+        code in 500..599 -> true
+        else -> false
+    }
+
+    /**
+     * Exponential backoff (base 1s, capped 30s) for retry [attempt] (1-based). attempt<=0 -> 0.
+     * attempt 1 -> 1s, 2 -> 2s, 3 -> 4s, 4 -> 8s, 5 -> 16s, then capped at 30s.
+     */
+    fun uploadBackoffMs(attempt: Int): Long {
+        if (attempt <= 0) return 0L
+        // Guard the shift so a large attempt never overflows before the cap clamps it.
+        val shift = (attempt - 1).coerceAtMost(20)
+        val raw = BACKOFF_BASE_MS shl shift
+        return raw.coerceIn(0L, BACKOFF_CAP_MS)
+    }
+
+    /**
+     * Upload progress as an integer percentage 0..100. total<=0 -> 0 (unknown size). Clamped so a
+     * loaded>total race never reports >100.
+     */
+    fun uploadProgressPct(loaded: Long, total: Long): Int {
+        if (total <= 0L) return 0
+        val pct = (loaded.toDouble() / total.toDouble() * 100.0).toInt()
+        return pct.coerceIn(0, 100)
+    }
+
+    /** True when [s] is an absolute http(s) origin usable as a CDN base (not a relative path). */
+    private fun isAbsoluteUrl(s: String): Boolean =
+        s.startsWith("http://", ignoreCase = true) || s.startsWith("https://", ignoreCase = true)
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/media/MediaCdnMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/media/MediaCdnMathTest.kt
@@ -1,0 +1,143 @@
+package com.testlogon.android.feature.messaging.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** FE-141 — pure JVM tests for media-CDN url resolution + upload retry/progress math. */
+class MediaCdnMathTest {
+
+    // ---- resolveMediaUrl ----
+
+    @Test
+    fun resolve_prefersAbsoluteApiUrl() {
+        val out = MediaCdnMath.resolveMediaUrl(
+            url = "https://cdn.example.com/a/b.jpg",
+            bucket = "media",
+            key = "conv/1/x.jpg",
+            cdnBase = "https://other.cdn",
+        )
+        assertEquals("https://cdn.example.com/a/b.jpg", out)
+    }
+
+    @Test
+    fun resolve_trimsAndPrefersUrl() {
+        val out = MediaCdnMath.resolveMediaUrl("  https://x/y.jpg  ", "m", "k", null)
+        assertEquals("https://x/y.jpg", out)
+    }
+
+    @Test
+    fun resolve_blankUrl_usesCdnBaseWhenAbsolute() {
+        val out = MediaCdnMath.resolveMediaUrl(
+            url = "   ",
+            bucket = "media-bucket",
+            key = "conv/1/photo name.jpg",
+            cdnBase = "https://cdn.bitbazaar.cc/",
+        )
+        assertEquals("https://cdn.bitbazaar.cc/media-bucket/conv/1/photo%20name.jpg", out)
+    }
+
+    @Test
+    fun resolve_nullUrl_usesCdnBaseNoTrailingSlash() {
+        val out = MediaCdnMath.resolveMediaUrl(null, "b", "k1/k2.png", "https://cdn.io")
+        assertEquals("https://cdn.io/b/k1/k2.png", out)
+    }
+
+    @Test
+    fun resolve_noCdnBase_fallsBackToMockRelative() {
+        val out = MediaCdnMath.resolveMediaUrl(null, "media", "conv/1/x.jpg", null)
+        assertEquals("/mock/s3/media/conv/1/x.jpg", out)
+    }
+
+    @Test
+    fun resolve_relativeCdnBase_fallsBackToMockRelative() {
+        // A non-absolute cdnBase is not usable as an origin -> mock fallback (dev/mock unchanged).
+        val out = MediaCdnMath.resolveMediaUrl(null, "media", "k.jpg", "/mock/s3")
+        assertEquals("/mock/s3/media/k.jpg", out)
+    }
+
+    @Test
+    fun resolve_bucketless_mockRelative() {
+        val out = MediaCdnMath.resolveMediaUrl(null, null, "bare-key.jpg", null)
+        assertEquals("/mock/s3/bare-key.jpg", out)
+    }
+
+    @Test
+    fun resolve_cdnBaseButNoBucket_fallsBackToMockRelative() {
+        // Without a bucket we cannot build a CDN object url -> mock fallback.
+        val out = MediaCdnMath.resolveMediaUrl(null, "", "k.jpg", "https://cdn.io")
+        assertEquals("/mock/s3/k.jpg", out)
+    }
+
+    @Test
+    fun resolve_noUrlNoKey_null() {
+        assertNull(MediaCdnMath.resolveMediaUrl(null, "bucket", null, "https://cdn.io"))
+        assertNull(MediaCdnMath.resolveMediaUrl("", "bucket", "  ", null))
+    }
+
+    // ---- encodeMediaKey ----
+
+    @Test
+    fun encode_keepsSlashes_encodesSpecials() {
+        assertEquals("a/b%20c/d%2Be.jpg", MediaCdnMath.encodeMediaKey("a/b c/d+e.jpg"))
+    }
+
+    @Test
+    fun encode_plainKeyUnchanged() {
+        assertEquals("conv/1/photo.jpg", MediaCdnMath.encodeMediaKey("conv/1/photo.jpg"))
+    }
+
+    // ---- isRetryableUploadStatus ----
+
+    @Test
+    fun retryable_transportAndThrottleAnd5xx() {
+        assertTrue(MediaCdnMath.isRetryableUploadStatus(0))
+        assertTrue(MediaCdnMath.isRetryableUploadStatus(408))
+        assertTrue(MediaCdnMath.isRetryableUploadStatus(429))
+        assertTrue(MediaCdnMath.isRetryableUploadStatus(500))
+        assertTrue(MediaCdnMath.isRetryableUploadStatus(503))
+    }
+
+    @Test
+    fun notRetryable_permanent4xx() {
+        assertFalse(MediaCdnMath.isRetryableUploadStatus(400))
+        assertFalse(MediaCdnMath.isRetryableUploadStatus(403)) // expired presign -> restart, not auto-retry
+        assertFalse(MediaCdnMath.isRetryableUploadStatus(404))
+        assertFalse(MediaCdnMath.isRetryableUploadStatus(422))
+        assertFalse(MediaCdnMath.isRetryableUploadStatus(200))
+    }
+
+    // ---- uploadBackoffMs ----
+
+    @Test
+    fun backoff_exponentialThenCapped() {
+        assertEquals(0L, MediaCdnMath.uploadBackoffMs(0))
+        assertEquals(0L, MediaCdnMath.uploadBackoffMs(-3))
+        assertEquals(1_000L, MediaCdnMath.uploadBackoffMs(1))
+        assertEquals(2_000L, MediaCdnMath.uploadBackoffMs(2))
+        assertEquals(4_000L, MediaCdnMath.uploadBackoffMs(3))
+        assertEquals(8_000L, MediaCdnMath.uploadBackoffMs(4))
+        assertEquals(16_000L, MediaCdnMath.uploadBackoffMs(5))
+        assertEquals(30_000L, MediaCdnMath.uploadBackoffMs(6)) // 32s -> capped
+        assertEquals(30_000L, MediaCdnMath.uploadBackoffMs(100)) // no overflow
+    }
+
+    // ---- uploadProgressPct ----
+
+    @Test
+    fun progress_clampAndUnknown() {
+        assertEquals(0, MediaCdnMath.uploadProgressPct(0, 0))
+        assertEquals(0, MediaCdnMath.uploadProgressPct(50, 0))
+        assertEquals(0, MediaCdnMath.uploadProgressPct(0, 200))
+        assertEquals(50, MediaCdnMath.uploadProgressPct(100, 200))
+        assertEquals(100, MediaCdnMath.uploadProgressPct(200, 200))
+        assertEquals(100, MediaCdnMath.uploadProgressPct(300, 200)) // loaded>total race
+    }
+
+    @Test
+    fun maxRetriesConstant() {
+        assertEquals(5, MediaCdnMath.MAX_UPLOAD_RETRIES)
+    }
+}

--- a/frontend/src/api/endpoints/messaging.ts
+++ b/frontend/src/api/endpoints/messaging.ts
@@ -55,6 +55,12 @@ import type { ProductCardPayload, OrderCardPayload } from "@/lib/ecomCards";
 import type { LocationCardPayload } from "@/lib/locationCards";
 import { isMessagingDmLotteryEnabled, isMessagingEncryptionEnabled } from "@/lib/featureFlags";
 import { encryptBytes } from "@/lib/messageEncryption";
+import {
+  MAX_UPLOAD_RETRIES,
+  isRetryableUploadStatus,
+  uploadBackoffMs,
+  uploadProgressPct,
+} from "@/lib/mediaCdn";
 
 export const getConversations = async (cursor?: string) => {
   const networkFn = async () => {
@@ -338,17 +344,86 @@ export const timeoutCall = (callId: string, body?: { reason?: string; idempotenc
     ...(body?.idempotency_key ? { idempotency_key: body.idempotency_key } : {}),
   });
 
-const uploadToPresignedUrl = async (uploadUrl: string, file: File, contentType: string) => {
-  const resp = await fetch(uploadUrl, {
-    method: "PUT",
-    body: file,
-    headers: {
-      "Content-Type": contentType,
-    },
+/** Progress callback: receives an integer 0..100 upload percent. */
+export type UploadProgressCb = (pct: number) => void;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * PUT a blob to a presigned URL using XMLHttpRequest so we can surface upload
+ * progress (FE-141), with a bounded retry loop on transient failures
+ * (network / 408 / 429 / 5xx). fetch() cannot report upload progress, hence XHR.
+ */
+const putBlobWithProgress = (
+  uploadUrl: string,
+  body: Blob,
+  contentType: string,
+  onProgress?: UploadProgressCb,
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("PUT", uploadUrl, true);
+    xhr.setRequestHeader("Content-Type", contentType);
+    if (onProgress && xhr.upload) {
+      xhr.upload.onprogress = (e: ProgressEvent) => {
+        if (e.lengthComputable) onProgress(uploadProgressPct(e.loaded, e.total));
+      };
+    }
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        if (onProgress) onProgress(100);
+        resolve();
+      } else {
+        const err = new Error(`Upload failed (${xhr.status})`) as Error & { status?: number };
+        err.status = xhr.status;
+        reject(err);
+      }
+    };
+    // Network-level failures: report status 0 so the retry loop treats them as retryable.
+    xhr.onerror = () => {
+      const err = new Error("Upload failed (network error)") as Error & { status?: number };
+      err.status = 0;
+      reject(err);
+    };
+    xhr.onabort = () => {
+      const err = new Error("Upload aborted") as Error & { status?: number };
+      err.status = 0;
+      reject(err);
+    };
+    xhr.send(body);
   });
-  if (!resp.ok) {
-    throw new Error("Failed to upload image");
+
+const uploadBlobToPresignedUrl = async (
+  uploadUrl: string,
+  body: Blob,
+  contentType: string,
+  onProgress?: UploadProgressCb,
+): Promise<void> => {
+  let attempt = 0;
+  // Total tries = 1 initial + MAX_UPLOAD_RETRIES retries.
+  for (;;) {
+    try {
+      await putBlobWithProgress(uploadUrl, body, contentType, onProgress);
+      return;
+    } catch (e) {
+      const status = (e as { status?: number })?.status ?? 0;
+      const canRetry = attempt < MAX_UPLOAD_RETRIES && isRetryableUploadStatus(status);
+      if (!canRetry) throw e instanceof Error ? e : new Error("Failed to upload media");
+      attempt += 1;
+      // Reset the visible progress before the retry so the bar restarts cleanly.
+      if (onProgress) onProgress(0);
+      await sleep(uploadBackoffMs(attempt));
+    }
   }
+};
+
+const uploadToPresignedUrl = async (
+  uploadUrl: string,
+  file: File,
+  contentType: string,
+  onProgress?: UploadProgressCb,
+) => {
+  await uploadBlobToPresignedUrl(uploadUrl, file, contentType, onProgress);
 };
 
 /** Read natural width/height from an image File. Returns undefined for non-images (e.g. PDFs). */
@@ -394,6 +469,7 @@ export const sendImageMessage = async (
     tip_payment_method_id?: string;
     send_at?: number;
     encryption_password?: string;
+    onProgress?: UploadProgressCb;
   },
 ) => {
   const file = formData.get("file");
@@ -422,14 +498,19 @@ export const sendImageMessage = async (
     const { envelope, encryptedBytes } = await encryptBytes(fileBytes, options.encryption_password);
     encryptionEnvelope = { ...envelope };
     const encryptedBlob = new Blob([encryptedBytes], { type: "application/octet-stream" });
-    const resp = await fetch(presign.upload_url, {
-      method: "PUT",
-      body: encryptedBlob,
-      headers: { "Content-Type": "application/octet-stream" },
-    });
-    if (!resp.ok) throw new Error("Failed to upload encrypted media");
+    await uploadBlobToPresignedUrl(
+      presign.upload_url,
+      encryptedBlob,
+      "application/octet-stream",
+      options?.onProgress,
+    );
   } else {
-    await uploadToPresignedUrl(presign.upload_url, file, presign.content_type || contentType);
+    await uploadToPresignedUrl(
+      presign.upload_url,
+      file,
+      presign.content_type || contentType,
+      options?.onProgress,
+    );
   }
 
   const payload: SendImageMessageReq = {
@@ -468,13 +549,14 @@ export const sendImageMessage = async (
 export const uploadConversationMedia = async (
   conversationId: string,
   file: File,
+  onProgress?: UploadProgressCb,
 ): Promise<{ key: string; bucket: string; content_type: string }> => {
   const contentType = file.type || "application/octet-stream";
   const presign = await api.post<{ upload_url: string; bucket: string; key: string; content_type: string }>(
     `/messaging/conversations/${conversationId}/images/presign`,
     { content_type: contentType, filename: file.name || "upload" },
   );
-  await uploadToPresignedUrl(presign.upload_url, file, presign.content_type || contentType);
+  await uploadToPresignedUrl(presign.upload_url, file, presign.content_type || contentType, onProgress);
   return { key: presign.key, bucket: presign.bucket, content_type: presign.content_type || contentType };
 };
 

--- a/frontend/src/api/endpoints/messagingAdapter.ts
+++ b/frontend/src/api/endpoints/messagingAdapter.ts
@@ -1,4 +1,8 @@
 import type { Conversation, Message } from "@/api/types";
+import { resolveMediaUrl } from "@/lib/mediaCdn";
+
+// FE-141: real CDN base for media, read at build. Empty -> mock path (dev unchanged).
+const MEDIA_CDN_BASE = (import.meta.env.VITE_MEDIA_CDN_BASE_URL as string | undefined) ?? "";
 
 type RawConversation = Partial<Conversation> & {
   created_at?: number | string;
@@ -20,8 +24,9 @@ type RawMessage = Partial<Message> & {
 };
 
 const buildS3ObjectUrl = (bucket?: string, key?: string): string | undefined => {
-  if (!bucket || !key) return undefined;
-  return `/mock/s3/${bucket}/${encodeURIComponent(key).replace(/%2F/g, "/")}`;
+  // FE-141: delegate to the pure resolver. With no CDN configured this returns
+  // the identical /mock/s3/... path, so dev/mock behavior is unchanged.
+  return resolveMediaUrl({ bucket, key }, { cdnBase: MEDIA_CDN_BASE });
 };
 
 const buildFileManagerUrl = (path?: string): string | undefined => {

--- a/frontend/src/lib/mediaCdn.test.ts
+++ b/frontend/src/lib/mediaCdn.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_UPLOAD_RETRIES,
+  encodeMediaKey,
+  resolveMediaUrl,
+  isRetryableUploadStatus,
+  uploadBackoffMs,
+  uploadProgressPct,
+} from "./mediaCdn";
+
+describe("encodeMediaKey", () => {
+  it("encodes each segment but preserves separators", () => {
+    expect(encodeMediaKey("a/b c/d.png")).toBe("a/b%20c/d.png");
+  });
+  it("encodes special chars within a segment", () => {
+    expect(encodeMediaKey("conv/msg#1?x.png")).toBe("conv/msg%231%3Fx.png");
+  });
+  it("handles a single segment", () => {
+    expect(encodeMediaKey("file.png")).toBe("file.png");
+  });
+});
+
+describe("resolveMediaUrl", () => {
+  it("returns null/undefined for empty input", () => {
+    expect(resolveMediaUrl(undefined)).toBeUndefined();
+    expect(resolveMediaUrl(null)).toBeUndefined();
+    expect(resolveMediaUrl("")).toBeUndefined();
+  });
+
+  it("returns already-absolute http(s) URLs as-is", () => {
+    expect(resolveMediaUrl("https://cdn.x/y.png", { cdnBase: "https://other" })).toBe(
+      "https://cdn.x/y.png",
+    );
+    expect(resolveMediaUrl("http://cdn.x/y.png")).toBe("http://cdn.x/y.png");
+  });
+
+  it("joins a relative path to the CDN base", () => {
+    expect(resolveMediaUrl("/media/a.png", { cdnBase: "https://cdn.x" })).toBe(
+      "https://cdn.x/media/a.png",
+    );
+    expect(resolveMediaUrl("media/a.png", { cdnBase: "https://cdn.x/" })).toBe(
+      "https://cdn.x/media/a.png",
+    );
+  });
+
+  it("falls back to apiBase for relative paths when no CDN", () => {
+    expect(resolveMediaUrl("/media/a.png", { apiBase: "https://api.x" })).toBe(
+      "https://api.x/media/a.png",
+    );
+  });
+
+  it("returns the relative path unchanged when no base configured", () => {
+    expect(resolveMediaUrl("/media/a.png")).toBe("/media/a.png");
+  });
+
+  it("builds a CDN object URL from bucket/key", () => {
+    expect(
+      resolveMediaUrl({ bucket: "media", key: "conv/1/pic name.png" }, { cdnBase: "https://cdn.x" }),
+    ).toBe("https://cdn.x/media/conv/1/pic%20name.png");
+  });
+
+  it("falls back to /mock/s3 for bucket/key when no CDN (dev unchanged)", () => {
+    expect(resolveMediaUrl({ bucket: "media", key: "conv/1/pic.png" })).toBe(
+      "/mock/s3/media/conv/1/pic.png",
+    );
+  });
+
+  it("prefers an explicit absolute url field over bucket/key", () => {
+    expect(
+      resolveMediaUrl(
+        { bucket: "media", key: "k.png", url: "https://abs/x.png" },
+        { cdnBase: "https://cdn.x" },
+      ),
+    ).toBe("https://abs/x.png");
+  });
+
+  it("resolves a relative url field against the CDN base", () => {
+    expect(
+      resolveMediaUrl({ bucket: "media", key: "k.png", url: "/rel/x.png" }, { cdnBase: "https://cdn.x" }),
+    ).toBe("https://cdn.x/rel/x.png");
+  });
+
+  it("returns undefined for an object missing bucket or key and no url", () => {
+    expect(resolveMediaUrl({ bucket: "media" })).toBeUndefined();
+    expect(resolveMediaUrl({ key: "k" })).toBeUndefined();
+  });
+});
+
+describe("isRetryableUploadStatus", () => {
+  it("retries on network error (0)", () => {
+    expect(isRetryableUploadStatus(0)).toBe(true);
+  });
+  it("retries on 408/429 and 5xx", () => {
+    expect(isRetryableUploadStatus(408)).toBe(true);
+    expect(isRetryableUploadStatus(429)).toBe(true);
+    expect(isRetryableUploadStatus(500)).toBe(true);
+    expect(isRetryableUploadStatus(503)).toBe(true);
+    expect(isRetryableUploadStatus(599)).toBe(true);
+  });
+  it("does not retry on typical 4xx client errors", () => {
+    expect(isRetryableUploadStatus(400)).toBe(false);
+    expect(isRetryableUploadStatus(403)).toBe(false);
+    expect(isRetryableUploadStatus(404)).toBe(false);
+  });
+  it("does not retry on success", () => {
+    expect(isRetryableUploadStatus(200)).toBe(false);
+    expect(isRetryableUploadStatus(204)).toBe(false);
+  });
+});
+
+describe("uploadBackoffMs", () => {
+  it("grows exponentially", () => {
+    expect(uploadBackoffMs(1)).toBe(500);
+    expect(uploadBackoffMs(2)).toBe(1000);
+    expect(uploadBackoffMs(3)).toBe(2000);
+  });
+  it("caps the backoff", () => {
+    expect(uploadBackoffMs(99)).toBe(8000);
+  });
+  it("treats attempt < 1 as 1", () => {
+    expect(uploadBackoffMs(0)).toBe(500);
+  });
+});
+
+describe("uploadProgressPct", () => {
+  it("computes a clamped integer percent", () => {
+    expect(uploadProgressPct(0, 100)).toBe(0);
+    expect(uploadProgressPct(50, 100)).toBe(50);
+    expect(uploadProgressPct(100, 100)).toBe(100);
+    expect(uploadProgressPct(1, 3)).toBe(33);
+  });
+  it("clamps out-of-range and guards divide-by-zero", () => {
+    expect(uploadProgressPct(200, 100)).toBe(100);
+    expect(uploadProgressPct(-5, 100)).toBe(0);
+    expect(uploadProgressPct(5, 0)).toBe(0);
+    expect(uploadProgressPct(NaN, 100)).toBe(0);
+  });
+});
+
+describe("MAX_UPLOAD_RETRIES", () => {
+  it("is a small positive integer", () => {
+    expect(MAX_UPLOAD_RETRIES).toBeGreaterThan(0);
+    expect(Number.isInteger(MAX_UPLOAD_RETRIES)).toBe(true);
+  });
+});

--- a/frontend/src/lib/mediaCdn.ts
+++ b/frontend/src/lib/mediaCdn.ts
@@ -1,0 +1,92 @@
+// FE-141 (EPIC E, <- BE-141): pure helpers for resolving media URLs against a
+// real CDN base and for driving upload progress + retry. No DOM, no network —
+// all side-effecting concerns (XHR, import.meta.env) live in the callers.
+
+/** Max number of upload attempts beyond the first before giving up. */
+export const MAX_UPLOAD_RETRIES = 3;
+
+/** Encode each path segment of an S3 key while preserving the "/" separators. */
+export function encodeMediaKey(key: string): string {
+  return key
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+const stripTrailingSlash = (s: string): string => s.replace(/\/+$/, "");
+const stripLeadingSlash = (s: string): string => s.replace(/^\/+/, "");
+
+const isAbsoluteUrl = (s: string): boolean => /^https?:\/\//i.test(s);
+
+export type MediaRef = string | { bucket?: string; key?: string; url?: string };
+
+export interface ResolveMediaOpts {
+  /** Real CDN origin/base (e.g. https://cdn.example.com). Empty/undefined -> mock. */
+  cdnBase?: string;
+  /** API base to join relative paths against when no CDN is configured. */
+  apiBase?: string;
+}
+
+/**
+ * Resolve a media reference to a URL suitable for an <img>/<video>/<audio> src.
+ * - already-absolute http(s) URL (or explicit `url` field) -> returned as-is
+ * - relative path string -> joined to cdnBase (else apiBase, else returned as-is)
+ * - {bucket,key} -> `${cdnBase}/${bucket}/${encodeMediaKey(key)}`, else the
+ *   existing `/mock/s3/...` fallback so dev/mock behavior is unchanged.
+ */
+export function resolveMediaUrl(
+  input: MediaRef | undefined | null,
+  opts: ResolveMediaOpts = {},
+): string | undefined {
+  if (input == null) return undefined;
+  const cdnBase = opts.cdnBase ? stripTrailingSlash(opts.cdnBase) : "";
+  const apiBase = opts.apiBase ? stripTrailingSlash(opts.apiBase) : "";
+
+  if (typeof input === "string") {
+    const s = input.trim();
+    if (!s) return undefined;
+    if (isAbsoluteUrl(s)) return s;
+    // Relative path: prefer CDN, then API base, else leave as-is.
+    const base = cdnBase || apiBase;
+    if (!base) return s;
+    return `${base}/${stripLeadingSlash(s)}`;
+  }
+
+  // Object form. An explicit absolute/relative url wins.
+  if (typeof input.url === "string" && input.url.trim()) {
+    return resolveMediaUrl(input.url, opts);
+  }
+  const { bucket, key } = input;
+  if (!bucket || !key) return undefined;
+  const encodedKey = encodeMediaKey(key);
+  if (cdnBase) return `${cdnBase}/${bucket}/${encodedKey}`;
+  // Mock fallback (matches the legacy buildS3ObjectUrl output exactly).
+  return `/mock/s3/${bucket}/${encodedKey}`;
+}
+
+/**
+ * Whether an upload failure with the given HTTP status (or 0 for a network
+ * error) is worth retrying. Retries on: network (0), 408, 429, and any 5xx.
+ */
+export function isRetryableUploadStatus(status: number): boolean {
+  if (status === 0) return true; // network error / aborted / no response
+  if (status === 408 || status === 429) return true;
+  if (status >= 500 && status <= 599) return true;
+  return false;
+}
+
+/** Exponential backoff (ms) for the Nth retry attempt (1-indexed), capped. */
+export function uploadBackoffMs(attempt: number): number {
+  const n = Math.max(1, Math.floor(attempt));
+  const base = 500 * 2 ** (n - 1); // 500, 1000, 2000, ...
+  return Math.min(base, 8000);
+}
+
+/** Clamp a loaded/total pair to an integer 0..100 progress percent. */
+export function uploadProgressPct(loaded: number, total: number): number {
+  if (!Number.isFinite(loaded) || !Number.isFinite(total) || total <= 0) return 0;
+  const pct = Math.round((loaded / total) * 100);
+  if (pct < 0) return 0;
+  if (pct > 100) return 100;
+  return pct;
+}

--- a/frontend/src/pages/messages/ConversationView.tsx
+++ b/frontend/src/pages/messages/ConversationView.tsx
@@ -90,6 +90,21 @@ interface ConversationViewProps {
   onClaimSuccess?: (state: string, agentUserId: string) => void;
 }
 
+// FE-141: payload for the image/media send mutation (also reused to retry a
+// failed upload with the identical arguments).
+type ImageUploadArgs = {
+  file: File;
+  consumptionPolicy?: "none" | "view_once";
+  caption?: string;
+  expires_in_seconds?: number;
+  lock_price_cents?: number;
+  lock_description?: string;
+  tip_amount_cents?: number;
+  tip_payment_method_id?: string;
+  send_at?: number;
+  encryption_password?: string;
+};
+
 export function ConversationView({ conversation, onBack, onClaimSuccess }: ConversationViewProps) {
   const userId = useAuthStore((s) => s.userId);
   const liveLocation = useLiveLocationShare();
@@ -136,6 +151,11 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
     previewUrl: string;
     kind: "image" | "video" | "audio";
   } | null>(null);
+
+  // FE-141: image/media upload progress (0..100) + a Retry affordance for a
+  // failed upload. `failedImageArgs` holds the last failing mutation payload.
+  const [uploadProgress, setUploadProgress] = React.useState<number | null>(null);
+  const [failedImageArgs, setFailedImageArgs] = React.useState<ImageUploadArgs | null>(null);
 
   const classifyDroppedFile = React.useCallback((file: File): { kind: "image" | "video" | "audio" | null } => {
     if (file.type.startsWith("image/") || file.type === "application/pdf") return { kind: "image" };
@@ -440,18 +460,7 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
   });
 
   const sendImage = useMutation({
-    mutationFn: (args: {
-      file: File;
-      consumptionPolicy?: "none" | "view_once";
-      caption?: string;
-      expires_in_seconds?: number;
-      lock_price_cents?: number;
-      lock_description?: string;
-      tip_amount_cents?: number;
-      tip_payment_method_id?: string;
-      send_at?: number;
-      encryption_password?: string;
-    }) => {
+    mutationFn: (args: ImageUploadArgs) => {
       const fd = new FormData();
       fd.append("file", args.file);
       return sendImageMessage(convoId, fd, {
@@ -464,9 +473,14 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         tip_payment_method_id: args.tip_payment_method_id,
         send_at: args.send_at,
         encryption_password: args.encryption_password,
+        // FE-141: drive the upload progress bar; scheduled sends stay indeterminate.
+        onProgress: args.send_at ? undefined : (pct) => setUploadProgress(pct),
       });
     },
     onMutate: async (args) => {
+      // FE-141: a fresh attempt clears any prior failure and starts the bar at 0.
+      setFailedImageArgs(null);
+      setUploadProgress(args.send_at ? null : 0);
       // Skip optimistic update for scheduled image messages
       if (args.send_at) return { snapshot: undefined, optimisticUrl: undefined, isScheduled: true };
 
@@ -522,12 +536,18 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
       }
       queryClient.invalidateQueries({ queryKey: ["messages", convoId] });
       queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      setUploadProgress(null);
+      setFailedImageArgs(null);
     },
-    onError: (_err, _args, context) => {
+    onError: (_err, args, context) => {
       if (context?.optimisticUrl) URL.revokeObjectURL(context.optimisticUrl);
       if (context?.snapshot) {
         queryClient.setQueryData(["messages", convoId], context.snapshot);
       }
+      // FE-141: retries inside uploadToPresignedUrl are exhausted by now; offer a
+      // manual Retry with the same payload.
+      setUploadProgress(null);
+      setFailedImageArgs(args);
       toast.error("Failed to send image");
     },
   });
@@ -1520,6 +1540,49 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
 
       {/* Typing indicator */}
       <TypingIndicator conversationId={convoId} />
+
+      {/* FE-141: media upload progress + retry-on-failure affordance. */}
+      {uploadProgress !== null && !failedImageArgs && (
+        <div className="px-3 pt-1" data-testid="upload-progress">
+          <div className="flex items-center gap-2">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{ width: `${uploadProgress}%` }}
+              />
+            </div>
+            <span className="text-xs text-muted-foreground tabular-nums">{uploadProgress}%</span>
+          </div>
+        </div>
+      )}
+      {failedImageArgs && (
+        <div
+          className="mx-3 mt-1 flex items-center justify-between gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-1.5"
+          data-testid="upload-failed"
+        >
+          <span className="text-xs text-destructive">Upload failed.</span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="text-xs font-medium text-primary hover:underline"
+              onClick={() => {
+                const args = failedImageArgs;
+                setFailedImageArgs(null);
+                if (args) sendImage.mutate(args);
+              }}
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              className="text-xs text-muted-foreground hover:underline"
+              onClick={() => setFailedImageArgs(null)}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Compose */}
       <ComposeBar

--- a/frontend/src/pages/messages/MessageBubble.tsx
+++ b/frontend/src/pages/messages/MessageBubble.tsx
@@ -4,6 +4,7 @@ import { MoreHorizontal, Forward, Trash2, Lock, Loader2, Pencil, Info, Download,
 import { useMutation, useQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { resolveMediaUrl } from "@/lib/mediaCdn";
 import { isMessagingEncryptionEnabled, isMessagingTranslationEnabled, messagingTranslationDefaultLang } from "@/lib/featureFlags";
 import { translateMessage } from "@/api/endpoints/messagingAi";
 import { isEmojiOnly } from "@/utils/emoji";
@@ -198,10 +199,18 @@ const openBlobInEphemeralWindow = (blob: Blob) => {
   }
 };
 
+// FE-141: real CDN base for media, read at build. Empty -> mock path (dev unchanged).
+const MEDIA_CDN_BASE = (import.meta.env.VITE_MEDIA_CDN_BASE_URL as string | undefined) ?? "";
+
 const buildS3ObjectUrl = (bucket?: string, key?: string): string | undefined => {
-  if (!bucket || !key) return undefined;
-  return `/mock/s3/${bucket}/${encodeURIComponent(key).replace(/%2F/g, "/")}`;
+  // FE-141: delegate to the shared resolver; identical /mock/s3 fallback when no CDN.
+  return resolveMediaUrl({ bucket, key }, { cdnBase: MEDIA_CDN_BASE });
 };
+
+// FE-141: resolve a possibly-relative media URL from the API against the CDN
+// base. Already-absolute http(s) URLs pass through unchanged.
+const cdnUrl = (u?: string | null): string | undefined =>
+  resolveMediaUrl(u ?? undefined, { cdnBase: MEDIA_CDN_BASE });
 
 function replyPreviewText(msg: Message): string {
   // FE-120: never leak the content of a still-locked scheduled reveal.
@@ -1279,7 +1288,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
               {message.kind === "image" && message.image?.preview_url && (
                 <div className="relative overflow-hidden rounded-lg">
                   <img
-                    src={message.image.preview_url}
+                    src={cdnUrl(message.image.preview_url)}
                     alt="Locked image preview"
                     className="w-full max-h-48 object-cover"
                     style={{ imageRendering: "pixelated", filter: "blur(2px)", transform: "scale(1.05)" }}
@@ -1585,7 +1594,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                 className="mt-1 block"
               >
                 <img
-                  src={message.image.url}
+                  src={cdnUrl(message.image.url)}
                   alt="Shared image"
                   className="max-h-64 rounded-lg object-cover"
                 />
@@ -1603,7 +1612,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                       item.content_type?.startsWith("video/") ? (
                         <video
                           key={i}
-                          src={item.url}
+                          src={cdnUrl(item.url)}
                           className="w-full aspect-square object-cover rounded"
                           muted
                           playsInline
@@ -1613,7 +1622,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                       ) : (
                         <img
                           key={i}
-                          src={item.url}
+                          src={cdnUrl(item.url)}
                           alt={item.filename ?? `Image ${i + 1}`}
                           className="w-full aspect-square object-cover rounded"
                         />
@@ -1634,7 +1643,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                           item.content_type?.startsWith("video/") ? (
                             <video
                               key={i}
-                              src={item.url}
+                              src={cdnUrl(item.url)}
                               className="w-full aspect-square object-cover rounded"
                               muted
                               playsInline
@@ -1644,7 +1653,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                           ) : (
                             <img
                               key={i}
-                              src={item.url}
+                              src={cdnUrl(item.url)}
                               alt={item.filename ?? `Locked image ${i + 1}`}
                               className="w-full aspect-square object-cover rounded"
                             />
@@ -1849,7 +1858,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                 <span className="text-xs text-muted-foreground">Voice message</span>
               </div>
               <WaveformPlayer
-                audioUrl={message.voice_message.audio_url}
+                audioUrl={cdnUrl(message.voice_message.audio_url) ?? message.voice_message.audio_url}
                 waveform={message.voice_message.waveform_data}
                 durationSeconds={message.voice_message.duration_seconds}
                 consumed={message.consumption_state === "consumed"}
@@ -2572,7 +2581,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
                 </button>
               )}
               <a
-                href={message.image.url}
+                href={cdnUrl(message.image.url)}
                 download
                 className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20"
                 onClick={(e) => {
@@ -2595,7 +2604,7 @@ export function MessageBubble({ message, isOwn, showSender, conversationId, onRe
             <DialogDescription className="sr-only">Full-size image view</DialogDescription>
             <div className="flex items-center justify-center min-h-[60vh] p-4">
               <img
-                src={message.image.url}
+                src={cdnUrl(message.image.url)}
                 alt="Full size image"
                 className="max-h-[80vh] max-w-full object-contain rounded-lg"
               />


### PR DESCRIPTION
## FE-141 — media from CDN + upload progress + retry (EPIC E)

Renders images/voice/video from real **CDN URLs**, shows **upload progress**, and **retries** failed uploads. CDN base is env/buildConfig-driven with an **empty default → dev/mock behavior is byte-unchanged**.

### Web
- NEW pure `lib/mediaCdn.ts` (+23 vitest) — `resolveMediaUrl` (absolute passthrough / relative→CDN / bucket+key→CDN / mock fallback), `encodeMediaKey`, `isRetryableUploadStatus`, `uploadBackoffMs`, `uploadProgressPct`, `MAX_UPLOAD_RETRIES`.
- `buildS3ObjectUrl` (adapter + MessageBubble) delegates to `resolveMediaUrl` with `VITE_MEDIA_CDN_BASE_URL`, applied at image/gallery-video/voice render sites (prefers an absolute API url).
- `uploadToPresignedUrl` rewritten as **XHR** `putBlobWithProgress` + retry loop (backoff, retryable statuses only); `onProgress` threaded through `sendImageMessage` (plain + encrypted) + `uploadConversationMedia`; `ConversationView` shows a % progress bar + Retry/Dismiss banner.

### Android
- NEW pure `MediaCdnMath.kt` (+16 JVM tests) wired into `MessagingDomain` image/gallery/`deriveS3Url` mapping with `BuildConfig.MEDIA_CDN_BASE` (empty default).
- Per-byte upload progress (`ProgressRequestBody` → outbox `uploadPercent` → determinate indicator) and outbox retry **already existed** — hardened URL resolution around them; Coil `RelativeUrlMapper` still absolutizes mock paths. Encrypted upload untouched.

### Gates
- Web: tsc 0 · build green · 23/23 vitest
- Android: BUILD SUCCESSFUL · MediaCdnMathTest 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
