### PR TITLE
FE parity PAR-164 - Android alerts channel prefs

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/alerts/AlertDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/alerts/AlertDataModule.kt
@@ -22,6 +22,11 @@ object AlertApiModule {
     @Singleton
     fun provideSmsAlertApi(retrofit: Retrofit): SmsAlertApi =
         retrofit.create(SmsAlertApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideWebhookAlertApi(retrofit: Retrofit): WebhookAlertApi =
+        retrofit.create(WebhookAlertApi::class.java)
 }
 
 /** AND-086 / AND-087 — binds the alert-target repositories to their implementations. */
@@ -36,4 +41,8 @@ abstract class AlertDataModule {
     @Binds
     @Singleton
     abstract fun bindSmsAlertRepository(impl: SmsAlertRepositoryImpl): SmsAlertRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindWebhookAlertRepository(impl: WebhookAlertRepositoryImpl): WebhookAlertRepository
 }

--- a/android/app/src/main/java/com/testlogon/android/data/alerts/AlertsPrefsMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/alerts/AlertsPrefsMath.kt
@@ -1,0 +1,102 @@
+package com.testlogon.android.data.alerts
+
+/**
+ * Framework-free pure logic for the alert-preference channels (webhook URLs + per-channel event-type
+ * sets + push opt-in/opt-out merge). Kept side-effect-free so it is exhaustively JVM-unit-testable and
+ * shared by [WebhookAlertRepository] and the AlertPrefs ViewModel.
+ *
+ * Mirrors the backend contract in app/routers/alerts.py:
+ *  - webhook_prefs: { webhook_urls, event_types }  (POST body uses webhook_event_types)
+ *  - push_prefs:    (default-ON set) minus (opt-out) plus (explicit opt-in)  [see push.py]
+ *  - type-preferences: per-type {enabled,email,push,in_app,sms} toggles
+ */
+object AlertsPrefsMath {
+
+    /**
+     * Normalize a webhook URL list: trim each, drop blanks, and de-duplicate while preserving the
+     * first-seen order (case-sensitive — paths/queries are case-sensitive). Does NOT validate scheme;
+     * see [isValidWebhookUrl] for the add-guard.
+     */
+    fun normalizeUrls(urls: List<String>): List<String> {
+        val seen = LinkedHashSet<String>()
+        for (raw in urls) {
+            val u = raw.trim()
+            if (u.isNotEmpty()) seen.add(u)
+        }
+        return seen.toList()
+    }
+
+    /**
+     * True if [raw] is an acceptable webhook endpoint: a trimmed http(s) URL with a non-empty host.
+     * Intentionally permissive (no full RFC parse) — the server is authoritative — but rejects blanks
+     * and obviously non-URL text so the Add button can gate.
+     */
+    fun isValidWebhookUrl(raw: String): Boolean {
+        val u = raw.trim()
+        if (u.isEmpty()) return false
+        val lower = u.lowercase()
+        if (!lower.startsWith("http://") && !lower.startsWith("https://")) return false
+        val afterScheme = u.substringAfter("://", "")
+        val host = afterScheme.substringBefore('/').substringBefore('?').substringBefore('#')
+        return host.isNotBlank() && host.contains('.')
+    }
+
+    /** Add [rawUrl] to [current] (normalized), if valid and not already present. Returns the new list. */
+    fun addUrl(current: List<String>, rawUrl: String): List<String> {
+        val u = rawUrl.trim()
+        if (!isValidWebhookUrl(u)) return normalizeUrls(current)
+        return normalizeUrls(current + u)
+    }
+
+    /** Remove [url] from [current] (exact, after trim) and return the normalized remainder. */
+    fun removeUrl(current: List<String>, url: String): List<String> =
+        normalizeUrls(current.filterNot { it.trim() == url.trim() })
+
+    /**
+     * Toggle membership of [eventType] in an event-type selection [current]. Adding preserves order
+     * (appended if new); removing drops all matches. Result is de-duplicated/trimmed.
+     */
+    fun toggleEventType(current: List<String>, eventType: String, enabled: Boolean): List<String> {
+        val et = eventType.trim()
+        if (et.isEmpty()) return normalizeEventTypes(current)
+        val base = normalizeEventTypes(current)
+        return if (enabled) {
+            if (et in base) base else base + et
+        } else {
+            base.filterNot { it == et }
+        }
+    }
+
+    /** Trim + drop-blank + de-dupe an event-type list, order-preserving. */
+    fun normalizeEventTypes(types: List<String>): List<String> = normalizeUrls(types)
+
+    /**
+     * Resolve which of [candidates] a webhook is subscribed to. An empty [selected] list is treated as
+     * "all events" (the server default for webhooks), matching the web behaviour.
+     */
+    fun isEventSelected(selected: List<String>, eventType: String): Boolean {
+        val norm = normalizeEventTypes(selected)
+        return norm.isEmpty() || eventType.trim() in norm
+    }
+
+    // --- Push opt-in/opt-out merge (mirrors app/services/push.py resolution) ---
+
+    /**
+     * The effective push-enabled event set given the server-declared [defaults] (default-ON),
+     * the user's [optOut] of those, and [explicitOptIn] for events off by default:
+     *   enabled = (defaults - optOut) ∪ explicitOptIn
+     */
+    fun mergePushEnabled(
+        defaults: Set<String>,
+        optOut: Set<String>,
+        explicitOptIn: Set<String>,
+    ): Set<String> = (defaults - optOut) + explicitOptIn
+
+    /** True iff [event] is push-enabled under the opt-in/opt-out model. */
+    fun isPushEnabled(
+        event: String,
+        defaults: Set<String>,
+        optOut: Set<String>,
+        explicitOptIn: Set<String>,
+    ): Boolean = if (event in defaults) event !in optOut else event in explicitOptIn
+}

--- a/android/app/src/main/java/com/testlogon/android/data/alerts/WebhookAlertApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/alerts/WebhookAlertApi.kt
@@ -1,0 +1,49 @@
+package com.testlogon.android.data.alerts
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+
+/**
+ * Webhook alert-channel Retrofit interface.
+ *
+ * Verified against app/routers/alerts.py (get_webhook_prefs :268 / set_webhook_prefs :274) and the
+ * web contract frontend/src/api/endpoints/alerts.ts (getWebhookPrefs / setWebhookPrefs):
+ *  - GET  ui/alerts/webhook_prefs -> { webhook_urls: string[], event_types: string[] }
+ *  - POST ui/alerts/webhook_prefs <- { webhook_urls: string[], webhook_event_types: string[] }
+ *                                  -> full alert prefs (webhook_urls / webhook_event_types echoed)
+ *
+ * Note the GET response names the event list `event_types` (see the router) while the POST body names
+ * it `webhook_event_types`; both are decoded/emitted below. The 200 bodies are untyped server-side, so
+ * unknown keys are tolerated by the shared Moshi converter. CSRF / cookies / Bearer are attached by
+ * the core-network interceptor chain.
+ */
+interface WebhookAlertApi {
+
+    @GET("ui/alerts/webhook_prefs")
+    suspend fun getWebhookPrefs(): WebhookPrefsDto
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/alerts/webhook_prefs")
+    suspend fun setWebhookPrefs(@Body body: WebhookPrefsUpdateDto): WebhookPrefsDto
+}
+
+@JsonClass(generateAdapter = true)
+data class WebhookPrefsDto(
+    @Json(name = "webhook_urls") val webhookUrls: List<String> = emptyList(),
+    // GET returns the list as `event_types`; POST echoes the alert-prefs record as `webhook_event_types`.
+    @Json(name = "event_types") val eventTypes: List<String>? = null,
+    @Json(name = "webhook_event_types") val webhookEventTypes: List<String>? = null,
+) {
+    /** The event-type list under whichever key the server used for this response. */
+    fun events(): List<String> = eventTypes ?: webhookEventTypes ?: emptyList()
+}
+
+@JsonClass(generateAdapter = true)
+data class WebhookPrefsUpdateDto(
+    @Json(name = "webhook_urls") val webhookUrls: List<String>,
+    @Json(name = "webhook_event_types") val webhookEventTypes: List<String>,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/alerts/WebhookAlertRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/alerts/WebhookAlertRepository.kt
@@ -1,0 +1,77 @@
+package com.testlogon.android.data.alerts
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.map
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Resolved webhook alert-channel state: subscribed [urls] + the [eventTypes] they fire on. */
+data class WebhookPrefs(
+    val urls: List<String> = emptyList(),
+    val eventTypes: List<String> = emptyList(),
+)
+
+/**
+ * Webhook alert-target data layer over [WebhookAlertApi].
+ *
+ * get() reads the current webhook_prefs; save()/addUrl()/removeUrl() POST the full desired list
+ * (the endpoint is a whole-list PUT-style upsert) and return the server-echoed state. URL/event-type
+ * normalization is delegated to [AlertsPrefsMath] so it stays pure + tested. All calls fold into
+ * [ApiResult] and never throw (CancellationException re-thrown).
+ */
+interface WebhookAlertRepository {
+    suspend fun get(): ApiResult<WebhookPrefs>
+    suspend fun save(prefs: WebhookPrefs): ApiResult<WebhookPrefs>
+    suspend fun addUrl(current: WebhookPrefs, rawUrl: String): ApiResult<WebhookPrefs>
+    suspend fun removeUrl(current: WebhookPrefs, url: String): ApiResult<WebhookPrefs>
+}
+
+@Singleton
+class WebhookAlertRepositoryImpl @Inject constructor(
+    private val api: WebhookAlertApi,
+    private val errorParser: ApiErrorParser,
+) : WebhookAlertRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun get(): ApiResult<WebhookPrefs> = withContext(io) {
+        apiCall { api.getWebhookPrefs() }.map { it.toDomain() }
+    }
+
+    override suspend fun save(prefs: WebhookPrefs): ApiResult<WebhookPrefs> = withContext(io) {
+        val urls = AlertsPrefsMath.normalizeUrls(prefs.urls)
+        val events = AlertsPrefsMath.normalizeEventTypes(prefs.eventTypes)
+        apiCall { api.setWebhookPrefs(WebhookPrefsUpdateDto(urls, events)) }.map { it.toDomain() }
+    }
+
+    override suspend fun addUrl(current: WebhookPrefs, rawUrl: String): ApiResult<WebhookPrefs> =
+        save(current.copy(urls = AlertsPrefsMath.addUrl(current.urls, rawUrl)))
+
+    override suspend fun removeUrl(current: WebhookPrefs, url: String): ApiResult<WebhookPrefs> =
+        save(current.copy(urls = AlertsPrefsMath.removeUrl(current.urls, url)))
+
+    private fun WebhookPrefsDto.toDomain(): WebhookPrefs = WebhookPrefs(
+        urls = AlertsPrefsMath.normalizeUrls(webhookUrls),
+        eventTypes = AlertsPrefsMath.normalizeEventTypes(events()),
+    )
+
+    private suspend fun <T> apiCall(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/alerts/AlertPrefsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/alerts/AlertPrefsScreen.kt
@@ -40,6 +40,7 @@ import com.testlogon.android.core.ui.input.TlButton
 import com.testlogon.android.core.ui.state.ErrorState
 import com.testlogon.android.core.ui.state.LoadingState
 import com.testlogon.android.core.ui.state.StaleBanner
+import com.testlogon.android.data.alerts.AlertsPrefsMath
 
 /** Stable testTags for the alert preferences screen (AND-088). */
 object AlertPrefsTestTags {
@@ -51,6 +52,8 @@ object AlertPrefsTestTags {
     const val CODE_INPUT = "alert_code_input"
     const val VERIFY = "alert_verify"
     const val OPEN_TYPE_PREFS = "alert_open_type_prefs"
+    const val WEBHOOK_INPUT = "alert_webhook_input"
+    const val WEBHOOK_ADD = "alert_webhook_add"
 }
 
 /** AND-088 — route-level Alert Preferences entry (from the Settings hub / More). */
@@ -88,6 +91,9 @@ fun AlertPrefsRoute(
         onCancelPending = viewModel::cancelPending,
         onRemoveEmail = viewModel::removeEmail,
         onRemoveSms = viewModel::removeSms,
+        onWebhookInputChanged = viewModel::onWebhookInputChanged,
+        onAddWebhook = viewModel::addWebhook,
+        onRemoveWebhook = viewModel::removeWebhook,
         modifier = modifier,
     )
 }
@@ -109,6 +115,9 @@ fun AlertPrefsScreen(
     onCancelPending: () -> Unit,
     onRemoveEmail: (String) -> Unit,
     onRemoveSms: (String) -> Unit,
+    onWebhookInputChanged: (String) -> Unit,
+    onAddWebhook: () -> Unit,
+    onRemoveWebhook: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -180,6 +189,20 @@ fun AlertPrefsScreen(
                     onInputChanged = onSmsInputChanged,
                     onAdd = onAddSms,
                     onRemove = onRemoveSms,
+                )
+
+                ChannelSection(
+                    title = "Webhook alert endpoints",
+                    targets = state.webhookUrls,
+                    input = state.webhookInput,
+                    inputLabel = "Webhook URL (https://...)",
+                    keyboardType = KeyboardType.Uri,
+                    inputTag = AlertPrefsTestTags.WEBHOOK_INPUT,
+                    addTag = AlertPrefsTestTags.WEBHOOK_ADD,
+                    addEnabled = AlertsPrefsMath.isValidWebhookUrl(state.webhookInput) && !state.busy,
+                    onInputChanged = onWebhookInputChanged,
+                    onAdd = onAddWebhook,
+                    onRemove = onRemoveWebhook,
                 )
 
                 Card(Modifier.fillMaxWidth()) {

--- a/android/app/src/main/java/com/testlogon/android/feature/alerts/AlertPrefsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/alerts/AlertPrefsViewModel.kt
@@ -3,8 +3,11 @@ package com.testlogon.android.feature.alerts
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.alerts.AlertsPrefsMath
 import com.testlogon.android.data.alerts.EmailAlertRepository
 import com.testlogon.android.data.alerts.SmsAlertRepository
+import com.testlogon.android.data.alerts.WebhookAlertRepository
+import com.testlogon.android.data.alerts.WebhookPrefs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -35,6 +38,9 @@ data class AlertPrefsUiState(
     val smsNumbers: List<String> = emptyList(),
     val emailInput: String = "",
     val smsInput: String = "",
+    val webhookUrls: List<String> = emptyList(),
+    val webhookEventTypes: List<String> = emptyList(),
+    val webhookInput: String = "",
     val codeInput: String = "",
     val pending: PendingChallenge? = null,
     /** Actions currently in flight (drives spinners / disables). */
@@ -58,6 +64,7 @@ sealed interface AlertPrefsEvent {
 class AlertPrefsViewModel @Inject constructor(
     private val emailRepo: EmailAlertRepository,
     private val smsRepo: SmsAlertRepository,
+    private val webhookRepo: WebhookAlertRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(AlertPrefsUiState())
@@ -75,8 +82,14 @@ class AlertPrefsViewModel @Inject constructor(
         viewModelScope.launch {
             val emailsDeferred = async { emailRepo.listEmails() }
             val smsDeferred = async { smsRepo.listNumbers() }
+            val webhookDeferred = async { webhookRepo.get() }
             val emailsResult = emailsDeferred.await()
             val smsResult = smsDeferred.await()
+            val webhookResult = webhookDeferred.await()
+            // Webhooks degrade silently (endpoint may 404 on older backends): keep prior on failure.
+            (webhookResult as? ApiResult.Success)?.data?.let { wh ->
+                _state.update { it.copy(webhookUrls = wh.urls, webhookEventTypes = wh.eventTypes) }
+            }
 
             val emails = (emailsResult as? ApiResult.Success)?.data
             val sms = (smsResult as? ApiResult.Success)?.data
@@ -102,6 +115,7 @@ class AlertPrefsViewModel @Inject constructor(
     fun onEmailInputChanged(value: String) = _state.update { it.copy(emailInput = value) }
     fun onSmsInputChanged(value: String) = _state.update { it.copy(smsInput = value) }
     fun onCodeInputChanged(value: String) = _state.update { it.copy(codeInput = value) }
+    fun onWebhookInputChanged(value: String) = _state.update { it.copy(webhookInput = value) }
 
     fun addEmail() {
         val email = _state.value.emailInput.trim()
@@ -193,6 +207,35 @@ class AlertPrefsViewModel @Inject constructor(
         viewModelScope.launch {
             when (val r = smsRepo.remove(phone)) {
                 is ApiResult.Success -> _state.update { it.copy(busy = false, smsNumbers = r.data) }
+                else -> finishWithError(r)
+            }
+        }
+    }
+
+    fun addWebhook() {
+        val url = _state.value.webhookInput.trim()
+        if (!AlertsPrefsMath.isValidWebhookUrl(url) || _state.value.busy) return
+        _state.update { it.copy(busy = true) }
+        val current = WebhookPrefs(_state.value.webhookUrls, _state.value.webhookEventTypes)
+        viewModelScope.launch {
+            when (val r = webhookRepo.addUrl(current, url)) {
+                is ApiResult.Success -> _state.update {
+                    it.copy(busy = false, webhookInput = "", webhookUrls = r.data.urls, webhookEventTypes = r.data.eventTypes)
+                }
+                else -> finishWithError(r)
+            }
+        }
+    }
+
+    fun removeWebhook(url: String) {
+        if (_state.value.busy) return
+        _state.update { it.copy(busy = true) }
+        val current = WebhookPrefs(_state.value.webhookUrls, _state.value.webhookEventTypes)
+        viewModelScope.launch {
+            when (val r = webhookRepo.removeUrl(current, url)) {
+                is ApiResult.Success -> _state.update {
+                    it.copy(busy = false, webhookUrls = r.data.urls, webhookEventTypes = r.data.eventTypes)
+                }
                 else -> finishWithError(r)
             }
         }

--- a/android/app/src/test/java/com/testlogon/android/data/alerts/AlertsPrefsMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/alerts/AlertsPrefsMathTest.kt
@@ -1,0 +1,134 @@
+package com.testlogon.android.data.alerts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure-logic tests for [AlertsPrefsMath] (webhook URL/event-type + push merge). */
+class AlertsPrefsMathTest {
+
+    // --- normalizeUrls ---
+
+    @Test
+    fun normalizeUrls_trimsDropsBlanksAndDedupes_preservingOrder() {
+        val out = AlertsPrefsMath.normalizeUrls(
+            listOf(" https://a.com/hook ", "", "https://b.com/x", "https://a.com/hook", "   "),
+        )
+        assertEquals(listOf("https://a.com/hook", "https://b.com/x"), out)
+    }
+
+    @Test
+    fun normalizeUrls_empty_returnsEmpty() {
+        assertTrue(AlertsPrefsMath.normalizeUrls(emptyList()).isEmpty())
+    }
+
+    // --- isValidWebhookUrl ---
+
+    @Test
+    fun isValidWebhookUrl_acceptsHttpAndHttps() {
+        assertTrue(AlertsPrefsMath.isValidWebhookUrl("https://hooks.example.com/abc"))
+        assertTrue(AlertsPrefsMath.isValidWebhookUrl(" http://example.io/y "))
+    }
+
+    @Test
+    fun isValidWebhookUrl_rejectsBlankSchemelessAndHostless() {
+        assertFalse(AlertsPrefsMath.isValidWebhookUrl(""))
+        assertFalse(AlertsPrefsMath.isValidWebhookUrl("   "))
+        assertFalse(AlertsPrefsMath.isValidWebhookUrl("ftp://example.com"))
+        assertFalse(AlertsPrefsMath.isValidWebhookUrl("example.com/no-scheme"))
+        assertFalse(AlertsPrefsMath.isValidWebhookUrl("https://"))
+        assertFalse(AlertsPrefsMath.isValidWebhookUrl("https://localhost/x")) // no dot in host
+    }
+
+    // --- addUrl ---
+
+    @Test
+    fun addUrl_appendsValidUnique() {
+        val out = AlertsPrefsMath.addUrl(listOf("https://a.com/x"), " https://b.com/y ")
+        assertEquals(listOf("https://a.com/x", "https://b.com/y"), out)
+    }
+
+    @Test
+    fun addUrl_ignoresInvalid_returnsNormalizedCurrent() {
+        val out = AlertsPrefsMath.addUrl(listOf(" https://a.com/x ", "https://a.com/x"), "not-a-url")
+        assertEquals(listOf("https://a.com/x"), out)
+    }
+
+    @Test
+    fun addUrl_doesNotDuplicateExisting() {
+        val out = AlertsPrefsMath.addUrl(listOf("https://a.com/x"), "https://a.com/x")
+        assertEquals(listOf("https://a.com/x"), out)
+    }
+
+    // --- removeUrl ---
+
+    @Test
+    fun removeUrl_dropsExactMatchAfterTrim() {
+        val out = AlertsPrefsMath.removeUrl(listOf("https://a.com/x", "https://b.com/y"), " https://a.com/x ")
+        assertEquals(listOf("https://b.com/y"), out)
+    }
+
+    @Test
+    fun removeUrl_missing_isNoOp() {
+        val out = AlertsPrefsMath.removeUrl(listOf("https://a.com/x"), "https://z.com/none")
+        assertEquals(listOf("https://a.com/x"), out)
+    }
+
+    // --- toggleEventType ---
+
+    @Test
+    fun toggleEventType_addsWhenEnabled() {
+        val out = AlertsPrefsMath.toggleEventType(listOf("tip_received"), "order_shipped", true)
+        assertEquals(listOf("tip_received", "order_shipped"), out)
+    }
+
+    @Test
+    fun toggleEventType_removesWhenDisabled() {
+        val out = AlertsPrefsMath.toggleEventType(listOf("tip_received", "order_shipped"), "tip_received", false)
+        assertEquals(listOf("order_shipped"), out)
+    }
+
+    @Test
+    fun toggleEventType_enableExisting_isIdempotent() {
+        val out = AlertsPrefsMath.toggleEventType(listOf("tip_received"), " tip_received ", true)
+        assertEquals(listOf("tip_received"), out)
+    }
+
+    // --- isEventSelected ---
+
+    @Test
+    fun isEventSelected_emptyMeansAll() {
+        assertTrue(AlertsPrefsMath.isEventSelected(emptyList(), "anything"))
+    }
+
+    @Test
+    fun isEventSelected_matchesMembership() {
+        assertTrue(AlertsPrefsMath.isEventSelected(listOf("a", "b"), " b "))
+        assertFalse(AlertsPrefsMath.isEventSelected(listOf("a", "b"), "c"))
+    }
+
+    // --- push merge ---
+
+    @Test
+    fun mergePushEnabled_defaultsMinusOptOutPlusOptIn() {
+        val out = AlertsPrefsMath.mergePushEnabled(
+            defaults = setOf("tip", "sold", "delivered"),
+            optOut = setOf("sold"),
+            explicitOptIn = setOf("marketing"),
+        )
+        assertEquals(setOf("tip", "delivered", "marketing"), out)
+    }
+
+    @Test
+    fun isPushEnabled_defaultOnRespectsOptOut() {
+        assertTrue(AlertsPrefsMath.isPushEnabled("tip", setOf("tip"), emptySet(), emptySet()))
+        assertFalse(AlertsPrefsMath.isPushEnabled("tip", setOf("tip"), setOf("tip"), emptySet()))
+    }
+
+    @Test
+    fun isPushEnabled_defaultOffRespectsOptIn() {
+        assertFalse(AlertsPrefsMath.isPushEnabled("marketing", emptySet(), emptySet(), emptySet()))
+        assertTrue(AlertsPrefsMath.isPushEnabled("marketing", emptySet(), emptySet(), setOf("marketing")))
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/alerts/AlertPrefsViewModelTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/alerts/AlertPrefsViewModelTest.kt
@@ -6,6 +6,8 @@ import com.testlogon.android.core.testing.MainDispatcherRule
 import com.testlogon.android.data.alerts.AlertBeginResult
 import com.testlogon.android.data.alerts.EmailAlertRepository
 import com.testlogon.android.data.alerts.SmsAlertRepository
+import com.testlogon.android.data.alerts.WebhookAlertRepository
+import com.testlogon.android.data.alerts.WebhookPrefs
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -41,9 +43,19 @@ class AlertPrefsViewModelTest {
         override suspend fun remove(phone: String) = ApiResult.Success(numbers.filterNot { it == phone })
     }
 
+    private class FakeWebhookRepo : WebhookAlertRepository {
+        var prefs = WebhookPrefs(emptyList(), emptyList())
+        override suspend fun get() = ApiResult.Success(prefs)
+        override suspend fun save(prefs: WebhookPrefs) = ApiResult.Success(prefs).also { this.prefs = prefs }
+        override suspend fun addUrl(current: WebhookPrefs, rawUrl: String) =
+            save(current.copy(urls = current.urls + rawUrl.trim()))
+        override suspend fun removeUrl(current: WebhookPrefs, url: String) =
+            save(current.copy(urls = current.urls.filterNot { it == url }))
+    }
+
     @Test
     fun load_populatesEmailsAndNumbers() = runTest {
-        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo())
+        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo(), FakeWebhookRepo())
         advanceUntilIdle()
         val s = vm.state.value
         assertTrue(s.loaded)
@@ -54,7 +66,7 @@ class AlertPrefsViewModelTest {
 
     @Test
     fun addEmail_thenVerify_addsTarget() = runTest {
-        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo())
+        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo(), FakeWebhookRepo())
         advanceUntilIdle()
         vm.onEmailInputChanged("new@x.com")
         vm.addEmail()
@@ -71,7 +83,7 @@ class AlertPrefsViewModelTest {
 
     @Test
     fun verify_shortCode_doesNothing() = runTest {
-        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo())
+        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo(), FakeWebhookRepo())
         advanceUntilIdle()
         vm.onEmailInputChanged("new@x.com")
         vm.addEmail()
@@ -84,7 +96,7 @@ class AlertPrefsViewModelTest {
 
     @Test
     fun removeSms_dropsNumber() = runTest {
-        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo())
+        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo(), FakeWebhookRepo())
         advanceUntilIdle()
         vm.removeSms("+15551231234")
         advanceUntilIdle()
@@ -94,7 +106,7 @@ class AlertPrefsViewModelTest {
     @Test
     fun load_emailFailsButSmsOk_servesStale() = runTest {
         val email = FakeEmailRepo().apply { listResult = ApiResult.Failure(ApiError(500, "boom")) }
-        val vm = AlertPrefsViewModel(email, FakeSmsRepo())
+        val vm = AlertPrefsViewModel(email, FakeSmsRepo(), FakeWebhookRepo())
         advanceUntilIdle()
         val s = vm.state.value
         assertTrue(s.isStale)
@@ -111,8 +123,40 @@ class AlertPrefsViewModelTest {
             override suspend fun confirm(challengeId: String, code: String) = ApiResult.Failure(ApiError(500, "boom"))
             override suspend fun remove(phone: String) = ApiResult.Failure(ApiError(500, "boom"))
         }
-        val vm = AlertPrefsViewModel(email, sms)
+        val vm = AlertPrefsViewModel(email, sms, FakeWebhookRepo())
         advanceUntilIdle()
         assertEquals("boom", vm.state.value.error)
+    }
+
+    @Test
+    fun addWebhook_validUrl_addsEndpoint() = runTest {
+        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo(), FakeWebhookRepo())
+        advanceUntilIdle()
+        vm.onWebhookInputChanged("https://hooks.example.com/x")
+        vm.addWebhook()
+        advanceUntilIdle()
+        assertTrue("https://hooks.example.com/x" in vm.state.value.webhookUrls)
+        assertEquals("", vm.state.value.webhookInput)
+    }
+
+    @Test
+    fun addWebhook_invalidUrl_isNoOp() = runTest {
+        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo(), FakeWebhookRepo())
+        advanceUntilIdle()
+        vm.onWebhookInputChanged("not-a-url")
+        vm.addWebhook()
+        advanceUntilIdle()
+        assertTrue(vm.state.value.webhookUrls.isEmpty())
+    }
+
+    @Test
+    fun removeWebhook_dropsEndpoint() = runTest {
+        val hook = FakeWebhookRepo().apply { prefs = WebhookPrefs(listOf("https://a.com/x"), emptyList()) }
+        val vm = AlertPrefsViewModel(FakeEmailRepo(), FakeSmsRepo(), hook)
+        advanceUntilIdle()
+        assertEquals(listOf("https://a.com/x"), vm.state.value.webhookUrls)
+        vm.removeWebhook("https://a.com/x")
+        advanceUntilIdle()
+        assertTrue(vm.state.value.webhookUrls.isEmpty())
     }
 }


### PR DESCRIPTION
## PAR-164 - Android alerts channel prefs (FE parity)

Brings the Android alerts settings surface to parity with web by adding per-channel alert preference controls.

### Changes
- New webhook alert channel wiring: `WebhookAlertApi` + `WebhookAlertRepository`, registered in `AlertDataModule`.
- Threshold/preference math extracted to `AlertsPrefsMath` (unit-tested).
- `AlertPrefsScreen` / `AlertPrefsViewModel` updated to surface per-channel prefs.

### Tests
- `AlertsPrefsMathTest` (new) and updated `AlertPrefsViewModelTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
