### PR TITLE
FE parity PAR-137 - Android catalog advanced (seller)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/sellerstore/CatalogSellerMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/sellerstore/CatalogSellerMath.kt
@@ -1,0 +1,153 @@
+package com.testlogon.android.data.sellerstore
+
+/**
+ * ECOM (catalog depth) — pure, side-effect-free helpers for the advanced seller product editor
+ * (variants / price components / bundle components / product features). Kept UI- and network-free so
+ * they can be exhaustively unit-tested on the JVM. Mirrors the backend contract in
+ * app/services/product_price_components.py + product_variants.py and the web helpers in
+ * frontend/src/api/endpoints/productDepth.ts (formatCents / formatDeltaCents).
+ *
+ * All money is integer minor units (cents). No floating-point arithmetic on money.
+ */
+object CatalogSellerMath {
+
+    /** The valid PriceType values (mirrors PriceTypeEnum in app/models.py). */
+    val PRICE_TYPES: List<String> = listOf(
+        "LIST", "DEFAULT", "PROMO", "COMPETITIVE", "MINIMUM", "AVERAGE_COST",
+    )
+
+    /** The valid product types (mirrors the web ProductType union). */
+    val PRODUCT_TYPES: List<String> = listOf(
+        "standalone", "virtual", "variant", "bundle", "kit", "digital",
+    )
+
+    /** True when [productType] is one that may carry bundle components (bundle or kit). */
+    fun isBundleType(productType: String?): Boolean =
+        productType == "bundle" || productType == "kit"
+
+    /** True when [priceType] is one of the recognised price types (case-sensitive, as the server is). */
+    fun isValidPriceType(priceType: String?): Boolean =
+        priceType != null && priceType in PRICE_TYPES
+
+    /**
+     * Sum of a variant's feature price deltas over the item's base price.
+     *
+     * @param basePriceCents the parent item's scalar price (>= 0).
+     * @param deltas the price_delta_cents of each selected feature value (may be negative for discounts).
+     * @return the effective variant price, floored at 0 (a product is never sold for negative money).
+     */
+    fun variantEffectivePriceCents(basePriceCents: Long, deltas: List<Long>): Long {
+        val sum = basePriceCents + deltas.sum()
+        return if (sum < 0L) 0L else sum
+    }
+
+    /**
+     * Total cents contributed by a bundle's components: sum of (unit price * quantity) across lines.
+     * Lines with an unknown (null) component price are treated as 0 (the server may not have resolved
+     * a price yet). Quantities <= 0 are ignored (the server enforces quantity >= 1 on write).
+     */
+    fun bundleTotalCents(lines: List<BundleLineMath>): Long =
+        lines.sumOf { line ->
+            val qty = line.quantity.coerceAtLeast(0)
+            val unit = line.unitPriceCents ?: 0L
+            unit * qty
+        }
+
+    /**
+     * A price component is "active" as of [asOf] (epoch seconds) when it has taken effect
+     * (effective_at <= asOf) and has not yet expired (expires_at is null OR expires_at >= asOf).
+     */
+    fun isPriceComponentActive(effectiveAt: Long, expiresAt: Long?, asOf: Long): Boolean =
+        effectiveAt <= asOf && (expiresAt == null || expiresAt >= asOf)
+
+    /**
+     * Resolve the active price-component amount for a set of components of one price type, newest
+     * effective-date first (mirrors resolve_effective_price's GSI walk). Returns null when none are
+     * active — the caller then falls back to the scalar price (for DEFAULT) or 0.
+     */
+    fun resolveActiveAmountCents(components: List<PriceComponentMath>, asOf: Long): Long? =
+        components
+            .sortedByDescending { it.effectiveAt }
+            .firstOrNull { isPriceComponentActive(it.effectiveAt, it.expiresAt, asOf) }
+            ?.amountCents
+
+    /**
+     * Client-side validation for a new price component before POST. Returns null when valid, otherwise
+     * a short human-readable reason. Mirrors the server field constraints (amount >= 0, effective_at
+     * >= 0, expires_at (if set) must be after effective_at) + a valid price type.
+     */
+    fun validatePriceComponent(
+        priceType: String?,
+        amountCents: Long,
+        effectiveAt: Long,
+        expiresAt: Long?,
+    ): String? = when {
+        !isValidPriceType(priceType) -> "Choose a price type"
+        amountCents < 0L -> "Amount can't be negative"
+        effectiveAt < 0L -> "Invalid effective time"
+        expiresAt != null && expiresAt < effectiveAt -> "Expiry must be after the effective time"
+        else -> null
+    }
+
+    /**
+     * Client-side validation for creating a variant. Returns null when valid, otherwise a reason.
+     * A variant must map at least one feature category to a value, and every mapped value must be
+     * non-blank (mirrors the server's non-empty feature_values dict requirement).
+     */
+    fun validateVariant(featureValues: Map<String, String>): String? = when {
+        featureValues.isEmpty() -> "Pick at least one option"
+        featureValues.any { it.key.isBlank() || it.value.isBlank() } -> "Every option needs a value"
+        else -> null
+    }
+
+    /**
+     * Client-side validation for adding a bundle component. Returns null when valid, otherwise a reason.
+     * Guards against self-reference and non-positive quantity (server enforces quantity 1..100000).
+     */
+    fun validateBundleComponent(
+        parentItemId: String,
+        componentItemId: String,
+        quantity: Int,
+    ): String? = when {
+        componentItemId.isBlank() -> "Pick a component product"
+        componentItemId == parentItemId -> "A bundle can't contain itself"
+        quantity < 1 -> "Quantity must be at least 1"
+        quantity > 100_000 -> "Quantity is too large"
+        else -> null
+    }
+
+    /** Render integer cents as a plain "$#.##" string (locale-free; UI adds currency symbol). */
+    fun formatCents(cents: Long, currency: String = "USD"): String {
+        val negative = cents < 0L
+        val abs = if (negative) -cents else cents
+        val dollars = abs / 100
+        val rem = (abs % 100).toInt()
+        val body = "$dollars.${rem.toString().padStart(2, '0')}"
+        val symbol = if (currency == "USD") "$" else "$currency "
+        return if (negative) "-$symbol$body" else "$symbol$body"
+    }
+
+    /** Render a signed delta with an explicit +/- prefix (mirrors web formatDeltaCents). */
+    fun formatDeltaCents(cents: Long, currency: String = "USD"): String {
+        val sign = when {
+            cents > 0L -> "+"
+            cents < 0L -> "-"
+            else -> ""
+        }
+        val abs = if (cents < 0L) -cents else cents
+        return sign + formatCents(abs, currency)
+    }
+}
+
+/** Minimal projection of a bundle component line for [CatalogSellerMath.bundleTotalCents]. */
+data class BundleLineMath(
+    val quantity: Int,
+    val unitPriceCents: Long?,
+)
+
+/** Minimal projection of a price component for [CatalogSellerMath.resolveActiveAmountCents]. */
+data class PriceComponentMath(
+    val amountCents: Long,
+    val effectiveAt: Long,
+    val expiresAt: Long?,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthApi.kt
@@ -1,0 +1,171 @@
+package com.testlogon.android.data.sellerstore
+
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * ECOM (catalog depth) — Retrofit interface for the advanced seller product endpoints (OFBiz catalog
+ * depth). The basic seller CRUD lives on [SellerCatalogApi]; these are the depth extensions
+ * (variants / price components / bundle components / per-item product features / category tree / bulk).
+ * All paths are relative (resolve against the shared Retrofit base URL); session cookies + Bearer +
+ * X-CSRF-Token are attached by the core-network interceptor chain.
+ *
+ * Every route is feature-gated on the backend (S.product_depth_enabled): reads answer 404/501 when the
+ * flag is off — the repository degrades those to an honest-empty result. Mutations surface the error.
+ *
+ * Verified contract (app/routers/catalog.py; frontend/src/api/endpoints/productDepth.ts):
+ *  - GET/POST    ui/catalog/items/{id}/product-type
+ *  - GET/POST/DELETE  ui/catalog/items/{id}/variants[/{variant_id}]
+ *  - GET/POST/PUT ui/catalog/items/{id}/price-components
+ *  - GET         ui/catalog/items/{id}/effective-price
+ *  - GET/POST/DELETE  ui/catalog/items/{id}/bundle-components[/{component_id}]
+ *  - GET/POST/DELETE  ui/catalog/items/{id}/product-features[/{fc_id}[/values]]
+ *  - GET         ui/catalog/categories/{id}/tree | /breadcrumb
+ *  - POST        ui/catalog/categories/{id}/children ; PATCH .../move
+ *  - POST        ui/catalog/items/bulk-delete | bulk-update
+ */
+interface ProductDepthApi {
+
+    // ── product type ──
+    @GET("ui/catalog/items/{itemId}/product-type")
+    suspend fun getProductType(@Path("itemId") itemId: String): ProductTypeRespDto
+
+    @POST("ui/catalog/items/{itemId}/product-type")
+    suspend fun setProductType(
+        @Path("itemId") itemId: String,
+        @Body body: SetProductTypeReqDto,
+    ): ProductTypeRespDto
+
+    // ── variants ──
+    @GET("ui/catalog/items/{itemId}/variants")
+    suspend fun listVariants(
+        @Path("itemId") itemId: String,
+        @Query("limit") limit: Int = 100,
+    ): VariantListDto
+
+    @POST("ui/catalog/items/{itemId}/variants")
+    suspend fun createVariant(
+        @Path("itemId") itemId: String,
+        @Body body: CreateVariantReqDto,
+    ): VariantDto
+
+    @DELETE("ui/catalog/items/{itemId}/variants/{variantId}")
+    suspend fun deleteVariant(
+        @Path("itemId") itemId: String,
+        @Path("variantId") variantId: String,
+    )
+
+    // ── price components ──
+    @GET("ui/catalog/items/{itemId}/price-components")
+    suspend fun listPriceComponents(
+        @Path("itemId") itemId: String,
+        @Query("price_type") priceType: String? = null,
+    ): PriceComponentListDto
+
+    @POST("ui/catalog/items/{itemId}/price-components")
+    suspend fun addPriceComponent(
+        @Path("itemId") itemId: String,
+        @Body body: AddPriceComponentReqDto,
+    ): PriceComponentDto
+
+    @GET("ui/catalog/items/{itemId}/effective-price")
+    suspend fun getEffectivePrice(
+        @Path("itemId") itemId: String,
+        @Query("price_type") priceType: String = "DEFAULT",
+        @Query("as_of") asOf: Long? = null,
+    ): EffectivePriceDto
+
+    // ── bundle components ──
+    @GET("ui/catalog/items/{itemId}/bundle-components")
+    suspend fun listBundleComponents(@Path("itemId") itemId: String): BundleComponentListDto
+
+    @POST("ui/catalog/items/{itemId}/bundle-components")
+    suspend fun addBundleComponent(
+        @Path("itemId") itemId: String,
+        @Body body: AddBundleComponentReqDto,
+    ): BundleComponentDto
+
+    @DELETE("ui/catalog/items/{itemId}/bundle-components/{componentItemId}")
+    suspend fun removeBundleComponent(
+        @Path("itemId") itemId: String,
+        @Path("componentItemId") componentItemId: String,
+    )
+
+    // ── per-item product features ──
+    @GET("ui/catalog/items/{itemId}/product-features")
+    suspend fun listProductFeatures(@Path("itemId") itemId: String): ProductFeaturesDto
+
+    @POST("ui/catalog/items/{itemId}/product-features")
+    suspend fun createProductFeatureCategory(
+        @Path("itemId") itemId: String,
+        @Body body: CreateProductFeatureCategoryReqDto,
+    ): ProductFeatureCategoryDto
+
+    @POST("ui/catalog/items/{itemId}/product-features/{featureCategoryId}/values")
+    suspend fun addProductFeatureValue(
+        @Path("itemId") itemId: String,
+        @Path("featureCategoryId") featureCategoryId: String,
+        @Body body: AddProductFeatureValueReqDto,
+    ): ProductFeatureValueDto
+
+    @DELETE("ui/catalog/items/{itemId}/product-features/{featureCategoryId}")
+    suspend fun deleteProductFeatureCategory(
+        @Path("itemId") itemId: String,
+        @Path("featureCategoryId") featureCategoryId: String,
+    )
+
+    // ── category tree ──
+    @GET("ui/catalog/categories/{categoryId}/tree")
+    suspend fun getCategoryTree(
+        @Path("categoryId") categoryId: String,
+        @Query("max_depth") maxDepth: Int = 5,
+    ): CategoryTreeNodeDto
+
+    @GET("ui/catalog/categories/{categoryId}/breadcrumb")
+    suspend fun getCategoryBreadcrumb(@Path("categoryId") categoryId: String): CategoryBreadcrumbDto
+
+    @POST("ui/catalog/categories/{categoryId}/children")
+    suspend fun addCategoryChild(
+        @Path("categoryId") categoryId: String,
+        @Body body: AddCategoryChildReqDto,
+    ): Map<String, Any?>
+
+    @PATCH("ui/catalog/categories/{categoryId}/move")
+    suspend fun moveCategory(
+        @Path("categoryId") categoryId: String,
+        @Body body: MoveCategoryReqDto,
+    ): Map<String, Any?>
+
+    // ── bulk ──
+    @POST("ui/catalog/items/bulk-delete")
+    suspend fun bulkDelete(@Body body: BulkDeleteReqDto): BulkResultDto
+
+    @POST("ui/catalog/items/bulk-update")
+    suspend fun bulkUpdate(@Body body: BulkUpdateReqDto): BulkResultDto
+
+    // ── PUT set price components (replace-all for one price type) ──
+    @PUT("ui/catalog/items/{itemId}/price-components")
+    suspend fun setPriceComponents(
+        @Path("itemId") itemId: String,
+        @Body body: SetPriceComponentsReqDto,
+    ): SetPriceComponentsRespDto
+}
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+data class SetPriceComponentsReqDto(
+    @com.squareup.moshi.Json(name = "price_type") val priceType: String,
+    @com.squareup.moshi.Json(name = "components") val components: List<AddPriceComponentReqDto> = emptyList(),
+)
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+data class SetPriceComponentsRespDto(
+    @com.squareup.moshi.Json(name = "item_id") val itemId: String,
+    @com.squareup.moshi.Json(name = "price_type") val priceType: String,
+    @com.squareup.moshi.Json(name = "components") val components: List<PriceComponentDto> = emptyList(),
+)

--- a/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthDomain.kt
@@ -1,0 +1,139 @@
+package com.testlogon.android.data.sellerstore
+
+/**
+ * ECOM (catalog depth) — UI-facing domain models for the advanced seller product editor + wire→domain
+ * mappers. Money is integer minor units (cents). Kept free of Moshi/Retrofit annotations so the UI layer
+ * never sees the wire shapes.
+ */
+
+data class Variant(
+    val variantId: String,
+    val parentItemId: String,
+    val sku: String,
+    val featureValues: Map<String, String>,
+    val priceDeltaCents: Long,
+    val effectivePriceCents: Long,
+)
+
+data class PriceComponent(
+    val priceComponentId: String,
+    val itemId: String,
+    val priceType: String,
+    val amountCents: Long,
+    val currency: String,
+    val effectiveAt: Long,
+    val expiresAt: Long?,
+    val isActive: Boolean,
+)
+
+data class EffectivePrice(
+    val amountCents: Long,
+    val currency: String,
+    val priceComponentId: String?,
+    val source: String,
+)
+
+data class BundleComponent(
+    val parentItemId: String,
+    val componentItemId: String,
+    val quantity: Int,
+    val componentSku: String?,
+    val componentName: String?,
+    val componentPriceCents: Long?,
+)
+
+data class ProductFeatureCategory(
+    val featureCategoryId: String,
+    val name: String,
+    val position: Int,
+    val itemId: String,
+)
+
+data class ProductFeatureValue(
+    val featureValueId: String,
+    val featureCategoryId: String,
+    val value: String,
+    val priceDeltaCents: Long,
+    val position: Int,
+)
+
+data class ProductFeatures(
+    val itemId: String,
+    val categories: List<ProductFeatureCategory>,
+    val values: List<ProductFeatureValue>,
+) {
+    /** Values grouped under their owning feature category id (for a "Color: Red/Blue" style layout). */
+    fun valuesFor(featureCategoryId: String): List<ProductFeatureValue> =
+        values.filter { it.featureCategoryId == featureCategoryId }.sortedBy { it.position }
+}
+
+data class CategoryTreeNode(
+    val categoryId: String,
+    val name: String,
+    val children: List<CategoryTreeNode>,
+)
+
+// ── mappers ──────────────────────────────────────────────────────────────────
+
+fun VariantDto.toDomain(): Variant = Variant(
+    variantId = variantId,
+    parentItemId = parentItemId,
+    sku = sku,
+    featureValues = featureValues,
+    priceDeltaCents = priceDeltaCents,
+    effectivePriceCents = effectivePriceCents,
+)
+
+fun PriceComponentDto.toDomain(): PriceComponent = PriceComponent(
+    priceComponentId = priceComponentId,
+    itemId = itemId,
+    priceType = priceType,
+    amountCents = amountCents,
+    currency = currency,
+    effectiveAt = effectiveAt,
+    expiresAt = expiresAt,
+    isActive = isActive,
+)
+
+fun EffectivePriceDto.toDomain(): EffectivePrice = EffectivePrice(
+    amountCents = amountCents,
+    currency = currency,
+    priceComponentId = priceComponentId,
+    source = source,
+)
+
+fun BundleComponentDto.toDomain(): BundleComponent = BundleComponent(
+    parentItemId = parentItemId,
+    componentItemId = componentItemId,
+    quantity = quantity,
+    componentSku = componentSku,
+    componentName = componentName,
+    componentPriceCents = componentPriceCents,
+)
+
+fun ProductFeatureCategoryDto.toDomain(): ProductFeatureCategory = ProductFeatureCategory(
+    featureCategoryId = featureCategoryId,
+    name = name,
+    position = position,
+    itemId = itemId,
+)
+
+fun ProductFeatureValueDto.toDomain(): ProductFeatureValue = ProductFeatureValue(
+    featureValueId = featureValueId,
+    featureCategoryId = featureCategoryId,
+    value = value,
+    priceDeltaCents = priceDeltaCents,
+    position = position,
+)
+
+fun ProductFeaturesDto.toDomain(): ProductFeatures = ProductFeatures(
+    itemId = itemId,
+    categories = featureCategories.map { it.toDomain() },
+    values = values.map { it.toDomain() },
+)
+
+fun CategoryTreeNodeDto.toDomain(): CategoryTreeNode = CategoryTreeNode(
+    categoryId = categoryId,
+    name = name,
+    children = children.map { it.toDomain() },
+)

--- a/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthDtos.kt
@@ -1,0 +1,215 @@
+package com.testlogon.android.data.sellerstore
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * ECOM (catalog depth) — wire DTOs for the advanced seller product endpoints (OFBiz catalog depth:
+ * variants, price components, bundle components, per-item product features, category tree). All under
+ * the /ui/catalog router. Mirrors the LIVE Pydantic models in app/models.py and the web contract in
+ * frontend/src/api/endpoints/productDepth.ts. These endpoints are feature-gated on the backend
+ * (product_depth_enabled): reads return 404/501 when off — the repository degrades those to empty.
+ */
+
+// ── Product type (PRD-007) ───────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class ProductTypeRespDto(
+    @Json(name = "item_id") val itemId: String,
+    @Json(name = "product_type") val productType: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class SetProductTypeReqDto(
+    @Json(name = "product_type") val productType: String,
+)
+
+// ── Variants (PRD-007) ───────────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class VariantDto(
+    @Json(name = "variant_id") val variantId: String,
+    @Json(name = "parent_item_id") val parentItemId: String,
+    @Json(name = "sku") val sku: String,
+    @Json(name = "feature_values") val featureValues: Map<String, String> = emptyMap(),
+    @Json(name = "price_delta_cents") val priceDeltaCents: Long = 0,
+    @Json(name = "effective_price_cents") val effectivePriceCents: Long = 0,
+    @Json(name = "creator_id") val creatorId: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class VariantListDto(
+    @Json(name = "item_id") val itemId: String,
+    @Json(name = "variants") val variants: List<VariantDto> = emptyList(),
+    @Json(name = "count") val count: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CreateVariantReqDto(
+    @Json(name = "feature_values") val featureValues: Map<String, String>,
+    @Json(name = "sku_override") val skuOverride: String? = null,
+)
+
+// ── Price components (PRD-012) ───────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class PriceComponentDto(
+    @Json(name = "price_component_id") val priceComponentId: String,
+    @Json(name = "item_id") val itemId: String,
+    @Json(name = "price_type") val priceType: String,
+    @Json(name = "amount_cents") val amountCents: Long,
+    @Json(name = "currency") val currency: String = "USD",
+    @Json(name = "effective_at") val effectiveAt: Long,
+    @Json(name = "expires_at") val expiresAt: Long? = null,
+    @Json(name = "is_active") val isActive: Boolean = false,
+)
+
+@JsonClass(generateAdapter = true)
+data class PriceComponentListDto(
+    @Json(name = "item_id") val itemId: String,
+    @Json(name = "components") val components: List<PriceComponentDto> = emptyList(),
+    @Json(name = "count") val count: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class AddPriceComponentReqDto(
+    @Json(name = "price_type") val priceType: String,
+    @Json(name = "amount_cents") val amountCents: Long,
+    @Json(name = "currency") val currency: String = "USD",
+    @Json(name = "effective_at") val effectiveAt: Long,
+    @Json(name = "expires_at") val expiresAt: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class EffectivePriceDto(
+    @Json(name = "amount_cents") val amountCents: Long,
+    @Json(name = "currency") val currency: String = "USD",
+    @Json(name = "price_component_id") val priceComponentId: String? = null,
+    @Json(name = "source") val source: String,
+)
+
+// ── Bundle components (product_depth_bundles) ────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class BundleComponentDto(
+    @Json(name = "parent_item_id") val parentItemId: String,
+    @Json(name = "component_item_id") val componentItemId: String,
+    @Json(name = "quantity") val quantity: Int = 1,
+    @Json(name = "component_sku") val componentSku: String? = null,
+    @Json(name = "component_name") val componentName: String? = null,
+    @Json(name = "component_price_cents") val componentPriceCents: Long? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class BundleComponentListDto(
+    @Json(name = "parent_item_id") val parentItemId: String,
+    @Json(name = "components") val components: List<BundleComponentDto> = emptyList(),
+    @Json(name = "count") val count: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class AddBundleComponentReqDto(
+    @Json(name = "component_item_id") val componentItemId: String,
+    @Json(name = "quantity") val quantity: Int = 1,
+)
+
+// ── Per-item product features (PRD-006) ──────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class ProductFeatureCategoryDto(
+    @Json(name = "feature_category_id") val featureCategoryId: String,
+    @Json(name = "name") val name: String,
+    @Json(name = "position") val position: Int = 0,
+    @Json(name = "item_id") val itemId: String,
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class ProductFeatureValueDto(
+    @Json(name = "feature_value_id") val featureValueId: String,
+    @Json(name = "feature_category_id") val featureCategoryId: String,
+    @Json(name = "value") val value: String,
+    @Json(name = "price_delta_cents") val priceDeltaCents: Long = 0,
+    @Json(name = "position") val position: Int = 0,
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class ProductFeaturesDto(
+    @Json(name = "item_id") val itemId: String,
+    @Json(name = "feature_categories") val featureCategories: List<ProductFeatureCategoryDto> = emptyList(),
+    @Json(name = "values") val values: List<ProductFeatureValueDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class CreateProductFeatureCategoryReqDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "position") val position: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class AddProductFeatureValueReqDto(
+    @Json(name = "value") val value: String,
+    @Json(name = "price_delta_cents") val priceDeltaCents: Long = 0,
+    @Json(name = "position") val position: Int = 0,
+)
+
+// ── Category tree (PRD-004 / PRD-005 / PRD-014) ──────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CategoryTreeNodeDto(
+    @Json(name = "category_id") val categoryId: String,
+    @Json(name = "name") val name: String,
+    @Json(name = "children") val children: List<CategoryTreeNodeDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class CategoryBreadcrumbCrumbDto(
+    @Json(name = "category_id") val categoryId: String,
+    @Json(name = "name") val name: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class CategoryBreadcrumbDto(
+    @Json(name = "breadcrumb") val breadcrumb: List<CategoryBreadcrumbCrumbDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class AddCategoryChildReqDto(
+    @Json(name = "child_category_id") val childCategoryId: String,
+    @Json(name = "position") val position: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class MoveCategoryReqDto(
+    @Json(name = "new_parent_id") val newParentId: String,
+)
+
+// ── Bulk operations (UX-004) ─────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class BulkDeleteReqDto(
+    @Json(name = "item_ids") val itemIds: List<String>,
+)
+
+@JsonClass(generateAdapter = true)
+data class BulkUpdateReqDto(
+    @Json(name = "item_ids") val itemIds: List<String>,
+    @Json(name = "updates") val updates: Map<String, String>,
+)
+
+@JsonClass(generateAdapter = true)
+data class BulkResultRowDto(
+    @Json(name = "item_id") val itemId: String,
+    @Json(name = "ok") val ok: Boolean,
+    @Json(name = "error") val error: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class BulkResultDto(
+    @Json(name = "results") val results: List<BulkResultRowDto> = emptyList(),
+    @Json(name = "succeeded") val succeeded: Int = 0,
+    @Json(name = "failed") val failed: Int = 0,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/sellerstore/ProductDepthRepository.kt
@@ -1,0 +1,175 @@
+package com.testlogon.android.data.sellerstore
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.map
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * ECOM (catalog depth) — seller-side data layer for the advanced product endpoints over
+ * [ProductDepthApi]. Wraps every call in [ApiResult] and maps wire shapes to the [ProductDepthDomain]
+ * models.
+ *
+ * Degrade-on-404 (brief): the whole depth subsystem is behind a backend feature flag that answers
+ * 404 / 501 (`product_depth_not_enabled`) when off. READS treat those two statuses as an honest-empty
+ * result (empty list / null) rather than an error, so the editor renders a clean "not enabled" empty
+ * state. WRITES surface the failure so the user learns the mutation didn't happen.
+ */
+interface ProductDepthRepository {
+
+    suspend fun getProductType(itemId: String): ApiResult<String>
+    suspend fun setProductType(itemId: String, productType: String): ApiResult<String>
+
+    suspend fun listVariants(itemId: String): ApiResult<List<Variant>>
+    suspend fun createVariant(itemId: String, featureValues: Map<String, String>, skuOverride: String?): ApiResult<Variant>
+    suspend fun deleteVariant(itemId: String, variantId: String): ApiResult<Unit>
+
+    suspend fun listPriceComponents(itemId: String, priceType: String?): ApiResult<List<PriceComponent>>
+    suspend fun addPriceComponent(
+        itemId: String,
+        priceType: String,
+        amountCents: Long,
+        currency: String,
+        effectiveAt: Long,
+        expiresAt: Long?,
+    ): ApiResult<PriceComponent>
+    suspend fun effectivePrice(itemId: String, priceType: String, asOf: Long?): ApiResult<EffectivePrice>
+
+    suspend fun listBundleComponents(itemId: String): ApiResult<List<BundleComponent>>
+    suspend fun addBundleComponent(itemId: String, componentItemId: String, quantity: Int): ApiResult<BundleComponent>
+    suspend fun removeBundleComponent(itemId: String, componentItemId: String): ApiResult<Unit>
+
+    suspend fun listProductFeatures(itemId: String): ApiResult<ProductFeatures>
+    suspend fun createFeatureCategory(itemId: String, name: String, position: Int): ApiResult<ProductFeatureCategory>
+    suspend fun addFeatureValue(
+        itemId: String,
+        featureCategoryId: String,
+        value: String,
+        priceDeltaCents: Long,
+        position: Int,
+    ): ApiResult<ProductFeatureValue>
+    suspend fun deleteFeatureCategory(itemId: String, featureCategoryId: String): ApiResult<Unit>
+
+    suspend fun categoryTree(categoryId: String, maxDepth: Int): ApiResult<CategoryTreeNode?>
+    suspend fun addCategoryChild(categoryId: String, childCategoryId: String, position: Int): ApiResult<Unit>
+    suspend fun moveCategory(categoryId: String, newParentId: String): ApiResult<Unit>
+}
+
+@Singleton
+class ProductDepthRepositoryImpl @Inject constructor(
+    private val api: ProductDepthApi,
+    private val errorParser: ApiErrorParser,
+) : ProductDepthRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun getProductType(itemId: String): ApiResult<String> = withContext(io) {
+        readOrDefault(default = "standalone") { api.getProductType(itemId).productType }
+    }
+
+    override suspend fun setProductType(itemId: String, productType: String): ApiResult<String> =
+        withContext(io) { call { api.setProductType(itemId, SetProductTypeReqDto(productType)).productType } }
+
+    override suspend fun listVariants(itemId: String): ApiResult<List<Variant>> = withContext(io) {
+        readOrDefault(default = emptyList()) { api.listVariants(itemId).variants.map { it.toDomain() } }
+    }
+
+    override suspend fun createVariant(itemId: String, featureValues: Map<String, String>, skuOverride: String?): ApiResult<Variant> =
+        withContext(io) { call { api.createVariant(itemId, CreateVariantReqDto(featureValues, skuOverride?.takeIf { it.isNotBlank() })).toDomain() } }
+
+    override suspend fun deleteVariant(itemId: String, variantId: String): ApiResult<Unit> =
+        withContext(io) { call { api.deleteVariant(itemId, variantId) } }
+
+    override suspend fun listPriceComponents(itemId: String, priceType: String?): ApiResult<List<PriceComponent>> =
+        withContext(io) { readOrDefault(default = emptyList()) { api.listPriceComponents(itemId, priceType).components.map { it.toDomain() } } }
+
+    override suspend fun addPriceComponent(
+        itemId: String,
+        priceType: String,
+        amountCents: Long,
+        currency: String,
+        effectiveAt: Long,
+        expiresAt: Long?,
+    ): ApiResult<PriceComponent> = withContext(io) {
+        call { api.addPriceComponent(itemId, AddPriceComponentReqDto(priceType, amountCents, currency, effectiveAt, expiresAt)).toDomain() }
+    }
+
+    override suspend fun effectivePrice(itemId: String, priceType: String, asOf: Long?): ApiResult<EffectivePrice> =
+        withContext(io) { call { api.getEffectivePrice(itemId, priceType, asOf).toDomain() } }
+
+    override suspend fun listBundleComponents(itemId: String): ApiResult<List<BundleComponent>> =
+        withContext(io) { readOrDefault(default = emptyList()) { api.listBundleComponents(itemId).components.map { it.toDomain() } } }
+
+    override suspend fun addBundleComponent(itemId: String, componentItemId: String, quantity: Int): ApiResult<BundleComponent> =
+        withContext(io) { call { api.addBundleComponent(itemId, AddBundleComponentReqDto(componentItemId, quantity)).toDomain() } }
+
+    override suspend fun removeBundleComponent(itemId: String, componentItemId: String): ApiResult<Unit> =
+        withContext(io) { call { api.removeBundleComponent(itemId, componentItemId) } }
+
+    override suspend fun listProductFeatures(itemId: String): ApiResult<ProductFeatures> = withContext(io) {
+        readOrDefault(default = ProductFeatures(itemId, emptyList(), emptyList())) { api.listProductFeatures(itemId).toDomain() }
+    }
+
+    override suspend fun createFeatureCategory(itemId: String, name: String, position: Int): ApiResult<ProductFeatureCategory> =
+        withContext(io) { call { api.createProductFeatureCategory(itemId, CreateProductFeatureCategoryReqDto(name, position)).toDomain() } }
+
+    override suspend fun addFeatureValue(
+        itemId: String,
+        featureCategoryId: String,
+        value: String,
+        priceDeltaCents: Long,
+        position: Int,
+    ): ApiResult<ProductFeatureValue> = withContext(io) {
+        call { api.addProductFeatureValue(itemId, featureCategoryId, AddProductFeatureValueReqDto(value, priceDeltaCents, position)).toDomain() }
+    }
+
+    override suspend fun deleteFeatureCategory(itemId: String, featureCategoryId: String): ApiResult<Unit> =
+        withContext(io) { call { api.deleteProductFeatureCategory(itemId, featureCategoryId) } }
+
+    override suspend fun categoryTree(categoryId: String, maxDepth: Int): ApiResult<CategoryTreeNode?> = withContext(io) {
+        readOrDefault(default = null) { api.getCategoryTree(categoryId, maxDepth).toDomain() }
+    }
+
+    override suspend fun addCategoryChild(categoryId: String, childCategoryId: String, position: Int): ApiResult<Unit> =
+        withContext(io) { call { api.addCategoryChild(categoryId, AddCategoryChildReqDto(childCategoryId, position)); Unit } }
+
+    override suspend fun moveCategory(categoryId: String, newParentId: String): ApiResult<Unit> =
+        withContext(io) { call { api.moveCategory(categoryId, MoveCategoryReqDto(newParentId)); Unit } }
+
+    // ── plumbing ──
+
+    /** Mutation wrapper: HTTP errors become Failure, transport errors NetworkError. */
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    /**
+     * Read wrapper with degrade-on-flag-off: a 404 or 501 (the two statuses the depth flag raises when
+     * disabled) resolves to [default] Success rather than Failure, so reads render an honest-empty state.
+     * Other HTTP errors and transport failures propagate normally.
+     */
+    private suspend fun <T> readOrDefault(default: T, block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == 404 || e.code() == 501) ApiResult.Success(default)
+        else ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/sellerstore/SellerStoreDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/sellerstore/SellerStoreDataModule.kt
@@ -23,6 +23,11 @@ object SellerStoreApiModule {
 
     @Provides
     @Singleton
+    fun provideProductDepthApi(retrofit: Retrofit): ProductDepthApi =
+        retrofit.create(ProductDepthApi::class.java)
+
+    @Provides
+    @Singleton
     fun provideSellerOrdersApi(retrofit: Retrofit): SellerOrdersApi =
         retrofit.create(SellerOrdersApi::class.java)
 
@@ -39,6 +44,10 @@ abstract class SellerStoreDataModule {
     @Binds
     @Singleton
     abstract fun bindSellerCatalogRepository(impl: SellerCatalogRepositoryImpl): SellerCatalogRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindProductDepthRepository(impl: ProductDepthRepositoryImpl): ProductDepthRepository
 
     @Binds
     @Singleton

--- a/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ListingEditorScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ListingEditorScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.AddPhotoAlternate
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -62,6 +63,7 @@ object ListingEditorTestTags {
     const val PICK_IMAGE = "listing_pick_image"
     const val SAVE = "listing_save"
     const val DELETE = "listing_delete"
+    const val ADVANCED_DEPTH = "listing_advanced_depth"
 
     /** LIVECOM L5 — the seller-set affiliate commission percent field. */
     const val AFFILIATE_COMMISSION = "listing_affiliate_commission_input"
@@ -71,6 +73,7 @@ object ListingEditorTestTags {
 fun ListingEditorRoute(
     onDone: () -> Unit,
     onBack: () -> Unit,
+    onOpenDepth: (itemId: String, itemName: String) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier,
     viewModel: ListingEditorViewModel = hiltViewModel(),
 ) {
@@ -102,6 +105,7 @@ fun ListingEditorRoute(
         onPickImage = { picker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
         onSave = viewModel::save,
         onDelete = viewModel::deleteListing,
+        onOpenDepth = { state.savedItemId?.let { onOpenDepth(it, state.name) } },
         onBack = onBack,
         modifier = modifier,
     )
@@ -119,6 +123,7 @@ fun ListingEditorScreen(
     onPickImage: () -> Unit,
     onSave: () -> Unit,
     onDelete: () -> Unit,
+    onOpenDepth: () -> Unit = {},
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -214,6 +219,15 @@ fun ListingEditorScreen(
                     CircularProgressIndicator(Modifier.height(20.dp), strokeWidth = 2.dp)
                 } else {
                     Text(stringResource(R.string.listing_save))
+                }
+            }
+            if (state.canOpenDepth) {
+                OutlinedButton(
+                    onClick = onOpenDepth,
+                    modifier = Modifier.fillMaxWidth().testTag(ListingEditorTestTags.ADVANCED_DEPTH),
+                ) {
+                    Icon(Icons.Outlined.Tune, contentDescription = null)
+                    Text("  Advanced product options")
                 }
             }
         }

--- a/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ListingEditorViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ListingEditorViewModel.kt
@@ -46,8 +46,13 @@ data class ListingEditorUiState(
      * endpoints. Only meaningful for an existing (saved) listing.
      */
     val affiliateCommissionText: String = "",
+    /** ECOM (catalog depth) — the saved item's id, once resolved; null while creating. Gates the depth editor entry. */
+    val savedItemId: String? = null,
 ) {
     val canSave: Boolean get() = name.isNotBlank() && priceText.isNotBlank() && !saving && !uploadingImage
+
+    /** ECOM (catalog depth) — the advanced product-depth editor is only reachable for a saved item. */
+    val canOpenDepth: Boolean get() = savedItemId != null
 }
 
 sealed interface ListingEditorEvent {
@@ -99,6 +104,7 @@ class ListingEditorViewModel @Inject constructor(
                             priceText = centsToText(item.priceCents),
                             stockText = item.stockCount?.toString().orEmpty(),
                             imageUrl = item.thumbnailUrl,
+                            savedItemId = item.itemId,
                         )
                     }
                     loadCommission(item.itemId)

--- a/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ProductDepthScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ProductDepthScreen.kt
@@ -1,0 +1,381 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.sellerstore
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.sellerstore.CatalogSellerMath
+
+/** ECOM (catalog depth) — stable test tags for the advanced product editor. */
+object ProductDepthTestTags {
+    const val SCREEN = "product_depth_screen"
+    const val PRODUCT_TYPE_ROW = "product_depth_type_row"
+    const val VARIANTS = "product_depth_variants"
+    const val PRICE_COMPONENTS = "product_depth_price_components"
+    const val BUNDLE = "product_depth_bundle"
+    const val FEATURES = "product_depth_features"
+    const val ADD_PRICE_COMPONENT = "product_depth_add_price_component"
+    const val ADD_BUNDLE_COMPONENT = "product_depth_add_bundle_component"
+    const val ADD_FEATURE_CATEGORY = "product_depth_add_feature_category"
+}
+
+@Composable
+fun ProductDepthRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ProductDepthViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { e -> when (e) { is ProductDepthEvent.Message -> snackbarHostState.showSnackbar(e.text) } }
+    }
+
+    ProductDepthScreen(
+        state = state,
+        priceTypes = viewModel.priceTypes,
+        productTypes = viewModel.productTypes,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onSetProductType = viewModel::setProductType,
+        onAddPriceComponent = viewModel::addPriceComponent,
+        onCreateVariant = viewModel::createVariant,
+        onDeleteVariant = viewModel::deleteVariant,
+        onAddBundleComponent = viewModel::addBundleComponent,
+        onRemoveBundleComponent = viewModel::removeBundleComponent,
+        onCreateFeatureCategory = viewModel::createFeatureCategory,
+        onAddFeatureValue = viewModel::addFeatureValue,
+        onDeleteFeatureCategory = viewModel::deleteFeatureCategory,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ProductDepthScreen(
+    state: ProductDepthUiState,
+    priceTypes: List<String>,
+    productTypes: List<String>,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onSetProductType: (String) -> Unit,
+    onAddPriceComponent: (priceType: String, amount: String, effectiveAt: Long, expiresAt: Long?) -> Unit,
+    onCreateVariant: (Map<String, String>, String?) -> Unit,
+    onDeleteVariant: (String) -> Unit,
+    onAddBundleComponent: (componentItemId: String, quantity: String) -> Unit,
+    onRemoveBundleComponent: (String) -> Unit,
+    onCreateFeatureCategory: (String) -> Unit,
+    onAddFeatureValue: (featureCategoryId: String, value: String, priceDelta: String) -> Unit,
+    onDeleteFeatureCategory: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(ProductDepthTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text(state.itemName.ifBlank { "Product depth" }) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        if (state.loading) {
+            Box(Modifier.fillMaxSize().padding(padding)) { LoadingState() }
+            return@Scaffold
+        }
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            ProductTypeSection(state, productTypes, onSetProductType)
+            FeaturesSection(state, onCreateFeatureCategory, onAddFeatureValue, onDeleteFeatureCategory)
+            VariantsSection(state, onCreateVariant, onDeleteVariant)
+            PriceComponentsSection(state, priceTypes, onAddPriceComponent)
+            if (state.isBundle) {
+                BundleSection(state, onAddBundleComponent, onRemoveBundleComponent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionCard(title: String, tag: String, content: @Composable ColumnScope.() -> Unit) {
+    Card(Modifier.fillMaxWidth().testTag(tag)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ProductTypeSection(
+    state: ProductDepthUiState,
+    productTypes: List<String>,
+    onSet: (String) -> Unit,
+) {
+    SectionCard("Product type", ProductDepthTestTags.PRODUCT_TYPE_ROW) {
+        Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            productTypes.forEach { pt ->
+                FilterChip(selected = state.productType == pt, onClick = { onSet(pt) }, label = { Text(pt) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeaturesSection(
+    state: ProductDepthUiState,
+    onCreateCategory: (String) -> Unit,
+    onAddValue: (String, String, String) -> Unit,
+    onDeleteCategory: (String) -> Unit,
+) {
+    var newCategory by rememberSaveable { mutableStateOf("") }
+    SectionCard("Features (options)", ProductDepthTestTags.FEATURES) {
+        val features = state.features
+        if (features == null || features.categories.isEmpty()) {
+            Text("No feature options yet.", style = MaterialTheme.typography.bodySmall)
+        } else {
+            features.categories.sortedBy { it.position }.forEach { fc ->
+                Row(Modifier.fillMaxWidth(), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                    Text(fc.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium, modifier = Modifier.weight(1f))
+                    IconButton(onClick = { onDeleteCategory(fc.featureCategoryId) }) {
+                        Icon(Icons.Outlined.Delete, contentDescription = "Delete feature")
+                    }
+                }
+                FeatureValuesRow(state, fc.featureCategoryId, onAddValue)
+                HorizontalDivider()
+            }
+        }
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+            OutlinedTextField(
+                value = newCategory,
+                onValueChange = { newCategory = it },
+                label = { Text("New option (e.g. Color)") },
+                singleLine = true,
+                modifier = Modifier.weight(1f),
+            )
+            OutlinedButton(
+                onClick = { if (newCategory.isNotBlank()) { onCreateCategory(newCategory); newCategory = "" } },
+                modifier = Modifier.testTag(ProductDepthTestTags.ADD_FEATURE_CATEGORY),
+            ) { Icon(Icons.Outlined.Add, contentDescription = "Add") }
+        }
+    }
+}
+
+@Composable
+private fun FeatureValuesRow(
+    state: ProductDepthUiState,
+    featureCategoryId: String,
+    onAddValue: (String, String, String) -> Unit,
+) {
+    var value by rememberSaveable(featureCategoryId) { mutableStateOf("") }
+    var delta by rememberSaveable(featureCategoryId) { mutableStateOf("") }
+    val values = state.features?.valuesFor(featureCategoryId).orEmpty()
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        values.forEach { v ->
+            val label = if (v.priceDeltaCents != 0L) "${v.value} (${CatalogSellerMath.formatDeltaCents(v.priceDeltaCents)})" else v.value
+            AssistChip(onClick = {}, label = { Text(label) })
+        }
+    }
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+        OutlinedTextField(value = value, onValueChange = { value = it }, label = { Text("Value") }, singleLine = true, modifier = Modifier.weight(1f))
+        OutlinedTextField(
+            value = delta,
+            onValueChange = { delta = it },
+            label = { Text("+/- \$") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.weight(1f),
+        )
+        OutlinedButton(onClick = { if (value.isNotBlank()) { onAddValue(featureCategoryId, value, delta); value = ""; delta = "" } }) {
+            Icon(Icons.Outlined.Add, contentDescription = "Add value")
+        }
+    }
+}
+
+@Composable
+private fun VariantsSection(
+    state: ProductDepthUiState,
+    onCreate: (Map<String, String>, String?) -> Unit,
+    onDelete: (String) -> Unit,
+) {
+    var sku by rememberSaveable { mutableStateOf("") }
+    SectionCard("Variants", ProductDepthTestTags.VARIANTS) {
+        if (state.variants.isEmpty()) {
+            Text("No variants yet.", style = MaterialTheme.typography.bodySmall)
+        } else {
+            state.variants.forEach { v ->
+                Row(Modifier.fillMaxWidth(), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        Text(v.sku, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+                        Text(
+                            "${CatalogSellerMath.formatCents(v.effectivePriceCents)} • ${CatalogSellerMath.formatDeltaCents(v.priceDeltaCents)}",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    IconButton(onClick = { onDelete(v.variantId) }) { Icon(Icons.Outlined.Delete, contentDescription = "Delete variant") }
+                }
+                HorizontalDivider()
+            }
+        }
+        // Variant creation needs a feature-value map, built from the item's features.
+        val features = state.features
+        val selection = remember { mutableStateMapOf<String, String>() }
+        features?.categories?.sortedBy { it.position }?.forEach { fc ->
+            Text(fc.name, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium)
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                features.valuesFor(fc.featureCategoryId).forEach { v ->
+                    FilterChip(
+                        selected = selection[fc.featureCategoryId] == v.featureValueId,
+                        onClick = { selection[fc.featureCategoryId] = v.featureValueId },
+                        label = { Text(v.value) },
+                    )
+                }
+            }
+        }
+        OutlinedTextField(value = sku, onValueChange = { sku = it }, label = { Text("SKU override (optional)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+        OutlinedButton(
+            onClick = { onCreate(selection.toMap(), sku.takeIf { it.isNotBlank() }); selection.clear(); sku = "" },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Icon(Icons.Outlined.Add, contentDescription = null); Text("  Add variant") }
+    }
+}
+
+@Composable
+private fun PriceComponentsSection(
+    state: ProductDepthUiState,
+    priceTypes: List<String>,
+    onAdd: (String, String, Long, Long?) -> Unit,
+) {
+    var selectedType by rememberSaveable { mutableStateOf("DEFAULT") }
+    var amount by rememberSaveable { mutableStateOf("") }
+    SectionCard("Price components", ProductDepthTestTags.PRICE_COMPONENTS) {
+        if (state.priceComponents.isEmpty()) {
+            Text("No price components yet.", style = MaterialTheme.typography.bodySmall)
+        } else {
+            state.priceComponents.forEach { pc ->
+                Text(
+                    "${pc.priceType}: ${CatalogSellerMath.formatCents(pc.amountCents, pc.currency)}${if (pc.isActive) " • active" else ""}",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+        Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            priceTypes.forEach { t -> FilterChip(selected = selectedType == t, onClick = { selectedType = t }, label = { Text(t) }) }
+        }
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+            OutlinedTextField(
+                value = amount,
+                onValueChange = { amount = it },
+                label = { Text("Amount \$") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.weight(1f),
+            )
+            OutlinedButton(
+                onClick = { onAdd(selectedType, amount, System.currentTimeMillis() / 1000L, null); amount = "" },
+                modifier = Modifier.testTag(ProductDepthTestTags.ADD_PRICE_COMPONENT),
+            ) { Icon(Icons.Outlined.Add, contentDescription = "Add price component") }
+        }
+    }
+}
+
+@Composable
+private fun BundleSection(
+    state: ProductDepthUiState,
+    onAdd: (String, String) -> Unit,
+    onRemove: (String) -> Unit,
+) {
+    var componentId by rememberSaveable { mutableStateOf("") }
+    var qty by rememberSaveable { mutableStateOf("1") }
+    SectionCard("Bundle components", ProductDepthTestTags.BUNDLE) {
+        if (state.bundleComponents.isEmpty()) {
+            Text("No components yet.", style = MaterialTheme.typography.bodySmall)
+        } else {
+            state.bundleComponents.forEach { bc ->
+                Row(Modifier.fillMaxWidth(), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        Text(bc.componentName ?: bc.componentItemId, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            "x${bc.quantity}${bc.componentPriceCents?.let { " • " + CatalogSellerMath.formatCents(it) } ?: ""}",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    IconButton(onClick = { onRemove(bc.componentItemId) }) { Icon(Icons.Outlined.Delete, contentDescription = "Remove component") }
+                }
+            }
+            Text("Bundle total: ${CatalogSellerMath.formatCents(state.bundleTotalCents)}", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+        }
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+            OutlinedTextField(value = componentId, onValueChange = { componentId = it }, label = { Text("Component item id") }, singleLine = true, modifier = Modifier.weight(2f))
+            OutlinedTextField(
+                value = qty,
+                onValueChange = { qty = it.filter { c -> c.isDigit() } },
+                label = { Text("Qty") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.weight(1f),
+            )
+            OutlinedButton(
+                onClick = { if (componentId.isNotBlank()) { onAdd(componentId, qty); componentId = ""; qty = "1" } },
+                modifier = Modifier.testTag(ProductDepthTestTags.ADD_BUNDLE_COMPONENT),
+            ) { Icon(Icons.Outlined.Add, contentDescription = "Add component") }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ProductDepthViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/sellerstore/ProductDepthViewModel.kt
@@ -1,0 +1,239 @@
+package com.testlogon.android.feature.sellerstore
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.sellerstore.BundleComponent
+import com.testlogon.android.data.sellerstore.CatalogSellerMath
+import com.testlogon.android.data.sellerstore.PriceComponent
+import com.testlogon.android.data.sellerstore.ProductDepthRepository
+import com.testlogon.android.data.sellerstore.ProductFeatures
+import com.testlogon.android.data.sellerstore.Variant
+import com.testlogon.android.navigation.ProductDepthDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+import java.math.RoundingMode
+import javax.inject.Inject
+
+/**
+ * ECOM (catalog depth) — drives the advanced seller product editor: product type, variants, price
+ * components, bundle components and per-item product features for one catalog item. Every list read is
+ * degrade-on-flag-off (the repository maps 404/501 to empty), so with the depth flag disabled the screen
+ * simply shows empty sections; mutations surface errors via a snackbar.
+ */
+data class ProductDepthUiState(
+    val itemId: String,
+    val itemName: String,
+    val loading: Boolean = true,
+    val productType: String = "standalone",
+    val variants: List<Variant> = emptyList(),
+    val priceComponents: List<PriceComponent> = emptyList(),
+    val bundleComponents: List<BundleComponent> = emptyList(),
+    val features: ProductFeatures? = null,
+    val busy: Boolean = false,
+) {
+    val isBundle: Boolean get() = CatalogSellerMath.isBundleType(productType)
+    val bundleTotalCents: Long
+        get() = CatalogSellerMath.bundleTotalCents(
+            bundleComponents.map {
+                com.testlogon.android.data.sellerstore.BundleLineMath(it.quantity, it.componentPriceCents)
+            },
+        )
+}
+
+sealed interface ProductDepthEvent {
+    data class Message(val text: String) : ProductDepthEvent
+}
+
+@HiltViewModel
+class ProductDepthViewModel @Inject constructor(
+    private val repo: ProductDepthRepository,
+    savedState: SavedStateHandle,
+) : ViewModel() {
+
+    private val itemId: String = checkNotNull(savedState[ProductDepthDest.ARG_ITEM_ID])
+    private val itemName: String = savedState.get<String>(ProductDepthDest.ARG_ITEM_NAME).orEmpty()
+
+    private val _uiState = MutableStateFlow(ProductDepthUiState(itemId = itemId, itemName = itemName))
+    val uiState: StateFlow<ProductDepthUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<ProductDepthEvent>(Channel.BUFFERED)
+    val events: Flow<ProductDepthEvent> = _events.receiveAsFlow()
+
+    val priceTypes: List<String> = CatalogSellerMath.PRICE_TYPES
+    val productTypes: List<String> = CatalogSellerMath.PRODUCT_TYPES
+
+    init { refresh() }
+
+    fun refresh() {
+        _uiState.update { it.copy(loading = true) }
+        viewModelScope.launch {
+            (repo.getProductType(itemId) as? ApiResult.Success)?.let { r -> _uiState.update { s -> s.copy(productType = r.data) } }
+            loadVariants()
+            loadPriceComponents()
+            loadBundle()
+            loadFeatures()
+            _uiState.update { it.copy(loading = false) }
+        }
+    }
+
+    private suspend fun loadVariants() {
+        (repo.listVariants(itemId) as? ApiResult.Success)?.let { r -> _uiState.update { it.copy(variants = r.data) } }
+    }
+
+    private suspend fun loadPriceComponents() {
+        (repo.listPriceComponents(itemId, priceType = null) as? ApiResult.Success)?.let { r ->
+            _uiState.update { it.copy(priceComponents = r.data) }
+        }
+    }
+
+    private suspend fun loadBundle() {
+        (repo.listBundleComponents(itemId) as? ApiResult.Success)?.let { r -> _uiState.update { it.copy(bundleComponents = r.data) } }
+    }
+
+    private suspend fun loadFeatures() {
+        (repo.listProductFeatures(itemId) as? ApiResult.Success)?.let { r -> _uiState.update { it.copy(features = r.data) } }
+    }
+
+    // ── product type ──
+    fun setProductType(type: String) = mutate {
+        when (val r = repo.setProductType(itemId, type)) {
+            is ApiResult.Success -> { _uiState.update { it.copy(productType = r.data) }; loadBundle() }
+            is ApiResult.Failure -> emit(r.error.message)
+            is ApiResult.NetworkError -> emit(OFFLINE)
+        }
+    }
+
+    // ── price components ──
+    /** amountText is a decimal-dollar string; effective/expires are epoch-second longs (expires nullable). */
+    fun addPriceComponent(priceType: String, amountText: String, effectiveAt: Long, expiresAt: Long?) {
+        val cents = parseCents(amountText)
+        if (cents == null) { emit(BAD_AMOUNT); return }
+        val reason = CatalogSellerMath.validatePriceComponent(priceType, cents, effectiveAt, expiresAt)
+        if (reason != null) { emit(reason); return }
+        mutate {
+            when (val r = repo.addPriceComponent(itemId, priceType, cents, "USD", effectiveAt, expiresAt)) {
+                is ApiResult.Success -> loadPriceComponents()
+                is ApiResult.Failure -> emit(r.error.message)
+                is ApiResult.NetworkError -> emit(OFFLINE)
+            }
+        }
+    }
+
+    // ── variants ──
+    fun createVariant(featureValues: Map<String, String>, skuOverride: String?) {
+        val reason = CatalogSellerMath.validateVariant(featureValues)
+        if (reason != null) { emit(reason); return }
+        mutate {
+            when (val r = repo.createVariant(itemId, featureValues, skuOverride)) {
+                is ApiResult.Success -> loadVariants()
+                is ApiResult.Failure -> emit(r.error.message)
+                is ApiResult.NetworkError -> emit(OFFLINE)
+            }
+        }
+    }
+
+    fun deleteVariant(variantId: String) = mutate {
+        when (val r = repo.deleteVariant(itemId, variantId)) {
+            is ApiResult.Success -> loadVariants()
+            is ApiResult.Failure -> emit(r.error.message)
+            is ApiResult.NetworkError -> emit(OFFLINE)
+        }
+    }
+
+    // ── bundle components ──
+    fun addBundleComponent(componentItemId: String, quantityText: String) {
+        val qty = quantityText.trim().toIntOrNull() ?: 1
+        val reason = CatalogSellerMath.validateBundleComponent(itemId, componentItemId.trim(), qty)
+        if (reason != null) { emit(reason); return }
+        mutate {
+            when (val r = repo.addBundleComponent(itemId, componentItemId.trim(), qty)) {
+                is ApiResult.Success -> loadBundle()
+                is ApiResult.Failure -> emit(r.error.message)
+                is ApiResult.NetworkError -> emit(OFFLINE)
+            }
+        }
+    }
+
+    fun removeBundleComponent(componentItemId: String) = mutate {
+        when (val r = repo.removeBundleComponent(itemId, componentItemId)) {
+            is ApiResult.Success -> loadBundle()
+            is ApiResult.Failure -> emit(r.error.message)
+            is ApiResult.NetworkError -> emit(OFFLINE)
+        }
+    }
+
+    // ── per-item features ──
+    fun createFeatureCategory(name: String) {
+        if (name.isBlank()) { emit(NAME_REQUIRED); return }
+        mutate {
+            when (val r = repo.createFeatureCategory(itemId, name.trim(), position = 0)) {
+                is ApiResult.Success -> loadFeatures()
+                is ApiResult.Failure -> emit(r.error.message)
+                is ApiResult.NetworkError -> emit(OFFLINE)
+            }
+        }
+    }
+
+    fun addFeatureValue(featureCategoryId: String, value: String, priceDeltaText: String) {
+        if (value.isBlank()) { emit(VALUE_REQUIRED); return }
+        val delta = parseSignedCents(priceDeltaText) ?: 0L
+        mutate {
+            when (val r = repo.addFeatureValue(itemId, featureCategoryId, value.trim(), delta, position = 0)) {
+                is ApiResult.Success -> loadFeatures()
+                is ApiResult.Failure -> emit(r.error.message)
+                is ApiResult.NetworkError -> emit(OFFLINE)
+            }
+        }
+    }
+
+    fun deleteFeatureCategory(featureCategoryId: String) = mutate {
+        when (val r = repo.deleteFeatureCategory(itemId, featureCategoryId)) {
+            is ApiResult.Success -> loadFeatures()
+            is ApiResult.Failure -> emit(r.error.message)
+            is ApiResult.NetworkError -> emit(OFFLINE)
+        }
+    }
+
+    // ── plumbing ──
+    private fun mutate(block: suspend () -> Unit) {
+        _uiState.update { it.copy(busy = true) }
+        viewModelScope.launch {
+            try { block() } finally { _uiState.update { it.copy(busy = false) } }
+        }
+    }
+
+    private fun emit(text: String) { viewModelScope.launch { _events.send(ProductDepthEvent.Message(text)) } }
+
+    /** Positive decimal-dollar string -> non-negative cents, or null if invalid. */
+    private fun parseCents(text: String): Long? = try {
+        BigDecimal(text.trim()).movePointRight(2).setScale(0, RoundingMode.HALF_UP).longValueExact().takeIf { it >= 0 }
+    } catch (_: Exception) {
+        null
+    }
+
+    /** Signed decimal-dollar string (delta may be negative) -> cents, or null if invalid. */
+    private fun parseSignedCents(text: String): Long? = try {
+        text.trim().takeIf { it.isNotBlank() }?.let {
+            BigDecimal(it).movePointRight(2).setScale(0, RoundingMode.HALF_UP).longValueExact()
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    companion object {
+        private const val OFFLINE = "You're offline"
+        private const val BAD_AMOUNT = "Enter a valid amount"
+        private const val NAME_REQUIRED = "Enter a name"
+        private const val VALUE_REQUIRED = "Enter a value"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -265,6 +265,7 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         wishlistDestination(navController)
         sellerStoreDestination(navController)
         listingEditorDestination(navController)
+        productDepthDestination(navController)
         sellerOrdersDestination(navController)
         sellerSalesDestination(navController)
         // D4 - buyer order shipment-tracking (reached from buyer shipment alerts).

--- a/android/app/src/main/java/com/testlogon/android/navigation/SellerStoreNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/SellerStoreNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.testlogon.android.feature.sellerstore.ListingEditorRoute
+import com.testlogon.android.feature.sellerstore.ProductDepthRoute
 import com.testlogon.android.feature.sellerstore.SellerOrdersRoute
 import com.testlogon.android.feature.sellerstore.SellerSalesRoute
 import com.testlogon.android.feature.sellerstore.SellerStoreRoute
@@ -48,6 +49,21 @@ data object ListingEditorDest {
         "seller/store/${Uri.encode(categoryId)}/listing/${Uri.encode(itemId ?: NEW)}"
 }
 
+
+/**
+ * ECOM (catalog depth) — the advanced product editor (variants / price components / bundle components /
+ * per-item features) for one SAVED catalog item. Reached only from the listing editor, so it is not a
+ * top-level More entry. The item name is passed for the title; everything else is loaded by item id.
+ */
+data object ProductDepthDest {
+    const val ARG_ITEM_ID = "itemId"
+    const val ARG_ITEM_NAME = "itemName"
+    const val ROUTE = "seller/store/depth/{$ARG_ITEM_ID}?name={$ARG_ITEM_NAME}"
+
+    fun build(itemId: String, itemName: String): String =
+        "seller/store/depth/${Uri.encode(itemId)}?name=${Uri.encode(itemName)}"
+}
+
 /** Registers "My store": item rows open the listing editor; the add-item FAB opens it in create mode. */
 fun NavGraphBuilder.sellerStoreDestination(navController: NavHostController) {
     composable(SellerStoreDest.ROUTE) {
@@ -75,6 +91,9 @@ fun NavGraphBuilder.listingEditorDestination(navController: NavHostController) {
         ListingEditorRoute(
             onDone = { navController.popBackStack() },
             onBack = { navController.popBackStack() },
+            onOpenDepth = { itemId, itemName ->
+                navController.navigate(ProductDepthDest.build(itemId, itemName)) { launchSingleTop = true }
+            },
         )
     }
 }
@@ -102,5 +121,23 @@ fun NavGraphBuilder.sellerSalesDestination(navController: NavHostController) {
             onBack = { navController.popBackStack() },
             initialSaleId = entry.arguments?.getString(SellerSalesDest.ARG_SALE),
         )
+    }
+}
+
+
+/** Registers the advanced product-depth editor (nav args via SavedStateHandle). */
+fun NavGraphBuilder.productDepthDestination(navController: NavHostController) {
+    composable(
+        route = ProductDepthDest.ROUTE,
+        arguments = listOf(
+            navArgument(ProductDepthDest.ARG_ITEM_ID) { type = NavType.StringType },
+            navArgument(ProductDepthDest.ARG_ITEM_NAME) {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            },
+        ),
+    ) {
+        ProductDepthRoute(onBack = { navController.popBackStack() })
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/data/sellerstore/CatalogSellerMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/sellerstore/CatalogSellerMathTest.kt
@@ -1,0 +1,164 @@
+package com.testlogon.android.data.sellerstore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * ECOM (catalog depth) — JVM unit tests for [CatalogSellerMath]. Pure logic, no Android/network deps.
+ */
+class CatalogSellerMathTest {
+
+    // ── variant effective price ──────────────────────────────────────────────
+
+    @Test
+    fun `variant price sums positive and negative deltas over base`() {
+        assertEquals(1500L, CatalogSellerMath.variantEffectivePriceCents(1000L, listOf(300L, 200L)))
+        assertEquals(800L, CatalogSellerMath.variantEffectivePriceCents(1000L, listOf(-200L)))
+    }
+
+    @Test
+    fun `variant price floors at zero, never negative`() {
+        assertEquals(0L, CatalogSellerMath.variantEffectivePriceCents(500L, listOf(-900L)))
+    }
+
+    @Test
+    fun `variant price with no deltas equals base`() {
+        assertEquals(2500L, CatalogSellerMath.variantEffectivePriceCents(2500L, emptyList()))
+    }
+
+    // ── bundle total ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `bundle total sums unit price times quantity across lines`() {
+        val lines = listOf(
+            BundleLineMath(quantity = 2, unitPriceCents = 500L),
+            BundleLineMath(quantity = 3, unitPriceCents = 100L),
+        )
+        assertEquals(1300L, CatalogSellerMath.bundleTotalCents(lines))
+    }
+
+    @Test
+    fun `bundle total treats null unit price as zero and ignores non-positive qty`() {
+        val lines = listOf(
+            BundleLineMath(quantity = 4, unitPriceCents = null),
+            BundleLineMath(quantity = 0, unitPriceCents = 999L),
+            BundleLineMath(quantity = -1, unitPriceCents = 999L),
+            BundleLineMath(quantity = 2, unitPriceCents = 250L),
+        )
+        assertEquals(500L, CatalogSellerMath.bundleTotalCents(lines))
+    }
+
+    // ── price component active window ────────────────────────────────────────
+
+    @Test
+    fun `price component active within window`() {
+        assertTrue(CatalogSellerMath.isPriceComponentActive(effectiveAt = 100L, expiresAt = 200L, asOf = 150L))
+    }
+
+    @Test
+    fun `price component with null expiry is active once effective`() {
+        assertTrue(CatalogSellerMath.isPriceComponentActive(effectiveAt = 100L, expiresAt = null, asOf = 100L))
+    }
+
+    @Test
+    fun `price component not yet effective is inactive`() {
+        assertFalse(CatalogSellerMath.isPriceComponentActive(effectiveAt = 200L, expiresAt = null, asOf = 150L))
+    }
+
+    @Test
+    fun `price component past expiry is inactive`() {
+        assertFalse(CatalogSellerMath.isPriceComponentActive(effectiveAt = 100L, expiresAt = 140L, asOf = 150L))
+    }
+
+    // ── resolve active amount (newest-effective-first) ───────────────────────
+
+    @Test
+    fun `resolve picks newest effective active component`() {
+        val comps = listOf(
+            PriceComponentMath(amountCents = 900L, effectiveAt = 100L, expiresAt = null),
+            PriceComponentMath(amountCents = 800L, effectiveAt = 200L, expiresAt = null),
+        )
+        assertEquals(800L, CatalogSellerMath.resolveActiveAmountCents(comps, asOf = 250L))
+    }
+
+    @Test
+    fun `resolve skips expired newest and falls to older active`() {
+        val comps = listOf(
+            PriceComponentMath(amountCents = 700L, effectiveAt = 100L, expiresAt = null),
+            PriceComponentMath(amountCents = 600L, effectiveAt = 200L, expiresAt = 220L),
+        )
+        assertEquals(700L, CatalogSellerMath.resolveActiveAmountCents(comps, asOf = 300L))
+    }
+
+    @Test
+    fun `resolve returns null when none active`() {
+        val comps = listOf(
+            PriceComponentMath(amountCents = 600L, effectiveAt = 500L, expiresAt = null),
+        )
+        assertNull(CatalogSellerMath.resolveActiveAmountCents(comps, asOf = 100L))
+    }
+
+    // ── validation ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `validatePriceComponent accepts a good component`() {
+        assertNull(CatalogSellerMath.validatePriceComponent("PROMO", 1000L, 100L, 200L))
+        assertNull(CatalogSellerMath.validatePriceComponent("DEFAULT", 0L, 0L, null))
+    }
+
+    @Test
+    fun `validatePriceComponent rejects bad type, negative amount, and inverted window`() {
+        assertEquals("Choose a price type", CatalogSellerMath.validatePriceComponent("BOGUS", 100L, 0L, null))
+        assertEquals("Amount can't be negative", CatalogSellerMath.validatePriceComponent("LIST", -1L, 0L, null))
+        assertEquals("Expiry must be after the effective time", CatalogSellerMath.validatePriceComponent("LIST", 100L, 200L, 150L))
+    }
+
+    @Test
+    fun `validateVariant requires non-blank feature mapping`() {
+        assertNull(CatalogSellerMath.validateVariant(mapOf("fc1" to "fv1")))
+        assertEquals("Pick at least one option", CatalogSellerMath.validateVariant(emptyMap()))
+        assertEquals("Every option needs a value", CatalogSellerMath.validateVariant(mapOf("fc1" to "")))
+    }
+
+    @Test
+    fun `validateBundleComponent guards self-reference and quantity`() {
+        assertNull(CatalogSellerMath.validateBundleComponent("p1", "c1", 1))
+        assertEquals("A bundle can't contain itself", CatalogSellerMath.validateBundleComponent("p1", "p1", 1))
+        assertEquals("Quantity must be at least 1", CatalogSellerMath.validateBundleComponent("p1", "c1", 0))
+        assertEquals("Pick a component product", CatalogSellerMath.validateBundleComponent("p1", "", 1))
+    }
+
+    // ── flags & formatting ───────────────────────────────────────────────────
+
+    @Test
+    fun `isBundleType true only for bundle and kit`() {
+        assertTrue(CatalogSellerMath.isBundleType("bundle"))
+        assertTrue(CatalogSellerMath.isBundleType("kit"))
+        assertFalse(CatalogSellerMath.isBundleType("standalone"))
+        assertFalse(CatalogSellerMath.isBundleType(null))
+    }
+
+    @Test
+    fun `isValidPriceType matches server enum case-sensitively`() {
+        assertTrue(CatalogSellerMath.isValidPriceType("AVERAGE_COST"))
+        assertFalse(CatalogSellerMath.isValidPriceType("average_cost"))
+        assertFalse(CatalogSellerMath.isValidPriceType(null))
+    }
+
+    @Test
+    fun `formatCents renders dollars and cents`() {
+        assertEquals("$12.34", CatalogSellerMath.formatCents(1234L))
+        assertEquals("$0.05", CatalogSellerMath.formatCents(5L))
+        assertEquals("-$1.00", CatalogSellerMath.formatCents(-100L))
+    }
+
+    @Test
+    fun `formatDeltaCents renders explicit sign`() {
+        assertEquals("+$3.00", CatalogSellerMath.formatDeltaCents(300L))
+        assertEquals("-$2.50", CatalogSellerMath.formatDeltaCents(-250L))
+        assertEquals("$0.00", CatalogSellerMath.formatDeltaCents(0L))
+    }
+}


### PR DESCRIPTION
## FE parity PAR-137 - Android catalog advanced (seller)

Brings the Android seller-store catalog to parity with the advanced (product-depth) seller surface.

### What was added
- Product depth data layer: `ProductDepthApi`, `ProductDepthDtos`, `ProductDepthDomain`, `ProductDepthRepository`.
- `ProductDepthScreen` + `ProductDepthViewModel` for the advanced catalog view.
- `CatalogSellerMath` pricing/depth helper with unit tests (`CatalogSellerMathTest`).

### Reuse notes
- Reuses the existing `SellerStoreDataModule` DI wiring, `ListingEditor` screen/view model, and the `SellerStoreNavigation` / `AuthenticatedGraph` navigation graph.

### Gate
- Feature is reachable only via the existing gated seller-store navigation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
