### PR TITLE
FE-143: WebRTC connection-state UI + ICE restart + TURN refresh (web + Android) — completes EPIC E

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/webrtc/CallSignalingHub.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/webrtc/CallSignalingHub.kt
@@ -16,6 +16,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import com.testlogon.android.feature.call.domain.CallConnectionMath
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,6 +45,8 @@ class CallSignalingHub @Inject constructor(
     private val callManager: CallManager,
     private val peer: PeerConnectionController,
     private val iceServers: IceServersProvider,
+    private val iceServersRepository: IceServersRepository,
+    private val clock: com.testlogon.android.core.data.cache.Clock,
     private val signalingApi: SignalingApi,
     private val scope: CoroutineScope,
 ) {
@@ -55,6 +61,9 @@ class CallSignalingHub @Inject constructor(
     private var started = false
     private var negotiationJob: Job? = null
     private var negotiatingCallId: String? = null
+
+    // FE-143 - how often the TURN-refresh ticker re-checks the credential TTL on a live call.
+    private val TURN_REFRESH_POLL_MS = 15_000L
 
     @Synchronized
     fun start() {
@@ -177,6 +186,67 @@ class CallSignalingHub @Inject constructor(
             peer.lifecycle.collect { lc ->
                 Log.d("TLHUB", "negotiate lifecycle=$lc call=${call.callId}")
                 if (lc is PeerLifecycle.Connected) callManager.onConnected()
+            }
+        }
+
+        // FE-143 - ICE restart on reconnect. Watch the raw ICE connection state; when it FAILS (or sits
+        // DISCONNECTED past the grace) re-fetch fresh TURN creds (forceRefresh), apply them to the live
+        // peer, and drive an ICE restart. The offerer forwards a fresh iceRestart offer; the answerer will
+        // answer the peer's restart offer through the existing inbound handler. A mutex guards overlapping
+        // restarts so a burst of FAILED/DISCONNECTED callbacks cannot fire concurrent restarts.
+        val restartMutex = Mutex()
+        launch {
+            var disconnectedSinceMs = 0L
+            peer.iceState.collect { iceName ->
+                val upper = iceName.trim().uppercase()
+                val nowMs = clock.now()
+                if (upper == "DISCONNECTED") {
+                    if (disconnectedSinceMs == 0L) disconnectedSinceMs = nowMs
+                } else {
+                    disconnectedSinceMs = 0L
+                }
+                val disconnectedForSec =
+                    if (disconnectedSinceMs == 0L) Long.MAX_VALUE else (nowMs - disconnectedSinceMs) / 1_000L
+                if (call.role == PeerRole.OFFERER &&
+                    CallConnectionMath.shouldIceRestart(iceName, disconnectedForSec) &&
+                    !restartMutex.isLocked
+                ) {
+                    restartMutex.withLock {
+                        Log.d("TLHUB", "ICE restart trigger iceState=$iceName call=${call.callId}")
+                        val fresh = iceServersRepository.getIceServers(call.callId, forceRefresh = true)
+                        if (fresh is com.testlogon.android.core.model.ApiResult.Success) {
+                            peer.setConfiguration(fresh.data.servers)
+                        }
+                        when (val restart = peer.restartIce()) {
+                            is PeerResult.Ok -> restart.value?.let {
+                                send(call, "webrtc.offer", mapOf("sdp" to it.sdp, "sdp_type" to "offer"))
+                            }
+                            else -> Log.d("TLHUB", "ICE restart returned $restart")
+                        }
+                    }
+                }
+            }
+        }
+
+        // FE-143 - refresh TURN creds before the TTL expires on a long call, so relays stay valid past the
+        // granted TTL. Polls the repository (cached / stale-while-revalidate) and, once inside the refresh
+        // lead window, force-refreshes and applies the new servers to the live peer with setConfiguration.
+        // This job is a child of negotiate()'s coroutineScope, so it is cancelled with the negotiation on
+        // any terminal phase (structured concurrency - no leak).
+        launch {
+            while (isActive) {
+                delay(TURN_REFRESH_POLL_MS)
+                val nowSec = clock.now() / 1_000L
+                val current = iceServersRepository.getIceServers(call.callId)
+                if (current !is com.testlogon.android.core.model.ApiResult.Success) continue
+                val expiresAtSec = current.data.expiresAtEpochMs / 1_000L
+                if (CallConnectionMath.shouldRefreshTurn(expiresAtSec, nowSec)) {
+                    Log.d("TLHUB", "TURN refresh before TTL call=${call.callId}")
+                    val refreshed = iceServersRepository.getIceServers(call.callId, forceRefresh = true)
+                    if (refreshed is com.testlogon.android.core.model.ApiResult.Success) {
+                        peer.setConfiguration(refreshed.data.servers)
+                    }
+                }
             }
         }
         launch {

--- a/android/app/src/main/java/com/testlogon/android/data/webrtc/PeerConnectionController.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/webrtc/PeerConnectionController.kt
@@ -27,6 +27,13 @@ interface PeerConnectionController {
     val lifecycle: StateFlow<PeerLifecycle>
 
     /**
+     * FE-143 — the raw libwebrtc ICE connection-state NAME (NEW/CHECKING/CONNECTED/COMPLETED/
+     * DISCONNECTED/FAILED/CLOSED). Hot; starts "NEW". Fed to [CallConnectionMath] for the connection-state
+     * UI + the ICE-restart decision. The stub stays "NEW".
+     */
+    val iceState: StateFlow<String>
+
+    /**
      * Locally-gathered (trickled) ICE candidates to forward to the peer over signaling. Hot; the real impl
      * emits one per `onIceCandidate`. The stub never emits.
      */
@@ -46,6 +53,19 @@ interface PeerConnectionController {
 
     /** Accept a remote ICE candidate. */
     suspend fun addIceCandidate(candidate: IceCandidate): PeerResult<Unit>
+
+    /**
+     * FE-143 — trigger an ICE restart (re-gather candidates + renegotiate) on an existing peer, e.g. after
+     * an ICE FAILED/persisted-DISCONNECTED. The offerer produces a fresh iceRestart offer to forward over
+     * signaling; the answerer only primes its side. No-op (NotConfigured) if no peer exists.
+     */
+    suspend fun restartIce(): PeerResult<SdpDescription?>
+
+    /**
+     * FE-143 — apply a refreshed ICE-server list to the live peer (setConfiguration) so a long call keeps
+     * valid TURN relays past the credential TTL. No-op if no peer exists.
+     */
+    fun setConfiguration(iceServers: List<IceServer>)
 
     /** Idempotent teardown. Disposes native refs + stops capture. */
     fun close()
@@ -102,6 +122,9 @@ class StubPeerConnectionController @Inject constructor() : PeerConnectionControl
     private val _lifecycle = MutableStateFlow<PeerLifecycle>(PeerLifecycle.Idle)
     override val lifecycle: StateFlow<PeerLifecycle> = _lifecycle.asStateFlow()
 
+    private val _iceState = MutableStateFlow("NEW")
+    override val iceState: StateFlow<String> = _iceState.asStateFlow()
+
     private val _ice = MutableSharedFlow<IceCandidate>()
     override val localIceCandidates: SharedFlow<IceCandidate> = _ice.asSharedFlow()
 
@@ -110,6 +133,9 @@ class StubPeerConnectionController @Inject constructor() : PeerConnectionControl
     override suspend fun createAnswer(): PeerResult<SdpDescription> = PeerResult.NotConfigured
     override suspend fun setRemoteDescription(sdp: SdpDescription): PeerResult<Unit> = PeerResult.NotConfigured
     override suspend fun addIceCandidate(candidate: IceCandidate): PeerResult<Unit> = PeerResult.NotConfigured
+
+    override suspend fun restartIce(): PeerResult<SdpDescription?> = PeerResult.NotConfigured
+    override fun setConfiguration(iceServers: List<IceServer>) { /* no peer in the stub */ }
 
     override fun close() {
         _lifecycle.value = PeerLifecycle.Closed

--- a/android/app/src/main/java/com/testlogon/android/data/webrtc/RealPeerConnectionController.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/webrtc/RealPeerConnectionController.kt
@@ -59,6 +59,9 @@ class RealPeerConnectionController @Inject constructor(
     )
     override val localIceCandidates: SharedFlow<IceCandidate> = _localIce.asSharedFlow()
 
+    private val _iceState = MutableStateFlow("NEW")
+    override val iceState: StateFlow<String> = _iceState.asStateFlow()
+
     private var peer: PeerConnection? = null
     private var audioSource: AudioSource? = null
     private var audioTrack: AudioTrack? = null
@@ -160,6 +163,41 @@ class RealPeerConnectionController @Inject constructor(
         }
     }
 
+    override suspend fun restartIce(): PeerResult<SdpDescription?> {
+        val pc = peer ?: return PeerResult.NotConfigured
+        return try {
+            // Kick libwebrtc to re-gather relay/host candidates on the existing peer.
+            pc.restartIce()
+            // Offerer produces a fresh iceRestart offer to forward over signaling; answerer just primes.
+            val constraints = MediaConstraints().apply {
+                mandatory.add(MediaConstraints.KeyValuePair("IceRestart", "true"))
+            }
+            val offer = awaitCreate { pc.createOffer(it, constraints) }
+                ?: return PeerResult.Ok(null)
+            if (!awaitSet { pc.setLocalDescription(it, offer) }) return PeerResult.Ok(null)
+            PeerResult.Ok(offer.toDomain())
+        } catch (t: Throwable) {
+            PeerResult.Failed(t.javaClass.simpleName)
+        }
+    }
+
+    override fun setConfiguration(iceServers: List<IceServer>) {
+        val pc = peer ?: return
+        val servers = iceServers.map { srv ->
+            val b = PeerConnection.IceServer.builder(srv.urls)
+            srv.username?.let { b.setUsername(it) }
+            srv.credential?.let { b.setPassword(it) }
+            b.createIceServer()
+        }
+        val cfg = PeerConnection.RTCConfiguration(servers).apply {
+            sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
+            continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY
+            bundlePolicy = PeerConnection.BundlePolicy.MAXBUNDLE
+            rtcpMuxPolicy = PeerConnection.RtcpMuxPolicy.REQUIRE
+        }
+        runCatching { pc.setConfiguration(cfg) }
+    }
+
     override fun close() {
         runCatching { capturer?.stopCapture() }
         runCatching { capturer?.dispose() }
@@ -171,6 +209,7 @@ class RealPeerConnectionController @Inject constructor(
         capturer = null; surfaceHelper = null; videoSource = null; audioSource = null
         videoTrack = null; audioTrack = null; peer = null
         mediaHolder.clear()
+        _iceState.value = "CLOSED"
         _lifecycle.value = PeerLifecycle.Closed
     }
 
@@ -207,7 +246,10 @@ class RealPeerConnectionController @Inject constructor(
             }
         }
 
-        override fun onIceConnectionChange(s: PeerConnection.IceConnectionState) { Log.d("TLHUB", "peer iceState=$s") }
+        override fun onIceConnectionChange(s: PeerConnection.IceConnectionState) {
+            Log.d("TLHUB", "peer iceState=$s")
+            _iceState.value = s.name
+        }
         override fun onIceCandidatesRemoved(candidates: Array<out RtcIceCandidate>) {}
         override fun onSignalingChange(s: PeerConnection.SignalingState) {}
         override fun onIceGatheringChange(s: PeerConnection.IceGatheringState) {}

--- a/android/app/src/main/java/com/testlogon/android/feature/call/domain/CallConnectionMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/call/domain/CallConnectionMath.kt
@@ -1,0 +1,67 @@
+package com.testlogon.android.feature.call.domain
+
+/**
+ * FE-143 — pure (android-free, SDK-free) mapping + timing math for the WebRTC connection-state UI, ICE
+ * restart, and TURN-credential refresh. All inputs are Strings / Longs so this is fully JVM-unit-testable
+ * without pulling in the native WebRTC SDK (the ICE state is passed as its libwebrtc enum NAME).
+ *
+ * Reference for the ICE connection-state names (livekit.org.webrtc.PeerConnection.IceConnectionState):
+ * NEW, CHECKING, CONNECTED, COMPLETED, FAILED, DISCONNECTED, CLOSED.
+ */
+object CallConnectionMath {
+
+    /** Lead time (seconds) before TURN-credential expiry at which we proactively refresh on a long call. */
+    const val TURN_REFRESH_LEAD_SEC: Long = 60
+
+    /**
+     * Grace (seconds) a peer may sit in DISCONNECTED before we treat it as needing an ICE restart. A brief
+     * DISCONNECTED is often self-healing (WebRTC keeps probing), so we only restart once it persists.
+     */
+    const val ICE_DISCONNECT_GRACE_SEC: Long = 5
+
+    /**
+     * Maps a libwebrtc IceConnectionState enum NAME to the coarse UI connection status. Unknown/blank names
+     * fall back to CONNECTING (the safest "still working" state) so a new/unexpected value never crashes.
+     */
+    fun mapConnectionStatus(iceState: String?): CallConnectionStatus =
+        when (iceState?.trim()?.uppercase()) {
+            "NEW", "CHECKING" -> CallConnectionStatus.CONNECTING
+            "CONNECTED", "COMPLETED" -> CallConnectionStatus.CONNECTED
+            "DISCONNECTED" -> CallConnectionStatus.RECONNECTING
+            "FAILED" -> CallConnectionStatus.FAILED
+            "CLOSED" -> CallConnectionStatus.CLOSED
+            else -> CallConnectionStatus.CONNECTING
+        }
+
+    /**
+     * Whether an ICE restart should be triggered for [iceState]. FAILED always restarts. DISCONNECTED
+     * restarts only once it has persisted past [ICE_DISCONNECT_GRACE_SEC] (measured by the caller as
+     * [disconnectedForSec]); a brief blip is left to WebRTC's own re-probing.
+     */
+    fun shouldIceRestart(iceState: String?, disconnectedForSec: Long = Long.MAX_VALUE): Boolean =
+        when (iceState?.trim()?.uppercase()) {
+            "FAILED" -> true
+            "DISCONNECTED" -> disconnectedForSec >= ICE_DISCONNECT_GRACE_SEC
+            else -> false
+        }
+
+    /** True once the TURN credentials have expired at [nowSec] (expiry is epoch SECONDS). */
+    fun isTurnExpired(expiresAtSec: Long, nowSec: Long): Boolean = nowSec >= expiresAtSec
+
+    /**
+     * True when TURN credentials should be proactively refreshed: within [leadSec] of expiry (or already
+     * expired). A non-positive [expiresAtSec] means "no known expiry" (e.g. STUN-only fallback) — never
+     * refresh in that case.
+     */
+    fun shouldRefreshTurn(
+        expiresAtSec: Long,
+        nowSec: Long,
+        leadSec: Long = TURN_REFRESH_LEAD_SEC,
+    ): Boolean {
+        if (expiresAtSec <= 0L) return false
+        return nowSec >= expiresAtSec - leadSec
+    }
+}
+
+/** FE-143 — coarse UI connection status derived from the peer ICE connection state. */
+enum class CallConnectionStatus { CONNECTING, CONNECTED, RECONNECTING, FAILED, CLOSED }

--- a/android/app/src/main/java/com/testlogon/android/feature/call/domain/CallManager.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/call/domain/CallManager.kt
@@ -58,6 +58,18 @@ class CallManager @Inject constructor(
     private var ringTimeoutJob: Job? = null
     private var heartbeatJob: Job? = null
 
+    init {
+        // FE-143 - mirror the peer ICE connection state into the call snapshot so the call UI can render a
+        // connection-state badge. App-scoped: one shared peer / one active call, so a single collector is
+        // sufficient; it projects the raw ICE state name via the pure CallConnectionMath mapping.
+        scope.launch {
+            peer.iceState.collect { iceName ->
+                if (_state.value.call == null) return@collect
+                _state.update { it.copy(connectionStatus = CallConnectionMath.mapConnectionStatus(iceName)) }
+            }
+        }
+    }
+
     /** True while a call occupies the manager (single-active-call invariant, AND-296 FR-10). */
     fun isBusy(): Boolean = _state.value.phase != CallPhase.Idle && !_state.value.phase.isTerminal
 
@@ -181,7 +193,7 @@ class CallManager @Inject constructor(
         }
         android.util.Log.d("TLHUB", "onConnected: phase->Connected call=${active.callId}")
         ringTimeoutJob?.cancel()
-        _state.update { it.copy(phase = CallPhase.Connected(clock.now())) }
+        _state.update { it.copy(phase = CallPhase.Connected(clock.now()), connectionStatus = CallConnectionStatus.CONNECTED) }
         startHeartbeat(active)
     }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/call/domain/CallPhase.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/call/domain/CallPhase.kt
@@ -54,6 +54,12 @@ data class CallSessionState(
     val peerName: String? = null,
     val elapsedSeconds: Long = 0,
     val warnLowBalance: Boolean = false,
+    /**
+     * FE-143 — coarse WebRTC connection status derived from the peer ICE connection state
+     * ([CallConnectionMath.mapConnectionStatus]). Null until the peer starts negotiating; the UI renders a
+     * Connecting / Connected / Reconnecting / Connection-failed badge from it.
+     */
+    val connectionStatus: CallConnectionStatus? = null,
     val minutesRemaining: Double? = null,
     /**
      * AND-296/297 — set true when the FLAGGED WebRTC media stubs returned NotConfigured, so the UI can

--- a/android/app/src/main/java/com/testlogon/android/feature/call/ui/OutgoingCallScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/call/ui/OutgoingCallScreen.kt
@@ -111,6 +111,17 @@ fun OutgoingCallScreen(
                 .testTag("outgoing_call_phase")
                 .semantics { liveRegion = LiveRegionMode.Polite },
         )
+        connectionBadge(state)?.let { badge ->
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = badge,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .testTag("outgoing_call_connection")
+                    .semantics { liveRegion = LiveRegionMode.Polite },
+            )
+        }
         if (state.mediaUnavailable) {
             Spacer(Modifier.height(8.dp))
             Text(
@@ -185,4 +196,22 @@ internal fun formatDuration(totalSeconds: Long): String {
     val minutes = s / 60
     val seconds = s % 60
     return "%02d:%02d".format(minutes, seconds)
+}
+
+/**
+ * FE-143 - connection-state badge copy for the call screen. Rendered alongside the phase label so a user on
+ * a flaky NAT sees Connecting / Connected / Reconnecting / Connection failed as the ICE state changes.
+ * Only shown once the WebRTC connection status is known (i.e. negotiation has started).
+ */
+@Composable
+private fun connectionBadge(state: CallUiState): String? = when (state.connectionStatus) {
+    com.testlogon.android.feature.call.domain.CallConnectionStatus.CONNECTING ->
+        stringResource(R.string.call_conn_connecting)
+    com.testlogon.android.feature.call.domain.CallConnectionStatus.CONNECTED ->
+        stringResource(R.string.call_conn_connected)
+    com.testlogon.android.feature.call.domain.CallConnectionStatus.RECONNECTING ->
+        stringResource(R.string.call_conn_reconnecting)
+    com.testlogon.android.feature.call.domain.CallConnectionStatus.FAILED ->
+        stringResource(R.string.call_conn_failed)
+    com.testlogon.android.feature.call.domain.CallConnectionStatus.CLOSED, null -> null
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/call/ui/OutgoingCallViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/call/ui/OutgoingCallViewModel.kt
@@ -32,6 +32,8 @@ data class CallUiState(
     val elapsedSeconds: Long,
     val mediaUnavailable: Boolean,
     val canRetry: Boolean,
+    // FE-143 - WebRTC connection status for the connection-state badge (null until negotiation starts).
+    val connectionStatus: com.testlogon.android.feature.call.domain.CallConnectionStatus? = null,
 )
 
 /** Coarse UI phase derived from the domain [CallPhase]. */
@@ -181,6 +183,7 @@ class OutgoingCallViewModel @Inject constructor(
         elapsedSeconds = elapsedSeconds,
         mediaUnavailable = mediaUnavailable,
         canRetry = phase is CallPhase.Failed,
+        connectionStatus = connectionStatus,
     )
 
     private fun CallPhase.toUiPhase(): CallUiPhase = when (this) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1026,6 +1026,10 @@
     <string name="call_status_ended">Call ended</string>
     <string name="call_status_failed">Call failed</string>
     <string name="call_media_unavailable">Call media unavailable</string>
+    <string name="call_conn_connecting">Connecting</string>
+    <string name="call_conn_connected">Connected</string>
+    <string name="call_conn_reconnecting">Reconnecting…</string>
+    <string name="call_conn_failed">Connection failed</string>
     <string name="call_end">End</string>
     <string name="call_end_cd">End call</string>
     <string name="call_start_cd">Call</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/call/domain/CallConnectionMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/call/domain/CallConnectionMathTest.kt
@@ -1,0 +1,99 @@
+package com.testlogon.android.feature.call.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** FE-143 — pure unit tests for the connection-state / ICE-restart / TURN-refresh math. */
+class CallConnectionMathTest {
+
+    // ── mapConnectionStatus ──────────────────────────────────────────────────────────────────────
+    @Test fun `new maps to connecting`() =
+        assertEquals(CallConnectionStatus.CONNECTING, CallConnectionMath.mapConnectionStatus("NEW"))
+
+    @Test fun `checking maps to connecting`() =
+        assertEquals(CallConnectionStatus.CONNECTING, CallConnectionMath.mapConnectionStatus("CHECKING"))
+
+    @Test fun `connected maps to connected`() =
+        assertEquals(CallConnectionStatus.CONNECTED, CallConnectionMath.mapConnectionStatus("CONNECTED"))
+
+    @Test fun `completed maps to connected`() =
+        assertEquals(CallConnectionStatus.CONNECTED, CallConnectionMath.mapConnectionStatus("COMPLETED"))
+
+    @Test fun `disconnected maps to reconnecting`() =
+        assertEquals(CallConnectionStatus.RECONNECTING, CallConnectionMath.mapConnectionStatus("DISCONNECTED"))
+
+    @Test fun `failed maps to failed`() =
+        assertEquals(CallConnectionStatus.FAILED, CallConnectionMath.mapConnectionStatus("FAILED"))
+
+    @Test fun `closed maps to closed`() =
+        assertEquals(CallConnectionStatus.CLOSED, CallConnectionMath.mapConnectionStatus("CLOSED"))
+
+    @Test fun `lowercase and whitespace are normalised`() =
+        assertEquals(CallConnectionStatus.CONNECTED, CallConnectionMath.mapConnectionStatus("  connected "))
+
+    @Test fun `unknown or null falls back to connecting`() {
+        assertEquals(CallConnectionStatus.CONNECTING, CallConnectionMath.mapConnectionStatus(null))
+        assertEquals(CallConnectionStatus.CONNECTING, CallConnectionMath.mapConnectionStatus("WAT"))
+    }
+
+    // ── shouldIceRestart ─────────────────────────────────────────────────────────────────────────
+    @Test fun `failed always restarts`() =
+        assertTrue(CallConnectionMath.shouldIceRestart("FAILED", disconnectedForSec = 0))
+
+    @Test fun `disconnected within grace does not restart`() =
+        assertFalse(CallConnectionMath.shouldIceRestart("DISCONNECTED", disconnectedForSec = 1))
+
+    @Test fun `disconnected past grace restarts`() =
+        assertTrue(
+            CallConnectionMath.shouldIceRestart(
+                "DISCONNECTED",
+                disconnectedForSec = CallConnectionMath.ICE_DISCONNECT_GRACE_SEC,
+            ),
+        )
+
+    @Test fun `connected never restarts`() =
+        assertFalse(CallConnectionMath.shouldIceRestart("CONNECTED", disconnectedForSec = 999))
+
+    @Test fun `null never restarts`() =
+        assertFalse(CallConnectionMath.shouldIceRestart(null))
+
+    // ── isTurnExpired ────────────────────────────────────────────────────────────────────────────
+    @Test fun `turn not expired before expiry`() =
+        assertFalse(CallConnectionMath.isTurnExpired(expiresAtSec = 1000, nowSec = 999))
+
+    @Test fun `turn expired at and after expiry`() {
+        assertTrue(CallConnectionMath.isTurnExpired(expiresAtSec = 1000, nowSec = 1000))
+        assertTrue(CallConnectionMath.isTurnExpired(expiresAtSec = 1000, nowSec = 1001))
+    }
+
+    // ── shouldRefreshTurn ────────────────────────────────────────────────────────────────────────
+    @Test fun `refresh not due well before lead window`() =
+        assertFalse(
+            CallConnectionMath.shouldRefreshTurn(expiresAtSec = 1000, nowSec = 800, leadSec = 60),
+        )
+
+    @Test fun `refresh due once inside lead window`() =
+        assertTrue(
+            CallConnectionMath.shouldRefreshTurn(expiresAtSec = 1000, nowSec = 940, leadSec = 60),
+        )
+
+    @Test fun `refresh due when already expired`() =
+        assertTrue(
+            CallConnectionMath.shouldRefreshTurn(expiresAtSec = 1000, nowSec = 5000, leadSec = 60),
+        )
+
+    @Test fun `no expiry means never refresh`() {
+        assertFalse(CallConnectionMath.shouldRefreshTurn(expiresAtSec = 0, nowSec = 5000))
+        assertFalse(CallConnectionMath.shouldRefreshTurn(expiresAtSec = -1, nowSec = 5000))
+    }
+
+    @Test fun `default lead constant is used`() =
+        assertTrue(
+            CallConnectionMath.shouldRefreshTurn(
+                expiresAtSec = 1000,
+                nowSec = 1000 - CallConnectionMath.TURN_REFRESH_LEAD_SEC,
+            ),
+        )
+}

--- a/frontend/src/hooks/useRtcPeerConnection.ts
+++ b/frontend/src/hooks/useRtcPeerConnection.ts
@@ -16,6 +16,11 @@ import type { CallUiState } from "@/pages/messages/CallSessionOverlay";
 import type { DirectCallMode, SignalingPayload } from "@/api/endpoints/messaging";
 import { fetchTurnCredentials, sendSignalingEvent } from "@/api/endpoints/messaging";
 import { acquireLocalMedia, createIceCandidateBuffer, generateNonce, generateEventId } from "@/lib/webrtc";
+import {
+  shouldIceRestart,
+  shouldRefreshTurn,
+  TURN_REFRESH_LEAD_SEC,
+} from "@/lib/callConnection";
 
 /** Grace period (ms) before escalating ICE "disconnected" to CONNECTION_LOST. */
 const ICE_DISCONNECT_GRACE_MS = 3000;
@@ -40,6 +45,7 @@ export interface UseRtcPeerConnectionReturn {
   remoteStream: MediaStream | null;
   resources: CallRuntimeResources | null;
   connectionState: RTCPeerConnectionState | null;
+  iceConnectionState: RTCIceConnectionState | null;
   performIceRestart: () => Promise<void>;
 }
 
@@ -85,6 +91,7 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
   const [localStream, setLocalStream] = React.useState<MediaStream | null>(null);
   const [remoteStream, setRemoteStream] = React.useState<MediaStream | null>(null);
   const [connectionState, setConnectionState] = React.useState<RTCPeerConnectionState | null>(null);
+  const [iceConnectionState, setIceConnectionState] = React.useState<RTCIceConnectionState | null>(null);
   const [resources, setResources] = React.useState<CallRuntimeResources | null>(null);
 
   // Stable refs for callbacks to avoid re-triggering the effect
@@ -99,6 +106,10 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
   const setupCallIdRef = React.useRef<string | null>(null);
   const pcRef = React.useRef<RTCPeerConnection | null>(null);
   const iceDisconnectTimerRef = React.useRef<number | null>(null);
+  // TURN credential expiry (epoch seconds) for proactive refresh on long calls.
+  const turnExpiresAtRef = React.useRef<number | null>(null);
+  // Guards against overlapping ICE restarts (failed + disconnected can both fire).
+  const iceRestartInProgressRef = React.useRef<boolean>(false);
 
   const activate = enabled && !!callId && shouldActivate(phase, role);
 
@@ -125,6 +136,7 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
           username: s.username,
           credential: s.credential,
         }));
+        turnExpiresAtRef.current = turnResp.expires_at ?? null;
       } catch {
         // TURN fetch may fail (feature disabled, etc.) — continue with empty ICE servers
         // (will use STUN/host candidates only, or fail gracefully)
@@ -215,6 +227,7 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
       //    their own within this window.
       pc.oniceconnectionstatechange = () => {
         const state = pc.iceConnectionState;
+        setIceConnectionState(state);
 
         if (state === "disconnected") {
           // Start grace period
@@ -226,6 +239,10 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
             // Re-check — might have recovered during grace period
             if (pc.iceConnectionState === "disconnected") {
               onConnectionLostRef.current?.("ICE connection interrupted.");
+              // FE-143: past grace on a persistent disconnect — restart ICE.
+              if (shouldIceRestart("disconnected", true)) {
+                void maybeIceRestartRef.current?.();
+              }
             }
           }, ICE_DISCONNECT_GRACE_MS);
         } else if (state === "failed") {
@@ -235,6 +252,10 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
             iceDisconnectTimerRef.current = null;
           }
           onConnectionLostRef.current?.("ICE connection failed.");
+          // FE-143: attempt an ICE restart (refreshes TURN relays first).
+          if (shouldIceRestart(state)) {
+            void maybeIceRestartRef.current?.();
+          }
         } else if (state === "connected" || state === "completed") {
           // Connection recovered — cancel any pending grace timer and notify success
           if (iceDisconnectTimerRef.current != null) {
@@ -428,6 +449,7 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
       if (iceServers.length > 0) {
         pc.setConfiguration({ iceServers });
       }
+      turnExpiresAtRef.current = turnResp.expires_at ?? turnExpiresAtRef.current;
     } catch {
       // TURN refresh failed — continue with existing credentials
     }
@@ -455,6 +477,66 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
     }
   }, [callId, conversationId, peerId]);
 
+  // FE-143: overlap-guarded ICE restart. Multiple ICE state transitions
+  // (disconnected-past-grace, then failed) can each request a restart; the
+  // guard ensures only one renegotiation is in flight at a time.
+  const maybeIceRestart = React.useCallback(async () => {
+    if (iceRestartInProgressRef.current) return;
+    const pc = pcRef.current;
+    if (!pc || pc.connectionState === "closed") return;
+    iceRestartInProgressRef.current = true;
+    try {
+      await performIceRestart();
+    } finally {
+      iceRestartInProgressRef.current = false;
+    }
+  }, [performIceRestart]);
+
+  // Ref so the (stable) PC event handlers set up in the setup effect can reach
+  // the latest maybeIceRestart without re-running setup.
+  const maybeIceRestartRef = React.useRef(maybeIceRestart);
+  maybeIceRestartRef.current = maybeIceRestart;
+
+  // FE-143: refresh TURN credentials before the allocation TTL expires so calls
+  // that outlive the TTL keep valid relays. Re-uses fetchTurnCredentials and
+  // pushes the new ice_servers into the live PC via setConfiguration. Degrades
+  // gracefully (no-op) when TURN is disabled / returns no servers.
+  const refreshTurnCredentials = React.useCallback(async () => {
+    const pc = pcRef.current;
+    if (!pc || pc.connectionState === "closed" || !callId) return;
+    try {
+      const turnResp = await fetchTurnCredentials(callId);
+      const iceServers: RTCIceServer[] = turnResp.ice_servers.map((s) => ({
+        urls: s.urls,
+        username: s.username,
+        credential: s.credential,
+      }));
+      if (iceServers.length > 0) {
+        pc.setConfiguration({ iceServers });
+      }
+      turnExpiresAtRef.current = turnResp.expires_at ?? turnExpiresAtRef.current;
+    } catch {
+      // TURN refresh failed (feature disabled, transient error) — keep going on
+      // existing credentials / STUN. Never crash the call over a refresh miss.
+    }
+  }, [callId]);
+
+  // Periodic TTL check while connected. A single interval polls a pure
+  // predicate (shouldRefreshTurn) against the tracked expiry; the timer is torn
+  // down when the hook deactivates (see deps) so there are no leaks.
+  React.useEffect(() => {
+    if (!activate || !callId) return;
+    const intervalId = window.setInterval(() => {
+      const expiresAt = turnExpiresAtRef.current;
+      if (expiresAt == null) return; // STUN-only / TURN disabled — nothing to refresh
+      const nowSec = Math.floor(Date.now() / 1000);
+      if (shouldRefreshTurn(expiresAt, nowSec, TURN_REFRESH_LEAD_SEC)) {
+        void refreshTurnCredentials();
+      }
+    }, 15000);
+    return () => window.clearInterval(intervalId);
+  }, [activate, callId, refreshTurnCredentials]);
+
   // Trigger ICE restart when state machine moves to outgoing_connecting after
   // a reconnect attempt (retryCount > 0).
   React.useEffect(() => {
@@ -480,8 +562,11 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
         setLocalStream(null);
         setRemoteStream(null);
         setConnectionState(null);
+        setIceConnectionState(null);
         setupCallIdRef.current = null;
         pcRef.current = null;
+        turnExpiresAtRef.current = null;
+        iceRestartInProgressRef.current = false;
       }
       // Clear any pending ICE disconnect timer
       if (iceDisconnectTimerRef.current != null) {
@@ -513,6 +598,7 @@ export function useRtcPeerConnection(params: UseRtcPeerConnectionParams): UseRtc
     remoteStream,
     resources,
     connectionState,
+    iceConnectionState,
     performIceRestart,
   };
 }

--- a/frontend/src/lib/callConnection.test.ts
+++ b/frontend/src/lib/callConnection.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TURN_REFRESH_LEAD_SEC,
+  mapConnectionStatus,
+  connectionBadge,
+  shouldIceRestart,
+  isTurnExpired,
+  shouldRefreshTurn,
+  type CallConnectionStatus,
+} from "./callConnection";
+
+describe("mapConnectionStatus", () => {
+  it("returns 'new' when both states are unknown", () => {
+    expect(mapConnectionStatus(null, null)).toEqual({ status: "new", label: "Starting…" });
+    expect(mapConnectionStatus("new", "new").status).toBe("new");
+    expect(mapConnectionStatus(undefined, undefined).status).toBe("new");
+  });
+
+  it("maps connecting/checking to 'connecting'", () => {
+    expect(mapConnectionStatus("connecting", null).status).toBe("connecting");
+    expect(mapConnectionStatus(null, "checking").status).toBe("connecting");
+    expect(mapConnectionStatus("connecting", "checking").label).toBe("Connecting…");
+  });
+
+  it("maps connected/completed to 'connected'", () => {
+    expect(mapConnectionStatus("connected", "connected").status).toBe("connected");
+    expect(mapConnectionStatus(null, "completed").status).toBe("connected");
+    expect(mapConnectionStatus("connected", null).label).toBe("Connected");
+  });
+
+  it("maps disconnected to 'reconnecting'", () => {
+    expect(mapConnectionStatus("disconnected", "disconnected").status).toBe("reconnecting");
+    expect(mapConnectionStatus(null, "disconnected").status).toBe("reconnecting");
+    expect(mapConnectionStatus("disconnected", "disconnected").label).toBe("Reconnecting…");
+  });
+
+  it("maps failed to 'failed'", () => {
+    expect(mapConnectionStatus("failed", null).status).toBe("failed");
+    expect(mapConnectionStatus(null, "failed").status).toBe("failed");
+    expect(mapConnectionStatus("failed", "failed").label).toBe("Connection failed");
+  });
+
+  it("maps closed to 'closed'", () => {
+    expect(mapConnectionStatus("closed", null).status).toBe("closed");
+    expect(mapConnectionStatus("closed", "closed").label).toBe("Call ended");
+  });
+
+  describe("precedence: failed > connected > reconnecting > connecting > new", () => {
+    it("failed beats connected", () => {
+      expect(mapConnectionStatus("failed", "connected").status).toBe("failed");
+      expect(mapConnectionStatus("connected", "failed").status).toBe("failed");
+    });
+
+    it("failed beats closed", () => {
+      expect(mapConnectionStatus("closed", "failed").status).toBe("failed");
+    });
+
+    it("connected beats reconnecting(disconnected) when pc is connected", () => {
+      // pc connected but ice disconnected -> connected wins per precedence
+      expect(mapConnectionStatus("connected", "disconnected").status).toBe("connected");
+    });
+
+    it("reconnecting beats connecting", () => {
+      expect(mapConnectionStatus("disconnected", "checking").status).toBe("reconnecting");
+    });
+
+    it("connecting beats new", () => {
+      expect(mapConnectionStatus("connecting", "new").status).toBe("connecting");
+    });
+  });
+});
+
+describe("connectionBadge", () => {
+  it("returns label + tone for every status", () => {
+    const expected: Record<CallConnectionStatus, string> = {
+      new: "neutral",
+      connecting: "info",
+      connected: "success",
+      reconnecting: "warning",
+      failed: "danger",
+      closed: "neutral",
+    };
+    (Object.keys(expected) as CallConnectionStatus[]).forEach((status) => {
+      const badge = connectionBadge(status);
+      expect(badge.tone).toBe(expected[status]);
+      expect(badge.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("label matches mapConnectionStatus label for connected", () => {
+    expect(connectionBadge("connected").label).toBe(mapConnectionStatus("connected", null).label);
+  });
+});
+
+describe("shouldIceRestart", () => {
+  it("always restarts on failed", () => {
+    expect(shouldIceRestart("failed")).toBe(true);
+    expect(shouldIceRestart("failed", false)).toBe(true);
+  });
+
+  it("restarts on disconnected only past grace", () => {
+    expect(shouldIceRestart("disconnected")).toBe(false);
+    expect(shouldIceRestart("disconnected", false)).toBe(false);
+    expect(shouldIceRestart("disconnected", true)).toBe(true);
+  });
+
+  it("does not restart on healthy/other states", () => {
+    expect(shouldIceRestart("connected", true)).toBe(false);
+    expect(shouldIceRestart("checking", true)).toBe(false);
+    expect(shouldIceRestart("completed", true)).toBe(false);
+    expect(shouldIceRestart("new", true)).toBe(false);
+    expect(shouldIceRestart(null, true)).toBe(false);
+    expect(shouldIceRestart(undefined, true)).toBe(false);
+  });
+});
+
+describe("isTurnExpired", () => {
+  it("is false strictly before expiry", () => {
+    expect(isTurnExpired(1000, 999)).toBe(false);
+  });
+
+  it("is true at and after expiry", () => {
+    expect(isTurnExpired(1000, 1000)).toBe(true);
+    expect(isTurnExpired(1000, 1001)).toBe(true);
+  });
+});
+
+describe("shouldRefreshTurn", () => {
+  it("does not refresh when comfortably before the lead window", () => {
+    // expires at 1000, lead 60 -> refresh boundary is 940
+    expect(shouldRefreshTurn(1000, 939, 60)).toBe(false);
+  });
+
+  it("refreshes once within the lead window", () => {
+    expect(shouldRefreshTurn(1000, 940, 60)).toBe(true);
+    expect(shouldRefreshTurn(1000, 970, 60)).toBe(true);
+  });
+
+  it("refreshes when already expired", () => {
+    expect(shouldRefreshTurn(1000, 1001, 60)).toBe(true);
+  });
+
+  it("uses TURN_REFRESH_LEAD_SEC as the default lead", () => {
+    const expires = 5000;
+    const boundary = expires - TURN_REFRESH_LEAD_SEC;
+    expect(shouldRefreshTurn(expires, boundary - 1)).toBe(false);
+    expect(shouldRefreshTurn(expires, boundary)).toBe(true);
+  });
+
+  it("has a positive default lead", () => {
+    expect(TURN_REFRESH_LEAD_SEC).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/lib/callConnection.ts
+++ b/frontend/src/lib/callConnection.ts
@@ -1,0 +1,134 @@
+/**
+ * callConnection — pure, deterministic helpers for WebRTC call connection
+ * state (FE-143, EPIC E). These have no browser/RTC dependencies so they are
+ * unit-testable in isolation. All time is passed in as integer epoch seconds
+ * (nowSec injected) — nothing here reads the clock.
+ *
+ * Responsibilities:
+ *  - mapConnectionStatus: collapse RTCPeerConnectionState + RTCIceConnectionState
+ *    into a single UI status with a deterministic precedence.
+ *  - connectionBadge: presentation (label + tone) for a status.
+ *  - shouldIceRestart: decide when to trigger an ICE restart.
+ *  - isTurnExpired / shouldRefreshTurn: TURN credential TTL math for long calls.
+ */
+
+/** Coarse connection status surfaced in the call UI. */
+export type CallConnectionStatus =
+  | "new"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "failed"
+  | "closed";
+
+export interface ConnectionStatusResult {
+  status: CallConnectionStatus;
+  label: string;
+}
+
+/** Visual tone for a connection badge. */
+export type ConnectionBadgeTone = "neutral" | "info" | "success" | "warning" | "danger";
+
+export interface ConnectionBadge {
+  label: string;
+  tone: ConnectionBadgeTone;
+}
+
+/**
+ * Seconds before a TURN credential's expiry at which we proactively refresh.
+ * Kept comfortably ahead of typical fetch + ICE-reconfig latency so a long
+ * call never runs on an expired allocation.
+ */
+export const TURN_REFRESH_LEAD_SEC = 60;
+
+const STATUS_LABEL: Record<CallConnectionStatus, string> = {
+  new: "Starting…",
+  connecting: "Connecting…",
+  connected: "Connected",
+  reconnecting: "Reconnecting…",
+  failed: "Connection failed",
+  closed: "Call ended",
+};
+
+/**
+ * Collapse the two native RTC state enums into one UI status.
+ *
+ * Precedence (highest first):
+ *   failed > closed > connected > reconnecting(disconnected) > connecting > new
+ *
+ * The PeerConnection aggregate (pcState) is authoritative for terminal/success
+ * states; the ICE state distinguishes a transient "disconnected" (-> reconnecting)
+ * from a clean "connecting". A null for either enum is treated as "not yet known".
+ */
+export function mapConnectionStatus(
+  pcState: RTCPeerConnectionState | null | undefined,
+  iceState: RTCIceConnectionState | null | undefined,
+): ConnectionStatusResult {
+  // failed wins over everything
+  if (pcState === "failed" || iceState === "failed") {
+    return { status: "failed", label: STATUS_LABEL.failed };
+  }
+  if (pcState === "closed") {
+    return { status: "closed", label: STATUS_LABEL.closed };
+  }
+  // connected/completed is a positive signal from either enum
+  if (pcState === "connected" || iceState === "connected" || iceState === "completed") {
+    return { status: "connected", label: STATUS_LABEL.connected };
+  }
+  // a live-but-interrupted connection: ICE dropped to disconnected
+  if (pcState === "disconnected" || iceState === "disconnected") {
+    return { status: "reconnecting", label: STATUS_LABEL.reconnecting };
+  }
+  if (pcState === "connecting" || iceState === "checking") {
+    return { status: "connecting", label: STATUS_LABEL.connecting };
+  }
+  return { status: "new", label: STATUS_LABEL.new };
+}
+
+const BADGE_TONE: Record<CallConnectionStatus, ConnectionBadgeTone> = {
+  new: "neutral",
+  connecting: "info",
+  connected: "success",
+  reconnecting: "warning",
+  failed: "danger",
+  closed: "neutral",
+};
+
+/** Presentation for a connection status: label + tone. */
+export function connectionBadge(status: CallConnectionStatus): ConnectionBadge {
+  return { label: STATUS_LABEL[status], tone: BADGE_TONE[status] };
+}
+
+/**
+ * Whether an ICE restart should be attempted for the given ICE state.
+ *
+ * - "failed": always restart (the connection is dead, negotiation is required).
+ * - "disconnected": restart only once the grace period has elapsed — a brief
+ *   blip often self-heals. `pastGrace` is decided by the caller (which owns the
+ *   grace timer); default false so a bare "disconnected" does not thrash.
+ */
+export function shouldIceRestart(
+  iceState: RTCIceConnectionState | null | undefined,
+  pastGrace = false,
+): boolean {
+  if (iceState === "failed") return true;
+  if (iceState === "disconnected") return pastGrace;
+  return false;
+}
+
+/** Whether a TURN credential (expiry in epoch seconds) is already expired. */
+export function isTurnExpired(expiresAtSec: number, nowSec: number): boolean {
+  return nowSec >= expiresAtSec;
+}
+
+/**
+ * Whether TURN credentials should be refreshed now: true once we are within
+ * `leadSec` of expiry (and, a fortiori, once already expired).
+ */
+export function shouldRefreshTurn(
+  expiresAtSec: number,
+  nowSec: number,
+  leadSec: number = TURN_REFRESH_LEAD_SEC,
+): boolean {
+  return nowSec >= expiresAtSec - leadSec;
+}

--- a/frontend/src/pages/messages/CallSessionOverlay.tsx
+++ b/frontend/src/pages/messages/CallSessionOverlay.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import type { DirectCallMode } from "@/api/endpoints/messaging";
 import { useConnectionQuality, type ConnectionQuality } from "@/hooks/useConnectionQuality";
 import { CallBillingOverlay } from "@/components/calls/CallBillingOverlay";
+import { mapConnectionStatus, connectionBadge, type ConnectionBadgeTone } from "@/lib/callConnection";
 
 export type CallUiState =
   | "idle"
@@ -48,6 +49,8 @@ interface Props {
   localStream?: MediaStream | null;
   remoteStream?: MediaStream | null;
   peerConnection?: RTCPeerConnection | null;
+  connectionState?: RTCPeerConnectionState | null;
+  iceConnectionState?: RTCIceConnectionState | null;
   isMuted?: boolean;
   isCameraOff?: boolean;
   onAccept: () => void;
@@ -293,6 +296,49 @@ function ConnectionQualityIndicator({
   );
 }
 
+// ─── Connection-state badge (FE-143) ───────────────────────────────────────
+
+const badgeToneClass: Record<ConnectionBadgeTone, string> = {
+  neutral: "bg-muted text-muted-foreground",
+  info: "bg-blue-500/15 text-blue-600 dark:text-blue-300",
+  success: "bg-green-500/15 text-green-600 dark:text-green-300",
+  warning: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
+  danger: "bg-red-500/15 text-red-600 dark:text-red-300",
+};
+
+/**
+ * Renders the granular WebRTC connection state (from mapConnectionStatus) as a
+ * small pill next to the coarse phase text. Hidden until at least one of the
+ * RTC state enums is known.
+ */
+function ConnectionStateBadge({
+  connectionState,
+  iceConnectionState,
+  className,
+}: {
+  connectionState?: RTCPeerConnectionState | null;
+  iceConnectionState?: RTCIceConnectionState | null;
+  className?: string;
+}) {
+  if (connectionState == null && iceConnectionState == null) return null;
+  const { status } = mapConnectionStatus(connectionState, iceConnectionState);
+  const badge = connectionBadge(status);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        badgeToneClass[badge.tone],
+        className,
+      )}
+      data-testid="connection-state-badge"
+      data-connection-status={status}
+      aria-label={`Connection: ${badge.label}`}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
 // ─── Main component ────────────────────────────────────────────────────────
 
 /** Detect if a failure is permission-related based on the reason message. */
@@ -310,6 +356,8 @@ export function CallSessionOverlay({
   localStream,
   remoteStream,
   peerConnection,
+  connectionState,
+  iceConnectionState,
   isMuted,
   isCameraOff,
   onAccept,
@@ -449,6 +497,10 @@ export function CallSessionOverlay({
               />
               <span className="text-sm font-medium">{session.peerName}</span>
               <CallTimer running />
+              <ConnectionStateBadge
+                connectionState={connectionState}
+                iceConnectionState={iceConnectionState}
+              />
             </div>
           </div>
 
@@ -569,7 +621,10 @@ export function CallSessionOverlay({
                   rtt={connectionQuality.rtt}
                   packetLoss={connectionQuality.packetLoss}
                 />
-                <span className="text-xs text-muted-foreground">Connected</span>
+                <ConnectionStateBadge
+                  connectionState={connectionState}
+                  iceConnectionState={iceConnectionState}
+                />
                 <CallTimer running />
               </div>
             </div>
@@ -659,6 +714,14 @@ export function CallSessionOverlay({
             {!isPermissionDenied && session.state === "outgoing_connecting" && `Connecting to ${session.peerName}…`}
             {!isPermissionDenied && session.state === "reconnecting" && `Reconnecting to ${session.peerName}…`}
             {!isPermissionDenied && isOutcome && (session.reasonMessage ?? outcomeCopy[session.state as keyof typeof outcomeCopy])}
+            {!isPermissionDenied && (session.state === "outgoing_connecting" || session.state === "reconnecting") && (
+              <span className="ml-2 align-middle">
+                <ConnectionStateBadge
+                  connectionState={connectionState}
+                  iceConnectionState={iceConnectionState}
+                />
+              </span>
+            )}
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/pages/messages/ConversationView.tsx
+++ b/frontend/src/pages/messages/ConversationView.tsx
@@ -861,7 +861,7 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
   const rtcEnabled = callMachine.phase !== "idle" &&
     !["declined", "busy", "timeout", "ended", "failure"].includes(callMachine.phase);
 
-  const { resources: rtcResources, localStream: rtcLocalStream, remoteStream: rtcRemoteStream } = useRtcPeerConnection({
+  const { resources: rtcResources, localStream: rtcLocalStream, remoteStream: rtcRemoteStream, connectionState: rtcConnectionState, iceConnectionState: rtcIceConnectionState } = useRtcPeerConnection({
     callId: callMachine.callId,
     conversationId: convoId,
     role: callMachine.role,
@@ -1773,6 +1773,8 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         localStream={rtcLocalStream ?? mediaCapture.stream ?? null}
         remoteStream={rtcRemoteStream ?? null}
         peerConnection={rtcResources?.peerConnection ?? null}
+        connectionState={rtcConnectionState}
+        iceConnectionState={rtcIceConnectionState}
         onAccept={async () => {
           if (!callMachine.callId) return;
 


### PR DESCRIPTION
## FE-143 — WebRTC call UI on TURN (completes EPIC E — final ticket)

Surfaces WebRTC **connection state** in the call UI, **restarts ICE** on reconnect, and **refreshes TURN creds** before TTL on long calls, so calls connect across NATs and show a connected state. The real TURN server/creds remain a backend **ops/env gate** (BE-143: `MESSAGING_WEBRTC_TURN_ENABLED/_URLS/_SECRET`); the client consumes them and **degrades to STUN-only** (no crash) when absent.

### Web
- NEW pure `lib/callConnection.ts` (+23 vitest) — `mapConnectionStatus` (precedence failed>closed>connected>reconnecting>connecting>new), `connectionBadge`, `shouldIceRestart`, `isTurnExpired`, `shouldRefreshTurn`, `TURN_REFRESH_LEAD_SEC`.
- `useRtcPeerConnection` tracks/returns `iceConnectionState`, triggers an overlap-guarded ICE restart on failed / disconnected-past-grace (re-fetching TURN first), and runs a 15s TURN-refresh timer (`setConfiguration` before expiry, cleaned up on teardown); `CallSessionOverlay` renders a connection-state badge (ConversationView threads the states in).

### Android
- NEW pure `CallConnectionMath.kt` (+21 JVM tests); `RealPeerConnectionController` publishes ICE state from `onIceConnectionChange` + implements `restartIce()`/`setConfiguration()`; `CallSignalingHub` runs an ICE-restart watcher + TURN-refresh ticker (children of `negotiate()`'s scope, cancelled on terminal phase); `CallManager` maps ICE state → `connectionStatus`; `OutgoingCallScreen` renders the badge. Reuses `IceServersRepository` (forceRefresh) verbatim. STUN fallback preserved; `WEBRTC_FORCE_RELAY` untouched.

### Gates
- Web: tsc 0 · build green · 23/23 vitest
- Android: BUILD SUCCESSFUL · CallConnectionMathTest 21/21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
