### PR TITLE
FE parity PAR-102 - pay-to-message privacy + allowlist (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyMath.kt
@@ -1,0 +1,84 @@
+package com.testlogon.android.feature.settings.msgprivacy
+
+import kotlin.math.roundToInt
+
+/**
+ * TIP-B4 (TIP-404) — pure, framework-free decision + formatting logic for the caller's
+ * pay-to-message (message-privacy) settings. Kept as a tiny pure object so validation and the
+ * dollars<->cents conversion are unit-testable without a network, Compose, or a ViewModel, and are
+ * reused by [MessagePrivacyViewModel]. Mirrors the web contract's client-side rules.
+ *
+ * Money model: the UI edits the minimum tip as a DOLLARS string; the wire carries `min_tip_cents`
+ * (an Int). All conversion + validation of that boundary lives here.
+ */
+object MessagePrivacyMath {
+
+    /** Server ceiling on the minimum tip: \$1000 == 100_000 cents. */
+    const val MAX_MIN_TIP_CENTS = 100_000
+
+    /** Sentinel dollars string shown when the gate turns on but no min is on file yet. */
+    const val DEFAULT_MIN_TIP_DOLLARS = "1.0"
+
+    /** Outcome of validating the min-tip field for a Save. */
+    sealed interface MinTipResult {
+        /** Valid — [cents] is the wire value to PUT. */
+        data class Valid(val cents: Int) : MinTipResult
+
+        /** Invalid — [message] is the user-facing form error. */
+        data class Invalid(val message: String) : MinTipResult
+    }
+
+    const val ERROR_TOO_LOW = "Set a minimum tip greater than \$0 to require a tip."
+    const val ERROR_TOO_HIGH = "Minimum tip can't exceed \$1000."
+
+    /**
+     * Validate + convert the min-tip [dollarsInput] for a Save, given whether the gate is on.
+     *
+     * When [requireTip] is on the amount must be > \$0 and <= \$1000. When the gate is off the field
+     * is advisory: any blank/invalid/negative value coalesces to 0 cents (nothing to enforce), so
+     * Save always succeeds.
+     */
+    fun validateMinTip(requireTip: Boolean, dollarsInput: String): MinTipResult {
+        val dollars = dollarsInput.trim().toDoubleOrNull()
+        if (!requireTip) {
+            val cents = dollarsToCents((dollars ?: 0.0).coerceAtLeast(0.0))
+            return MinTipResult.Valid(cents)
+        }
+        return when {
+            dollars == null || dollars <= 0.0 -> MinTipResult.Invalid(ERROR_TOO_LOW)
+            dollarsToCents(dollars) > MAX_MIN_TIP_CENTS -> MinTipResult.Invalid(ERROR_TOO_HIGH)
+            else -> MinTipResult.Valid(dollarsToCents(dollars))
+        }
+    }
+
+    /** Round a non-negative dollars amount to whole cents (banker-free, half-up via roundToInt). */
+    fun dollarsToCents(dollars: Double): Int = (dollars.coerceAtLeast(0.0) * 100).roundToInt()
+
+    /**
+     * Format [cents] as the editable dollars string for the field. Zero/negative shows the default
+     * sentinel (so the user isn't asked to require "\$0"); otherwise a plain decimal of dollars.
+     */
+    fun centsToDollarsField(cents: Int): String =
+        if (cents > 0) (cents / 100.0).toString() else DEFAULT_MIN_TIP_DOLLARS
+
+    /**
+     * True when [userId] is already present in [allowlist] (case-insensitive). Callers use this to
+     * reject a duplicate add before hitting the network.
+     */
+    fun isDuplicateAllowlistEntry(allowlist: List<String>, userId: String): Boolean {
+        val trimmed = userId.trim()
+        return allowlist.any { it.equals(trimmed, ignoreCase = true) }
+    }
+
+    /** Normalize a raw allowlist input; blank -> null (nothing to add). */
+    fun normalizeAllowlistInput(raw: String): String? = raw.trim().ifEmpty { null }
+
+    /**
+     * Degrade-on-404: a missing message-privacy config (the caller has never set a gate) is
+     * equivalent to the default OFF gate, not an error. True when [status] should be coalesced to a
+     * default [MessagePrivacy] instead of surfacing an error.
+     */
+    fun isBenignMissingConfig(status: Int?): Boolean = status == HTTP_NOT_FOUND
+
+    const val HTTP_NOT_FOUND = 404
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyRepository.kt
@@ -43,8 +43,23 @@ class DefaultMessagePrivacyRepository @Inject constructor(
     private val errorParser: ApiErrorParser,
 ) : MessagePrivacyRepository {
 
+    /**
+     * Degrade-on-404: a caller who has never configured a gate has no row server-side. If the
+     * endpoint answers 404 we coalesce to the default OFF gate rather than surfacing an error, so
+     * the settings screen still opens and lets them turn the gate on.
+     */
     override suspend fun get(): ApiResult<MessagePrivacy> =
-        withContext(Dispatchers.IO) { call { api.get().toDomain() } }
+        withContext(Dispatchers.IO) {
+            when (val result = call { api.get().toDomain() }) {
+                is ApiResult.Failure ->
+                    if (MessagePrivacyMath.isBenignMissingConfig(result.error.status)) {
+                        ApiResult.Success(DEFAULT)
+                    } else {
+                        result
+                    }
+                else -> result
+            }
+        }
 
     override suspend fun update(requireTipToMessage: Boolean, minTipCents: Int): ApiResult<MessagePrivacy> =
         withContext(Dispatchers.IO) {
@@ -84,5 +99,14 @@ class DefaultMessagePrivacyRepository @Inject constructor(
         ApiResult.Failure(errorParser.fromThrowable(e))
     } catch (e: IOException) {
         ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private companion object {
+        /** Default gate for a caller with no server-side config (degrade-on-404). */
+        val DEFAULT = MessagePrivacy(
+            requireTipToMessage = false,
+            minTipCents = 0,
+            tipFreeAllowlist = emptyList(),
+        )
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyViewModel.kt
@@ -9,14 +9,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 /**
  * TIP-B4 (TIP-404) — drives [MessagePrivacyUiState] for the pay-to-message settings.
  *
- * Loads the caller's gate, validates the min-tip (must be > $0 when the gate is on, <= $1000), and
- * on Save PUTs require_tip_to_message + min_tip_cents. The allowlist add/remove go through the
- * dedicated endpoints and refresh the list from the server's echo.
+ * Loads the caller's gate, validates the min-tip via [MessagePrivacyMath] (must be > $0 when the
+ * gate is on, <= $1000), and on Save PUTs require_tip_to_message + min_tip_cents. The allowlist
+ * add/remove go through the dedicated endpoints and refresh the list from the server's echo. All
+ * pure validation/formatting lives in [MessagePrivacyMath].
  */
 @HiltViewModel
 class MessagePrivacyViewModel @Inject constructor(
@@ -54,18 +54,11 @@ class MessagePrivacyViewModel @Inject constructor(
         val current = _uiState.value as? MessagePrivacyUiState.Content ?: return
         if (current.saving || current.mutatingAllowlist != null) return
 
-        val minCents = if (current.requireTip) {
-            val dollars = current.minTipDollars.trim().toDoubleOrNull()
-            when {
-                dollars == null || dollars <= 0.0 ->
-                    return fail(current, "Set a minimum tip greater than \$0 to require a tip.")
-                dollars > 1000.0 ->
-                    return fail(current, "Minimum tip can't exceed \$1000.")
-                else -> (dollars * 100).roundToInt()
-            }
-        } else {
-            // Gate off: preserve whatever min is on file (default 0 when blank/invalid).
-            ((current.minTipDollars.trim().toDoubleOrNull() ?: 0.0).coerceAtLeast(0.0) * 100).roundToInt()
+        val minCents = when (
+            val v = MessagePrivacyMath.validateMinTip(current.requireTip, current.minTipDollars)
+        ) {
+            is MessagePrivacyMath.MinTipResult.Invalid -> return fail(current, v.message)
+            is MessagePrivacyMath.MinTipResult.Valid -> v.cents
         }
 
         _uiState.value = current.copy(saving = true, formError = null, savedMessage = null)
@@ -83,9 +76,9 @@ class MessagePrivacyViewModel @Inject constructor(
 
     fun addAllowlist() {
         val current = _uiState.value as? MessagePrivacyUiState.Content ?: return
-        val userId = current.allowlistInput.trim()
-        if (userId.isEmpty()) return fail(current, "Enter a user id to allow.")
-        if (current.allowlist.any { it.equals(userId, ignoreCase = true) }) {
+        val userId = MessagePrivacyMath.normalizeAllowlistInput(current.allowlistInput)
+            ?: return fail(current, "Enter a user id to allow.")
+        if (MessagePrivacyMath.isDuplicateAllowlistEntry(current.allowlist, userId)) {
             return fail(current, "That user is already on the allowlist.")
         }
         if (current.saving || current.mutatingAllowlist != null) return
@@ -127,7 +120,7 @@ class MessagePrivacyViewModel @Inject constructor(
         savedMessage: String? = null,
     ) = MessagePrivacyUiState.Content(
         requireTip = requireTipToMessage,
-        minTipDollars = if (minTipCents > 0) (minTipCents / 100.0).toString() else "1.0",
+        minTipDollars = MessagePrivacyMath.centsToDollarsField(minTipCents),
         allowlist = tipFreeAllowlist,
         allowlistInput = allowlistInput,
         savedMessage = savedMessage,

--- a/android/app/src/test/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/settings/msgprivacy/MessagePrivacyMathTest.kt
@@ -1,0 +1,151 @@
+package com.testlogon.android.feature.settings.msgprivacy
+
+import com.testlogon.android.feature.settings.msgprivacy.MessagePrivacyMath.MinTipResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** TIP-B4 (TIP-404) — pure unit tests for the pay-to-message validation + formatting logic. */
+class MessagePrivacyMathTest {
+
+    // --- validateMinTip: gate ON ---
+
+    @Test
+    fun requireOn_validAmount_returnsCents() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "5")
+        assertEquals(MinTipResult.Valid(500), r)
+    }
+
+    @Test
+    fun requireOn_decimalAmount_roundsToCents() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "2.99")
+        assertEquals(MinTipResult.Valid(299), r)
+    }
+
+    @Test
+    fun requireOn_zero_isInvalidTooLow() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "0")
+        assertEquals(MinTipResult.Invalid(MessagePrivacyMath.ERROR_TOO_LOW), r)
+    }
+
+    @Test
+    fun requireOn_negative_isInvalidTooLow() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "-3")
+        assertEquals(MinTipResult.Invalid(MessagePrivacyMath.ERROR_TOO_LOW), r)
+    }
+
+    @Test
+    fun requireOn_blank_isInvalidTooLow() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "   ")
+        assertEquals(MinTipResult.Invalid(MessagePrivacyMath.ERROR_TOO_LOW), r)
+    }
+
+    @Test
+    fun requireOn_nonNumeric_isInvalidTooLow() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "abc")
+        assertEquals(MinTipResult.Invalid(MessagePrivacyMath.ERROR_TOO_LOW), r)
+    }
+
+    @Test
+    fun requireOn_aboveMax_isInvalidTooHigh() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "1000.01")
+        assertEquals(MinTipResult.Invalid(MessagePrivacyMath.ERROR_TOO_HIGH), r)
+    }
+
+    @Test
+    fun requireOn_exactlyMax_isValid() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "1000")
+        assertEquals(MinTipResult.Valid(MessagePrivacyMath.MAX_MIN_TIP_CENTS), r)
+    }
+
+    @Test
+    fun requireOn_whitespacePadded_isTrimmed() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = true, dollarsInput = "  7.50 ")
+        assertEquals(MinTipResult.Valid(750), r)
+    }
+
+    // --- validateMinTip: gate OFF (advisory) ---
+
+    @Test
+    fun requireOff_blank_coalescesToZero() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = false, dollarsInput = "")
+        assertEquals(MinTipResult.Valid(0), r)
+    }
+
+    @Test
+    fun requireOff_negative_coalescesToZero() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = false, dollarsInput = "-9")
+        assertEquals(MinTipResult.Valid(0), r)
+    }
+
+    @Test
+    fun requireOff_positive_preservesCents() {
+        val r = MessagePrivacyMath.validateMinTip(requireTip = false, dollarsInput = "4")
+        assertEquals(MinTipResult.Valid(400), r)
+    }
+
+    // --- dollars <-> cents ---
+
+    @Test
+    fun dollarsToCents_roundsHalfUp() {
+        assertEquals(300, MessagePrivacyMath.dollarsToCents(2.999))
+        assertEquals(0, MessagePrivacyMath.dollarsToCents(0.0))
+        assertEquals(0, MessagePrivacyMath.dollarsToCents(-5.0))
+    }
+
+    @Test
+    fun centsToDollarsField_positive() {
+        assertEquals("5.0", MessagePrivacyMath.centsToDollarsField(500))
+    }
+
+    @Test
+    fun centsToDollarsField_zeroShowsDefault() {
+        assertEquals(MessagePrivacyMath.DEFAULT_MIN_TIP_DOLLARS, MessagePrivacyMath.centsToDollarsField(0))
+    }
+
+    @Test
+    fun centsToDollarsField_negativeShowsDefault() {
+        assertEquals(MessagePrivacyMath.DEFAULT_MIN_TIP_DOLLARS, MessagePrivacyMath.centsToDollarsField(-1))
+    }
+
+    // --- allowlist helpers ---
+
+    @Test
+    fun duplicateAllowlist_caseInsensitive() {
+        assertTrue(MessagePrivacyMath.isDuplicateAllowlistEntry(listOf("User-1"), "user-1"))
+    }
+
+    @Test
+    fun duplicateAllowlist_trimsInput() {
+        assertTrue(MessagePrivacyMath.isDuplicateAllowlistEntry(listOf("bob"), "  bob "))
+    }
+
+    @Test
+    fun duplicateAllowlist_absentReturnsFalse() {
+        assertFalse(MessagePrivacyMath.isDuplicateAllowlistEntry(listOf("alice"), "bob"))
+    }
+
+    @Test
+    fun normalizeAllowlistInput_blankIsNull() {
+        assertEquals(null, MessagePrivacyMath.normalizeAllowlistInput("   "))
+    }
+
+    @Test
+    fun normalizeAllowlistInput_trimsValue() {
+        assertEquals("carol", MessagePrivacyMath.normalizeAllowlistInput("  carol "))
+    }
+
+    // --- degrade-on-404 ---
+
+    @Test
+    fun missingConfig_404_isBenign() {
+        assertTrue(MessagePrivacyMath.isBenignMissingConfig(404))
+    }
+
+    @Test
+    fun missingConfig_otherStatus_isNotBenign() {
+        assertFalse(MessagePrivacyMath.isBenignMissingConfig(500))
+        assertFalse(MessagePrivacyMath.isBenignMissingConfig(null))
+    }
+}

--- a/frontend/src/api/endpoints/messaging.ts
+++ b/frontend/src/api/endpoints/messaging.ts
@@ -1653,3 +1653,83 @@ export async function sendVoicemail(
     mode: meta.mode,
   });
 }
+
+// ---- Pay-to-message privacy (TIP-401) ---------------------------------------
+//
+// Backend: GET/PUT /messaging/privacy/message,
+// POST /messaging/privacy/message/allowlist,
+// DELETE /messaging/privacy/message/allowlist/{allow_user_id}.
+// The read degrades-on-404 to an honest-empty gate (feature not deployed);
+// mutations propagate their errors so the UI can surface an error toast.
+import {
+  normalizeMessagePrivacy,
+  defaultMessagePrivacy,
+  type MessagePrivacy,
+} from "@/lib/messagePrivacy";
+
+export interface MessagePrivacyUpdate {
+  require_tip_to_message?: boolean;
+  min_tip_cents?: number;
+  tip_free_allowlist?: string[];
+}
+
+/**
+ * Read the callers pay-to-message settings. Degrade-on-404: if the endpoint is
+
+// ---- Pay-to-message privacy (TIP-401) ---------------------------------------
+//
+// Backend: GET/PUT /messaging/privacy/message,
+// POST /messaging/privacy/message/allowlist,
+// DELETE /messaging/privacy/message/allowlist/{allow_user_id}.
+// The read degrades-on-404 to an honest-empty gate (feature not deployed);
+// mutations propagate their errors so the UI can surface an error toast.
+import {
+  normalizeMessagePrivacy,
+  defaultMessagePrivacy,
+  type MessagePrivacy,
+} from "@/lib/messagePrivacy";
+
+export interface MessagePrivacyUpdate {
+  require_tip_to_message?: boolean;
+  min_tip_cents?: number;
+  tip_free_allowlist?: string[];
+}
+
+/**
+ * Read the caller's pay-to-message settings. Degrade-on-404: if the endpoint is
+ * not deployed we return the honest-empty default (gate off) rather than throw,
+ * so the settings surface renders an inert "off" state.
+ */
+export async function getMessagePrivacy(): Promise<MessagePrivacy> {
+  try {
+    const res = await api.get<unknown>("/messaging/privacy/message");
+    return normalizeMessagePrivacy(res);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return defaultMessagePrivacy();
+    throw err;
+  }
+}
+
+/** Update (partial) the caller's pay-to-message settings. */
+export async function updateMessagePrivacy(
+  patch: MessagePrivacyUpdate,
+): Promise<MessagePrivacy> {
+  const res = await api.put<unknown>("/messaging/privacy/message", patch);
+  return normalizeMessagePrivacy(res);
+}
+
+/** Add a user to the tip-free allowlist. Returns the updated settings. */
+export async function addAllowlist(userId: string): Promise<MessagePrivacy> {
+  const res = await api.post<unknown>("/messaging/privacy/message/allowlist", {
+    user_id: userId,
+  });
+  return normalizeMessagePrivacy(res);
+}
+
+/** Remove a user from the tip-free allowlist. Returns the updated settings. */
+export async function removeAllowlist(userId: string): Promise<MessagePrivacy> {
+  const res = await api.del<unknown>(
+    `/messaging/privacy/message/allowlist/${encodeURIComponent(userId)}`,
+  );
+  return normalizeMessagePrivacy(res);
+}

--- a/frontend/src/lib/messagePrivacy.test.ts
+++ b/frontend/src/lib/messagePrivacy.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultMessagePrivacy,
+  normalizeMessagePrivacy,
+  validateMinAmountCents,
+  formatCents,
+  isAllowlisted,
+  isGatedForSender,
+  describePrivacy,
+  MAX_MIN_TIP_CENTS,
+  type MessagePrivacy,
+} from "./messagePrivacy";
+
+describe("defaultMessagePrivacy", () => {
+  it("returns an honest-empty gate", () => {
+    expect(defaultMessagePrivacy()).toEqual({
+      require_tip_to_message: false,
+      min_tip_cents: 0,
+      tip_free_allowlist: [],
+    });
+  });
+  it("returns a fresh array each call (no shared mutation)", () => {
+    const a = defaultMessagePrivacy();
+    a.tip_free_allowlist.push("x");
+    expect(defaultMessagePrivacy().tip_free_allowlist).toEqual([]);
+  });
+});
+
+describe("normalizeMessagePrivacy", () => {
+  it("defaults on null / non-object", () => {
+    expect(normalizeMessagePrivacy(null)).toEqual(defaultMessagePrivacy());
+    expect(normalizeMessagePrivacy(42)).toEqual(defaultMessagePrivacy());
+    expect(normalizeMessagePrivacy(undefined)).toEqual(defaultMessagePrivacy());
+  });
+  it("coerces a well-formed record", () => {
+    expect(
+      normalizeMessagePrivacy({
+        require_tip_to_message: true,
+        min_tip_cents: 500,
+        tip_free_allowlist: ["u1", "u2"],
+      }),
+    ).toEqual({ require_tip_to_message: true, min_tip_cents: 500, tip_free_allowlist: ["u1", "u2"] });
+  });
+  it("treats truthy-but-not-true require flag as false", () => {
+    expect(normalizeMessagePrivacy({ require_tip_to_message: 1 }).require_tip_to_message).toBe(false);
+  });
+  it("floors fractional cents and zeroes negatives / NaN", () => {
+    expect(normalizeMessagePrivacy({ min_tip_cents: 199.9 }).min_tip_cents).toBe(199);
+    expect(normalizeMessagePrivacy({ min_tip_cents: -5 }).min_tip_cents).toBe(0);
+    expect(normalizeMessagePrivacy({ min_tip_cents: "nope" }).min_tip_cents).toBe(0);
+  });
+  it("dedupes + trims + drops empties in the allowlist", () => {
+    expect(
+      normalizeMessagePrivacy({ tip_free_allowlist: ["a", " a ", "", "b", "a"] }).tip_free_allowlist,
+    ).toEqual(["a", "b"]);
+  });
+});
+
+describe("validateMinAmountCents", () => {
+  it("accepts a valid integer cents value", () => {
+    expect(validateMinAmountCents(500)).toEqual({ ok: true, cents: 500 });
+  });
+  it("accepts numeric strings", () => {
+    expect(validateMinAmountCents("1234")).toEqual({ ok: true, cents: 1234 });
+  });
+  it("accepts zero", () => {
+    expect(validateMinAmountCents(0)).toEqual({ ok: true, cents: 0 });
+  });
+  it("accepts the max boundary", () => {
+    expect(validateMinAmountCents(MAX_MIN_TIP_CENTS)).toEqual({ ok: true, cents: MAX_MIN_TIP_CENTS });
+  });
+  it("rejects empty / non-numeric", () => {
+    expect(validateMinAmountCents("").ok).toBe(false);
+    expect(validateMinAmountCents("abc").ok).toBe(false);
+  });
+  it("rejects negatives", () => {
+    const r = validateMinAmountCents(-1);
+    expect(r.ok).toBe(false);
+    expect(r.cents).toBe(0);
+  });
+  it("rejects fractional cents but reports the floor", () => {
+    const r = validateMinAmountCents(10.5);
+    expect(r.ok).toBe(false);
+    expect(r.cents).toBe(10);
+  });
+  it("rejects over-cap and clamps the reported value", () => {
+    const r = validateMinAmountCents(MAX_MIN_TIP_CENTS + 1);
+    expect(r.ok).toBe(false);
+    expect(r.cents).toBe(MAX_MIN_TIP_CENTS);
+  });
+});
+
+describe("formatCents", () => {
+  it("formats dollars and cents", () => {
+    expect(formatCents(0)).toBe("$0.00");
+    expect(formatCents(500)).toBe("$5.00");
+    expect(formatCents(1234)).toBe("$12.34");
+  });
+  it("clamps negatives and rounds NaN to $0.00", () => {
+    expect(formatCents(-100)).toBe("$0.00");
+    expect(formatCents(Number.NaN)).toBe("$0.00");
+  });
+});
+
+describe("isAllowlisted", () => {
+  const p: MessagePrivacy = {
+    require_tip_to_message: true,
+    min_tip_cents: 100,
+    tip_free_allowlist: ["friend-1", "friend-2"],
+  };
+  it("true for a listed user", () => {
+    expect(isAllowlisted(p, "friend-1")).toBe(true);
+    expect(isAllowlisted(p, " friend-2 ")).toBe(true);
+  });
+  it("false for an unlisted / empty user or null privacy", () => {
+    expect(isAllowlisted(p, "stranger")).toBe(false);
+    expect(isAllowlisted(p, "")).toBe(false);
+    expect(isAllowlisted(null, "friend-1")).toBe(false);
+  });
+});
+
+describe("isGatedForSender", () => {
+  const p: MessagePrivacy = {
+    require_tip_to_message: true,
+    min_tip_cents: 100,
+    tip_free_allowlist: ["friend-1"],
+  };
+  it("gates a stranger when the gate is on", () => {
+    expect(isGatedForSender(p, "stranger")).toBe(true);
+  });
+  it("does not gate an allowlisted sender", () => {
+    expect(isGatedForSender(p, "friend-1")).toBe(false);
+  });
+  it("does not gate when the gate is off", () => {
+    expect(isGatedForSender({ ...p, require_tip_to_message: false }, "stranger")).toBe(false);
+    expect(isGatedForSender(null, "stranger")).toBe(false);
+  });
+});
+
+describe("describePrivacy", () => {
+  it("describes an off gate", () => {
+    expect(describePrivacy(defaultMessagePrivacy())).toBe("Anyone can message you for free.");
+  });
+  it("describes an on gate with no exemptions", () => {
+    expect(
+      describePrivacy({ require_tip_to_message: true, min_tip_cents: 250, tip_free_allowlist: [] }),
+    ).toBe("New senders must tip at least $2.50 to reach your inbox.");
+  });
+  it("pluralizes the exemption count", () => {
+    expect(
+      describePrivacy({ require_tip_to_message: true, min_tip_cents: 100, tip_free_allowlist: ["a"] }),
+    ).toContain("1 person is exempt");
+    expect(
+      describePrivacy({
+        require_tip_to_message: true,
+        min_tip_cents: 100,
+        tip_free_allowlist: ["a", "b"],
+      }),
+    ).toContain("2 people are exempt");
+  });
+});

--- a/frontend/src/lib/messagePrivacy.ts
+++ b/frontend/src/lib/messagePrivacy.ts
@@ -1,0 +1,127 @@
+// messagePrivacy.ts — pure, side-effect-free helpers for the pay-to-message
+// (TIP-401 "require a tip to message me") privacy surface. All money is handled
+// in INTEGER CENTS end to end, matching the backend contract
+// (MessagePrivacyOut.min_tip_cents: int, 0..100_000).
+//
+// Nothing in here does I/O — it is unit-tested in messagePrivacy.test.ts and
+// consumed by the API layer (endpoints/messaging.ts) and the settings dialog.
+
+/** The shape the backend returns for GET/PUT /messaging/privacy/message. */
+export interface MessagePrivacy {
+  require_tip_to_message: boolean;
+  /** Minimum tip required to reach the inbox, in integer cents. */
+  min_tip_cents: number;
+  /** User ids that bypass the tip gate entirely. */
+  tip_free_allowlist: string[];
+}
+
+/** Backend cap on min_tip_cents (Field(ge=0, le=100_000)). */
+export const MIN_TIP_CENTS_MIN = 0;
+export const MAX_MIN_TIP_CENTS = 100_000;
+
+/** The honest-empty default used when the endpoint 404s / user never set it. */
+export function defaultMessagePrivacy(): MessagePrivacy {
+  return { require_tip_to_message: false, min_tip_cents: 0, tip_free_allowlist: [] };
+}
+
+/**
+ * Coerce an arbitrary server/JSON blob into a well-formed MessagePrivacy,
+ * filling defaults for anything missing or malformed. Never throws.
+ */
+export function normalizeMessagePrivacy(raw: unknown): MessagePrivacy {
+  const out = defaultMessagePrivacy();
+  if (!raw || typeof raw !== "object") return out;
+  const r = raw as Record<string, unknown>;
+  out.require_tip_to_message = r.require_tip_to_message === true;
+  const cents = Number(r.min_tip_cents);
+  out.min_tip_cents = Number.isFinite(cents) && cents > 0 ? Math.floor(cents) : 0;
+  if (Array.isArray(r.tip_free_allowlist)) {
+    const seen = new Set<string>();
+    for (const x of r.tip_free_allowlist) {
+      const s = String(x ?? "").trim();
+      if (s && !seen.has(s)) {
+        seen.add(s);
+        out.tip_free_allowlist.push(s);
+      }
+    }
+  }
+  return out;
+}
+
+export interface CentsValidation {
+  ok: boolean;
+  /** The clamped/parsed integer cents value (valid regardless of ok). */
+  cents: number;
+  /** Human-readable reason when ok === false. */
+  error?: string;
+}
+
+/**
+ * Validate a user-entered minimum-tip amount expressed in CENTS. Accepts a
+ * number or a numeric string. Must be a non-negative integer within the
+ * backend range [0, 100_000]. Returns a clamped cents value alongside the ok
+ * flag so callers can both gate the save and show a sane field value.
+ */
+export function validateMinAmountCents(input: number | string): CentsValidation {
+  const n = typeof input === "string" ? Number(input.trim()) : input;
+  if (input === "" || input == null || !Number.isFinite(n)) {
+    return { ok: false, cents: 0, error: "Enter an amount in cents" };
+  }
+  if (n < 0) {
+    return { ok: false, cents: 0, error: "Amount cannot be negative" };
+  }
+  if (!Number.isInteger(n)) {
+    return { ok: false, cents: Math.floor(n), error: "Amount must be a whole number of cents" };
+  }
+  if (n > MAX_MIN_TIP_CENTS) {
+    return {
+      ok: false,
+      cents: MAX_MIN_TIP_CENTS,
+      error: `Amount cannot exceed ${MAX_MIN_TIP_CENTS} cents`,
+    };
+  }
+  return { ok: true, cents: n };
+}
+
+/** Format integer cents as a "$X.XX" USD string. Clamps negatives to $0.00. */
+export function formatCents(cents: number): string {
+  const c = Number.isFinite(cents) ? Math.max(0, Math.round(cents)) : 0;
+  return `$${(c / 100).toFixed(2)}`;
+}
+
+/**
+ * True if `userId` is currently on the tip-free allowlist (may message without
+ * paying). Empty / falsy ids are never allowlisted.
+ */
+export function isAllowlisted(privacy: MessagePrivacy | null | undefined, userId: string): boolean {
+  if (!privacy || !userId) return false;
+  const target = String(userId).trim();
+  if (!target) return false;
+  return privacy.tip_free_allowlist.includes(target);
+}
+
+/**
+ * Whether `senderId` would be gated (must attach a tip) when messaging a user
+ * with these settings — the FRONTEND mirror of the backend bypass logic that is
+ * knowable client-side: gate is off, or the sender is allowlisted, means no
+ * gate. (Mutual-follow / established-conversation bypasses are server-only.)
+ */
+export function isGatedForSender(
+  privacy: MessagePrivacy | null | undefined,
+  senderId: string,
+): boolean {
+  if (!privacy || !privacy.require_tip_to_message) return false;
+  if (isAllowlisted(privacy, senderId)) return false;
+  return true;
+}
+
+/** One-line human summary of the current gate for the settings UI. */
+export function describePrivacy(privacy: MessagePrivacy): string {
+  if (!privacy.require_tip_to_message) {
+    return "Anyone can message you for free.";
+  }
+  const amt = formatCents(privacy.min_tip_cents);
+  const n = privacy.tip_free_allowlist.length;
+  const allow = n === 0 ? "" : ` (${n} ${n === 1 ? "person is" : "people are"} exempt)`;
+  return `New senders must tip at least ${amt} to reach your inbox${allow}.`;
+}

--- a/frontend/src/pages/messages/ConversationList.tsx
+++ b/frontend/src/pages/messages/ConversationList.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { locationPreview } from "@/lib/locationCards";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Search, Plus, MessageSquare, Users, BellOff } from "lucide-react";
+import { Search, Plus, MessageSquare, Users, BellOff, Settings2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -21,6 +21,7 @@ import type { Conversation, Message, UserSearchResult } from "@/api/types";
 import { isPendingInvite } from "@/lib/conversationActions";
 import { PresenceDot } from "./PresenceDot";
 import { UserSearch } from "./UserSearch";
+import { MessagePrivacyDialog } from "./MessagePrivacyDialog";
 import { useAuthStore } from "@/stores/authStore";
 import { transferPreview } from "@/lib/cryptoTransfer";
 import { isRevealLocked } from "@/lib/revealAt";
@@ -37,6 +38,7 @@ export function ConversationList({ activeId, onSelect }: ConversationListProps) 
   const navigate = useNavigate();
   const [search, setSearch] = React.useState("");
   const [newConvoOpen, setNewConvoOpen] = React.useState(false);
+  const [privacyOpen, setPrivacyOpen] = React.useState(false);
   const [isGroupMode, setIsGroupMode] = React.useState(false);
   const [groupTitle, setGroupTitle] = React.useState("");
   const [groupParticipants, setGroupParticipants] = React.useState<UserSearchResult[]>([]);
@@ -265,6 +267,15 @@ export function ConversationList({ activeId, onSelect }: ConversationListProps) 
           <Users className="h-4 w-4" />
           New Group
         </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Message privacy settings"
+          title="Message privacy"
+          onClick={() => setPrivacyOpen(true)}
+        >
+          <Settings2 className="h-4 w-4" />
+        </Button>
       </div>
 
       {/* New conversation dialog */}
@@ -332,6 +343,9 @@ export function ConversationList({ activeId, onSelect }: ConversationListProps) 
           </div>
         </DialogContent>
       </Dialog>
+
+      {/* Pay-to-message (TIP-401) privacy settings */}
+      <MessagePrivacyDialog open={privacyOpen} onOpenChange={setPrivacyOpen} />
     </div>
   );
 }

--- a/frontend/src/pages/messages/MessagePrivacyDialog.tsx
+++ b/frontend/src/pages/messages/MessagePrivacyDialog.tsx
@@ -1,0 +1,230 @@
+import * as React from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { X, ShieldCheck } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { UserSearch } from "./UserSearch";
+import type { UserSearchResult } from "@/api/types";
+import {
+  getMessagePrivacy,
+  updateMessagePrivacy,
+  addAllowlist,
+  removeAllowlist,
+} from "@/api/endpoints/messaging";
+import {
+  defaultMessagePrivacy,
+  validateMinAmountCents,
+  formatCents,
+  describePrivacy,
+  type MessagePrivacy,
+} from "@/lib/messagePrivacy";
+
+const QUERY_KEY = ["messaging", "privacy", "message"] as const;
+
+interface MessagePrivacyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Pay-to-message (TIP-401) settings surface: toggle the tip gate, set the
+ * minimum tip in integer cents, and manage the tip-free allowlist. Reads
+ * degrade-on-404 (honest-empty, gate off); mutations surface an error toast.
+ */
+export function MessagePrivacyDialog({ open, onOpenChange }: MessagePrivacyDialogProps) {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery<MessagePrivacy>({
+    queryKey: QUERY_KEY,
+    queryFn: getMessagePrivacy,
+    enabled: open,
+    retry: false,
+  });
+
+  const privacy = data ?? defaultMessagePrivacy();
+
+  // Local draft of the min-amount field (cents, as a string for the input).
+  const [amountInput, setAmountInput] = React.useState<string>("");
+  React.useEffect(() => {
+    if (data) setAmountInput(String(data.min_tip_cents));
+  }, [data]);
+
+  const write = (next: MessagePrivacy) => queryClient.setQueryData(QUERY_KEY, next);
+
+  const toggleMutation = useMutation({
+    mutationFn: (require: boolean) => updateMessagePrivacy({ require_tip_to_message: require }),
+    onSuccess: write,
+    onError: () => toast.error("Could not update your message privacy. Try again."),
+  });
+
+  const amountMutation = useMutation({
+    mutationFn: (cents: number) => updateMessagePrivacy({ min_tip_cents: cents }),
+    onSuccess: (next) => {
+      write(next);
+      toast.success(`Minimum tip set to ${formatCents(next.min_tip_cents)}.`);
+    },
+    onError: () => toast.error("Could not save the minimum amount. Try again."),
+  });
+
+  const addMutation = useMutation({
+    mutationFn: (userId: string) => addAllowlist(userId),
+    onSuccess: write,
+    onError: () => toast.error("Could not add that person to the allowlist."),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (userId: string) => removeAllowlist(userId),
+    onSuccess: write,
+    onError: () => toast.error("Could not remove that person from the allowlist."),
+  });
+
+  const amountValidation = validateMinAmountCents(amountInput);
+  const amountDirty = amountInput !== String(privacy.min_tip_cents);
+
+  const handleSaveAmount = () => {
+    if (!amountValidation.ok) return;
+    amountMutation.mutate(amountValidation.cents);
+  };
+
+  const handleAddUser = (user: UserSearchResult) => {
+    if (!user.user_id) return;
+    if (privacy.tip_free_allowlist.includes(user.user_id)) return;
+    addMutation.mutate(user.user_id);
+  };
+
+  const busy =
+    toggleMutation.isPending ||
+    amountMutation.isPending ||
+    addMutation.isPending ||
+    removeMutation.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            Message Privacy
+          </DialogTitle>
+          <DialogDescription>{describePrivacy(privacy)}</DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="py-6 text-center text-sm text-muted-foreground">Loading...</div>
+        ) : (
+          <div className="space-y-4">
+            {/* Require-tip toggle */}
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="require-tip" className="text-sm font-medium">
+                  Require a tip to message me
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  New senders must attach a tip to reach your inbox.
+                </p>
+              </div>
+              <Switch
+                id="require-tip"
+                checked={privacy.require_tip_to_message}
+                disabled={busy}
+                onCheckedChange={(v) => toggleMutation.mutate(v)}
+              />
+            </div>
+
+            {privacy.require_tip_to_message && (
+              <>
+                <Separator />
+                {/* Minimum amount (cents) */}
+                <div className="space-y-1.5">
+                  <Label htmlFor="min-amount" className="text-sm font-medium">
+                    Minimum tip (cents)
+                  </Label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      id="min-amount"
+                      type="number"
+                      min={0}
+                      step={1}
+                      inputMode="numeric"
+                      value={amountInput}
+                      disabled={busy}
+                      onChange={(e) => setAmountInput(e.target.value)}
+                      className="w-32"
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      = {formatCents(amountValidation.cents)}
+                    </span>
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="ml-auto"
+                      disabled={busy || !amountValidation.ok || !amountDirty}
+                      onClick={handleSaveAmount}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                  {!amountValidation.ok && amountInput !== "" && (
+                    <p className="text-xs text-destructive">{amountValidation.error}</p>
+                  )}
+                </div>
+
+                <Separator />
+                {/* Allowlist */}
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Tip-free allowlist</Label>
+                  <p className="text-xs text-muted-foreground">
+                    These people can always message you for free.
+                  </p>
+                  <UserSearch
+                    onSelect={handleAddUser}
+                    placeholder="Add a person to the allowlist..."
+                  />
+                  {privacy.tip_free_allowlist.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No one is exempt yet.</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2 pt-1">
+                      {privacy.tip_free_allowlist.map((uid) => (
+                        <Badge key={uid} variant="secondary" className="gap-1 pr-1">
+                          <span className="max-w-[10rem] truncate">{uid}</span>
+                          <button
+                            type="button"
+                            aria-label={`Remove ${uid}`}
+                            className="rounded-full p-0.5 hover:bg-muted"
+                            disabled={busy}
+                            onClick={() => removeMutation.mutate(uid)}
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## FE parity PAR-102 - pay-to-message privacy + allowlist (web + Android)

Brings the pay-to-message privacy + allowlist surface to feature parity across web and Android.

### Web
- New `frontend/src/lib/messagePrivacy.ts` privacy/allowlist + pricing helpers (unit-tested in `messagePrivacy.test.ts`).
- New `MessagePrivacyDialog.tsx` wired into `ConversationList.tsx`.
- `api/endpoints/messaging.ts` extended for privacy settings + per-user allowlist.

### Android
- New `MessagePrivacyMath.kt` allowlist/pricing logic (unit-tested in `MessagePrivacyMathTest.kt`).
- `MessagePrivacyRepository.kt` + `MessagePrivacyViewModel.kt` wiring.

### Gates
- Web: vitest (`payment-incident-frontend-e2e`).
- Backend matrix: `payment-incident-backend-matrix`.
- Android unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
