### PR TITLE
FE parity PAR-143 - Android HR (positions/employments/payroll)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/hr/HrDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/hr/HrDataModule.kt
@@ -1,0 +1,30 @@
+package com.testlogon.android.data.hr
+
+import com.testlogon.android.core.network.hr.HrApi
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** HRM-009 — provides the [HrApi] on the shared (authenticated) Retrofit. */
+@Module
+@InstallIn(SingletonComponent::class)
+object HrApiModule {
+
+    @Provides
+    @Singleton
+    fun provideHrApi(retrofit: Retrofit): HrApi = retrofit.create(HrApi::class.java)
+}
+
+/** HRM-009 — binds the HR read repository over [HrApi]. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class HrDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindHrRepository(impl: HrRepositoryImpl): HrRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/hr/HrRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/hr/HrRepository.kt
@@ -1,0 +1,169 @@
+package com.testlogon.android.data.hr
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.map
+import com.testlogon.android.core.model.hr.Employment
+import com.testlogon.android.core.model.hr.EmploymentStatus
+import com.testlogon.android.core.model.hr.HrMoney
+import com.testlogon.android.core.model.hr.HrPage
+import com.testlogon.android.core.model.hr.PayPeriod
+import com.testlogon.android.core.model.hr.PayrollLine
+import com.testlogon.android.core.model.hr.PayrollRun
+import com.testlogon.android.core.model.hr.PayrollRunStatus
+import com.testlogon.android.core.model.hr.Position
+import com.testlogon.android.core.model.hr.PositionStatus
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.hr.EmploymentDto
+import com.testlogon.android.core.network.hr.HrApi
+import com.testlogon.android.core.network.hr.PayrollLineDto
+import com.testlogon.android.core.network.hr.PayrollRunDto
+import com.testlogon.android.core.network.hr.PositionDto
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * HRM-009 (Android) — HR / Payroll read data layer over [HrApi].
+ *
+ * Wraps every call in [ApiResult] (matching the invoices/billing repositories): CancellationException is
+ * re-thrown; HTTP errors fold to Failure (via [ApiErrorParser]) — a 404 there is the feature-flag-off
+ * signal the ViewModel degrades to "unavailable"; transport failures to NetworkError. DTOs are mapped to
+ * core-model domain before returning (no raw DTOs leak out).
+ *
+ * All reads are idempotent GETs (the core-network RetryInterceptor handles bounded retry on network
+ * errors). No mutating routes are surfaced in this pass.
+ */
+interface HrRepository {
+
+    suspend fun listPositions(status: String?, cursor: String?, limit: Int): ApiResult<HrPage<Position>>
+    suspend fun getPosition(positionId: String): ApiResult<Position>
+
+    suspend fun listEmployments(
+        partyId: String?,
+        status: String?,
+        cursor: String?,
+        limit: Int,
+    ): ApiResult<HrPage<Employment>>
+
+    suspend fun getEmployment(employmentId: String): ApiResult<Employment>
+
+    suspend fun listPayrollRuns(status: String?, cursor: String?, limit: Int): ApiResult<HrPage<PayrollRun>>
+    suspend fun getPayrollRun(payrollRunId: String): ApiResult<PayrollRun>
+    suspend fun getPayrollRunLines(payrollRunId: String): ApiResult<List<PayrollLine>>
+}
+
+@Singleton
+class HrRepositoryImpl @Inject constructor(
+    private val api: HrApi,
+    private val errorParser: ApiErrorParser,
+) : HrRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun listPositions(
+        status: String?,
+        cursor: String?,
+        limit: Int,
+    ): ApiResult<HrPage<Position>> = withContext(io) {
+        call { api.listPositions(status = status, cursor = cursor, limit = limit) }
+            .map { dto -> HrPage(dto.items.map { it.toDomain() }, dto.nextCursor?.takeIf { it.isNotBlank() }) }
+    }
+
+    override suspend fun getPosition(positionId: String): ApiResult<Position> = withContext(io) {
+        call { api.getPosition(positionId) }.map { it.toDomain() }
+    }
+
+    override suspend fun listEmployments(
+        partyId: String?,
+        status: String?,
+        cursor: String?,
+        limit: Int,
+    ): ApiResult<HrPage<Employment>> = withContext(io) {
+        call { api.listEmployments(partyId = partyId, status = status, cursor = cursor, limit = limit) }
+            .map { dto -> HrPage(dto.items.map { it.toDomain() }, dto.nextCursor?.takeIf { it.isNotBlank() }) }
+    }
+
+    override suspend fun getEmployment(employmentId: String): ApiResult<Employment> = withContext(io) {
+        call { api.getEmployment(employmentId) }.map { it.toDomain() }
+    }
+
+    override suspend fun listPayrollRuns(
+        status: String?,
+        cursor: String?,
+        limit: Int,
+    ): ApiResult<HrPage<PayrollRun>> = withContext(io) {
+        call { api.listPayrollRuns(status = status, cursor = cursor, limit = limit) }
+            .map { dto -> HrPage(dto.items.map { it.toDomain() }, dto.nextCursor?.takeIf { it.isNotBlank() }) }
+    }
+
+    override suspend fun getPayrollRun(payrollRunId: String): ApiResult<PayrollRun> = withContext(io) {
+        call { api.getPayrollRun(payrollRunId) }.map { it.toDomain() }
+    }
+
+    override suspend fun getPayrollRunLines(payrollRunId: String): ApiResult<List<PayrollLine>> =
+        withContext(io) {
+            call { api.getPayrollRunLines(payrollRunId) }.map { dto -> dto.lines.map { it.toDomain() } }
+        }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}
+
+// ---- Mappers (DTO -> core-model domain). TOTAL: unknown enums -> UNKNOWN, 0 timestamps -> null. ----
+
+private fun Long.epochSecondsOrNull(): Long? = takeIf { it > 0 }
+private fun Long?.epochSecondsOrNull(): Long? = this?.takeIf { it > 0 }
+
+internal fun PositionDto.toDomain(): Position = Position(
+    positionId = positionId,
+    title = title,
+    department = department?.takeIf { it.isNotBlank() },
+    status = PositionStatus.fromWire(status),
+    createdAtEpochSeconds = createdAt.epochSecondsOrNull(),
+    updatedAtEpochSeconds = updatedAt.epochSecondsOrNull(),
+)
+
+internal fun EmploymentDto.toDomain(): Employment = Employment(
+    employmentId = employmentId,
+    partyId = partyId,
+    positionId = positionId,
+    orgPartyId = orgPartyId,
+    status = EmploymentStatus.fromWire(status),
+    startDateEpochSeconds = startDate.epochSecondsOrNull(),
+    endDateEpochSeconds = endDate.epochSecondsOrNull(),
+    payRate = HrMoney(payRateCents, currency),
+    payPeriod = PayPeriod.fromWire(payPeriod),
+    createdAtEpochSeconds = createdAt.epochSecondsOrNull(),
+    updatedAtEpochSeconds = updatedAt.epochSecondsOrNull(),
+)
+
+internal fun PayrollLineDto.toDomain(): PayrollLine = PayrollLine(
+    employmentId = employmentId,
+    partyId = partyId,
+    gross = HrMoney(grossCents, currency),
+)
+
+internal fun PayrollRunDto.toDomain(): PayrollRun = PayrollRun(
+    payrollRunId = payrollRunId,
+    periodStartEpochSeconds = periodStart.epochSecondsOrNull(),
+    periodEndEpochSeconds = periodEnd.epochSecondsOrNull(),
+    status = PayrollRunStatus.fromWire(status),
+    lines = lines.map { it.toDomain() },
+    approvedBy = approvedBy?.takeIf { it.isNotBlank() },
+    postedAtEpochSeconds = postedAt.epochSecondsOrNull(),
+    createdAtEpochSeconds = createdAt.epochSecondsOrNull(),
+    updatedAtEpochSeconds = updatedAt.epochSecondsOrNull(),
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/hr/HrEmploymentDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/hr/HrEmploymentDetailScreen.kt
@@ -1,0 +1,102 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.hr
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.R
+import com.testlogon.android.core.model.hr.Employment
+import com.testlogon.android.core.model.hr.HrMath
+import com.testlogon.android.core.model.hr.Position
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+
+/** HRM-009 — employment detail route. Arg is the STRING employment_id. */
+@Composable
+fun HrEmploymentDetailRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: HrEmploymentDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    Scaffold(
+        modifier = modifier.testTag("hr_employment_detail_screen"),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.hr_employment_detail_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val s = state) {
+            is HrEmploymentDetailUiState.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            is HrEmploymentDetailUiState.Unavailable -> EmptyState(
+                title = stringResource(R.string.hr_unavailable_title),
+                body = stringResource(R.string.hr_unavailable_body),
+                modifier = Modifier.padding(padding),
+            )
+            is HrEmploymentDetailUiState.Error -> ErrorState(
+                message = s.message,
+                onRetry = viewModel::retry,
+                modifier = Modifier.padding(padding),
+            )
+            is HrEmploymentDetailUiState.Content -> EmploymentDetailBody(
+                employment = s.employment,
+                position = s.position,
+                modifier = Modifier.padding(padding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmploymentDetailBody(employment: Employment, position: Position?, modifier: Modifier = Modifier) {
+    val now = System.currentTimeMillis() / 1000L
+    Column(modifier = modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+        Field(stringResource(R.string.hr_field_status), employmentStatusLabel(employment.status))
+        position?.let { Field(stringResource(R.string.hr_field_position), it.title.ifBlank { it.positionId }) }
+        Field(stringResource(R.string.hr_field_party), employment.partyId.ifBlank { "—" })
+        Field(stringResource(R.string.hr_field_org), employment.orgPartyId.ifBlank { "—" })
+        Field(stringResource(R.string.hr_field_pay_rate), HrMath.payRateLabel(employment))
+        Field(stringResource(R.string.hr_field_pay_period), payPeriodLabel(employment.payPeriod))
+        HrMath.annualizedComp(employment)?.let {
+            Field(stringResource(R.string.hr_field_annualized), HrMath.formatMoney(it))
+        }
+        Field(stringResource(R.string.hr_field_start), formatHrDate(employment.startDateEpochSeconds) ?: "—")
+        Field(stringResource(R.string.hr_field_end), formatHrDate(employment.endDateEpochSeconds) ?: "—")
+        HrMath.employmentTenureLabel(employment, now)?.let {
+            Field(stringResource(R.string.hr_field_tenure), it)
+        }
+    }
+}
+
+@Composable
+private fun Field(label: String, value: String) {
+    ListItem(headlineContent = { Text(value) }, overlineContent = { Text(label) })
+    HorizontalDivider()
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/hr/HrEmploymentDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/hr/HrEmploymentDetailViewModel.kt
@@ -1,0 +1,76 @@
+package com.testlogon.android.feature.hr
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.hr.Employment
+import com.testlogon.android.core.model.hr.Position
+import com.testlogon.android.data.hr.HrRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** HRM-009 — employment detail screen state. */
+sealed interface HrEmploymentDetailUiState {
+    data object Loading : HrEmploymentDetailUiState
+
+    /** [position] is a best-effort enrichment (the position title); null when it could not be loaded. */
+    data class Content(val employment: Employment, val position: Position?) : HrEmploymentDetailUiState
+    data object Unavailable : HrEmploymentDetailUiState
+    data class Error(val message: String, val canRetry: Boolean) : HrEmploymentDetailUiState
+}
+
+/**
+ * HRM-009 — employment detail presentation logic. Loads `/ui/hr/employments/{id}` once, then makes a
+ * best-effort follow-up fetch of the linked position (for its title); a failed position fetch does NOT
+ * fail the screen. Degrade-on-404 -> Unavailable; 403 -> non-retryable Error.
+ */
+@HiltViewModel
+class HrEmploymentDetailViewModel @Inject constructor(
+    private val repository: HrRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val employmentId: String = checkNotNull(savedStateHandle[ARG_EMPLOYMENT_ID]) {
+        "HrEmploymentDetailViewModel requires an '$ARG_EMPLOYMENT_ID' nav argument"
+    }
+
+    private val _state = MutableStateFlow<HrEmploymentDetailUiState>(HrEmploymentDetailUiState.Loading)
+    val state: StateFlow<HrEmploymentDetailUiState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun retry() = load()
+
+    private fun load() {
+        _state.value = HrEmploymentDetailUiState.Loading
+        viewModelScope.launch {
+            _state.value = when (val r = repository.getEmployment(employmentId)) {
+                is ApiResult.Success -> {
+                    val position = (repository.getPosition(r.data.positionId) as? ApiResult.Success)?.data
+                    HrEmploymentDetailUiState.Content(r.data, position)
+                }
+                is ApiResult.Failure -> when (r.error.status) {
+                    404 -> HrEmploymentDetailUiState.Unavailable
+                    403 -> HrEmploymentDetailUiState.Error("You do not have access to HR.", canRetry = false)
+                    else -> HrEmploymentDetailUiState.Error(
+                        r.error.message.ifBlank { "Could not load employment." },
+                        canRetry = true,
+                    )
+                }
+                is ApiResult.NetworkError ->
+                    HrEmploymentDetailUiState.Error("Network error. Check your connection.", canRetry = true)
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_EMPLOYMENT_ID = "employment_id"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/hr/HrFormat.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/hr/HrFormat.kt
@@ -1,0 +1,50 @@
+package com.testlogon.android.feature.hr
+
+import com.testlogon.android.core.model.hr.EmploymentStatus
+import com.testlogon.android.core.model.hr.PayPeriod
+import com.testlogon.android.core.model.hr.PayrollRunStatus
+import com.testlogon.android.core.model.hr.PositionStatus
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * HRM-009 — pure, JVM-testable HR label/date formatting (no Android types), mirroring the AND-243
+ * InvoiceFormat helpers. Dates use [DateFormat]/[Date] (NOT java.time, API26+). Status label mapping is
+ * total (an UNKNOWN enum falls back to a readable dash-free literal).
+ */
+
+/** Epoch-seconds -> localized medium date string, or null when [epochSeconds] is null. */
+fun formatHrDate(epochSeconds: Long?, locale: Locale = Locale.getDefault()): String? {
+    if (epochSeconds == null) return null
+    return DateFormat.getDateInstance(DateFormat.MEDIUM, locale).format(Date(epochSeconds * 1000L))
+}
+
+fun positionStatusLabel(status: PositionStatus): String = when (status) {
+    PositionStatus.OPEN -> "Open"
+    PositionStatus.FILLED -> "Filled"
+    PositionStatus.CLOSED -> "Closed"
+    PositionStatus.UNKNOWN -> "Unknown"
+}
+
+fun employmentStatusLabel(status: EmploymentStatus): String = when (status) {
+    EmploymentStatus.ACTIVE -> "Active"
+    EmploymentStatus.TERMINATED -> "Terminated"
+    EmploymentStatus.ON_LEAVE -> "On leave"
+    EmploymentStatus.UNKNOWN -> "Unknown"
+}
+
+fun payPeriodLabel(period: PayPeriod): String = when (period) {
+    PayPeriod.MONTHLY -> "Monthly"
+    PayPeriod.BIWEEKLY -> "Biweekly"
+    PayPeriod.WEEKLY -> "Weekly"
+    PayPeriod.HOURLY -> "Hourly"
+    PayPeriod.UNKNOWN -> "Unknown"
+}
+
+fun payrollStatusLabel(status: PayrollRunStatus): String = when (status) {
+    PayrollRunStatus.DRAFT -> "Draft"
+    PayrollRunStatus.APPROVED -> "Approved"
+    PayrollRunStatus.POSTED -> "Posted"
+    PayrollRunStatus.UNKNOWN -> "Unknown"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/hr/HrHubScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/hr/HrHubScreen.kt
@@ -1,0 +1,197 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.hr
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.R
+import com.testlogon.android.core.model.hr.Employment
+import com.testlogon.android.core.model.hr.HrMath
+import com.testlogon.android.core.model.hr.PayrollRun
+import com.testlogon.android.core.model.hr.Position
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+
+/** HRM-009 — stable testTags for the HR hub. */
+object HrTestTags {
+    const val SCREEN = "hr_screen"
+    const val TABS = "hr_tabs"
+    const val LIST = "hr_list"
+    const val ROW = "hr_row"
+    const val EMPTY = "hr_empty"
+    const val ERROR = "hr_error"
+}
+
+/** HRM-009 — route-level HR hub, reachable from the More hub (operator-only). */
+@Composable
+fun HrHubRoute(
+    onEmploymentClick: (String) -> Unit,
+    onPayrollClick: (String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: HrHubViewModel = hiltViewModel(),
+) {
+    val positions by viewModel.positions.collectAsStateWithLifecycle()
+    val employments by viewModel.employments.collectAsStateWithLifecycle()
+    val payroll by viewModel.payroll.collectAsStateWithLifecycle()
+
+    var selected by rememberSaveable { mutableStateOf(HrTab.POSITIONS) }
+
+    Scaffold(
+        modifier = modifier.testTag(HrTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.hr_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            TabRow(selectedTabIndex = selected.ordinal, modifier = Modifier.testTag(HrTestTags.TABS)) {
+                HrTab.entries.forEach { tab ->
+                    Tab(
+                        selected = selected == tab,
+                        onClick = { selected = tab },
+                        text = { Text(stringResource(hrTabLabel(tab))) },
+                    )
+                }
+            }
+            when (selected) {
+                HrTab.POSITIONS -> ListPane(
+                    state = positions,
+                    onRetry = { viewModel.retry(HrTab.POSITIONS) },
+                    emptyTitle = stringResource(R.string.hr_positions_empty),
+                ) { list -> items(list, key = { it.positionId }) { PositionRow(it) } }
+
+                HrTab.EMPLOYMENTS -> ListPane(
+                    state = employments,
+                    onRetry = { viewModel.retry(HrTab.EMPLOYMENTS) },
+                    emptyTitle = stringResource(R.string.hr_employments_empty),
+                ) { list ->
+                    items(list, key = { it.employmentId }) { emp ->
+                        EmploymentRow(emp, onClick = { onEmploymentClick(emp.employmentId) })
+                    }
+                }
+
+                HrTab.PAYROLL -> ListPane(
+                    state = payroll,
+                    onRetry = { viewModel.retry(HrTab.PAYROLL) },
+                    emptyTitle = stringResource(R.string.hr_payroll_empty),
+                ) { list ->
+                    items(list, key = { it.payrollRunId }) { run ->
+                        PayrollRow(run, onClick = { onPayrollClick(run.payrollRunId) })
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun <T> ListPane(
+    state: HrListUiState<T>,
+    onRetry: () -> Unit,
+    emptyTitle: String,
+    itemsBlock: androidx.compose.foundation.lazy.LazyListScope.(List<T>) -> Unit,
+) {
+    when (state) {
+        is HrListUiState.Loading -> LoadingState()
+        is HrListUiState.Unavailable -> EmptyState(
+            title = stringResource(R.string.hr_unavailable_title),
+            body = stringResource(R.string.hr_unavailable_body),
+            modifier = Modifier.testTag(HrTestTags.EMPTY),
+        )
+        is HrListUiState.Error -> ErrorState(
+            message = state.message,
+            onRetry = onRetry,
+            modifier = Modifier.testTag(HrTestTags.ERROR),
+        )
+        is HrListUiState.Content -> if (state.items.isEmpty()) {
+            EmptyState(title = emptyTitle, modifier = Modifier.testTag(HrTestTags.EMPTY))
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize().testTag(HrTestTags.LIST)) {
+                itemsBlock(state.items)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PositionRow(position: Position) {
+    ListItem(
+        modifier = Modifier.testTag(HrTestTags.ROW),
+        headlineContent = { Text(position.title.ifBlank { position.positionId }) },
+        supportingContent = {
+            val dept = position.department
+            Text(if (dept.isNullOrBlank()) positionStatusLabel(position.status) else "$dept · ${positionStatusLabel(position.status)}")
+        },
+    )
+    HorizontalDivider()
+}
+
+@Composable
+private fun EmploymentRow(employment: Employment, onClick: () -> Unit) {
+    ListItem(
+        modifier = Modifier.clickable(onClick = onClick).testTag(HrTestTags.ROW),
+        headlineContent = { Text(employment.partyId.ifBlank { employment.employmentId }) },
+        supportingContent = {
+            Text("${employmentStatusLabel(employment.status)} · ${HrMath.payRateLabel(employment)}")
+        },
+    )
+    HorizontalDivider()
+}
+
+@Composable
+private fun PayrollRow(run: PayrollRun, onClick: () -> Unit) {
+    val total = HrMath.formatMoney(HrMath.runGrossTotal(run))
+    val period = listOfNotNull(formatHrDate(run.periodStartEpochSeconds), formatHrDate(run.periodEndEpochSeconds))
+        .joinToString(" – ")
+    ListItem(
+        modifier = Modifier.clickable(onClick = onClick).testTag(HrTestTags.ROW),
+        headlineContent = { Text(period.ifBlank { run.payrollRunId }) },
+        supportingContent = { Text("${payrollStatusLabel(run.status)} · $total") },
+    )
+    HorizontalDivider()
+}
+
+private fun hrTabLabel(tab: HrTab): Int = when (tab) {
+    HrTab.POSITIONS -> R.string.hr_tab_positions
+    HrTab.EMPLOYMENTS -> R.string.hr_tab_employments
+    HrTab.PAYROLL -> R.string.hr_tab_payroll
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/hr/HrHubViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/hr/HrHubViewModel.kt
@@ -1,0 +1,113 @@
+package com.testlogon.android.feature.hr
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.hr.Employment
+import com.testlogon.android.core.model.hr.PayrollRun
+import com.testlogon.android.core.model.hr.Position
+import com.testlogon.android.data.hr.HrRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** HRM-009 — the three tabs of the HR hub. */
+enum class HrTab { POSITIONS, EMPLOYMENTS, PAYROLL }
+
+/**
+ * HRM-009 — generic per-tab list state.
+ *
+ *  - [Loading]     — first fetch in flight.
+ *  - [Content]     — items (possibly empty) fetched OK.
+ *  - [Unavailable] — degrade-on-404 (the hr_enabled / hr_payroll_enabled flag is off): NOT an error, the
+ *                    surface is simply not enabled for this deployment/account. Shown as a calm empty note.
+ *  - [Error]       — 403 (not admin) or any other failure; retryable except for 403.
+ */
+sealed interface HrListUiState<out T> {
+    data object Loading : HrListUiState<Nothing>
+    data class Content<T>(val items: List<T>) : HrListUiState<T>
+    data object Unavailable : HrListUiState<Nothing>
+    data class Error(val message: String, val canRetry: Boolean) : HrListUiState<Nothing>
+}
+
+/**
+ * HRM-009 — HR hub presentation logic (admin/root only; the More entry is operatorOnly and the backend
+ * 403/404 remains authoritative). Loads all three read surfaces (positions, employments, payroll runs)
+ * on construction; each maps its own [HrListUiState]. A 404 degrades to [Unavailable] (feature-flag off);
+ * a 403 maps to a non-retryable [Error]; transport/5xx map to a retryable [Error].
+ *
+ * The ViewModel imports no Retrofit/Moshi/Compose; it consumes [ApiResult] only.
+ */
+@HiltViewModel
+class HrHubViewModel @Inject constructor(
+    private val repository: HrRepository,
+) : ViewModel() {
+
+    private val _positions = MutableStateFlow<HrListUiState<Position>>(HrListUiState.Loading)
+    val positions: StateFlow<HrListUiState<Position>> = _positions.asStateFlow()
+
+    private val _employments = MutableStateFlow<HrListUiState<Employment>>(HrListUiState.Loading)
+    val employments: StateFlow<HrListUiState<Employment>> = _employments.asStateFlow()
+
+    private val _payroll = MutableStateFlow<HrListUiState<PayrollRun>>(HrListUiState.Loading)
+    val payroll: StateFlow<HrListUiState<PayrollRun>> = _payroll.asStateFlow()
+
+    init {
+        loadPositions()
+        loadEmployments()
+        loadPayroll()
+    }
+
+    fun retry(tab: HrTab) = when (tab) {
+        HrTab.POSITIONS -> loadPositions()
+        HrTab.EMPLOYMENTS -> loadEmployments()
+        HrTab.PAYROLL -> loadPayroll()
+    }
+
+    private fun loadPositions() {
+        _positions.value = HrListUiState.Loading
+        viewModelScope.launch {
+            _positions.value = reduce(repository.listPositions(status = null, cursor = null, limit = LIMIT)) {
+                it.items
+            }
+        }
+    }
+
+    private fun loadEmployments() {
+        _employments.value = HrListUiState.Loading
+        viewModelScope.launch {
+            _employments.value = reduce(
+                repository.listEmployments(partyId = null, status = null, cursor = null, limit = LIMIT),
+            ) { it.items }
+        }
+    }
+
+    private fun loadPayroll() {
+        _payroll.value = HrListUiState.Loading
+        viewModelScope.launch {
+            _payroll.value = reduce(repository.listPayrollRuns(status = null, cursor = null, limit = LIMIT)) {
+                it.items
+            }
+        }
+    }
+
+    private fun <R, T> reduce(result: ApiResult<R>, items: (R) -> List<T>): HrListUiState<T> = when (result) {
+        is ApiResult.Success -> HrListUiState.Content(items(result.data))
+        is ApiResult.Failure -> when (result.error.status) {
+            404 -> HrListUiState.Unavailable
+            403 -> HrListUiState.Error("You do not have access to HR.", canRetry = false)
+            else -> HrListUiState.Error(
+                result.error.message.ifBlank { "Could not load HR data." },
+                canRetry = true,
+            )
+        }
+        is ApiResult.NetworkError -> HrListUiState.Error("Network error. Check your connection.", canRetry = true)
+    }
+
+    private companion object {
+        const val LIMIT = 50
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/hr/HrPayrollDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/hr/HrPayrollDetailScreen.kt
@@ -1,0 +1,112 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.hr
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.R
+import com.testlogon.android.core.model.hr.HrMath
+import com.testlogon.android.core.model.hr.PayrollLine
+import com.testlogon.android.core.model.hr.PayrollRun
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+
+/** HRM-009 — payroll-run detail route. Arg is the STRING payroll_run_id. */
+@Composable
+fun HrPayrollDetailRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: HrPayrollDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    Scaffold(
+        modifier = modifier.testTag("hr_payroll_detail_screen"),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.hr_payroll_detail_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val s = state) {
+            is HrPayrollDetailUiState.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            is HrPayrollDetailUiState.Unavailable -> EmptyState(
+                title = stringResource(R.string.hr_unavailable_title),
+                body = stringResource(R.string.hr_unavailable_body),
+                modifier = Modifier.padding(padding),
+            )
+            is HrPayrollDetailUiState.Error -> ErrorState(
+                message = s.message,
+                onRetry = viewModel::retry,
+                modifier = Modifier.padding(padding),
+            )
+            is HrPayrollDetailUiState.Content -> PayrollDetailBody(
+                run = s.run,
+                lines = s.lines,
+                modifier = Modifier.padding(padding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PayrollDetailBody(run: PayrollRun, lines: List<PayrollLine>, modifier: Modifier = Modifier) {
+    val total = HrMath.formatMoney(HrMath.runGrossTotal(run))
+    val period = listOfNotNull(formatHrDate(run.periodStartEpochSeconds), formatHrDate(run.periodEndEpochSeconds))
+        .joinToString(" – ")
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        item {
+            Field(stringResource(R.string.hr_field_status), payrollStatusLabel(run.status))
+            if (period.isNotBlank()) Field(stringResource(R.string.hr_field_period), period)
+            Field(stringResource(R.string.hr_field_gross_total), total)
+            run.approvedBy?.let { Field(stringResource(R.string.hr_field_approved_by), it) }
+            formatHrDate(run.postedAtEpochSeconds)?.let { Field(stringResource(R.string.hr_field_posted_at), it) }
+            Text(
+                stringResource(R.string.hr_payroll_lines_header),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        if (lines.isEmpty()) {
+            item { EmptyState(title = stringResource(R.string.hr_payroll_lines_empty)) }
+        } else {
+            items(lines, key = { it.employmentId }) { line ->
+                ListItem(
+                    headlineContent = { Text(line.partyId.ifBlank { line.employmentId }) },
+                    trailingContent = { Text(HrMath.formatMoney(line.gross)) },
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}
+
+@Composable
+private fun Field(label: String, value: String) {
+    ListItem(headlineContent = { Text(value) }, overlineContent = { Text(label) })
+    HorizontalDivider()
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/hr/HrPayrollDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/hr/HrPayrollDetailViewModel.kt
@@ -1,0 +1,75 @@
+package com.testlogon.android.feature.hr
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.hr.PayrollLine
+import com.testlogon.android.core.model.hr.PayrollRun
+import com.testlogon.android.data.hr.HrRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** HRM-009 — payroll-run detail screen state. */
+sealed interface HrPayrollDetailUiState {
+    data object Loading : HrPayrollDetailUiState
+    data class Content(val run: PayrollRun, val lines: List<PayrollLine>) : HrPayrollDetailUiState
+    data object Unavailable : HrPayrollDetailUiState
+    data class Error(val message: String, val canRetry: Boolean) : HrPayrollDetailUiState
+}
+
+/**
+ * HRM-009 — payroll-run detail presentation logic. Loads the run header (`/ui/hr/payroll/{id}`) and its
+ * line breakdown (`/ui/hr/payroll/{id}/lines`). The run embeds lines too; the dedicated lines call is
+ * authoritative, falling back to the embedded lines when it fails. Degrade-on-404 -> Unavailable.
+ */
+@HiltViewModel
+class HrPayrollDetailViewModel @Inject constructor(
+    private val repository: HrRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val payrollRunId: String = checkNotNull(savedStateHandle[ARG_PAYROLL_RUN_ID]) {
+        "HrPayrollDetailViewModel requires an '$ARG_PAYROLL_RUN_ID' nav argument"
+    }
+
+    private val _state = MutableStateFlow<HrPayrollDetailUiState>(HrPayrollDetailUiState.Loading)
+    val state: StateFlow<HrPayrollDetailUiState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun retry() = load()
+
+    private fun load() {
+        _state.value = HrPayrollDetailUiState.Loading
+        viewModelScope.launch {
+            _state.value = when (val r = repository.getPayrollRun(payrollRunId)) {
+                is ApiResult.Success -> {
+                    val lines = (repository.getPayrollRunLines(payrollRunId) as? ApiResult.Success)?.data
+                        ?: r.data.lines
+                    HrPayrollDetailUiState.Content(r.data, lines)
+                }
+                is ApiResult.Failure -> when (r.error.status) {
+                    404 -> HrPayrollDetailUiState.Unavailable
+                    403 -> HrPayrollDetailUiState.Error("You do not have access to HR.", canRetry = false)
+                    else -> HrPayrollDetailUiState.Error(
+                        r.error.message.ifBlank { "Could not load payroll run." },
+                        canRetry = true,
+                    )
+                }
+                is ApiResult.NetworkError ->
+                    HrPayrollDetailUiState.Error("Network error. Check your connection.", canRetry = true)
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_PAYROLL_RUN_ID = "payroll_run_id"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1360,6 +1360,16 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.ACCOUNT,
             operatorOnly = true,
         ),
+        // HRM-009: HR & payroll (positions / employments / payroll views). Admin/root only server-side.
+        MoreEntry(
+            id = "hr",
+            labelRes = R.string.more_entry_hr,
+            icon = Icons.Outlined.Groups,
+            route = MoreRoutes.HR,
+            hub = MoreHub.ADMIN,
+            section = MoreSection.ACCOUNT,
+            operatorOnly = true,
+        ),
         MoreEntry(
             id = "subscription_tiers",
             labelRes = R.string.more_entry_subscription_tiers,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -308,6 +308,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         fanClubDestinations(navController)
         // AND-243: invoices list (paged) + invoice detail (line items/totals + email + view-PDF).
         invoicesDestinations(navController)
+        // HRM-009: HR & payroll hub (positions/employments/payroll read) + employment/payroll detail.
+        hrDestinations(navController)
         // AND-244: refund-requests list + submit (from order/txn detail) + detail (status tracking).
         refundsDestinations(navController)
         // AND-245: disputes list + file (open a dispute from order/txn detail) + detail (status).

--- a/android/app/src/main/java/com/testlogon/android/navigation/HrNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/HrNavigation.kt
@@ -1,0 +1,61 @@
+package com.testlogon.android.navigation
+
+import android.net.Uri
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.feature.hr.HrEmploymentDetailRoute
+import com.testlogon.android.feature.hr.HrEmploymentDetailViewModel
+import com.testlogon.android.feature.hr.HrHubRoute
+import com.testlogon.android.feature.hr.HrPayrollDetailRoute
+import com.testlogon.android.feature.hr.HrPayrollDetailViewModel
+
+/** HRM-009 — the HR hub route (operator-only; reached from the More hub). */
+data object HrHubDest {
+    const val ROUTE = "hr"
+}
+
+/** HRM-009 — employment detail route; arg is the STRING employment_id. */
+data object HrEmploymentDetailDest {
+    const val ARG = HrEmploymentDetailViewModel.ARG_EMPLOYMENT_ID
+    const val ROUTE = "hr/employments/{$ARG}"
+
+    fun build(employmentId: String): String = "hr/employments/${Uri.encode(employmentId)}"
+}
+
+/** HRM-009 — payroll-run detail route; arg is the STRING payroll_run_id. */
+data object HrPayrollDetailDest {
+    const val ARG = HrPayrollDetailViewModel.ARG_PAYROLL_RUN_ID
+    const val ROUTE = "hr/payroll/{$ARG}"
+
+    fun build(payrollRunId: String): String = "hr/payroll/${Uri.encode(payrollRunId)}"
+}
+
+/** HRM-009 — registers the HR hub + detail destinations in the authenticated graph. */
+fun NavGraphBuilder.hrDestinations(navController: NavHostController) {
+    composable(HrHubDest.ROUTE) {
+        HrHubRoute(
+            onEmploymentClick = { id ->
+                navController.navigate(HrEmploymentDetailDest.build(id)) { launchSingleTop = true }
+            },
+            onPayrollClick = { id ->
+                navController.navigate(HrPayrollDetailDest.build(id)) { launchSingleTop = true }
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable(
+        route = HrEmploymentDetailDest.ROUTE,
+        arguments = listOf(navArgument(HrEmploymentDetailDest.ARG) { type = NavType.StringType }),
+    ) {
+        HrEmploymentDetailRoute(onBack = { navController.popBackStack() })
+    }
+    composable(
+        route = HrPayrollDetailDest.ROUTE,
+        arguments = listOf(navArgument(HrPayrollDetailDest.ARG) { type = NavType.StringType }),
+    ) {
+        HrPayrollDetailRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -172,6 +172,9 @@ object MoreRoutes {
     // AND-248: the read-only billing-config view (root-gated server-side; 403 surfaces as an error).
     const val BILLING_CONFIG = BillingConfigDest.ROUTE
 
+    // HRM-009: the HR & payroll hub (positions / employments / payroll runs read views). Operator-only.
+    const val HR = HrHubDest.ROUTE
+
     // AND-252: the creator earnings dashboard (totals + chart + breakdown). Base route (no range arg);
     // the registered composable route carries an optional `?range=` deep-link arg.
     const val EARNINGS = EarningsDest.ROUTE_BASE
@@ -720,6 +723,7 @@ object MoreRoutes {
             TAX_DOCUMENTS,
             TAX_FORMS_1099,
             BILLING_CONFIG,
+            HR,
             SUBSCRIPTION_TIERS,
             CREATOR_SUBSCRIBERS,
             CREATOR_TIERS,

--- a/android/app/src/main/res/values/strings_hr.xml
+++ b/android/app/src/main/res/values/strings_hr.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- HRM-009 - HR / Payroll surface strings (operator-only More hub entry + hub/detail screens). -->
+<resources>
+    <!-- More hub entry -->
+    <string name="more_entry_hr">HR &amp; payroll</string>
+
+    <!-- Hub -->
+    <string name="hr_title">HR &amp; payroll</string>
+    <string name="hr_tab_positions">Positions</string>
+    <string name="hr_tab_employments">Employments</string>
+    <string name="hr_tab_payroll">Payroll</string>
+    <string name="hr_positions_empty">No positions.</string>
+    <string name="hr_employments_empty">No employments.</string>
+    <string name="hr_payroll_empty">No payroll runs.</string>
+
+    <!-- Degrade-on-404 (feature flag off) -->
+    <string name="hr_unavailable_title">HR is not enabled</string>
+    <string name="hr_unavailable_body">The HR &amp; payroll module is not enabled for this account.</string>
+
+    <!-- Employment detail -->
+    <string name="hr_employment_detail_title">Employment</string>
+    <string name="hr_field_status">Status</string>
+    <string name="hr_field_position">Position</string>
+    <string name="hr_field_party">Employee</string>
+    <string name="hr_field_org">Organization</string>
+    <string name="hr_field_pay_rate">Pay rate</string>
+    <string name="hr_field_pay_period">Pay period</string>
+    <string name="hr_field_annualized">Annualized</string>
+    <string name="hr_field_start">Start date</string>
+    <string name="hr_field_end">End date</string>
+    <string name="hr_field_tenure">Tenure</string>
+
+    <!-- Payroll detail -->
+    <string name="hr_payroll_detail_title">Payroll run</string>
+    <string name="hr_field_period">Period</string>
+    <string name="hr_field_gross_total">Gross total</string>
+    <string name="hr_field_approved_by">Approved by</string>
+    <string name="hr_field_posted_at">Posted</string>
+    <string name="hr_payroll_lines_header">Lines</string>
+    <string name="hr_payroll_lines_empty">No lines.</string>
+</resources>

--- a/android/app/src/test/java/com/testlogon/android/core/model/hr/HrMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/core/model/hr/HrMathTest.kt
@@ -1,0 +1,146 @@
+package com.testlogon.android.core.model.hr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** HRM-009 — pure JVM unit tests for [HrMath] (no Android / network deps). */
+class HrMathTest {
+
+    private fun line(cents: Long, currency: String = "USD") =
+        PayrollLine(employmentId = "e", partyId = "p", gross = HrMoney(cents, currency))
+
+    private fun employment(
+        rateCents: Long,
+        period: PayPeriod,
+        start: Long? = null,
+        end: Long? = null,
+        currency: String = "USD",
+    ) = Employment(
+        employmentId = "e1",
+        partyId = "p1",
+        positionId = "pos1",
+        orgPartyId = "org1",
+        status = EmploymentStatus.ACTIVE,
+        startDateEpochSeconds = start,
+        endDateEpochSeconds = end,
+        payRate = HrMoney(rateCents, currency),
+        payPeriod = period,
+        createdAtEpochSeconds = null,
+        updatedAtEpochSeconds = null,
+    )
+
+    private fun run(lines: List<PayrollLine>) = PayrollRun(
+        payrollRunId = "r1",
+        periodStartEpochSeconds = null,
+        periodEndEpochSeconds = null,
+        status = PayrollRunStatus.DRAFT,
+        lines = lines,
+        approvedBy = null,
+        postedAtEpochSeconds = null,
+        createdAtEpochSeconds = null,
+        updatedAtEpochSeconds = null,
+    )
+
+    @Test
+    fun totalGrossCents_sumsLines() {
+        assertEquals(0L, HrMath.totalGrossCents(emptyList()))
+        assertEquals(6000L, HrMath.totalGrossCents(listOf(line(1000), line(2000), line(3000))))
+    }
+
+    @Test
+    fun runGrossTotal_usesFirstLineCurrency() {
+        val total = HrMath.runGrossTotal(run(listOf(line(2500, "EUR"), line(2500, "EUR"))))
+        assertEquals(5000L, total.cents)
+        assertEquals("EUR", total.currency)
+    }
+
+    @Test
+    fun runGrossTotal_emptyUsesFallbackCurrency() {
+        val total = HrMath.runGrossTotal(run(emptyList()), fallbackCurrency = "GBP")
+        assertEquals(0L, total.cents)
+        assertEquals("GBP", total.currency)
+    }
+
+    @Test
+    fun formatMoney_padsMinorUnits() {
+        assertEquals("12.34 USD", HrMath.formatMoney(HrMoney(1234, "usd")))
+        assertEquals("12.05 USD", HrMath.formatMoney(HrMoney(1205, "USD")))
+        assertEquals("0.00 USD", HrMath.formatMoney(HrMoney(0, "USD")))
+    }
+
+    @Test
+    fun formatMoney_handlesNegative() {
+        assertEquals("-5.00 USD", HrMath.formatMoney(HrMoney(-500, "USD")))
+    }
+
+    @Test
+    fun tenureDays_nullWhenNoStart() {
+        assertNull(HrMath.tenureDays(null, null, nowEpochSeconds = 1_000_000))
+        assertNull(HrMath.tenureDays(0, null, nowEpochSeconds = 1_000_000))
+    }
+
+    @Test
+    fun tenureDays_nullWhenStartInFuture() {
+        assertNull(HrMath.tenureDays(2_000_000, null, nowEpochSeconds = 1_000_000))
+    }
+
+    @Test
+    fun tenureDays_countsWholeDays() {
+        val start = HrMath.SECONDS_PER_DAY // day 1 (positive; 0 means "no date")
+        val now = 11L * HrMath.SECONDS_PER_DAY + 500L // 10 days after start + change
+        assertEquals(10L, HrMath.tenureDays(start, null, now))
+    }
+
+    @Test
+    fun tenureDays_usesEndWhenPresent() {
+        val start = HrMath.SECONDS_PER_DAY
+        val end = 4L * HrMath.SECONDS_PER_DAY // 3 days after start
+        assertEquals(3L, HrMath.tenureDays(start, end, nowEpochSeconds = 999L * HrMath.SECONDS_PER_DAY))
+    }
+
+    @Test
+    fun tenureLabel_days() {
+        assertEquals("0 days", HrMath.tenureLabel(0))
+        assertEquals("1 day", HrMath.tenureLabel(1))
+        assertEquals("29 days", HrMath.tenureLabel(29))
+        assertNull(HrMath.tenureLabel(null))
+    }
+
+    @Test
+    fun tenureLabel_months() {
+        assertEquals("2 months", HrMath.tenureLabel(90))
+        assertEquals("1 month", HrMath.tenureLabel(30))
+    }
+
+    @Test
+    fun tenureLabel_years() {
+        assertEquals("1 year", HrMath.tenureLabel(366))
+        val twoYearsFourMonths = (2 * 365.25 + 4 * 30.4375).toLong()
+        assertEquals("2 years, 4 months", HrMath.tenureLabel(twoYearsFourMonths))
+    }
+
+    @Test
+    fun annualizedCents_perPeriod() {
+        assertEquals(120_000L, HrMath.annualizedCents(10_000, PayPeriod.MONTHLY))
+        assertEquals(260_000L, HrMath.annualizedCents(10_000, PayPeriod.BIWEEKLY))
+        assertEquals(520_000L, HrMath.annualizedCents(10_000, PayPeriod.WEEKLY))
+        assertEquals(52_000L * 40, HrMath.annualizedCents(1_000, PayPeriod.HOURLY))
+        assertNull(HrMath.annualizedCents(1_000, PayPeriod.UNKNOWN))
+    }
+
+    @Test
+    fun annualizedComp_preservesCurrency() {
+        val comp = HrMath.annualizedComp(employment(10_000, PayPeriod.MONTHLY, currency = "CAD"))
+        assertEquals(120_000L, comp?.cents)
+        assertEquals("CAD", comp?.currency)
+        assertNull(HrMath.annualizedComp(employment(10_000, PayPeriod.UNKNOWN)))
+    }
+
+    @Test
+    fun payRateLabel_suffixesPeriod() {
+        assertEquals("100.00 USD / month", HrMath.payRateLabel(employment(10_000, PayPeriod.MONTHLY)))
+        assertEquals("10.00 USD / hour", HrMath.payRateLabel(employment(1_000, PayPeriod.HOURLY)))
+        assertEquals("100.00 USD", HrMath.payRateLabel(employment(10_000, PayPeriod.UNKNOWN)))
+    }
+}

--- a/android/core-model/src/main/java/com/testlogon/android/core/model/hr/HrMath.kt
+++ b/android/core-model/src/main/java/com/testlogon/android/core/model/hr/HrMath.kt
@@ -1,0 +1,133 @@
+package com.testlogon.android.core.model.hr
+
+/**
+ * HRM-009 (Android) — pure (framework-free) HR / payroll arithmetic + formatting helpers.
+ *
+ * Deliberately has NO Android / network / coroutine / java.time dependency so it is unit-testable on the
+ * plain JVM (see HrMathTest). All money is integer *_cents; there is NO float money arithmetic.
+ *
+ * Mirrors the backend contract (app/routers/hr.py, app/services/hr_payroll.py) + the web contract
+ * (frontend/src/api/endpoints/hr.ts):
+ *  - Money is integer cents + ISO-4217 currency.
+ *  - Dates/timestamps are epoch-SECONDS.
+ *  - A payroll run's gross total is the sum of its line gross_cents (single currency per run).
+ */
+object HrMath {
+
+    const val SECONDS_PER_DAY: Long = 86_400L
+    private const val DAYS_PER_YEAR = 365.25
+    private const val DAYS_PER_MONTH = 30.4375 // 365.25 / 12
+
+    /**
+     * Sum the gross cents of a set of payroll lines. Callers should pass lines of ONE currency (a run is
+     * single-currency); this sums the raw cents regardless. Empty -> 0.
+     */
+    fun totalGrossCents(lines: List<PayrollLine>): Long =
+        lines.fold(0L) { acc, ln -> acc + ln.gross.cents }
+
+    /**
+     * The gross total of a payroll run as [HrMoney]. Currency is taken from the first line, falling back
+     * to [fallbackCurrency] when the run has no lines. Never throws.
+     */
+    fun runGrossTotal(run: PayrollRun, fallbackCurrency: String = "USD"): HrMoney {
+        val currency = run.lines.firstOrNull()?.gross?.currency ?: fallbackCurrency
+        return HrMoney(totalGrossCents(run.lines), currency)
+    }
+
+    /**
+     * Format integer cents as a plain major-unit decimal string with 2 fraction digits and the currency
+     * code appended, e.g. 123456 / "USD" -> "1234.56 USD". Locale-independent (no grouping) so it is
+     * deterministic in tests; the screen may re-format with the device locale. Negative cents are
+     * rendered with a leading '-'.
+     */
+    fun formatMoney(money: HrMoney): String {
+        val cents = money.cents
+        val negative = cents < 0
+        val abs = if (negative) -cents else cents
+        val major = abs / 100
+        val minor = abs % 100
+        val sign = if (negative) "-" else ""
+        val minorStr = if (minor < 10) "0$minor" else minor.toString()
+        return "$sign$major.$minorStr ${money.currency.uppercase()}"
+    }
+
+    /**
+     * Whole days between [startEpochSeconds] and an end (or "now"). Returns null when the start is null or
+     * in the future relative to the end. Uses floor division on the second delta.
+     */
+    fun tenureDays(startEpochSeconds: Long?, endEpochSeconds: Long?, nowEpochSeconds: Long): Long? {
+        if (startEpochSeconds == null || startEpochSeconds <= 0) return null
+        val end = endEpochSeconds ?: nowEpochSeconds
+        val delta = end - startEpochSeconds
+        if (delta < 0) return null
+        return delta / SECONDS_PER_DAY
+    }
+
+    /**
+     * Human tenure label from a day count, e.g. "0 days", "1 day", "3 months", "1 year", "2 years, 4
+     * months". Returns null for a null day count. 1..29 days -> "N day(s)"; <1 year -> "N month(s)";
+     * >=1 year -> "Y year(s)[, M month(s)]".
+     */
+    fun tenureLabel(days: Long?): String? {
+        if (days == null) return null
+        if (days < 0) return null
+        if (days < 30) return "$days ${plural(days, "day")}"
+        val years = (days / DAYS_PER_YEAR).toLong()
+        if (years < 1) {
+            val months = (days / DAYS_PER_MONTH).toLong().coerceAtLeast(1)
+            return "$months ${plural(months, "month")}"
+        }
+        val remainderDays = days - (years * DAYS_PER_YEAR).toLong()
+        val months = (remainderDays / DAYS_PER_MONTH).toLong()
+        val yearPart = "$years ${plural(years, "year")}"
+        return if (months <= 0) yearPart else "$yearPart, $months ${plural(months, "month")}"
+    }
+
+    /** Convenience: tenure label directly from an employment's dates. */
+    fun employmentTenureLabel(employment: Employment, nowEpochSeconds: Long): String? =
+        tenureLabel(
+            tenureDays(
+                employment.startDateEpochSeconds,
+                employment.endDateEpochSeconds,
+                nowEpochSeconds,
+            ),
+        )
+
+    /**
+     * Annualised compensation in cents for a pay rate at a given [PayPeriod]. HOURLY assumes a
+     * [hoursPerWeek] work week (default 40) x 52 weeks. Returns null for an UNKNOWN period. Never throws.
+     */
+    fun annualizedCents(
+        payRateCents: Long,
+        period: PayPeriod,
+        hoursPerWeek: Int = 40,
+    ): Long? = when (period) {
+        PayPeriod.MONTHLY -> payRateCents * 12
+        PayPeriod.BIWEEKLY -> payRateCents * 26
+        PayPeriod.WEEKLY -> payRateCents * 52
+        PayPeriod.HOURLY -> payRateCents * hoursPerWeek.toLong() * 52L
+        PayPeriod.UNKNOWN -> null
+    }
+
+    /** Annualised compensation as [HrMoney] (currency preserved). Null when the period is UNKNOWN. */
+    fun annualizedComp(employment: Employment, hoursPerWeek: Int = 40): HrMoney? {
+        val cents = annualizedCents(employment.payRate.cents, employment.payPeriod, hoursPerWeek)
+            ?: return null
+        return HrMoney(cents, employment.payRate.currency)
+    }
+
+    /** A short pay-rate label, e.g. "1234.56 USD / month". Falls back to a bare amount for UNKNOWN. */
+    fun payRateLabel(employment: Employment): String {
+        val amount = formatMoney(employment.payRate)
+        val suffix = when (employment.payPeriod) {
+            PayPeriod.MONTHLY -> " / month"
+            PayPeriod.BIWEEKLY -> " / 2 weeks"
+            PayPeriod.WEEKLY -> " / week"
+            PayPeriod.HOURLY -> " / hour"
+            PayPeriod.UNKNOWN -> ""
+        }
+        return "$amount$suffix"
+    }
+
+    private fun plural(n: Long, unit: String): String = if (n == 1L) unit else "${unit}s"
+}

--- a/android/core-model/src/main/java/com/testlogon/android/core/model/hr/HrModel.kt
+++ b/android/core-model/src/main/java/com/testlogon/android/core/model/hr/HrModel.kt
@@ -1,0 +1,122 @@
+package com.testlogon.android.core.model.hr
+
+/**
+ * HRM-009 (Android) — framework-free HR / Payroll domain models.
+ *
+ * Conventions (matching core-model/invoices, core-model/syndicates):
+ *  - Money is integer cents + ISO-4217 currency (the backend's `*_cents`). No BigDecimal / float.
+ *  - Timestamps/dates are epoch-SECONDS Longs (NOT java.time) so this stays JVM-unit-testable; screens
+ *    format via a pure helper. A 0 / null value maps to null.
+ *  - Enums use an UNKNOWN fallback for forward compatibility (the backend statuses are free strings).
+ *
+ * These are pure data classes; DTO -> domain mapping lives in the app-layer repository (which owns the
+ * Retrofit DTOs). This module has NO network/Android dependency.
+ */
+
+/** Integer cents + ISO-4217 currency. */
+data class HrMoney(val cents: Long, val currency: String)
+
+/** Position lifecycle. Backend values: OPEN | FILLED | CLOSED. */
+enum class PositionStatus {
+    OPEN, FILLED, CLOSED, UNKNOWN;
+
+    companion object {
+        fun fromWire(value: String?): PositionStatus = when (value?.uppercase()) {
+            "OPEN" -> OPEN
+            "FILLED" -> FILLED
+            "CLOSED" -> CLOSED
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** Employment lifecycle. Backend values: ACTIVE | TERMINATED | ON_LEAVE. */
+enum class EmploymentStatus {
+    ACTIVE, TERMINATED, ON_LEAVE, UNKNOWN;
+
+    companion object {
+        fun fromWire(value: String?): EmploymentStatus = when (value?.uppercase()) {
+            "ACTIVE" -> ACTIVE
+            "TERMINATED" -> TERMINATED
+            "ON_LEAVE" -> ON_LEAVE
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** Pay cadence. Backend values: MONTHLY | BIWEEKLY | WEEKLY | HOURLY. */
+enum class PayPeriod {
+    MONTHLY, BIWEEKLY, WEEKLY, HOURLY, UNKNOWN;
+
+    companion object {
+        fun fromWire(value: String?): PayPeriod = when (value?.uppercase()) {
+            "MONTHLY" -> MONTHLY
+            "BIWEEKLY" -> BIWEEKLY
+            "WEEKLY" -> WEEKLY
+            "HOURLY" -> HOURLY
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** Payroll-run lifecycle. Backend values: DRAFT | APPROVED | POSTED. */
+enum class PayrollRunStatus {
+    DRAFT, APPROVED, POSTED, UNKNOWN;
+
+    companion object {
+        fun fromWire(value: String?): PayrollRunStatus = when (value?.uppercase()) {
+            "DRAFT" -> DRAFT
+            "APPROVED" -> APPROVED
+            "POSTED" -> POSTED
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** A job position. [department] may be blank/absent. */
+data class Position(
+    val positionId: String,
+    val title: String,
+    val department: String?,
+    val status: PositionStatus,
+    val createdAtEpochSeconds: Long?,
+    val updatedAtEpochSeconds: Long?,
+)
+
+/** An employment record (a party in a position, at a pay rate). */
+data class Employment(
+    val employmentId: String,
+    val partyId: String,
+    val positionId: String,
+    val orgPartyId: String,
+    val status: EmploymentStatus,
+    val startDateEpochSeconds: Long?,
+    val endDateEpochSeconds: Long?,
+    val payRate: HrMoney,
+    val payPeriod: PayPeriod,
+    val createdAtEpochSeconds: Long?,
+    val updatedAtEpochSeconds: Long?,
+)
+
+/** A single payroll line: gross pay for one employment within a run. */
+data class PayrollLine(
+    val employmentId: String,
+    val partyId: String,
+    val gross: HrMoney,
+)
+
+/** A payroll run header + its embedded lines. */
+data class PayrollRun(
+    val payrollRunId: String,
+    val periodStartEpochSeconds: Long?,
+    val periodEndEpochSeconds: Long?,
+    val status: PayrollRunStatus,
+    val lines: List<PayrollLine>,
+    val approvedBy: String?,
+    val postedAtEpochSeconds: Long?,
+    val createdAtEpochSeconds: Long?,
+    val updatedAtEpochSeconds: Long?,
+)
+
+/** One page of items + the forward cursor (null / blank = end of pagination). */
+data class HrPage<T>(val items: List<T>, val nextCursor: String?)

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/hr/HrApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/hr/HrApi.kt
@@ -1,0 +1,159 @@
+package com.testlogon.android.core.network.hr
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * HRM-009 (Android) — Retrofit interface + Moshi DTOs for the OFBiz HR / Payroll surface.
+ *
+ * Prefix `/ui/hr`; admin/root only. Feature-flag guarded server-side (hr_enabled / hr_payroll_enabled):
+ * when off the backend answers 404 {code:"hr_disabled"|"hr_payroll_disabled"} — the repository/ViewModel
+ * degrade that to an empty/unavailable surface rather than an error.
+ *
+ * VERIFIED against the web contract (frontend/src/api/endpoints/hr.ts) + backend app/routers/hr.py.
+ * Money is uniformly integer cents (`*_cents`); dates/timestamps are epoch-SECONDS Longs. Session cookie +
+ * Authorization Bearer + X-CSRF-Token are attached by the shared core-network interceptors.
+ *
+ * Scope here is the READ surface (list/detail/view). The mutating routes (create/patch/terminate/
+ * approve/post) exist on the backend but are intentionally NOT surfaced on Android in this pass.
+ *
+ * Endpoint citations (app/routers/hr.py / hr.ts):
+ *  - GET ui/hr/positions                       -> {items:[Position], next_cursor}
+ *  - GET ui/hr/positions/{position_id}         -> Position
+ *  - GET ui/hr/employments                     -> {items:[Employment], next_cursor}
+ *  - GET ui/hr/employments/{employment_id}     -> Employment
+ *  - GET ui/hr/payroll                         -> {items:[PayrollRun], next_cursor}
+ *  - GET ui/hr/payroll/{payroll_run_id}        -> PayrollRun
+ *  - GET ui/hr/payroll/{payroll_run_id}/lines  -> {lines:[PayrollLine]}
+ */
+interface HrApi {
+
+    /** Paged positions list. `status` filter is optional (OPEN|FILLED|CLOSED). Idempotent GET. */
+    @GET("ui/hr/positions")
+    suspend fun listPositions(
+        @Query("status") status: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int = DEFAULT_LIMIT,
+    ): PositionPageDto
+
+    /** A single position's detail. Idempotent GET. */
+    @GET("ui/hr/positions/{position_id}")
+    suspend fun getPosition(@Path("position_id") positionId: String): PositionDto
+
+    /** Paged employments list. `party_id`/`status` filters optional. Idempotent GET. */
+    @GET("ui/hr/employments")
+    suspend fun listEmployments(
+        @Query("party_id") partyId: String? = null,
+        @Query("status") status: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int = DEFAULT_LIMIT,
+    ): EmploymentPageDto
+
+    /** A single employment's detail. Idempotent GET. */
+    @GET("ui/hr/employments/{employment_id}")
+    suspend fun getEmployment(@Path("employment_id") employmentId: String): EmploymentDto
+
+    /** Paged payroll-run list. `status` filter optional (DRAFT|APPROVED|POSTED). Idempotent GET. */
+    @GET("ui/hr/payroll")
+    suspend fun listPayrollRuns(
+        @Query("status") status: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int = DEFAULT_LIMIT,
+    ): PayrollRunPageDto
+
+    /** A single payroll run (header + embedded lines). Idempotent GET. */
+    @GET("ui/hr/payroll/{payroll_run_id}")
+    suspend fun getPayrollRun(@Path("payroll_run_id") payrollRunId: String): PayrollRunDto
+
+    /** The payroll run's line breakdown ({lines:[...]}). Idempotent GET. */
+    @GET("ui/hr/payroll/{payroll_run_id}/lines")
+    suspend fun getPayrollRunLines(@Path("payroll_run_id") payrollRunId: String): PayrollLinesDto
+
+    companion object {
+        const val DEFAULT_LIMIT = 50
+    }
+}
+
+// ---- Position DTOs ----
+
+/** Position (PositionOut). Verified: hr.ts Position. `department` is nullable upstream. */
+@JsonClass(generateAdapter = true)
+data class PositionDto(
+    @Json(name = "position_id") val positionId: String,
+    @Json(name = "title") val title: String = "",
+    @Json(name = "department") val department: String? = null,
+    @Json(name = "status") val status: String = "OPEN",
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class PositionPageDto(
+    @Json(name = "items") val items: List<PositionDto> = emptyList(),
+    @Json(name = "next_cursor") val nextCursor: String? = null,
+)
+
+// ---- Employment DTOs ----
+
+/** Employment (EmploymentOut). Verified: hr.ts Employment. `end_date` nullable (null = still active). */
+@JsonClass(generateAdapter = true)
+data class EmploymentDto(
+    @Json(name = "employment_id") val employmentId: String,
+    @Json(name = "party_id") val partyId: String = "",
+    @Json(name = "position_id") val positionId: String = "",
+    @Json(name = "org_party_id") val orgPartyId: String = "",
+    @Json(name = "status") val status: String = "ACTIVE",
+    @Json(name = "start_date") val startDate: Long = 0,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "pay_rate_cents") val payRateCents: Long = 0,
+    @Json(name = "pay_period") val payPeriod: String = "MONTHLY",
+    @Json(name = "currency") val currency: String = "USD",
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class EmploymentPageDto(
+    @Json(name = "items") val items: List<EmploymentDto> = emptyList(),
+    @Json(name = "next_cursor") val nextCursor: String? = null,
+)
+
+// ---- Payroll DTOs ----
+
+/** A single payroll line (gross pay for one employment). Verified: hr.ts PayrollLine. */
+@JsonClass(generateAdapter = true)
+data class PayrollLineDto(
+    @Json(name = "employment_id") val employmentId: String = "",
+    @Json(name = "party_id") val partyId: String = "",
+    @Json(name = "gross_cents") val grossCents: Long = 0,
+    @Json(name = "currency") val currency: String = "USD",
+)
+
+/** PayrollRun (PayrollRunOut). Verified: hr.ts PayrollRun. `lines` embedded; period_* epoch-seconds. */
+@JsonClass(generateAdapter = true)
+data class PayrollRunDto(
+    @Json(name = "payroll_run_id") val payrollRunId: String,
+    @Json(name = "period_start") val periodStart: Long = 0,
+    @Json(name = "period_end") val periodEnd: Long = 0,
+    @Json(name = "status") val status: String = "DRAFT",
+    @Json(name = "lines") val lines: List<PayrollLineDto> = emptyList(),
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+    @Json(name = "approved_by") val approvedBy: String? = null,
+    @Json(name = "posted_at") val postedAt: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PayrollRunPageDto(
+    @Json(name = "items") val items: List<PayrollRunDto> = emptyList(),
+    @Json(name = "next_cursor") val nextCursor: String? = null,
+)
+
+/** PayrollLinesResp. Verified: hr.ts PayrollLinesResp — the flat {lines:[...]} envelope. */
+@JsonClass(generateAdapter = true)
+data class PayrollLinesDto(
+    @Json(name = "lines") val lines: List<PayrollLineDto> = emptyList(),
+)


### PR DESCRIPTION
## PAR-143 - Android HR parity (positions / employments / payroll)

Brings the native Android client to parity with the web HR surfaces:

- HR hub listing positions and employments
- Employment detail screen
- Payroll detail / breakdown screen
- New `core-model` HR types + math helpers, `core-network` `HrApi`, repository, and DI module
- More-hub + navigation wiring (gated)

Unit-tested (`HrMathTest`); feature-gated behind the More catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
