### PR TITLE
FE parity PAR-140 - Android CRM sales MVP (leads + pipeline)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmDataModule.kt
@@ -1,0 +1,37 @@
+package com.testlogon.android.data.crm
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** CRM-AND-1 — provides the [LeadsApi] + [SalesApi] on the shared Retrofit. */
+@Module
+@InstallIn(SingletonComponent::class)
+object CrmApiModule {
+
+    @Provides
+    @Singleton
+    fun provideLeadsApi(retrofit: Retrofit): LeadsApi = retrofit.create(LeadsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSalesApi(retrofit: Retrofit): SalesApi = retrofit.create(SalesApi::class.java)
+}
+
+/** CRM-AND-1 — binds the CRM repositories to their implementations. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CrmDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindLeadsRepository(impl: LeadsRepositoryImpl): LeadsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSalesRepository(impl: SalesRepositoryImpl): SalesRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmDtos.kt
@@ -1,0 +1,194 @@
+package com.testlogon.android.data.crm
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * CRM-AND-1 — wire DTOs for the SuiteCRM Leads (/ui/leads) + Opportunities (/ui/sales) surfaces.
+ *
+ * Field names mirror the LIVE contract in frontend/src/api/endpoints/leads.ts +
+ * frontend/src/api/endpoints/opportunities.ts (which themselves mirror the Pydantic models in
+ * app/models.py). Every field is nullable / defaulted so a partial or drifted server body decodes
+ * rather than throwing; unknown fields are ignored by Moshi.
+ */
+
+// ─────────────────────────────  LEADS  ─────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class LeadDto(
+    @Json(name = "lead_id") val leadId: String = "",
+    @Json(name = "first_name") val firstName: String = "",
+    @Json(name = "last_name") val lastName: String = "",
+    @Json(name = "email") val email: String = "",
+    @Json(name = "phone") val phone: String? = null,
+    @Json(name = "company") val company: String? = null,
+    @Json(name = "title") val title: String? = null,
+    @Json(name = "lead_source") val leadSource: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "status") val status: String = "new",
+    @Json(name = "assigned_to") val assignedTo: String? = null,
+    @Json(name = "score") val score: Int = 0,
+    @Json(name = "website") val website: String? = null,
+    @Json(name = "created_by") val createdBy: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+    @Json(name = "converted_at") val convertedAt: Long? = null,
+    @Json(name = "converted_party_id") val convertedPartyId: String? = null,
+    @Json(name = "converted_org_id") val convertedOrgId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadListRespDto(
+    @Json(name = "leads") val leads: List<LeadDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadCreateInDto(
+    @Json(name = "first_name") val firstName: String,
+    @Json(name = "last_name") val lastName: String,
+    @Json(name = "email") val email: String,
+    @Json(name = "phone") val phone: String? = null,
+    @Json(name = "company") val company: String? = null,
+    @Json(name = "title") val title: String? = null,
+    @Json(name = "lead_source") val leadSource: String? = null,
+    @Json(name = "description") val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadUpdateInDto(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "assigned_to") val assignedTo: String? = null,
+    @Json(name = "score") val score: Int? = null,
+    @Json(name = "description") val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadConversionInDto(
+    @Json(name = "create_account") val createAccount: Boolean? = null,
+    @Json(name = "account_name") val accountName: String? = null,
+    @Json(name = "create_opportunity") val createOpportunity: Boolean? = null,
+    @Json(name = "opportunity_name") val opportunityName: String? = null,
+    @Json(name = "opportunity_amount_cents") val opportunityAmountCents: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class OpportunityStubDto(
+    @Json(name = "opportunity_id") val opportunityId: String = "",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "amount_cents") val amountCents: Long = 0,
+    @Json(name = "currency") val currency: String = "USD",
+    @Json(name = "stage") val stage: String = "prospecting",
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadConversionResultDto(
+    @Json(name = "lead_id") val leadId: String = "",
+    @Json(name = "status") val status: String = "converted",
+    @Json(name = "converted_party_id") val convertedPartyId: String? = null,
+    @Json(name = "converted_org_id") val convertedOrgId: String? = null,
+    @Json(name = "opportunity") val opportunity: OpportunityStubDto? = null,
+    @Json(name = "converted_at") val convertedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadScoreResultDto(
+    @Json(name = "lead_id") val leadId: String = "",
+    @Json(name = "score") val score: Int = 0,
+    @Json(name = "computed_at") val computedAt: Long = 0,
+    @Json(name = "trigger") val trigger: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadActivityDto(
+    @Json(name = "activity_id") val activityId: String = "",
+    @Json(name = "lead_id") val leadId: String = "",
+    @Json(name = "activity_type") val activityType: String = "note",
+    @Json(name = "subject") val subject: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "actor_sub") val actorSub: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadActivityListRespDto(
+    @Json(name = "activities") val activities: List<LeadActivityDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LeadLogActivityInDto(
+    @Json(name = "activity_type") val activityType: String,
+    @Json(name = "subject") val subject: String? = null,
+    @Json(name = "description") val description: String? = null,
+)
+
+// ─────────────────────────  OPPORTUNITIES  ─────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class OpportunityOutDto(
+    @Json(name = "opp_id") val oppId: String = "",
+    @Json(name = "owner_sub") val ownerSub: String? = null,
+    @Json(name = "name") val name: String = "",
+    @Json(name = "stage") val stage: String = "prospecting",
+    @Json(name = "amount_cents") val amountCents: Long = 0,
+    @Json(name = "weighted_amount_cents") val weightedAmountCents: Long = 0,
+    @Json(name = "close_date") val closeDate: Long = 0,
+    @Json(name = "probability") val probability: Int = 0,
+    @Json(name = "lead_source") val leadSource: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "account_party_id") val accountPartyId: String? = null,
+    @Json(name = "contact_party_id") val contactPartyId: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class OpportunityListRespDto(
+    @Json(name = "items") val items: List<OpportunityOutDto> = emptyList(),
+    @Json(name = "next_cursor") val nextCursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class OpportunityCreateInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "stage") val stage: String,
+    @Json(name = "amount_cents") val amountCents: Long,
+    @Json(name = "close_date") val closeDate: Long,
+    @Json(name = "probability") val probability: Int? = null,
+    @Json(name = "lead_source") val leadSource: String? = null,
+    @Json(name = "description") val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class OpportunityUpdateInDto(
+    @Json(name = "stage") val stage: String? = null,
+    @Json(name = "amount_cents") val amountCents: Long? = null,
+    @Json(name = "probability") val probability: Int? = null,
+    @Json(name = "close_date") val closeDate: Long? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class StageConfigItemOutDto(
+    @Json(name = "stage_key") val stageKey: String = "",
+    @Json(name = "label") val label: String = "",
+    @Json(name = "probability_default") val probabilityDefault: Int = 0,
+    @Json(name = "order") val order: Int = 0,
+    @Json(name = "is_won") val isWon: Boolean = false,
+    @Json(name = "is_lost") val isLost: Boolean = false,
+    @Json(name = "color") val color: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class StageConfigOutDto(
+    @Json(name = "stages") val stages: List<StageConfigItemOutDto> = emptyList(),
+    @Json(name = "updated_at") val updatedAt: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class FeatureStatusDto(
+    @Json(name = "enabled") val enabled: Boolean = false,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmModels.kt
@@ -1,0 +1,137 @@
+package com.testlogon.android.data.crm
+
+/**
+ * CRM-AND-1 — domain models for the CRM Sales surface (no raw DTOs leak into the UI) + DTO→domain mappers.
+ */
+
+/** A CRM lead / prospect. */
+data class Lead(
+    val leadId: String,
+    val firstName: String,
+    val lastName: String,
+    val email: String,
+    val phone: String?,
+    val company: String?,
+    val title: String?,
+    val leadSource: String?,
+    val description: String?,
+    val status: String,
+    val score: Int,
+    val assignedTo: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val convertedAt: Long?,
+) {
+    val fullName: String
+        get() = listOf(firstName, lastName).filter { it.isNotBlank() }.joinToString(" ").ifBlank { email }
+
+    val isConverted: Boolean get() = status == "converted" || convertedAt != null
+}
+
+data class LeadActivity(
+    val activityId: String,
+    val activityType: String,
+    val subject: String?,
+    val description: String?,
+    val createdAt: Long,
+)
+
+data class LeadConversionResult(
+    val leadId: String,
+    val status: String,
+    val opportunityId: String?,
+    val opportunityName: String?,
+    val opportunityAmountCents: Long,
+    val convertedAt: Long,
+)
+
+/** An opportunity in the sales pipeline. Implements [CrmSalesMath.PipelineOppLike] for the roll-ups. */
+data class Opportunity(
+    val oppId: String,
+    val name: String,
+    override val stage: String,
+    override val amountCents: Long,
+    val serverWeightedCents: Long,
+    override val probability: Int,
+    val closeDate: Long,
+    val leadSource: String?,
+    val description: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+) : CrmSalesMath.PipelineOppLike
+
+data class StageConfigItem(
+    val stageKey: String,
+    val label: String,
+    val probabilityDefault: Int,
+    val order: Int,
+    val isWon: Boolean,
+    val isLost: Boolean,
+)
+
+// ── DTO -> domain mappers ──────────────────────────────────────────────────
+
+internal fun LeadDto.toDomain(): Lead = Lead(
+    leadId = leadId,
+    firstName = firstName,
+    lastName = lastName,
+    email = email,
+    phone = phone,
+    company = company,
+    title = title,
+    leadSource = leadSource,
+    description = description,
+    status = status,
+    score = score,
+    assignedTo = assignedTo,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    convertedAt = convertedAt,
+)
+
+internal fun LeadActivityDto.toDomain(): LeadActivity = LeadActivity(
+    activityId = activityId,
+    activityType = activityType,
+    subject = subject,
+    description = description,
+    createdAt = createdAt,
+)
+
+internal fun LeadConversionResultDto.toDomain(): LeadConversionResult = LeadConversionResult(
+    leadId = leadId,
+    status = status,
+    opportunityId = opportunity?.opportunityId,
+    opportunityName = opportunity?.name,
+    opportunityAmountCents = opportunity?.amountCents ?: 0L,
+    convertedAt = convertedAt,
+)
+
+internal fun OpportunityOutDto.toDomain(): Opportunity {
+    val effectiveProbability =
+        if (probability > 0) probability else CrmSalesMath.defaultProbabilityFor(stage)
+    val effectiveWeighted =
+        if (weightedAmountCents > 0) weightedAmountCents
+        else CrmSalesMath.weightedAmountCents(amountCents, effectiveProbability, stage)
+    return Opportunity(
+        oppId = oppId,
+        name = name,
+        stage = stage,
+        amountCents = amountCents,
+        serverWeightedCents = effectiveWeighted,
+        probability = effectiveProbability,
+        closeDate = closeDate,
+        leadSource = leadSource,
+        description = description,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+}
+
+internal fun StageConfigItemOutDto.toDomain(): StageConfigItem = StageConfigItem(
+    stageKey = stageKey,
+    label = label.ifBlank { CrmSalesMath.stageLabel(stageKey) },
+    probabilityDefault = probabilityDefault,
+    order = order,
+    isWon = isWon,
+    isLost = isLost,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmRepository.kt
@@ -1,0 +1,202 @@
+package com.testlogon.android.data.crm
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// ── Aggregate results ───────────────────────────────────────────────────────
+
+/** A leads page + a module-disabled flag (degrade-on-404). */
+data class LeadsPage(
+    val leads: List<Lead>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
+/** The pipeline snapshot: stage config + opportunities, with a module-disabled flag (degrade-on-404/503). */
+data class PipelineSnapshot(
+    val stages: List<StageConfigItem>,
+    val opportunities: List<Opportunity>,
+    val moduleDisabled: Boolean = false,
+)
+
+// ───────────────────────────  LEADS  ────────────────────────────────
+
+interface LeadsRepository {
+    suspend fun list(status: String? = null): ApiResult<LeadsPage>
+    suspend fun get(leadId: String): ApiResult<Lead>
+    suspend fun create(body: LeadCreateInDto): ApiResult<Lead>
+    suspend fun updateStatus(leadId: String, status: String): ApiResult<Lead>
+    suspend fun convert(leadId: String, body: LeadConversionInDto): ApiResult<LeadConversionResult>
+    suspend fun computeScore(leadId: String): ApiResult<Int>
+    suspend fun listActivities(leadId: String): ApiResult<List<LeadActivity>>
+    suspend fun logActivity(leadId: String, body: LeadLogActivityInDto): ApiResult<LeadActivity>
+}
+
+@Singleton
+class LeadsRepositoryImpl @Inject constructor(
+    private val api: LeadsApi,
+    private val errorParser: ApiErrorParser,
+) : LeadsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun list(status: String?): ApiResult<LeadsPage> = withContext(io) {
+        when (val r = call { api.listLeads(status = status) }) {
+            is ApiResult.Success -> ApiResult.Success(
+                LeadsPage(r.data.leads.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure ->
+                // Degrade-on-404: the Leads module is off -> render an empty, non-error state.
+                if (r.error.status == 404) ApiResult.Success(LeadsPage(emptyList(), null, moduleDisabled = true))
+                else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun get(leadId: String): ApiResult<Lead> = withContext(io) {
+        call { api.getLead(leadId).toDomain() }
+    }
+
+    override suspend fun create(body: LeadCreateInDto): ApiResult<Lead> = withContext(io) {
+        call { api.createLead(body).toDomain() }
+    }
+
+    override suspend fun updateStatus(leadId: String, status: String): ApiResult<Lead> = withContext(io) {
+        call { api.updateLead(leadId, LeadUpdateInDto(status = status)).toDomain() }
+    }
+
+    override suspend fun convert(
+        leadId: String,
+        body: LeadConversionInDto,
+    ): ApiResult<LeadConversionResult> = withContext(io) {
+        call { api.convertLead(leadId, body).toDomain() }
+    }
+
+    override suspend fun computeScore(leadId: String): ApiResult<Int> = withContext(io) {
+        call { api.computeScore(leadId).score }
+    }
+
+    override suspend fun listActivities(leadId: String): ApiResult<List<LeadActivity>> = withContext(io) {
+        when (val r = call { api.listActivities(leadId) }) {
+            is ApiResult.Success -> ApiResult.Success(r.data.activities.map { it.toDomain() })
+            is ApiResult.Failure -> if (r.error.status == 404) ApiResult.Success(emptyList()) else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun logActivity(
+        leadId: String,
+        body: LeadLogActivityInDto,
+    ): ApiResult<LeadActivity> = withContext(io) {
+        call { api.logActivity(leadId, body).toDomain() }
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}
+
+// ───────────────────────────  SALES  ────────────────────────────────
+
+interface SalesRepository {
+    /** One combined pull for the pipeline board: feature status + stages + opportunities. */
+    suspend fun pipeline(): ApiResult<PipelineSnapshot>
+    suspend fun getOpportunity(oppId: String): ApiResult<Opportunity>
+    suspend fun create(body: OpportunityCreateInDto): ApiResult<Opportunity>
+    suspend fun moveStage(oppId: String, stage: String): ApiResult<Opportunity>
+}
+
+@Singleton
+class SalesRepositoryImpl @Inject constructor(
+    private val api: SalesApi,
+    private val errorParser: ApiErrorParser,
+) : SalesRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun pipeline(): ApiResult<PipelineSnapshot> = withContext(io) {
+        // Opportunities is the primary call; feature-status + stages are best-effort.
+        when (val opps = call { api.listOpportunities() }) {
+            is ApiResult.Success -> {
+                val stages = (call { api.listStages() } as? ApiResult.Success)?.data
+                    ?.stages?.map { it.toDomain() }?.sortedBy { it.order }
+                    ?: defaultStages()
+                ApiResult.Success(
+                    PipelineSnapshot(
+                        stages = stages,
+                        opportunities = opps.data.items.map { it.toDomain() },
+                    ),
+                )
+            }
+            is ApiResult.Failure ->
+                // Degrade-on-404/503: the pipeline module is off -> empty, non-error state.
+                if (opps.error.status == 404 || opps.error.status == 503) {
+                    ApiResult.Success(PipelineSnapshot(defaultStages(), emptyList(), moduleDisabled = true))
+                } else {
+                    opps
+                }
+            is ApiResult.NetworkError -> opps
+        }
+    }
+
+    override suspend fun getOpportunity(oppId: String): ApiResult<Opportunity> = withContext(io) {
+        call { api.getOpportunity(oppId).toDomain() }
+    }
+
+    override suspend fun create(body: OpportunityCreateInDto): ApiResult<Opportunity> = withContext(io) {
+        call { api.createOpportunity(body).toDomain() }
+    }
+
+    override suspend fun moveStage(oppId: String, stage: String): ApiResult<Opportunity> = withContext(io) {
+        call {
+            api.updateOpportunity(
+                oppId,
+                OpportunityUpdateInDto(
+                    stage = stage,
+                    probability = CrmSalesMath.defaultProbabilityFor(stage),
+                ),
+            ).toDomain()
+        }
+    }
+
+    /** Client-side default stage list (mirrors the web OPPORTUNITY_STAGES) used if /stages degrades. */
+    private fun defaultStages(): List<StageConfigItem> =
+        CrmSalesMath.STAGE_ORDER.mapIndexed { idx, key ->
+            StageConfigItem(
+                stageKey = key,
+                label = CrmSalesMath.stageLabel(key),
+                probabilityDefault = CrmSalesMath.defaultProbabilityFor(key),
+                order = idx,
+                isWon = CrmSalesMath.isWonStage(key),
+                isLost = CrmSalesMath.isLostStage(key),
+            )
+        }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}
+
+/** Small helper for callers that need the [ApiError] status without a `when`. */
+internal fun ApiResult<*>.statusOrNull(): Int? = (this as? ApiResult.Failure)?.error?.status

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmSalesMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmSalesMath.kt
@@ -1,0 +1,210 @@
+package com.testlogon.android.data.crm
+
+/**
+ * CRM-AND-1 — PURE, framework-free logic for the CRM Sales surface. No Android / java.time types, so
+ * every function here is JVM-unit-testable (mirrors the KbMath / PurchaseHistoryMath idiom).
+ *
+ * Responsibilities:
+ *  - lead-score bucketing (server score 0..maxScore -> Cold / Warm / Hot band for the list badge).
+ *  - opportunity stage classification (won / lost / closed / open) mirroring the web helpers in
+ *    frontend/src/api/endpoints/opportunities.ts (isWonStage / isLostStage / isClosedStage).
+ *  - pipeline weighted-forecast maths: per-stage weighted amount (amount * probability) and the
+ *    open-pipeline weighted roll-up used by the pipeline board header.
+ *  - cents formatting (integer cents -> "$1,234.56") with no locale/Android dependency.
+ *
+ * Degrade, never throw: null / malformed inputs are treated as "nothing to show" (empty / zero)
+ * rather than raising, so a 404 (module disabled) or dev-host drift renders cleanly.
+ */
+object CrmSalesMath {
+
+    // ── Lead scoring ────────────────────────────────────────────────────────
+
+    /** Coarse lead-quality band derived from the server's numeric score. */
+    enum class LeadScoreBand { COLD, WARM, HOT }
+
+    /** Default backend cap (LeadScoreRules.max_score default in app/services/leads.py). */
+    const val DEFAULT_MAX_SCORE: Int = 100
+
+    /**
+     * Bucket a raw lead score into a coarse band for the list badge.
+     *
+     * The score is clamped into 0..[maxScore] first (degrade on out-of-range / negative caps). The band
+     * split is on the fraction of the cap: < 1/3 -> COLD, < 2/3 -> WARM, else HOT. A non-positive
+     * [maxScore] degrades to COLD (nothing meaningful to bucket).
+     */
+    fun scoreBand(score: Int, maxScore: Int = DEFAULT_MAX_SCORE): LeadScoreBand {
+        if (maxScore <= 0) return LeadScoreBand.COLD
+        val clamped = score.coerceIn(0, maxScore)
+        val fraction = clamped.toDouble() / maxScore.toDouble()
+        return when {
+            fraction < 1.0 / 3.0 -> LeadScoreBand.COLD
+            fraction < 2.0 / 3.0 -> LeadScoreBand.WARM
+            else -> LeadScoreBand.HOT
+        }
+    }
+
+    // ── Opportunity stage classification (mirror opportunities.ts) ───────────
+
+    const val STAGE_CLOSED_WON: String = "closed_won"
+    const val STAGE_CLOSED_LOST: String = "closed_lost"
+
+    fun isWonStage(stage: String?): Boolean = stage == STAGE_CLOSED_WON
+
+    fun isLostStage(stage: String?): Boolean = stage == STAGE_CLOSED_LOST
+
+    fun isClosedStage(stage: String?): Boolean = isWonStage(stage) || isLostStage(stage)
+
+    fun isOpenStage(stage: String?): Boolean = !isClosedStage(stage)
+
+    /**
+     * Human label for a stage key. Prefers the curated map (mirrors STAGE_LABELS in opportunities.ts);
+     * unknown keys fall back to a title-cased de-underscored form so a new server stage still renders.
+     */
+    fun stageLabel(stage: String?): String {
+        if (stage.isNullOrBlank()) return "—"
+        STAGE_LABELS[stage]?.let { return it }
+        return stage.split('_')
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { part -> part.replaceFirstChar { it.uppercaseChar() } }
+    }
+
+    /** Canonical stage order (open stages first, then won, then lost) mirroring the web OPPORTUNITY_STAGES. */
+    val STAGE_ORDER: List<String> = listOf(
+        "prospecting",
+        "qualification",
+        "needs_analysis",
+        "value_proposition",
+        "id_decision_makers",
+        "proposal_price_quote",
+        "negotiation_review",
+        STAGE_CLOSED_WON,
+        STAGE_CLOSED_LOST,
+    )
+
+    private val STAGE_LABELS: Map<String, String> = mapOf(
+        "prospecting" to "Prospecting",
+        "qualification" to "Qualification",
+        "needs_analysis" to "Needs Analysis",
+        "value_proposition" to "Value Proposition",
+        "id_decision_makers" to "Decision Makers",
+        "proposal_price_quote" to "Proposal / Quote",
+        "negotiation_review" to "Negotiation",
+        STAGE_CLOSED_WON to "Closed Won",
+        STAGE_CLOSED_LOST to "Closed Lost",
+    )
+
+    /** Default win-probability for a stage, used when the server omits a per-opportunity probability. */
+    fun defaultProbabilityFor(stage: String?): Int = when (stage) {
+        "prospecting" -> 10
+        "qualification" -> 20
+        "needs_analysis" -> 25
+        "value_proposition" -> 40
+        "id_decision_makers" -> 50
+        "proposal_price_quote" -> 65
+        "negotiation_review" -> 80
+        STAGE_CLOSED_WON -> 100
+        STAGE_CLOSED_LOST -> 0
+        else -> 10
+    }
+
+    // ── Weighted forecast maths ─────────────────────────────────────────────
+
+    /**
+     * Weighted amount for one opportunity: amount * (probability / 100), rounded to whole cents.
+     *
+     * [probability] is clamped into 0..100. A closed_lost stage always weights to 0 and closed_won to the
+     * full amount, regardless of a stale probability field (mirrors the backend weighting invariant).
+     * Negative amounts degrade to 0.
+     */
+    fun weightedAmountCents(amountCents: Long, probability: Int, stage: String? = null): Long {
+        if (amountCents <= 0L) return 0L
+        if (isLostStage(stage)) return 0L
+        if (isWonStage(stage)) return amountCents
+        val p = probability.coerceIn(0, 100)
+        // round half-up on cents
+        return (amountCents * p + 50) / 100
+    }
+
+    /**
+     * Open-pipeline weighted roll-up: sum of [weightedAmountCents] across the OPEN opportunities only
+     * (closed_won / closed_lost excluded — they are realised / dead, not pipeline). Returns 0 for empty.
+     */
+    fun openPipelineWeightedCents(opps: List<PipelineOppLike>): Long =
+        opps.asSequence()
+            .filter { isOpenStage(it.stage) }
+            .sumOf { weightedAmountCents(it.amountCents, it.probability, it.stage) }
+
+    /** Total un-weighted amount across OPEN opportunities. */
+    fun openPipelineAmountCents(opps: List<PipelineOppLike>): Long =
+        opps.asSequence().filter { isOpenStage(it.stage) }.sumOf { maxOf(0L, it.amountCents) }
+
+    /** Total realised (closed_won) amount. */
+    fun wonAmountCents(opps: List<PipelineOppLike>): Long =
+        opps.asSequence().filter { isWonStage(it.stage) }.sumOf { maxOf(0L, it.amountCents) }
+
+    /**
+     * Win-rate over CLOSED opportunities only: won / (won + lost), as a 0..100 percentage rounded to the
+     * nearest whole percent. Returns 0 when nothing is closed yet (avoid a divide-by-zero).
+     */
+    fun winRatePct(opps: List<PipelineOppLike>): Int {
+        val won = opps.count { isWonStage(it.stage) }
+        val lost = opps.count { isLostStage(it.stage) }
+        val closed = won + lost
+        if (closed == 0) return 0
+        return ((won.toDouble() / closed.toDouble()) * 100.0 + 0.5).toInt()
+    }
+
+    /** Group opportunities by stage, preserving [STAGE_ORDER] then any unknown trailing stages. */
+    fun groupByStage(opps: List<PipelineOppLike>): List<Pair<String, List<PipelineOppLike>>> {
+        val byStage = opps.groupBy { it.stage ?: "prospecting" }
+        val ordered = STAGE_ORDER.filter { byStage.containsKey(it) }
+        val extras = byStage.keys.filter { it !in STAGE_ORDER }.sorted()
+        return (ordered + extras).map { it to (byStage[it] ?: emptyList()) }
+    }
+
+    // ── Cents formatting ────────────────────────────────────────────────────
+
+    /** Integer cents -> "$1,234.56" (USD-style, no locale dependency so it is deterministic in tests). */
+    fun formatCents(cents: Long, currencySymbol: String = "$"): String {
+        val negative = cents < 0
+        val abs = if (negative) -cents else cents
+        val dollars = abs / 100
+        val remainder = (abs % 100).toInt()
+        val grouped = groupThousands(dollars)
+        val centsPart = if (remainder < 10) "0$remainder" else remainder.toString()
+        val sign = if (negative) "-" else ""
+        return "$sign$currencySymbol$grouped.$centsPart"
+    }
+
+    private fun groupThousands(value: Long): String {
+        val digits = value.toString()
+        if (digits.length <= 3) return digits
+        val sb = StringBuilder()
+        val firstGroup = digits.length % 3
+        var idx = 0
+        if (firstGroup > 0) {
+            sb.append(digits, 0, firstGroup)
+            idx = firstGroup
+        }
+        while (idx < digits.length) {
+            if (sb.isNotEmpty()) sb.append(',')
+            sb.append(digits, idx, idx + 3)
+            idx += 3
+        }
+        return sb.toString()
+    }
+
+    /** Minimal shape the pipeline maths need from an opportunity (keeps the maths DTO/domain-agnostic). */
+    interface PipelineOppLike {
+        val stage: String?
+        val amountCents: Long
+        val probability: Int
+    }
+
+    /** Convenience concrete carrier for tests / callers that don't have a domain object handy. */
+    data class PipelineOpp(
+        override val stage: String?,
+        override val amountCents: Long,
+        override val probability: Int,
+    ) : PipelineOppLike
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/LeadsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/LeadsApi.kt
@@ -1,0 +1,68 @@
+package com.testlogon.android.data.crm
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * CRM-AND-1 — Retrofit interface for SuiteCRM Leads (LED-*). Paths are relative; cookies /
+ * Authorization / X-CSRF-Token are attached by the core-network interceptor chain.
+ *
+ * Backend gates on S.leads_enabled — when off every route returns 404 ("Leads module not enabled");
+ * the repository maps that to a degraded/empty result. Verified against
+ * frontend/src/api/endpoints/leads.ts.
+ *
+ * MVP scope: list / get / create / update / convert / score / activities. Merge / duplicates /
+ * prospects / admin scoring-rules are deferred to phase-2 (noted in the repository).
+ */
+interface LeadsApi {
+
+    @GET("ui/leads")
+    suspend fun listLeads(
+        @Query("status") status: String? = null,
+        @Query("lead_source") leadSource: String? = null,
+        @Query("assigned_to") assignedTo: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): LeadListRespDto
+
+    @GET("ui/leads/{leadId}")
+    suspend fun getLead(@Path("leadId") leadId: String): LeadDto
+
+    @POST("ui/leads")
+    suspend fun createLead(@Body body: LeadCreateInDto): LeadDto
+
+    @PATCH("ui/leads/{leadId}")
+    suspend fun updateLead(
+        @Path("leadId") leadId: String,
+        @Body body: LeadUpdateInDto,
+    ): LeadDto
+
+    @POST("ui/leads/{leadId}/convert")
+    suspend fun convertLead(
+        @Path("leadId") leadId: String,
+        @Body body: LeadConversionInDto,
+    ): LeadConversionResultDto
+
+    @POST("ui/leads/{leadId}/score")
+    suspend fun computeScore(
+        @Path("leadId") leadId: String,
+        @Body body: Map<String, String> = emptyMap(),
+    ): LeadScoreResultDto
+
+    @GET("ui/leads/{leadId}/activities")
+    suspend fun listActivities(
+        @Path("leadId") leadId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): LeadActivityListRespDto
+
+    @POST("ui/leads/{leadId}/activities")
+    suspend fun logActivity(
+        @Path("leadId") leadId: String,
+        @Body body: LeadLogActivityInDto,
+    ): LeadActivityDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/SalesApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/SalesApi.kt
@@ -1,0 +1,46 @@
+package com.testlogon.android.data.crm
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * CRM-AND-1 — Retrofit interface for SuiteCRM Opportunities (OPP-*). Router prefix /ui/sales.
+ *
+ * Backend gates on S.sales_pipeline_enabled — endpoints 503 when off (feature-status never 503s); the
+ * repository treats 503/404 as a degraded/empty result. Verified against
+ * frontend/src/api/endpoints/opportunities.ts.
+ *
+ * MVP scope: feature-status / stages / list / get / create / update (stage move). Forecast / quota /
+ * reports / contact-roles are deferred to phase-2 (noted in the repository).
+ */
+interface SalesApi {
+
+    @GET("ui/sales/feature-status")
+    suspend fun getFeatureStatus(): FeatureStatusDto
+
+    @GET("ui/sales/stages")
+    suspend fun listStages(): StageConfigOutDto
+
+    @GET("ui/sales/opportunities")
+    suspend fun listOpportunities(
+        @Query("stage") stage: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): OpportunityListRespDto
+
+    @GET("ui/sales/opportunities/{oppId}")
+    suspend fun getOpportunity(@Path("oppId") oppId: String): OpportunityOutDto
+
+    @POST("ui/sales/opportunities")
+    suspend fun createOpportunity(@Body body: OpportunityCreateInDto): OpportunityOutDto
+
+    @PATCH("ui/sales/opportunities/{oppId}")
+    suspend fun updateOpportunity(
+        @Path("oppId") oppId: String,
+        @Body body: OpportunityUpdateInDto,
+    ): OpportunityOutDto
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmComposers.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmComposers.kt
@@ -1,0 +1,148 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.testlogon.android.data.crm.CrmSalesMath
+
+/**
+ * CRM-AND-1 — create-lead dialog. Minimal MVP form (first / last / email required; company + source
+ * optional). Uses an AlertDialog so it works without any new dependency.
+ */
+@Composable
+fun CreateLeadSheet(
+    submitting: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onSubmit: (first: String, last: String, email: String, company: String?, source: String?) -> Unit,
+) {
+    var first by remember { mutableStateOf("") }
+    var last by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var company by remember { mutableStateOf("") }
+    var source by remember { mutableStateOf("web_site") }
+
+    AlertDialog(
+        onDismissRequest = { if (!submitting) onDismiss() },
+        title = { Text("New lead") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(first, { first = it }, label = { Text("First name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(last, { last = it }, label = { Text("Last name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(email, { email = it }, label = { Text("Email") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(company, { company = it }, label = { Text("Company (optional)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                Text("Source", style = MaterialTheme.typography.labelMedium)
+                SourceChips(selected = source, onSelected = { source = it })
+                if (error != null) {
+                    Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = !submitting,
+                onClick = { onSubmit(first, last, email, company, source) },
+            ) {
+                if (submitting) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Create")
+            }
+        },
+        dismissButton = { TextButton(enabled = !submitting, onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+private val LEAD_SOURCES = listOf("web_site", "cold_call", "email", "campaign", "trade_show", "word_of_mouth", "other")
+
+@Composable
+private fun SourceChips(selected: String, onSelected: (String) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        LEAD_SOURCES.forEach { s ->
+            FilterChip(
+                selected = s == selected,
+                onClick = { onSelected(s) },
+                label = { Text(s.replace('_', ' ')) },
+            )
+        }
+    }
+}
+
+/**
+ * CRM-AND-1 — create-opportunity dialog. Name + amount required; stage chosen from the pipeline stages.
+ * Close date defaults to +30 days (passed in by the caller as epoch seconds).
+ */
+@Composable
+fun CreateOpportunitySheet(
+    submitting: Boolean,
+    error: String?,
+    stageKeys: List<String>,
+    defaultStage: String,
+    onDismiss: () -> Unit,
+    onSubmit: (name: String, stage: String, amountDollars: String) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var amount by remember { mutableStateOf("") }
+    var stage by remember { mutableStateOf(defaultStage) }
+
+    AlertDialog(
+        onDismissRequest = { if (!submitting) onDismiss() },
+        title = { Text("New opportunity") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(name, { name = it }, label = { Text("Name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(amount, { amount = it }, label = { Text("Amount (USD)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                Text("Stage", style = MaterialTheme.typography.labelMedium)
+                Row(
+                    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    stageKeys.forEach { s ->
+                        FilterChip(
+                            selected = s == stage,
+                            onClick = { stage = s },
+                            label = { Text(CrmSalesMath.stageLabel(s)) },
+                        )
+                    }
+                }
+                if (error != null) {
+                    Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = !submitting, onClick = { onSubmit(name, stage, amount) }) {
+                if (submitting) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Create")
+            }
+        },
+        dismissButton = { TextButton(enabled = !submitting, onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/LeadDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/LeadDetailScreen.kt
@@ -1,0 +1,321 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.crm.CrmSalesMath
+import com.testlogon.android.data.crm.Lead
+import com.testlogon.android.data.crm.LeadActivity
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object CrmLeadDetailTestTags {
+    const val SCREEN = "crm_lead_detail_screen"
+    const val CONTENT = "crm_lead_detail_content"
+}
+
+private fun formatDate(tsSeconds: Long): String {
+    if (tsSeconds <= 0) return "—"
+    return SimpleDateFormat("MMM d, yyyy", Locale.getDefault()).format(Date(tsSeconds * 1000))
+}
+
+@Composable
+fun LeadDetailRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: LeadDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    LeadDetailScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onRecomputeScore = viewModel::recomputeScore,
+        onLogActivity = viewModel::logActivity,
+        onConvert = viewModel::convert,
+        onClearActionMessage = viewModel::clearActionMessage,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun LeadDetailScreen(
+    state: LeadDetailUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onRecomputeScore: () -> Unit,
+    onLogActivity: (type: String, subject: String, description: String) -> Unit,
+    onConvert: (accountName: String?, createOpportunity: Boolean, opportunityName: String?) -> Unit,
+    onClearActionMessage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showConvert by remember { mutableStateOf(false) }
+    var showLog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.actionMessage) {
+        state.actionMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            onClearActionMessage()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmLeadDetailTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            androidx.compose.material3.TopAppBar(
+                title = { Text(state.lead?.fullName ?: "Lead") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            LeadDetailUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            LeadDetailUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load lead.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            LeadDetailUiState.Phase.Content -> {
+                val lead = state.lead ?: return@Scaffold
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp)
+                        .testTag(CrmLeadDetailTestTags.CONTENT),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    LeadSummaryCard(lead)
+                    if (!lead.isConverted) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                enabled = !state.actionInProgress,
+                                onClick = { showConvert = true },
+                            ) { Text("Convert") }
+                            OutlinedButton(
+                                enabled = !state.actionInProgress,
+                                onClick = onRecomputeScore,
+                            ) { Text("Re-score") }
+                        }
+                    } else {
+                        Text(
+                            "Converted ${formatDate(lead.convertedAt ?: 0)}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    ActivitiesCard(
+                        activities = state.activities,
+                        onAdd = { showLog = true },
+                        enabled = !state.actionInProgress,
+                    )
+                    if (state.actionInProgress) {
+                        CircularProgressIndicator()
+                    }
+                }
+            }
+        }
+    }
+
+    if (showConvert) {
+        ConvertDialog(
+            defaultName = state.lead?.company ?: state.lead?.fullName ?: "",
+            onDismiss = { showConvert = false },
+            onConfirm = { account, makeOpp, oppName ->
+                onConvert(account, makeOpp, oppName)
+                showConvert = false
+            },
+        )
+    }
+    if (showLog) {
+        LogActivityDialog(
+            onDismiss = { showLog = false },
+            onConfirm = { type, subject, description ->
+                onLogActivity(type, subject, description)
+                showLog = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun LeadSummaryCard(lead: Lead) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(lead.fullName, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+            InfoLine("Email", lead.email)
+            lead.phone?.takeIf { it.isNotBlank() }?.let { InfoLine("Phone", it) }
+            lead.company?.takeIf { it.isNotBlank() }?.let { InfoLine("Company", it) }
+            lead.title?.takeIf { it.isNotBlank() }?.let { InfoLine("Title", it) }
+            lead.leadSource?.takeIf { it.isNotBlank() }?.let { InfoLine("Source", it.replace('_', ' ')) }
+            InfoLine("Status", lead.status.replace('_', ' '))
+            InfoLine("Score", "${lead.score} (${bandLabel(lead.score)})")
+            lead.description?.takeIf { it.isNotBlank() }?.let {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                Text(it, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+private fun bandLabel(score: Int): String = when (CrmSalesMath.scoreBand(score)) {
+    CrmSalesMath.LeadScoreBand.HOT -> "Hot"
+    CrmSalesMath.LeadScoreBand.WARM -> "Warm"
+    CrmSalesMath.LeadScoreBand.COLD -> "Cold"
+}
+
+@Composable
+private fun InfoLine(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun ActivitiesCard(activities: List<LeadActivity>, onAdd: () -> Unit, enabled: Boolean) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("Activity", style = MaterialTheme.typography.titleMedium)
+                TextButton(enabled = enabled, onClick = onAdd) { Text("Log") }
+            }
+            if (activities.isEmpty()) {
+                Text(
+                    "No activity yet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                activities.forEach { a ->
+                    Column {
+                        Text(
+                            "${a.activityType.replace('_', ' ')} · ${formatDate(a.createdAt)}",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        a.subject?.takeIf { it.isNotBlank() }?.let {
+                            Text(it, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+                        }
+                        a.description?.takeIf { it.isNotBlank() }?.let {
+                            Text(it, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConvertDialog(
+    defaultName: String,
+    onDismiss: () -> Unit,
+    onConfirm: (accountName: String?, createOpportunity: Boolean, opportunityName: String?) -> Unit,
+) {
+    var accountName by remember { mutableStateOf(defaultName) }
+    var oppName by remember { mutableStateOf("") }
+    var makeOpp by remember { mutableStateOf(true) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Convert lead") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(accountName, { accountName = it }, label = { Text("Account name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text("Also create an opportunity")
+                    androidx.compose.material3.Switch(checked = makeOpp, onCheckedChange = { makeOpp = it })
+                }
+                if (makeOpp) {
+                    OutlinedTextField(oppName, { oppName = it }, label = { Text("Opportunity name (optional)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(accountName, makeOpp, oppName) }) { Text("Convert") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+private val ACTIVITY_TYPES = listOf("note", "call", "task", "email")
+
+@Composable
+private fun LogActivityDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (type: String, subject: String, description: String) -> Unit,
+) {
+    var type by remember { mutableStateOf("note") }
+    var subject by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Log activity") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    ACTIVITY_TYPES.forEach { t ->
+                        androidx.compose.material3.FilterChip(
+                            selected = t == type,
+                            onClick = { type = t },
+                            label = { Text(t) },
+                        )
+                    }
+                }
+                OutlinedTextField(subject, { subject = it }, label = { Text("Subject") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(description, { description = it }, label = { Text("Notes") }, modifier = Modifier.fillMaxWidth())
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(type, subject, description) }) { Text("Save") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/LeadDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/LeadDetailViewModel.kt
@@ -1,0 +1,169 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.Lead
+import com.testlogon.android.data.crm.LeadActivity
+import com.testlogon.android.data.crm.LeadConversionInDto
+import com.testlogon.android.data.crm.LeadConversionResult
+import com.testlogon.android.data.crm.LeadLogActivityInDto
+import com.testlogon.android.data.crm.LeadsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class LeadDetailUiState(
+    val phase: Phase = Phase.Loading,
+    val lead: Lead? = null,
+    val activities: List<LeadActivity> = emptyList(),
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+    val actionInProgress: Boolean = false,
+    val actionMessage: String? = null,
+    val conversion: LeadConversionResult? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-1 — lead detail: the lead + its activity timeline, plus the convert / score / log-activity
+ * actions. Keyed by the [ARG_LEAD_ID] nav arg via [SavedStateHandle].
+ */
+@HiltViewModel
+class LeadDetailViewModel @Inject constructor(
+    private val repository: LeadsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val leadId: String = checkNotNull(savedStateHandle[ARG_LEAD_ID]) {
+        "LeadDetailViewModel requires a $ARG_LEAD_ID nav arg"
+    }
+
+    private val _uiState = MutableStateFlow(LeadDetailUiState())
+    val uiState: StateFlow<LeadDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update {
+            it.copy(phase = if (it.lead == null) LeadDetailUiState.Phase.Loading else it.phase)
+        }
+        viewModelScope.launch {
+            coroutineScope {
+                val leadDeferred = async { repository.get(leadId) }
+                val activitiesDeferred = async { repository.listActivities(leadId) }
+                when (val leadR = leadDeferred.await()) {
+                    is ApiResult.Success -> {
+                        val activities =
+                            (activitiesDeferred.await() as? ApiResult.Success)?.data ?: emptyList()
+                        _uiState.update {
+                            it.copy(
+                                phase = LeadDetailUiState.Phase.Content,
+                                lead = leadR.data,
+                                activities = activities,
+                                isOffline = false,
+                                errorMessage = null,
+                            )
+                        }
+                    }
+                    is ApiResult.Failure -> _uiState.update {
+                        it.copy(
+                            phase = if (it.lead != null) LeadDetailUiState.Phase.Content else LeadDetailUiState.Phase.Error,
+                            errorMessage = leadR.error.message,
+                            isOffline = false,
+                        )
+                    }
+                    is ApiResult.NetworkError -> _uiState.update {
+                        it.copy(
+                            phase = if (it.lead != null) LeadDetailUiState.Phase.Content else LeadDetailUiState.Phase.Error,
+                            errorMessage = "You're offline. Try again.",
+                            isOffline = true,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun recomputeScore() = runAction {
+        when (val r = repository.computeScore(leadId)) {
+            is ApiResult.Success -> "Lead score updated to ${r.data}."
+            is ApiResult.Failure -> r.error.message
+            is ApiResult.NetworkError -> "You're offline. Try again."
+        }
+    }
+
+    fun logActivity(type: String, subject: String, description: String) {
+        if (subject.isBlank() && description.isBlank()) return
+        runAction {
+            val body = LeadLogActivityInDto(
+                activityType = type,
+                subject = subject.ifBlank { null },
+                description = description.ifBlank { null },
+            )
+            when (val r = repository.logActivity(leadId, body)) {
+                is ApiResult.Success -> "Activity logged."
+                is ApiResult.Failure -> r.error.message
+                is ApiResult.NetworkError -> "You're offline. Try again."
+            }
+        }
+    }
+
+    /** Convert to account + opportunity. On success the conversion result is surfaced. */
+    fun convert(accountName: String?, createOpportunity: Boolean, opportunityName: String?) {
+        _uiState.update { it.copy(actionInProgress = true, actionMessage = null) }
+        viewModelScope.launch {
+            val body = LeadConversionInDto(
+                createAccount = true,
+                accountName = accountName?.ifBlank { null },
+                createOpportunity = createOpportunity,
+                opportunityName = opportunityName?.ifBlank { null },
+            )
+            when (val r = repository.convert(leadId, body)) {
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            actionInProgress = false,
+                            conversion = r.data,
+                            actionMessage = "Lead converted.",
+                        )
+                    }
+                    load()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(actionInProgress = false, actionMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(actionInProgress = false, actionMessage = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun clearActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+
+    private fun runAction(block: suspend () -> String?) {
+        _uiState.update { it.copy(actionInProgress = true, actionMessage = null) }
+        viewModelScope.launch {
+            val message = block()
+            _uiState.update { it.copy(actionInProgress = false, actionMessage = message) }
+            load()
+        }
+    }
+
+    companion object {
+        const val ARG_LEAD_ID = "leadId"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/LeadsListScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/LeadsListScreen.kt
@@ -1,0 +1,225 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.crm.CrmSalesMath
+import com.testlogon.android.data.crm.Lead
+
+object CrmLeadsTestTags {
+    const val SCREEN = "crm_leads_screen"
+    const val CONTENT = "crm_leads_content"
+    const val LOADING = "crm_leads_loading"
+    const val ERROR = "crm_leads_error"
+    const val FAB = "crm_leads_fab"
+}
+
+/** CRM-AND-1 — route-level leads list entry (reachable from the More hub). */
+@Composable
+fun LeadsListRoute(
+    onLeadClick: (String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: LeadsListViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    LeadsListScreen(
+        state = state,
+        onLeadClick = onLeadClick,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onCreateLead = viewModel::createLead,
+        onClearCreateError = viewModel::clearCreateError,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun LeadsListScreen(
+    state: LeadsListUiState,
+    onLeadClick: (String) -> Unit,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onCreateLead: (String, String, String, String?, String?, (String) -> Unit) -> Unit,
+    onClearCreateError: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showCreate by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmLeadsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Leads") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showCreate = true },
+                modifier = Modifier.testTag(CrmLeadsTestTags.FAB),
+            ) { Icon(Icons.Filled.Add, contentDescription = "New lead") }
+        },
+    ) { padding ->
+        when (state.phase) {
+            LeadsListUiState.Phase.Loading -> LoadingState(
+                modifier = Modifier.padding(padding).testTag(CrmLeadsTestTags.LOADING),
+            )
+            LeadsListUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load leads.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding).testTag(CrmLeadsTestTags.ERROR),
+            )
+            LeadsListUiState.Phase.Content -> PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.moduleDisabled) {
+                        InfoBanner("The Leads module is not enabled for this account.")
+                    }
+                    if (state.leads.isEmpty()) {
+                        EmptyState(
+                            title = if (state.moduleDisabled) "Leads unavailable" else "No leads yet",
+                            body = if (state.moduleDisabled) null else "Tap + to add your first lead.",
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize().testTag(CrmLeadsTestTags.CONTENT),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(state.leads, key = { it.leadId }) { lead ->
+                                LeadRow(lead = lead, onClick = { onLeadClick(lead.leadId) })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        CreateLeadSheet(
+            submitting = state.createSubmitting,
+            error = state.createError,
+            onDismiss = {
+                showCreate = false
+                onClearCreateError()
+            },
+            onSubmit = { first, last, email, company, source ->
+                onCreateLead(first, last, email, company, source) { _ ->
+                    showCreate = false
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun LeadRow(lead: Lead, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(lead.fullName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                val subtitle = listOfNotNull(lead.company?.ifBlank { null }, lead.email.ifBlank { null })
+                    .joinToString(" · ")
+                if (subtitle.isNotBlank()) {
+                    Text(
+                        subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    "Status: ${lead.status.replace('_', ' ')}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            ScoreBadge(lead.score)
+        }
+    }
+}
+
+@Composable
+private fun ScoreBadge(score: Int) {
+    val band = CrmSalesMath.scoreBand(score)
+    val (bg, label) = when (band) {
+        CrmSalesMath.LeadScoreBand.HOT -> Color(0xFFB3261E) to "Hot"
+        CrmSalesMath.LeadScoreBand.WARM -> Color(0xFFF9A825) to "Warm"
+        CrmSalesMath.LeadScoreBand.COLD -> Color(0xFF5C6BC0) to "Cold"
+    }
+    Surface(color = bg, contentColor = Color.White, shape = MaterialTheme.shapes.small) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(score.toString(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Text(label, style = MaterialTheme.typography.labelSmall)
+        }
+    }
+}
+
+@Composable
+internal fun InfoBanner(message: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(message, modifier = Modifier.padding(16.dp), style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/LeadsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/LeadsViewModel.kt
@@ -1,0 +1,131 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.Lead
+import com.testlogon.android.data.crm.LeadCreateInDto
+import com.testlogon.android.data.crm.LeadsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class LeadsListUiState(
+    val phase: Phase = Phase.Loading,
+    val leads: List<Lead> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+    // create-lead sheet
+    val createSubmitting: Boolean = false,
+    val createError: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-1 — drives the leads list + inline create.
+ *
+ * A load pulls GET /ui/leads; a 404 (module disabled) degrades to an empty, non-error state with a
+ * `moduleDisabled` banner rather than an error screen. Create posts then re-loads.
+ */
+@HiltViewModel
+class LeadsListViewModel @Inject constructor(
+    private val repository: LeadsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LeadsListUiState())
+    val uiState: StateFlow<LeadsListUiState> = _uiState.asStateFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    private fun load(fromUser: Boolean) {
+        val hasContent = _uiState.value.leads.isNotEmpty()
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent) it.phase else LeadsListUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repository.list()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = LeadsListUiState.Phase.Content,
+                        leads = r.data.leads,
+                        moduleDisabled = r.data.moduleDisabled,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.leads.isNotEmpty()) LeadsListUiState.Phase.Content else LeadsListUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.leads.isNotEmpty()) LeadsListUiState.Phase.Content else LeadsListUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    /** Submit a new lead. Invokes [onCreated] with the new lead id on success. */
+    fun createLead(
+        firstName: String,
+        lastName: String,
+        email: String,
+        company: String?,
+        leadSource: String?,
+        onCreated: (String) -> Unit,
+    ) {
+        if (firstName.isBlank() || lastName.isBlank() || email.isBlank()) {
+            _uiState.update { it.copy(createError = "First name, last name and email are required.") }
+            return
+        }
+        _uiState.update { it.copy(createSubmitting = true, createError = null) }
+        viewModelScope.launch {
+            val body = LeadCreateInDto(
+                firstName = firstName.trim(),
+                lastName = lastName.trim(),
+                email = email.trim(),
+                company = company?.trim()?.ifBlank { null },
+                leadSource = leadSource?.ifBlank { null },
+            )
+            when (val r = repository.create(body)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createSubmitting = false, createError = null) }
+                    onCreated(r.data.leadId)
+                    load(fromUser = false)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun clearCreateError() = _uiState.update { it.copy(createError = null) }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/PipelineScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/PipelineScreen.kt
@@ -1,0 +1,277 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.crm.CrmSalesMath
+import com.testlogon.android.data.crm.Opportunity
+
+object CrmPipelineTestTags {
+    const val SCREEN = "crm_pipeline_screen"
+    const val CONTENT = "crm_pipeline_content"
+    const val LOADING = "crm_pipeline_loading"
+    const val ERROR = "crm_pipeline_error"
+    const val FAB = "crm_pipeline_fab"
+    const val OPEN_WEIGHTED = "crm_pipeline_open_weighted"
+}
+
+@Composable
+fun PipelineRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PipelineViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PipelineScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onMoveStage = viewModel::moveStage,
+        onCreate = viewModel::createOpportunity,
+        onClearCreateError = viewModel::clearCreateError,
+        onClearActionMessage = viewModel::clearActionMessage,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PipelineScreen(
+    state: PipelineUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onMoveStage: (oppId: String, stage: String) -> Unit,
+    onCreate: (name: String, stage: String, amountDollars: String, closeDate: Long, onCreated: () -> Unit) -> Unit,
+    onClearCreateError: () -> Unit,
+    onClearActionMessage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showCreate by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.actionMessage) {
+        state.actionMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            onClearActionMessage()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmPipelineTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Sales pipeline") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showCreate = true },
+                modifier = Modifier.testTag(CrmPipelineTestTags.FAB),
+            ) { Icon(Icons.Filled.Add, contentDescription = "New opportunity") }
+        },
+    ) { padding ->
+        when (state.phase) {
+            PipelineUiState.Phase.Loading -> LoadingState(
+                modifier = Modifier.padding(padding).testTag(CrmPipelineTestTags.LOADING),
+            )
+            PipelineUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load the pipeline.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding).testTag(CrmPipelineTestTags.ERROR),
+            )
+            PipelineUiState.Phase.Content -> PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            ) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize().testTag(CrmPipelineTestTags.CONTENT),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    if (state.isOffline) item { OfflineBanner(onRetry = onRetry) }
+                    if (state.moduleDisabled) {
+                        item { InfoBanner("The sales pipeline is not enabled for this account.") }
+                    }
+                    item { ForecastHeader(state) }
+                    state.columns.forEach { column ->
+                        if (column.opportunities.isNotEmpty()) {
+                            item(key = "hdr_${column.stageKey}") { StageHeader(column.label, column.opportunities.size, column.weightedAmountCents) }
+                            items(column.opportunities, key = { it.oppId }) { opp ->
+                                OpportunityCard(
+                                    opp = opp,
+                                    stageKeys = state.columns.map { it.stageKey },
+                                    moving = state.movingOppId == opp.oppId,
+                                    onMoveStage = { newStage -> onMoveStage(opp.oppId, newStage) },
+                                )
+                            }
+                        }
+                    }
+                    if (state.columns.all { it.opportunities.isEmpty() } && !state.moduleDisabled) {
+                        item {
+                            Text(
+                                "No opportunities yet. Tap + to add one.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        val stageKeys = state.stages.map { it.stageKey }.ifEmpty { CrmSalesMath.STAGE_ORDER }
+        val defaultClose = System.currentTimeMillis() / 1000 + 30L * 24 * 3600
+        CreateOpportunitySheet(
+            submitting = state.createSubmitting,
+            error = state.createError,
+            stageKeys = stageKeys.filterNot { CrmSalesMath.isClosedStage(it) },
+            defaultStage = stageKeys.firstOrNull { !CrmSalesMath.isClosedStage(it) } ?: "prospecting",
+            onDismiss = {
+                showCreate = false
+                onClearCreateError()
+            },
+            onSubmit = { name, stage, amount ->
+                onCreate(name, stage, amount, defaultClose) { showCreate = false }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ForecastHeader(state: PipelineUiState) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Forecast", style = MaterialTheme.typography.titleMedium)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Stat(CrmSalesMath.formatCents(state.openWeightedCents), "Weighted", CrmPipelineTestTags.OPEN_WEIGHTED)
+                Stat(CrmSalesMath.formatCents(state.openAmountCents), "Open", null)
+                Stat(CrmSalesMath.formatCents(state.wonAmountCents), "Won", null)
+                Stat("${state.winRatePct}%", "Win rate", null)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Stat(value: String, label: String, testTag: String?) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = if (testTag != null) Modifier.testTag(testTag) else Modifier) {
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun StageHeader(label: String, count: Int, weightedCents: Long) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("$label ($count)", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+        Text(CrmSalesMath.formatCents(weightedCents), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun OpportunityCard(
+    opp: Opportunity,
+    stageKeys: List<String>,
+    moving: Boolean,
+    onMoveStage: (String) -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(opp.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Medium)
+                Text(
+                    "${CrmSalesMath.formatCents(opp.amountCents)} · ${opp.probability}%",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    "Weighted ${CrmSalesMath.formatCents(CrmSalesMath.weightedAmountCents(opp.amountCents, opp.probability, opp.stage))}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Surface(color = MaterialTheme.colorScheme.secondaryContainer, contentColor = MaterialTheme.colorScheme.onSecondaryContainer, shape = MaterialTheme.shapes.small) {
+                Text(
+                    CrmSalesMath.stageLabel(opp.stage),
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                )
+            }
+            IconButton(onClick = { menuOpen = true }, enabled = !moving) {
+                Icon(Icons.Filled.MoreVert, contentDescription = "Move stage")
+            }
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                stageKeys.filter { it != opp.stage }.forEach { stage ->
+                    DropdownMenuItem(
+                        text = { Text(CrmSalesMath.stageLabel(stage)) },
+                        onClick = {
+                            menuOpen = false
+                            onMoveStage(stage)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/PipelineViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/PipelineViewModel.kt
@@ -1,0 +1,208 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CrmSalesMath
+import com.testlogon.android.data.crm.Opportunity
+import com.testlogon.android.data.crm.OpportunityCreateInDto
+import com.testlogon.android.data.crm.SalesRepository
+import com.testlogon.android.data.crm.StageConfigItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** One stage column on the pipeline board with its opportunities and roll-ups. */
+data class PipelineColumn(
+    val stageKey: String,
+    val label: String,
+    val opportunities: List<Opportunity>,
+    val totalAmountCents: Long,
+    val weightedAmountCents: Long,
+)
+
+data class PipelineUiState(
+    val phase: Phase = Phase.Loading,
+    val columns: List<PipelineColumn> = emptyList(),
+    val stages: List<StageConfigItem> = emptyList(),
+    val openWeightedCents: Long = 0,
+    val openAmountCents: Long = 0,
+    val wonAmountCents: Long = 0,
+    val winRatePct: Int = 0,
+    val moduleDisabled: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+    // create-opportunity sheet
+    val createSubmitting: Boolean = false,
+    val createError: String? = null,
+    // per-card stage-move progress
+    val movingOppId: String? = null,
+    val actionMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-1 — drives the opportunities pipeline board (stage columns + weighted-forecast header) and the
+ * create / stage-move actions.
+ *
+ * A load pulls the combined pipeline snapshot; a 404/503 (module disabled) degrades to an empty,
+ * non-error board with a banner. Roll-ups are computed purely via [CrmSalesMath].
+ */
+@HiltViewModel
+class PipelineViewModel @Inject constructor(
+    private val repository: SalesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PipelineUiState())
+    val uiState: StateFlow<PipelineUiState> = _uiState.asStateFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    private fun load(fromUser: Boolean) {
+        val hasContent = _uiState.value.columns.isNotEmpty()
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent) it.phase else PipelineUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repository.pipeline()) {
+                is ApiResult.Success -> {
+                    val opps = r.data.opportunities
+                    val columns = buildColumns(r.data.stages, opps)
+                    _uiState.update {
+                        it.copy(
+                            phase = PipelineUiState.Phase.Content,
+                            columns = columns,
+                            stages = r.data.stages,
+                            openWeightedCents = CrmSalesMath.openPipelineWeightedCents(opps),
+                            openAmountCents = CrmSalesMath.openPipelineAmountCents(opps),
+                            wonAmountCents = CrmSalesMath.wonAmountCents(opps),
+                            winRatePct = CrmSalesMath.winRatePct(opps),
+                            moduleDisabled = r.data.moduleDisabled,
+                            isRefreshing = false,
+                            isOffline = false,
+                            errorMessage = null,
+                        )
+                    }
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.columns.isNotEmpty()) PipelineUiState.Phase.Content else PipelineUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.columns.isNotEmpty()) PipelineUiState.Phase.Content else PipelineUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun buildColumns(
+        stages: List<StageConfigItem>,
+        opps: List<Opportunity>,
+    ): List<PipelineColumn> {
+        val order = if (stages.isNotEmpty()) stages.map { it.stageKey } else CrmSalesMath.STAGE_ORDER
+        val labels = stages.associate { it.stageKey to it.label }
+        val byStage = opps.groupBy { it.stage }
+        val extras = byStage.keys.filter { it !in order }
+        return (order + extras).map { key ->
+            val items = byStage[key].orEmpty().sortedByDescending { it.amountCents }
+            PipelineColumn(
+                stageKey = key,
+                label = labels[key] ?: CrmSalesMath.stageLabel(key),
+                opportunities = items,
+                totalAmountCents = items.sumOf { maxOf(0L, it.amountCents) },
+                weightedAmountCents = items.sumOf {
+                    CrmSalesMath.weightedAmountCents(it.amountCents, it.probability, it.stage)
+                },
+            )
+        }
+    }
+
+    fun moveStage(oppId: String, newStage: String) {
+        _uiState.update { it.copy(movingOppId = oppId, actionMessage = null) }
+        viewModelScope.launch {
+            val message = when (val r = repository.moveStage(oppId, newStage)) {
+                is ApiResult.Success -> "Moved to ${CrmSalesMath.stageLabel(newStage)}."
+                is ApiResult.Failure -> r.error.message
+                is ApiResult.NetworkError -> "You're offline. Try again."
+            }
+            _uiState.update { it.copy(movingOppId = null, actionMessage = message) }
+            load(fromUser = false)
+        }
+    }
+
+    fun createOpportunity(
+        name: String,
+        stage: String,
+        amountDollars: String,
+        closeDateEpochSeconds: Long,
+        onCreated: () -> Unit,
+    ) {
+        if (name.isBlank()) {
+            _uiState.update { it.copy(createError = "Name is required.") }
+            return
+        }
+        val cents = parseDollarsToCents(amountDollars)
+        if (cents == null) {
+            _uiState.update { it.copy(createError = "Enter a valid amount.") }
+            return
+        }
+        _uiState.update { it.copy(createSubmitting = true, createError = null) }
+        viewModelScope.launch {
+            val body = OpportunityCreateInDto(
+                name = name.trim(),
+                stage = stage,
+                amountCents = cents,
+                closeDate = closeDateEpochSeconds,
+                probability = CrmSalesMath.defaultProbabilityFor(stage),
+            )
+            when (val r = repository.create(body)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createSubmitting = false, createError = null) }
+                    onCreated()
+                    load(fromUser = false)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun clearCreateError() = _uiState.update { it.copy(createError = null) }
+    fun clearActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+
+    /** "1,234.56" / "1234" -> cents; null on garbage. Pure enough for the create sheet gate. */
+    private fun parseDollarsToCents(raw: String): Long? {
+        val cleaned = raw.trim().replace(",", "").removePrefix("$")
+        if (cleaned.isBlank()) return null
+        val value = cleaned.toDoubleOrNull() ?: return null
+        if (value < 0) return null
+        return Math.round(value * 100.0)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -723,6 +723,23 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.APP,
         ),
+        // CRM-AND-1: SuiteCRM leads + sales-pipeline surfaces (degrade-on-404 when the modules are off).
+        MoreEntry(
+            id = "crm_leads",
+            labelRes = R.string.more_entry_crm_leads,
+            icon = Icons.Outlined.GroupAdd,
+            route = MoreRoutes.CRM_LEADS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "crm_pipeline",
+            labelRes = R.string.more_entry_crm_pipeline,
+            icon = Icons.Outlined.TrendingUp,
+            route = MoreRoutes.CRM_PIPELINE,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.APP,
+        ),
         MoreEntry(
             id = "videos",
             labelRes = R.string.more_entry_videos,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -397,6 +397,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         earningsDestinations(navController)
         // TIPX-D3/D4: ledger-backed tip insights (top supporters + received/sent history).
         tipInsightsDestinations(navController)
+        // CRM-AND-1: SuiteCRM leads list/detail + sales pipeline board.
+        crmDestinations(navController)
         // AND-254: creator engagement-rate analytics (server rate + trend chart + breakdown).
         engagementDestinations(navController)
         // AND-399: account-wide analytics dashboards (read) — KPI tiles + views/subscriber charts +

--- a/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
@@ -1,0 +1,53 @@
+package com.testlogon.android.navigation
+
+import android.net.Uri
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.feature.crm.LeadDetailRoute
+import com.testlogon.android.feature.crm.LeadDetailViewModel
+import com.testlogon.android.feature.crm.LeadsListRoute
+import com.testlogon.android.feature.crm.PipelineRoute
+
+/** CRM-AND-1 — the CRM leads list route (reached from the More hub / Growth). */
+data object CrmLeadsDest {
+    const val ROUTE = "crm/leads"
+}
+
+/** CRM-AND-1 — the CRM lead detail route; the arg is the STRING lead_id (path param). */
+data object CrmLeadDetailDest {
+    const val ARG_LEAD_ID = LeadDetailViewModel.ARG_LEAD_ID
+    const val ROUTE = "crm/leads/{$ARG_LEAD_ID}"
+
+    fun build(leadId: String): String = "crm/leads/${Uri.encode(leadId)}"
+}
+
+/** CRM-AND-1 — the sales-pipeline board route. */
+data object CrmPipelineDest {
+    const val ROUTE = "crm/pipeline"
+}
+
+/** CRM-AND-1 — registers the CRM leads list + detail + pipeline destinations in the authenticated graph. */
+fun NavGraphBuilder.crmDestinations(navController: NavHostController) {
+    composable(CrmLeadsDest.ROUTE) {
+        LeadsListRoute(
+            onLeadClick = { leadId ->
+                navController.navigate(CrmLeadDetailDest.build(leadId)) { launchSingleTop = true }
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable(
+        route = CrmLeadDetailDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmLeadDetailDest.ARG_LEAD_ID) { type = NavType.StringType },
+        ),
+    ) {
+        LeadDetailRoute(onBack = { navController.popBackStack() })
+    }
+    composable(CrmPipelineDest.ROUTE) {
+        PipelineRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -55,6 +55,10 @@ object MoreRoutes {
     // AND-093: achievements (earned/locked + progress).
     val ACHIEVEMENTS: String get() = MainDest.Achievements.route
 
+    // CRM-AND-1: SuiteCRM leads list + lead detail (/ui/leads) and the sales pipeline board (/ui/sales).
+    val CRM_LEADS: String get() = CrmLeadsDest.ROUTE
+    val CRM_PIPELINE: String get() = CrmPipelineDest.ROUTE
+
     // AND-189: the caller's videos library grid.
     val VIDEOS: String get() = VideosLibraryDest.ROUTE
 
@@ -654,6 +658,8 @@ object MoreRoutes {
             ACTIVITY,
             SAVED,
             ACHIEVEMENTS,
+            CRM_LEADS,
+            CRM_PIPELINE,
             VIDEOS,
             VOD_CATALOG,
             VOD_RENTALS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -94,6 +94,8 @@
     <string name="more_entry_activity">Activity</string>
     <string name="more_entry_saved">Saved</string>
     <string name="more_entry_achievements">Achievements</string>
+    <string name="more_entry_crm_leads">Leads</string>
+    <string name="more_entry_crm_pipeline">Sales pipeline</string>
     <string name="more_entry_videos">My videos</string>
     <string name="more_entry_vod_catalog">Browse videos</string>
     <string name="more_entry_clips">Clips</string>

--- a/android/app/src/test/java/com/testlogon/android/data/crm/CrmSalesMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/crm/CrmSalesMathTest.kt
@@ -1,0 +1,158 @@
+package com.testlogon.android.data.crm
+
+import com.testlogon.android.data.crm.CrmSalesMath.LeadScoreBand
+import com.testlogon.android.data.crm.CrmSalesMath.PipelineOpp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * CRM-AND-1 — JVM unit tests for the pure CRM Sales logic (lead-score bucketing, stage classification,
+ * weighted-forecast maths, cents formatting). No Android types; degrade-on-empty / degrade-on-bad-input
+ * is asserted so the UI never crashes on a 404 (module disabled) or dev-host drift.
+ */
+class CrmSalesMathTest {
+
+    // ── scoreBand ────────────────────────────────────────────────────────────
+
+    @Test
+    fun scoreBand_bucketsAcrossThirds() {
+        assertEquals(LeadScoreBand.COLD, CrmSalesMath.scoreBand(0))
+        assertEquals(LeadScoreBand.COLD, CrmSalesMath.scoreBand(32))
+        assertEquals(LeadScoreBand.WARM, CrmSalesMath.scoreBand(34))
+        assertEquals(LeadScoreBand.WARM, CrmSalesMath.scoreBand(60))
+        assertEquals(LeadScoreBand.HOT, CrmSalesMath.scoreBand(67))
+        assertEquals(LeadScoreBand.HOT, CrmSalesMath.scoreBand(100))
+    }
+
+    @Test
+    fun scoreBand_clampsOutOfRange() {
+        assertEquals(LeadScoreBand.COLD, CrmSalesMath.scoreBand(-50))
+        assertEquals(LeadScoreBand.HOT, CrmSalesMath.scoreBand(9999))
+    }
+
+    @Test
+    fun scoreBand_customMaxScore() {
+        // max 10 -> 3 is cold(<3.33), 4 warm(<6.66), 8 hot
+        assertEquals(LeadScoreBand.COLD, CrmSalesMath.scoreBand(3, maxScore = 10))
+        assertEquals(LeadScoreBand.WARM, CrmSalesMath.scoreBand(4, maxScore = 10))
+        assertEquals(LeadScoreBand.HOT, CrmSalesMath.scoreBand(8, maxScore = 10))
+    }
+
+    @Test
+    fun scoreBand_nonPositiveMax_degradesToCold() {
+        assertEquals(LeadScoreBand.COLD, CrmSalesMath.scoreBand(50, maxScore = 0))
+        assertEquals(LeadScoreBand.COLD, CrmSalesMath.scoreBand(50, maxScore = -1))
+    }
+
+    // ── stage classification ──────────────────────────────────────────────────
+
+    @Test
+    fun stageClassification_wonLostClosedOpen() {
+        assertTrue(CrmSalesMath.isWonStage("closed_won"))
+        assertFalse(CrmSalesMath.isWonStage("closed_lost"))
+        assertTrue(CrmSalesMath.isLostStage("closed_lost"))
+        assertTrue(CrmSalesMath.isClosedStage("closed_won"))
+        assertTrue(CrmSalesMath.isClosedStage("closed_lost"))
+        assertFalse(CrmSalesMath.isClosedStage("prospecting"))
+        assertTrue(CrmSalesMath.isOpenStage("qualification"))
+        assertFalse(CrmSalesMath.isOpenStage("closed_won"))
+    }
+
+    @Test
+    fun stageLabel_curatedAndFallback() {
+        assertEquals("Prospecting", CrmSalesMath.stageLabel("prospecting"))
+        assertEquals("Closed Won", CrmSalesMath.stageLabel("closed_won"))
+        // unknown server stage -> title-cased de-underscored
+        assertEquals("Some New Stage", CrmSalesMath.stageLabel("some_new_stage"))
+        assertEquals("—", CrmSalesMath.stageLabel(null))
+        assertEquals("—", CrmSalesMath.stageLabel("  "))
+    }
+
+    @Test
+    fun defaultProbability_monotonicIshAndBounds() {
+        assertEquals(10, CrmSalesMath.defaultProbabilityFor("prospecting"))
+        assertEquals(100, CrmSalesMath.defaultProbabilityFor("closed_won"))
+        assertEquals(0, CrmSalesMath.defaultProbabilityFor("closed_lost"))
+        assertEquals(10, CrmSalesMath.defaultProbabilityFor("mystery"))
+    }
+
+    // ── weightedAmountCents ────────────────────────────────────────────────────
+
+    @Test
+    fun weightedAmount_appliesProbability() {
+        assertEquals(5000L, CrmSalesMath.weightedAmountCents(10000L, 50, "qualification"))
+        // round half up: 10000 * 33 = 330000 -> /100 = 3300 (exact); 12345*33=407385 +50 /100 = 4074
+        assertEquals(4074L, CrmSalesMath.weightedAmountCents(12345L, 33, "qualification"))
+    }
+
+    @Test
+    fun weightedAmount_wonIsFull_lostIsZero() {
+        assertEquals(10000L, CrmSalesMath.weightedAmountCents(10000L, 10, "closed_won"))
+        assertEquals(0L, CrmSalesMath.weightedAmountCents(10000L, 90, "closed_lost"))
+    }
+
+    @Test
+    fun weightedAmount_clampsProbabilityAndNonPositiveAmount() {
+        assertEquals(10000L, CrmSalesMath.weightedAmountCents(10000L, 150, "qualification"))
+        assertEquals(0L, CrmSalesMath.weightedAmountCents(10000L, -20, "qualification"))
+        assertEquals(0L, CrmSalesMath.weightedAmountCents(0L, 50, "qualification"))
+        assertEquals(0L, CrmSalesMath.weightedAmountCents(-100L, 50, "qualification"))
+    }
+
+    // ── pipeline roll-ups ──────────────────────────────────────────────────────
+
+    private val sample = listOf(
+        PipelineOpp("prospecting", 100_00L, 10),
+        PipelineOpp("negotiation_review", 200_00L, 80),
+        PipelineOpp("closed_won", 500_00L, 100),
+        PipelineOpp("closed_lost", 999_00L, 90),
+    )
+
+    @Test
+    fun openPipeline_excludesClosed() {
+        // open weighted: 10000*10% =1000 ; 20000*80% =16000 => 17000
+        assertEquals(170_00L, CrmSalesMath.openPipelineWeightedCents(sample))
+        assertEquals(300_00L, CrmSalesMath.openPipelineAmountCents(sample))
+        assertEquals(500_00L, CrmSalesMath.wonAmountCents(sample))
+    }
+
+    @Test
+    fun openPipeline_emptyIsZero() {
+        assertEquals(0L, CrmSalesMath.openPipelineWeightedCents(emptyList()))
+        assertEquals(0L, CrmSalesMath.wonAmountCents(emptyList()))
+        assertEquals(0, CrmSalesMath.winRatePct(emptyList()))
+    }
+
+    @Test
+    fun winRate_overClosedOnly() {
+        // 1 won, 1 lost -> 50%
+        assertEquals(50, CrmSalesMath.winRatePct(sample))
+        val allWon = listOf(PipelineOpp("closed_won", 1L, 100), PipelineOpp("closed_won", 1L, 100))
+        assertEquals(100, CrmSalesMath.winRatePct(allWon))
+    }
+
+    @Test
+    fun groupByStage_ordersByCanonicalThenExtras() {
+        val opps = listOf(
+            PipelineOpp("closed_won", 1L, 100),
+            PipelineOpp("prospecting", 1L, 10),
+            PipelineOpp("zzz_custom", 1L, 10),
+        )
+        val grouped = CrmSalesMath.groupByStage(opps)
+        assertEquals(listOf("prospecting", "closed_won", "zzz_custom"), grouped.map { it.first })
+    }
+
+    // ── formatCents ────────────────────────────────────────────────────────────
+
+    @Test
+    fun formatCents_groupsAndPads() {
+        assertEquals("$0.00", CrmSalesMath.formatCents(0L))
+        assertEquals("$1.05", CrmSalesMath.formatCents(105L))
+        assertEquals("$12.34", CrmSalesMath.formatCents(1234L))
+        assertEquals("$1,234.56", CrmSalesMath.formatCents(123456L))
+        assertEquals("$1,234,567.89", CrmSalesMath.formatCents(123456789L))
+        assertEquals("-$1.00", CrmSalesMath.formatCents(-100L))
+    }
+}


### PR DESCRIPTION
## FE parity PAR-140 - Android CRM sales MVP (leads + pipeline)

Brings the Android client to parity with web by adding a CRM sales MVP: leads capture and a stage-based sales pipeline.

### What is included
- Data layer: `CrmRepository`, DTOs/models, `LeadsApi` + `SalesApi`, and `CrmSalesMath`.
- UI: leads list + lead detail screens, pipeline screen, and CRM composers.
- Navigation wired via `CrmNavigation` and exposed through the More hub (gated).
- Unit coverage for sales math (`CrmSalesMathTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
