### PR TITLE
FE parity PAR-103 - video comment tip (web)

### DIFF
--- a/frontend/src/api/endpoints/gallery.ts
+++ b/frontend/src/api/endpoints/gallery.ts
@@ -89,6 +89,8 @@ export interface VideoComment {
   image_height?: number | null;
   reactions_counts?: Record<string, number>;
   my_reactions?: string[];
+  // TIP-303: running total tipped to this comment (cents).
+  tip_total_cents?: number;
 }
 
 export interface AddVideoCommentReq {
@@ -213,6 +215,33 @@ export const unreactFromVideoComment = (
   api.post<VideoComment>(
     `/ui/videos/${videoId}/comments/${commentId}/unreact`,
     { emoji },
+  );
+
+export interface VideoCommentTipResponse {
+  ok: boolean;
+  video_id: string;
+  comment_id: string;
+  amount_cents: number;
+  currency: string;
+  tip_total_cents: number;
+}
+
+// TIP-303 (web): tip a video comment. Mirrors the newsfeed comment-tip idiom
+// (POST /ui/videos/{id}/comments/{cid}/tip) and threads the chosen payment
+// method so the tipper is charged on their selected card.
+export const tipVideoComment = (
+  videoId: string,
+  commentId: string,
+  amountCents: number,
+  paymentMethodId?: string,
+): Promise<VideoCommentTipResponse> =>
+  api.post<VideoCommentTipResponse>(
+    `/ui/videos/${videoId}/comments/${commentId}/tip`,
+    {
+      amount_cents: amountCents,
+      currency: "usd",
+      ...(paymentMethodId ? { payment_method_id: paymentMethodId } : {}),
+    },
   );
 
 export const listVideoComments = (

--- a/frontend/src/lib/videoCommentTip.test.ts
+++ b/frontend/src/lib/videoCommentTip.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_TIP_CENTS,
+  parseTipDollarsToCents,
+  validateTipCents,
+} from "./videoCommentTip";
+
+describe("validateTipCents", () => {
+  it("accepts a normal positive integer cents value", () => {
+    expect(validateTipCents(100)).toEqual({ ok: true, cents: 100 });
+  });
+
+  it("accepts the maximum allowed value", () => {
+    expect(validateTipCents(MAX_TIP_CENTS)).toEqual({
+      ok: true,
+      cents: MAX_TIP_CENTS,
+    });
+  });
+
+  it("rejects zero", () => {
+    const r = validateTipCents(0);
+    expect(r.ok).toBe(false);
+    expect(r.cents).toBeUndefined();
+    expect(r.error).toBeTruthy();
+  });
+
+  it("rejects negative amounts", () => {
+    expect(validateTipCents(-50).ok).toBe(false);
+  });
+
+  it("rejects non-integer cents", () => {
+    const r = validateTipCents(12.5);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/whole number/i);
+  });
+
+  it("rejects amounts over the ceiling", () => {
+    expect(validateTipCents(MAX_TIP_CENTS + 1).ok).toBe(false);
+  });
+
+  it("rejects NaN and Infinity", () => {
+    expect(validateTipCents(NaN).ok).toBe(false);
+    expect(validateTipCents(Infinity).ok).toBe(false);
+  });
+
+  it("rejects non-number inputs", () => {
+    expect(validateTipCents("100").ok).toBe(false);
+    expect(validateTipCents(null).ok).toBe(false);
+    expect(validateTipCents(undefined).ok).toBe(false);
+  });
+});
+
+describe("parseTipDollarsToCents", () => {
+  it("parses whole dollars", () => {
+    expect(parseTipDollarsToCents("5")).toBe(500);
+  });
+
+  it("parses fractional dollars", () => {
+    expect(parseTipDollarsToCents("2.50")).toBe(250);
+  });
+
+  it("rounds to the nearest cent", () => {
+    expect(parseTipDollarsToCents("2.505")).toBe(251);
+  });
+
+  it("returns null for empty / whitespace input", () => {
+    expect(parseTipDollarsToCents("")).toBeNull();
+    expect(parseTipDollarsToCents("   ")).toBeNull();
+  });
+
+  it("returns null for non-numeric or non-positive input", () => {
+    expect(parseTipDollarsToCents("abc")).toBeNull();
+    expect(parseTipDollarsToCents("0")).toBeNull();
+    expect(parseTipDollarsToCents("-3")).toBeNull();
+  });
+
+  it("round-trips into a valid tip", () => {
+    const cents = parseTipDollarsToCents("2.50");
+    expect(cents).not.toBeNull();
+    expect(validateTipCents(cents as number)).toEqual({ ok: true, cents: 250 });
+  });
+});

--- a/frontend/src/lib/videoCommentTip.ts
+++ b/frontend/src/lib/videoCommentTip.ts
@@ -1,0 +1,51 @@
+// TIP-303 (web): pure helpers for tipping a VIDEO COMMENT.
+//
+// The tip amount is expressed in whole cents (matching the backend
+// VideoCommentTipIn contract: { amount_cents, currency, payment_method_id? }).
+// These helpers keep the amount-validation logic out of the React component so
+// it can be unit tested without a DOM.
+
+/** Hard ceiling for a single comment tip (in cents) = $10,000. */
+export const MAX_TIP_CENTS = 1_000_000;
+
+export interface TipCentsResult {
+  ok: boolean;
+  /** Normalized integer cents, only present when ok. */
+  cents?: number;
+  /** Human-readable reason, only present when !ok. */
+  error?: string;
+}
+
+/**
+ * Validate a tip amount given in cents. Rejects non-finite, non-integer,
+ * non-positive, and over-ceiling values. Returns the normalized cents on
+ * success so callers can trust the value they send to the API.
+ */
+export function validateTipCents(cents: unknown): TipCentsResult {
+  if (typeof cents !== "number" || !Number.isFinite(cents)) {
+    return { ok: false, error: "Enter a tip amount." };
+  }
+  if (!Number.isInteger(cents)) {
+    return { ok: false, error: "Tip must be a whole number of cents." };
+  }
+  if (cents <= 0) {
+    return { ok: false, error: "Tip must be greater than $0." };
+  }
+  if (cents > MAX_TIP_CENTS) {
+    return { ok: false, error: "Tip exceeds the maximum allowed." };
+  }
+  return { ok: true, cents };
+}
+
+/**
+ * Parse a user-entered dollar string (e.g. "2.50") into integer cents.
+ * Returns null when the input is empty or not a positive money value.
+ * Rounds to the nearest cent to avoid float dust (2.505 -> 251).
+ */
+export function parseTipDollarsToCents(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const dollars = Number(trimmed);
+  if (!Number.isFinite(dollars) || dollars <= 0) return null;
+  return Math.round(dollars * 100);
+}

--- a/frontend/src/pages/feed/TipDialog.tsx
+++ b/frontend/src/pages/feed/TipDialog.tsx
@@ -13,6 +13,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { tipPostDirect, tipComment } from "@/api/endpoints/newsfeed";
+import { tipVideoComment } from "@/api/endpoints/gallery";
+import { validateTipCents } from "@/lib/videoCommentTip";
 import { getPaymentMethods } from "@/api/endpoints/billing";
 import type { PaymentMethod } from "@/api/types";
 
@@ -25,16 +27,23 @@ interface TipDialogProps {
   authorId: string;
   /** If provided, tips the comment instead of the post directly */
   commentId?: string;
+  /**
+   * TIP-303 (web): when provided, this dialog tips a VIDEO comment via the
+   * gallery endpoint instead of the newsfeed post/comment endpoints. Reuses the
+   * same amount picker + payment-method selector idiom.
+   */
+  videoComment?: { videoId: string; commentId: string };
 }
 
-export function TipDialog({ open, onOpenChange, postId, authorId, commentId }: TipDialogProps) {
+export function TipDialog({ open, onOpenChange, postId, authorId, commentId, videoComment }: TipDialogProps) {
   const queryClient = useQueryClient();
   const [amountCents, setAmountCents] = useState<number>(100);
   const [customValue, setCustomValue] = useState("");
   const [isCustom, setIsCustom] = useState(false);
   const [selectedPmId, setSelectedPmId] = useState<string | null>(null);
 
-  const isCommentTip = Boolean(commentId);
+  const isVideoCommentTip = Boolean(videoComment);
+  const isCommentTip = Boolean(commentId) && !isVideoCommentTip;
 
   // TIPX-B4 (F9) — payment methods are needed for BOTH post AND comment tips now, so the tipper can
   // pick a card and the comment tip honors it (previously comment tips silently used the default).
@@ -77,7 +86,30 @@ export function TipDialog({ open, onOpenChange, postId, authorId, commentId }: T
     onError: () => toast.error("Failed to send tip"),
   });
 
-  const mutation = isCommentTip ? commentTipMutation : postTipMutation;
+  const videoCommentTipMutation = useMutation({
+    mutationFn: () =>
+      tipVideoComment(
+        videoComment!.videoId,
+        videoComment!.commentId,
+        amountCents,
+        effectivePm?.payment_method_id,
+      ),
+    onSuccess: () => {
+      toast.success(`Tip of $${(amountCents / 100).toFixed(2)} sent!`);
+      void queryClient.invalidateQueries({
+        queryKey: ["video-comments", videoComment!.videoId],
+      });
+      onOpenChange(false);
+      resetState();
+    },
+    onError: () => toast.error("Failed to send tip"),
+  });
+
+  const mutation = isVideoCommentTip
+    ? videoCommentTipMutation
+    : isCommentTip
+      ? commentTipMutation
+      : postTipMutation;
 
   const resetState = () => {
     setAmountCents(100);
@@ -104,11 +136,16 @@ export function TipDialog({ open, onOpenChange, postId, authorId, commentId }: T
   // TIPX-B4 (F9) — a saved PM is required (and selectable) for BOTH post and comment tips now.
   const pmRequired = paymentMethods.length > 0;
   const canSubmit =
-    amountCents > 0 &&
+    validateTipCents(amountCents).ok &&
     !mutation.isPending &&
     (!pmRequired || Boolean(effectivePm));
 
   const handleSend = () => {
+    const check = validateTipCents(amountCents);
+    if (!check.ok) {
+      toast.error(check.error ?? "Enter a valid tip amount.");
+      return;
+    }
     mutation.mutate();
   };
 
@@ -123,7 +160,7 @@ export function TipDialog({ open, onOpenChange, postId, authorId, commentId }: T
 
         <p className="text-sm text-muted-foreground">
           Tip <span className="font-medium text-foreground">{authorId}</span>
-          {isCommentTip ? " for their comment" : " for this post"}
+          {isVideoCommentTip || isCommentTip ? " for their comment" : " for this post"}
         </p>
 
         {/* Preset amounts */}

--- a/frontend/src/pages/gallery/VideoDetailPage.tsx
+++ b/frontend/src/pages/gallery/VideoDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   Heart,
   MessageCircle,
   Send,
+  DollarSign,
   Trash2,
   Loader2,
   Smile,
@@ -59,6 +60,7 @@ import { uploadPostImage } from "@/api/endpoints/newsfeed";
 import { useAuthStore } from "@/stores/authStore";
 import { cn } from "@/lib/utils";
 import SimilarVideos from "@/pages/videos/SimilarVideos";
+import { TipDialog } from "@/pages/feed/TipDialog";
 
 const COMMENT_REACTION_EMOJIS = ["👍", "❤️", "😂", "🔥", "😮"];
 
@@ -87,6 +89,7 @@ function VideoCommentRow({
   const [editing, setEditing] = useState(false);
   const [editText, setEditText] = useState(comment.text ?? "");
   const [reportOpen, setReportOpen] = useState(false);
+  const [tipOpen, setTipOpen] = useState(false);
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ["video-comments", videoId] });
@@ -225,6 +228,25 @@ function VideoCommentRow({
             <p className="text-sm">{comment.text}</p>
           )}
 
+          {/* TIP-303: tip total + Tip action (non-own comments) */}
+          <div className="mt-0.5 flex items-center gap-2">
+            {(comment.tip_total_cents ?? 0) > 0 && (
+              <span className="text-[10px] text-emerald-600">
+                ${((comment.tip_total_cents ?? 0) / 100).toFixed(2)} tipped
+              </span>
+            )}
+            {!isOwn && (
+              <button
+                type="button"
+                onClick={() => setTipOpen(true)}
+                className="flex items-center gap-0.5 text-[10px] text-muted-foreground transition-colors hover:text-emerald-600"
+              >
+                <DollarSign className="h-3 w-3" />
+                Tip
+              </button>
+            )}
+          </div>
+
           {/* Reaction bar */}
           <div className="mt-1 flex flex-wrap items-center gap-1">
             {COMMENT_REACTION_EMOJIS.map((emoji) => {
@@ -313,6 +335,16 @@ function VideoCommentRow({
           onSubmit={async (payload) => {
             await reportMut.mutateAsync(payload);
           }}
+        />
+      )}
+
+      {!isOwn && (
+        <TipDialog
+          open={tipOpen}
+          onOpenChange={setTipOpen}
+          postId={videoId}
+          authorId={comment.user_id}
+          videoComment={{ videoId, commentId: comment.comment_id }}
         />
       )}
     </>


### PR DESCRIPTION
## FE parity PAR-103 - video comment tip (web)

Brings the web client to parity with the Android native tip-on-video-comment feature.

### Web changes
- New `frontend/src/lib/videoCommentTip.ts` helper + `videoCommentTip.test.ts` unit test
- Wire `TipDialog` into `VideoDetailPage` comment rows so users can tip a specific comment
- Extend the gallery API endpoint (`api/endpoints/gallery.ts`) with the comment-tip mutation

### Gates
- Frontend vitest (`videoCommentTip.test.ts`)
- Required checks: `payment-incident-backend-matrix` + `payment-incident-frontend-e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
