### PR TITLE
FE parity PAR-145 - Android workflow-rules / maintenance / signature packets

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceModule.kt
@@ -1,0 +1,23 @@
+package com.testlogon.android.feature.maintenance
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * WOV — Hilt wiring for the Maintenance Work Orders feature repository seam. The impl consumes the
+ * core-network [com.testlogon.android.core.network.maintenance.MaintenanceOrdersApi] + shared
+ * ApiErrorParser; NO new endpoint module, migration, or dependency is added here.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MaintenanceModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindMaintenanceOrdersRepository(
+        impl: MaintenanceOrdersRepositoryImpl,
+    ): MaintenanceOrdersRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrderModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrderModel.kt
@@ -1,0 +1,134 @@
+package com.testlogon.android.feature.maintenance
+
+import com.testlogon.android.core.network.maintenance.MaintenanceOrderDto
+import java.time.Instant
+
+/**
+ * WOV — feature domain + DTO mappers + PURE status logic for the Maintenance Work Orders surface.
+ * Android-free + JVM-testable.
+ *
+ * Enums carry the wire token + a lenient UNKNOWN fallback (mirrors the core-network signing enums'
+ * fromToken discipline) so an unrecognized server value never throws. Timestamps are Unix-second Longs
+ * on the wire; 0/null degrade to null [Instant].
+ */
+
+/** Work-order priority (mirrors WoPriority). */
+enum class WoPriority(val token: String) {
+    URGENT("urgent"),
+    HIGH("high"),
+    NORMAL("normal"),
+    LOW("low"),
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        fun fromToken(t: String?): WoPriority = entries.firstOrNull { it.token == t } ?: UNKNOWN
+    }
+}
+
+/** Work-order lifecycle status (mirrors WoStatus). */
+enum class WoStatus(val token: String) {
+    OPEN("open"),
+    ASSIGNED("assigned"),
+    IN_PROGRESS("in_progress"),
+    COMPLETED("completed"),
+    CANCELLED("cancelled"),
+    UNKNOWN("unknown"),
+    ;
+
+    /** Terminal states accept no further transition. */
+    val isTerminal: Boolean get() = this == COMPLETED || this == CANCELLED
+
+    companion object {
+        fun fromToken(t: String?): WoStatus = entries.firstOrNull { it.token == t } ?: UNKNOWN
+    }
+}
+
+/** One maintenance work order (mapped from [MaintenanceOrderDto]). */
+data class MaintenanceOrder(
+    val workOrderId: String,
+    val propertyId: String,
+    val title: String,
+    val description: String? = null,
+    val priority: WoPriority = WoPriority.NORMAL,
+    val status: WoStatus = WoStatus.OPEN,
+    val unitId: String? = null,
+    val vendorId: String? = null,
+    val assigneeSub: String? = null,
+    val scheduledFor: Instant? = null,
+    val costCents: Long? = null,
+    val createdAt: Instant? = null,
+    val updatedAt: Instant? = null,
+    val completedAt: Instant? = null,
+    val escrowAmountCents: Long? = null,
+    val escrowStatus: String? = null,
+)
+
+private fun epochToInstant(sec: Long?): Instant? =
+    sec?.takeIf { it > 0 }?.let { Instant.ofEpochSecond(it) }
+
+/** Maps a transport work order to the feature domain. */
+fun MaintenanceOrderDto.toDomain(): MaintenanceOrder = MaintenanceOrder(
+    workOrderId = workOrderId,
+    propertyId = propertyId,
+    title = title,
+    description = description,
+    priority = WoPriority.fromToken(priority),
+    status = WoStatus.fromToken(woStatus),
+    unitId = unitId,
+    vendorId = vendorId,
+    assigneeSub = assigneeSub,
+    scheduledFor = epochToInstant(scheduledFor),
+    costCents = costCents,
+    createdAt = epochToInstant(createdAt),
+    updatedAt = epochToInstant(updatedAt),
+    completedAt = epochToInstant(completedAt),
+    escrowAmountCents = escrowAmountCents,
+    escrowStatus = escrowStatus,
+)
+
+/**
+ * PURE work-order state machine: the set of [WoStatus] a work order may transition INTO from [from].
+ * Mirrors the backend's allowed transitions (open -> assigned/in_progress/cancelled; assigned ->
+ * in_progress/cancelled; in_progress -> completed/cancelled). Terminal + UNKNOWN states allow nothing.
+ *
+ * `open -> completed` is intentionally NOT offered directly (work must be picked up first); the caller
+ * moves through in_progress. This drives which status buttons the detail UI enables.
+ */
+fun allowedTransitions(from: WoStatus): Set<WoStatus> = when (from) {
+    WoStatus.OPEN -> setOf(WoStatus.ASSIGNED, WoStatus.IN_PROGRESS, WoStatus.CANCELLED)
+    WoStatus.ASSIGNED -> setOf(WoStatus.IN_PROGRESS, WoStatus.CANCELLED)
+    WoStatus.IN_PROGRESS -> setOf(WoStatus.COMPLETED, WoStatus.CANCELLED)
+    WoStatus.COMPLETED, WoStatus.CANCELLED, WoStatus.UNKNOWN -> emptySet()
+}
+
+/** True iff [target] is a legal next status from [from]. */
+fun canTransition(from: WoStatus, target: WoStatus): Boolean = target in allowedTransitions(from)
+
+/**
+ * PURE list ordering for the board: OPEN/ASSIGNED/IN_PROGRESS first (active), then terminal; within a
+ * status, higher priority first, then most-recently-updated first. Stable + total so the UI list is
+ * deterministic.
+ */
+fun sortForBoard(orders: List<MaintenanceOrder>): List<MaintenanceOrder> {
+    fun statusRank(s: WoStatus): Int = when (s) {
+        WoStatus.IN_PROGRESS -> 0
+        WoStatus.ASSIGNED -> 1
+        WoStatus.OPEN -> 2
+        WoStatus.COMPLETED -> 3
+        WoStatus.CANCELLED -> 4
+        WoStatus.UNKNOWN -> 5
+    }
+    fun priorityRank(p: WoPriority): Int = when (p) {
+        WoPriority.URGENT -> 0
+        WoPriority.HIGH -> 1
+        WoPriority.NORMAL -> 2
+        WoPriority.LOW -> 3
+        WoPriority.UNKNOWN -> 4
+    }
+    return orders.sortedWith(
+        compareBy<MaintenanceOrder> { statusRank(it.status) }
+            .thenBy { priorityRank(it.priority) }
+            .thenByDescending { it.updatedAt ?: Instant.EPOCH },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersRepository.kt
@@ -1,0 +1,119 @@
+package com.testlogon.android.feature.maintenance
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.maintenance.CreateMaintenanceOrderRequest
+import com.testlogon.android.core.network.maintenance.MaintenanceOrdersApi
+import com.testlogon.android.core.network.maintenance.TransitionMaintenanceOrderRequest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * WOV — data layer for the Maintenance Work Orders MVP (list + create + status transition).
+ *
+ * REUSES the core-network [MaintenanceOrdersApi] (raw DTOs) + shared [ApiErrorParser]; maps each DTO to
+ * the feature domain BEFORE the typed [ApiResult] (mirrors SignatureRepositoryImpl). DEGRADE-ON-404: a
+ * 404 (whole feature flag off) surfaces as an [ApiResult.Failure] with status 404, which the ViewModel
+ * renders as a friendly unavailable state rather than an error.
+ */
+interface MaintenanceOrdersRepository {
+
+    /** System-wide list, optionally filtered by status. */
+    suspend fun list(
+        status: WoStatus? = null,
+        limit: Int? = null,
+    ): ApiResult<List<MaintenanceOrder>>
+
+    /** Create a property-scoped work order. */
+    suspend fun create(
+        propertyId: String,
+        title: String,
+        description: String? = null,
+        priority: WoPriority? = null,
+        unitId: String? = null,
+        scheduledFor: Long? = null,
+    ): ApiResult<MaintenanceOrder>
+
+    /** Transition a work order to [target] (property scopes authorization). */
+    suspend fun transition(
+        workOrderId: String,
+        propertyId: String,
+        target: WoStatus,
+        costCents: Long? = null,
+    ): ApiResult<MaintenanceOrder>
+}
+
+@Singleton
+class MaintenanceOrdersRepositoryImpl @Inject constructor(
+    private val api: MaintenanceOrdersApi,
+    private val errorParser: ApiErrorParser,
+) : MaintenanceOrdersRepository {
+
+    override suspend fun list(status: WoStatus?, limit: Int?): ApiResult<List<MaintenanceOrder>> =
+        withContext(Dispatchers.IO) {
+            call {
+                api.listWorkOrders(woStatus = status?.token, limit = limit)
+                    .items.map { it.toDomain() }
+            }
+        }
+
+    override suspend fun create(
+        propertyId: String,
+        title: String,
+        description: String?,
+        priority: WoPriority?,
+        unitId: String?,
+        scheduledFor: Long?,
+    ): ApiResult<MaintenanceOrder> = withContext(Dispatchers.IO) {
+        call {
+            val body = CreateMaintenanceOrderRequest(
+                title = title,
+                description = description?.takeIf { it.isNotBlank() },
+                priority = priority?.token,
+                propertyId = propertyId,
+                unitId = unitId?.takeIf { it.isNotBlank() },
+                scheduledFor = scheduledFor,
+            )
+            api.createWorkOrder(propertyId, body).toDomain()
+        }
+    }
+
+    override suspend fun transition(
+        workOrderId: String,
+        propertyId: String,
+        target: WoStatus,
+        costCents: Long?,
+    ): ApiResult<MaintenanceOrder> = withContext(Dispatchers.IO) {
+        call {
+            val body = TransitionMaintenanceOrderRequest(
+                propertyId = propertyId,
+                targetStatus = target.token,
+                costCents = costCents,
+            )
+            api.transitionWorkOrder(workOrderId, body).toDomain()
+        }
+    }
+
+    /** Folds a block into [ApiResult]; mirrors SignatureRepositoryImpl.call. */
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersScreen.kt
@@ -1,0 +1,278 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.maintenance
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/** WOV — stable testTags for the Maintenance Work Orders screen. */
+object MaintenanceOrdersTestTags {
+    const val SCREEN = "maintenance_orders_screen"
+    const val FAB = "maintenance_orders_fab"
+    const val RETRY = "maintenance_orders_retry"
+    const val CREATE_SUBMIT = "maintenance_create_submit"
+
+    fun row(workOrderId: String): String = "maintenance_order_row_$workOrderId"
+}
+
+@Composable
+fun MaintenanceOrdersRoute(
+    onBack: () -> Unit,
+    viewModel: MaintenanceOrdersViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    MaintenanceOrdersScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onRetry = viewModel::load,
+        onCreate = viewModel::create,
+        onTransition = viewModel::transition,
+    )
+}
+
+@Composable
+fun MaintenanceOrdersScreen(
+    state: MaintenanceOrdersUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onCreate: (propertyId: String, title: String, description: String?, priority: WoPriority) -> Unit,
+    onTransition: (MaintenanceOrder, WoStatus) -> Unit,
+) {
+    var showCreate by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = Modifier.testTag(MaintenanceOrdersTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Work orders") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (state !is MaintenanceOrdersUiState.Unavailable) {
+                FloatingActionButton(
+                    onClick = { showCreate = true },
+                    modifier = Modifier.testTag(MaintenanceOrdersTestTags.FAB),
+                ) { Icon(Icons.Filled.Add, contentDescription = "New work order") }
+            }
+        },
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when (state) {
+                is MaintenanceOrdersUiState.Loading ->
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                is MaintenanceOrdersUiState.Unavailable ->
+                    CenteredMessage("Work orders aren't enabled for this account.")
+
+                is MaintenanceOrdersUiState.Empty ->
+                    CenteredMessage("No work orders yet. Tap + to create one.")
+
+                is MaintenanceOrdersUiState.Error -> Column(
+                    modifier = Modifier.align(Alignment.Center),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(state.error.message, style = MaterialTheme.typography.bodyMedium)
+                    Button(onClick = onRetry, modifier = Modifier.testTag(MaintenanceOrdersTestTags.RETRY)) {
+                        Text("Retry")
+                    }
+                }
+
+                is MaintenanceOrdersUiState.Content -> PullToRefreshBox(
+                    isRefreshing = state.isRefreshing,
+                    onRefresh = onRefresh,
+                ) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(state.orders, key = { it.workOrderId }) { order ->
+                            OrderRow(order = order, onTransition = onTransition)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        CreateOrderDialog(
+            onDismiss = { showCreate = false },
+            onSubmit = { propertyId, title, description, priority ->
+                onCreate(propertyId, title, description, priority)
+                showCreate = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.BoxScope.CenteredMessage(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+    )
+}
+
+@Composable
+private fun OrderRow(order: MaintenanceOrder, onTransition: (MaintenanceOrder, WoStatus) -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag(MaintenanceOrdersTestTags.row(order.workOrderId)),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(order.title, style = MaterialTheme.typography.titleMedium)
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AssistChip(onClick = {}, label = { Text(statusLabel(order.status)) })
+                AssistChip(onClick = {}, label = { Text(priorityLabel(order.priority)) })
+            }
+            order.description?.takeIf { it.isNotBlank() }?.let {
+                Text(it, style = MaterialTheme.typography.bodyMedium)
+            }
+            val nexts = allowedTransitions(order.status).toList()
+            if (nexts.isNotEmpty()) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    nexts.forEach { target ->
+                        OutlinedButton(onClick = { onTransition(order, target) }) {
+                            Text(statusLabel(target))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateOrderDialog(
+    onDismiss: () -> Unit,
+    onSubmit: (propertyId: String, title: String, description: String?, priority: WoPriority) -> Unit,
+) {
+    var propertyId by remember { mutableStateOf("") }
+    var title by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var priority by remember { mutableStateOf(WoPriority.NORMAL) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card {
+            Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("New work order", style = MaterialTheme.typography.titleLarge)
+                OutlinedTextField(
+                    value = propertyId,
+                    onValueChange = { propertyId = it },
+                    label = { Text("Property ID") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    label = { Text("Title") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Description (optional)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOf(WoPriority.URGENT, WoPriority.HIGH, WoPriority.NORMAL, WoPriority.LOW)
+                        .forEach { p ->
+                            FilterChip(
+                                selected = priority == p,
+                                onClick = { priority = p },
+                                label = { Text(priorityLabel(p)) },
+                            )
+                        }
+                }
+                androidx.compose.foundation.layout.Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                    Button(
+                        onClick = {
+                            onSubmit(
+                                propertyId.trim(),
+                                title.trim(),
+                                description.trim().takeIf { it.isNotBlank() },
+                                priority,
+                            )
+                        },
+                        enabled = propertyId.isNotBlank() && title.isNotBlank(),
+                        modifier = Modifier.testTag(MaintenanceOrdersTestTags.CREATE_SUBMIT),
+                    ) { Text("Create") }
+                }
+            }
+        }
+    }
+}
+
+private fun statusLabel(s: WoStatus): String = when (s) {
+    WoStatus.OPEN -> "Open"
+    WoStatus.ASSIGNED -> "Assign"
+    WoStatus.IN_PROGRESS -> "Start"
+    WoStatus.COMPLETED -> "Complete"
+    WoStatus.CANCELLED -> "Cancel"
+    WoStatus.UNKNOWN -> "Unknown"
+}
+
+private fun priorityLabel(p: WoPriority): String = when (p) {
+    WoPriority.URGENT -> "Urgent"
+    WoPriority.HIGH -> "High"
+    WoPriority.NORMAL -> "Normal"
+    WoPriority.LOW -> "Low"
+    WoPriority.UNKNOWN -> "—"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersUiState.kt
@@ -1,0 +1,44 @@
+package com.testlogon.android.feature.maintenance
+
+import com.testlogon.android.core.model.ApiError
+
+/**
+ * WOV — UI envelope + pure fold for the Maintenance Work Orders list surface. Android-free + JVM-testable.
+ *
+ * DEGRADE-ON-404: a 404 (the whole feature flag off) folds to a distinct [Unavailable] state — a calm
+ * "not enabled" message, NOT an error with a retry. Any other failure with no prior content -> [Error].
+ */
+sealed interface MaintenanceOrdersUiState {
+
+    data object Loading : MaintenanceOrdersUiState
+
+    /** A non-empty, board-sorted list. */
+    data class Content(
+        val orders: List<MaintenanceOrder>,
+        val isRefreshing: Boolean = false,
+        val staleError: ApiError? = null,
+    ) : MaintenanceOrdersUiState
+
+    /** Loaded successfully with zero rows. */
+    data object Empty : MaintenanceOrdersUiState
+
+    /** The feature is not enabled on this server (404). */
+    data object Unavailable : MaintenanceOrdersUiState
+
+    /** A terminal load error with no prior content. */
+    data class Error(val error: ApiError) : MaintenanceOrdersUiState
+}
+
+/**
+ * PURE fold of a list-load result into a [MaintenanceOrdersUiState]. A 404 -> [Unavailable]; any other
+ * error -> [Error]; empty list -> [Empty]; else [Content] (board-sorted).
+ */
+fun foldOrdersResult(
+    orders: List<MaintenanceOrder>?,
+    error: ApiError?,
+): MaintenanceOrdersUiState = when {
+    error != null && error.status == 404 -> MaintenanceOrdersUiState.Unavailable
+    error != null -> MaintenanceOrdersUiState.Error(error)
+    orders == null || orders.isEmpty() -> MaintenanceOrdersUiState.Empty
+    else -> MaintenanceOrdersUiState.Content(orders = sortForBoard(orders))
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/maintenance/MaintenanceOrdersViewModel.kt
@@ -1,0 +1,126 @@
+package com.testlogon.android.feature.maintenance
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * WOV — presentation logic for the Maintenance Work Orders list + create + status MVP.
+ *
+ * READ: [load] / [refresh] read the system-wide list ONCE (no poll loop). WRITE: [create] posts a
+ * property-scoped work order and [transition] moves a work order's status; both refresh the list on
+ * success and emit a one-shot event. DEGRADE-ON-404 is handled by [foldOrdersResult] (-> Unavailable).
+ */
+@HiltViewModel
+class MaintenanceOrdersViewModel @Inject constructor(
+    private val repository: MaintenanceOrdersRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<MaintenanceOrdersUiState>(MaintenanceOrdersUiState.Loading)
+    val uiState: StateFlow<MaintenanceOrdersUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<MaintenanceEvent>(Channel.BUFFERED)
+    val events: Flow<MaintenanceEvent> = _events.receiveAsFlow()
+
+    private var loadJob: Job? = null
+    private var writeJob: Job? = null
+
+    init {
+        load()
+    }
+
+    fun load() {
+        if (_uiState.value !is MaintenanceOrdersUiState.Content) {
+            _uiState.value = MaintenanceOrdersUiState.Loading
+        }
+        fetch(showRefreshing = false)
+    }
+
+    fun refresh() {
+        (_uiState.value as? MaintenanceOrdersUiState.Content)?.let {
+            _uiState.value = it.copy(isRefreshing = true)
+        }
+        fetch(showRefreshing = true)
+    }
+
+    private fun fetch(showRefreshing: Boolean) {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            when (val result = repository.list()) {
+                is ApiResult.Success -> _uiState.value = foldOrdersResult(result.data, null)
+                is ApiResult.Failure -> onLoadError(result.error, showRefreshing)
+                is ApiResult.NetworkError ->
+                    onLoadError(ApiError(ApiError.STATUS_NETWORK, NETWORK_MESSAGE), showRefreshing)
+            }
+        }
+    }
+
+    private fun onLoadError(error: ApiError, wasRefreshing: Boolean) {
+        val current = _uiState.value
+        // Keep prior content visible on a refresh failure (stale display); otherwise fold to the state.
+        _uiState.value = if (wasRefreshing && current is MaintenanceOrdersUiState.Content) {
+            current.copy(isRefreshing = false, staleError = error)
+        } else {
+            foldOrdersResult(null, error)
+        }
+    }
+
+    /** Create a property-scoped work order; refreshes the list on success. Guards double-submit. */
+    fun create(
+        propertyId: String,
+        title: String,
+        description: String?,
+        priority: WoPriority,
+    ) {
+        if (propertyId.isBlank() || title.isBlank()) return
+        if (writeJob?.isActive == true) return
+        writeJob = viewModelScope.launch {
+            when (val result = repository.create(propertyId, title, description, priority)) {
+                is ApiResult.Success -> {
+                    _events.send(MaintenanceEvent.Created(result.data.workOrderId))
+                    fetch(showRefreshing = false)
+                }
+                is ApiResult.Failure -> _events.send(MaintenanceEvent.WriteFailed(result.error.message))
+                is ApiResult.NetworkError -> _events.send(MaintenanceEvent.WriteFailed(NETWORK_MESSAGE))
+            }
+        }
+    }
+
+    /** Transition a work order; no-op when the transition is illegal. Refreshes on success. */
+    fun transition(order: MaintenanceOrder, target: WoStatus) {
+        if (!canTransition(order.status, target)) return
+        if (writeJob?.isActive == true) return
+        writeJob = viewModelScope.launch {
+            when (val result = repository.transition(order.workOrderId, order.propertyId, target)) {
+                is ApiResult.Success -> {
+                    _events.send(MaintenanceEvent.Transitioned(order.workOrderId, target))
+                    fetch(showRefreshing = false)
+                }
+                is ApiResult.Failure -> _events.send(MaintenanceEvent.WriteFailed(result.error.message))
+                is ApiResult.NetworkError -> _events.send(MaintenanceEvent.WriteFailed(NETWORK_MESSAGE))
+            }
+        }
+    }
+
+    private companion object {
+        const val NETWORK_MESSAGE = "Couldn't reach the server. Try again."
+    }
+}
+
+/** One-shot events for the maintenance surface. */
+sealed interface MaintenanceEvent {
+    data class Created(val workOrderId: String) : MaintenanceEvent
+    data class Transitioned(val workOrderId: String, val target: WoStatus) : MaintenanceEvent
+    data class WriteFailed(val message: String) : MaintenanceEvent
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -117,6 +117,31 @@ import javax.inject.Singleton
 class MoreCatalog @Inject constructor() {
     val entries: List<MoreEntry> = listOf(
         MoreEntry(
+            id = "signing_inbox",
+            labelRes = R.string.more_entry_signing_inbox,
+            icon = Icons.Outlined.Description,
+            route = MoreRoutes.SIGNING_INBOX,
+            hub = MoreHub.INBOX,
+            section = MoreSection.ACCOUNT,
+        ),
+        MoreEntry(
+            id = "maintenance_orders",
+            labelRes = R.string.more_entry_maintenance_orders,
+            icon = Icons.Outlined.Apartment,
+            route = MoreRoutes.MAINTENANCE_ORDERS,
+            hub = MoreHub.ACCOUNT,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "workflow_rules",
+            labelRes = R.string.more_entry_workflow_rules,
+            icon = Icons.Outlined.Hub,
+            route = MoreRoutes.WORKFLOW_RULES,
+            hub = MoreHub.ADMIN,
+            section = MoreSection.SUPPORT,
+            operatorOnly = true,
+        ),
+        MoreEntry(
             id = "profile",
             labelRes = R.string.more_entry_profile,
             icon = Icons.Outlined.Person,

--- a/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxDomain.kt
@@ -1,0 +1,63 @@
+package com.testlogon.android.feature.signing.packetlist
+
+import com.testlogon.android.core.network.signing.PacketStatus
+import com.testlogon.android.core.network.signing.SigningInboxItemDto
+import java.time.Instant
+
+/**
+ * SUX-008 — feature domain + DTO mappers for the signing INBOX (the four browse buckets that back the
+ * "list packets" surface). This is the piece that turns the AND-344 [PacketStatusFilter] scaffolding
+ * (which anticipated a future backend list) into a real list feature now that the awaiting / sent /
+ * completed-for-me / drafts endpoints exist.
+ *
+ * REUSE: the lenient [PacketStatus] enum from core-network is reused verbatim (UNKNOWN fallback). The
+ * inbox row `status` is a raw wire String, mapped through [PacketStatus.fromToken] here. Timestamps are
+ * ISO-8601 Strings on the wire and parsed to [Instant] via runCatching (malformed/absent -> null, never
+ * throws), mirroring [com.testlogon.android.feature.signing.model.SignaturePacket].
+ *
+ * Android-free + JVM-testable.
+ */
+
+/** Which inbox bucket a row belongs to; drives the endpoint called and the section header. */
+enum class SigningInboxBucket {
+    AWAITING,
+    SENT,
+    COMPLETED,
+    DRAFTS,
+}
+
+/** One row in a signing inbox list (mapped from [SigningInboxItemDto]). */
+data class SigningInboxItem(
+    val packetId: String,
+    val status: PacketStatus,
+    val ownerUserId: String? = null,
+    val sourceName: String? = null,
+    val statusChip: String? = null,
+    val statusText: String? = null,
+    val role: String? = null,
+    val createdAt: Instant? = null,
+    val sentAt: Instant? = null,
+    val completedAt: Instant? = null,
+) {
+    /** A best-effort display title: the source document name, falling back to the packet id. */
+    val displayTitle: String
+        get() = sourceName?.takeIf { it.isNotBlank() } ?: packetId
+}
+
+/** Parses an optional ISO-8601 instant string; any parse failure or null degrades to null. */
+private fun parseInstant(raw: String?): Instant? =
+    raw?.takeIf { it.isNotBlank() }?.let { runCatching { Instant.parse(it) }.getOrNull() }
+
+/** Maps a transport inbox row to the feature domain. */
+fun SigningInboxItemDto.toDomain(): SigningInboxItem = SigningInboxItem(
+    packetId = packetId,
+    status = PacketStatus.fromToken(status),
+    ownerUserId = ownerUserId,
+    sourceName = sourceName,
+    statusChip = statusChip,
+    statusText = statusText,
+    role = role,
+    createdAt = parseInstant(createdAt),
+    sentAt = parseInstant(sentAt),
+    completedAt = parseInstant(completedAt),
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxMath.kt
@@ -1,0 +1,109 @@
+package com.testlogon.android.feature.signing.packetlist
+
+import com.testlogon.android.core.model.ApiError
+
+/**
+ * SUX-008 — PURE presentation logic for the signing INBOX. No I/O, no Android; JVM-testable.
+ *
+ * The inbox is assembled from up to four independent endpoint loads (awaiting / sent / completed / drafts).
+ * Any subset may 404 (the whole feature is flag-gated server-side: SIGNATURE_PACKETS-off -> 404). The rules
+ * here express the DEGRADE-ON-404 contract: a 404 (or any failure) on one bucket drops THAT bucket only; the
+ * surface still renders from whatever buckets loaded. The screen shows [SigningInboxUiState.Empty] only when
+ * every bucket loaded with zero rows, and [Error] only when every bucket failed (nothing to show).
+ */
+
+/** A single rendered inbox bucket: its kind + the rows that loaded for it. */
+data class SigningInboxSection(
+    val bucket: SigningInboxBucket,
+    val items: List<SigningInboxItem>,
+) {
+    val count: Int get() = items.size
+}
+
+/** The UI envelope for the whole inbox surface. */
+sealed interface SigningInboxUiState {
+
+    /** Initial load (all four buckets in flight). */
+    data object Loading : SigningInboxUiState
+
+    /**
+     * At least one bucket loaded. [sections] contains ONLY non-empty buckets, in canonical order
+     * (awaiting first — it is the actionable one). [awaitingCount] powers a badge even when other
+     * buckets dominate the list.
+     */
+    data class Content(
+        val sections: List<SigningInboxSection>,
+        val isRefreshing: Boolean = false,
+    ) : SigningInboxUiState {
+        val awaitingCount: Int
+            get() = sections.firstOrNull { it.bucket == SigningInboxBucket.AWAITING }?.count ?: 0
+
+        val totalCount: Int get() = sections.sumOf { it.count }
+    }
+
+    /** Every bucket loaded successfully but returned zero rows. */
+    data object Empty : SigningInboxUiState
+
+    /** Every bucket failed (nothing to render). Carries the first error for the retry affordance. */
+    data class Error(val error: ApiError) : SigningInboxUiState
+}
+
+/**
+ * The per-bucket load outcome the ViewModel feeds in. A [failure] of null means the bucket loaded (its
+ * [items] are authoritative, possibly empty); a non-null [failure] means the bucket did not load (its
+ * rows are unknown and it is dropped). A 404 is a failure like any other — see [isSuppressible404].
+ */
+data class BucketLoad(
+    val bucket: SigningInboxBucket,
+    val items: List<SigningInboxItem> = emptyList(),
+    val failure: ApiError? = null,
+) {
+    val loaded: Boolean get() = failure == null
+
+    /** True when this bucket's failure is a 404 — the flag-off / not-found signal we silently degrade on. */
+    val isSuppressible404: Boolean get() = failure?.status == 404
+}
+
+/** Canonical render order: the actionable bucket first, drafts last. */
+val CANONICAL_BUCKET_ORDER: List<SigningInboxBucket> = listOf(
+    SigningInboxBucket.AWAITING,
+    SigningInboxBucket.SENT,
+    SigningInboxBucket.COMPLETED,
+    SigningInboxBucket.DRAFTS,
+)
+
+/**
+ * Folds the four (or fewer) [BucketLoad]s into a [SigningInboxUiState].
+ *
+ * Rules:
+ *  - Buckets that LOADED with rows become sections (canonical order); empty loaded buckets are omitted.
+ *  - If at least one bucket loaded and any rows exist -> [Content].
+ *  - If every bucket loaded but ALL are empty -> [Empty].
+ *  - If NO bucket loaded (all failed) -> [Error] with the first failure (404 preferred as least-alarming).
+ *
+ * [isRefreshing] is passed straight through to a resulting [Content].
+ */
+fun buildInboxState(
+    loads: List<BucketLoad>,
+    isRefreshing: Boolean = false,
+): SigningInboxUiState {
+    val loaded = loads.filter { it.loaded }
+    if (loaded.isEmpty()) {
+        // Every bucket failed. Prefer a 404 (flag-off / not-found) as the surfaced error so the retry
+        // affordance reads as "nothing here" rather than a scary transport failure when appropriate.
+        val firstError = loads.firstOrNull { it.isSuppressible404 }?.failure
+            ?: loads.firstOrNull { it.failure != null }?.failure
+        return firstError?.let { SigningInboxUiState.Error(it) } ?: SigningInboxUiState.Empty
+    }
+
+    val sections = CANONICAL_BUCKET_ORDER.mapNotNull { bucket ->
+        val load = loaded.firstOrNull { it.bucket == bucket } ?: return@mapNotNull null
+        if (load.items.isEmpty()) null else SigningInboxSection(bucket, load.items)
+    }
+
+    return if (sections.isEmpty()) {
+        SigningInboxUiState.Empty
+    } else {
+        SigningInboxUiState.Content(sections = sections, isRefreshing = isRefreshing)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxModule.kt
@@ -1,0 +1,22 @@
+package com.testlogon.android.feature.signing.packetlist
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * SUX-008 — Hilt wiring for the signing INBOX repository seam. Kept separate from the DETAIL feature's
+ * SigningDataModule so the browse-list layer stays self-contained. The impl consumes the shared
+ * [com.testlogon.android.core.network.signing.SigningApi] + [ApiErrorParser] provided by core-network;
+ * NO new endpoint module, migration, or dependency is added.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SigningInboxModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSigningInboxRepository(impl: SigningInboxRepositoryImpl): SigningInboxRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxRepository.kt
@@ -1,0 +1,76 @@
+package com.testlogon.android.feature.signing.packetlist
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.signing.SigningApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * SUX-008 — data layer for the signing INBOX browse buckets.
+ *
+ * Deliberately SEPARATE from [com.testlogon.android.feature.signing.data.SignatureRepository] (the
+ * DETAIL repo): adding list members to that interface would force an override into all five existing
+ * fakes across the signing test tree. This inbox repo REUSES the same [SigningApi] (AND-339 + the
+ * SUX-008 inbox additions) and the shared [ApiErrorParser], and maps each row to the feature domain
+ * before the typed [ApiResult] — the identical wrap discipline as SignatureRepositoryImpl.
+ *
+ * DEGRADE-ON-404: each bucket call returns its own [ApiResult]; a 404 surfaces as an [ApiResult.Failure]
+ * with status 404 which the ViewModel treats as "this bucket unavailable" (see SigningInboxMath).
+ */
+interface SigningInboxRepository {
+
+    /** Packets awaiting the caller's signature. */
+    suspend fun awaiting(limit: Int = 100): ApiResult<List<SigningInboxItem>>
+
+    /** Packets the caller sent (as owner). */
+    suspend fun sent(limit: Int = 100): ApiResult<List<SigningInboxItem>>
+
+    /** Completed packets the caller signed. */
+    suspend fun completedForMe(limit: Int = 100): ApiResult<List<SigningInboxItem>>
+
+    /** The caller's draft packets. */
+    suspend fun drafts(limit: Int = 100): ApiResult<List<SigningInboxItem>>
+}
+
+@Singleton
+class SigningInboxRepositoryImpl @Inject constructor(
+    private val signingApi: SigningApi,
+    private val errorParser: ApiErrorParser,
+) : SigningInboxRepository {
+
+    override suspend fun awaiting(limit: Int): ApiResult<List<SigningInboxItem>> =
+        withContext(Dispatchers.IO) { call { signingApi.listAwaiting(limit).items.map { it.toDomain() } } }
+
+    override suspend fun sent(limit: Int): ApiResult<List<SigningInboxItem>> =
+        withContext(Dispatchers.IO) { call { signingApi.listSent(limit).items.map { it.toDomain() } } }
+
+    override suspend fun completedForMe(limit: Int): ApiResult<List<SigningInboxItem>> =
+        withContext(Dispatchers.IO) { call { signingApi.listCompletedForMe(limit).items.map { it.toDomain() } } }
+
+    override suspend fun drafts(limit: Int): ApiResult<List<SigningInboxItem>> =
+        withContext(Dispatchers.IO) { call { signingApi.listDrafts(limit).items.map { it.toDomain() } } }
+
+    /** Folds a block into [ApiResult]; mirrors SignatureRepositoryImpl.call. */
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxScreen.kt
@@ -1,0 +1,184 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.signing.packetlist
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Draw
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/** SUX-008 — stable testTags for the signing INBOX screen. */
+object SigningInboxTestTags {
+    const val SCREEN = "signing_inbox_screen"
+    const val RETRY = "signing_inbox_retry"
+    const val EMPTY = "signing_inbox_empty"
+
+    /** Per-row tag, suffixed by the packet id. */
+    fun row(packetId: String): String = "signing_inbox_row_$packetId"
+}
+
+/**
+ * SUX-008 — the signing INBOX ("list packets") route. Groups the four browse buckets and opens the
+ * EXISTING packet DETAIL (view + SIGN + mark-done) on row tap.
+ */
+@Composable
+fun SigningInboxRoute(
+    onBack: () -> Unit,
+    onOpenPacket: (String) -> Unit,
+    viewModel: SigningInboxViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    SigningInboxScreen(
+        state = state,
+        onBack = onBack,
+        onOpenPacket = onOpenPacket,
+        onRefresh = viewModel::refresh,
+        onRetry = viewModel::load,
+    )
+}
+
+@Composable
+fun SigningInboxScreen(
+    state: SigningInboxUiState,
+    onBack: () -> Unit,
+    onOpenPacket: (String) -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.testTag(SigningInboxTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Signatures") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when (state) {
+                is SigningInboxUiState.Loading -> {
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+                }
+
+                is SigningInboxUiState.Empty -> {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center).testTag(SigningInboxTestTags.EMPTY),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Icon(Icons.Outlined.Draw, contentDescription = null)
+                        Text("No documents to sign", style = MaterialTheme.typography.titleMedium)
+                        Text(
+                            "Packets sent to you for signature will appear here.",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+
+                is SigningInboxUiState.Error -> {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(state.error.message, style = MaterialTheme.typography.bodyMedium)
+                        Button(
+                            onClick = onRetry,
+                            modifier = Modifier.testTag(SigningInboxTestTags.RETRY),
+                        ) { Text("Retry") }
+                    }
+                }
+
+                is SigningInboxUiState.Content -> {
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = onRefresh,
+                    ) {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            state.sections.forEach { section ->
+                                item(key = "header_${section.bucket.name}") {
+                                    Text(
+                                        text = sectionTitle(section.bucket, section.count),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+                                    )
+                                }
+                                items(section.items, key = { it.packetId }) { row ->
+                                    SigningInboxRow(row = row, onClick = { onOpenPacket(row.packetId) })
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SigningInboxRow(row: SigningInboxItem, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(SigningInboxTestTags.row(row.packetId))
+            .clickable(onClick = onClick),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = row.displayTitle,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val subtitle = row.statusText?.takeIf { it.isNotBlank() }
+                ?: row.statusChip?.takeIf { it.isNotBlank() }
+                ?: row.status.token
+            Text(text = subtitle, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+private fun sectionTitle(bucket: SigningInboxBucket, count: Int): String {
+    val label = when (bucket) {
+        SigningInboxBucket.AWAITING -> "Awaiting my signature"
+        SigningInboxBucket.SENT -> "Sent"
+        SigningInboxBucket.COMPLETED -> "Completed"
+        SigningInboxBucket.DRAFTS -> "Drafts"
+    }
+    return "$label ($count)"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/signing/packetlist/SigningInboxViewModel.kt
@@ -1,0 +1,91 @@
+package com.testlogon.android.feature.signing.packetlist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * SUX-008 — presentation logic for the signing INBOX ("list packets" surface).
+ *
+ * Loads the four browse buckets (awaiting / sent / completed / drafts) IN PARALLEL, folds each into a
+ * [BucketLoad], and builds the [SigningInboxUiState] via the pure [buildInboxState]. There is NO poll
+ * loop — refresh is manual (pull-to-refresh / retry). DEGRADE-ON-404: a 404 (or any failure) on one
+ * bucket drops that bucket only; the surface renders from whatever loaded, and only collapses to Empty /
+ * Error when every bucket is empty / failed respectively.
+ *
+ * Tapping a row opens the EXISTING packet DETAIL screen (view + SIGN + mark-done already live there), so
+ * this VM only emits an OpenPacket nav event; it owns no write.
+ */
+@HiltViewModel
+class SigningInboxViewModel @Inject constructor(
+    private val repository: SigningInboxRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<SigningInboxUiState>(SigningInboxUiState.Loading)
+    val uiState: StateFlow<SigningInboxUiState> = _uiState.asStateFlow()
+
+    /** Single in-flight load guard. */
+    private var loadJob: Job? = null
+
+    init {
+        load()
+    }
+
+    /** Initial read: flashes the spinner, then lands on Content / Empty / Error. */
+    fun load() {
+        if (_uiState.value !is SigningInboxUiState.Content) {
+            _uiState.value = SigningInboxUiState.Loading
+        }
+        refreshInternal(showRefreshing = false)
+    }
+
+    /** Manual refresh: keeps prior content visible with the refreshing flag while the loads run. */
+    fun refresh() {
+        val current = _uiState.value
+        if (current is SigningInboxUiState.Content) {
+            _uiState.value = current.copy(isRefreshing = true)
+        }
+        refreshInternal(showRefreshing = true)
+    }
+
+    private fun refreshInternal(showRefreshing: Boolean) {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            val loads = coroutineScope {
+                val awaiting = async { toBucketLoad(SigningInboxBucket.AWAITING, repository.awaiting()) }
+                val sent = async { toBucketLoad(SigningInboxBucket.SENT, repository.sent()) }
+                val completed =
+                    async { toBucketLoad(SigningInboxBucket.COMPLETED, repository.completedForMe()) }
+                val drafts = async { toBucketLoad(SigningInboxBucket.DRAFTS, repository.drafts()) }
+                listOf(awaiting.await(), sent.await(), completed.await(), drafts.await())
+            }
+            _uiState.value = buildInboxState(loads, isRefreshing = false)
+        }
+    }
+
+    private fun toBucketLoad(
+        bucket: SigningInboxBucket,
+        result: ApiResult<List<SigningInboxItem>>,
+    ): BucketLoad = when (result) {
+        is ApiResult.Success -> BucketLoad(bucket, items = result.data)
+        is ApiResult.Failure -> BucketLoad(bucket, failure = result.error)
+        is ApiResult.NetworkError -> BucketLoad(
+            bucket,
+            failure = ApiError(status = ApiError.STATUS_NETWORK, message = NETWORK_MESSAGE),
+        )
+    }
+
+    private companion object {
+        const val NETWORK_MESSAGE = "Couldn't reach the server. Try again."
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowModule.kt
@@ -1,0 +1,21 @@
+package com.testlogon.android.feature.workflow
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * WFL — Hilt wiring for the SuiteCRM Workflow feature repository seam. The impl consumes the core-network
+ * [com.testlogon.android.core.network.workflow.WorkflowRulesApi] + shared ApiErrorParser; NO new endpoint
+ * module, migration, or dependency is added here.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class WorkflowModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindWorkflowRulesRepository(impl: WorkflowRulesRepositoryImpl): WorkflowRulesRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRuleModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRuleModel.kt
@@ -1,0 +1,87 @@
+package com.testlogon.android.feature.workflow
+
+import com.testlogon.android.core.network.workflow.WorkflowRuleDto
+import java.time.Instant
+
+/**
+ * WFL — feature domain + DTO mappers + PURE summary logic for the SuiteCRM Workflow admin list/read MVP.
+ * Android-free + JVM-testable.
+ *
+ * Target-module + trigger-type are lenient enums (UNKNOWN fallback) mirroring the web constant lists.
+ * Timestamps are Unix-second Longs on the wire; 0 degrades to null [Instant].
+ */
+
+/** Module a rule targets (mirrors WORKFLOW_TARGET_MODULES). */
+enum class WorkflowTargetModule(val token: String) {
+    TICKET("ticket"),
+    CONTACT("contact"),
+    ORDER("order"),
+    SUBSCRIPTION("subscription"),
+    LEAD("lead"),
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        fun fromToken(t: String?): WorkflowTargetModule = entries.firstOrNull { it.token == t } ?: UNKNOWN
+    }
+}
+
+/** Trigger kind for a rule (mirrors WORKFLOW_TRIGGER_TYPES). */
+enum class WorkflowTriggerType(val token: String) {
+    ON_SAVE("on_save"),
+    ON_SCHEDULE("on_schedule"),
+    ON_TIME_ELAPSED("on_time_elapsed"),
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        fun fromToken(t: String?): WorkflowTriggerType = entries.firstOrNull { it.token == t } ?: UNKNOWN
+    }
+}
+
+/** One workflow rule (mapped from [WorkflowRuleDto]). */
+data class WorkflowRule(
+    val ruleId: String,
+    val name: String,
+    val description: String = "",
+    val targetModule: WorkflowTargetModule = WorkflowTargetModule.UNKNOWN,
+    val triggerType: WorkflowTriggerType = WorkflowTriggerType.UNKNOWN,
+    val conditionCount: Int = 0,
+    val actionCount: Int = 0,
+    val enabled: Boolean = false,
+    val createdBy: String = "",
+    val createdAt: Instant? = null,
+    val updatedAt: Instant? = null,
+)
+
+private fun epochToInstant(sec: Long?): Instant? =
+    sec?.takeIf { it > 0 }?.let { Instant.ofEpochSecond(it) }
+
+/** Maps a transport rule to the feature domain (counting conditions/actions, not carrying raw payloads). */
+fun WorkflowRuleDto.toDomain(): WorkflowRule = WorkflowRule(
+    ruleId = ruleId,
+    name = name,
+    description = description,
+    targetModule = WorkflowTargetModule.fromToken(targetModule),
+    triggerType = WorkflowTriggerType.fromToken(triggerType),
+    conditionCount = conditions.size,
+    actionCount = actions.size,
+    enabled = enabled,
+    createdBy = createdBy,
+    createdAt = epochToInstant(createdAt),
+    updatedAt = epochToInstant(updatedAt),
+)
+
+/**
+ * PURE list ordering for the admin rule list: enabled rules first, then by name (case-insensitive),
+ * stable + total. This is the read-only board's deterministic order.
+ */
+fun sortRules(rules: List<WorkflowRule>): List<WorkflowRule> =
+    rules.sortedWith(
+        compareByDescending<WorkflowRule> { it.enabled }
+            .thenBy { it.name.lowercase() }
+            .thenBy { it.ruleId },
+    )
+
+/** PURE count of enabled rules — powers the list header badge. */
+fun enabledCount(rules: List<WorkflowRule>): Int = rules.count { it.enabled }

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesRepository.kt
@@ -1,0 +1,66 @@
+package com.testlogon.android.feature.workflow
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.workflow.WorkflowRulesApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * WFL — data layer for the SuiteCRM Workflow admin list/read MVP.
+ *
+ * REUSES the core-network [WorkflowRulesApi] + shared [ApiErrorParser]; maps DTOs to domain BEFORE the
+ * typed [ApiResult]. DEGRADE-ON-404: the whole router 404s when CRM_WORKFLOW_ENABLED is off (or 403 for
+ * non-admins); both surface as an [ApiResult.Failure] the ViewModel folds to a calm unavailable state.
+ *
+ * READ ONLY: create/update/delete/enable/disable + drip sequences + run history are intentionally out of
+ * scope for the MVP (mutations are admin-heavy and the web surfaces them separately).
+ */
+interface WorkflowRulesRepository {
+
+    /** List workflow rules (optionally enabled-only), mapped + count-summarized. */
+    suspend fun listRules(enabledOnly: Boolean? = null, limit: Int? = null): ApiResult<List<WorkflowRule>>
+
+    /** Read one rule's detail. */
+    suspend fun getRule(ruleId: String): ApiResult<WorkflowRule>
+}
+
+@Singleton
+class WorkflowRulesRepositoryImpl @Inject constructor(
+    private val api: WorkflowRulesApi,
+    private val errorParser: ApiErrorParser,
+) : WorkflowRulesRepository {
+
+    override suspend fun listRules(
+        enabledOnly: Boolean?,
+        limit: Int?,
+    ): ApiResult<List<WorkflowRule>> = withContext(Dispatchers.IO) {
+        call { api.listRules(enabledOnly = enabledOnly, limit = limit).rules.map { it.toDomain() } }
+    }
+
+    override suspend fun getRule(ruleId: String): ApiResult<WorkflowRule> =
+        withContext(Dispatchers.IO) { call { api.getRule(ruleId).toDomain() } }
+
+    /** Folds a block into [ApiResult]; mirrors SignatureRepositoryImpl.call. */
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesScreen.kt
@@ -1,0 +1,170 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.workflow
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/** WFL — stable testTags for the workflow-rules admin list screen. */
+object WorkflowRulesTestTags {
+    const val SCREEN = "workflow_rules_screen"
+    const val RETRY = "workflow_rules_retry"
+
+    fun row(ruleId: String): String = "workflow_rule_row_$ruleId"
+}
+
+@Composable
+fun WorkflowRulesRoute(
+    onBack: () -> Unit,
+    viewModel: WorkflowRulesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    WorkflowRulesScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onRetry = viewModel::load,
+    )
+}
+
+@Composable
+fun WorkflowRulesScreen(
+    state: WorkflowRulesUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.testTag(WorkflowRulesTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Workflow rules") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when (state) {
+                is WorkflowRulesUiState.Loading ->
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                is WorkflowRulesUiState.Unavailable ->
+                    Text(
+                        "Workflow automation isn't enabled for this account.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                    )
+
+                is WorkflowRulesUiState.Empty ->
+                    Text(
+                        "No workflow rules configured.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                    )
+
+                is WorkflowRulesUiState.Error -> Column(
+                    modifier = Modifier.align(Alignment.Center),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(state.error.message, style = MaterialTheme.typography.bodyMedium)
+                    Button(onClick = onRetry, modifier = Modifier.testTag(WorkflowRulesTestTags.RETRY)) {
+                        Text("Retry")
+                    }
+                }
+
+                is WorkflowRulesUiState.Content -> PullToRefreshBox(
+                    isRefreshing = state.isRefreshing,
+                    onRefresh = onRefresh,
+                ) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        item(key = "header") {
+                            Text(
+                                text = "${state.rules.size} rules • ${state.enabledCount} enabled",
+                                style = MaterialTheme.typography.titleSmall,
+                                modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+                            )
+                        }
+                        items(state.rules, key = { it.ruleId }) { rule -> RuleRow(rule) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RuleRow(rule: WorkflowRule) {
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag(WorkflowRulesTestTags.row(rule.ruleId)),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(rule.name, style = MaterialTheme.typography.titleMedium)
+            rule.description.takeIf { it.isNotBlank() }?.let {
+                Text(it, style = MaterialTheme.typography.bodyMedium)
+            }
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AssistChip(onClick = {}, label = { Text(if (rule.enabled) "Enabled" else "Disabled") })
+                AssistChip(onClick = {}, label = { Text(moduleLabel(rule.targetModule)) })
+                AssistChip(onClick = {}, label = { Text(triggerLabel(rule.triggerType)) })
+            }
+            Text(
+                "${rule.conditionCount} conditions • ${rule.actionCount} actions",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+}
+
+private fun moduleLabel(m: WorkflowTargetModule): String = when (m) {
+    WorkflowTargetModule.TICKET -> "Ticket"
+    WorkflowTargetModule.CONTACT -> "Contact"
+    WorkflowTargetModule.ORDER -> "Order"
+    WorkflowTargetModule.SUBSCRIPTION -> "Subscription"
+    WorkflowTargetModule.LEAD -> "Lead"
+    WorkflowTargetModule.UNKNOWN -> "—"
+}
+
+private fun triggerLabel(t: WorkflowTriggerType): String = when (t) {
+    WorkflowTriggerType.ON_SAVE -> "On save"
+    WorkflowTriggerType.ON_SCHEDULE -> "On schedule"
+    WorkflowTriggerType.ON_TIME_ELAPSED -> "On time elapsed"
+    WorkflowTriggerType.UNKNOWN -> "—"
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesUiState.kt
@@ -1,0 +1,44 @@
+package com.testlogon.android.feature.workflow
+
+import com.testlogon.android.core.model.ApiError
+
+/**
+ * WFL — UI envelope + pure fold for the workflow-rules admin list. Android-free + JVM-testable.
+ *
+ * DEGRADE-ON-404: a 404 (flag off) OR 403 (not admin) folds to [Unavailable] — a calm message, not a
+ * scary error/retry. Any other failure with no prior content -> [Error].
+ */
+sealed interface WorkflowRulesUiState {
+
+    data object Loading : WorkflowRulesUiState
+
+    data class Content(
+        val rules: List<WorkflowRule>,
+        val enabledCount: Int,
+        val isRefreshing: Boolean = false,
+    ) : WorkflowRulesUiState
+
+    data object Empty : WorkflowRulesUiState
+
+    /** Feature not enabled (404) or caller not an admin (403). */
+    data object Unavailable : WorkflowRulesUiState
+
+    data class Error(val error: ApiError) : WorkflowRulesUiState
+}
+
+/**
+ * PURE fold of a list-load result. 404/403 -> [Unavailable]; other error -> [Error]; empty -> [Empty];
+ * else [Content] (sorted, with the enabled-count badge).
+ */
+fun foldRulesResult(
+    rules: List<WorkflowRule>?,
+    error: ApiError?,
+): WorkflowRulesUiState = when {
+    error != null && (error.status == 404 || error.status == 403) -> WorkflowRulesUiState.Unavailable
+    error != null -> WorkflowRulesUiState.Error(error)
+    rules == null || rules.isEmpty() -> WorkflowRulesUiState.Empty
+    else -> {
+        val sorted = sortRules(rules)
+        WorkflowRulesUiState.Content(rules = sorted, enabledCount = enabledCount(sorted))
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesViewModel.kt
@@ -1,0 +1,63 @@
+package com.testlogon.android.feature.workflow
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * WFL — presentation logic for the SuiteCRM Workflow admin list/read MVP. READ ONLY: [load] / [refresh]
+ * read the rule list ONCE (no poll loop, no writes). DEGRADE-ON-404/403 handled by [foldRulesResult].
+ */
+@HiltViewModel
+class WorkflowRulesViewModel @Inject constructor(
+    private val repository: WorkflowRulesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<WorkflowRulesUiState>(WorkflowRulesUiState.Loading)
+    val uiState: StateFlow<WorkflowRulesUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    init {
+        load()
+    }
+
+    fun load() {
+        if (_uiState.value !is WorkflowRulesUiState.Content) {
+            _uiState.value = WorkflowRulesUiState.Loading
+        }
+        fetch(showRefreshing = false)
+    }
+
+    fun refresh() {
+        (_uiState.value as? WorkflowRulesUiState.Content)?.let {
+            _uiState.value = it.copy(isRefreshing = true)
+        }
+        fetch(showRefreshing = true)
+    }
+
+    private fun fetch(showRefreshing: Boolean) {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            when (val result = repository.listRules()) {
+                is ApiResult.Success -> _uiState.value = foldRulesResult(result.data, null)
+                is ApiResult.Failure -> _uiState.value = foldRulesResult(null, result.error)
+                is ApiResult.NetworkError ->
+                    _uiState.value =
+                        foldRulesResult(null, ApiError(ApiError.STATUS_NETWORK, NETWORK_MESSAGE))
+            }
+        }
+    }
+
+    private companion object {
+        const val NETWORK_MESSAGE = "Couldn't reach the server. Try again."
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -479,6 +479,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // field-manifest placeholder, events, status-driven action). No backend packet-list endpoint, so
         // the "list" half is deferred.
         signingDestinations(navController)
+        maintenanceOrdersDestination(navController)
+        workflowRulesDestination(navController)
         // AND-353: organizations members/roles (list members + pending invites + invite/change-role/
         // remove with permission gating + self-protection). Nested graph so the members + invite screens
         // share one ViewModel.

--- a/android/app/src/main/java/com/testlogon/android/navigation/MaintenanceNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MaintenanceNavigation.kt
@@ -1,0 +1,22 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.maintenance.MaintenanceOrdersRoute
+
+/**
+ * WOV — the Maintenance Work Orders destination (reached from the More hub). Mirrors web
+ * /ui/maintenance-orders. List + create + status transition; degrades to an "unavailable" state when the
+ * MAINTENANCE_ORDERS_ENABLED flag is off (the backend 404s).
+ */
+data object MaintenanceOrdersDest {
+    const val ROUTE = "maintenance/work-orders"
+}
+
+/** Registers the Maintenance Work Orders destination. */
+fun NavGraphBuilder.maintenanceOrdersDestination(navController: NavHostController) {
+    composable(MaintenanceOrdersDest.ROUTE) {
+        MaintenanceOrdersRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -626,6 +626,16 @@ object MoreRoutes {
     val CONTACT: String get() = LegalRoutes.CONTACT
 
     /** Routes the hub treats as registered (real destinations or intentionally-surfaced stubs). */
+
+    // SUX-008: e-signature inbox (list packets -> view -> SIGN/complete).
+    const val SIGNING_INBOX = SigningInboxDest.ROUTE
+
+    // WOV: property maintenance work orders (list + create + status).
+    const val MAINTENANCE_ORDERS = MaintenanceOrdersDest.ROUTE
+
+    // WFL: SuiteCRM workflow rules admin (read-only list; operator-only).
+    const val WORKFLOW_RULES = WorkflowRulesDest.ROUTE
+
     val REGISTERED: Set<String>
         get() = setOf(
             PROFILE,
@@ -851,6 +861,9 @@ object MoreRoutes {
             TERMS,
             GUIDELINES,
             CONTACT,
+            SIGNING_INBOX,
+            MAINTENANCE_ORDERS,
+            WORKFLOW_RULES,
         )
 }
 

--- a/android/app/src/main/java/com/testlogon/android/navigation/SigningNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/SigningNavigation.kt
@@ -10,6 +10,7 @@ import androidx.navigation.navArgument
 import com.testlogon.android.feature.signing.PacketDetailRoute
 import com.testlogon.android.feature.signing.PacketDetailViewModel
 import com.testlogon.android.feature.signing.SigningEntryRoute
+import com.testlogon.android.feature.signing.packetlist.SigningInboxRoute
 import com.testlogon.android.feature.signing.capture.SigningRoute
 import com.testlogon.android.feature.signing.capture.SigningViewModel
 import com.testlogon.android.feature.signing.document.DocumentViewerRoute
@@ -28,6 +29,15 @@ import dagger.hilt.android.EntryPointAccessors
  * timeline + the status-driven primary action. onOpenPdf (-> the PDF viewer) and onSign (the assigned-
  * signer deep flow -> AND-342/343) are defaulted no-ops for now.
  */
+/**
+ * SUX-008 - the signing INBOX ("list packets") destination. Backed by the four browse endpoints
+ * (awaiting / sent / completed-for-me / drafts) that shipped after AND-340's load-by-id-only entry.
+ * Rows open the existing packet DETAIL. This is the More-hub entry point for the signing feature.
+ */
+data object SigningInboxDest {
+    const val ROUTE = "signing/inbox"
+}
+
 data object SigningEntryDest {
     const val ROUTE = "signing/entry"
 }
@@ -82,6 +92,14 @@ interface SignedDraftHandoffEntryPoint {
 
 /** AND-340 - registers the Signing entry + packet-detail screens in the authenticated graph. */
 fun NavGraphBuilder.signingDestinations(navController: NavHostController) {
+    composable(SigningInboxDest.ROUTE) {
+        SigningInboxRoute(
+            onBack = { navController.popBackStack() },
+            onOpenPacket = { packetId ->
+                navController.navigate(SigningPacketDetailDest.build(packetId))
+            },
+        )
+    }
     composable(SigningEntryDest.ROUTE) {
         SigningEntryRoute(
             onBack = { navController.popBackStack() },

--- a/android/app/src/main/java/com/testlogon/android/navigation/WorkflowNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/WorkflowNavigation.kt
@@ -1,0 +1,22 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.workflow.WorkflowRulesRoute
+
+/**
+ * WFL — the SuiteCRM Workflow admin destination (reached from the More hub, operator-only). Mirrors web
+ * /ui/admin/crm/workflow. Read-only list of workflow rules; degrades to an "unavailable" state when the
+ * CRM_WORKFLOW_ENABLED flag is off (404) or the caller is not an admin (403).
+ */
+data object WorkflowRulesDest {
+    const val ROUTE = "admin/crm/workflow/rules"
+}
+
+/** Registers the workflow-rules admin destination. */
+fun NavGraphBuilder.workflowRulesDestination(navController: NavHostController) {
+    composable(WorkflowRulesDest.ROUTE) {
+        WorkflowRulesRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4850,6 +4850,9 @@
     <string name="ideas_status_converted">Converted</string>
     <string name="ideas_status_unknown">Unknown</string>
     <string name="more_entry_licenses">Licenses</string>
+    <string name="more_entry_signing_inbox">Signatures</string>
+    <string name="more_entry_maintenance_orders">Work orders</string>
+    <string name="more_entry_workflow_rules">Workflow rules</string>
     <string name="licenses_title">Licenses</string>
     <string name="licenses_tab_issued">Issued</string>
     <string name="licenses_tab_requests">Requests</string>

--- a/android/app/src/test/java/com/testlogon/android/feature/maintenance/MaintenanceOrderModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/maintenance/MaintenanceOrderModelTest.kt
@@ -1,0 +1,108 @@
+package com.testlogon.android.feature.maintenance
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.network.maintenance.MaintenanceOrderDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** WOV — pure tests for the work-order state machine, board sort, DTO mapping + list fold. */
+class MaintenanceOrderModelTest {
+
+    private fun order(
+        id: String,
+        status: WoStatus = WoStatus.OPEN,
+        priority: WoPriority = WoPriority.NORMAL,
+        updated: Long = 0,
+    ) = MaintenanceOrder(
+        workOrderId = id,
+        propertyId = "prop",
+        title = "t-$id",
+        status = status,
+        priority = priority,
+        updatedAt = updated.takeIf { it > 0 }?.let { java.time.Instant.ofEpochSecond(it) },
+    )
+
+    @Test
+    fun allowedTransitions_open() {
+        assertEquals(
+            setOf(WoStatus.ASSIGNED, WoStatus.IN_PROGRESS, WoStatus.CANCELLED),
+            allowedTransitions(WoStatus.OPEN),
+        )
+    }
+
+    @Test
+    fun allowedTransitions_inProgress() {
+        assertEquals(setOf(WoStatus.COMPLETED, WoStatus.CANCELLED), allowedTransitions(WoStatus.IN_PROGRESS))
+    }
+
+    @Test
+    fun terminalStates_allowNothing() {
+        assertTrue(allowedTransitions(WoStatus.COMPLETED).isEmpty())
+        assertTrue(allowedTransitions(WoStatus.CANCELLED).isEmpty())
+        assertTrue(WoStatus.COMPLETED.isTerminal)
+        assertFalse(WoStatus.OPEN.isTerminal)
+    }
+
+    @Test
+    fun canTransition_rejectsIllegal_openToCompleted() {
+        assertFalse(canTransition(WoStatus.OPEN, WoStatus.COMPLETED))
+        assertTrue(canTransition(WoStatus.IN_PROGRESS, WoStatus.COMPLETED))
+    }
+
+    @Test
+    fun sortForBoard_activeBeforeTerminal_thenPriority() {
+        val sorted = sortForBoard(
+            listOf(
+                order("done", status = WoStatus.COMPLETED),
+                order("low", status = WoStatus.OPEN, priority = WoPriority.LOW),
+                order("urgent", status = WoStatus.OPEN, priority = WoPriority.URGENT),
+                order("active", status = WoStatus.IN_PROGRESS),
+            ),
+        )
+        assertEquals(listOf("active", "urgent", "low", "done"), sorted.map { it.workOrderId })
+    }
+
+    @Test
+    fun dtoMapper_lenientEnums_andEpochZeroToNull() {
+        val dto = MaintenanceOrderDto(
+            workOrderId = "w1",
+            propertyId = "p1",
+            title = "Fix sink",
+            priority = "weird",
+            woStatus = "in_progress",
+            createdAt = 0,
+            updatedAt = 100,
+        )
+        val d = dto.toDomain()
+        assertEquals(WoPriority.UNKNOWN, d.priority)
+        assertEquals(WoStatus.IN_PROGRESS, d.status)
+        assertNull(d.createdAt)
+        assertEquals(java.time.Instant.ofEpochSecond(100), d.updatedAt)
+    }
+
+    @Test
+    fun foldOrdersResult_404_isUnavailable() {
+        val state = foldOrdersResult(null, ApiError(status = 404, message = "no"))
+        assertEquals(MaintenanceOrdersUiState.Unavailable, state)
+    }
+
+    @Test
+    fun foldOrdersResult_otherError_isError() {
+        val state = foldOrdersResult(null, ApiError(status = 500, message = "boom"))
+        assertTrue(state is MaintenanceOrdersUiState.Error)
+    }
+
+    @Test
+    fun foldOrdersResult_emptyList_isEmpty_andNonEmptyIsSortedContent() {
+        assertEquals(MaintenanceOrdersUiState.Empty, foldOrdersResult(emptyList(), null))
+        val state = foldOrdersResult(
+            listOf(order("done", status = WoStatus.COMPLETED), order("active", status = WoStatus.IN_PROGRESS)),
+            null,
+        )
+        assertTrue(state is MaintenanceOrdersUiState.Content)
+        assertEquals("active", (state as MaintenanceOrdersUiState.Content).orders.first().workOrderId)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/signing/SignatureRepositoryTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/signing/SignatureRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Moshi
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.core.network.error.ApiErrorParser
 import com.testlogon.android.core.network.signing.CreateSignaturePacketRequest
+import com.testlogon.android.core.network.signing.SigningInboxListDto
 import com.testlogon.android.core.network.signing.CreateSignaturePacketResponse
 import com.testlogon.android.core.network.signing.LegalNoticeDto
 import com.testlogon.android.core.network.signing.PacketRole
@@ -330,6 +331,14 @@ class SignatureRepositoryTest {
         }
 
         override suspend fun downloadFinalPdf(packetId: String): Response<ResponseBody> = unused()
+
+        override suspend fun listAwaiting(limit: Int): SigningInboxListDto = unused()
+
+        override suspend fun listSent(limit: Int): SigningInboxListDto = unused()
+
+        override suspend fun listCompletedForMe(limit: Int): SigningInboxListDto = unused()
+
+        override suspend fun listDrafts(limit: Int): SigningInboxListDto = unused()
 
         override suspend fun listTemplates(): SignatureTemplateListDto = unused()
 

--- a/android/app/src/test/java/com/testlogon/android/feature/signing/packetlist/SigningInboxMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/signing/packetlist/SigningInboxMathTest.kt
@@ -1,0 +1,126 @@
+package com.testlogon.android.feature.signing.packetlist
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.network.signing.PacketStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** SUX-008 — pure tests for the signing inbox fold (buildInboxState) + degrade-on-404 contract. */
+class SigningInboxMathTest {
+
+    private fun item(id: String, status: PacketStatus = PacketStatus.SENT) =
+        SigningInboxItem(packetId = id, status = status)
+
+    private fun loaded(bucket: SigningInboxBucket, vararg ids: String) =
+        BucketLoad(bucket, items = ids.map { item(it) })
+
+    private fun failed(bucket: SigningInboxBucket, status: Int) =
+        BucketLoad(bucket, failure = ApiError(status = status, message = "x"))
+
+    @Test
+    fun allBucketsEmpty_isEmpty() {
+        val state = buildInboxState(
+            listOf(
+                BucketLoad(SigningInboxBucket.AWAITING),
+                BucketLoad(SigningInboxBucket.SENT),
+                BucketLoad(SigningInboxBucket.COMPLETED),
+                BucketLoad(SigningInboxBucket.DRAFTS),
+            ),
+        )
+        assertEquals(SigningInboxUiState.Empty, state)
+    }
+
+    @Test
+    fun nonEmptyBuckets_becomeSectionsInCanonicalOrder() {
+        val state = buildInboxState(
+            listOf(
+                loaded(SigningInboxBucket.DRAFTS, "d1"),
+                loaded(SigningInboxBucket.AWAITING, "a1", "a2"),
+                BucketLoad(SigningInboxBucket.SENT), // empty -> omitted
+                loaded(SigningInboxBucket.COMPLETED, "c1"),
+            ),
+        )
+        assertTrue(state is SigningInboxUiState.Content)
+        val content = state as SigningInboxUiState.Content
+        assertEquals(
+            listOf(
+                SigningInboxBucket.AWAITING,
+                SigningInboxBucket.COMPLETED,
+                SigningInboxBucket.DRAFTS,
+            ),
+            content.sections.map { it.bucket },
+        )
+        assertEquals(2, content.awaitingCount)
+        assertEquals(4, content.totalCount)
+    }
+
+    @Test
+    fun oneBucket404_dropsThatBucketOnly() {
+        // awaiting 404s (flag-partial), the rest load -> content still renders from the loaded buckets.
+        val state = buildInboxState(
+            listOf(
+                failed(SigningInboxBucket.AWAITING, 404),
+                loaded(SigningInboxBucket.SENT, "s1"),
+                BucketLoad(SigningInboxBucket.COMPLETED),
+                BucketLoad(SigningInboxBucket.DRAFTS),
+            ),
+        )
+        assertTrue(state is SigningInboxUiState.Content)
+        val content = state as SigningInboxUiState.Content
+        assertEquals(listOf(SigningInboxBucket.SENT), content.sections.map { it.bucket })
+        assertEquals(0, content.awaitingCount)
+    }
+
+    @Test
+    fun allBucketsFail404_isError_withThe404() {
+        val state = buildInboxState(
+            listOf(
+                failed(SigningInboxBucket.AWAITING, 404),
+                failed(SigningInboxBucket.SENT, 404),
+                failed(SigningInboxBucket.COMPLETED, 404),
+                failed(SigningInboxBucket.DRAFTS, 404),
+            ),
+        )
+        assertTrue(state is SigningInboxUiState.Error)
+        assertEquals(404, (state as SigningInboxUiState.Error).error.status)
+    }
+
+    @Test
+    fun allBucketsFailMixed_prefers404AsSurfacedError() {
+        val state = buildInboxState(
+            listOf(
+                failed(SigningInboxBucket.AWAITING, 500),
+                failed(SigningInboxBucket.SENT, 404),
+                failed(SigningInboxBucket.COMPLETED, 500),
+                failed(SigningInboxBucket.DRAFTS, 500),
+            ),
+        )
+        assertTrue(state is SigningInboxUiState.Error)
+        assertEquals(404, (state as SigningInboxUiState.Error).error.status)
+    }
+
+    @Test
+    fun dtoMapper_parsesStatusAndTitle() {
+        val dto = com.testlogon.android.core.network.signing.SigningInboxItemDto(
+            packetId = "p1",
+            status = "partially_signed",
+            sourceName = "Lease.pdf",
+        )
+        val domain = dto.toDomain()
+        assertEquals(PacketStatus.PARTIALLY_SIGNED, domain.status)
+        assertEquals("Lease.pdf", domain.displayTitle)
+    }
+
+    @Test
+    fun dtoMapper_unknownStatus_fallsBack_andTitleFallsBackToId() {
+        val dto = com.testlogon.android.core.network.signing.SigningInboxItemDto(
+            packetId = "p2",
+            status = "weird_status",
+            sourceName = null,
+        )
+        val domain = dto.toDomain()
+        assertEquals(PacketStatus.UNKNOWN, domain.status)
+        assertEquals("p2", domain.displayTitle)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/workflow/WorkflowRuleModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/workflow/WorkflowRuleModelTest.kt
@@ -1,0 +1,83 @@
+package com.testlogon.android.feature.workflow
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.network.workflow.WorkflowRuleDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** WFL — pure tests for workflow-rule mapping, sort, enabled-count + list fold (degrade on 404/403). */
+class WorkflowRuleModelTest {
+
+    private fun rule(id: String, name: String, enabled: Boolean) = WorkflowRule(
+        ruleId = id,
+        name = name,
+        enabled = enabled,
+    )
+
+    @Test
+    fun dtoMapper_countsConditionsActions_andLenientEnums() {
+        val dto = WorkflowRuleDto(
+            ruleId = "r1",
+            name = "Escalate",
+            targetModule = "ticket",
+            triggerType = "on_save",
+            conditions = listOf(mapOf("field" to "x"), mapOf("field" to "y")),
+            actions = listOf(mapOf("action_type" to "send_email")),
+            enabled = true,
+        )
+        val d = dto.toDomain()
+        assertEquals(WorkflowTargetModule.TICKET, d.targetModule)
+        assertEquals(WorkflowTriggerType.ON_SAVE, d.triggerType)
+        assertEquals(2, d.conditionCount)
+        assertEquals(1, d.actionCount)
+    }
+
+    @Test
+    fun dtoMapper_unknownModuleAndTrigger_fallBack() {
+        val dto = WorkflowRuleDto(ruleId = "r2", name = "n", targetModule = "zzz", triggerType = "qqq")
+        val d = dto.toDomain()
+        assertEquals(WorkflowTargetModule.UNKNOWN, d.targetModule)
+        assertEquals(WorkflowTriggerType.UNKNOWN, d.triggerType)
+    }
+
+    @Test
+    fun sortRules_enabledFirst_thenNameCaseInsensitive() {
+        val sorted = sortRules(
+            listOf(
+                rule("1", "beta", enabled = false),
+                rule("2", "Alpha", enabled = true),
+                rule("3", "alpha", enabled = false),
+            ),
+        )
+        assertEquals(listOf("2", "3", "1"), sorted.map { it.ruleId })
+    }
+
+    @Test
+    fun enabledCount_counts() {
+        assertEquals(
+            2,
+            enabledCount(listOf(rule("1", "a", true), rule("2", "b", false), rule("3", "c", true))),
+        )
+    }
+
+    @Test
+    fun foldRulesResult_404and403_areUnavailable() {
+        assertEquals(WorkflowRulesUiState.Unavailable, foldRulesResult(null, ApiError(404, "x")))
+        assertEquals(WorkflowRulesUiState.Unavailable, foldRulesResult(null, ApiError(403, "x")))
+    }
+
+    @Test
+    fun foldRulesResult_otherError_isError_emptyIsEmpty_contentSorted() {
+        assertTrue(foldRulesResult(null, ApiError(500, "x")) is WorkflowRulesUiState.Error)
+        assertEquals(WorkflowRulesUiState.Empty, foldRulesResult(emptyList(), null))
+        val state = foldRulesResult(
+            listOf(rule("1", "b", false), rule("2", "a", true)),
+            null,
+        )
+        assertTrue(state is WorkflowRulesUiState.Content)
+        val content = state as WorkflowRulesUiState.Content
+        assertEquals("2", content.rules.first().ruleId)
+        assertEquals(1, content.enabledCount)
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/maintenance/MaintenanceNetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/maintenance/MaintenanceNetworkModule.kt
@@ -1,0 +1,24 @@
+package com.testlogon.android.core.network.maintenance
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * Hilt wiring for the Maintenance Work Orders transport layer. Provides [MaintenanceOrdersApi] from the
+ * shared singleton [Retrofit] (reusing the production OkHttp / Moshi / converter config; no new Retrofit,
+ * OkHttp, Moshi or dependency is introduced). The WOV DTOs use only String / Long / Boolean fields, so
+ * the shared reflective Moshi decodes them without any new adapter. Mirrors SigningNetworkModule.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object MaintenanceNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideMaintenanceOrdersApi(retrofit: Retrofit): MaintenanceOrdersApi =
+        retrofit.create(MaintenanceOrdersApi::class.java)
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/maintenance/MaintenanceOrderDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/maintenance/MaintenanceOrderDtos.kt
@@ -1,0 +1,69 @@
+package com.testlogon.android.core.network.maintenance
+
+import com.squareup.moshi.Json
+
+/**
+ * Transport DTOs for the Maintenance Work Orders surface (WOV-001..WOV-005).
+ *
+ * Backend router: app/routers/maintenance_orders.py (prefix /ui, cookie/bearer session).
+ * Master flag: MAINTENANCE_ORDERS_ENABLED (default false -> 404 on all endpoints) — the repository
+ * degrades on 404.
+ *
+ * Mirrors frontend/src/api/endpoints/maintenanceOrders.ts (MaintenanceOrderOut / WoListOut /
+ * MaintenanceOrderIn / MaintenanceOrderTransitionIn) and app/models.py WOV models.
+ *
+ * CODEGEN NOTE: core-network decodes via the reflective Moshi factory, so every wire key carries an
+ * explicit @Json(name=...). Optional fields are nullable with defaults so a sparse row decodes. All
+ * timestamps are Unix-second Longs (nullable where the backend allows null). `priority` / `wo_status`
+ * are raw wire Strings mapped through the lenient domain enums in :app (no second enum adapter here).
+ */
+
+/** One maintenance work order (mirrors MaintenanceOrderOut). `work_order_id` is required. */
+data class MaintenanceOrderDto(
+    @Json(name = "work_order_id") val workOrderId: String,
+    @Json(name = "property_id") val propertyId: String,
+    @Json(name = "unit_id") val unitId: String? = null,
+    @Json(name = "vendor_id") val vendorId: String? = null,
+    @Json(name = "assignee_sub") val assigneeSub: String? = null,
+    @Json(name = "title") val title: String,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "priority") val priority: String = "normal",
+    @Json(name = "wo_status") val woStatus: String = "open",
+    @Json(name = "scheduled_for") val scheduledFor: Long? = null,
+    @Json(name = "cost_cents") val costCents: Long? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+    @Json(name = "completed_at") val completedAt: Long? = null,
+    @Json(name = "correlation_id") val correlationId: String? = null,
+    @Json(name = "actor_sub") val actorSub: String? = null,
+    @Json(name = "escrow_amount_cents") val escrowAmountCents: Long? = null,
+    @Json(name = "escrow_status") val escrowStatus: String? = null,
+)
+
+/** The {items, count, cursor} list envelope (mirrors WoListOut). */
+data class MaintenanceOrderListDto(
+    @Json(name = "items") val items: List<MaintenanceOrderDto> = emptyList(),
+    @Json(name = "count") val count: Int = 0,
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+/** Create body for a property-scoped work order (mirrors MaintenanceOrderIn). */
+data class CreateMaintenanceOrderRequest(
+    @Json(name = "title") val title: String,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "priority") val priority: String? = null,
+    @Json(name = "property_id") val propertyId: String,
+    @Json(name = "unit_id") val unitId: String? = null,
+    @Json(name = "scheduled_for") val scheduledFor: Long? = null,
+    @Json(name = "correlation_id") val correlationId: String? = null,
+    @Json(name = "amount_cents") val amountCents: Long? = null,
+)
+
+/** Status-transition body (mirrors MaintenanceOrderTransitionIn). `property_id` scopes authorization. */
+data class TransitionMaintenanceOrderRequest(
+    @Json(name = "property_id") val propertyId: String,
+    @Json(name = "target_status") val targetStatus: String,
+    @Json(name = "cost_cents") val costCents: Long? = null,
+    @Json(name = "assignee_sub") val assigneeSub: String? = null,
+    @Json(name = "vendor_id") val vendorId: String? = null,
+)

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/maintenance/MaintenanceOrdersApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/maintenance/MaintenanceOrdersApi.kt
@@ -1,0 +1,65 @@
+package com.testlogon.android.core.network.maintenance
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface for the Maintenance Work Orders endpoint surface (WOV). Transport only.
+ *
+ * Paths have NO leading slash (relative to the shared Retrofit base URL, matching the rest of
+ * core-network). All calls are suspend. Mutating verbs carry an explicit JSON Content-Type. Session
+ * cookies / Authorization Bearer / X-CSRF-Token are attached globally by the core-network interceptors.
+ * Mutations require admin/root server-side (they 403 otherwise); reads are any-authenticated.
+ *
+ * Mirrors frontend/src/api/endpoints/maintenanceOrders.ts. The system-wide list + property-scoped create
+ * + the transition PATCH are the three the Android MVP wires (list + create + status). The board-columns
+ * / vendor endpoints are intentionally NOT ported here (deferred — see repository KDoc).
+ */
+interface MaintenanceOrdersApi {
+
+    /** System-wide work-order list, optionally filtered by status / assignee (cursor-paged). */
+    @GET("ui/maintenance/work-orders")
+    suspend fun listWorkOrders(
+        @Query("wo_status") woStatus: String? = null,
+        @Query("assignee_sub") assigneeSub: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): MaintenanceOrderListDto
+
+    /** Property-scoped list. */
+    @GET("ui/properties/{propertyId}/work-orders")
+    suspend fun listPropertyWorkOrders(
+        @Path("propertyId") propertyId: String,
+        @Query("wo_status") woStatus: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): MaintenanceOrderListDto
+
+    /** Read one work order (property-scoped). */
+    @GET("ui/properties/{propertyId}/work-orders/{workOrderId}")
+    suspend fun getWorkOrder(
+        @Path("propertyId") propertyId: String,
+        @Path("workOrderId") workOrderId: String,
+    ): MaintenanceOrderDto
+
+    /** Create a property-scoped work order. */
+    @Headers("Content-Type: application/json")
+    @POST("ui/properties/{propertyId}/work-orders")
+    suspend fun createWorkOrder(
+        @Path("propertyId") propertyId: String,
+        @Body body: CreateMaintenanceOrderRequest,
+    ): MaintenanceOrderDto
+
+    /** Transition a work order's status (assigned / in_progress / completed / cancelled). */
+    @Headers("Content-Type: application/json")
+    @PATCH("ui/maintenance/work-orders/{workOrderId}")
+    suspend fun transitionWorkOrder(
+        @Path("workOrderId") workOrderId: String,
+        @Body body: TransitionMaintenanceOrderRequest,
+    ): MaintenanceOrderDto
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/signing/SigningApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/signing/SigningApi.kt
@@ -7,6 +7,7 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 import retrofit2.http.Streaming
 
 /**
@@ -75,6 +76,24 @@ interface SigningApi {
     @Streaming
     @GET("v1/signature-packets/{packetId}/final-pdf")
     suspend fun downloadFinalPdf(@Path("packetId") packetId: String): Response<ResponseBody>
+
+    // ---- Signing inbox (SUX-008 browse lists) ----
+    //
+    // The four browse endpoints that did not exist when AND-339 shipped the load-by-id-only API. All
+    // return the same {items, count} envelope ([SigningInboxListDto]); the repository maps it to domain
+    // and the SigningInboxViewModel groups the four buckets. `limit` mirrors the web default of 100.
+
+    @GET("v1/signature-packets/awaiting")
+    suspend fun listAwaiting(@Query("limit") limit: Int = 100): SigningInboxListDto
+
+    @GET("v1/signature-packets/sent")
+    suspend fun listSent(@Query("limit") limit: Int = 100): SigningInboxListDto
+
+    @GET("v1/signature-packets/completed-for-me")
+    suspend fun listCompletedForMe(@Query("limit") limit: Int = 100): SigningInboxListDto
+
+    @GET("v1/signature-packets/drafts")
+    suspend fun listDrafts(@Query("limit") limit: Int = 100): SigningInboxListDto
 
     // ---- Templates ----
 

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/signing/SigningInboxDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/signing/SigningInboxDtos.kt
@@ -1,0 +1,43 @@
+package com.testlogon.android.core.network.signing
+
+import com.squareup.moshi.Json
+
+/**
+ * Transport DTOs for the signing INBOX list surface (SUX-008) — the four browse endpoints that did not
+ * exist when AND-339 shipped the load-by-id-only API:
+ *
+ *   GET v1/signature-packets/awaiting          — packets awaiting the caller's signature
+ *   GET v1/signature-packets/sent              — packets the caller sent (as owner)
+ *   GET v1/signature-packets/completed-for-me  — completed packets the caller signed
+ *   GET v1/signature-packets/drafts            — the caller's draft packets
+ *
+ * All four return the SAME {items, count} envelope ([SigningInboxListDto]). This mirrors the web
+ * contract (frontend/src/api/endpoints/signaturePackets.ts SigningInboxItem / SigningInboxList) and the
+ * backend Pydantic models (app/routers/signature_packets.py SigningInboxItemOut / SigningInboxListOut).
+ *
+ * CODEGEN NOTE: like the rest of core-network signing, these decode via the reflective Moshi factory, so
+ * every wire key carries an explicit @Json(name=...). All optional fields are nullable with defaults so
+ * a sparse row decodes. `status` is a raw String (NOT the [PacketStatus] enum) because the inbox rows
+ * echo the packet status verbatim and we render it through [PacketStatus.fromToken] in the domain mapper
+ * (keeping the lenient UNKNOWN fallback without a second enum adapter on the wire).
+ */
+
+/** One row in a signing inbox list. `packet_id` + `status` are required; everything else is optional. */
+data class SigningInboxItemDto(
+    @Json(name = "packet_id") val packetId: String,
+    @Json(name = "status") val status: String,
+    @Json(name = "owner_user_id") val ownerUserId: String? = null,
+    @Json(name = "source_name") val sourceName: String? = null,
+    @Json(name = "status_chip") val statusChip: String? = null,
+    @Json(name = "status_text") val statusText: String? = null,
+    @Json(name = "role") val role: String? = null,
+    @Json(name = "created_at") val createdAt: String? = null,
+    @Json(name = "sent_at") val sentAt: String? = null,
+    @Json(name = "completed_at") val completedAt: String? = null,
+)
+
+/** The {items, count} envelope returned by all four inbox endpoints. */
+data class SigningInboxListDto(
+    @Json(name = "items") val items: List<SigningInboxItemDto> = emptyList(),
+    @Json(name = "count") val count: Int = 0,
+)

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowNetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowNetworkModule.kt
@@ -1,0 +1,24 @@
+package com.testlogon.android.core.network.workflow
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * Hilt wiring for the SuiteCRM Workflow (WFL) transport layer. Provides [WorkflowRulesApi] from the
+ * shared singleton [Retrofit] (reusing the production OkHttp / Moshi / converter config; no new Retrofit,
+ * OkHttp, Moshi or dependency is introduced). The WFL read DTOs use String / Long / Boolean / loosely-
+ * typed Map fields, which the shared reflective Moshi decodes without any new adapter.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object WorkflowNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideWorkflowRulesApi(retrofit: Retrofit): WorkflowRulesApi =
+        retrofit.create(WorkflowRulesApi::class.java)
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRuleDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRuleDtos.kt
@@ -1,0 +1,43 @@
+package com.testlogon.android.core.network.workflow
+
+import com.squareup.moshi.Json
+
+/**
+ * Transport DTOs for the SuiteCRM Workflow (WFL) admin surface — READ subset.
+ *
+ * Backend router: app/routers/workflow_rules.py (prefix /ui/admin/crm/workflow).
+ * Gated by CRM_WORKFLOW_ENABLED (default OFF -> 404); the repository degrades on 404.
+ *
+ * Mirrors frontend/src/api/endpoints/crmWorkflow.ts (WorkflowRuleOut / WorkflowRuleListOut). The Android
+ * MVP is list/read only, so only the read shapes are ported (create/update/delete/enable/disable + drip
+ * sequences + run history are intentionally NOT ported — see repository KDoc).
+ *
+ * CODEGEN NOTE: reflective Moshi factory -> explicit @Json(name=...) on every key. The loosely-typed
+ * config / conditions / actions payloads are Map / List<Map> of String -> Any? with @JvmSuppressWildcards
+ * to keep Moshi's generic resolution happy. Timestamps are Unix-second Longs.
+ */
+
+/** One workflow rule (mirrors WorkflowRuleOut). `rule_id` + `name` are required. */
+data class WorkflowRuleDto(
+    @Json(name = "rule_id") val ruleId: String,
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String = "",
+    @Json(name = "target_module") val targetModule: String = "",
+    @Json(name = "trigger_type") val triggerType: String = "",
+    @Json(name = "trigger_config")
+    val triggerConfig: Map<String, @JvmSuppressWildcards Any?> = emptyMap(),
+    @Json(name = "conditions")
+    val conditions: List<Map<String, @JvmSuppressWildcards Any?>> = emptyList(),
+    @Json(name = "actions")
+    val actions: List<Map<String, @JvmSuppressWildcards Any?>> = emptyList(),
+    @Json(name = "enabled") val enabled: Boolean = false,
+    @Json(name = "created_by") val createdBy: String = "",
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+/** The rule-list envelope (mirrors WorkflowRuleListOut). */
+data class WorkflowRuleListDto(
+    @Json(name = "rules") val rules: List<WorkflowRuleDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRulesApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRulesApi.kt
@@ -1,0 +1,27 @@
+package com.testlogon.android.core.network.workflow
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface for the SuiteCRM Workflow (WFL) admin endpoint surface — READ subset. Transport
+ * only. Paths have NO leading slash (relative to the shared base URL). Session cookies / Authorization
+ * Bearer / X-CSRF-Token are attached globally. These reads are admin-gated server-side (403 for members)
+ * and the whole router 404s when CRM_WORKFLOW_ENABLED is off.
+ *
+ * Mirrors frontend/src/api/endpoints/crmWorkflow.ts listWorkflowRules / getWorkflowRule.
+ */
+interface WorkflowRulesApi {
+
+    @GET("ui/admin/crm/workflow/rules")
+    suspend fun listRules(
+        @Query("target_module") targetModule: String? = null,
+        @Query("enabled_only") enabledOnly: Boolean? = null,
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): WorkflowRuleListDto
+
+    @GET("ui/admin/crm/workflow/rules/{ruleId}")
+    suspend fun getRule(@Path("ruleId") ruleId: String): WorkflowRuleDto
+}

--- a/android/core-network/src/test/java/com/testlogon/android/core/network/maintenance/MaintenanceOrderDtoJsonTest.kt
+++ b/android/core-network/src/test/java/com/testlogon/android/core/network/maintenance/MaintenanceOrderDtoJsonTest.kt
@@ -1,0 +1,63 @@
+package com.testlogon.android.core.network.maintenance
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** WOV — DTO-level Moshi decode tests for the Maintenance Work Orders list envelope. */
+class MaintenanceOrderDtoJsonTest {
+
+    private val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+
+    @Test
+    fun list_decodesOrdersCountCursor() {
+        val json = """
+            {
+              "items": [
+                {
+                  "work_order_id": "w1",
+                  "property_id": "prop1",
+                  "unit_id": null,
+                  "vendor_id": null,
+                  "assignee_sub": null,
+                  "title": "Fix sink",
+                  "description": "Kitchen sink leak",
+                  "priority": "urgent",
+                  "wo_status": "open",
+                  "scheduled_for": null,
+                  "cost_cents": null,
+                  "created_at": 1700000000,
+                  "updated_at": 1700000100,
+                  "completed_at": null,
+                  "correlation_id": "c1",
+                  "actor_sub": "a1",
+                  "escrow_amount_cents": null,
+                  "escrow_status": null
+                }
+              ],
+              "count": 1,
+              "cursor": "next"
+            }
+        """.trimIndent()
+        val dto = moshi.adapter(MaintenanceOrderListDto::class.java).fromJson(json)!!
+        assertEquals(1, dto.count)
+        assertEquals("next", dto.cursor)
+        val row = dto.items.first()
+        assertEquals("w1", row.workOrderId)
+        assertEquals("urgent", row.priority)
+        assertEquals(1700000100L, row.updatedAt)
+    }
+
+    @Test
+    fun sparseRow_usesDefaults() {
+        val json = """{"items":[{"work_order_id":"w2","property_id":"p2","title":"t"}],"count":1}"""
+        val dto = moshi.adapter(MaintenanceOrderListDto::class.java).fromJson(json)!!
+        val row = dto.items.first()
+        assertEquals("normal", row.priority)
+        assertEquals("open", row.woStatus)
+        assertNull(dto.cursor)
+        assertNull(row.completedAt)
+    }
+}

--- a/android/core-network/src/test/java/com/testlogon/android/core/network/signing/SigningInboxDtoJsonTest.kt
+++ b/android/core-network/src/test/java/com/testlogon/android/core/network/signing/SigningInboxDtoJsonTest.kt
@@ -1,0 +1,63 @@
+package com.testlogon.android.core.network.signing
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * SUX-008 — DTO-level Moshi decode tests for the signing INBOX list envelope. Uses the reflective
+ * KotlinJsonAdapterFactory (as production does). The inbox DTOs are plain String fields, so no enum
+ * adapter is needed here.
+ */
+class SigningInboxDtoJsonTest {
+
+    private val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+
+    @Test
+    fun inboxList_decodesItemsAndCount() {
+        val json = """
+            {
+              "items": [
+                {
+                  "packet_id": "p1",
+                  "owner_user_id": "u1",
+                  "source_name": "Lease.pdf",
+                  "status": "sent",
+                  "status_chip": "Awaiting",
+                  "status_text": "Awaiting your signature",
+                  "role": "signer",
+                  "created_at": "2026-01-01T00:00:00Z"
+                }
+              ],
+              "count": 1
+            }
+        """.trimIndent()
+        val dto = moshi.adapter(SigningInboxListDto::class.java).fromJson(json)!!
+        assertEquals(1, dto.count)
+        assertEquals(1, dto.items.size)
+        val row = dto.items.first()
+        assertEquals("p1", row.packetId)
+        assertEquals("Lease.pdf", row.sourceName)
+        assertEquals("Awaiting your signature", row.statusText)
+    }
+
+    @Test
+    fun inboxList_sparseRow_decodesWithDefaults() {
+        val json = """{"items":[{"packet_id":"p2","status":"draft"}],"count":1}"""
+        val dto = moshi.adapter(SigningInboxListDto::class.java).fromJson(json)!!
+        val row = dto.items.first()
+        assertEquals("p2", row.packetId)
+        assertEquals("draft", row.status)
+        assertNull(row.sourceName)
+        assertNull(row.role)
+    }
+
+    @Test
+    fun inboxList_emptyBody_decodesToEmptyEnvelope() {
+        val dto = moshi.adapter(SigningInboxListDto::class.java).fromJson("{}")!!
+        assertEquals(0, dto.count)
+        assertEquals(0, dto.items.size)
+    }
+}

--- a/android/core-network/src/test/java/com/testlogon/android/core/network/workflow/WorkflowRuleDtoJsonTest.kt
+++ b/android/core-network/src/test/java/com/testlogon/android/core/network/workflow/WorkflowRuleDtoJsonTest.kt
@@ -1,0 +1,56 @@
+package com.testlogon.android.core.network.workflow
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** WFL — DTO-level Moshi decode tests for the workflow-rule list envelope (loosely-typed payloads). */
+class WorkflowRuleDtoJsonTest {
+
+    private val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+
+    @Test
+    fun ruleList_decodesRulesWithNestedPayloads() {
+        val json = """
+            {
+              "rules": [
+                {
+                  "rule_id": "r1",
+                  "name": "Escalate urgent tickets",
+                  "description": "auto-assign",
+                  "target_module": "ticket",
+                  "trigger_type": "on_save",
+                  "trigger_config": {"debounce": 5},
+                  "conditions": [{"field": "priority", "operator": "eq", "value": "urgent"}],
+                  "actions": [{"action_type": "modify_field", "config": {"field": "owner"}}],
+                  "enabled": true,
+                  "created_by": "admin",
+                  "created_at": 1700000000,
+                  "updated_at": 1700000100
+                }
+              ],
+              "cursor": null
+            }
+        """.trimIndent()
+        val dto = moshi.adapter(WorkflowRuleListDto::class.java).fromJson(json)!!
+        assertEquals(1, dto.rules.size)
+        val rule = dto.rules.first()
+        assertEquals("r1", rule.ruleId)
+        assertEquals("ticket", rule.targetModule)
+        assertEquals(1, rule.conditions.size)
+        assertEquals(1, rule.actions.size)
+        assertTrue(rule.enabled)
+    }
+
+    @Test
+    fun sparseRule_usesDefaults() {
+        val json = """{"rules":[{"rule_id":"r2","name":"n"}]}"""
+        val dto = moshi.adapter(WorkflowRuleListDto::class.java).fromJson(json)!!
+        val rule = dto.rules.first()
+        assertEquals("", rule.description)
+        assertEquals(0, rule.conditions.size)
+        assertEquals(false, rule.enabled)
+    }
+}


### PR DESCRIPTION
## FE parity PAR-145 - Android workflow-rules / maintenance / signature packets

Adds Android parity surfaces to match the web/backend feature set:

- **Workflow rules**: network DTOs + API, feature module, list screen and view model.
- **Maintenance orders**: network DTOs + API, feature module, screen, UI state and view model.
- **Signature packets inbox**: signing inbox domain/math, DTOs, repository, screen and view model.

Wired into the More catalog and the authenticated navigation graph. Includes unit tests for domain math and DTO JSON round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
