### PR TITLE
fix(tests): PAR-136 follow-up — implement events()/receipt() in FakeMessaging PurchasesRepository fake

### DIFF
--- a/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/messaging/FakeMessaging.kt
@@ -1360,6 +1360,10 @@ private fun fakePurchasesRepository(): com.testlogon.android.data.purchases.Purc
             com.testlogon.android.core.model.ApiResult.Failure(
                 com.testlogon.android.core.model.ApiError(status = 404, message = "nf"),
             )
+        override suspend fun events(txnId: String, limit: Int) =
+            com.testlogon.android.core.model.ApiResult.Success(emptyList<com.testlogon.android.data.purchases.PurchaseEvent>())
+        override suspend fun receipt(txnId: String) =
+            com.testlogon.android.core.model.ApiResult.Success<com.testlogon.android.data.purchases.PurchaseReceipt?>(null)
     }
 
 


### PR DESCRIPTION
Follow-up to #281. PAR-136 added events()/receipt() to PurchasesRepository; a stale no-op fake in feature/messaging/FakeMessaging.kt did not override them, breaking :app:compileDebugUnitTestKotlin on main. Adds the two overrides (events→empty Success, receipt→null Success). Restores the Android unit-test gate to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)