### PR TITLE
FE parity PAR-133 - Android marketing campaigns

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsApi.kt
@@ -1,0 +1,187 @@
+package com.testlogon.android.data.marketing.campaigns
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface + Moshi DTOs for the OFBiz Marketing CAMPAIGNS surface (MKT).
+ *
+ * Mirrors frontend/src/api/endpoints/marketing.ts (BASE /ui/marketing, router
+ * app/routers/marketing_campaigns.py). Reads (`require_ui_session`) are ungated so they answer even
+ * when the MARKETING_CAMPAIGNS_ENABLED flag is off (empty results). Mutations call `_require_enabled()`
+ * → 404 while the flag is off, so the repo degrades-on-404 (reads honest-empty, writes error).
+ *
+ * This is DISTINCT from [com.testlogon.android.data.marketing.MarketingApi], which targets the
+ * `/ui/agents/marketing` marketing *content agent* (blog/social content). Do not conflate.
+ *
+ * Timestamps are epoch-SECONDS (Long). Session cookies / Bearer / X-CSRF-Token are attached by
+ * interceptors; paths are relative (base URL carries the trailing slash).
+ */
+interface MarketingCampaignsApi {
+
+    // ---- Campaigns ----
+
+    @GET("ui/marketing/campaigns")
+    suspend fun listCampaigns(
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): CampaignListRespDto
+
+    @GET("ui/marketing/campaigns/{campaignId}")
+    suspend fun getCampaign(@Path("campaignId") campaignId: String): MarketingCampaignDto
+
+    @POST("ui/marketing/campaigns")
+    suspend fun createCampaign(@Body body: MarketingCampaignCreateInDto): MarketingCampaignDto
+
+    @PATCH("ui/marketing/campaigns/{campaignId}")
+    suspend fun updateCampaign(
+        @Path("campaignId") campaignId: String,
+        @Body body: MarketingCampaignUpdateInDto,
+    ): MarketingCampaignDto
+
+    @POST("ui/marketing/campaigns/{campaignId}/transition")
+    suspend fun transitionCampaign(
+        @Path("campaignId") campaignId: String,
+        @Body body: CampaignTransitionInDto,
+    ): MarketingCampaignDto
+
+    @POST("ui/marketing/campaigns/{campaignId}/send")
+    suspend fun sendCampaign(
+        @Path("campaignId") campaignId: String,
+        @Body body: Map<String, String> = emptyMap(),
+    ): CampaignSendRespDto
+
+    // ---- Contact lists ----
+
+    @GET("ui/marketing/lists")
+    suspend fun listContactLists(): List<ContactListDto>
+
+    @POST("ui/marketing/lists")
+    suspend fun createContactList(@Body body: ContactListCreateInDto): ContactListDto
+
+    @GET("ui/marketing/lists/{listId}/members")
+    suspend fun listContactListMembers(
+        @Path("listId") listId: String,
+        @Query("include_suppressed") includeSuppressed: Boolean = true,
+    ): List<ContactListMemberDto>
+
+    // ---- Segments ----
+
+    @GET("ui/marketing/segments")
+    suspend fun listSegments(): List<PartySegmentDto>
+
+    @GET("ui/marketing/segments/{segmentId}")
+    suspend fun getSegment(@Path("segmentId") segmentId: String): PartySegmentDto
+}
+
+// ---- Campaign DTOs ----
+
+@JsonClass(generateAdapter = true)
+data class MarketingCampaignDto(
+    @Json(name = "campaign_id") val campaignId: String = "",
+    @Json(name = "owner_id") val ownerId: String = "",
+    val name: String = "",
+    val objective: String = "",
+    val status: String = "",
+    @Json(name = "budget_cents") val budgetCents: Long = 0,
+    @Json(name = "ad_campaign_id") val adCampaignId: String? = null,
+    @Json(name = "promo_code_ids") val promoCodeIds: List<String>? = null,
+    @Json(name = "contact_list_ids") val contactListIds: List<String>? = null,
+    @Json(name = "segment_ids") val segmentIds: List<String>? = null,
+    @Json(name = "tracking_code") val trackingCode: String? = null,
+    @Json(name = "start_date") val startDate: Long? = null,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CampaignListRespDto(
+    val campaigns: List<MarketingCampaignDto> = emptyList(),
+    val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class MarketingCampaignCreateInDto(
+    val name: String,
+    val objective: String,
+    @Json(name = "budget_cents") val budgetCents: Long,
+    @Json(name = "contact_list_ids") val contactListIds: List<String>? = null,
+    @Json(name = "segment_ids") val segmentIds: List<String>? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class MarketingCampaignUpdateInDto(
+    val name: String? = null,
+    val objective: String? = null,
+    @Json(name = "budget_cents") val budgetCents: Long? = null,
+    val status: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CampaignTransitionInDto(
+    @Json(name = "target_status") val targetStatus: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class CampaignSendRespDto(
+    @Json(name = "campaign_id") val campaignId: String = "",
+    @Json(name = "sent_count") val sentCount: Int = 0,
+    @Json(name = "skipped_count") val skippedCount: Int = 0,
+    @Json(name = "snapshot_ts") val snapshotTs: Long = 0,
+)
+
+// ---- Contact-list DTOs ----
+
+@JsonClass(generateAdapter = true)
+data class ContactListDto(
+    @Json(name = "list_id") val listId: String = "",
+    @Json(name = "owner_id") val ownerId: String = "",
+    val name: String = "",
+    val description: String? = null,
+    @Json(name = "member_count") val memberCount: Int = 0,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class ContactListCreateInDto(
+    val name: String,
+    val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ContactListMemberDto(
+    @Json(name = "list_id") val listId: String = "",
+    @Json(name = "party_id") val partyId: String = "",
+    @Json(name = "joined_at") val joinedAt: Long? = null,
+    val suppressed: Boolean? = null,
+    @Json(name = "display_name") val displayName: String? = null,
+)
+
+// ---- Segment DTOs ----
+
+@JsonClass(generateAdapter = true)
+data class SegmentPredicateDto(
+    val attribute: String = "",
+    val operator: String = "",
+    val value: Any? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PartySegmentDto(
+    @Json(name = "segment_id") val segmentId: String = "",
+    @Json(name = "owner_id") val ownerId: String = "",
+    val name: String = "",
+    val description: String? = null,
+    val predicates: List<SegmentPredicateDto>? = null,
+    @Json(name = "candidate_source") val candidateSource: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsDataModule.kt
@@ -1,0 +1,32 @@
+package com.testlogon.android.data.marketing.campaigns
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Provides [MarketingCampaignsApi] on the shared (authenticated) Retrofit. */
+@Module
+@InstallIn(SingletonComponent::class)
+object MarketingCampaignsApiModule {
+
+    @Provides
+    @Singleton
+    fun provideMarketingCampaignsApi(retrofit: Retrofit): MarketingCampaignsApi =
+        retrofit.create(MarketingCampaignsApi::class.java)
+}
+
+/** Binds the Marketing-campaigns data-layer implementation. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MarketingCampaignsDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindMarketingCampaignsRepository(
+        impl: MarketingCampaignsRepositoryImpl,
+    ): MarketingCampaignsRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsDomain.kt
@@ -1,0 +1,130 @@
+package com.testlogon.android.data.marketing.campaigns
+
+/**
+ * Framework-free domain models + total DTO -> domain mappers for OFBiz Marketing CAMPAIGNS.
+ *
+ * Mirrors the web marketing pages (campaigns list/create, contact lists, segments). Timestamps are
+ * epoch-seconds. Status/objective are folded into [MarketingMath] enums so the UI can gate lifecycle
+ * actions exactly like the web pages.
+ */
+
+data class MarketingCampaign(
+    val id: String,
+    val name: String,
+    val objective: MarketingMath.CampaignObjective?,
+    val objectiveRaw: String,
+    val status: MarketingMath.CampaignStatus,
+    val budgetCents: Long,
+    val contactListIds: List<String>,
+    val segmentIds: List<String>,
+    val trackingCode: String?,
+    val startDateSeconds: Long?,
+    val endDateSeconds: Long?,
+    val createdAtSeconds: Long,
+    val updatedAtSeconds: Long,
+) {
+    val budgetLabel: String get() = MarketingMath.formatBudget(budgetCents)
+    val allowedTransitions: List<MarketingMath.CampaignStatus>
+        get() = MarketingMath.allowedTransitions(status)
+    val canSend: Boolean get() = MarketingMath.canSend(status)
+}
+
+data class MarketingCampaignPage(
+    val campaigns: List<MarketingCampaign>,
+    val cursor: String?,
+) {
+    val isEmpty: Boolean get() = campaigns.isEmpty()
+}
+
+data class ContactList(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val memberCount: Int,
+    val createdAtSeconds: Long,
+    val updatedAtSeconds: Long,
+) {
+    val sizeLabel: String get() = MarketingMath.formatSegmentSize(memberCount)
+}
+
+data class ContactListMember(
+    val partyId: String,
+    val displayName: String?,
+    val suppressed: Boolean,
+    val joinedAtSeconds: Long?,
+) {
+    val label: String get() = displayName?.takeIf { it.isNotBlank() } ?: partyId
+}
+
+data class SegmentPredicate(
+    val attribute: String,
+    val operator: String,
+    val value: String,
+) {
+    val summary: String get() = MarketingMath.formatPredicate(attribute, operator, value)
+}
+
+data class PartySegment(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val predicates: List<SegmentPredicate>,
+    val candidateSource: String?,
+    val createdAtSeconds: Long,
+    val updatedAtSeconds: Long,
+)
+
+// ---- Mappers (DTO -> domain) ----
+
+internal fun MarketingCampaignDto.toDomain(): MarketingCampaign = MarketingCampaign(
+    id = campaignId,
+    name = name,
+    objective = MarketingMath.CampaignObjective.from(objective),
+    objectiveRaw = objective,
+    status = MarketingMath.CampaignStatus.from(status),
+    budgetCents = budgetCents,
+    contactListIds = contactListIds.orEmpty(),
+    segmentIds = segmentIds.orEmpty(),
+    trackingCode = trackingCode?.takeIf { it.isNotBlank() },
+    startDateSeconds = startDate,
+    endDateSeconds = endDate,
+    createdAtSeconds = createdAt,
+    updatedAtSeconds = updatedAt,
+)
+
+internal fun CampaignListRespDto.toDomain(): MarketingCampaignPage = MarketingCampaignPage(
+    campaigns = campaigns.map { it.toDomain() },
+    cursor = cursor,
+)
+
+internal fun ContactListDto.toDomain(): ContactList = ContactList(
+    id = listId,
+    name = name,
+    description = description?.takeIf { it.isNotBlank() },
+    memberCount = memberCount,
+    createdAtSeconds = createdAt,
+    updatedAtSeconds = updatedAt,
+)
+
+internal fun ContactListMemberDto.toDomain(): ContactListMember = ContactListMember(
+    partyId = partyId,
+    displayName = displayName?.takeIf { it.isNotBlank() },
+    suppressed = suppressed == true,
+    joinedAtSeconds = joinedAt,
+)
+
+internal fun SegmentPredicateDto.toDomain(): SegmentPredicate = SegmentPredicate(
+    attribute = attribute,
+    operator = operator,
+    value = value?.toString().orEmpty(),
+)
+
+internal fun PartySegmentDto.toDomain(): PartySegment = PartySegment(
+    id = segmentId,
+    name = name,
+    description = description?.takeIf { it.isNotBlank() },
+    predicates = predicates.orEmpty().map { it.toDomain() },
+    candidateSource = candidateSource?.takeIf { it.isNotBlank() },
+    createdAtSeconds = createdAt,
+    updatedAtSeconds = updatedAt,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingCampaignsRepository.kt
@@ -1,0 +1,157 @@
+package com.testlogon.android.data.marketing.campaigns
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer over [MarketingCampaignsApi] for OFBiz Marketing CAMPAIGNS.
+ *
+ * Degrade-on-404: the backend read endpoints are ungated, but when the MARKETING_CAMPAIGNS_ENABLED
+ * flag is off the WHOLE router may 404. Reads therefore fold a 404 into an honest-EMPTY result so the
+ * UI shows an empty hub rather than an error; mutations surface the failure (Failure) so the user sees
+ * "not enabled". Every call is wrapped in [ApiResult].
+ */
+interface MarketingCampaignsRepository {
+    suspend fun loadCampaigns(): ApiResult<MarketingCampaignPage>
+    suspend fun createCampaign(
+        name: String,
+        objective: MarketingMath.CampaignObjective,
+        budgetCents: Long,
+    ): ApiResult<MarketingCampaign>
+    suspend fun transition(campaignId: String, target: MarketingMath.CampaignStatus): ApiResult<Unit>
+    suspend fun send(campaignId: String): ApiResult<CampaignSendResult>
+
+    suspend fun loadLists(): ApiResult<List<ContactList>>
+    suspend fun createList(name: String, description: String?): ApiResult<ContactList>
+    suspend fun loadListMembers(listId: String): ApiResult<List<ContactListMember>>
+
+    suspend fun loadSegments(): ApiResult<List<PartySegment>>
+    suspend fun getSegment(segmentId: String): ApiResult<PartySegment>
+}
+
+/** Send result surfaced to the UI. */
+data class CampaignSendResult(
+    val sentCount: Int,
+    val skippedCount: Int,
+)
+
+@Singleton
+class MarketingCampaignsRepositoryImpl @Inject constructor(
+    private val api: MarketingCampaignsApi,
+    private val errorParser: ApiErrorParser,
+) : MarketingCampaignsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun loadCampaigns(): ApiResult<MarketingCampaignPage> = withContext(io) {
+        readOrEmpty(MarketingCampaignPage(emptyList(), null)) {
+            api.listCampaigns(limit = PAGE_SIZE).toDomain()
+        }
+    }
+
+    override suspend fun createCampaign(
+        name: String,
+        objective: MarketingMath.CampaignObjective,
+        budgetCents: Long,
+    ): ApiResult<MarketingCampaign> = withContext(io) {
+        call {
+            api.createCampaign(
+                MarketingCampaignCreateInDto(
+                    name = name.trim(),
+                    objective = objective.wire,
+                    budgetCents = budgetCents,
+                ),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun transition(
+        campaignId: String,
+        target: MarketingMath.CampaignStatus,
+    ): ApiResult<Unit> = withContext(io) {
+        call {
+            api.transitionCampaign(campaignId, CampaignTransitionInDto(targetStatus = target.wire))
+            Unit
+        }
+    }
+
+    override suspend fun send(campaignId: String): ApiResult<CampaignSendResult> = withContext(io) {
+        call {
+            val r = api.sendCampaign(campaignId)
+            CampaignSendResult(sentCount = r.sentCount, skippedCount = r.skippedCount)
+        }
+    }
+
+    override suspend fun loadLists(): ApiResult<List<ContactList>> = withContext(io) {
+        readOrEmpty(emptyList()) { api.listContactLists().map { it.toDomain() } }
+    }
+
+    override suspend fun createList(name: String, description: String?): ApiResult<ContactList> =
+        withContext(io) {
+            call {
+                api.createContactList(
+                    ContactListCreateInDto(
+                        name = name.trim(),
+                        description = description?.trim()?.takeIf { it.isNotEmpty() },
+                    ),
+                ).toDomain()
+            }
+        }
+
+    override suspend fun loadListMembers(listId: String): ApiResult<List<ContactListMember>> =
+        withContext(io) {
+            readOrEmpty(emptyList()) {
+                api.listContactListMembers(listId).map { it.toDomain() }
+            }
+        }
+
+    override suspend fun loadSegments(): ApiResult<List<PartySegment>> = withContext(io) {
+        readOrEmpty(emptyList()) { api.listSegments().map { it.toDomain() } }
+    }
+
+    override suspend fun getSegment(segmentId: String): ApiResult<PartySegment> = withContext(io) {
+        call { api.getSegment(segmentId).toDomain() }
+    }
+
+    /**
+     * Runs an idempotent read, folding a 404 (module disabled / not found) into [empty] so the hub
+     * degrades to an honest-empty state instead of an error.
+     */
+    private suspend fun <T> readOrEmpty(empty: T, block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == HTTP_NOT_FOUND) ApiResult.Success(empty) else ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private companion object {
+        private const val PAGE_SIZE = 50
+        private const val HTTP_NOT_FOUND = 404
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/marketing/campaigns/MarketingMath.kt
@@ -1,0 +1,187 @@
+package com.testlogon.android.data.marketing.campaigns
+
+import java.util.Locale
+
+/**
+ * Framework-free pure logic for OFBiz Marketing CAMPAIGNS: the campaign lifecycle state machine
+ * (a 1:1 mirror of `_CAMPAIGN_TRANSITIONS` in app/services/marketing_campaigns.py), plus display
+ * formatters for money (budget cents) and segment/list sizes.
+ *
+ * Nothing here touches Android, Retrofit or coroutines, so it is fully unit-testable on the JVM.
+ */
+object MarketingMath {
+
+    /**
+     * Campaign lifecycle. Values match the server status strings exactly (lowercase). UNKNOWN folds any
+     * unrecognized server string so the UI never crashes on a new backend status.
+     */
+    enum class CampaignStatus(val wire: String) {
+        DRAFT("draft"),
+        SCHEDULED("scheduled"),
+        ACTIVE("active"),
+        PAUSED("paused"),
+        COMPLETED("completed"),
+        ARCHIVED("archived"),
+        UNKNOWN("");
+
+        companion object {
+            fun from(raw: String?): CampaignStatus = when (raw?.lowercase(Locale.US)) {
+                "draft" -> DRAFT
+                "scheduled" -> SCHEDULED
+                "active" -> ACTIVE
+                "paused" -> PAUSED
+                "completed" -> COMPLETED
+                "archived" -> ARCHIVED
+                else -> UNKNOWN
+            }
+        }
+    }
+
+    /** Campaign objective. Values match the server objective strings. */
+    enum class CampaignObjective(val wire: String, val label: String) {
+        AWARENESS("awareness", "Awareness"),
+        TRAFFIC("traffic", "Traffic"),
+        CONVERSIONS("conversions", "Conversions"),
+        RETENTION("retention", "Retention");
+
+        companion object {
+            val ALL: List<CampaignObjective> = entries
+
+            fun from(raw: String?): CampaignObjective? = when (raw?.lowercase(Locale.US)) {
+                "awareness" -> AWARENESS
+                "traffic" -> TRAFFIC
+                "conversions" -> CONVERSIONS
+                "retention" -> RETENTION
+                else -> null
+            }
+        }
+    }
+
+    /**
+     * The allowed status transitions, mirroring the backend state machine exactly:
+     *   draft     -> scheduled, active, archived
+     *   scheduled -> active, archived
+     *   active    -> paused, completed, archived
+     *   paused    -> active, archived
+     *   completed -> archived
+     *   archived  -> (terminal)
+     */
+    private val TRANSITIONS: Map<CampaignStatus, Set<CampaignStatus>> = mapOf(
+        CampaignStatus.DRAFT to setOf(CampaignStatus.SCHEDULED, CampaignStatus.ACTIVE, CampaignStatus.ARCHIVED),
+        CampaignStatus.SCHEDULED to setOf(CampaignStatus.ACTIVE, CampaignStatus.ARCHIVED),
+        CampaignStatus.ACTIVE to setOf(CampaignStatus.PAUSED, CampaignStatus.COMPLETED, CampaignStatus.ARCHIVED),
+        CampaignStatus.PAUSED to setOf(CampaignStatus.ACTIVE, CampaignStatus.ARCHIVED),
+        CampaignStatus.COMPLETED to setOf(CampaignStatus.ARCHIVED),
+        CampaignStatus.ARCHIVED to emptySet(),
+        CampaignStatus.UNKNOWN to emptySet(),
+    )
+
+    /** The valid target states reachable from [current], in a stable display order. */
+    fun allowedTransitions(current: CampaignStatus): List<CampaignStatus> {
+        val allowed = TRANSITIONS[current].orEmpty()
+        // Preserve enum declaration order for deterministic UI.
+        return CampaignStatus.entries.filter { it in allowed }
+    }
+
+    /** True when [current] -> [target] is a legal transition. */
+    fun canTransition(current: CampaignStatus, target: CampaignStatus): Boolean =
+        target in TRANSITIONS[current].orEmpty()
+
+    /** True when the campaign is in a terminal state (no further transitions). */
+    fun isTerminal(status: CampaignStatus): Boolean = TRANSITIONS[status].orEmpty().isEmpty()
+
+    /**
+     * "Send" (materialize + fan-out to recipients) is only meaningful for a live campaign, matching the
+     * web affordance which surfaces Send on active campaigns.
+     */
+    fun canSend(status: CampaignStatus): Boolean = status == CampaignStatus.ACTIVE
+
+    /**
+     * Format an integer cents budget as USD, e.g. 150000 -> "$1,500.00", 0 -> "$0.00".
+     * Negative values (should not occur) are formatted with a leading minus.
+     */
+    fun formatBudget(cents: Long): String {
+        val negative = cents < 0
+        val abs = if (negative) -cents else cents
+        val dollars = abs / 100
+        val remainder = (abs % 100).toInt()
+        val grouped = groupThousands(dollars)
+        val body = "$" + grouped + "." + remainder.toString().padStart(2, '0')
+        return if (negative) "-$body" else body
+    }
+
+    /**
+     * Parse a user-entered dollar string (e.g. "1500", "1,500.50", "$25") into integer cents, or null
+     * when the input is blank / not a valid non-negative amount. Used to validate the create form.
+     */
+    fun parseBudgetToCents(input: String): Long? {
+        val cleaned = input.trim().removePrefix("$").replace(",", "")
+        if (cleaned.isEmpty()) return null
+        val value = cleaned.toDoubleOrNull() ?: return null
+        if (value < 0.0 || value.isNaN() || value.isInfinite()) return null
+        return Math.round(value * 100.0)
+    }
+
+    /**
+     * Human-friendly size label for a segment or contact list, e.g.
+     *  0     -> "No members"
+     *  1     -> "1 member"
+     *  42    -> "42 members"
+     *  1500  -> "1.5K members"
+     *  2_000_000 -> "2M members"
+     */
+    fun formatSegmentSize(count: Int): String {
+        if (count <= 0) return "No members"
+        val noun = if (count == 1) "member" else "members"
+        return compact(count) + " " + noun
+    }
+
+    /** Compact-number formatting (1_500 -> "1.5K", 2_000_000 -> "2M"). */
+    fun compact(count: Int): String = when {
+        count < 1_000 -> count.toString()
+        count < 1_000_000 -> trimTenth(count / 1_000.0) + "K"
+        else -> trimTenth(count / 1_000_000.0) + "M"
+    }
+
+    /** One-line predicate summary, e.g. "total_spend_cents >= 1000". */
+    fun formatPredicate(attribute: String, operator: String, value: String): String {
+        val op = when (operator.lowercase(Locale.US)) {
+            "eq" -> "="
+            "neq" -> "≠"
+            "gt" -> ">"
+            "gte" -> "≥"
+            "lt" -> "<"
+            "lte" -> "≤"
+            "in" -> "in"
+            "not_in" -> "not in"
+            else -> operator
+        }
+        return "$attribute $op $value".trim()
+    }
+
+    // ---- internal helpers ----
+
+    private fun trimTenth(v: Double): String {
+        val rounded = Math.round(v * 10.0) / 10.0
+        return if (rounded % 1.0 == 0.0) rounded.toLong().toString()
+        else String.format(Locale.US, "%.1f", rounded)
+    }
+
+    private fun groupThousands(n: Long): String {
+        val s = n.toString()
+        if (s.length <= 3) return s
+        val sb = StringBuilder()
+        val first = s.length % 3
+        if (first > 0) {
+            sb.append(s, 0, first)
+            if (s.length > first) sb.append(',')
+        }
+        var i = first
+        while (i < s.length) {
+            sb.append(s, i, i + 3)
+            if (i + 3 < s.length) sb.append(',')
+            i += 3
+        }
+        return sb.toString()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/marketingcampaigns/MarketingCampaignsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/marketingcampaigns/MarketingCampaignsScreen.kt
@@ -1,0 +1,456 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.marketingcampaigns
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.marketing.campaigns.ContactList
+import com.testlogon.android.data.marketing.campaigns.MarketingCampaign
+import com.testlogon.android.data.marketing.campaigns.MarketingMath
+import com.testlogon.android.data.marketing.campaigns.PartySegment
+
+object MarketingCampaignsTestTags {
+    const val SCREEN = "mktc_screen"
+    const val LOADING = "mktc_loading"
+    const val EMPTY = "mktc_empty"
+    const val ERROR = "mktc_error"
+    const val OFFLINE = "mktc_offline"
+    const val FAB = "mktc_fab"
+    const val TAB_PREFIX = "mktc_tab_"
+    const val CAMPAIGN_PREFIX = "mktc_campaign_"
+    const val LIST_PREFIX = "mktc_list_"
+    const val SEGMENT_PREFIX = "mktc_segment_"
+    const val CREATE_FORM = "mktc_create_form"
+    const val CREATE_SUBMIT = "mktc_create_submit"
+}
+
+@Composable
+fun MarketingCampaignsRoute(
+    onBack: () -> Unit,
+    onSessionExpired: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MarketingCampaignsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is MarketingCampaignsEffect.ShowMessage ->
+                    snackbarHostState.showSnackbar(context.getString(effect.resId))
+                is MarketingCampaignsEffect.ShowText ->
+                    snackbarHostState.showSnackbar(effect.text)
+            }
+        }
+    }
+    LaunchedEffect(state.phase) {
+        if (state.phase == MarketingCampaignsUiState.Phase.SessionExpired) onSessionExpired()
+    }
+
+    MarketingCampaignsScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onSelectTab = viewModel::onSelectTab,
+        onOpenCreateCampaign = viewModel::onOpenCreateCampaign,
+        onDismissCreateCampaign = viewModel::onDismissCreateCampaign,
+        onCampaignNameChange = viewModel::onCampaignNameChange,
+        onCampaignObjectiveChange = viewModel::onCampaignObjectiveChange,
+        onCampaignBudgetChange = viewModel::onCampaignBudgetChange,
+        onSubmitCreateCampaign = viewModel::onSubmitCreateCampaign,
+        onTransition = viewModel::onTransition,
+        onSend = viewModel::onSend,
+        onOpenCreateList = viewModel::onOpenCreateList,
+        onDismissCreateList = viewModel::onDismissCreateList,
+        onListNameChange = viewModel::onListNameChange,
+        onListDescriptionChange = viewModel::onListDescriptionChange,
+        onSubmitCreateList = viewModel::onSubmitCreateList,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun MarketingCampaignsScreen(
+    state: MarketingCampaignsUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onSelectTab: (MarketingCampaignsTab) -> Unit,
+    onOpenCreateCampaign: () -> Unit,
+    onDismissCreateCampaign: () -> Unit,
+    onCampaignNameChange: (String) -> Unit,
+    onCampaignObjectiveChange: (MarketingMath.CampaignObjective) -> Unit,
+    onCampaignBudgetChange: (String) -> Unit,
+    onSubmitCreateCampaign: () -> Unit,
+    onTransition: (MarketingCampaign, MarketingMath.CampaignStatus) -> Unit,
+    onSend: (MarketingCampaign) -> Unit,
+    onOpenCreateList: () -> Unit,
+    onDismissCreateList: () -> Unit,
+    onListNameChange: (String) -> Unit,
+    onListDescriptionChange: (String) -> Unit,
+    onSubmitCreateList: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(MarketingCampaignsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Marketing campaigns") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            val canCreate = state.tab == MarketingCampaignsTab.CAMPAIGNS ||
+                state.tab == MarketingCampaignsTab.LISTS
+            if (state.phase == MarketingCampaignsUiState.Phase.Content && canCreate) {
+                Button(
+                    onClick = {
+                        if (state.tab == MarketingCampaignsTab.CAMPAIGNS) onOpenCreateCampaign() else onOpenCreateList()
+                    },
+                    modifier = Modifier.testTag(MarketingCampaignsTestTags.FAB),
+                ) {
+                    Icon(Icons.Outlined.Add, contentDescription = null)
+                    Text(if (state.tab == MarketingCampaignsTab.CAMPAIGNS) "New campaign" else "New list")
+                }
+            }
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TabRow(selectedTabIndex = state.tab.ordinal) {
+                MarketingCampaignsTab.entries.forEach { tab ->
+                    Tab(
+                        selected = state.tab == tab,
+                        onClick = { onSelectTab(tab) },
+                        text = { Text(tab.label) },
+                        modifier = Modifier.testTag(MarketingCampaignsTestTags.TAB_PREFIX + tab.name),
+                    )
+                }
+            }
+
+            when (state.phase) {
+                MarketingCampaignsUiState.Phase.Loading ->
+                    LoadingState(modifier = Modifier.testTag(MarketingCampaignsTestTags.LOADING))
+                MarketingCampaignsUiState.Phase.Error ->
+                    ErrorState(
+                        message = state.errorMessage ?: "Something went wrong.",
+                        onRetry = onRetry,
+                        modifier = Modifier.testTag(MarketingCampaignsTestTags.ERROR),
+                    )
+                MarketingCampaignsUiState.Phase.Offline ->
+                    Column {
+                        OfflineBanner(
+                            onRetry = onRetry,
+                            modifier = Modifier.testTag(MarketingCampaignsTestTags.OFFLINE),
+                        )
+                    }
+                MarketingCampaignsUiState.Phase.SessionExpired -> Unit
+                MarketingCampaignsUiState.Phase.Content ->
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = onRefresh,
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        TabContent(
+                            state = state,
+                            onTransition = onTransition,
+                            onSend = onSend,
+                        )
+                    }
+            }
+        }
+    }
+
+    if (state.createCampaign.isOpen) {
+        CreateCampaignDialog(
+            form = state.createCampaign,
+            onDismiss = onDismissCreateCampaign,
+            onNameChange = onCampaignNameChange,
+            onObjectiveChange = onCampaignObjectiveChange,
+            onBudgetChange = onCampaignBudgetChange,
+            onSubmit = onSubmitCreateCampaign,
+        )
+    }
+    if (state.createList.isOpen) {
+        CreateListDialog(
+            form = state.createList,
+            onDismiss = onDismissCreateList,
+            onNameChange = onListNameChange,
+            onDescriptionChange = onListDescriptionChange,
+            onSubmit = onSubmitCreateList,
+        )
+    }
+}
+
+@Composable
+private fun TabContent(
+    state: MarketingCampaignsUiState,
+    onTransition: (MarketingCampaign, MarketingMath.CampaignStatus) -> Unit,
+    onSend: (MarketingCampaign) -> Unit,
+) {
+    if (state.isEmptyForTab) {
+        val title = when (state.tab) {
+            MarketingCampaignsTab.CAMPAIGNS -> "No campaigns yet"
+            MarketingCampaignsTab.LISTS -> "No contact lists yet"
+            MarketingCampaignsTab.SEGMENTS -> "No segments yet"
+        }
+        val body = when (state.tab) {
+            MarketingCampaignsTab.CAMPAIGNS -> "Create a campaign to reach your audience."
+            MarketingCampaignsTab.LISTS -> "Create a list to group contacts."
+            MarketingCampaignsTab.SEGMENTS -> "Segments are defined on the web console."
+        }
+        EmptyState(
+            title = title,
+            body = body,
+            modifier = Modifier.testTag(MarketingCampaignsTestTags.EMPTY),
+        )
+        return
+    }
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        when (state.tab) {
+            MarketingCampaignsTab.CAMPAIGNS -> items(state.campaigns, key = { it.id }) { c ->
+                CampaignCard(
+                    campaign = c,
+                    busy = state.busyCampaignId == c.id,
+                    onTransition = onTransition,
+                    onSend = onSend,
+                )
+            }
+            MarketingCampaignsTab.LISTS -> items(state.lists, key = { it.id }) { l -> ListCard(l) }
+            MarketingCampaignsTab.SEGMENTS -> items(state.segments, key = { it.id }) { s -> SegmentCard(s) }
+        }
+    }
+}
+
+@Composable
+private fun CampaignCard(
+    campaign: MarketingCampaign,
+    busy: Boolean,
+    onTransition: (MarketingCampaign, MarketingMath.CampaignStatus) -> Unit,
+    onSend: (MarketingCampaign) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(MarketingCampaignsTestTags.CAMPAIGN_PREFIX + campaign.id)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(campaign.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                "${campaign.objective?.label ?: campaign.objectiveRaw} · ${campaign.budgetLabel}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            AssistChip(onClick = {}, label = { Text(campaign.status.name.lowercase()) })
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (campaign.canSend) {
+                    OutlinedButton(onClick = { onSend(campaign) }, enabled = !busy) { Text("Send") }
+                }
+                campaign.allowedTransitions.forEach { target ->
+                    OutlinedButton(onClick = { onTransition(campaign, target) }, enabled = !busy) {
+                        Text(transitionVerb(target))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun transitionVerb(target: MarketingMath.CampaignStatus): String = when (target) {
+    MarketingMath.CampaignStatus.SCHEDULED -> "Schedule"
+    MarketingMath.CampaignStatus.ACTIVE -> "Activate"
+    MarketingMath.CampaignStatus.PAUSED -> "Pause"
+    MarketingMath.CampaignStatus.COMPLETED -> "Complete"
+    MarketingMath.CampaignStatus.ARCHIVED -> "Archive"
+    else -> target.name.lowercase()
+}
+
+@Composable
+private fun ListCard(list: ContactList) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(MarketingCampaignsTestTags.LIST_PREFIX + list.id)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(list.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            list.description?.let { Text(it, style = MaterialTheme.typography.bodyMedium) }
+            Text(list.sizeLabel, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun SegmentCard(segment: PartySegment) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(MarketingCampaignsTestTags.SEGMENT_PREFIX + segment.id)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(segment.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            segment.description?.let { Text(it, style = MaterialTheme.typography.bodyMedium) }
+            segment.predicates.forEach { p ->
+                Text("• ${p.summary}", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateCampaignDialog(
+    form: CreateCampaignFormState,
+    onDismiss: () -> Unit,
+    onNameChange: (String) -> Unit,
+    onObjectiveChange: (MarketingMath.CampaignObjective) -> Unit,
+    onBudgetChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(modifier = Modifier.testTag(MarketingCampaignsTestTags.CREATE_FORM)) {
+            Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("New campaign", style = MaterialTheme.typography.titleLarge)
+                OutlinedTextField(
+                    value = form.name,
+                    onValueChange = onNameChange,
+                    label = { Text("Name") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                ObjectiveDropdown(
+                    selected = form.objective,
+                    enabled = !form.isSubmitting,
+                    onSelect = onObjectiveChange,
+                )
+                OutlinedTextField(
+                    value = form.budget,
+                    onValueChange = onBudgetChange,
+                    label = { Text("Budget (USD)") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.align(Alignment.End)) {
+                    TextButton(onClick = onDismiss, enabled = !form.isSubmitting) { Text("Cancel") }
+                    Button(
+                        onClick = onSubmit,
+                        enabled = form.canSubmit,
+                        modifier = Modifier.testTag(MarketingCampaignsTestTags.CREATE_SUBMIT),
+                    ) { Text("Create") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ObjectiveDropdown(
+    selected: MarketingMath.CampaignObjective,
+    enabled: Boolean,
+    onSelect: (MarketingMath.CampaignObjective) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        OutlinedButton(onClick = { if (enabled) expanded = true }, enabled = enabled, modifier = Modifier.fillMaxWidth()) {
+            Text("Objective: ${selected.label}")
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            MarketingMath.CampaignObjective.ALL.forEach { o ->
+                DropdownMenuItem(text = { Text(o.label) }, onClick = { onSelect(o); expanded = false })
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateListDialog(
+    form: CreateListFormState,
+    onDismiss: () -> Unit,
+    onNameChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(modifier = Modifier.testTag(MarketingCampaignsTestTags.CREATE_FORM)) {
+            Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("New contact list", style = MaterialTheme.typography.titleLarge)
+                OutlinedTextField(
+                    value = form.name,
+                    onValueChange = onNameChange,
+                    label = { Text("Name") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.description,
+                    onValueChange = onDescriptionChange,
+                    label = { Text("Description (optional)") },
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.align(Alignment.End)) {
+                    TextButton(onClick = onDismiss, enabled = !form.isSubmitting) { Text("Cancel") }
+                    Button(
+                        onClick = onSubmit,
+                        enabled = form.canSubmit,
+                        modifier = Modifier.testTag(MarketingCampaignsTestTags.CREATE_SUBMIT),
+                    ) { Text("Create") }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/marketingcampaigns/MarketingCampaignsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/marketingcampaigns/MarketingCampaignsUiState.kt
@@ -1,0 +1,66 @@
+package com.testlogon.android.feature.marketingcampaigns
+
+import androidx.annotation.StringRes
+import com.testlogon.android.data.marketing.campaigns.ContactList
+import com.testlogon.android.data.marketing.campaigns.MarketingCampaign
+import com.testlogon.android.data.marketing.campaigns.MarketingMath
+import com.testlogon.android.data.marketing.campaigns.PartySegment
+
+/** Top-level tabs of the Marketing-campaigns hub (web MKT: campaigns / lists / segments). */
+enum class MarketingCampaignsTab(val label: String) {
+    CAMPAIGNS("Campaigns"),
+    LISTS("Lists"),
+    SEGMENTS("Segments"),
+}
+
+/** Render-ready state for the Marketing-campaigns hub. */
+data class MarketingCampaignsUiState(
+    val phase: Phase = Phase.Loading,
+    val tab: MarketingCampaignsTab = MarketingCampaignsTab.CAMPAIGNS,
+    val campaigns: List<MarketingCampaign> = emptyList(),
+    val lists: List<ContactList> = emptyList(),
+    val segments: List<PartySegment> = emptyList(),
+    val isRefreshing: Boolean = false,
+    val errorMessage: String? = null,
+    val busyCampaignId: String? = null,
+    val createCampaign: CreateCampaignFormState = CreateCampaignFormState(),
+    val createList: CreateListFormState = CreateListFormState(),
+) {
+    enum class Phase { Loading, Content, SessionExpired, Error, Offline }
+
+    val isEmptyForTab: Boolean
+        get() = when (tab) {
+            MarketingCampaignsTab.CAMPAIGNS -> campaigns.isEmpty()
+            MarketingCampaignsTab.LISTS -> lists.isEmpty()
+            MarketingCampaignsTab.SEGMENTS -> segments.isEmpty()
+        }
+}
+
+/** Create-campaign form. Mirrors the web validation: name + objective + non-negative budget. */
+data class CreateCampaignFormState(
+    val isOpen: Boolean = false,
+    val name: String = "",
+    val objective: MarketingMath.CampaignObjective = MarketingMath.CampaignObjective.AWARENESS,
+    val budget: String = "",
+    val isSubmitting: Boolean = false,
+) {
+    val budgetCents: Long? get() = MarketingMath.parseBudgetToCents(budget.ifBlank { "0" })
+    val canSubmit: Boolean
+        get() = !isSubmitting && name.trim().isNotEmpty() && budgetCents != null
+}
+
+/** Create contact-list form. Name required; description optional. */
+data class CreateListFormState(
+    val isOpen: Boolean = false,
+    val name: String = "",
+    val description: String = "",
+    val isSubmitting: Boolean = false,
+) {
+    val canSubmit: Boolean get() = !isSubmitting && name.trim().isNotEmpty()
+}
+
+/** One-shot side effects. */
+sealed interface MarketingCampaignsEffect {
+    data class ShowMessage(@StringRes val resId: Int) : MarketingCampaignsEffect
+    data class ShowText(val text: String) : MarketingCampaignsEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/marketingcampaigns/MarketingCampaignsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/marketingcampaigns/MarketingCampaignsViewModel.kt
@@ -1,0 +1,232 @@
+package com.testlogon.android.feature.marketingcampaigns
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.R
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.marketing.campaigns.MarketingCampaign
+import com.testlogon.android.data.marketing.campaigns.MarketingCampaignsRepository
+import com.testlogon.android.data.marketing.campaigns.MarketingMath
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives [MarketingCampaignsUiState] from [MarketingCampaignsRepository]. Loads all three collections
+ * (campaigns / lists / segments) on first composition + pull-to-refresh. Campaigns support create +
+ * lifecycle transition + send; contact-lists support create; segments are read-only on mobile
+ * (create/edit deferred to web). Degrade-on-404: reads honest-empty, mutations surface errors.
+ */
+@HiltViewModel
+class MarketingCampaignsViewModel @Inject constructor(
+    private val repository: MarketingCampaignsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MarketingCampaignsUiState())
+    val uiState: StateFlow<MarketingCampaignsUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<MarketingCampaignsEffect>(Channel.BUFFERED)
+    val effects: Flow<MarketingCampaignsEffect> = _effects.receiveAsFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onResumed() = load(fromUser = false, force = true)
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    fun onSelectTab(tab: MarketingCampaignsTab) {
+        if (_uiState.value.tab == tab) return
+        _uiState.update { it.copy(tab = tab) }
+    }
+
+    // ---- create campaign ----
+    fun onOpenCreateCampaign() = _uiState.update { it.copy(createCampaign = CreateCampaignFormState(isOpen = true)) }
+    fun onDismissCreateCampaign() {
+        if (_uiState.value.createCampaign.isSubmitting) return
+        _uiState.update { it.copy(createCampaign = CreateCampaignFormState(isOpen = false)) }
+    }
+    fun onCampaignNameChange(v: String) =
+        _uiState.update { it.copy(createCampaign = it.createCampaign.copy(name = v)) }
+    fun onCampaignObjectiveChange(v: MarketingMath.CampaignObjective) =
+        _uiState.update { it.copy(createCampaign = it.createCampaign.copy(objective = v)) }
+    fun onCampaignBudgetChange(v: String) =
+        _uiState.update { it.copy(createCampaign = it.createCampaign.copy(budget = v)) }
+
+    fun onSubmitCreateCampaign() {
+        val form = _uiState.value.createCampaign
+        val cents = form.budgetCents
+        if (!form.canSubmit || cents == null) return
+        _uiState.update { it.copy(createCampaign = it.createCampaign.copy(isSubmitting = true)) }
+        viewModelScope.launch {
+            when (val r = repository.createCampaign(form.name, form.objective, cents)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createCampaign = CreateCampaignFormState(isOpen = false)) }
+                    _effects.send(MarketingCampaignsEffect.ShowMessage(R.string.mktc_campaign_created))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> failCreateCampaign(r.error.status, r.error.message)
+                is ApiResult.NetworkError -> failCreateCampaign(null, null)
+            }
+        }
+    }
+
+    private suspend fun failCreateCampaign(status: Int?, message: String?) {
+        _uiState.update { it.copy(createCampaign = it.createCampaign.copy(isSubmitting = false)) }
+        if (status == HTTP_UNAUTHORIZED) {
+            _uiState.update { it.copy(phase = MarketingCampaignsUiState.Phase.SessionExpired) }
+        } else if (message != null) {
+            _effects.send(MarketingCampaignsEffect.ShowText(message))
+        } else {
+            _effects.send(MarketingCampaignsEffect.ShowMessage(R.string.mktc_action_failed))
+        }
+    }
+
+    // ---- campaign lifecycle ----
+    fun onTransition(c: MarketingCampaign, target: MarketingMath.CampaignStatus) {
+        if (_uiState.value.busyCampaignId != null) return
+        if (!MarketingMath.canTransition(c.status, target)) return
+        _uiState.update { it.copy(busyCampaignId = c.id) }
+        viewModelScope.launch {
+            val r = repository.transition(c.id, target)
+            _uiState.update { it.copy(busyCampaignId = null) }
+            when (r) {
+                is ApiResult.Success -> {
+                    _effects.send(MarketingCampaignsEffect.ShowMessage(R.string.mktc_action_done))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> handleMutationFailure(r.error.status, r.error.message)
+                is ApiResult.NetworkError -> _effects.send(MarketingCampaignsEffect.ShowMessage(R.string.mktc_action_failed))
+            }
+        }
+    }
+
+    fun onSend(c: MarketingCampaign) {
+        if (_uiState.value.busyCampaignId != null || !c.canSend) return
+        _uiState.update { it.copy(busyCampaignId = c.id) }
+        viewModelScope.launch {
+            val r = repository.send(c.id)
+            _uiState.update { it.copy(busyCampaignId = null) }
+            when (r) {
+                is ApiResult.Success ->
+                    _effects.send(MarketingCampaignsEffect.ShowText("Sent ${r.data.sentCount} · skipped ${r.data.skippedCount}"))
+                is ApiResult.Failure -> handleMutationFailure(r.error.status, r.error.message)
+                is ApiResult.NetworkError -> _effects.send(MarketingCampaignsEffect.ShowMessage(R.string.mktc_action_failed))
+            }
+        }
+    }
+
+    private suspend fun handleMutationFailure(status: Int, message: String) {
+        if (status == HTTP_UNAUTHORIZED) {
+            _uiState.update { it.copy(phase = MarketingCampaignsUiState.Phase.SessionExpired) }
+        } else {
+            _effects.send(MarketingCampaignsEffect.ShowText(message))
+        }
+    }
+
+    // ---- create contact list ----
+    fun onOpenCreateList() = _uiState.update { it.copy(createList = CreateListFormState(isOpen = true)) }
+    fun onDismissCreateList() {
+        if (_uiState.value.createList.isSubmitting) return
+        _uiState.update { it.copy(createList = CreateListFormState(isOpen = false)) }
+    }
+    fun onListNameChange(v: String) =
+        _uiState.update { it.copy(createList = it.createList.copy(name = v)) }
+    fun onListDescriptionChange(v: String) =
+        _uiState.update { it.copy(createList = it.createList.copy(description = v)) }
+
+    fun onSubmitCreateList() {
+        val form = _uiState.value.createList
+        if (!form.canSubmit) return
+        _uiState.update { it.copy(createList = it.createList.copy(isSubmitting = true)) }
+        viewModelScope.launch {
+            when (val r = repository.createList(form.name, form.description)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createList = CreateListFormState(isOpen = false)) }
+                    _effects.send(MarketingCampaignsEffect.ShowMessage(R.string.mktc_list_created))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> {
+                    _uiState.update { it.copy(createList = it.createList.copy(isSubmitting = false)) }
+                    if (r.error.status == HTTP_UNAUTHORIZED) {
+                        _uiState.update { it.copy(phase = MarketingCampaignsUiState.Phase.SessionExpired) }
+                    } else {
+                        _effects.send(MarketingCampaignsEffect.ShowText(r.error.message))
+                    }
+                }
+                is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(createList = it.createList.copy(isSubmitting = false)) }
+                    _effects.send(MarketingCampaignsEffect.ShowMessage(R.string.mktc_action_failed))
+                }
+            }
+        }
+    }
+
+    // ---- load ----
+    private fun load(fromUser: Boolean, force: Boolean = false) {
+        val hasContent = _uiState.value.phase == MarketingCampaignsUiState.Phase.Content
+        if (_uiState.value.isRefreshing && !force) return
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent && !force) it.phase else MarketingCampaignsUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            val campaignsR = repository.loadCampaigns()
+            val listsR = repository.loadLists()
+            val segmentsR = repository.loadSegments()
+
+            // Session-expiry short-circuits regardless of tab.
+            val unauthorized = listOf(campaignsR, listsR, segmentsR).any {
+                it is ApiResult.Failure && it.error.status == HTTP_UNAUTHORIZED
+            }
+            if (unauthorized) {
+                _uiState.update { it.copy(phase = MarketingCampaignsUiState.Phase.SessionExpired, isRefreshing = false) }
+                return@launch
+            }
+
+            val anyNetworkError = listOf(campaignsR, listsR, segmentsR).any { it is ApiResult.NetworkError }
+            val firstFailure = listOf(campaignsR, listsR, segmentsR).firstNotNullOfOrNull {
+                (it as? ApiResult.Failure)?.error
+            }
+
+            val campaigns = (campaignsR as? ApiResult.Success)?.data?.campaigns.orEmpty()
+            val lists = (listsR as? ApiResult.Success)?.data.orEmpty()
+            val segments = (segmentsR as? ApiResult.Success)?.data.orEmpty()
+
+            // If everything failed with no partial data, surface an error/offline screen.
+            val allFailed = campaignsR !is ApiResult.Success &&
+                listsR !is ApiResult.Success &&
+                segmentsR !is ApiResult.Success
+            val phase = when {
+                allFailed && anyNetworkError -> MarketingCampaignsUiState.Phase.Offline
+                allFailed -> MarketingCampaignsUiState.Phase.Error
+                else -> MarketingCampaignsUiState.Phase.Content
+            }
+
+            _uiState.update {
+                it.copy(
+                    phase = phase,
+                    campaigns = campaigns,
+                    lists = lists,
+                    segments = segments,
+                    isRefreshing = false,
+                    errorMessage = firstFailure?.message,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        private const val HTTP_UNAUTHORIZED = 401
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -909,6 +909,14 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.APP,
         ),
         MoreEntry(
+            id = "marketing_campaigns",
+            labelRes = R.string.more_entry_marketing_campaigns,
+            icon = Icons.Outlined.Campaign,
+            route = MoreRoutes.MARKETING_CAMPAIGNS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
             id = "costs",
             labelRes = R.string.more_entry_costs,
             icon = Icons.Outlined.AccountBalance,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -419,6 +419,7 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         stylistDestinations(navController)
         // B4 web-parity: Marketing content agent (dashboard + editor + calendar + engagement).
         marketingDestinations(navController)
+        marketingCampaignsDestinations(navController)
         // B4 web-parity: Accountant/cost agent (overview + breakdown + budgets + alerts).
         costsDestinations(navController)
         // B4 web-parity: Compliance/Security agent (findings + audits + compliance + trends).

--- a/android/app/src/main/java/com/testlogon/android/navigation/MarketingCampaignsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MarketingCampaignsNavigation.kt
@@ -1,0 +1,26 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.marketingcampaigns.MarketingCampaignsRoute
+
+/**
+ * OFBiz Marketing CAMPAIGNS hub (web MKT: /ui/marketing campaigns + lists + segments, router
+ * app/routers/marketing_campaigns.py). require_ui_session (usable by the test user). Reads degrade to
+ * empty when the MARKETING_CAMPAIGNS_ENABLED flag is off; mutations surface a "not enabled" error.
+ *
+ * DISTINCT from [MarketingDashboardDest] (the /ui/agents/marketing content agent).
+ */
+data object MarketingCampaignsDest {
+    const val ROUTE = "marketing/campaigns"
+}
+
+fun NavGraphBuilder.marketingCampaignsDestinations(navController: NavHostController) {
+    composable(MarketingCampaignsDest.ROUTE) {
+        MarketingCampaignsRoute(
+            onBack = { navController.popBackStack() },
+            onSessionExpired = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -259,6 +259,8 @@ object MoreRoutes {
 
     // B4 web-parity: Marketing content agent (web /agents/marketing). require_ui_session (usable).
     const val MARKETING = MarketingDashboardDest.ROUTE
+    // OFBiz Marketing CAMPAIGNS hub (web /ui/marketing: campaigns/lists/segments). require_ui_session.
+    const val MARKETING_CAMPAIGNS = MarketingCampaignsDest.ROUTE
     // B4 web-parity: Accountant/cost-tracking agent (web /agents/costs). require_ui_session (usable).
     const val COSTS = CostOverviewDest.ROUTE
     // B4 web-parity: Compliance agent (web /agents/compliance). require_ui_session (usable).
@@ -693,6 +695,7 @@ object MoreRoutes {
             DOC_COVERAGE,
             STYLIST,
             MARKETING,
+            MARKETING_CAMPAIGNS,
             COSTS,
             COMPLIANCE,
             SECURITY,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5172,6 +5172,12 @@
     <!-- B4 web-parity: More entries for Stylist + Marketing agents -->
     <string name="more_entry_stylist">Design (Stylist)</string>
     <string name="more_entry_marketing">Marketing</string>
+    <string name="more_entry_marketing_campaigns">Marketing campaigns</string>
+    <!-- Marketing campaigns (OFBiz MKT) hub -->
+    <string name="mktc_campaign_created">Campaign created</string>
+    <string name="mktc_list_created">List created</string>
+    <string name="mktc_action_done">Done</string>
+    <string name="mktc_action_failed">Action failed</string>
 
     <!-- Stylist / UI-design agent -->
     <string name="stylist_overview_title">Design Overview</string>

--- a/android/app/src/test/java/com/testlogon/android/data/marketing/campaigns/MarketingMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/marketing/campaigns/MarketingMathTest.kt
@@ -1,0 +1,152 @@
+package com.testlogon.android.data.marketing.campaigns
+
+import com.testlogon.android.data.marketing.campaigns.MarketingMath.CampaignObjective
+import com.testlogon.android.data.marketing.campaigns.MarketingMath.CampaignStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [MarketingMath] — the campaign state machine + display formatters. These pin the
+ * transition table to the backend `_CAMPAIGN_TRANSITIONS` and lock the money/size formatting.
+ */
+class MarketingMathTest {
+
+    // ---- status parsing ----
+
+    @Test
+    fun status_from_parsesKnownAndUnknown() {
+        assertEquals(CampaignStatus.DRAFT, CampaignStatus.from("draft"))
+        assertEquals(CampaignStatus.ACTIVE, CampaignStatus.from("ACTIVE"))
+        assertEquals(CampaignStatus.ARCHIVED, CampaignStatus.from("archived"))
+        assertEquals(CampaignStatus.UNKNOWN, CampaignStatus.from("weird"))
+        assertEquals(CampaignStatus.UNKNOWN, CampaignStatus.from(null))
+    }
+
+    // ---- transitions mirror the backend state machine ----
+
+    @Test
+    fun transitions_draft() {
+        assertEquals(
+            listOf(CampaignStatus.SCHEDULED, CampaignStatus.ACTIVE, CampaignStatus.ARCHIVED),
+            MarketingMath.allowedTransitions(CampaignStatus.DRAFT),
+        )
+    }
+
+    @Test
+    fun transitions_scheduled() {
+        assertEquals(
+            listOf(CampaignStatus.ACTIVE, CampaignStatus.ARCHIVED),
+            MarketingMath.allowedTransitions(CampaignStatus.SCHEDULED),
+        )
+    }
+
+    @Test
+    fun transitions_active() {
+        assertEquals(
+            listOf(CampaignStatus.PAUSED, CampaignStatus.COMPLETED, CampaignStatus.ARCHIVED),
+            MarketingMath.allowedTransitions(CampaignStatus.ACTIVE),
+        )
+    }
+
+    @Test
+    fun transitions_paused_and_completed() {
+        assertEquals(
+            listOf(CampaignStatus.ACTIVE, CampaignStatus.ARCHIVED),
+            MarketingMath.allowedTransitions(CampaignStatus.PAUSED),
+        )
+        assertEquals(
+            listOf(CampaignStatus.ARCHIVED),
+            MarketingMath.allowedTransitions(CampaignStatus.COMPLETED),
+        )
+    }
+
+    @Test
+    fun transitions_archivedIsTerminal() {
+        assertTrue(MarketingMath.allowedTransitions(CampaignStatus.ARCHIVED).isEmpty())
+        assertTrue(MarketingMath.isTerminal(CampaignStatus.ARCHIVED))
+        assertFalse(MarketingMath.isTerminal(CampaignStatus.DRAFT))
+    }
+
+    @Test
+    fun canTransition_rejectsIllegalHops() {
+        assertTrue(MarketingMath.canTransition(CampaignStatus.DRAFT, CampaignStatus.ACTIVE))
+        // completed -> active is NOT allowed
+        assertFalse(MarketingMath.canTransition(CampaignStatus.COMPLETED, CampaignStatus.ACTIVE))
+        // draft -> paused is NOT allowed
+        assertFalse(MarketingMath.canTransition(CampaignStatus.DRAFT, CampaignStatus.PAUSED))
+        // unknown -> anything is not allowed
+        assertFalse(MarketingMath.canTransition(CampaignStatus.UNKNOWN, CampaignStatus.ACTIVE))
+    }
+
+    @Test
+    fun canSend_onlyActive() {
+        assertTrue(MarketingMath.canSend(CampaignStatus.ACTIVE))
+        assertFalse(MarketingMath.canSend(CampaignStatus.DRAFT))
+        assertFalse(MarketingMath.canSend(CampaignStatus.PAUSED))
+    }
+
+    // ---- objective ----
+
+    @Test
+    fun objective_parsesAndListsAll() {
+        assertEquals(CampaignObjective.CONVERSIONS, CampaignObjective.from("conversions"))
+        assertNull(CampaignObjective.from("nope"))
+        assertEquals(4, CampaignObjective.ALL.size)
+    }
+
+    // ---- budget formatting ----
+
+    @Test
+    fun formatBudget_variousMagnitudes() {
+        assertEquals("$0.00", MarketingMath.formatBudget(0))
+        assertEquals("$1.00", MarketingMath.formatBudget(100))
+        assertEquals("$1.05", MarketingMath.formatBudget(105))
+        assertEquals("$1,500.00", MarketingMath.formatBudget(150_000))
+        assertEquals("$1,234,567.89", MarketingMath.formatBudget(123_456_789))
+        assertEquals("-$1.00", MarketingMath.formatBudget(-100))
+    }
+
+    @Test
+    fun parseBudgetToCents_validAndInvalid() {
+        assertEquals(150_000L, MarketingMath.parseBudgetToCents("1500"))
+        assertEquals(150_050L, MarketingMath.parseBudgetToCents("1,500.50"))
+        assertEquals(2_500L, MarketingMath.parseBudgetToCents("$25"))
+        assertEquals(0L, MarketingMath.parseBudgetToCents("0"))
+        assertNull(MarketingMath.parseBudgetToCents(""))
+        assertNull(MarketingMath.parseBudgetToCents("abc"))
+        assertNull(MarketingMath.parseBudgetToCents("-5"))
+    }
+
+    // ---- segment / list size ----
+
+    @Test
+    fun formatSegmentSize_pluralizationAndCompaction() {
+        assertEquals("No members", MarketingMath.formatSegmentSize(0))
+        assertEquals("No members", MarketingMath.formatSegmentSize(-3))
+        assertEquals("1 member", MarketingMath.formatSegmentSize(1))
+        assertEquals("42 members", MarketingMath.formatSegmentSize(42))
+        assertEquals("1.5K members", MarketingMath.formatSegmentSize(1_500))
+        assertEquals("2M members", MarketingMath.formatSegmentSize(2_000_000))
+    }
+
+    @Test
+    fun compact_boundaries() {
+        assertEquals("999", MarketingMath.compact(999))
+        assertEquals("1K", MarketingMath.compact(1_000))
+        assertEquals("12.3K", MarketingMath.compact(12_345))
+        assertEquals("1M", MarketingMath.compact(1_000_000))
+    }
+
+    // ---- predicate ----
+
+    @Test
+    fun formatPredicate_mapsOperators() {
+        assertEquals("total_spend_cents ≥ 1000", MarketingMath.formatPredicate("total_spend_cents", "gte", "1000"))
+        assertEquals("profile_country = US", MarketingMath.formatPredicate("profile_country", "eq", "US"))
+        assertEquals("tier in a,b", MarketingMath.formatPredicate("tier", "in", "a,b"))
+        assertEquals("x not in y", MarketingMath.formatPredicate("x", "not_in", "y"))
+    }
+}


### PR DESCRIPTION
## FE parity PAR-133 - Android marketing campaigns

Brings the web marketing-campaigns feature to Android for FE parity.

### What was added
- New `data/marketing/campaigns` layer: `MarketingCampaignsApi`, `MarketingCampaignsRepository`, `MarketingCampaignsDomain`, `MarketingCampaignsDataModule` (DI), and `MarketingMath` helpers.
- New `feature/marketingcampaigns` surface: `MarketingCampaignsScreen`, `MarketingCampaignsUiState`, `MarketingCampaignsViewModel`.
- Navigation wiring: `MarketingCampaignsNavigation`, plus updates to `AuthenticatedGraph`, `MoreRoutes`, `MoreCatalog`, and `strings.xml`.

### Reuse notes
Reuses the existing data-module/DI and math helper patterns; unit-tested via `MarketingMathTest`.

### Gate
Feature is reached only through the More-catalog entry (gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
