### PR TITLE
FE parity PAR-142 - Android Knowledge Base

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/knowledgebase/KbMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/knowledgebase/KbMath.kt
@@ -1,0 +1,152 @@
+package com.testlogon.android.data.knowledgebase
+
+import com.testlogon.android.core.model.kb.KbArticleSummary
+import com.testlogon.android.core.network.kb.KbConstants
+
+/**
+ * KB-AND-1 - PURE, framework-free logic for the Knowledge Base surface. No Android / java.time types, so every
+ * function here is JVM-unit-testable (mirrors the PurchaseHistoryMath idiom).
+ *
+ * Responsibilities:
+ *  - htmlToPlainText: turn raw server body_html into a Compose-safe plain-text body (no WebView / no HTML
+ *    renderer). Degrade, never throw: unknown / malformed markup passes through as text.
+ *  - snippet: build a bounded excerpt for a list row (prefer the server excerpt, else derive from the body).
+ *  - client-side search filter + relevance ranking (used when the caller wants to filter a already-loaded
+ *    page locally, and by the search screen's query pre-validation).
+ *  - status / helpfulness formatting helpers.
+ *
+ * Degrade-on-404: the repository maps a 404 (KB flag off) to an EMPTY list; these helpers all treat empty /
+ * null inputs as "nothing to show" rather than throwing, so the empty state renders cleanly.
+ */
+object KbMath {
+
+    /** Max characters in a derived list snippet before an ellipsis is appended. */
+    const val SNIPPET_MAX_LENGTH: Int = 160
+
+    /** The minimum trimmed query length the search screen will actually dispatch (shorter -> no-op). */
+    const val MIN_QUERY_LENGTH: Int = 2
+
+    private val TAG_REGEX = Regex("<[^>]*>")
+    private val WHITESPACE_REGEX = Regex("\\s+")
+
+    /** A small map of the common named/numeric HTML entities the KB body uses; unknown entities pass through. */
+    private val ENTITIES: Map<String, String> = mapOf(
+        "&amp;" to "&",
+        "&lt;" to "<",
+        "&gt;" to ">",
+        "&quot;" to "\"",
+        "&#39;" to "'",
+        "&apos;" to "'",
+        "&nbsp;" to " ",
+    )
+
+    /**
+     * Strips HTML tags from raw body_html and returns collapsed plain text. Block-level tags (</p>, <br>, <li>
+     * ...) are converted to a single newline BEFORE tag removal so paragraphs don't run together; remaining
+     * tags are dropped; a small entity table is decoded; runs of spaces/tabs collapse to one space while
+     * paragraph newlines are preserved. Null / blank -> "". Never throws (malformed markup degrades to text).
+     */
+    fun htmlToPlainText(html: String?): String {
+        val raw = html?.takeIf { it.isNotBlank() } ?: return ""
+        // Normalise block boundaries to newlines so structure survives tag stripping.
+        var s = raw
+            .replace(Regex("(?i)<\\s*br\\s*/?>"), "\n")
+            .replace(Regex("(?i)</\\s*(p|div|li|h[1-6]|tr|ul|ol|blockquote)\\s*>"), "\n")
+            .replace(Regex("(?i)<\\s*li[^>]*>"), "\n• ")
+        s = TAG_REGEX.replace(s, "")
+        s = decodeEntities(s)
+        // Collapse horizontal whitespace per line, drop empty lines, trim.
+        val lines = s.split('\n')
+            .map { WHITESPACE_REGEX.replace(it, " ").trim() }
+            .filter { it.isNotEmpty() }
+        return lines.joinToString("\n")
+    }
+
+    /** Decodes the known entity set; leaves unknown entities as-is (forward-compatible, never throws). */
+    internal fun decodeEntities(text: String): String {
+        var out = text
+        for ((entity, replacement) in ENTITIES) {
+            out = out.replace(entity, replacement)
+        }
+        return out
+    }
+
+    /**
+     * A bounded one-line snippet for a list row. Prefers a non-blank server [excerpt]; otherwise derives one
+     * from the plain-text [body]. The result is single-line (newlines -> spaces), trimmed, and truncated to
+     * [SNIPPET_MAX_LENGTH] with an ellipsis on a word boundary. Empty inputs -> "".
+     */
+    fun snippet(excerpt: String?, body: String?, maxLength: Int = SNIPPET_MAX_LENGTH): String {
+        val source = excerpt?.takeIf { it.isNotBlank() } ?: body.orEmpty()
+        val flat = WHITESPACE_REGEX.replace(source.replace('\n', ' '), " ").trim()
+        if (flat.length <= maxLength) return flat
+        val cut = flat.substring(0, maxLength)
+        val lastSpace = cut.lastIndexOf(' ')
+        val base = if (lastSpace >= maxLength / 2) cut.substring(0, lastSpace) else cut
+        return base.trimEnd().trimEnd('.', ',', ';', ':') + "…"
+    }
+
+    /** True when [query] is worth dispatching to the server search (trimmed length >= [MIN_QUERY_LENGTH]). */
+    fun isSearchable(query: String?): Boolean =
+        (query?.trim()?.length ?: 0) >= MIN_QUERY_LENGTH
+
+    /** Human label for a raw article status token. Unknown / blank -> a Title-Cased fallback or "". */
+    fun statusLabel(status: String?): String = when (status?.trim()?.lowercase()) {
+        KbConstants.ArticleStatus.DRAFT -> "Draft"
+        KbConstants.ArticleStatus.PUBLISHED -> "Published"
+        KbConstants.ArticleStatus.EXPIRED -> "Expired"
+        null, "" -> ""
+        else -> status.trim().replaceFirstChar { it.uppercase() }
+    }
+
+    /**
+     * Helpfulness ratio 0f..1f (helpful / (helpful + notHelpful)), or null when there are NO votes (so the UI
+     * hides the meter rather than showing a misleading 0%). Negative inputs are clamped to 0.
+     */
+    fun helpfulnessRatio(helpful: Long, notHelpful: Long): Float? {
+        val up = helpful.coerceAtLeast(0L)
+        val down = notHelpful.coerceAtLeast(0L)
+        val total = up + down
+        if (total <= 0L) return null
+        return up.toFloat() / total.toFloat()
+    }
+
+    /** Formats [helpfulnessRatio] as a whole-percent string ("83%"); null ratio -> "". */
+    fun helpfulnessPercent(helpful: Long, notHelpful: Long): String {
+        val ratio = helpfulnessRatio(helpful, notHelpful) ?: return ""
+        return "${Math.round(ratio * 100f)}%"
+    }
+
+    /**
+     * CLIENT-SIDE relevance filter + ranking over an already-loaded page (used to refine a loaded list without
+     * a round-trip). Case-insensitive substring match over title + excerpt + tags. A blank query returns the
+     * input unchanged (server order preserved). Ranking: title-prefix > title-contains > tag-match >
+     * excerpt-contains; ties keep the incoming order (stable sort).
+     */
+    fun filterAndRank(items: List<KbArticleSummary>, query: String?): List<KbArticleSummary> {
+        val q = query?.trim()?.lowercase().orEmpty()
+        if (q.isEmpty()) return items
+        return items
+            .mapNotNull { item ->
+                val score = relevanceScore(item, q)
+                if (score <= 0) null else item to score
+            }
+            .sortedByDescending { it.second }
+            .map { it.first }
+    }
+
+    /** Higher is more relevant; 0 means no match. Pure integer scoring so ties are deterministic. */
+    internal fun relevanceScore(item: KbArticleSummary, lowerQuery: String): Int {
+        if (lowerQuery.isEmpty()) return 0
+        val title = item.title?.lowercase().orEmpty()
+        val excerpt = item.excerpt?.lowercase().orEmpty()
+        val tags = item.tags.map { it.lowercase() }
+        var score = 0
+        if (title.startsWith(lowerQuery)) score += 100
+        if (title.contains(lowerQuery)) score += 40
+        if (tags.any { it == lowerQuery }) score += 30
+        if (tags.any { it.contains(lowerQuery) }) score += 15
+        if (excerpt.contains(lowerQuery)) score += 10
+        return score
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/data/KbDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/data/KbDataModule.kt
@@ -1,0 +1,22 @@
+package com.testlogon.android.feature.knowledgebase.data
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * KB-AND-1 - Hilt wiring for the READ-ONLY Knowledge Base feature. Binds the repository seam to its default
+ * impl, which consumes the [com.testlogon.android.core.network.kb.KbApi] and the shared
+ * [com.testlogon.android.core.network.error.ApiErrorParser]. NO new endpoint module, migration, or dependency
+ * is added here. Mirrors the AND-372 TicketsDataModule pattern.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class KbDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindKbRepository(impl: KbRepositoryImpl): KbRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/data/KbMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/data/KbMappers.kt
@@ -1,0 +1,71 @@
+package com.testlogon.android.feature.knowledgebase.data
+
+import com.testlogon.android.core.model.kb.KbArticle
+import com.testlogon.android.core.model.kb.KbArticleSummary
+import com.testlogon.android.core.model.kb.KbAttachment
+import com.testlogon.android.core.model.kb.KbCategory
+import com.testlogon.android.core.network.kb.KbArticleDto
+import com.testlogon.android.core.network.kb.KbArticleSummaryDto
+import com.testlogon.android.core.network.kb.KbAttachmentDto
+import com.testlogon.android.core.network.kb.KbCategoryDto
+import com.testlogon.android.data.knowledgebase.KbMath
+
+/**
+ * KB-AND-1 - DTO -> domain mappers for the READ-ONLY Knowledge Base surface.
+ *
+ * PLACEMENT: core-model has NO dependency on core-network's DTOs (and core-network has no domain dep), so the
+ * bridging mapper lives here in the :app feature, which depends on BOTH (mirrors AND-372 TicketMappers).
+ *
+ * Key transforms:
+ *  - the enum-like `status` field is kept RAW (unknown-safe - no enum parse, never throws).
+ *  - the full article's raw body_html is stripped to PLAIN TEXT here (KbMath.htmlToPlainText) so the Compose
+ *    renderer never sees markup.
+ *  - counters (view / helpful / not_helpful) default to 0 when the wire omits them.
+ *  - timestamps pass through as EPOCH-seconds Longs.
+ */
+fun KbArticleSummaryDto.toDomain(): KbArticleSummary = KbArticleSummary(
+    articleId = articleId,
+    title = title,
+    excerpt = excerpt,
+    status = status,
+    categoryId = categoryId,
+    category = category,
+    tags = tags,
+    updatedAt = updatedAt,
+    viewCount = viewCount ?: 0L,
+    helpfulCount = helpfulCount ?: 0L,
+    notHelpfulCount = notHelpfulCount ?: 0L,
+)
+
+fun KbArticleDto.toDomain(): KbArticle = KbArticle(
+    articleId = articleId,
+    title = title,
+    body = KbMath.htmlToPlainText(bodyHtml),
+    excerpt = excerpt,
+    status = status,
+    categoryId = categoryId,
+    category = category,
+    authorSub = authorSub,
+    tags = tags,
+    updatedAt = updatedAt,
+    publishedAt = publishedAt,
+    viewCount = viewCount ?: 0L,
+    helpfulCount = helpfulCount ?: 0L,
+    notHelpfulCount = notHelpfulCount ?: 0L,
+    attachments = attachments.map { it.toDomain() },
+)
+
+fun KbAttachmentDto.toDomain(): KbAttachment = KbAttachment(
+    attachmentId = attachmentId,
+    filename = filename,
+    contentType = contentType,
+    sizeBytes = sizeBytes,
+    url = url,
+)
+
+fun KbCategoryDto.toDomain(): KbCategory = KbCategory(
+    categoryId = categoryId,
+    name = name,
+    description = description,
+    sortOrder = sortOrder ?: 0,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/data/KbRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/data/KbRepository.kt
@@ -1,0 +1,114 @@
+package com.testlogon.android.feature.knowledgebase.data
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.kb.KbArticle
+import com.testlogon.android.core.model.kb.KbArticleSummary
+import com.testlogon.android.core.model.kb.KbCategory
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.kb.KbApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * KB-AND-1 - READ-ONLY data layer for the Knowledge Base (help centre) surface, over the [KbApi] transport.
+ *
+ * Reads the AUTHENTICATED /kb/ endpoints (list / search / detail / categories) and maps the RAW DTO to the
+ * core-model domain, folding into [ApiResult] via [call] (mirrors AND-372 TicketsRepository).
+ *
+ * DEGRADE-ON-404: the KB routes 404 when knowledge_base_enabled is off (flag defaults off). A 404 is NOT an
+ * error surface here - the list / search / categories reads map a 404 to an EMPTY Success (the screen shows a
+ * clean empty state), and the article detail read maps a 404 to Success(null) (the screen shows "not found").
+ * Every OTHER HTTP status, malformed JSON, and transport failure still surfaces as Failure / NetworkError.
+ *
+ * NO mutations, NO Room cache, NO paging this wave (the KB list is a single bounded first-page GET; cursor
+ * paging is DEFERRED - the cursor is threaded on the API but the repo takes the first page).
+ */
+interface KbRepository {
+
+    /** GET published articles (optionally scoped to [categoryId]), mapped. 404 -> empty. */
+    suspend fun listArticles(categoryId: String? = null): ApiResult<List<KbArticleSummary>>
+
+    /** Full-text search, mapped. A blank query and a 404 both map to an empty Success. */
+    suspend fun search(query: String): ApiResult<List<KbArticleSummary>>
+
+    /** GET one full article, mapped. 404 -> Success(null) (flag off OR unknown id -> "not found"). */
+    suspend fun getArticle(articleId: String): ApiResult<KbArticle?>
+
+    /** GET the KB categories, mapped. 404 -> empty. */
+    suspend fun listCategories(): ApiResult<List<KbCategory>>
+
+    companion object {
+        const val PAGE_LIMIT = 50
+    }
+}
+
+@Singleton
+class KbRepositoryImpl @Inject constructor(
+    private val api: KbApi,
+    private val errorParser: ApiErrorParser,
+) : KbRepository {
+
+    override suspend fun listArticles(categoryId: String?): ApiResult<List<KbArticleSummary>> =
+        withContext(Dispatchers.IO) {
+            callOr404Empty(emptyList()) {
+                api.listArticles(categoryId = categoryId, limit = KbRepository.PAGE_LIMIT)
+                    .items.map { it.toDomain() }
+            }
+        }
+
+    override suspend fun search(query: String): ApiResult<List<KbArticleSummary>> =
+        withContext(Dispatchers.IO) {
+            val q = query.trim()
+            if (q.isEmpty()) return@withContext ApiResult.Success(emptyList())
+            callOr404Empty(emptyList()) {
+                api.search(q = q, limit = KbRepository.PAGE_LIMIT).items.map { it.toDomain() }
+            }
+        }
+
+    override suspend fun getArticle(articleId: String): ApiResult<KbArticle?> =
+        withContext(Dispatchers.IO) {
+            callOr404Empty<KbArticle?>(null) {
+                api.getArticle(articleId).toDomain()
+            }
+        }
+
+    override suspend fun listCategories(): ApiResult<List<KbCategory>> =
+        withContext(Dispatchers.IO) {
+            callOr404Empty(emptyList()) {
+                api.listCategories().categories.map { it.toDomain() }
+            }
+        }
+
+    /**
+     * Folds a block into [ApiResult] with DEGRADE-ON-404: an HTTP 404 (KB flag off / unknown id) resolves to
+     * Success([fallback]) instead of a Failure. Every other HTTP status -> Failure (via [ApiErrorParser],
+     * preserving the code so a 401 still surfaces as Failure(status=401) for the VM's re-auth handoff);
+     * malformed JSON -> Failure; transport failures -> NetworkError. Cancellation is re-thrown.
+     */
+    private suspend fun <T> callOr404Empty(fallback: T, block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == HTTP_NOT_FOUND) ApiResult.Success(fallback)
+        else ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private companion object {
+        const val HTTP_NOT_FOUND = 404
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbDetailScreen.kt
@@ -1,0 +1,196 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.knowledgebase.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Article
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.R
+import com.testlogon.android.core.model.kb.KbArticle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.StaleBanner
+
+/** KB-AND-1 - stable testTags for the Knowledge Base article detail screen. */
+object KbDetailTestTags {
+    const val SCREEN = "kb_detail_screen"
+    const val NOT_FOUND = "kb_detail_not_found"
+    const val ERROR_RETRY = "kb_detail_error_retry"
+    const val BODY = "kb_detail_body"
+}
+
+/**
+ * KB-AND-1 - route-level entry for the Knowledge Base article detail (screen 2). Collects the state and wires
+ * the one-shot NavigateToLogin effect to the re-auth handoff.
+ */
+@Composable
+fun KbDetailRoute(
+    onBack: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    viewModel: KbDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is KbEffect.NavigateToLogin -> onNavigateToLogin()
+            }
+        }
+    }
+
+    KbDetailScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onRetry = viewModel::onRetry,
+    )
+}
+
+/** KB-AND-1 - stateless Knowledge Base article detail (title + tags + plain-text body). */
+@Composable
+fun KbDetailScreen(
+    state: KbDetailUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(KbDetailTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.kb_detail_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.kb_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        val isRefreshing = (state as? KbDetailUiState.Content)?.isRefreshing == true
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = onRefresh,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            when (state) {
+                is KbDetailUiState.Loading -> LoadingState()
+
+                is KbDetailUiState.NotFound ->
+                    EmptyState(
+                        modifier = Modifier.testTag(KbDetailTestTags.NOT_FOUND),
+                        title = stringResource(R.string.kb_detail_not_found_title),
+                        body = stringResource(R.string.kb_detail_not_found_body),
+                        imageVector = Icons.Outlined.Article,
+                    )
+
+                is KbDetailUiState.Error ->
+                    ErrorState(
+                        modifier = Modifier.testTag(KbDetailTestTags.ERROR_RETRY),
+                        message = state.error.message,
+                        onRetry = onRetry,
+                    )
+
+                is KbDetailUiState.Content ->
+                    KbDetailContent(article = state.article, isStale = state.isStale, onRetry = onRetry)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun KbDetailContent(
+    article: KbArticle,
+    isStale: Boolean,
+    onRetry: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        StaleBanner(stale = isStale, refreshing = false, onRetry = onRetry)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = article.title?.ifBlank { null } ?: stringResource(R.string.kb_article_untitled),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            val meta = detailMeta(article)
+            if (meta.isNotBlank()) {
+                Text(
+                    text = meta,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (article.tags.isNotEmpty()) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    article.tags.forEach { tag ->
+                        AssistChip(onClick = {}, enabled = false, label = { Text(tag) })
+                    }
+                }
+            }
+            HorizontalDivider()
+            val body = article.body?.ifBlank { null } ?: article.excerpt?.ifBlank { null }
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(KbDetailTestTags.BODY),
+                text = body ?: stringResource(R.string.kb_detail_empty_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+/** Category • helpfulness • updated-time meta line for the detail header (blank parts dropped). */
+@Composable
+private fun detailMeta(article: KbArticle): String {
+    val parts = mutableListOf<String>()
+    article.category?.ifBlank { null }?.let { parts.add(it) }
+    val pct = com.testlogon.android.data.knowledgebase.KbMath
+        .helpfulnessPercent(article.helpfulCount, article.notHelpfulCount)
+    if (pct.isNotBlank()) parts.add(stringResource(R.string.kb_helpful_pct, pct))
+    val updated = kbRelativeTime(article.updatedAt)
+    if (updated.isNotBlank()) parts.add(stringResource(R.string.kb_updated, updated))
+    return parts.joinToString("  •  ")
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbDetailUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbDetailUiState.kt
@@ -1,0 +1,27 @@
+package com.testlogon.android.feature.knowledgebase.ui
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.kb.KbArticle
+
+/**
+ * KB-AND-1 - the exhaustive UI state for the Knowledge Base ARTICLE DETAIL screen.
+ *
+ * [Loading] is the first-load spinner; [Content] carries the full article (body already plain-text) plus an
+ * in-memory [isStale] flag; [NotFound] is the degrade-on-404 state (KB flag off OR unknown id -> Success(null)
+ * from the repo); [Error] carries the [ApiError]. A terminal 401 is emitted as a one-shot
+ * [KbEffect.NavigateToLogin], not a variant.
+ */
+sealed interface KbDetailUiState {
+
+    data object Loading : KbDetailUiState
+
+    data class Content(
+        val article: KbArticle,
+        val isRefreshing: Boolean = false,
+        val isStale: Boolean = false,
+    ) : KbDetailUiState
+
+    data object NotFound : KbDetailUiState
+
+    data class Error(val error: ApiError) : KbDetailUiState
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbDetailViewModel.kt
@@ -1,0 +1,112 @@
+package com.testlogon.android.feature.knowledgebase.ui
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.feature.knowledgebase.data.KbRepository
+import com.testlogon.android.navigation.KbArticleDetailDest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * KB-AND-1 - drives the [KbDetailUiState] for the Knowledge Base ARTICLE DETAIL screen.
+ *
+ * articleId arrives as a nav arg via [SavedStateHandle] (survives process death). [load] fetches the full
+ * article (repo maps a 404 to Success(null) -> [KbDetailUiState.NotFound], degrade-on-404). Pull-to-refresh
+ * re-reads but, on a NON-401 failure, KEEPS the last-good Content and flips isStale (IN-MEMORY only). A
+ * TERMINAL 401 -> one-shot [KbEffect.NavigateToLogin] (re-auth handoff).
+ */
+@HiltViewModel
+class KbDetailViewModel @Inject constructor(
+    private val repository: KbRepository,
+    savedState: SavedStateHandle,
+) : ViewModel() {
+
+    val articleId: String =
+        checkNotNull(savedState[KbArticleDetailDest.ARG_ARTICLE_ID]) {
+            "missing ${KbArticleDetailDest.ARG_ARTICLE_ID} nav arg"
+        }
+
+    private val _uiState = MutableStateFlow<KbDetailUiState>(KbDetailUiState.Loading)
+    val uiState: StateFlow<KbDetailUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<KbEffect>(Channel.BUFFERED)
+    val effects: Flow<KbEffect> = _effects.receiveAsFlow()
+
+    private var loadJob: Job? = null
+
+    init {
+        load()
+    }
+
+    fun load() {
+        if (loadJob?.isActive == true) return
+        _uiState.value = KbDetailUiState.Loading
+        fetch(isRefresh = false)
+    }
+
+    fun onRetry() = load()
+
+    fun refresh() {
+        if (loadJob?.isActive == true) return
+        (_uiState.value as? KbDetailUiState.Content)?.let {
+            _uiState.value = it.copy(isRefreshing = true)
+        }
+        fetch(isRefresh = true)
+    }
+
+    private fun fetch(isRefresh: Boolean) {
+        loadJob = viewModelScope.launch {
+            when (val result = repository.getArticle(articleId)) {
+                is ApiResult.Success -> {
+                    val article = result.data
+                    _uiState.value = if (article == null) {
+                        KbDetailUiState.NotFound
+                    } else {
+                        KbDetailUiState.Content(article = article, isRefreshing = false, isStale = false)
+                    }
+                }
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) {
+                        _effects.send(KbEffect.NavigateToLogin)
+                        clearRefreshing()
+                    } else {
+                        emitFailure(isRefresh, result.error)
+                    }
+                }
+                is ApiResult.NetworkError ->
+                    emitFailure(isRefresh, ApiError(status = ApiError.STATUS_NETWORK, message = OFFLINE_FALLBACK))
+            }
+        }
+    }
+
+    private fun emitFailure(isRefresh: Boolean, error: ApiError) {
+        val prior = _uiState.value as? KbDetailUiState.Content
+        _uiState.value = if (isRefresh && prior != null) {
+            prior.copy(isRefreshing = false, isStale = true)
+        } else {
+            KbDetailUiState.Error(error)
+        }
+    }
+
+    private fun clearRefreshing() {
+        (_uiState.value as? KbDetailUiState.Content)?.let {
+            _uiState.value = it.copy(isRefreshing = false)
+        }
+    }
+
+    private companion object {
+        const val HTTP_UNAUTHORIZED = 401
+        const val OFFLINE_FALLBACK = "Couldn't reach the server. Pull down to retry."
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbListScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbListScreen.kt
@@ -1,0 +1,314 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.knowledgebase.ui
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.MenuBook
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.R
+import com.testlogon.android.core.model.kb.KbArticleSummary
+import com.testlogon.android.core.model.kb.KbCategory
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.StaleBanner
+import com.testlogon.android.data.knowledgebase.KbMath
+
+/** KB-AND-1 - stable testTags for the Knowledge Base list / search screen + its rows. */
+object KbListTestTags {
+    const val SCREEN = "kb_list_screen"
+    const val SEARCH = "kb_search_field"
+    const val EMPTY = "kb_empty"
+    const val ERROR_RETRY = "kb_error_retry"
+
+    fun row(articleId: String) = "kb_article_row_$articleId"
+}
+
+/**
+ * KB-AND-1 - route-level entry for the Knowledge Base list (screen 1). Collects the state, wires the one-shot
+ * NavigateToLogin effect to the re-auth handoff, and taps through to an article's detail.
+ */
+@Composable
+fun KbListRoute(
+    onBack: () -> Unit,
+    onOpenArticle: (String) -> Unit,
+    onNavigateToLogin: () -> Unit,
+    viewModel: KbListViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is KbEffect.NavigateToLogin -> onNavigateToLogin()
+            }
+        }
+    }
+
+    KbListScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onRetry = viewModel::onRetry,
+        onQueryChange = viewModel::onQueryChange,
+        onSelectCategory = viewModel::onSelectCategory,
+        onArticleClick = onOpenArticle,
+    )
+}
+
+/** KB-AND-1 - stateless Knowledge Base list: search box + optional category chips + article rows. */
+@Composable
+fun KbListScreen(
+    state: KbListUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onQueryChange: (String) -> Unit,
+    onSelectCategory: (String?) -> Unit,
+    onArticleClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(KbListTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.kb_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.kb_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        val content = state as? KbListUiState.Content
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            KbSearchField(
+                query = content?.query.orEmpty(),
+                onQueryChange = onQueryChange,
+            )
+            if (content != null && content.categories.isNotEmpty()) {
+                KbCategoryChips(
+                    categories = content.categories,
+                    selectedId = content.selectedCategoryId,
+                    onSelect = onSelectCategory,
+                )
+            }
+            val isRefreshing = content?.isRefreshing == true
+            PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                when (state) {
+                    is KbListUiState.Loading -> LoadingState()
+
+                    is KbListUiState.Empty ->
+                        EmptyState(
+                            modifier = Modifier.testTag(KbListTestTags.EMPTY),
+                            title = stringResource(R.string.kb_empty_title),
+                            body = stringResource(R.string.kb_empty_body),
+                            imageVector = Icons.Outlined.MenuBook,
+                        )
+
+                    is KbListUiState.Error ->
+                        ErrorState(
+                            modifier = Modifier.testTag(KbListTestTags.ERROR_RETRY),
+                            message = state.error.message,
+                            onRetry = onRetry,
+                        )
+
+                    is KbListUiState.Content ->
+                        KbListContent(state = state, onRetry = onRetry, onArticleClick = onArticleClick)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun KbSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        singleLine = true,
+        leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
+        placeholder = { Text(stringResource(R.string.kb_search_placeholder)) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag(KbListTestTags.SEARCH),
+    )
+}
+
+@Composable
+private fun KbCategoryChips(
+    categories: List<KbCategory>,
+    selectedId: String?,
+    onSelect: (String?) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FilterChip(
+            selected = selectedId == null,
+            onClick = { onSelect(null) },
+            label = { Text(stringResource(R.string.kb_category_all)) },
+        )
+        categories.forEach { cat ->
+            FilterChip(
+                selected = selectedId == cat.categoryId,
+                onClick = { onSelect(cat.categoryId) },
+                label = {
+                    Text(cat.name?.ifBlank { null } ?: stringResource(R.string.kb_category_untitled))
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun KbListContent(
+    state: KbListUiState.Content,
+    onRetry: () -> Unit,
+    onArticleClick: (String) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        StaleBanner(stale = state.isStale, refreshing = false, onRetry = onRetry)
+        if (state.articles.isEmpty()) {
+            EmptyState(
+                modifier = Modifier.testTag(KbListTestTags.EMPTY),
+                title = stringResource(R.string.kb_no_results_title),
+                body = stringResource(R.string.kb_no_results_body),
+                imageVector = Icons.Outlined.Search,
+            )
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(items = state.articles, key = { it.articleId }) { article ->
+                    KbArticleRow(article = article, onClick = { onArticleClick(article.articleId) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun KbArticleRow(
+    article: KbArticleSummary,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .testTag(KbListTestTags.row(article.articleId))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = article.title?.ifBlank { null } ?: stringResource(R.string.kb_article_untitled),
+                style = MaterialTheme.typography.titleSmall,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val snippet = KbMath.snippet(article.excerpt, null)
+            if (snippet.isNotBlank()) {
+                Text(
+                    text = snippet,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            val meta = buildRowMeta(article)
+            if (meta.isNotBlank()) {
+                Text(
+                    text = meta,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/** Composes the secondary meta line: category • helpfulness • updated-time (blank parts dropped). */
+@Composable
+private fun buildRowMeta(article: KbArticleSummary): String {
+    val parts = mutableListOf<String>()
+    article.category?.ifBlank { null }?.let { parts.add(it) }
+    val pct = KbMath.helpfulnessPercent(article.helpfulCount, article.notHelpfulCount)
+    if (pct.isNotBlank()) parts.add(stringResource(R.string.kb_helpful_pct, pct))
+    val updated = kbRelativeTime(article.updatedAt)
+    if (updated.isNotBlank()) parts.add(stringResource(R.string.kb_updated, updated))
+    return parts.joinToString("  •  ")
+}
+
+/**
+ * KB-AND-1 - relative-time copy from an EPOCH-SECONDS value. UI-only (android.text.format); returns "" for
+ * null / non-positive timestamps. Mirrors the AND-372 tickets helper.
+ */
+internal fun kbRelativeTime(epochSeconds: Long?, nowMs: Long = System.currentTimeMillis()): String {
+    if (epochSeconds == null || epochSeconds <= 0L) return ""
+    return DateUtils.getRelativeTimeSpanString(
+        epochSeconds * 1000L,
+        nowMs,
+        DateUtils.MINUTE_IN_MILLIS,
+    ).toString()
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbListUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbListUiState.kt
@@ -1,0 +1,40 @@
+package com.testlogon.android.feature.knowledgebase.ui
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.kb.KbArticleSummary
+import com.testlogon.android.core.model.kb.KbCategory
+
+/**
+ * KB-AND-1 - the exhaustive UI state for the Knowledge Base LIST / SEARCH screen.
+ *
+ * Sealed so the screen renders mutually-exclusive surfaces; a new variant forces an exhaustive `when`.
+ * [Loading] is the first-load spinner; [Content] carries the articles + the (optional) category chips + the
+ * active query + an in-memory [isStale] flag (last-good kept on a refresh failure) + [isRefreshing];
+ * [Empty] is the zero-results state (also the degrade-on-404 state - the KB flag is off); [Error] carries the
+ * [ApiError]. A terminal 401 is NOT a variant - it is a one-shot [KbEffect.NavigateToLogin].
+ */
+sealed interface KbListUiState {
+
+    data object Loading : KbListUiState
+
+    data class Content(
+        val articles: List<KbArticleSummary>,
+        val categories: List<KbCategory> = emptyList(),
+        val selectedCategoryId: String? = null,
+        val query: String = "",
+        val isRefreshing: Boolean = false,
+        val isStale: Boolean = false,
+    ) : KbListUiState
+
+    data object Empty : KbListUiState
+
+    data class Error(val error: ApiError) : KbListUiState
+}
+
+/**
+ * KB-AND-1 - one-shot navigation effects for the KB ViewModels. [NavigateToLogin] is emitted on a TERMINAL 401
+ * so the screen routes to the login / unauthenticated graph (re-auth handoff) rather than a generic error.
+ */
+sealed interface KbEffect {
+    data object NavigateToLogin : KbEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbListViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/knowledgebase/ui/KbListViewModel.kt
@@ -1,0 +1,156 @@
+package com.testlogon.android.feature.knowledgebase.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.kb.KbArticleSummary
+import com.testlogon.android.core.model.kb.KbCategory
+import com.testlogon.android.data.knowledgebase.KbMath
+import com.testlogon.android.feature.knowledgebase.data.KbRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * KB-AND-1 - drives the [KbListUiState] for the Knowledge Base LIST / SEARCH screen.
+ *
+ * On init it loads the categories (best-effort) + the first page of published articles. A non-blank query
+ * routes to the search endpoint; clearing the query (or a too-short query) falls back to the category-scoped
+ * list. Selecting a category chip re-lists scoped to it. Pull-to-refresh re-reads but, on a NON-401 failure,
+ * KEEPS the last-good content and flips isStale (IN-MEMORY only). A TERMINAL 401 -> one-shot
+ * [KbEffect.NavigateToLogin]. Degrade-on-404 (KB flag off) resolves to the clean [KbListUiState.Empty].
+ */
+@HiltViewModel
+class KbListViewModel @Inject constructor(
+    private val repository: KbRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<KbListUiState>(KbListUiState.Loading)
+    val uiState: StateFlow<KbListUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<KbEffect>(Channel.BUFFERED)
+    val effects: Flow<KbEffect> = _effects.receiveAsFlow()
+
+    private var categories: List<KbCategory> = emptyList()
+    private var query: String = ""
+    private var selectedCategoryId: String? = null
+    private var loadJob: Job? = null
+
+    init {
+        load()
+    }
+
+    fun load() {
+        if (loadJob?.isActive == true) return
+        _uiState.value = KbListUiState.Loading
+        fetch(isRefresh = false)
+    }
+
+    fun onRetry() = load()
+
+    fun refresh() {
+        if (loadJob?.isActive == true) return
+        (_uiState.value as? KbListUiState.Content)?.let {
+            _uiState.value = it.copy(isRefreshing = true)
+        }
+        fetch(isRefresh = true)
+    }
+
+    /** Called as the user edits the search box. Empty / too-short -> the category-scoped list. */
+    fun onQueryChange(newQuery: String) {
+        query = newQuery
+        if (loadJob?.isActive == true) return
+        _uiState.value = KbListUiState.Loading
+        fetch(isRefresh = false)
+    }
+
+    /** Selecting a category chip (null clears the filter). Ignored while a query is active. */
+    fun onSelectCategory(categoryId: String?) {
+        selectedCategoryId = categoryId
+        if (loadJob?.isActive == true) return
+        _uiState.value = KbListUiState.Loading
+        fetch(isRefresh = false)
+    }
+
+    private fun fetch(isRefresh: Boolean) {
+        loadJob = viewModelScope.launch {
+            // Categories are best-effort; a failure there never blocks the article list.
+            if (categories.isEmpty()) {
+                (repository.listCategories() as? ApiResult.Success)?.let { categories = it.data }
+            }
+
+            val result: ApiResult<List<KbArticleSummary>> =
+                if (KbMath.isSearchable(query)) {
+                    repository.search(query.trim())
+                } else {
+                    repository.listArticles(categoryId = selectedCategoryId)
+                }
+
+            when (result) {
+                is ApiResult.Success -> emitSuccess(result.data)
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) {
+                        _effects.send(KbEffect.NavigateToLogin)
+                        clearRefreshing()
+                    } else {
+                        emitFailure(isRefresh, result.error)
+                    }
+                }
+                is ApiResult.NetworkError ->
+                    emitFailure(isRefresh, ApiError(status = ApiError.STATUS_NETWORK, message = OFFLINE_FALLBACK))
+            }
+        }
+    }
+
+    private fun emitSuccess(articles: List<KbArticleSummary>) {
+        _uiState.value = if (articles.isEmpty()) {
+            // Distinguish a filtered/searched-but-empty result from a raw empty: still Empty, but keep the
+            // chrome (chips + query) so the user can clear the filter — only when there is a query/filter.
+            if (query.isBlank() && selectedCategoryId == null) {
+                KbListUiState.Empty
+            } else {
+                KbListUiState.Content(
+                    articles = emptyList(),
+                    categories = categories,
+                    selectedCategoryId = selectedCategoryId,
+                    query = query,
+                )
+            }
+        } else {
+            KbListUiState.Content(
+                articles = articles,
+                categories = categories,
+                selectedCategoryId = selectedCategoryId,
+                query = query,
+            )
+        }
+    }
+
+    private fun emitFailure(isRefresh: Boolean, error: ApiError) {
+        val prior = _uiState.value as? KbListUiState.Content
+        _uiState.value = if (isRefresh && prior != null) {
+            prior.copy(isRefreshing = false, isStale = true)
+        } else {
+            KbListUiState.Error(error)
+        }
+    }
+
+    private fun clearRefreshing() {
+        (_uiState.value as? KbListUiState.Content)?.let {
+            _uiState.value = it.copy(isRefreshing = false)
+        }
+    }
+
+    private companion object {
+        const val HTTP_UNAUTHORIZED = 401
+        const val OFFLINE_FALLBACK = "Couldn't reach the server. Pull down to retry."
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.outlined.Copyright
 import androidx.compose.material.icons.outlined.CardGiftcard
 import androidx.compose.material.icons.outlined.ReceiptLong
 import androidx.compose.material.icons.outlined.ManageSearch
+import androidx.compose.material.icons.outlined.MenuBook
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.outlined.Sell
 import androidx.compose.material.icons.outlined.Balance
@@ -1670,6 +1671,15 @@ class MoreCatalog @Inject constructor() {
             labelRes = R.string.more_entry_tickets,
             icon = Icons.Outlined.SupportAgent,
             route = MoreRoutes.TICKETS,
+            hub = MoreHub.SUPPORT,
+            section = MoreSection.SUPPORT,
+        ),
+        // KB-AND-1: READ-ONLY Knowledge Base (help centre). Article list / search -> detail.
+        MoreEntry(
+            id = "knowledge_base",
+            labelRes = R.string.more_entry_knowledge_base,
+            icon = Icons.Outlined.MenuBook,
+            route = MoreRoutes.KNOWLEDGE_BASE,
             hub = MoreHub.SUPPORT,
             section = MoreSection.SUPPORT,
         ),

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -518,6 +518,9 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // list (Paging-3 over the AND-371 next_cursor) -> a ticket thread (embedded messages, mine-vs-other).
         // Composing / replying / member or status edits are AND-373 and OUT OF SCOPE.
         ticketsDestinations(navController)
+        // KB-AND-1: READ-ONLY Knowledge Base (help centre). Article list / search -> article detail.
+        // Degrade-on-404 when knowledge_base_enabled is off (clean empty / not-found).
+        knowledgeBaseDestinations(navController)
         // B-SUP (batch 7): role-branched Support. The landing resolves /ui/me.is_admin and renders the
         // USER help experience (create + view my tickets) or the ADMIN helpdesk/moderation queue, then
         // drills into a shared ticket thread (isAdmin nav arg gates the admin status/assign controls).

--- a/android/app/src/main/java/com/testlogon/android/navigation/KnowledgeBaseNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/KnowledgeBaseNavigation.kt
@@ -1,0 +1,61 @@
+package com.testlogon.android.navigation
+
+import android.net.Uri
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.core.model.LogoutReason
+import com.testlogon.android.feature.knowledgebase.ui.KbDetailRoute
+import com.testlogon.android.feature.knowledgebase.ui.KbListRoute
+
+/**
+ * KB-AND-1 - the READ-ONLY Knowledge Base (help centre) destinations: an article LIST / SEARCH -> an article
+ * DETAIL. The detail ViewModel reads its {articleId} nav arg from SavedStateHandle. There are NO mutations
+ * (create / edit / rate are OUT OF SCOPE this wave). Degrade-on-404: when the KB flag is off the list resolves
+ * to a clean empty state and detail resolves to "not found".
+ */
+data object KbListDest {
+    const val ROUTE = "kb/articles"
+}
+
+data object KbArticleDetailDest {
+    const val ARG_ARTICLE_ID = "articleId"
+    const val ROUTE = "kb/articles/{$ARG_ARTICLE_ID}"
+
+    fun build(articleId: String): String = "kb/articles/${Uri.encode(articleId)}"
+}
+
+/**
+ * KB-AND-1 - registers the KB list -> detail destinations in the authenticated graph (one shared nav graph;
+ * NOT forked). Each screen's one-shot NavigateToLogin effect (a TERMINAL 401) routes to the login /
+ * unauthenticated graph carrying [LogoutReason.SESSION_EXPIRED] (mirrors the AND-372 tickets handoff).
+ */
+fun NavGraphBuilder.knowledgeBaseDestinations(navController: NavHostController) {
+    composable(route = KbListDest.ROUTE) {
+        KbListRoute(
+            onBack = { navController.popBackStack() },
+            onOpenArticle = { articleId ->
+                navController.navigate(KbArticleDetailDest.build(articleId)) { launchSingleTop = true }
+            },
+            onNavigateToLogin = { navController.navigateToKbReauth() },
+        )
+    }
+    composable(
+        route = KbArticleDetailDest.ROUTE,
+        arguments = listOf(
+            navArgument(KbArticleDetailDest.ARG_ARTICLE_ID) { type = NavType.StringType },
+        ),
+    ) {
+        KbDetailRoute(
+            onBack = { navController.popBackStack() },
+            onNavigateToLogin = { navController.navigateToKbReauth() },
+        )
+    }
+}
+
+/** KB-AND-1 - the terminal-401 re-auth handoff (mirrors the AND-372 tickets handoff). */
+private fun NavHostController.navigateToKbReauth() {
+    navigate(AuthDest.Login.build(LogoutReason.SESSION_EXPIRED.name)) { launchSingleTop = true }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -406,6 +406,9 @@ object MoreRoutes {
     // AND-372: READ-ONLY ticket spaces + threads (support / helpdesk). Spaces list -> ticket list -> thread.
     const val TICKETS = TicketSpacesListDest.ROUTE
 
+    // KB-AND-1: READ-ONLY Knowledge Base (help centre). Article list / search -> detail.
+    const val KNOWLEDGE_BASE = KbListDest.ROUTE
+
     // B-SUP (batch 7): the role-branched Support landing (USER help / ADMIN helpdesk queue).
     const val SUPPORT = SupportDest.ROUTE
 
@@ -757,6 +760,7 @@ object MoreRoutes {
             BOOSTS,
             SEO,
             TICKETS,
+            KNOWLEDGE_BASE,
             SUPPORT,
             WEBHOOKS,
             ADMIN_DASHBOARD,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4288,6 +4288,24 @@
     <string name="tickets_message_empty">(no message)</string>
     <string name="ticket_reply_placeholder">Write a reply…</string>
     <string name="ticket_reply_send_cd">Send reply</string>
+    <!-- KB-AND-1: READ-ONLY Knowledge Base (help centre). Article list / search -> detail. -->
+    <string name="more_entry_knowledge_base">Knowledge base</string>
+    <string name="kb_title">Knowledge base</string>
+    <string name="kb_back">Back</string>
+    <string name="kb_search_placeholder">Search help articles</string>
+    <string name="kb_category_all">All</string>
+    <string name="kb_category_untitled">Category</string>
+    <string name="kb_article_untitled">Untitled article</string>
+    <string name="kb_empty_title">No articles yet</string>
+    <string name="kb_empty_body">Published help articles will appear here.</string>
+    <string name="kb_no_results_title">No matching articles</string>
+    <string name="kb_no_results_body">Try a different search or clear the filter.</string>
+    <string name="kb_helpful_pct">%1$s helpful</string>
+    <string name="kb_updated">Updated %1$s</string>
+    <string name="kb_detail_title">Article</string>
+    <string name="kb_detail_not_found_title">Article unavailable</string>
+    <string name="kb_detail_not_found_body">This article could not be found.</string>
+    <string name="kb_detail_empty_body">This article has no content yet.</string>
     <string name="ticket_reply_char_counter">%1$d / %2$d</string>
     <string name="ticket_reply_sending">Sending…</string>
     <string name="ticket_reply_failed">Couldn\'t send</string>

--- a/android/app/src/test/java/com/testlogon/android/data/knowledgebase/KbMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/knowledgebase/KbMathTest.kt
@@ -1,0 +1,167 @@
+package com.testlogon.android.data.knowledgebase
+
+import com.testlogon.android.core.model.kb.KbArticleSummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * KB-AND-1 - JVM unit tests for the pure Knowledge Base logic (HTML-to-text, snippet, search predicates,
+ * relevance ranking, status + helpfulness formatting). No Android types; degrade-on-empty / degrade-on-bad
+ * input is asserted so the UI never crashes on dev-host drift or a 404 (KB flag off).
+ */
+class KbMathTest {
+
+    private fun summary(
+        id: String = "a",
+        title: String? = null,
+        excerpt: String? = null,
+        tags: List<String> = emptyList(),
+    ) = KbArticleSummary(articleId = id, title = title, excerpt = excerpt, tags = tags)
+
+    // ---- htmlToPlainText ----
+
+    @Test
+    fun htmlToPlainText_nullOrBlank_returnsEmpty() {
+        assertEquals("", KbMath.htmlToPlainText(null))
+        assertEquals("", KbMath.htmlToPlainText("   "))
+    }
+
+    @Test
+    fun htmlToPlainText_stripsTags_andDecodesEntities() {
+        val html = "<p>Hello &amp; <b>welcome</b></p>"
+        assertEquals("Hello & welcome", KbMath.htmlToPlainText(html))
+    }
+
+    @Test
+    fun htmlToPlainText_blockTags_becomeNewlines_notRunTogether() {
+        val html = "<p>First para</p><p>Second para</p>"
+        assertEquals("First para\nSecond para", KbMath.htmlToPlainText(html))
+    }
+
+    @Test
+    fun htmlToPlainText_listItems_getBullets() {
+        val html = "<ul><li>One</li><li>Two</li></ul>"
+        val out = KbMath.htmlToPlainText(html)
+        assertTrue(out.contains("• One"))
+        assertTrue(out.contains("• Two"))
+    }
+
+    @Test
+    fun htmlToPlainText_malformedMarkup_degradesToText_neverThrows() {
+        // Closed tags are stripped; the unknown entity is passed through verbatim (forward-compatible).
+        val out = KbMath.htmlToPlainText("<div>text <span>inner</span> &unknownentity;</div>")
+        assertFalse("closed tags must be stripped", out.contains("<span>"))
+        assertTrue(out.contains("text"))
+        assertTrue(out.contains("inner"))
+        assertTrue(out.contains("&unknownentity;"))
+    }
+
+    @Test
+    fun htmlToPlainText_collapsesWhitespace() {
+        assertEquals("a b c", KbMath.htmlToPlainText("a   b\t\t c"))
+    }
+
+    // ---- snippet ----
+
+    @Test
+    fun snippet_prefersExcerpt_overBody() {
+        assertEquals("The excerpt", KbMath.snippet("The excerpt", "the body text"))
+    }
+
+    @Test
+    fun snippet_fallsBackToBody_whenExcerptBlank() {
+        assertEquals("the body", KbMath.snippet("   ", "the body"))
+    }
+
+    @Test
+    fun snippet_truncatesOnWordBoundary_withEllipsis() {
+        val long = (1..40).joinToString(" ") { "word$it" }
+        val out = KbMath.snippet(null, long, maxLength = 20)
+        assertTrue("expected ellipsis, got: $out", out.endsWith("…"))
+        assertTrue("expected <= 21 chars, got ${out.length}", out.length <= 21)
+        assertFalse("should not cut mid-word", out.dropLast(1).endsWith("wor"))
+    }
+
+    @Test
+    fun snippet_emptyInputs_returnEmpty() {
+        assertEquals("", KbMath.snippet(null, null))
+        assertEquals("", KbMath.snippet("", ""))
+    }
+
+    // ---- isSearchable ----
+
+    @Test
+    fun isSearchable_requiresMinLength_afterTrim() {
+        assertFalse(KbMath.isSearchable(null))
+        assertFalse(KbMath.isSearchable(" a "))
+        assertTrue(KbMath.isSearchable("ab"))
+        assertTrue(KbMath.isSearchable("  refund "))
+    }
+
+    // ---- statusLabel ----
+
+    @Test
+    fun statusLabel_knownAndUnknown() {
+        assertEquals("Published", KbMath.statusLabel("published"))
+        assertEquals("Draft", KbMath.statusLabel("DRAFT"))
+        assertEquals("Expired", KbMath.statusLabel("expired"))
+        assertEquals("", KbMath.statusLabel(null))
+        assertEquals("", KbMath.statusLabel(""))
+        // Unknown token -> Title-Cased fallback (forward-compatible).
+        assertEquals("Archived", KbMath.statusLabel("archived"))
+    }
+
+    // ---- helpfulness ----
+
+    @Test
+    fun helpfulnessRatio_noVotes_isNull() {
+        assertNull(KbMath.helpfulnessRatio(0, 0))
+        // Negative inputs clamp to 0 -> still no votes.
+        assertNull(KbMath.helpfulnessRatio(-3, -1))
+    }
+
+    @Test
+    fun helpfulnessRatio_andPercent_compute() {
+        assertEquals(0.8f, KbMath.helpfulnessRatio(8, 2)!!, 0.0001f)
+        assertEquals("80%", KbMath.helpfulnessPercent(8, 2))
+        assertEquals("100%", KbMath.helpfulnessPercent(5, 0))
+        assertEquals("", KbMath.helpfulnessPercent(0, 0))
+    }
+
+    // ---- filterAndRank ----
+
+    @Test
+    fun filterAndRank_blankQuery_returnsInputUnchanged() {
+        val items = listOf(summary("a", title = "Alpha"), summary("b", title = "Beta"))
+        assertEquals(items, KbMath.filterAndRank(items, "   "))
+    }
+
+    @Test
+    fun filterAndRank_titlePrefix_outranksExcerptContains() {
+        val prefix = summary("p", title = "Refund policy")
+        val excerptOnly = summary("e", title = "Shipping", excerpt = "how to get a refund")
+        val ranked = KbMath.filterAndRank(listOf(excerptOnly, prefix), "refund")
+        assertEquals(listOf("p", "e"), ranked.map { it.articleId })
+    }
+
+    @Test
+    fun filterAndRank_dropsNonMatches() {
+        val items = listOf(
+            summary("a", title = "Billing help"),
+            summary("b", title = "Password reset"),
+        )
+        val ranked = KbMath.filterAndRank(items, "billing")
+        assertEquals(listOf("a"), ranked.map { it.articleId })
+    }
+
+    @Test
+    fun filterAndRank_tagExactMatch_scoresHigherThanExcerpt() {
+        val tagged = summary("t", title = "Guide", tags = listOf("refund"))
+        val excerpt = summary("e", title = "Guide2", excerpt = "mentions refund inline")
+        val ranked = KbMath.filterAndRank(listOf(excerpt, tagged), "refund")
+        assertEquals(listOf("t", "e"), ranked.map { it.articleId })
+    }
+}

--- a/android/core-model/src/main/java/com/testlogon/android/core/model/kb/KnowledgeBase.kt
+++ b/android/core-model/src/main/java/com/testlogon/android/core/model/kb/KnowledgeBase.kt
@@ -1,0 +1,72 @@
+package com.testlogon.android.core.model.kb
+
+/**
+ * KB-AND-1 - domain models for the READ-ONLY Knowledge Base (help centre) surface.
+ *
+ * core-model has NO Moshi / core-network dependency: these are plain domain types. The wire DTOs (core-network
+ * KbDtos) carry the enum-like `status` field as a RAW String; we keep it RAW here too (unknown-safe - an
+ * unexpected server token never crashes the UI). The DTO -> domain bridge lives in the :app feature
+ * (KbMappers) since core-model cannot depend on core-network.
+ *
+ * TIME: every timestamp is an EPOCH-seconds [Long] (relative-time formatting happens at the UI). Identity ids
+ * (articleId / categoryId) are opaque, required Strings; everything else is nullable / defaulted because the
+ * list / search fetch omits detail-only fields (e.g. body on a list row).
+ */
+
+/**
+ * One article SUMMARY row (list / search result). Carries NO body. [status] is a RAW String
+ * (draft / published / expired, unknown-safe). [tags] may be empty. [helpfulCount] / [notHelpfulCount] feed
+ * the helpfulness ratio shown in the list.
+ */
+data class KbArticleSummary(
+    val articleId: String,
+    val title: String? = null,
+    val excerpt: String? = null,
+    val status: String? = null,
+    val categoryId: String? = null,
+    val category: String? = null,
+    val tags: List<String> = emptyList(),
+    val updatedAt: Long? = null,
+    val viewCount: Long = 0L,
+    val helpfulCount: Long = 0L,
+    val notHelpfulCount: Long = 0L,
+)
+
+/**
+ * One FULL article (the detail fetch). [body] is PLAIN TEXT already stripped from the server body_html by the
+ * mapper (see KbMath.htmlToPlainText) - the Compose renderer never sees raw HTML. [status] is a RAW String.
+ */
+data class KbArticle(
+    val articleId: String,
+    val title: String? = null,
+    val body: String? = null,
+    val excerpt: String? = null,
+    val status: String? = null,
+    val categoryId: String? = null,
+    val category: String? = null,
+    val authorSub: String? = null,
+    val tags: List<String> = emptyList(),
+    val updatedAt: Long? = null,
+    val publishedAt: Long? = null,
+    val viewCount: Long = 0L,
+    val helpfulCount: Long = 0L,
+    val notHelpfulCount: Long = 0L,
+    val attachments: List<KbAttachment> = emptyList(),
+)
+
+/** One attachment on an article. [isOpenable] gates the open CTA (absolute http(s) URL only). */
+data class KbAttachment(
+    val attachmentId: String? = null,
+    val filename: String? = null,
+    val contentType: String? = null,
+    val sizeBytes: Long? = null,
+    val url: String? = null,
+)
+
+/** One KB category (flat top-level; the wire tree is not expanded on this READ surface). */
+data class KbCategory(
+    val categoryId: String,
+    val name: String? = null,
+    val description: String? = null,
+    val sortOrder: Int = 0,
+)

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/kb/KbApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/kb/KbApi.kt
@@ -1,0 +1,54 @@
+package com.testlogon.android.core.network.kb
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * KB-AND-1 - Retrofit interface for the Knowledge Base READ surface (list / search / detail / categories).
+ * Transport only; the repository layer wraps these RAW DTO returns into ApiResult. All calls are idempotent
+ * suspend GETs.
+ *
+ * Paths have NO leading slash (relative to the shared Retrofit base URL, matching the rest of the codebase).
+ * The shared authenticated client attaches the session cookie via the global interceptors - so these hit the
+ * AUTHENTICATED /kb/ endpoints (require_ui_session), mirroring the web authenticated client (listArticles /
+ * searchArticles / getArticle / listCategories). The @Path token is EXACTLY {articleId} / {categoryId}.
+ *
+ * A null @Query is dropped by Retrofit (cursor / categoryId sent only when non-null). The backend returns
+ * HTTP 404 for every route when knowledge_base_enabled is false - the repository maps that to a degraded
+ * (empty) result rather than an error surface (degrade-on-404).
+ *
+ * RETURN SHAPES (frontend-verified):
+ *  - search       -> KbSearchEnvelope       { items, query, cursor }
+ *  - listArticles -> KbArticleListEnvelope  { items, cursor, total }
+ *  - getArticle   -> KbArticleDto           (BARE object, embeds attachments[])
+ *  - listCategories -> KbCategoryListEnvelope { categories }
+ */
+interface KbApi {
+
+    /** GET the published articles (optionally scoped to a category). Pass [cursor] to fetch the next page. */
+    @GET("kb/articles")
+    suspend fun listArticles(
+        @Query("category_id") categoryId: String? = null,
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): KbArticleListEnvelope
+
+    /** Full-text search across articles. [q] is the raw query. Pass [cursor] for the next page. */
+    @GET("kb/search")
+    suspend fun search(
+        @Query("q") q: String,
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): KbSearchEnvelope
+
+    /** GET one full article (BARE object; embeds attachments[]). Idempotent; bumps the server view counter. */
+    @GET("kb/articles/{articleId}")
+    suspend fun getArticle(
+        @Path("articleId") articleId: String,
+    ): KbArticleDto
+
+    /** GET the KB categories (flat top-level list; children nested on the wire). */
+    @GET("kb/categories")
+    suspend fun listCategories(): KbCategoryListEnvelope
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/kb/KbDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/kb/KbDtos.kt
@@ -1,0 +1,137 @@
+package com.testlogon.android.core.network.kb
+
+import com.squareup.moshi.Json
+
+/**
+ * KB-AND-1 - transport DTOs for the Knowledge Base READ surface (mirrors app/routers/kb_articles.py and the
+ * web frontend/src/api/endpoints/knowledgeBase.ts Kb* interfaces).
+ *
+ * CODEGEN NOTE (identical to the AND-371 tickets DTOs): core-network does NOT apply the Moshi KSP codegen
+ * plugin, so these DTOs decode via the reflective KotlinJsonAdapterFactory registered on the shared Moshi in
+ * NetworkModule.provideMoshi. The reflective factory maps property names to JSON keys VERBATIM (Moshi does
+ * NOT auto snake_case), so every wire key is pinned with an explicit @Json(name = ...).
+ * @JsonClass(generateAdapter = true) is intentionally OMITTED and NO new dependency is introduced.
+ *
+ * Required wire keys (article_id / category_id) have NO default, so a missing key surfaces a JsonDataException
+ * (folded to Failure by the repository). Everything else is nullable with a null default (or an empty-list
+ * default for collections); unknown wire keys are tolerated leniently by the reflective adapter.
+ *
+ * ENUM-LIKE FIELDS: status is decoded as a RAW String (draft / published / expired) - NOT a Kotlin enum, so
+ * an unexpected server value NEVER fails deserialization. TIME fields are EPOCH integers typed as Long.
+ *
+ * FLAG GATE: the backend returns HTTP 404 for every KB route when knowledge_base_enabled is false; the
+ * repository maps that to an empty/degraded result (degrade-on-404) rather than an error surface.
+ *
+ * WIRE CONTRACT (OpenAPI / frontend-verified; relative paths, NO leading slash):
+ *   GET kb/search?q=&limit=&cursor=            -> KbSearchEnvelope     { items, query, cursor }
+ *   GET kb/articles?category_id=&limit=&cursor= -> KbArticleListEnvelope { items, cursor, total }
+ *   GET kb/articles/{articleId}                -> KbArticleDto (bare object; embeds attachments[])
+ *   GET kb/categories                          -> KbCategoryListEnvelope { categories }
+ */
+
+/** One attachment on an article (embedded in [KbArticleDto.attachments]). All fields defensive-nullable. */
+data class KbAttachmentDto(
+    @Json(name = "attachment_id") val attachmentId: String? = null,
+    @Json(name = "article_id") val articleId: String? = null,
+    @Json(name = "filename") val filename: String? = null,
+    @Json(name = "content_type") val contentType: String? = null,
+    @Json(name = "size_bytes") val sizeBytes: Long? = null,
+    @Json(name = "url") val url: String? = null,
+    @Json(name = "uploaded_by") val uploadedBy: String? = null,
+    @Json(name = "created_at") val createdAt: Long? = null,
+)
+
+/**
+ * One FULL article (the detail fetch GET kb/articles/{id}). `article_id` is required. `status` is an enum-like
+ * raw String (draft / published / expired). The list / search fetch returns [KbArticleSummaryDto] instead
+ * (NO body_html). `body_html` is raw server HTML - the presentation layer strips it to plain text for the
+ * Compose renderer (see KbMath.htmlToPlainText). Timestamps are EPOCH Longs.
+ */
+data class KbArticleDto(
+    @Json(name = "article_id") val articleId: String,
+    @Json(name = "title") val title: String? = null,
+    @Json(name = "body_html") val bodyHtml: String? = null,
+    @Json(name = "excerpt") val excerpt: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "category_id") val categoryId: String? = null,
+    @Json(name = "category") val category: String? = null,
+    @Json(name = "author_sub") val authorSub: String? = null,
+    @Json(name = "tags") val tags: List<String> = emptyList(),
+    @Json(name = "created_at") val createdAt: Long? = null,
+    @Json(name = "updated_at") val updatedAt: Long? = null,
+    @Json(name = "published_at") val publishedAt: Long? = null,
+    @Json(name = "expires_at") val expiresAt: Long? = null,
+    @Json(name = "view_count") val viewCount: Long? = null,
+    @Json(name = "helpful_count") val helpfulCount: Long? = null,
+    @Json(name = "not_helpful_count") val notHelpfulCount: Long? = null,
+    @Json(name = "attachments") val attachments: List<KbAttachmentDto> = emptyList(),
+)
+
+/**
+ * One article SUMMARY row (returned by the list + search fetches). Carries NO body_html. `article_id` is
+ * required; everything else is nullable / defaulted (a list row may omit detail-only fields).
+ */
+data class KbArticleSummaryDto(
+    @Json(name = "article_id") val articleId: String,
+    @Json(name = "title") val title: String? = null,
+    @Json(name = "excerpt") val excerpt: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "category_id") val categoryId: String? = null,
+    @Json(name = "category") val category: String? = null,
+    @Json(name = "author_sub") val authorSub: String? = null,
+    @Json(name = "tags") val tags: List<String> = emptyList(),
+    @Json(name = "created_at") val createdAt: Long? = null,
+    @Json(name = "updated_at") val updatedAt: Long? = null,
+    @Json(name = "published_at") val publishedAt: Long? = null,
+    @Json(name = "view_count") val viewCount: Long? = null,
+    @Json(name = "helpful_count") val helpfulCount: Long? = null,
+    @Json(name = "not_helpful_count") val notHelpfulCount: Long? = null,
+)
+
+/**
+ * One KB category. `category_id` is required. `children` is a (possibly empty) nested list - the tree is kept
+ * on the wire but this READ surface flattens to the top level (children rendered inline is DEFERRED).
+ */
+data class KbCategoryDto(
+    @Json(name = "category_id") val categoryId: String,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "parent_id") val parentId: String? = null,
+    @Json(name = "path") val path: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "sort_order") val sortOrder: Int? = null,
+    @Json(name = "created_at") val createdAt: Long? = null,
+    @Json(name = "updated_at") val updatedAt: Long? = null,
+    @Json(name = "children") val children: List<KbCategoryDto> = emptyList(),
+)
+
+/** Envelope for GET kb/articles (list). Carries items + cursor + total. */
+data class KbArticleListEnvelope(
+    @Json(name = "items") val items: List<KbArticleSummaryDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+    @Json(name = "total") val total: Int? = null,
+)
+
+/** Envelope for GET kb/search. Echoes the query and carries the summary items + a next cursor. */
+data class KbSearchEnvelope(
+    @Json(name = "items") val items: List<KbArticleSummaryDto> = emptyList(),
+    @Json(name = "query") val query: String? = null,
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+/** Envelope for GET kb/categories. */
+data class KbCategoryListEnvelope(
+    @Json(name = "categories") val categories: List<KbCategoryDto> = emptyList(),
+)
+
+/**
+ * KB-AND-1 - documented constants for the enum-like `status` wire field. Plain String constants (NOT a Kotlin
+ * enum) so an unexpected server value never fails deserialization; callers compare against these names but
+ * tolerate any other value.
+ */
+object KbConstants {
+    object ArticleStatus {
+        const val DRAFT = "draft"
+        const val PUBLISHED = "published"
+        const val EXPIRED = "expired"
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/kb/KbNetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/kb/KbNetworkModule.kt
@@ -1,0 +1,26 @@
+package com.testlogon.android.core.network.kb
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * KB-AND-1 - Hilt wiring for the Knowledge Base transport layer.
+ *
+ * Provides [KbApi] from the shared singleton [Retrofit] (reusing the production OkHttp / Moshi / converter
+ * config; no new Retrofit, OkHttp or Moshi is built, and NO new dependency is introduced). The KB DTOs decode
+ * with the reflective KotlinJsonAdapterFactory already on the shared Moshi (status is a plain String on the
+ * wire - no enum adapter is needed). Mirrors the AND-371 TicketsNetworkModule pattern.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object KbNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideKbApi(retrofit: Retrofit): KbApi =
+        retrofit.create(KbApi::class.java)
+}


### PR DESCRIPTION
## FE parity PAR-142 - Android Knowledge Base

Brings the native Android client to web parity by adding the Knowledge Base feature.

### Changes
- KB list + detail Compose screens with ViewModels and UI state.
- Repository, network (KbApi/DTOs/module), and core-model layers.
- More-hub catalog entry + navigation wiring (feature-gated).
- KbMath unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
