### PR TITLE
FE parity PAR-101 - conversation lifecycle (web + Android delete)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/messaging/group/ConversationDeleteMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/group/ConversationDeleteMath.kt
@@ -1,0 +1,25 @@
+package com.testlogon.android.data.messaging.group
+
+/**
+ * AND-160 — pure decision logic for the "Delete conversation" action (DELETE
+ * /messaging/conversations/{id}). Kept as a tiny pure object so the degrade-on-404 rule is
+ * unit-testable without a network or Room, and reused by [GroupRepositoryImpl.deleteConversation].
+ *
+ * Rule: a successful DELETE removes the conversation. A 404 (already gone) and a 410 (gone) are
+ * BENIGN — the end state is identical to a success (the conversation no longer exists), so we treat
+ * them as success and still evict the local cache / pop the thread. Every other status is a real
+ * failure surfaced to the caller.
+ */
+object ConversationDeleteMath {
+
+    const val HTTP_NOT_FOUND = 404
+    const val HTTP_GONE = 410
+
+    /**
+     * True when a non-2xx [status] should still be COALESCED to success (the conversation is already
+     * absent, so the user's intent — "make it gone" — is satisfied). Null (no HTTP status, e.g. a
+     * transport error) is NOT benign.
+     */
+    fun isBenignDeleteFailure(status: Int?): Boolean =
+        status == HTTP_NOT_FOUND || status == HTTP_GONE
+}

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/group/GroupApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/group/GroupApi.kt
@@ -104,6 +104,14 @@ interface GroupApi {
     /** AND-159 — accept a pending invite (no body). Empty 200. Non-idempotent POST. */
     @POST("messaging/conversations/{id}/accept")
     suspend fun accept(@Path("id") id: String)
+
+    /**
+     * AND-160 — delete the whole conversation (the final conversation-lifecycle route). No body;
+     * HTTP 200 with a body that is intentionally ignored (mirrors [removeParticipant]). A 404 means
+     * it is already gone — the repository degrades that to success. Non-idempotent DELETE.
+     */
+    @DELETE("messaging/conversations/{id}")
+    suspend fun deleteConversation(@Path("id") id: String)
 }
 
 /**

--- a/android/app/src/main/java/com/testlogon/android/data/messaging/group/GroupRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/messaging/group/GroupRepository.kt
@@ -88,6 +88,13 @@ interface GroupRepository {
 
     /** Accept a pending invite; re-GETs the conversation so membership flips to active. */
     suspend fun acceptInvite(conversationId: String): ApiResult<GroupSettings>
+
+    /**
+     * AND-160 — delete the conversation entirely (the final conversation-lifecycle route). On success
+     * (or a benign 404/410 already-gone) evicts the conversation + its roster from the local cache so
+     * the AND-121 list drops it at once. Non-idempotent (no auto-retry).
+     */
+    suspend fun deleteConversation(conversationId: String): ApiResult<Unit>
 }
 
 @Singleton
@@ -281,6 +288,27 @@ class GroupRepositoryImpl @Inject constructor(
                 is ApiResult.Failure ->
                     // 409 already-a-member -> coalesce to success by re-reading state.
                     if (r.error.status == HTTP_CONFLICT) getGroupSettings(conversationId) else r
+                is ApiResult.NetworkError -> r
+            }
+        }
+
+    override suspend fun deleteConversation(conversationId: String): ApiResult<Unit> =
+        withContext(io) {
+            when (val r = apiCall { api.deleteConversation(conversationId) }) {
+                is ApiResult.Success -> {
+                    conversationDao.deleteById(conversationId)
+                    participantDao.clearForConversation(conversationId)
+                    ApiResult.Success(Unit)
+                }
+                is ApiResult.Failure ->
+                    // A 404/410 (already deleted / gone) is benign — the end state matches success.
+                    if (ConversationDeleteMath.isBenignDeleteFailure(r.error.status)) {
+                        conversationDao.deleteById(conversationId)
+                        participantDao.clearForConversation(conversationId)
+                        ApiResult.Success(Unit)
+                    } else {
+                        r
+                    }
                 is ApiResult.NetworkError -> r
             }
         }

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadScreen.kt
@@ -198,6 +198,12 @@ object ThreadTestTags {
 
     /** #19 — the single "+" that opens the conversation-actions dropdown menu. */
     const val TOPBAR_MENU = "thread_topbar_menu"
+
+    /** AND-160 — delete-conversation overflow item + its confirm dialog. */
+    const val DELETE_CONVERSATION = "thread_delete_conversation"
+    const val DELETE_CONFIRM = "thread_delete_confirm"
+    const val DELETE_CONFIRM_YES = "thread_delete_confirm_yes"
+    const val DELETE_CONFIRM_CANCEL = "thread_delete_confirm_cancel"
 }
 
 /** AND-123 — route-level thread, reached from the conversation list. */
@@ -311,6 +317,7 @@ fun ThreadRoute(
                 is ThreadEvent.OpenFile -> openDownloadedFile(context, event.localPath, event.mimeType)
                 is ThreadEvent.Toast ->
                     android.widget.Toast.makeText(context, event.message, android.widget.Toast.LENGTH_SHORT).show()
+                is ThreadEvent.ConversationDeleted -> onBack()
                 is ThreadEvent.ScrollToMessage -> {
                     // AND-140 — jump-to-pinned: the list is reverseLayout, so map the key to its index.
                     val idx = state.messages.indexOfFirst { it.key == event.messageKey }
@@ -364,6 +371,7 @@ fun ThreadRoute(
         onOpenGroupDetails = onOpenGroupDetails,
         onMute = viewModel::onMute,
         onUnmute = viewModel::onUnmute,
+        onDeleteConversation = viewModel::onDeleteConversation,
         onRetry = viewModel::retry,
         onDraftChange = viewModel::onDraftChange,
         onSend = viewModel::onSend,
@@ -1043,6 +1051,8 @@ fun ThreadScreen(
     // FE-140 — per-conversation mute: onMute(optionId) / onUnmute, wired to the mute repo call.
     onMute: (String) -> Unit = {},
     onUnmute: () -> Unit = {},
+    // AND-160 — delete the whole conversation from the thread overflow menu (confirm dialog gates it).
+    onDeleteConversation: () -> Unit = {},
     onRetry: () -> Unit,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
@@ -1181,6 +1191,8 @@ fun ThreadScreen(
     var galleryVideoUrl by remember { mutableStateOf<String?>(null) }
     // FE-140 - per-conversation mute options bottom sheet.
     var showMuteSheet by remember { mutableStateOf(false) }
+    // AND-160 - delete-conversation confirm dialog visibility.
+    var showDeleteConfirm by remember { mutableStateOf(false) }
     val isConversationMuted = com.testlogon.android.feature.messaging.mute.MuteMath.isMuted(state.mutedUntil, nowSeconds)
     // #3 KEYBOARD DISMISS — clear the composer's focus + hide the IME without leaving the thread.
     val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
@@ -1242,6 +1254,32 @@ fun ThreadScreen(
                 }
             }
         }
+    }
+    // AND-160 - confirm before the destructive delete. Confirm calls onDeleteConversation (the VM
+    // deletes + evicts the cache + emits ConversationDeleted so the route pops back to the list).
+    if (showDeleteConfirm) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text(stringResource(R.string.thread_delete_conversation_title)) },
+            text = { Text(stringResource(R.string.thread_delete_conversation_body)) },
+            confirmButton = {
+                androidx.compose.material3.TextButton(
+                    onClick = {
+                        showDeleteConfirm = false
+                        onDeleteConversation()
+                    },
+                    enabled = !state.deleteInFlight,
+                    modifier = Modifier.testTag(ThreadTestTags.DELETE_CONFIRM_YES),
+                ) { Text(stringResource(R.string.thread_delete_conversation_confirm)) }
+            },
+            dismissButton = {
+                androidx.compose.material3.TextButton(
+                    onClick = { showDeleteConfirm = false },
+                    modifier = Modifier.testTag(ThreadTestTags.DELETE_CONFIRM_CANCEL),
+                ) { Text(stringResource(R.string.action_cancel)) }
+            },
+            modifier = Modifier.testTag(ThreadTestTags.DELETE_CONFIRM),
+        )
     }
     Scaffold(
         modifier = modifier.testTag(ThreadTestTags.SCREEN),
@@ -1434,6 +1472,15 @@ fun ThreadScreen(
                                 modifier = Modifier.testTag(ThreadTestTags.DISCARD_DRAFT),
                             )
                         }
+                        // AND-160 — delete the whole conversation (final lifecycle route). Opens a
+                        // confirm dialog; the VM does the delete + cache eviction + pop-back.
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text(stringResource(R.string.thread_delete_conversation)) },
+                            leadingIcon = { Icon(Icons.Filled.DeleteOutline, contentDescription = null) },
+                            enabled = !state.deleteInFlight,
+                            onClick = { menuOpen = false; showDeleteConfirm = true },
+                            modifier = Modifier.testTag(ThreadTestTags.DELETE_CONVERSATION),
+                        )
                     }
                 },
                 )

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadUiState.kt
@@ -66,6 +66,8 @@ data class ThreadUiState(
     val mutedUntil: Long = 0L,
     /** FE-140 - true while a mute/unmute network call is in flight (disables the menu item). */
     val muteActionInFlight: Boolean = false,
+    /** AND-160 - true while the delete-conversation network call is in flight (disables the menu item). */
+    val deleteInFlight: Boolean = false,
     /** Last draft sync outcome (non-blocking UX only). */
     val draftSyncState: DraftSyncState = DraftSyncState.Idle,
     // ---- AND-147: read receipts / views ----

--- a/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/messaging/thread/ThreadViewModel.kt
@@ -76,6 +76,9 @@ sealed interface ThreadEvent {
 
     /** #9 — show a transient toast (e.g. save-to-phone result). */
     data class Toast(val message: String) : ThreadEvent
+
+    /** AND-160 — the conversation was deleted; the screen should pop back to the list. */
+    data object ConversationDeleted : ThreadEvent
 }
 
 /**
@@ -319,6 +322,34 @@ class ThreadViewModel @Inject constructor(
         muteStore.setMuted(conversationId, priorUntil)
         _state.update { it.copy(muteActionInFlight = false) }
         _events.send(ThreadEvent.Toast(message))
+    }
+
+    /**
+     * AND-160 — delete this conversation entirely (the final conversation-lifecycle route). Guards
+     * against a double-tap, calls the shared GroupRepository.deleteConversation (which evicts the
+     * local cache so the AND-121 list drops it), then emits [ThreadEvent.ConversationDeleted] so the
+     * screen pops back. A benign 404/410 is coalesced to success inside the repo. On a real failure a
+     * toast is shown and the screen stays put.
+     */
+    fun onDeleteConversation() {
+        if (_state.value.deleteInFlight) return
+        _state.update { it.copy(deleteInFlight = true) }
+        viewModelScope.launch {
+            when (val r = groupRepository.deleteConversation(conversationId)) {
+                is ApiResult.Success -> {
+                    _state.update { it.copy(deleteInFlight = false) }
+                    _events.send(ThreadEvent.ConversationDeleted)
+                }
+                is ApiResult.Failure -> {
+                    _state.update { it.copy(deleteInFlight = false) }
+                    _events.send(ThreadEvent.Toast(r.error.message))
+                }
+                is ApiResult.NetworkError -> {
+                    _state.update { it.copy(deleteInFlight = false) }
+                    _events.send(ThreadEvent.Toast(OFFLINE_MESSAGE))
+                }
+            }
+        }
     }
 
     /**

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -851,6 +851,11 @@
 
     <!-- AND-141 — drafts -->
     <string name="draft_discard">Discard draft</string>
+    <!-- AND-160 - delete conversation (thread overflow) -->
+    <string name="thread_delete_conversation">Delete conversation</string>
+    <string name="thread_delete_conversation_title">Delete conversation?</string>
+    <string name="thread_delete_conversation_body">This removes the conversation from your list. This cannot be undone.</string>
+    <string name="thread_delete_conversation_confirm">Delete</string>
     <string name="draft_restored">Draft restored</string>
 
     <!-- AND-145 — presence -->

--- a/android/app/src/test/java/com/testlogon/android/data/messaging/MessagingRepositoryTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/messaging/MessagingRepositoryTest.kt
@@ -52,6 +52,9 @@ class MessagingRepositoryTest {
         }
         override fun observeUnreadConversationCount(): Flow<Int> =
             rows.map { list -> list.count { it.unreadCount > 0 } }
+        override suspend fun deleteById(id: String) {
+            rows.value = rows.value.filterNot { it.conversationId == id }
+        }
         override suspend fun clear() { rows.value = emptyList() }
     }
 

--- a/android/app/src/test/java/com/testlogon/android/data/messaging/group/ConversationDeleteMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/messaging/group/ConversationDeleteMathTest.kt
@@ -1,0 +1,34 @@
+package com.testlogon.android.data.messaging.group
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** AND-160 — pure unit tests for the delete-conversation degrade rule. */
+class ConversationDeleteMathTest {
+
+    @Test
+    fun notFound_isBenign() {
+        assertTrue(ConversationDeleteMath.isBenignDeleteFailure(404))
+    }
+
+    @Test
+    fun gone_isBenign() {
+        assertTrue(ConversationDeleteMath.isBenignDeleteFailure(410))
+    }
+
+    @Test
+    fun forbidden_isNotBenign() {
+        assertFalse(ConversationDeleteMath.isBenignDeleteFailure(403))
+    }
+
+    @Test
+    fun serverError_isNotBenign() {
+        assertFalse(ConversationDeleteMath.isBenignDeleteFailure(500))
+    }
+
+    @Test
+    fun nullStatus_transportError_isNotBenign() {
+        assertFalse(ConversationDeleteMath.isBenignDeleteFailure(null))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/messaging/group/FakeGroupRepository.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/messaging/group/FakeGroupRepository.kt
@@ -101,4 +101,12 @@ class FakeGroupRepository : GroupRepository {
         acceptCalls++
         return acceptResult
     }
+
+    var deleteCalls = mutableListOf<String>()
+    var deleteResult: ApiResult<Unit> = ApiResult.Success(Unit)
+
+    override suspend fun deleteConversation(conversationId: String): ApiResult<Unit> {
+        deleteCalls += conversationId
+        return deleteResult
+    }
 }

--- a/android/app/src/test/java/com/testlogon/android/data/messaging/group/GroupRepositoryContractTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/messaging/group/GroupRepositoryContractTest.kt
@@ -322,6 +322,9 @@ class GroupRepositoryContractTest {
         }
         override fun observeUnreadConversationCount(): Flow<Int> =
             rows.map { list -> list.count { it.unreadCount > 0 } }
+        override suspend fun deleteById(id: String) {
+            rows.value = rows.value.filterNot { it.conversationId == id }
+        }
         override suspend fun clear() { rows.value = emptyList() }
     }
 

--- a/android/app/src/test/java/com/testlogon/android/data/messaging/group/GroupRosterFlowGapTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/messaging/group/GroupRosterFlowGapTest.kt
@@ -130,6 +130,9 @@ class GroupRosterFlowGapTest {
         }
         override fun observeUnreadConversationCount(): Flow<Int> =
             rows.map { list -> list.count { it.unreadCount > 0 } }
+        override suspend fun deleteById(id: String) {
+            rows.value = rows.value.filterNot { it.conversationId == id }
+        }
         override suspend fun clear() { rows.value = emptyList() }
     }
 

--- a/android/core-data/src/main/java/com/testlogon/android/core/data/messaging/MessagingDao.kt
+++ b/android/core-data/src/main/java/com/testlogon/android/core/data/messaging/MessagingDao.kt
@@ -34,6 +34,14 @@ interface ConversationDao {
     @Query("SELECT COALESCE(SUM(CASE WHEN unreadCount > 0 THEN 1 ELSE 0 END), 0) FROM conversations")
     fun observeUnreadConversationCount(): Flow<Int>
 
+    /**
+     * Delete ONE conversation row from the local cache by id. Used by the thread-level
+     * "Delete conversation" action (DELETE /messaging/conversations/{id}); the reactive
+     * [observeAll] stream drops it from the list at once. No-op if the id is absent.
+     */
+    @Query("DELETE FROM conversations WHERE conversationId = :id")
+    suspend fun deleteById(id: String)
+
     @Query("DELETE FROM conversations")
     suspend fun clear()
 }

--- a/frontend/src/api/endpoints/messaging.ts
+++ b/frontend/src/api/endpoints/messaging.ts
@@ -727,6 +727,26 @@ export const updateParticipantRole = (
     body,
   );
 
+// Admin removes another participant from a group conversation.
+export const removeParticipant = (conversationId: string, participantId: string) =>
+  api.del<{ ok: boolean }>(
+    `/messaging/conversations/${conversationId}/participants/${participantId}`,
+  );
+
+// ─── Conversation lifecycle ────────────────
+
+// Accept a pending conversation invite (viewer status pending -> active).
+export const acceptConversation = (conversationId: string) =>
+  api.post<{ ok: boolean }>(`/messaging/conversations/${conversationId}/accept`, {});
+
+// Leave a conversation. Also used to DECLINE a pending invite (same endpoint).
+export const leaveConversation = (conversationId: string) =>
+  api.post<{ ok: boolean }>(`/messaging/conversations/${conversationId}/leave`, {});
+
+// Delete a conversation (only permitted for the last remaining active participant).
+export const deleteConversation = (conversationId: string) =>
+  api.del<{ ok: boolean; deleted: boolean }>(`/messaging/conversations/${conversationId}`);
+
 
 export const unlockMessage = (conversationId: string, messageId: string, paymentMethodId?: string) =>
   api.post<{ ok: boolean }>(`/messaging/conversations/${conversationId}/messages/${messageId}/unlock`, {

--- a/frontend/src/lib/conversationActions.test.ts
+++ b/frontend/src/lib/conversationActions.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPendingInvite,
+  isActiveMember,
+  activeParticipantCount,
+  canLeave,
+  canRespondToInvite,
+  canDelete,
+  canManageParticipants,
+  canRemoveParticipant,
+  leaveActionLabel,
+  deleteActionLabel,
+  roleToggleLabel,
+  nextRole,
+  type ConversationLifecycleView,
+} from "./conversationActions";
+
+const group = (
+  overrides: Partial<ConversationLifecycleView> = {},
+): ConversationLifecycleView => ({
+  status: "active",
+  type: "group",
+  participants: [
+    { user_id: "me", status: "active", role: "admin" },
+    { user_id: "them", status: "active", role: "member" },
+  ],
+  ...overrides,
+});
+
+describe("membership status helpers", () => {
+  it("detects a pending invite", () => {
+    expect(isPendingInvite({ status: "pending" })).toBe(true);
+    expect(isPendingInvite({ status: "active" })).toBe(false);
+    expect(isPendingInvite(null)).toBe(false);
+    expect(isPendingInvite(undefined)).toBe(false);
+  });
+
+  it("detects an active member", () => {
+    expect(isActiveMember({ status: "active" })).toBe(true);
+    expect(isActiveMember({ status: "pending" })).toBe(false);
+    expect(isActiveMember({ status: "left" })).toBe(false);
+  });
+
+  it("counts active participants and treats missing status as active", () => {
+    expect(activeParticipantCount(group())).toBe(2);
+    expect(
+      activeParticipantCount({
+        participants: [
+          { user_id: "a", status: "active" },
+          { user_id: "b", status: "left" },
+          { user_id: "c" }, // missing -> active
+        ],
+      }),
+    ).toBe(2);
+    expect(activeParticipantCount({})).toBe(0);
+  });
+});
+
+describe("canLeave / canRespondToInvite", () => {
+  it("allows leaving only when active", () => {
+    expect(canLeave({ status: "active" })).toBe(true);
+    expect(canLeave({ status: "pending" })).toBe(false);
+    expect(canLeave({ status: "left" })).toBe(false);
+  });
+
+  it("allows responding to an invite only when pending", () => {
+    expect(canRespondToInvite({ status: "pending" })).toBe(true);
+    expect(canRespondToInvite({ status: "active" })).toBe(false);
+  });
+});
+
+describe("canDelete", () => {
+  it("allows delete when the viewer is the only active participant", () => {
+    expect(
+      canDelete({ status: "active", participants: [{ user_id: "me", status: "active" }] }),
+    ).toBe(true);
+  });
+
+  it("blocks delete when other active participants exist", () => {
+    expect(canDelete(group())).toBe(false);
+  });
+
+  it("blocks delete for a non-active viewer", () => {
+    expect(canDelete({ status: "pending", participants: [{ user_id: "me", status: "pending" }] })).toBe(false);
+  });
+
+  it("permits the attempt when participant data is unknown (backend gates it)", () => {
+    expect(canDelete({ status: "active" })).toBe(true);
+  });
+});
+
+describe("canManageParticipants", () => {
+  it("is true for an active admin in a group", () => {
+    expect(canManageParticipants(group(), "me")).toBe(true);
+  });
+
+  it("is false for a non-admin member", () => {
+    expect(canManageParticipants(group(), "them")).toBe(false);
+  });
+
+  it("is false in a DM", () => {
+    expect(canManageParticipants(group({ type: "dm" }), "me")).toBe(false);
+  });
+
+  it("is false when viewer is not active", () => {
+    expect(canManageParticipants(group({ status: "pending" }), "me")).toBe(false);
+  });
+
+  it("is false without a viewer id", () => {
+    expect(canManageParticipants(group(), null)).toBe(false);
+    expect(canManageParticipants(group(), undefined)).toBe(false);
+  });
+});
+
+describe("canRemoveParticipant", () => {
+  it("lets an admin remove another participant", () => {
+    expect(canRemoveParticipant(group(), "me", "them")).toBe(true);
+  });
+
+  it("never lets an admin remove themselves", () => {
+    expect(canRemoveParticipant(group(), "me", "me")).toBe(false);
+  });
+
+  it("blocks non-admins", () => {
+    expect(canRemoveParticipant(group(), "them", "me")).toBe(false);
+  });
+});
+
+describe("labels", () => {
+  it("switches the leave label between decline and leave", () => {
+    expect(leaveActionLabel({ status: "pending" })).toBe("Decline invite");
+    expect(leaveActionLabel({ status: "active" })).toBe("Leave conversation");
+  });
+
+  it("labels delete by conversation type", () => {
+    expect(deleteActionLabel({ type: "group" })).toBe("Delete group");
+    expect(deleteActionLabel({ type: "dm" })).toBe("Delete conversation");
+    expect(deleteActionLabel({})).toBe("Delete conversation");
+  });
+
+  it("computes role toggle label and next role", () => {
+    expect(roleToggleLabel("admin")).toBe("Demote to member");
+    expect(roleToggleLabel("member")).toBe("Promote to admin");
+    expect(roleToggleLabel(undefined)).toBe("Promote to admin");
+    expect(nextRole("admin")).toBe("member");
+    expect(nextRole("member")).toBe("admin");
+    expect(nextRole(undefined)).toBe("admin");
+  });
+});

--- a/frontend/src/lib/conversationActions.ts
+++ b/frontend/src/lib/conversationActions.ts
@@ -1,0 +1,121 @@
+// Pure, side-effect-free helpers for conversation-lifecycle UI decisions.
+//
+// The backend (app/routers/messaging.py) exposes:
+//   POST   /messaging/conversations/{id}/accept                    — accept a pending invite
+//   POST   /messaging/conversations/{id}/leave                     — leave (active) OR decline (pending)
+//   DELETE /messaging/conversations/{id}                           — delete when last active participant
+//   DELETE /messaging/conversations/{id}/participants/{pid}        — admin removes a participant
+//   PATCH  /messaging/conversations/{id}/participants/{pid}        — admin changes a role
+//
+// The viewer's own membership status is projected onto Conversation.status by the
+// backend (`participant.get("status", ...)` in _conversation_out_from_items), so we
+// key the guards off that plus the viewer's role.
+
+export type ParticipantRole = "admin" | "member";
+export type MembershipStatus = "pending" | "active" | "left" | string;
+
+/** Minimal shape needed for lifecycle decisions (a Conversation satisfies this). */
+export interface ConversationLifecycleView {
+  /** The VIEWER's membership status, as projected onto Conversation.status. */
+  status?: MembershipStatus;
+  type?: "dm" | "group" | string;
+  /** Count of participants the client knows about (may include left members). */
+  participants?: Array<{ user_id: string; status?: string; role?: ParticipantRole | string }>;
+}
+
+/** True when the viewer has a pending (not-yet-accepted) invite to this conversation. */
+export function isPendingInvite(convo: ConversationLifecycleView | null | undefined): boolean {
+  return (convo?.status ?? "") === "pending";
+}
+
+/** True when the viewer is an active participant. */
+export function isActiveMember(convo: ConversationLifecycleView | null | undefined): boolean {
+  return (convo?.status ?? "") === "active";
+}
+
+/** Number of participants currently in the "active" state. */
+export function activeParticipantCount(convo: ConversationLifecycleView | null | undefined): number {
+  const parts = convo?.participants ?? [];
+  return parts.filter((p) => (p.status ?? "active") === "active").length;
+}
+
+/**
+ * The viewer can leave when they are an active member. Leaving a conversation you
+ * only have a pending invite to is expressed as "decline" (also POST /leave), so
+ * canLeave is specifically about the active case.
+ */
+export function canLeave(convo: ConversationLifecycleView | null | undefined): boolean {
+  return isActiveMember(convo);
+}
+
+/**
+ * A pending invite can be accepted or declined. Decline maps to the same /leave
+ * endpoint on the backend, but we surface it separately in the UI.
+ */
+export function canRespondToInvite(convo: ConversationLifecycleView | null | undefined): boolean {
+  return isPendingInvite(convo);
+}
+
+/**
+ * Delete is only allowed for the last remaining active participant — the backend
+ * rejects deletion while other active participants exist. We optimistically allow
+ * the action when the viewer is active and is the only known active participant;
+ * the backend remains the source of truth (a stale client count degrades to a 400
+ * -> error toast).
+ */
+export function canDelete(convo: ConversationLifecycleView | null | undefined): boolean {
+  if (!isActiveMember(convo)) return false;
+  const active = activeParticipantCount(convo);
+  // If we have participant data, require the viewer to be the only active one.
+  // With no participant data we still permit the attempt (backend will gate it).
+  return active <= 1;
+}
+
+/**
+ * Participant management (remove member / change role) is admin-only. Determined
+ * from the viewer's own participant record.
+ */
+export function canManageParticipants(
+  convo: ConversationLifecycleView | null | undefined,
+  viewerUserId: string | null | undefined,
+): boolean {
+  if (!isActiveMember(convo)) return false;
+  if ((convo?.type ?? "dm") !== "group") return false;
+  if (!viewerUserId) return false;
+  const me = (convo?.participants ?? []).find((p) => p.user_id === viewerUserId);
+  return (me?.role ?? "member") === "admin";
+}
+
+/**
+ * An admin may remove any OTHER active participant — never themselves (the backend
+ * returns 400 "Use /leave to remove yourself").
+ */
+export function canRemoveParticipant(
+  convo: ConversationLifecycleView | null | undefined,
+  viewerUserId: string | null | undefined,
+  targetUserId: string,
+): boolean {
+  if (!canManageParticipants(convo, viewerUserId)) return false;
+  return targetUserId !== viewerUserId;
+}
+
+/** Human label for the primary lifecycle action available to the viewer. */
+export function leaveActionLabel(convo: ConversationLifecycleView | null | undefined): string {
+  if (isPendingInvite(convo)) return "Decline invite";
+  return "Leave conversation";
+}
+
+/** Human label for the destructive delete action. */
+export function deleteActionLabel(convo: ConversationLifecycleView | null | undefined): string {
+  return (convo?.type ?? "dm") === "group" ? "Delete group" : "Delete conversation";
+}
+
+/** Label for the role toggle on a given participant. */
+export function roleToggleLabel(currentRole: ParticipantRole | string | undefined): string {
+  return (currentRole ?? "member") === "admin" ? "Demote to member" : "Promote to admin";
+}
+
+/** The role a toggle would move a participant to. */
+export function nextRole(currentRole: ParticipantRole | string | undefined): ParticipantRole {
+  return (currentRole ?? "member") === "admin" ? "member" : "admin";
+}

--- a/frontend/src/pages/messages/ConversationList.tsx
+++ b/frontend/src/pages/messages/ConversationList.tsx
@@ -18,6 +18,7 @@ import { EmptyState } from "@/components/shared/EmptyState";
 import { cn } from "@/lib/utils";
 import { getConversations, startConversation, startGroupConversation } from "@/api/endpoints/messaging";
 import type { Conversation, Message, UserSearchResult } from "@/api/types";
+import { isPendingInvite } from "@/lib/conversationActions";
 import { PresenceDot } from "./PresenceDot";
 import { UserSearch } from "./UserSearch";
 import { useAuthStore } from "@/stores/authStore";
@@ -154,6 +155,7 @@ export function ConversationList({ activeId, onSelect }: ConversationListProps) 
               const active = convo.conversation_id === activeId;
               const lastMsg = convo.last_message;
               const unread = (convo.unread_count ?? 0) > 0;
+              const pending = isPendingInvite(convo);
 
               const other = convo.type === "dm" ? convo.participants.find((p) => p.user_id !== userId) : undefined;
               const profilePath = other
@@ -207,6 +209,11 @@ export function ConversationList({ activeId, onSelect }: ConversationListProps) 
                       >
                         {name}
                       </span>
+                      {pending && (
+                        <Badge variant="secondary" className="shrink-0 text-[10px]">
+                          Invite
+                        </Badge>
+                      )}
                       {isMuted(convo.muted_until, Math.floor(Date.now() / 1000)) && (
                         <BellOff
                           className="h-3 w-3 shrink-0 text-muted-foreground"

--- a/frontend/src/pages/messages/ConversationView.tsx
+++ b/frontend/src/pages/messages/ConversationView.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useMutation, useQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import { ArrowLeft, Images, Users, Clock, MoreHorizontal, EyeOff, Pin, Phone, Video, Upload, Bell, BellOff } from "lucide-react";
+import { ArrowLeft, Images, Users, Clock, MoreHorizontal, EyeOff, Pin, Phone, Video, Upload, Bell, BellOff, LogOut, Trash2, Check, X } from "lucide-react";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import { Button } from "@/components/ui/button";
@@ -36,8 +36,18 @@ import {
   acceptCallInvite,
   declineCallInvite,
   endCall,
+  acceptConversation,
+  leaveConversation,
+  deleteConversation,
   type DirectCallMode,
 } from "@/api/endpoints/messaging";
+import {
+  isPendingInvite,
+  canLeave,
+  canDelete,
+  leaveActionLabel,
+  deleteActionLabel,
+} from "@/lib/conversationActions";
 import { useAuthStore } from "@/stores/authStore";
 import { useLiveLocationShare } from "./useLiveLocationShare";
 import { useOfflineStore } from "@/stores/offlineStore";
@@ -796,6 +806,48 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
     onError: () => toast.error("Failed to claim conversation"),
   });
 
+  // -- Conversation lifecycle (accept / decline / leave / delete) --
+  const pendingInvite = isPendingInvite(conversation);
+
+  const acceptMutation = useMutation({
+    mutationFn: () => acceptConversation(convoId),
+    onSuccess: () => {
+      toast.success("Invite accepted");
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["conversation-detail", convoId] });
+    },
+    onError: () => toast.error("Failed to accept invite"),
+  });
+
+  // Leaving an active conversation AND declining a pending invite both POST /leave.
+  const leaveMutation = useMutation({
+    mutationFn: () => leaveConversation(convoId),
+    onSuccess: () => {
+      toast.success(pendingInvite ? "Invite declined" : "You left the conversation");
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      onBack?.();
+    },
+    onError: () => toast.error(pendingInvite ? "Failed to decline invite" : "Failed to leave conversation"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteConversation(convoId),
+    onSuccess: () => {
+      toast.success("Conversation deleted");
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      onBack?.();
+    },
+    onError: (err) => {
+      const msg = err instanceof ApiError && err.status === 400
+        ? "Can't delete — other participants are still in this conversation"
+        : "Failed to delete conversation";
+      toast.error(msg);
+    },
+  });
+
+  const showLeave = canLeave(conversation);
+  const showDelete = canDelete(conversation);
+
   const [transferTarget, setTransferTarget] = React.useState("");
   const [transferDialogOpen, setTransferDialogOpen] = React.useState(false);
   const transferMutation = useMutation({
@@ -1394,6 +1446,26 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
                 Recordings
               </DropdownMenuItem>
             )}
+            {showLeave && (
+              <DropdownMenuItem
+                onClick={() => leaveMutation.mutate()}
+                disabled={leaveMutation.isPending}
+                className="text-destructive focus:text-destructive"
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                {leaveActionLabel(conversation)}
+              </DropdownMenuItem>
+            )}
+            {showDelete && (
+              <DropdownMenuItem
+                onClick={() => deleteMutation.mutate()}
+                disabled={deleteMutation.isPending}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                {deleteActionLabel(conversation)}
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
         {isGroup && (
@@ -1538,6 +1610,34 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         )}
       </div>
 
+      {/* Pending invite: accept/decline instead of composing */}
+      {pendingInvite ? (
+        <div className="border-t border-border bg-muted/40 px-4 py-3">
+          <p className="mb-2 text-sm text-muted-foreground">
+            You have been invited to this conversation.
+          </p>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={() => acceptMutation.mutate()}
+              disabled={acceptMutation.isPending || leaveMutation.isPending}
+            >
+              <Check className="mr-1.5 h-4 w-4" />
+              Accept
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => leaveMutation.mutate()}
+              disabled={acceptMutation.isPending || leaveMutation.isPending}
+            >
+              <X className="mr-1.5 h-4 w-4" />
+              Decline
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
       {/* Typing indicator */}
       <TypingIndicator conversationId={convoId} />
 
@@ -1695,6 +1795,8 @@ export function ConversationView({ conversation, onBack, onClaimSuccess }: Conve
         replyingTo={replyingTo}
         onCancelReply={() => setReplyingTo(null)}
       />
+        </>
+      )}
 
 
       {galleryEnabled && (

--- a/frontend/src/pages/messages/ParticipantsPanel.tsx
+++ b/frontend/src/pages/messages/ParticipantsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Users, X, Shield, User, UserPlus } from "lucide-react";
+import { Users, X, Shield, User, UserPlus, UserMinus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -17,8 +17,11 @@ import {
   getConversation,
   addParticipants,
   updateParticipantRole,
+  removeParticipant,
 } from "@/api/endpoints/messaging";
 import type { Participant } from "@/api/types";
+import { canManageParticipants, canRemoveParticipant } from "@/lib/conversationActions";
+import { useAuthStore } from "@/stores/authStore";
 import { UserSearch } from "./UserSearch";
 
 interface ParticipantsPanelProps {
@@ -34,6 +37,7 @@ export function ParticipantsPanel({
 }: ParticipantsPanelProps) {
   const queryClient = useQueryClient();
   const [showAddUser, setShowAddUser] = useState(false);
+  const viewerUserId = useAuthStore((s) => s.userId);
 
   const { data: convo } = useQuery({
     queryKey: ["conversation-detail", conversationId],
@@ -63,9 +67,21 @@ export function ParticipantsPanel({
     onError: () => toast.error("Failed to update role"),
   });
 
+  const removeMut = useMutation({
+    mutationFn: (pid: string) => removeParticipant(conversationId, pid),
+    onSuccess: () => {
+      toast.success("Participant removed");
+      void queryClient.invalidateQueries({ queryKey: ["conversation-detail", conversationId] });
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+    onError: () => toast.error("Failed to remove participant"),
+  });
+
   if (!open) return null;
 
   const participants: Participant[] = convo?.participants ?? [];
+  // Admin-only controls; guarded by the pure lib against the viewer's role.
+  const canManage = canManageParticipants(convo, viewerUserId);
 
   // Sort admins first
   const sorted = [...participants].sort((a, b) => {
@@ -103,25 +119,27 @@ export function ParticipantsPanel({
           </Button>
         </div>
 
-        {/* Add participant */}
-        <div className="border-b border-border p-3">
-          {showAddUser ? (
-            <UserSearch
-              placeholder="Search user to add..."
-              onSelect={(user) => addMut.mutate(user.user_id)}
-            />
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full"
-              onClick={() => setShowAddUser(true)}
-            >
-              <UserPlus className="mr-1.5 h-4 w-4" />
-              Add Participant
-            </Button>
-          )}
-        </div>
+        {/* Add participant (admins only) */}
+        {canManage && (
+          <div className="border-b border-border p-3">
+            {showAddUser ? (
+              <UserSearch
+                placeholder="Search user to add..."
+                onSelect={(user) => addMut.mutate(user.user_id)}
+              />
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => setShowAddUser(true)}
+              >
+                <UserPlus className="mr-1.5 h-4 w-4" />
+                Add Participant
+              </Button>
+            )}
+          </div>
+        )}
 
         {/* Participant list */}
         <div className="flex-1 overflow-y-auto">
@@ -144,34 +162,50 @@ export function ParticipantsPanel({
                   <p className="truncate text-xs text-muted-foreground">{p.user_id}</p>
                 </div>
 
-                {/* Role control */}
-                <Select
-                  value={p.role ?? "member"}
-                  onValueChange={(value) =>
-                    roleMut.mutate({ pid: p.user_id, role: value as "admin" | "member" })
-                  }
-                >
-                  <SelectTrigger className="h-7 w-24">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="admin">
-                      <span className="flex items-center gap-1">
-                        <Shield className="h-3 w-3" /> Admin
-                      </span>
-                    </SelectItem>
-                    <SelectItem value="member">
-                      <span className="flex items-center gap-1">
-                        <User className="h-3 w-3" /> Member
-                      </span>
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                {/* Role control -- admins only; otherwise read-only badge */}
+                {canManage ? (
+                  <Select
+                    value={p.role ?? "member"}
+                    onValueChange={(value) =>
+                      roleMut.mutate({ pid: p.user_id, role: value as "admin" | "member" })
+                    }
+                  >
+                    <SelectTrigger className="h-7 w-24">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="admin">
+                        <span className="flex items-center gap-1">
+                          <Shield className="h-3 w-3" /> Admin
+                        </span>
+                      </SelectItem>
+                      <SelectItem value="member">
+                        <span className="flex items-center gap-1">
+                          <User className="h-3 w-3" /> Member
+                        </span>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  isAdmin && (
+                    <Badge variant="outline" className="shrink-0 text-[10px]">
+                      Admin
+                    </Badge>
+                  )
+                )}
 
-                {isAdmin && (
-                  <Badge variant="outline" className="shrink-0 text-[10px]">
-                    Admin
-                  </Badge>
+                {/* Remove participant -- admins only, never self */}
+                {canRemoveParticipant(convo, viewerUserId, p.user_id) && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+                    aria-label={`Remove ${name}`}
+                    disabled={removeMut.isPending}
+                    onClick={() => removeMut.mutate(p.user_id)}
+                  >
+                    <UserMinus className="h-4 w-4" />
+                  </Button>
                 )}
               </div>
             );


### PR DESCRIPTION
## FE parity PAR-101 - conversation lifecycle (web + Android delete)

Brings the conversation lifecycle (delete / leave) to parity across web and Android.

### Web
- Add conversation delete/leave actions in the messaging API endpoints.
- Wire actions into ConversationList, ConversationView and ParticipantsPanel.
- New `conversationActions` helper with unit coverage.

### Android
- Wire conversation delete through GroupApi / GroupRepository.
- Surface delete in ThreadScreen / ThreadViewModel / ThreadUiState.
- New `ConversationDeleteMath` with unit test.

### Gates
- Web: vitest `conversationActions.test`.
- Android: `ConversationDeleteMathTest` + group repository contract / roster-flow-gap tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
