### PR TITLE
FE parity PAR-123 - Android delegate/moderator broadcast

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/delegates/data/DelegateBroadcastRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/delegates/data/DelegateBroadcastRepository.kt
@@ -5,6 +5,10 @@ import com.testlogon.android.core.model.delegates.DelegatePermission
 import com.testlogon.android.core.model.delegates.canControlBroadcast
 import com.testlogon.android.core.model.delegates.canModerateBroadcast
 import com.testlogon.android.core.network.delegates.DelegateBroadcastApi
+import com.testlogon.android.core.network.delegates.DelegatedAnnouncementIn
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastBanOut
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModLogEntry
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModeratorOut
 import com.testlogon.android.core.network.delegates.DelegatedModerationIn
 import com.testlogon.android.core.network.delegates.DelegatedScheduleSessionIn
 import com.testlogon.android.core.network.error.ApiErrorParser
@@ -19,9 +23,13 @@ import javax.inject.Singleton
  * Every action: requires an active delegate context (else "not in delegate mode"); GATES on the typed
  * permission (PermissionDenied WITHOUT calling the API when absent); calls [DelegateBroadcastApi] with the
  * active creatorId (attribution = @Path); and AUTO-EXITS on a 403. start / stop / schedule are gated by
- * broadcast_control; mute / ban by broadcast_moderate (there is NO broadcast_operate / broadcast_publish).
- * The full broadcast console is owned by the broadcast epic; this is the overlay control + a representative
- * moderation pair.
+ * broadcast_control; every moderation action (mute / ban / unban / pin / unpin / delete-chat / announce /
+ * moderator-register) AND the moderation READS (moderators / bans / log) by broadcast_moderate (there is
+ * NO broadcast_operate / broadcast_publish). Mirrors the web delegateBroadcast.ts surface 1:1.
+ *
+ * DEGRADE-ON-404: the READS ([moderators] / [bans] / [moderationLog]) fold a 404 (session gone / not yet
+ * live on this edge) into an honest EMPTY list rather than an error - a read must never wall the console.
+ * MUTATIONS never soften 404; a failed action surfaces as a Failure so the UI can notify.
  */
 @Singleton
 class DelegateBroadcastRepository @Inject constructor(
@@ -42,6 +50,8 @@ class DelegateBroadcastRepository @Inject constructor(
 
     /** True when the current context may MODERATE the creator's broadcast (broadcast_moderate). */
     fun canModerate(): Boolean = contextProvider.current().canModerateBroadcast()
+
+    // ---- Broadcast control (broadcast_control) ----
 
     /** START a broadcast session. Gated by broadcast_control. */
     suspend fun startSession(sessionId: String): ApiResult<Unit> =
@@ -64,6 +74,8 @@ class DelegateBroadcastRepository @Inject constructor(
             ).requireSuccess()
         }
 
+    // ---- Chat moderation mutations (broadcast_moderate) ----
+
     /** MUTE a viewer. Gated by broadcast_moderate. */
     suspend fun muteViewer(sessionId: String, userId: String, reason: String? = null): ApiResult<Unit> =
         guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
@@ -76,8 +88,77 @@ class DelegateBroadcastRepository @Inject constructor(
             api.banViewer(creatorId, sessionId, DelegatedModerationIn(userId, reason)).requireSuccess()
         }
 
+    /** UNBAN a viewer. Gated by broadcast_moderate. */
+    suspend fun unbanViewer(sessionId: String, userId: String): ApiResult<Unit> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.unbanViewer(creatorId, sessionId, userId).requireSuccess()
+        }
+
+    /** POST an announcement into broadcast chat. Gated by broadcast_moderate. */
+    suspend fun postAnnouncement(sessionId: String, text: String): ApiResult<Unit> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.postAnnouncement(creatorId, sessionId, DelegatedAnnouncementIn(text)).requireSuccess()
+        }
+
+    /** PIN a chat message. Gated by broadcast_moderate. */
+    suspend fun pinMessage(sessionId: String, messageId: String): ApiResult<Unit> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.pinMessage(creatorId, sessionId, messageId).requireSuccess()
+        }
+
+    /** UNPIN a chat message. Gated by broadcast_moderate. */
+    suspend fun unpinMessage(sessionId: String, messageId: String): ApiResult<Unit> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.unpinMessage(creatorId, sessionId, messageId).requireSuccess()
+        }
+
+    /** DELETE a chat message. Gated by broadcast_moderate. */
+    suspend fun deleteChatMessage(sessionId: String, messageId: String): ApiResult<Unit> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.deleteChatMessage(creatorId, sessionId, messageId).requireSuccess()
+        }
+
+    // ---- Moderator management (broadcast_moderate) ----
+
+    /** REGISTER the caller as an active moderator for this session. Gated by broadcast_moderate. */
+    suspend fun registerModerator(sessionId: String): ApiResult<Unit> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.registerModerator(creatorId, sessionId).requireSuccess()
+        }
+
+    // ---- Moderation reads (broadcast_moderate; DEGRADE-ON-404 to honest empty) ----
+
+    /** LIST active moderators (BARE ARRAY). Gated by broadcast_moderate. 404 -> honest empty. */
+    suspend fun moderators(sessionId: String): ApiResult<List<DelegatedBroadcastModeratorOut>> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.listModerators(creatorId, sessionId)
+        }.emptyOn404()
+
+    /** LIST banned viewers (BARE ARRAY). Gated by broadcast_moderate. 404 -> honest empty. */
+    suspend fun bans(sessionId: String): ApiResult<List<DelegatedBroadcastBanOut>> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.listBans(creatorId, sessionId)
+        }.emptyOn404()
+
+    /** GET the moderation log (BARE ARRAY). Gated by broadcast_moderate. 404 -> honest empty. */
+    suspend fun moderationLog(
+        sessionId: String,
+        limit: Int = 100,
+    ): ApiResult<List<DelegatedBroadcastModLogEntry>> =
+        guard.gated(DelegatePermission.BROADCAST_MODERATE) { creatorId ->
+            api.getModerationLog(creatorId, sessionId, limit)
+        }.emptyOn404()
+
     /** Maps a 2xx empty body to Unit; a non-2xx is folded into a Failure by the guard via HttpException. */
     private fun Response<Unit>.requireSuccess() {
         if (!isSuccessful) throw HttpException(this)
     }
+
+    /**
+     * DEGRADE-ON-404: a read whose Failure is a 404 (session gone / feed not live on this edge) becomes an
+     * honest EMPTY list rather than an error, so a read never walls the console. Any other Failure /
+     * NetworkError passes through unchanged (a permission-denied 403 still surfaces + auto-exits).
+     */
+    private fun <T> ApiResult<List<T>>.emptyOn404(): ApiResult<List<T>> =
+        if (this is ApiResult.Failure && error.status == 404) ApiResult.Success(emptyList()) else this
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateConsoleScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateConsoleScreen.kt
@@ -42,6 +42,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.R
 import com.testlogon.android.core.model.delegates.ManagedCreator
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastBanOut
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModLogEntry
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModeratorOut
 import com.testlogon.android.core.network.delegates.DelegatedConversationOut
 import com.testlogon.android.core.network.delegates.DelegatedPostOut
 
@@ -60,13 +63,32 @@ object DelegateConsoleTestTags {
     const val MANAGED_ROW_PREFIX = "delegate_console_managed_row_"
     const val MANAGED_ENTER_PREFIX = "delegate_console_managed_enter_"
     const val MANAGED_RETRY = "delegate_console_managed_retry"
+    // AND-360 — broadcast moderation console section.
+    const val MOD_SESSION_INPUT = "delegate_mod_session_input"
+    const val MOD_LOAD = "delegate_mod_load"
+    const val MOD_REGISTER = "delegate_mod_register"
+    const val MOD_START = "delegate_mod_start"
+    const val MOD_STOP = "delegate_mod_stop"
+    const val MOD_ANNOUNCE_INPUT = "delegate_mod_announce_input"
+    const val MOD_ANNOUNCE_SUBMIT = "delegate_mod_announce_submit"
+    const val MOD_USER_INPUT = "delegate_mod_user_input"
+    const val MOD_BAN = "delegate_mod_ban"
+    const val MOD_MUTE = "delegate_mod_mute"
+    const val MOD_MESSAGE_INPUT = "delegate_mod_message_input"
+    const val MOD_PIN = "delegate_mod_pin"
+    const val MOD_DELETE = "delegate_mod_delete"
+    const val MOD_BAN_ROW_PREFIX = "delegate_mod_ban_row_"
+    const val MOD_UNBAN_PREFIX = "delegate_mod_unban_"
+    const val MOD_MODERATOR_ROW_PREFIX = "delegate_mod_moderator_row_"
+    const val MOD_LOG_ROW_PREFIX = "delegate_mod_log_row_"
 }
 
 /**
  * AND-360 - route-level delegate console. Reachable from the More hub behind the managed-creator state. It
  * lists the managed creator's delegate feed posts + conversations and offers create-post / send-message
- * gated by feed_post / chat_respond, with the persistent banner - proving "a delegate can act in delegated
- * surfaces" WITHOUT touching the mature feed / messaging screens.
+ * gated by feed_post / chat_respond, plus the broadcast MODERATION console (broadcast_moderate /
+ * broadcast_control), with the persistent banner - proving "a delegate can act in delegated surfaces"
+ * WITHOUT touching the mature feed / messaging screens.
  */
 @Composable
 fun DelegateConsoleRoute(
@@ -85,8 +107,36 @@ fun DelegateConsoleRoute(
         onEnterCreator = viewModel::enter,
         onRetryManaged = viewModel::loadManagedCreators,
         onOpenThread = onOpenThread,
+        modActions = DelegateModActions(
+            onSessionChange = viewModel::setModerationSession,
+            onLoad = viewModel::loadModeration,
+            onRegister = viewModel::registerAsModerator,
+            onStart = viewModel::startBroadcast,
+            onStop = viewModel::stopBroadcast,
+            onAnnounce = viewModel::postAnnouncement,
+            onBan = { userId, reason -> viewModel.banViewer(userId, reason) },
+            onUnban = viewModel::unbanViewer,
+            onMute = { userId, reason -> viewModel.muteViewer(userId, reason) },
+            onPin = viewModel::pinMessage,
+            onDelete = viewModel::deleteChatMessage,
+        ),
     )
 }
+
+/** AND-360 - the moderation console callbacks bundled so the screen signature stays readable. */
+data class DelegateModActions(
+    val onSessionChange: (String) -> Unit = {},
+    val onLoad: () -> Unit = {},
+    val onRegister: () -> Unit = {},
+    val onStart: () -> Unit = {},
+    val onStop: () -> Unit = {},
+    val onAnnounce: (String) -> Unit = {},
+    val onBan: (userId: String, reason: String?) -> Unit = { _, _ -> },
+    val onUnban: (String) -> Unit = {},
+    val onMute: (userId: String, reason: String?) -> Unit = { _, _ -> },
+    val onPin: (String) -> Unit = {},
+    val onDelete: (String) -> Unit = {},
+)
 
 /** AND-360 - stateless delegate console screen. */
 @Composable
@@ -100,6 +150,7 @@ fun DelegateConsoleScreen(
     onEnterCreator: (String) -> Unit = {},
     onRetryManaged: () -> Unit = {},
     onOpenThread: (String) -> Unit = {},
+    modActions: DelegateModActions = DelegateModActions(),
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val loadFailedMessage = stringResource(R.string.delegate_console_load_failed)
@@ -148,6 +199,7 @@ fun DelegateConsoleScreen(
                     onCreatePost = onCreatePost,
                     onSendMessage = onSendMessage,
                     onOpenThread = onOpenThread,
+                    modActions = modActions,
                 )
             }
         }
@@ -265,6 +317,7 @@ private fun DelegateConsoleContent(
     onCreatePost: (String) -> Unit,
     onSendMessage: (conversationId: String, text: String) -> Unit,
     onOpenThread: (String) -> Unit = {},
+    modActions: DelegateModActions = DelegateModActions(),
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
@@ -311,6 +364,245 @@ private fun DelegateConsoleContent(
                     onOpenThread = onOpenThread,
                 )
             }
+        }
+
+        // ---- AND-360 broadcast moderation console ----
+        item { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
+        item {
+            Text(
+                stringResource(R.string.delegate_mod_heading),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+        moderationSection(state = state.moderation, actions = modActions)
+    }
+}
+
+/**
+ * AND-360 - the broadcast moderation console section (rendered inside the delegate console LazyColumn as
+ * `items`). Gated by broadcast_moderate for the section + broadcast_control for start/stop. The reads
+ * degrade-on-404 to empty in the repository, so an empty list = "nothing to show" not an error.
+ */
+private fun androidx.compose.foundation.lazy.LazyListScope.moderationSection(
+    state: DelegateModConsoleState,
+    actions: DelegateModActions,
+) {
+    if (!state.canModerate) {
+        item { Text(stringResource(R.string.delegate_mod_no_permission)) }
+        return
+    }
+    item { ModerationSessionBar(state = state, actions = actions) }
+    if (state.canControl) {
+        item {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = actions.onStart,
+                    enabled = !state.busy && state.sessionId.isNotBlank(),
+                    modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_START),
+                ) { Text(stringResource(R.string.delegate_mod_start)) }
+                OutlinedButton(
+                    onClick = actions.onStop,
+                    enabled = !state.busy && state.sessionId.isNotBlank(),
+                    modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_STOP),
+                ) { Text(stringResource(R.string.delegate_mod_stop)) }
+            }
+        }
+    }
+    if (state.readFailed) {
+        item {
+            Text(
+                stringResource(R.string.delegate_mod_read_failed),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+    item { ModerationActionBar(state = state, actions = actions) }
+
+    // Moderators
+    item {
+        Text(
+            stringResource(R.string.delegate_mod_moderators_heading),
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+    if (state.moderators.isEmpty()) {
+        item { Text(stringResource(R.string.delegate_mod_moderators_empty)) }
+    } else {
+        items(state.moderators, key = { it.delegateId }) { mod -> ModeratorRow(mod) }
+    }
+
+    // Bans
+    item {
+        Text(
+            stringResource(R.string.delegate_mod_bans_heading),
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+    if (state.bans.isEmpty()) {
+        item { Text(stringResource(R.string.delegate_mod_bans_empty)) }
+    } else {
+        items(state.bans, key = { it.userId }) { ban ->
+            BanRow(ban = ban, enabled = !state.busy, onUnban = { actions.onUnban(ban.userId) })
+        }
+    }
+
+    // Log
+    item {
+        Text(
+            stringResource(R.string.delegate_mod_log_heading),
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+    if (state.log.isEmpty()) {
+        item { Text(stringResource(R.string.delegate_mod_log_empty)) }
+    } else {
+        items(state.log, key = { it.eventId }) { entry -> LogRow(entry) }
+    }
+    item { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
+}
+
+@Composable
+private fun ModerationSessionBar(state: DelegateModConsoleState, actions: DelegateModActions) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedTextField(
+            value = state.sessionId,
+            onValueChange = actions.onSessionChange,
+            placeholder = { Text(stringResource(R.string.delegate_mod_session_hint)) },
+            modifier = Modifier.weight(1f).testTag(DelegateConsoleTestTags.MOD_SESSION_INPUT),
+        )
+        Button(
+            onClick = actions.onLoad,
+            enabled = state.sessionId.isNotBlank() && !state.loading,
+            modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_LOAD),
+        ) { Text(stringResource(R.string.delegate_mod_load)) }
+    }
+    if (state.registered) {
+        Text(
+            stringResource(R.string.delegate_mod_registered),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.tertiary,
+        )
+    } else {
+        OutlinedButton(
+            onClick = actions.onRegister,
+            enabled = state.sessionId.isNotBlank() && !state.busy,
+            modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_REGISTER),
+        ) { Text(stringResource(R.string.delegate_mod_register)) }
+    }
+}
+
+@Composable
+private fun ModerationActionBar(state: DelegateModConsoleState, actions: DelegateModActions) {
+    var announce by remember { mutableStateOf("") }
+    var userId by remember { mutableStateOf("") }
+    var messageId by remember { mutableStateOf("") }
+    val enabled = !state.busy && state.sessionId.isNotBlank()
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // Announcement
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = announce,
+                onValueChange = { announce = it },
+                placeholder = { Text(stringResource(R.string.delegate_mod_announce_hint)) },
+                modifier = Modifier.weight(1f).testTag(DelegateConsoleTestTags.MOD_ANNOUNCE_INPUT),
+            )
+            Button(
+                onClick = { actions.onAnnounce(announce); announce = "" },
+                enabled = enabled && announce.isNotBlank(),
+                modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_ANNOUNCE_SUBMIT),
+            ) { Text(stringResource(R.string.delegate_mod_announce)) }
+        }
+        // Viewer target: ban / mute
+        OutlinedTextField(
+            value = userId,
+            onValueChange = { userId = it },
+            placeholder = { Text(stringResource(R.string.delegate_mod_target_user_hint)) },
+            modifier = Modifier.fillMaxWidth().testTag(DelegateConsoleTestTags.MOD_USER_INPUT),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(
+                onClick = { actions.onBan(userId, null) },
+                enabled = enabled && userId.isNotBlank(),
+                modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_BAN),
+            ) { Text(stringResource(R.string.delegate_mod_ban)) }
+            OutlinedButton(
+                onClick = { actions.onMute(userId, null) },
+                enabled = enabled && userId.isNotBlank(),
+                modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_MUTE),
+            ) { Text(stringResource(R.string.delegate_mod_mute)) }
+        }
+        // Message target: pin / delete
+        OutlinedTextField(
+            value = messageId,
+            onValueChange = { messageId = it },
+            placeholder = { Text(stringResource(R.string.delegate_mod_target_message_hint)) },
+            modifier = Modifier.fillMaxWidth().testTag(DelegateConsoleTestTags.MOD_MESSAGE_INPUT),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(
+                onClick = { actions.onPin(messageId) },
+                enabled = enabled && messageId.isNotBlank(),
+                modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_PIN),
+            ) { Text(stringResource(R.string.delegate_mod_pin)) }
+            OutlinedButton(
+                onClick = { actions.onDelete(messageId) },
+                enabled = enabled && messageId.isNotBlank(),
+                modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_DELETE),
+            ) { Text(stringResource(R.string.delegate_mod_delete)) }
+        }
+    }
+}
+
+@Composable
+private fun ModeratorRow(mod: DelegatedBroadcastModeratorOut) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(DelegateConsoleTestTags.MOD_MODERATOR_ROW_PREFIX + mod.delegateId),
+    ) {
+        Text(mod.displayName ?: mod.delegateId, style = MaterialTheme.typography.bodyMedium)
+        mod.status?.let { Text(it, style = MaterialTheme.typography.labelSmall) }
+    }
+}
+
+@Composable
+private fun BanRow(ban: DelegatedBroadcastBanOut, enabled: Boolean, onUnban: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(DelegateConsoleTestTags.MOD_BAN_ROW_PREFIX + ban.userId),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(ban.userId, style = MaterialTheme.typography.bodyMedium)
+            ban.reason?.let { Text(it, style = MaterialTheme.typography.labelSmall) }
+        }
+        OutlinedButton(
+            onClick = onUnban,
+            enabled = enabled,
+            modifier = Modifier.testTag(DelegateConsoleTestTags.MOD_UNBAN_PREFIX + ban.userId),
+        ) { Text(stringResource(R.string.delegate_mod_unban)) }
+    }
+}
+
+@Composable
+private fun LogRow(entry: DelegatedBroadcastModLogEntry) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(DelegateConsoleTestTags.MOD_LOG_ROW_PREFIX + entry.eventId),
+    ) {
+        Text(
+            com.testlogon.android.core.model.delegates.DelegateModMath.moderationLabel(entry.moderationType),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        val target = entry.targetUserId ?: entry.targetMessageId
+        if (target != null) {
+            Text(target, style = MaterialTheme.typography.labelSmall)
         }
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateConsoleUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateConsoleUiState.kt
@@ -35,4 +35,7 @@ data class DelegateConsoleUiState(
     val managedError: Boolean = false,
     /** An Enter action is in flight for this creatorId (the row shows progress + is disabled). */
     val entering: String? = null,
+    // ---- AND-360: broadcast moderation console sub-state ----
+    /** Broadcast moderation console (moderators / bans / log + control), gated by broadcast_moderate / _control. */
+    val moderation: DelegateModConsoleState = DelegateModConsoleState(),
 )

--- a/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateConsoleViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateConsoleViewModel.kt
@@ -3,6 +3,7 @@ package com.testlogon.android.feature.delegates.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.feature.delegates.data.DelegateBroadcastRepository
 import com.testlogon.android.feature.delegates.data.DelegateFeedRepository
 import com.testlogon.android.feature.delegates.data.DelegateMessagingRepository
 import com.testlogon.android.feature.delegates.data.DelegationContextProvider
@@ -17,8 +18,10 @@ import javax.inject.Inject
 /**
  * AND-360 - the focused demonstration ViewModel: in delegate mode it loads the managed creator's delegate
  * feed posts (feed_read) + conversations (chat_read) and offers create-post (feed_post) / send-message
- * (chat_respond), each gated by the delegate repositories. This proves "a delegate can act in delegated
- * surfaces" without retrofitting the mature feed / broadcast / messaging screens.
+ * (chat_respond), each gated by the delegate repositories. It ALSO hosts the broadcast MODERATION console
+ * (broadcast_moderate / broadcast_control): register-as-moderator, moderators / bans / moderation-log
+ * reads (degrade-on-404 to empty), and the mutations (ban / unban / mute / pin / delete / announce / start
+ * / stop). This proves "a delegate can act in delegated surfaces" without retrofitting the mature screens.
  *
  * It observes the typed delegation context; when there is no active context the UI shows the enter prompt.
  * The repositories already block a permission-less action WITHOUT calling the API and AUTO-EXIT on a 403,
@@ -30,6 +33,7 @@ class DelegateConsoleViewModel @Inject constructor(
     private val delegationRepository: DelegationRepository,
     private val feedRepository: DelegateFeedRepository,
     private val messagingRepository: DelegateMessagingRepository,
+    private val broadcastRepository: DelegateBroadcastRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DelegateConsoleUiState())
@@ -56,6 +60,10 @@ class DelegateConsoleViewModel @Inject constructor(
                         canReadChat = messagingRepository.canRead(),
                         canRespond = messagingRepository.canRespond(),
                         entering = null,
+                        moderation = _uiState.value.moderation.copy(
+                            canModerate = broadcastRepository.canModerate(),
+                            canControl = broadcastRepository.canControl(),
+                        ),
                     )
                     load()
                 }
@@ -146,6 +154,110 @@ class DelegateConsoleViewModel @Inject constructor(
             when (messagingRepository.send(conversationId, text.trim())) {
                 is ApiResult.Success -> _uiState.value = _uiState.value.copy(notice = null)
                 else -> _uiState.value = _uiState.value.copy(notice = NOTICE_ACTION_FAILED)
+            }
+        }
+    }
+
+    // ---- AND-360 broadcast moderation console ----
+
+    /** Updates the session id the moderation console acts on. Does not fetch (the user taps Load). */
+    fun setModerationSession(sessionId: String) {
+        _uiState.value = _uiState.value.copy(
+            moderation = _uiState.value.moderation.copy(sessionId = sessionId),
+        )
+    }
+
+    /** Loads the moderators / bans / moderation-log for the entered session (reads degrade-on-404 to empty). */
+    fun loadModeration() {
+        val session = _uiState.value.moderation.sessionId.trim()
+        if (session.isBlank() || !broadcastRepository.canModerate()) return
+        _uiState.value = _uiState.value.copy(
+            moderation = _uiState.value.moderation.copy(loading = true, readFailed = false),
+        )
+        viewModelScope.launch {
+            val mods = broadcastRepository.moderators(session)
+            val bans = broadcastRepository.bans(session)
+            val log = broadcastRepository.moderationLog(session)
+            _uiState.value = _uiState.value.copy(
+                moderation = _uiState.value.moderation.copy(
+                    loading = false,
+                    moderators = (mods as? ApiResult.Success)?.data.orEmpty(),
+                    bans = (bans as? ApiResult.Success)?.data.orEmpty(),
+                    log = (log as? ApiResult.Success)?.data.orEmpty(),
+                    readFailed = mods !is ApiResult.Success ||
+                        bans !is ApiResult.Success ||
+                        log !is ApiResult.Success,
+                ),
+            )
+        }
+    }
+
+    /** REGISTER the caller as an active moderator for the entered session; reloads on success. */
+    fun registerAsModerator() {
+        runModeration { session ->
+            broadcastRepository.registerModerator(session).also {
+                if (it is ApiResult.Success) {
+                    _uiState.value = _uiState.value.copy(
+                        moderation = _uiState.value.moderation.copy(registered = true),
+                    )
+                }
+            }
+        }
+    }
+
+    /** BAN a viewer, then reload the console lists. */
+    fun banViewer(userId: String, reason: String?) =
+        runModeration { session -> broadcastRepository.banViewer(session, userId.trim(), reason?.trim()) }
+
+    /** UNBAN a viewer, then reload the console lists. */
+    fun unbanViewer(userId: String) =
+        runModeration { session -> broadcastRepository.unbanViewer(session, userId) }
+
+    /** MUTE a viewer, then reload the console lists. */
+    fun muteViewer(userId: String, reason: String?) =
+        runModeration { session -> broadcastRepository.muteViewer(session, userId.trim(), reason?.trim()) }
+
+    /** PIN a chat message, then reload the console lists. */
+    fun pinMessage(messageId: String) =
+        runModeration { session -> broadcastRepository.pinMessage(session, messageId.trim()) }
+
+    /** DELETE a chat message, then reload the console lists. */
+    fun deleteChatMessage(messageId: String) =
+        runModeration { session -> broadcastRepository.deleteChatMessage(session, messageId.trim()) }
+
+    /** POST an announcement, then reload the console lists. */
+    fun postAnnouncement(text: String) {
+        if (text.isBlank()) return
+        runModeration { session -> broadcastRepository.postAnnouncement(session, text.trim()) }
+    }
+
+    /** START the broadcast (gated by broadcast_control). */
+    fun startBroadcast() =
+        runModeration(reload = false) { session -> broadcastRepository.startSession(session) }
+
+    /** STOP the broadcast (gated by broadcast_control). */
+    fun stopBroadcast() =
+        runModeration(reload = false) { session -> broadcastRepository.stopSession(session) }
+
+    /**
+     * Shared runner for a moderation mutation: guards against a blank session / busy state, runs [action]
+     * with the trimmed session id, surfaces a notice on failure, and (when [reload]) refreshes the lists on
+     * success. A permission-less / revoked action is already blocked (or auto-exits) inside the repository.
+     */
+    private fun runModeration(
+        reload: Boolean = true,
+        action: suspend (session: String) -> ApiResult<Unit>,
+    ) {
+        val session = _uiState.value.moderation.sessionId.trim()
+        if (session.isBlank() || _uiState.value.moderation.busy) return
+        _uiState.value = _uiState.value.copy(moderation = _uiState.value.moderation.copy(busy = true))
+        viewModelScope.launch {
+            val result = action(session)
+            _uiState.value = _uiState.value.copy(moderation = _uiState.value.moderation.copy(busy = false))
+            if (result is ApiResult.Success) {
+                if (reload) loadModeration()
+            } else {
+                _uiState.value = _uiState.value.copy(notice = NOTICE_ACTION_FAILED)
             }
         }
     }

--- a/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateModConsoleState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/delegates/ui/DelegateModConsoleState.kt
@@ -1,0 +1,34 @@
+package com.testlogon.android.feature.delegates.ui
+
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastBanOut
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModLogEntry
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModeratorOut
+
+/**
+ * AND-360 - UI sub-state for the delegate BROADCAST MODERATION console section rendered inside the delegate
+ * console. It is only meaningful when the active context has broadcast_moderate (or broadcast_control for
+ * the start/stop affordances) and a session id has been entered.
+ *
+ * The reads ([moderators] / [bans] / [log]) degrade to honest-empty on a 404 in the repository, so an
+ * empty list here means "nothing to show" rather than an error; [readFailed] is only set for a genuine
+ * non-404 read failure. [busy] guards a mutation in flight so double-taps are ignored.
+ */
+data class DelegateModConsoleState(
+    /** True when the active context may moderate the broadcast (drives showing the whole section). */
+    val canModerate: Boolean = false,
+    /** True when the active context may start / stop / schedule (drives the control affordances). */
+    val canControl: Boolean = false,
+    /** The broadcast session id the moderator is acting on (entered by the user; blank = none yet). */
+    val sessionId: String = "",
+    /** True while a moderation read (moderators / bans / log) is in flight. */
+    val loading: Boolean = false,
+    /** A genuine (non-404) read failure occurred - the UI shows a retry. */
+    val readFailed: Boolean = false,
+    /** A mutation (ban / mute / pin / etc) is in flight - affordances are disabled to prevent double-taps. */
+    val busy: Boolean = false,
+    val moderators: List<DelegatedBroadcastModeratorOut> = emptyList(),
+    val bans: List<DelegatedBroadcastBanOut> = emptyList(),
+    val log: List<DelegatedBroadcastModLogEntry> = emptyList(),
+    /** True once the caller has registered as an active moderator for [sessionId] this session. */
+    val registered: Boolean = false,
+)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3920,6 +3920,31 @@
     <string name="delegate_console_managed_empty">No creators have added you as a delegate yet.</string>
     <string name="delegate_console_managed_error">Couldn\'t load the creators you can manage.</string>
     <string name="delegate_console_managed_retry">Retry</string>
+    <string name="delegate_mod_heading">Broadcast moderation</string>
+    <string name="delegate_mod_no_permission">You don\'t have permission to moderate this creator\'s broadcast.</string>
+    <string name="delegate_mod_session_hint">Broadcast session id</string>
+    <string name="delegate_mod_load">Load</string>
+    <string name="delegate_mod_register">Join as moderator</string>
+    <string name="delegate_mod_registered">You\'re an active moderator</string>
+    <string name="delegate_mod_start">Start broadcast</string>
+    <string name="delegate_mod_stop">Stop broadcast</string>
+    <string name="delegate_mod_moderators_heading">Active moderators</string>
+    <string name="delegate_mod_moderators_empty">No active moderators.</string>
+    <string name="delegate_mod_bans_heading">Banned viewers</string>
+    <string name="delegate_mod_bans_empty">No banned viewers.</string>
+    <string name="delegate_mod_unban">Unban</string>
+    <string name="delegate_mod_log_heading">Moderation log</string>
+    <string name="delegate_mod_log_empty">No moderation actions yet.</string>
+    <string name="delegate_mod_read_failed">Couldn\'t load moderation data.</string>
+    <string name="delegate_mod_announce_hint">Announcement…</string>
+    <string name="delegate_mod_announce">Announce</string>
+    <string name="delegate_mod_target_user_hint">Viewer id</string>
+    <string name="delegate_mod_ban">Ban</string>
+    <string name="delegate_mod_mute">Mute</string>
+    <string name="delegate_mod_target_message_hint">Message id</string>
+    <string name="delegate_mod_pin">Pin</string>
+    <string name="delegate_mod_delete">Delete</string>
+
 
     <!-- AND-364: content boost (paid post promotion). -->
     <string name="boost_title">Boost post</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/delegates/DelegateRepositoriesTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/delegates/DelegateRepositoriesTest.kt
@@ -244,4 +244,146 @@ class DelegateRepositoriesTest {
         assertTrue((result as ApiResult.Success).data.permissions.none { it.name == "FEED_POST" })
         assertTrue(!f.feed.canPost())
     }
+
+    // ---- AND-360 broadcast moderation (added) ----
+
+    @Test
+    fun broadcastUnban_withModerate_callsDelegatePath() = runTest {
+        val f = fixtures(scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_moderate"))
+        runCurrent()
+
+        val result = f.broadcast.unbanViewer("sess_1", "u_9")
+
+        assertTrue(result is ApiResult.Success)
+        assertEquals(Triple("cr_1", "sess_1", "u_9"), f.broadcastApi.unbanCalls.single())
+    }
+
+    @Test
+    fun broadcastAnnouncement_withoutModerate_doesNotCallApi() = runTest {
+        val f = fixtures(scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_control")) // control but NOT moderate
+        runCurrent()
+
+        val result = f.broadcast.postAnnouncement("sess_1", "hello all")
+
+        assertTrue(result is ApiResult.Failure)
+        assertEquals(403, (result as ApiResult.Failure).error.status)
+        assertTrue(f.broadcastApi.announcementCalls.isEmpty())
+    }
+
+    @Test
+    fun broadcastAnnouncement_withModerate_callsWithText() = runTest {
+        val f = fixtures(scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_moderate"))
+        runCurrent()
+
+        f.broadcast.postAnnouncement("sess_1", "hello all")
+
+        assertEquals("hello all", f.broadcastApi.announcementCalls.single().third.text)
+    }
+
+    @Test
+    fun broadcastPinDeleteRegister_withModerate_callDelegatePath() = runTest {
+        val f = fixtures(scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_moderate"))
+        runCurrent()
+
+        assertTrue(f.broadcast.pinMessage("sess_1", "m_1") is ApiResult.Success)
+        assertTrue(f.broadcast.unpinMessage("sess_1", "m_1") is ApiResult.Success)
+        assertTrue(f.broadcast.deleteChatMessage("sess_1", "m_2") is ApiResult.Success)
+        assertTrue(f.broadcast.registerModerator("sess_1") is ApiResult.Success)
+
+        assertEquals(Triple("cr_1", "sess_1", "m_1"), f.broadcastApi.pinCalls.single())
+        assertEquals(Triple("cr_1", "sess_1", "m_1"), f.broadcastApi.unpinCalls.single())
+        assertEquals(Triple("cr_1", "sess_1", "m_2"), f.broadcastApi.deleteChatCalls.single())
+        assertEquals("cr_1" to "sess_1", f.broadcastApi.registerModeratorCalls.single())
+    }
+
+    @Test
+    fun broadcastReads_withoutModerate_doNotCallApi() = runTest {
+        val f = fixtures(scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_control"))
+        runCurrent()
+
+        assertTrue(f.broadcast.moderators("sess_1") is ApiResult.Failure)
+        assertTrue(f.broadcast.bans("sess_1") is ApiResult.Failure)
+        assertTrue(f.broadcast.moderationLog("sess_1") is ApiResult.Failure)
+        assertTrue(f.broadcastApi.moderatorsCalls.isEmpty())
+        assertTrue(f.broadcastApi.bansCalls.isEmpty())
+        assertTrue(f.broadcastApi.logCalls.isEmpty())
+    }
+
+    @Test
+    fun broadcastReads_withModerate_returnListsAndCallPath() = runTest {
+        val broadcastApi = FakeDelegateBroadcastApi(
+            moderatorList = listOf(
+                com.testlogon.android.core.network.delegates.DelegatedBroadcastModeratorOut(delegateId = "d_1"),
+            ),
+            banList = listOf(
+                com.testlogon.android.core.network.delegates.DelegatedBroadcastBanOut(
+                    userId = "u_1", bannedBy = "d_1",
+                ),
+            ),
+            logList = listOf(
+                com.testlogon.android.core.network.delegates.DelegatedBroadcastModLogEntry(
+                    eventId = "e_1", moderatorId = "d_1", moderationType = "ban",
+                ),
+            ),
+        )
+        val f = fixtures(broadcastApi = broadcastApi, scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_moderate"))
+        runCurrent()
+
+        val mods = f.broadcast.moderators("sess_1")
+        val bans = f.broadcast.bans("sess_1")
+        val log = f.broadcast.moderationLog("sess_1", limit = 25)
+
+        assertTrue(mods is ApiResult.Success)
+        assertEquals("d_1", (mods as ApiResult.Success).data.single().delegateId)
+        assertTrue(bans is ApiResult.Success)
+        assertEquals("u_1", (bans as ApiResult.Success).data.single().userId)
+        assertTrue(log is ApiResult.Success)
+        assertEquals("ban", (log as ApiResult.Success).data.single().moderationType)
+        assertEquals(Triple("cr_1", "sess_1", 25), broadcastApi.logCalls.single())
+    }
+
+    @Test
+    fun broadcastReads_on404_degradeToHonestEmpty() = runTest {
+        val broadcastApi = FakeDelegateBroadcastApi(throwHttp = 404)
+        val f = fixtures(broadcastApi = broadcastApi, scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_moderate"))
+        runCurrent()
+
+        val mods = f.broadcast.moderators("sess_1")
+        val bans = f.broadcast.bans("sess_1")
+        val log = f.broadcast.moderationLog("sess_1")
+
+        assertTrue(mods is ApiResult.Success)
+        assertTrue((mods as ApiResult.Success).data.isEmpty())
+        assertTrue(bans is ApiResult.Success)
+        assertTrue((bans as ApiResult.Success).data.isEmpty())
+        assertTrue(log is ApiResult.Success)
+        assertTrue((log as ApiResult.Success).data.isEmpty())
+        // the API WAS called (recorded) - the softening happens at the repository, not by skipping the call
+        assertEquals(1, broadcastApi.moderatorsCalls.size)
+    }
+
+    @Test
+    fun broadcastReads_on403_stayFailure_notEmptied() = runTest {
+        val broadcastApi = FakeDelegateBroadcastApi(throwHttp = 403)
+        // still managed so no auto-exit interference
+        val delegatesApi = FakeDelegatesApi(
+            managed = listOf(ManagedCreatorOut(creatorId = "cr_1", status = "active")),
+        )
+        val f = fixtures(broadcastApi = broadcastApi, delegatesApi = delegatesApi, scope = backgroundScope)
+        f.store.setManagingCreator(managing("broadcast_moderate"))
+        runCurrent()
+
+        val mods = f.broadcast.moderators("sess_1")
+
+        assertTrue(mods is ApiResult.Failure)
+        assertEquals(403, (mods as ApiResult.Failure).error.status)
+    }
+
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/delegates/testing/FakeDelegateSurfaceApis.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/delegates/testing/FakeDelegateSurfaceApis.kt
@@ -3,6 +3,10 @@ package com.testlogon.android.feature.delegates.testing
 import com.testlogon.android.core.network.delegates.DelegateBroadcastApi
 import com.testlogon.android.core.network.delegates.DelegateFeedApi
 import com.testlogon.android.core.network.delegates.DelegateMessagingApi
+import com.testlogon.android.core.network.delegates.DelegatedAnnouncementIn
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastBanOut
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModLogEntry
+import com.testlogon.android.core.network.delegates.DelegatedBroadcastModeratorOut
 import com.testlogon.android.core.network.delegates.DelegatedConversationOut
 import com.testlogon.android.core.network.delegates.DelegatedMessageOut
 import com.testlogon.android.core.network.delegates.DelegatedModerationIn
@@ -93,6 +97,9 @@ class FakeDelegateMessagingApi(
 /** AND-360 - fake [DelegateBroadcastApi] recording control + moderation calls. */
 class FakeDelegateBroadcastApi(
     var throwHttp: Int? = null,
+    var moderatorList: List<DelegatedBroadcastModeratorOut> = emptyList(),
+    var banList: List<DelegatedBroadcastBanOut> = emptyList(),
+    var logList: List<DelegatedBroadcastModLogEntry> = emptyList(),
 ) : DelegateBroadcastApi {
 
     val startCalls = mutableListOf<Pair<String, String>>()
@@ -100,6 +107,15 @@ class FakeDelegateBroadcastApi(
     val scheduleCalls = mutableListOf<Pair<String, DelegatedScheduleSessionIn>>()
     val muteCalls = mutableListOf<Triple<String, String, DelegatedModerationIn>>()
     val banCalls = mutableListOf<Triple<String, String, DelegatedModerationIn>>()
+    val unbanCalls = mutableListOf<Triple<String, String, String>>()
+    val announcementCalls = mutableListOf<Triple<String, String, DelegatedAnnouncementIn>>()
+    val pinCalls = mutableListOf<Triple<String, String, String>>()
+    val unpinCalls = mutableListOf<Triple<String, String, String>>()
+    val deleteChatCalls = mutableListOf<Triple<String, String, String>>()
+    val registerModeratorCalls = mutableListOf<Pair<String, String>>()
+    val moderatorsCalls = mutableListOf<Pair<String, String>>()
+    val bansCalls = mutableListOf<Pair<String, String>>()
+    val logCalls = mutableListOf<Triple<String, String, Int>>()
 
     override suspend fun startSession(creatorId: String, sid: String): Response<Unit> {
         startCalls += creatorId to sid
@@ -140,5 +156,70 @@ class FakeDelegateBroadcastApi(
         banCalls += Triple(creatorId, sid, body)
         throwHttp?.let { throw httpError(it) }
         return Response.success(Unit)
+    }
+
+    override suspend fun unbanViewer(creatorId: String, sid: String, uid: String): Response<Unit> {
+        unbanCalls += Triple(creatorId, sid, uid)
+        throwHttp?.let { throw httpError(it) }
+        return Response.success(Unit)
+    }
+
+    override suspend fun postAnnouncement(
+        creatorId: String,
+        sid: String,
+        body: DelegatedAnnouncementIn,
+    ): Response<Unit> {
+        announcementCalls += Triple(creatorId, sid, body)
+        throwHttp?.let { throw httpError(it) }
+        return Response.success(Unit)
+    }
+
+    override suspend fun pinMessage(creatorId: String, sid: String, mid: String): Response<Unit> {
+        pinCalls += Triple(creatorId, sid, mid)
+        throwHttp?.let { throw httpError(it) }
+        return Response.success(Unit)
+    }
+
+    override suspend fun unpinMessage(creatorId: String, sid: String, mid: String): Response<Unit> {
+        unpinCalls += Triple(creatorId, sid, mid)
+        throwHttp?.let { throw httpError(it) }
+        return Response.success(Unit)
+    }
+
+    override suspend fun deleteChatMessage(creatorId: String, sid: String, mid: String): Response<Unit> {
+        deleteChatCalls += Triple(creatorId, sid, mid)
+        throwHttp?.let { throw httpError(it) }
+        return Response.success(Unit)
+    }
+
+    override suspend fun registerModerator(creatorId: String, sid: String): Response<Unit> {
+        registerModeratorCalls += creatorId to sid
+        throwHttp?.let { throw httpError(it) }
+        return Response.success(Unit)
+    }
+
+    override suspend fun listModerators(
+        creatorId: String,
+        sid: String,
+    ): List<DelegatedBroadcastModeratorOut> {
+        moderatorsCalls += creatorId to sid
+        throwHttp?.let { throw httpError(it) }
+        return moderatorList
+    }
+
+    override suspend fun listBans(creatorId: String, sid: String): List<DelegatedBroadcastBanOut> {
+        bansCalls += creatorId to sid
+        throwHttp?.let { throw httpError(it) }
+        return banList
+    }
+
+    override suspend fun getModerationLog(
+        creatorId: String,
+        sid: String,
+        limit: Int,
+    ): List<DelegatedBroadcastModLogEntry> {
+        logCalls += Triple(creatorId, sid, limit)
+        throwHttp?.let { throw httpError(it) }
+        return logList
     }
 }

--- a/android/core-model/src/main/java/com/testlogon/android/core/model/delegates/DelegateModMath.kt
+++ b/android/core-model/src/main/java/com/testlogon/android/core/model/delegates/DelegateModMath.kt
@@ -1,0 +1,124 @@
+package com.testlogon.android.core.model.delegates
+
+/**
+ * AND-360 - PURE permission / role gating math for the delegate broadcast MODERATION surface.
+ *
+ * core-model stays Moshi-free and has NO core-network dependency: this is plain domain logic with no
+ * Android / IO. It centralizes the "may this delegate perform this broadcast action?" decision so the
+ * repository, the ViewModel affordance-visibility and the tests all agree on one rule set, and it derives
+ * a couple of read-side summaries (moderation-type labels, whether a viewer is currently banned).
+ *
+ * THE RULE (mirrors the backend router gating): broadcast CONTROL actions (start / stop / schedule) need
+ * [DelegatePermission.BROADCAST_CONTROL]; every MODERATION action (mute / ban / unban / pin / unpin /
+ * delete-chat / announce / moderator-register) AND the moderation READS (moderators / bans / log) need
+ * [DelegatePermission.BROADCAST_MODERATE]. A null context = acting as oneself = no delegate grant = denied.
+ */
+
+/**
+ * The distinct delegate broadcast actions the UI can attempt. [requiredPermission] is the single typed
+ * permission that gates the action - the whole gating rule lives on the enum so there is exactly one
+ * source of truth.
+ */
+enum class BroadcastModAction(val requiredPermission: DelegatePermission) {
+    // ---- control ----
+    START(DelegatePermission.BROADCAST_CONTROL),
+    STOP(DelegatePermission.BROADCAST_CONTROL),
+    SCHEDULE(DelegatePermission.BROADCAST_CONTROL),
+
+    // ---- moderation (mutations) ----
+    MUTE(DelegatePermission.BROADCAST_MODERATE),
+    BAN(DelegatePermission.BROADCAST_MODERATE),
+    UNBAN(DelegatePermission.BROADCAST_MODERATE),
+    PIN(DelegatePermission.BROADCAST_MODERATE),
+    UNPIN(DelegatePermission.BROADCAST_MODERATE),
+    DELETE_CHAT(DelegatePermission.BROADCAST_MODERATE),
+    ANNOUNCE(DelegatePermission.BROADCAST_MODERATE),
+    REGISTER_MODERATOR(DelegatePermission.BROADCAST_MODERATE),
+
+    // ---- moderation (reads) ----
+    LIST_MODERATORS(DelegatePermission.BROADCAST_MODERATE),
+    LIST_BANS(DelegatePermission.BROADCAST_MODERATE),
+    VIEW_LOG(DelegatePermission.BROADCAST_MODERATE),
+    ;
+
+    /** True when this action gates on [DelegatePermission.BROADCAST_CONTROL] (start / stop / schedule). */
+    val isControl: Boolean get() = requiredPermission == DelegatePermission.BROADCAST_CONTROL
+
+    /** True when this action gates on [DelegatePermission.BROADCAST_MODERATE] (everything else). */
+    val isModeration: Boolean get() = requiredPermission == DelegatePermission.BROADCAST_MODERATE
+}
+
+/** AND-360 - the single, pure gating helpers for delegate broadcast moderation. */
+object DelegateModMath {
+
+    /**
+     * The core decision: may the delegate holding [context] perform [action]? A null context (acting as
+     * oneself) is always denied; otherwise the action's [BroadcastModAction.requiredPermission] must be in
+     * the granted set. [DelegatePermission.UNKNOWN] tokens in the set are inert (never gate anything on).
+     */
+    fun canPerform(context: DelegationContext?, action: BroadcastModAction): Boolean =
+        context != null && action.requiredPermission in context.permissions
+
+    /**
+     * The subset of [BroadcastModAction] the delegate holding [context] may currently perform. Empty when
+     * the context is null (acting as oneself). Used to drive affordance visibility without re-deriving the
+     * rule per widget.
+     */
+    fun allowedActions(context: DelegationContext?): Set<BroadcastModAction> =
+        if (context == null) emptySet()
+        else BroadcastModAction.entries.filter { it.requiredPermission in context.permissions }.toSet()
+
+    /**
+     * True when the context can perform ANY moderation action (drives showing the moderation console at
+     * all). Distinct from [canControl] so a moderate-only delegate still sees the console, and a
+     * control-only delegate does not see moderation affordances.
+     */
+    fun canModerate(context: DelegationContext?): Boolean =
+        context != null && DelegatePermission.BROADCAST_MODERATE in context.permissions
+
+    /** True when the context can perform broadcast control (start / stop / schedule). */
+    fun canControl(context: DelegationContext?): Boolean =
+        context != null && DelegatePermission.BROADCAST_CONTROL in context.permissions
+
+    /**
+     * True when [userId] appears in [bannedUserIds] (case-sensitive exact match). Lets the UI flip a
+     * ban row's affordance between Ban and Unban without duplicating the membership test. A blank
+     * [userId] is never considered banned.
+     */
+    fun isBanned(userId: String, bannedUserIds: Collection<String>): Boolean =
+        userId.isNotBlank() && userId in bannedUserIds
+
+    /**
+     * Maps a raw wire moderation_type token to a stable, human-facing label. Unknown / blank tokens fall
+     * through to a title-cased echo of the token (or "Action" when blank) so a new server type never
+     * renders as an empty cell. The mapping is intentionally exhaustive over the known delegate actions.
+     */
+    fun moderationLabel(moderationType: String?): String = when (moderationType?.trim()?.lowercase()) {
+        null, "" -> "Action"
+        "mute" -> "Muted a viewer"
+        "ban" -> "Banned a viewer"
+        "unban" -> "Unbanned a viewer"
+        "pin" -> "Pinned a message"
+        "unpin" -> "Unpinned a message"
+        "delete", "delete_chat", "delete_message" -> "Deleted a message"
+        "announce", "announcement" -> "Posted an announcement"
+        "start" -> "Started the broadcast"
+        "stop" -> "Stopped the broadcast"
+        "register", "moderator_register" -> "Joined as moderator"
+        else -> moderationType.trim().replaceFirstChar { it.uppercaseChar() }
+    }
+
+    /**
+     * Counts moderation-log entries by their normalized [moderationLabel]. Deterministic input order is
+     * preserved by using a LinkedHashMap. Empty input yields an empty map. Used for a compact "activity"
+     * summary at the top of the log without pulling a charting dep.
+     */
+    fun countByType(types: List<String?>): Map<String, Int> {
+        val counts = LinkedHashMap<String, Int>()
+        for (t in types) {
+            val label = moderationLabel(t)
+            counts[label] = (counts[label] ?: 0) + 1
+        }
+        return counts
+    }
+}

--- a/android/core-model/src/test/java/com/testlogon/android/core/model/delegates/DelegateModMathTest.kt
+++ b/android/core-model/src/test/java/com/testlogon/android/core/model/delegates/DelegateModMathTest.kt
@@ -1,0 +1,161 @@
+package com.testlogon.android.core.model.delegates
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * AND-360 - JVM unit tests for [DelegateModMath], the pure permission / role gating for the delegate
+ * broadcast moderation surface. No Android / IO. Covers: control vs moderate gating per action, the
+ * null-context (acting-as-oneself) deny, the allowed-action projection, ban-membership, the wire ->
+ * label mapping (known + unknown + blank) and the by-type counting.
+ */
+class DelegateModMathTest {
+
+    private fun ctx(vararg perms: DelegatePermission) =
+        DelegationContext(creatorId = "cr_1", creatorName = "Acme", permissions = perms.toSet())
+
+    // ---- canPerform: control gating ----
+
+    @Test
+    fun canPerform_start_requiresControl() {
+        val control = ctx(DelegatePermission.BROADCAST_CONTROL)
+        assertTrue(DelegateModMath.canPerform(control, BroadcastModAction.START))
+        assertTrue(DelegateModMath.canPerform(control, BroadcastModAction.STOP))
+        assertTrue(DelegateModMath.canPerform(control, BroadcastModAction.SCHEDULE))
+    }
+
+    @Test
+    fun canPerform_control_deniedForModerateOnly() {
+        val moderate = ctx(DelegatePermission.BROADCAST_MODERATE)
+        assertFalse(DelegateModMath.canPerform(moderate, BroadcastModAction.START))
+        assertFalse(DelegateModMath.canPerform(moderate, BroadcastModAction.STOP))
+        assertFalse(DelegateModMath.canPerform(moderate, BroadcastModAction.SCHEDULE))
+    }
+
+    // ---- canPerform: moderation gating ----
+
+    @Test
+    fun canPerform_moderationActions_requireModerate() {
+        val moderate = ctx(DelegatePermission.BROADCAST_MODERATE)
+        val actions = listOf(
+            BroadcastModAction.MUTE, BroadcastModAction.BAN, BroadcastModAction.UNBAN,
+            BroadcastModAction.PIN, BroadcastModAction.UNPIN, BroadcastModAction.DELETE_CHAT,
+            BroadcastModAction.ANNOUNCE, BroadcastModAction.REGISTER_MODERATOR,
+            BroadcastModAction.LIST_MODERATORS, BroadcastModAction.LIST_BANS, BroadcastModAction.VIEW_LOG,
+        )
+        actions.forEach { assertTrue("$it should be allowed", DelegateModMath.canPerform(moderate, it)) }
+    }
+
+    @Test
+    fun canPerform_moderation_deniedForControlOnly() {
+        val control = ctx(DelegatePermission.BROADCAST_CONTROL)
+        assertFalse(DelegateModMath.canPerform(control, BroadcastModAction.BAN))
+        assertFalse(DelegateModMath.canPerform(control, BroadcastModAction.ANNOUNCE))
+        assertFalse(DelegateModMath.canPerform(control, BroadcastModAction.VIEW_LOG))
+    }
+
+    @Test
+    fun canPerform_nullContext_alwaysDenied() {
+        assertFalse(DelegateModMath.canPerform(null, BroadcastModAction.START))
+        assertFalse(DelegateModMath.canPerform(null, BroadcastModAction.BAN))
+        assertFalse(DelegateModMath.canPerform(null, BroadcastModAction.VIEW_LOG))
+    }
+
+    @Test
+    fun canPerform_unknownPermissionInSet_isInert() {
+        val onlyUnknown = ctx(DelegatePermission.UNKNOWN)
+        assertFalse(DelegateModMath.canPerform(onlyUnknown, BroadcastModAction.BAN))
+        assertFalse(DelegateModMath.canPerform(onlyUnknown, BroadcastModAction.START))
+    }
+
+    // ---- allowedActions ----
+
+    @Test
+    fun allowedActions_nullContext_isEmpty() {
+        assertTrue(DelegateModMath.allowedActions(null).isEmpty())
+    }
+
+    @Test
+    fun allowedActions_moderateOnly_excludesControl() {
+        val allowed = DelegateModMath.allowedActions(ctx(DelegatePermission.BROADCAST_MODERATE))
+        assertTrue(BroadcastModAction.BAN in allowed)
+        assertTrue(BroadcastModAction.VIEW_LOG in allowed)
+        assertFalse(BroadcastModAction.START in allowed)
+        assertFalse(BroadcastModAction.SCHEDULE in allowed)
+    }
+
+    @Test
+    fun allowedActions_both_includesAll() {
+        val allowed = DelegateModMath.allowedActions(
+            ctx(DelegatePermission.BROADCAST_CONTROL, DelegatePermission.BROADCAST_MODERATE),
+        )
+        assertEquals(BroadcastModAction.entries.toSet(), allowed)
+    }
+
+    // ---- canModerate / canControl ----
+
+    @Test
+    fun canModerate_and_canControl_areIndependent() {
+        val moderate = ctx(DelegatePermission.BROADCAST_MODERATE)
+        val control = ctx(DelegatePermission.BROADCAST_CONTROL)
+        assertTrue(DelegateModMath.canModerate(moderate))
+        assertFalse(DelegateModMath.canControl(moderate))
+        assertTrue(DelegateModMath.canControl(control))
+        assertFalse(DelegateModMath.canModerate(control))
+        assertFalse(DelegateModMath.canModerate(null))
+        assertFalse(DelegateModMath.canControl(null))
+    }
+
+    // ---- isBanned ----
+
+    @Test
+    fun isBanned_matchesMembership_andRejectsBlank() {
+        val banned = listOf("u_1", "u_2")
+        assertTrue(DelegateModMath.isBanned("u_1", banned))
+        assertFalse(DelegateModMath.isBanned("u_3", banned))
+        assertFalse(DelegateModMath.isBanned("", banned))
+        assertFalse(DelegateModMath.isBanned("u_1", emptyList()))
+    }
+
+    // ---- moderationLabel ----
+
+    @Test
+    fun moderationLabel_mapsKnownTypes_caseInsensitive() {
+        assertEquals("Banned a viewer", DelegateModMath.moderationLabel("ban"))
+        assertEquals("Muted a viewer", DelegateModMath.moderationLabel("MUTE"))
+        assertEquals("Deleted a message", DelegateModMath.moderationLabel("delete_message"))
+        assertEquals("Posted an announcement", DelegateModMath.moderationLabel("announcement"))
+        assertEquals("Joined as moderator", DelegateModMath.moderationLabel("moderator_register"))
+    }
+
+    @Test
+    fun moderationLabel_blankOrNull_isActionDefault() {
+        assertEquals("Action", DelegateModMath.moderationLabel(null))
+        assertEquals("Action", DelegateModMath.moderationLabel("   "))
+    }
+
+    @Test
+    fun moderationLabel_unknownType_titleCasesEcho() {
+        assertEquals("Shadowban", DelegateModMath.moderationLabel("shadowban"))
+    }
+
+    // ---- countByType ----
+
+    @Test
+    fun countByType_groupsByNormalizedLabel_preservingOrder() {
+        val counts = DelegateModMath.countByType(listOf("ban", "MUTE", "ban", "announcement", null))
+        assertEquals(1, counts["Muted a viewer"])
+        assertEquals(2, counts["Banned a viewer"])
+        assertEquals(1, counts["Posted an announcement"])
+        assertEquals(1, counts["Action"])
+        // insertion order: first-seen label wins the slot
+        assertEquals(listOf("Banned a viewer", "Muted a viewer", "Posted an announcement", "Action"), counts.keys.toList())
+    }
+
+    @Test
+    fun countByType_empty_isEmptyMap() {
+        assertTrue(DelegateModMath.countByType(emptyList()).isEmpty())
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/delegates/DelegateBroadcastApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/delegates/DelegateBroadcastApi.kt
@@ -2,9 +2,12 @@ package com.testlogon.android.core.network.delegates
 
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 /**
  * AND-360 - Retrofit interface for the delegate-PATH BROADCAST surface (manage-as-creator broadcast).
@@ -12,14 +15,17 @@ import retrofit2.http.Path
  * ATTRIBUTION IS THE PATH: the managed creator id is the {creatorId} @Path segment, NOT a header. These
  * endpoints are DISTINCT from the self broadcast endpoints. Paths have NO leading slash. The shared CSRF /
  * Bearer / 401-refresh interceptors already cover these calls (NO new header interceptor). All calls are
- * suspend; mutations return Response of Unit (empty / 204 bodies) folded by isSuccessful.
+ * suspend; mutations return Response of Unit (empty / 204 bodies) folded by isSuccessful; the READ calls
+ * (moderators / bans / moderation-log) return BARE ARRAYS.
  *
  * PERMISSION SPLIT: start / stop / schedule are gated by broadcast_control; the moderation actions
- * (mute / ban / unban / pin / delete / announce) by broadcast_moderate. There is NO broadcast_operate /
- * broadcast_publish permission. @Path tokens are EXACTLY {creatorId} / {sid}. The full broadcast console
- * is owned by the broadcast epic; this models the control + a representative pair of moderation actions.
+ * (mute / ban / unban / pin / unpin / delete / announce / moderator-register) + the read lists by
+ * broadcast_moderate. There is NO broadcast_operate / broadcast_publish permission. @Path tokens are
+ * EXACTLY {creatorId} / {sid} / {mid} / {uid}. Mirrors the web delegateBroadcast.ts surface 1:1.
  */
 interface DelegateBroadcastApi {
+
+    // ---- Broadcast control (broadcast_control) ----
 
     /** START a managed creator's broadcast session (gated by broadcast_control). */
     @Headers("Content-Type: application/json")
@@ -45,6 +51,8 @@ interface DelegateBroadcastApi {
         @Body body: DelegatedScheduleSessionIn,
     ): Response<Unit>
 
+    // ---- Chat moderation (broadcast_moderate) ----
+
     /** MUTE a viewer in the managed creator's broadcast session (gated by broadcast_moderate). */
     @Headers("Content-Type: application/json")
     @POST("ui/broadcast/delegate/{creatorId}/sessions/{sid}/mute")
@@ -62,4 +70,78 @@ interface DelegateBroadcastApi {
         @Path("sid") sid: String,
         @Body body: DelegatedModerationIn,
     ): Response<Unit>
+
+    /** UNBAN a viewer from the managed creator's broadcast session (gated by broadcast_moderate). */
+    @DELETE("ui/broadcast/delegate/{creatorId}/sessions/{sid}/ban/{uid}")
+    suspend fun unbanViewer(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+        @Path("uid") uid: String,
+    ): Response<Unit>
+
+    /** POST an ANNOUNCEMENT in the managed creator's broadcast chat (gated by broadcast_moderate). */
+    @Headers("Content-Type: application/json")
+    @POST("ui/broadcast/delegate/{creatorId}/sessions/{sid}/announcement")
+    suspend fun postAnnouncement(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+        @Body body: DelegatedAnnouncementIn,
+    ): Response<Unit>
+
+    /** PIN a chat message in the managed creator's broadcast session (gated by broadcast_moderate). */
+    @Headers("Content-Type: application/json")
+    @POST("ui/broadcast/delegate/{creatorId}/sessions/{sid}/chat/{mid}/pin")
+    suspend fun pinMessage(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+        @Path("mid") mid: String,
+    ): Response<Unit>
+
+    /** UNPIN a chat message in the managed creator's broadcast session (gated by broadcast_moderate). */
+    @DELETE("ui/broadcast/delegate/{creatorId}/sessions/{sid}/chat/{mid}/pin")
+    suspend fun unpinMessage(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+        @Path("mid") mid: String,
+    ): Response<Unit>
+
+    /** DELETE a chat message from the managed creator's broadcast session (gated by broadcast_moderate). */
+    @DELETE("ui/broadcast/delegate/{creatorId}/sessions/{sid}/chat/{mid}")
+    suspend fun deleteChatMessage(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+        @Path("mid") mid: String,
+    ): Response<Unit>
+
+    // ---- Moderator management (broadcast_moderate) ----
+
+    /** REGISTER the caller as an active moderator for a broadcast session (gated by broadcast_moderate). */
+    @Headers("Content-Type: application/json")
+    @POST("ui/broadcast/delegate/{creatorId}/sessions/{sid}/moderator/register")
+    suspend fun registerModerator(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+    ): Response<Unit>
+
+    /** LIST active moderators for a broadcast session as a BARE ARRAY (gated by broadcast_moderate). */
+    @GET("ui/broadcast/delegate/{creatorId}/sessions/{sid}/moderators")
+    suspend fun listModerators(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+    ): List<DelegatedBroadcastModeratorOut>
+
+    /** LIST banned viewers for a broadcast session as a BARE ARRAY (gated by broadcast_moderate). */
+    @GET("ui/broadcast/delegate/{creatorId}/sessions/{sid}/bans")
+    suspend fun listBans(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+    ): List<DelegatedBroadcastBanOut>
+
+    /** GET the moderation action log for a broadcast session as a BARE ARRAY (gated by broadcast_moderate). */
+    @GET("ui/broadcast/delegate/{creatorId}/sessions/{sid}/moderation-log")
+    suspend fun getModerationLog(
+        @Path("creatorId") creatorId: String,
+        @Path("sid") sid: String,
+        @Query("limit") limit: Int = 100,
+    ): List<DelegatedBroadcastModLogEntry>
 }

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/delegates/DelegateSurfaceDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/delegates/DelegateSurfaceDtos.kt
@@ -103,3 +103,50 @@ data class DelegatedModerationIn(
     @Json(name = "user_id") val userId: String,
     @Json(name = "reason") val reason: String? = null,
 )
+
+/**
+ * AND-360 - body to post an ANNOUNCEMENT in the managed creator's broadcast chat (delegate path,
+ * broadcast_moderate). [text] is the announcement copy. Mirrors the web BroadcastAnnouncementReq.
+ */
+data class DelegatedAnnouncementIn(
+    @Json(name = "text") val text: String,
+)
+
+/**
+ * AND-360 - one active MODERATOR of a managed creator's broadcast session (delegate path, read). Mirrors
+ * the web BroadcastModeratorOut. [delegateId] is required; the rest is best-effort metadata that defaults
+ * leniently so a sparse row never crashes decoding.
+ */
+data class DelegatedBroadcastModeratorOut(
+    @Json(name = "delegate_id") val delegateId: String,
+    @Json(name = "display_name") val displayName: String? = null,
+    @Json(name = "connected_at") val connectedAt: Long? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "actions_count") val actionsCount: Int? = null,
+)
+
+/**
+ * AND-360 - one BANNED viewer of a managed creator's broadcast session (delegate path, read). Mirrors the
+ * web BroadcastBanOut. [userId] + [bannedBy] are required; the rest defaults leniently.
+ */
+data class DelegatedBroadcastBanOut(
+    @Json(name = "user_id") val userId: String,
+    @Json(name = "banned_by") val bannedBy: String,
+    @Json(name = "banned_by_display_name") val bannedByDisplayName: String? = null,
+    @Json(name = "banned_at") val bannedAt: Long? = null,
+    @Json(name = "reason") val reason: String? = null,
+)
+
+/**
+ * AND-360 - one entry in a managed creator's broadcast MODERATION LOG (delegate path, read). Mirrors the
+ * web BroadcastModerationLogEntry. [eventId] + [moderatorId] are required; targets / details are optional.
+ */
+data class DelegatedBroadcastModLogEntry(
+    @Json(name = "event_id") val eventId: String,
+    @Json(name = "moderator_id") val moderatorId: String,
+    @Json(name = "moderator_display_name") val moderatorDisplayName: String? = null,
+    @Json(name = "moderation_type") val moderationType: String? = null,
+    @Json(name = "target_user_id") val targetUserId: String? = null,
+    @Json(name = "target_message_id") val targetMessageId: String? = null,
+    @Json(name = "ts") val ts: Long? = null,
+)

--- a/android/core-network/src/test/java/com/testlogon/android/core/network/delegates/DelegateFeatureApiTest.kt
+++ b/android/core-network/src/test/java/com/testlogon/android/core/network/delegates/DelegateFeatureApiTest.kt
@@ -182,4 +182,110 @@ class DelegateFeatureApiTest {
         assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/ban", recorded.requestUrl?.encodedPath)
         assertTrue(recorded.body.readUtf8().contains("\"user_id\":\"u_9\""))
     }
+
+    // ---- AND-360 broadcast moderation endpoints (added) ----
+
+    @Test
+    fun unbanViewer_deletesBanPath_withUidSubstituted() = runTest {
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        broadcastApi().unbanViewer("cr_1", "sess_5", "u_9")
+
+        val recorded = server.takeRequest()
+        assertEquals("DELETE", recorded.method)
+        assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/ban/u_9", recorded.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun postAnnouncement_postsAnnouncementPath_withTextBody() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        broadcastApi().postAnnouncement("cr_1", "sess_5", DelegatedAnnouncementIn(text = "hi all"))
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/announcement", recorded.requestUrl?.encodedPath)
+        assertTrue(recorded.body.readUtf8().contains("\"text\":\"hi all\""))
+    }
+
+    @Test
+    fun pinAndUnpin_useChatPinPath_withMidSubstituted() = runTest {
+        server.enqueue(MockResponse().setResponseCode(204))
+        broadcastApi().pinMessage("cr_1", "sess_5", "m_3")
+        val pin = server.takeRequest()
+        assertEquals("POST", pin.method)
+        assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/chat/m_3/pin", pin.requestUrl?.encodedPath)
+
+        server.enqueue(MockResponse().setResponseCode(204))
+        broadcastApi().unpinMessage("cr_1", "sess_5", "m_3")
+        val unpin = server.takeRequest()
+        assertEquals("DELETE", unpin.method)
+        assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/chat/m_3/pin", unpin.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun deleteChatMessage_deletesChatPath_withMidSubstituted() = runTest {
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        broadcastApi().deleteChatMessage("cr_1", "sess_5", "m_3")
+
+        val recorded = server.takeRequest()
+        assertEquals("DELETE", recorded.method)
+        assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/chat/m_3", recorded.requestUrl?.encodedPath)
+    }
+
+    @Test
+    fun registerModerator_postsModeratorRegisterPath() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        broadcastApi().registerModerator("cr_1", "sess_5")
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals(
+            "/ui/broadcast/delegate/cr_1/sessions/sess_5/moderator/register",
+            recorded.requestUrl?.encodedPath,
+        )
+    }
+
+    @Test
+    fun listModerators_getsBareArray() = runTest {
+        server.enqueue(jsonResponse("""[{"delegate_id":"d_1","display_name":"Sam"}]"""))
+
+        val mods = broadcastApi().listModerators("cr_1", "sess_5")
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/moderators", recorded.requestUrl?.encodedPath)
+        assertEquals("d_1", mods.single().delegateId)
+    }
+
+    @Test
+    fun listBans_getsBareArray() = runTest {
+        server.enqueue(jsonResponse("""[{"user_id":"u_1","banned_by":"d_1","reason":"spam"}]"""))
+
+        val bans = broadcastApi().listBans("cr_1", "sess_5")
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals("/ui/broadcast/delegate/cr_1/sessions/sess_5/bans", recorded.requestUrl?.encodedPath)
+        assertEquals("u_1", bans.single().userId)
+    }
+
+    @Test
+    fun getModerationLog_getsBareArray_withLimitQuery() = runTest {
+        server.enqueue(jsonResponse("""[{"event_id":"e_1","moderator_id":"d_1","moderation_type":"ban"}]"""))
+
+        val log = broadcastApi().getModerationLog("cr_1", "sess_5", limit = 25)
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals(
+            "/ui/broadcast/delegate/cr_1/sessions/sess_5/moderation-log",
+            recorded.requestUrl?.encodedPath,
+        )
+        assertEquals("25", recorded.requestUrl?.queryParameter("limit"))
+        assertEquals("e_1", log.single().eventId)
+    }
+
 }

--- a/android/core-network/src/test/java/com/testlogon/android/core/network/delegates/DelegateSurfaceDtoJsonTest.kt
+++ b/android/core-network/src/test/java/com/testlogon/android/core/network/delegates/DelegateSurfaceDtoJsonTest.kt
@@ -84,4 +84,78 @@ class DelegateSurfaceDtoJsonTest {
         assertEquals("Acme", decoded.title)
         assertNull(decoded.lastMessagePreview)
     }
+
+    // ---- AND-360 broadcast moderation read DTOs (added) ----
+
+    private fun moderatorListAdapter() = moshi.adapter<List<DelegatedBroadcastModeratorOut>>(
+        Types.newParameterizedType(List::class.java, DelegatedBroadcastModeratorOut::class.java),
+    )
+
+    private fun banListAdapter() = moshi.adapter<List<DelegatedBroadcastBanOut>>(
+        Types.newParameterizedType(List::class.java, DelegatedBroadcastBanOut::class.java),
+    )
+
+    private fun logListAdapter() = moshi.adapter<List<DelegatedBroadcastModLogEntry>>(
+        Types.newParameterizedType(List::class.java, DelegatedBroadcastModLogEntry::class.java),
+    )
+
+    @Test
+    fun moderator_decodesRequiredId_andDefaultsOptionals() {
+        val mods = requireNotNull(
+            moderatorListAdapter().fromJson(
+                """[
+                    {"delegate_id":"d_1","display_name":"Sam","connected_at":123,"status":"online","actions_count":4},
+                    {"delegate_id":"d_2"}
+                ]""",
+            ),
+        )
+        assertEquals("d_1", mods[0].delegateId)
+        assertEquals("Sam", mods[0].displayName)
+        assertEquals(4, mods[0].actionsCount)
+        assertNull(mods[1].displayName)
+        assertNull(mods[1].connectedAt)
+    }
+
+    @Test
+    fun ban_decodesRequiredFields_andDefaultsOptionals() {
+        val bans = requireNotNull(
+            banListAdapter().fromJson(
+                """[
+                    {"user_id":"u_1","banned_by":"d_1","banned_by_display_name":"Sam","banned_at":99,"reason":"spam"},
+                    {"user_id":"u_2","banned_by":"d_1"}
+                ]""",
+            ),
+        )
+        assertEquals("u_1", bans[0].userId)
+        assertEquals("d_1", bans[0].bannedBy)
+        assertEquals("spam", bans[0].reason)
+        assertNull(bans[1].reason)
+        assertNull(bans[1].bannedAt)
+    }
+
+    @Test
+    fun modLog_decodesEntry_withOptionalTargets() {
+        val log = requireNotNull(
+            logListAdapter().fromJson(
+                """[
+                    {"event_id":"e_1","moderator_id":"d_1","moderation_type":"ban","target_user_id":"u_9","ts":42},
+                    {"event_id":"e_2","moderator_id":"d_1","moderation_type":"pin","target_message_id":"m_3"}
+                ]""",
+            ),
+        )
+        assertEquals("e_1", log[0].eventId)
+        assertEquals("ban", log[0].moderationType)
+        assertEquals("u_9", log[0].targetUserId)
+        assertNull(log[0].targetMessageId)
+        assertEquals("m_3", log[1].targetMessageId)
+        assertNull(log[1].targetUserId)
+    }
+
+    @Test
+    fun announcementIn_serializesText() {
+        val adapter = moshi.adapter(DelegatedAnnouncementIn::class.java)
+        val json = adapter.toJson(DelegatedAnnouncementIn(text = "attention"))
+        assertTrue(json.contains("\"text\":\"attention\""))
+    }
+
 }


### PR DESCRIPTION
## FE parity PAR-123 - Android delegate/moderator broadcast

Adds the Android delegate/moderator broadcast console to reach parity with the web surface.

### What was added
- Moderator console state (`DelegateModConsoleState`) and broadcast wiring in the delegate console screen/viewmodel/UI state.
- Broadcast repository (`DelegateBroadcastRepository`) plus `core-network` API + DTOs for the broadcast endpoints.
- `DelegateModMath` in `core-model` with unit coverage.

### Reuse notes
- Builds on the existing `DelegateConsole` screen/viewmodel and `DelegateSurface` DTO plumbing rather than introducing a new surface.

### Gate
- Feature stays behind the existing delegate/moderator gate; no new entry points are exposed to non-delegates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
