### PR TITLE
FE parity PAR-162 - file-manager mount management (web + Android)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/files/mounts/MountMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/files/mounts/MountMath.kt
@@ -1,0 +1,160 @@
+package com.testlogon.android.feature.files.mounts
+
+import com.testlogon.android.core.model.files.FileMountCreateRequest
+import java.util.Locale
+
+/**
+ * FM-MOUNTS - PURE (no Android deps), JVM-testable helpers for the file-manager Mounts surface:
+ * provider-config VALIDATION, mode/status normalisation + labels, and mount-path/prefix canonicalisation.
+ * Kept framework-free so the validation logic is unit-tested without Robolectric (mirrors the FE-170
+ * TradingDocsMath idiom).
+ *
+ * The rules mirror the backend Pydantic constraints (app/routers/filemanager.py FileMountCreateIn):
+ * mount_path 1..2048 chars, bucket 3..255 chars, prefix <= 2048 chars, mode in {read_only, read_write},
+ * status in {active, degraded, error, disabled}, auth_ref 1..256 chars. We validate CLIENT-SIDE first so
+ * the user gets inline field errors before a round-trip; the server remains the source of truth (a 422
+ * still surfaces its detail).
+ */
+
+/** Canonical mount access modes (backend `mode` values), in display order. */
+val MOUNT_MODES: List<String> = listOf("read_only", "read_write")
+
+/** Canonical mount status values (backend `status` values), in display order. */
+val MOUNT_STATUSES: List<String> = listOf("active", "degraded", "error", "disabled")
+
+private const val MOUNT_PATH_MAX = 2048
+private const val BUCKET_MIN = 3
+private const val BUCKET_MAX = 255
+private const val PREFIX_MAX = 2048
+private const val AUTH_REF_MIN = 1
+private const val AUTH_REF_MAX = 256
+
+/** Which field a [MountValidationError] is about (drives inline field highlighting). */
+enum class MountField { MOUNT_PATH, BUCKET, PREFIX, MODE, AUTH_REF, STATUS }
+
+/** A single, user-facing validation problem tied to a [field]. */
+data class MountValidationError(val field: MountField, val message: String)
+
+/** Result of validating a mount draft: [errors] empty == valid. */
+data class MountValidation(val errors: List<MountValidationError>) {
+    val isValid: Boolean get() = errors.isEmpty()
+    fun errorFor(field: MountField): String? = errors.firstOrNull { it.field == field }?.message
+}
+
+/** Human label for a mount [mode] code; unknown codes fall back to a title-cased raw code. */
+fun mountModeLabel(mode: String): String = when (mode.lowercase(Locale.ROOT)) {
+    "read_only" -> "Read only"
+    "read_write" -> "Read / write"
+    else -> titleCase(mode)
+}
+
+/** Human label for a mount [status] code; unknown codes fall back to a title-cased raw code. */
+fun mountStatusLabel(status: String): String = when (status.lowercase(Locale.ROOT)) {
+    "active" -> "Active"
+    "degraded" -> "Degraded"
+    "error" -> "Error"
+    "disabled" -> "Disabled"
+    else -> titleCase(status)
+}
+
+/**
+ * Canonicalise a mount path: trim, ensure a single leading slash, drop a trailing slash (except root).
+ * Blank input canonicalises to "/". This is what the create/update request should carry.
+ */
+fun canonicalMountPath(raw: String): String {
+    val trimmed = raw.trim()
+    if (trimmed.isEmpty()) return "/"
+    val withLead = if (trimmed.startsWith("/")) trimmed else "/$trimmed"
+    val collapsed = withLead.replace(Regex("/+"), "/")
+    return if (collapsed.length > 1) collapsed.trimEnd('/').ifEmpty { "/" } else collapsed
+}
+
+/** Canonicalise an optional prefix: trim; blank -> null (the backend treats absent == no prefix). */
+fun canonicalPrefix(raw: String?): String? = raw?.trim()?.ifBlank { null }
+
+private val BUCKET_RE = Regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$")
+
+/**
+ * Validate a mount draft (the fields the user typed). Returns a [MountValidation]; empty errors == OK.
+ * [mode] / [status] are validated against the canonical enum sets. This does NOT hit the network.
+ */
+fun validateMountDraft(
+    mountPath: String,
+    bucket: String,
+    prefix: String?,
+    mode: String,
+    authRef: String,
+    status: String,
+): MountValidation {
+    val errors = mutableListOf<MountValidationError>()
+
+    val path = mountPath.trim()
+    when {
+        path.isEmpty() -> errors += MountValidationError(MountField.MOUNT_PATH, "Mount path is required")
+        path.length > MOUNT_PATH_MAX ->
+            errors += MountValidationError(MountField.MOUNT_PATH, "Mount path is too long")
+    }
+
+    val b = bucket.trim()
+    when {
+        b.isEmpty() -> errors += MountValidationError(MountField.BUCKET, "Bucket is required")
+        b.length < BUCKET_MIN ->
+            errors += MountValidationError(MountField.BUCKET, "Bucket must be at least $BUCKET_MIN characters")
+        b.length > BUCKET_MAX ->
+            errors += MountValidationError(MountField.BUCKET, "Bucket is too long")
+        !BUCKET_RE.matches(b) ->
+            errors += MountValidationError(
+                MountField.BUCKET,
+                "Bucket may use lowercase letters, digits, dots and hyphens only",
+            )
+    }
+
+    val p = prefix?.trim().orEmpty()
+    if (p.length > PREFIX_MAX) errors += MountValidationError(MountField.PREFIX, "Prefix is too long")
+
+    if (mode.lowercase(Locale.ROOT) !in MOUNT_MODES) {
+        errors += MountValidationError(MountField.MODE, "Choose an access mode")
+    }
+
+    val a = authRef.trim()
+    when {
+        a.length < AUTH_REF_MIN -> errors += MountValidationError(MountField.AUTH_REF, "Credential reference is required")
+        a.length > AUTH_REF_MAX -> errors += MountValidationError(MountField.AUTH_REF, "Credential reference is too long")
+    }
+
+    if (status.lowercase(Locale.ROOT) !in MOUNT_STATUSES) {
+        errors += MountValidationError(MountField.STATUS, "Choose a status")
+    }
+
+    return MountValidation(errors)
+}
+
+/**
+ * Build a canonical [FileMountCreateRequest] from a validated draft (call [validateMountDraft] first).
+ * Applies [canonicalMountPath] / [canonicalPrefix] and lowercases the enums + bucket so the wire body is
+ * normalised regardless of user casing/whitespace.
+ */
+fun buildCreateRequest(
+    mountPath: String,
+    bucket: String,
+    prefix: String?,
+    mode: String,
+    authRef: String,
+    status: String,
+): FileMountCreateRequest = FileMountCreateRequest(
+    mount_path = canonicalMountPath(mountPath),
+    bucket = bucket.trim().lowercase(Locale.ROOT),
+    prefix = canonicalPrefix(prefix),
+    mode = mode.lowercase(Locale.ROOT),
+    auth_ref = authRef.trim(),
+    status = status.lowercase(Locale.ROOT),
+)
+
+private fun titleCase(raw: String): String =
+    raw.replace('_', ' ')
+        .split(' ')
+        .filter { it.isNotEmpty() }
+        .joinToString(" ") { w ->
+            w.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
+        }
+        .ifBlank { raw }

--- a/android/app/src/main/java/com/testlogon/android/feature/files/mounts/MountsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/files/mounts/MountsScreen.kt
@@ -1,0 +1,384 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.files.mounts
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.feature.files.mounts.data.FileMount
+import kotlinx.coroutines.flow.collectLatest
+
+/** FM-MOUNTS stable testTags for the Mounts management screen. */
+object MountsTestTags {
+    const val SCREEN = "mounts_screen"
+    const val LIST = "mounts_list"
+    const val EMPTY = "mounts_empty"
+    const val UNAVAILABLE = "mounts_unavailable"
+    const val ROW = "mount_row"
+    const val ADD = "mounts_add"
+    const val EDITOR = "mounts_editor"
+    const val SAVE = "mounts_editor_save"
+}
+
+/**
+ * FM-MOUNTS - route wrapper: collects the list + editor state, wires the snackbar event channel, and
+ * delegates to the stateless [MountsScreen].
+ */
+@Composable
+fun MountsRoute(
+    onBack: () -> Unit,
+    viewModel: MountsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val editor by viewModel.editor.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(viewModel) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                is MountsEvent.Message -> snackbarHostState.showSnackbar(event.text)
+            }
+        }
+    }
+
+    MountsScreen(
+        state = state,
+        editor = editor,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onRefresh = viewModel::refresh,
+        onRetry = viewModel::refresh,
+        onAdd = viewModel::openAdd,
+        onEdit = viewModel::openEdit,
+        onValidate = viewModel::validate,
+        onDelete = viewModel::delete,
+        onEditorMountPath = viewModel::onMountPathChanged,
+        onEditorBucket = viewModel::onBucketChanged,
+        onEditorPrefix = viewModel::onPrefixChanged,
+        onEditorMode = viewModel::onModeChanged,
+        onEditorAuthRef = viewModel::onAuthRefChanged,
+        onEditorStatus = viewModel::onStatusChanged,
+        onEditorSave = viewModel::save,
+        onEditorDismiss = viewModel::closeEditor,
+    )
+}
+
+@Composable
+fun MountsScreen(
+    state: MountsUiState,
+    editor: MountEditorState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onAdd: () -> Unit,
+    onEdit: (FileMount) -> Unit,
+    onValidate: (FileMount) -> Unit,
+    onDelete: (FileMount) -> Unit,
+    onEditorMountPath: (String) -> Unit,
+    onEditorBucket: (String) -> Unit,
+    onEditorPrefix: (String) -> Unit,
+    onEditorMode: (String) -> Unit,
+    onEditorAuthRef: (String) -> Unit,
+    onEditorStatus: (String) -> Unit,
+    onEditorSave: () -> Unit,
+    onEditorDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(MountsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Storage mounts") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (state.available && state.errorMessage == null) {
+                FloatingActionButton(onClick = onAdd, modifier = Modifier.testTag(MountsTestTags.ADD)) {
+                    Icon(Icons.Outlined.Add, contentDescription = "Add mount")
+                }
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading && state.isEmpty ->
+                    LoadingState(message = "Loading mounts…")
+
+                state.errorMessage != null ->
+                    ErrorState(message = state.errorMessage, onRetry = onRetry)
+
+                !state.available ->
+                    EmptyState(
+                        title = "Storage mounts unavailable",
+                        body = "Mount management is not enabled in this environment.",
+                        modifier = Modifier.testTag(MountsTestTags.UNAVAILABLE),
+                    )
+
+                state.isEmpty ->
+                    EmptyState(
+                        title = "No storage mounts",
+                        body = "Add a storage provider to mount external buckets into your files.",
+                        actionLabel = "Add mount",
+                        onAction = onAdd,
+                        modifier = Modifier.testTag(MountsTestTags.EMPTY),
+                    )
+
+                else -> PullToRefreshBox(
+                    isRefreshing = state.isRefreshing,
+                    onRefresh = onRefresh,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    LazyColumn(modifier = Modifier.fillMaxSize().testTag(MountsTestTags.LIST)) {
+                        items(items = state.mounts, key = { it.id }) { mount ->
+                            MountRow(
+                                mount = mount,
+                                onEdit = { onEdit(mount) },
+                                onValidate = { onValidate(mount) },
+                                onDelete = { onDelete(mount) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (editor.visible) {
+        MountEditorDialog(
+            editor = editor,
+            onMountPath = onEditorMountPath,
+            onBucket = onEditorBucket,
+            onPrefix = onEditorPrefix,
+            onMode = onEditorMode,
+            onAuthRef = onEditorAuthRef,
+            onStatus = onEditorStatus,
+            onSave = onEditorSave,
+            onDismiss = onEditorDismiss,
+        )
+    }
+}
+
+@Composable
+private fun MountRow(
+    mount: FileMount,
+    onEdit: () -> Unit,
+    onValidate: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .testTag(MountsTestTags.ROW),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(mount.mountPath, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = "${mount.provider} · ${mount.bucket}${mount.prefix?.let { "/$it" } ?: ""}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "${mountModeLabel(mount.mode)} · ${mountStatusLabel(mount.status)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            mount.lastError?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                IconButton(onClick = onValidate) {
+                    Icon(Icons.Outlined.Sync, contentDescription = "Test connection")
+                }
+                IconButton(onClick = onEdit) {
+                    Icon(Icons.Outlined.Edit, contentDescription = "Edit mount")
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Outlined.Delete, contentDescription = "Remove mount")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MountEditorDialog(
+    editor: MountEditorState,
+    onMountPath: (String) -> Unit,
+    onBucket: (String) -> Unit,
+    onPrefix: (String) -> Unit,
+    onMode: (String) -> Unit,
+    onAuthRef: (String) -> Unit,
+    onStatus: (String) -> Unit,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag(MountsTestTags.EDITOR),
+        title = { Text(if (editor.isEditing) "Edit mount" else "Add mount") },
+        confirmButton = {
+            TextButton(
+                onClick = onSave,
+                enabled = !editor.saving,
+                modifier = Modifier.testTag(MountsTestTags.SAVE),
+            ) { Text(if (editor.isEditing) "Save" else "Add") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !editor.saving) { Text("Cancel") }
+        },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = editor.mountPath,
+                    onValueChange = onMountPath,
+                    label = { Text("Mount path") },
+                    singleLine = true,
+                    isError = editor.errors.errorFor(MountField.MOUNT_PATH) != null,
+                    supportingText = { editor.errors.errorFor(MountField.MOUNT_PATH)?.let { Text(it) } },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = editor.bucket,
+                    onValueChange = onBucket,
+                    label = { Text("Bucket") },
+                    singleLine = true,
+                    isError = editor.errors.errorFor(MountField.BUCKET) != null,
+                    supportingText = { editor.errors.errorFor(MountField.BUCKET)?.let { Text(it) } },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = editor.prefix,
+                    onValueChange = onPrefix,
+                    label = { Text("Prefix (optional)") },
+                    singleLine = true,
+                    isError = editor.errors.errorFor(MountField.PREFIX) != null,
+                    supportingText = { editor.errors.errorFor(MountField.PREFIX)?.let { Text(it) } },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = editor.authRef,
+                    onValueChange = onAuthRef,
+                    label = { Text("Credential reference") },
+                    singleLine = true,
+                    isError = editor.errors.errorFor(MountField.AUTH_REF) != null,
+                    supportingText = { editor.errors.errorFor(MountField.AUTH_REF)?.let { Text(it) } },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                EnumDropdown(
+                    label = "Access mode",
+                    value = editor.mode,
+                    options = MOUNT_MODES,
+                    optionLabel = ::mountModeLabel,
+                    onSelected = onMode,
+                )
+                EnumDropdown(
+                    label = "Status",
+                    value = editor.status,
+                    options = MOUNT_STATUSES,
+                    optionLabel = ::mountStatusLabel,
+                    onSelected = onStatus,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun EnumDropdown(
+    label: String,
+    value: String,
+    options: List<String>,
+    optionLabel: (String) -> String,
+    onSelected: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = optionLabel(value),
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.fillMaxWidth().menuAnchor(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(optionLabel(option)) },
+                    onClick = {
+                        onSelected(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/files/mounts/MountsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/files/mounts/MountsViewModel.kt
@@ -1,0 +1,235 @@
+package com.testlogon.android.feature.files.mounts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.files.FileMountUpdateRequest
+import com.testlogon.android.feature.files.mounts.data.FileMount
+import com.testlogon.android.feature.files.mounts.data.MountsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * FM-MOUNTS - list state for the file-manager Mounts screen. [available] = false means the surface is
+ * not enabled in this environment (degrade-on-404/403) and the UI shows an honest "not available" state
+ * instead of an error. [errorMessage] is only set for GENUINE list failures (422/5xx/network).
+ */
+data class MountsUiState(
+    val mounts: List<FileMount> = emptyList(),
+    val available: Boolean = true,
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    val isEmpty: Boolean get() = mounts.isEmpty()
+}
+
+/**
+ * FM-MOUNTS - state of the add/edit mount editor sheet. [editingId] null = adding a new mount, non-null
+ * = editing the mount with that id. [errors] holds inline per-field validation messages from [MountMath].
+ */
+data class MountEditorState(
+    val visible: Boolean = false,
+    val editingId: String? = null,
+    val mountPath: String = "/",
+    val bucket: String = "",
+    val prefix: String = "",
+    val mode: String = MOUNT_MODES.first(),
+    val authRef: String = "",
+    val status: String = MOUNT_STATUSES.first(),
+    val saving: Boolean = false,
+    val errors: MountValidation = MountValidation(emptyList()),
+) {
+    val isEditing: Boolean get() = editingId != null
+}
+
+/** FM-MOUNTS - one-shot user-facing effects (snackbar messages). */
+sealed interface MountsEvent {
+    data class Message(val text: String) : MountsEvent
+}
+
+/**
+ * FM-MOUNTS - presentation logic for the Mounts management surface. Loads the mount list on
+ * construction; [refresh] re-fetches. The editor is opened via [openAdd] / [openEdit], its fields update
+ * through the on*Changed callbacks, and [save] validates CLIENT-SIDE (via [MountMath]) before the network
+ * call — invalid drafts populate inline [MountEditorState.errors] and never hit the wire. [validate] runs
+ * the server-side connectivity check; [delete] removes a mount. All mutations refresh the list on success.
+ */
+@HiltViewModel
+class MountsViewModel @Inject constructor(
+    private val repository: MountsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MountsUiState(isLoading = true))
+    val uiState: StateFlow<MountsUiState> = _uiState.asStateFlow()
+
+    private val _editor = MutableStateFlow(MountEditorState())
+    val editor: StateFlow<MountEditorState> = _editor.asStateFlow()
+
+    private val _events = Channel<MountsEvent>(Channel.BUFFERED)
+    val events: Flow<MountsEvent> = _events.receiveAsFlow()
+
+    init {
+        load(isRefresh = false)
+    }
+
+    fun refresh() = load(isRefresh = true)
+
+    private fun load(isRefresh: Boolean) {
+        _uiState.update {
+            it.copy(isLoading = !isRefresh, isRefreshing = isRefresh, errorMessage = null)
+        }
+        viewModelScope.launch {
+            when (val result = repository.listMounts()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        mounts = result.data.mounts,
+                        available = result.data.available,
+                        isLoading = false,
+                        isRefreshing = false,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(isLoading = false, isRefreshing = false, errorMessage = result.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(isLoading = false, isRefreshing = false, errorMessage = "Network error")
+                }
+            }
+        }
+    }
+
+    // ---- editor lifecycle ----
+
+    fun openAdd() {
+        _editor.value = MountEditorState(visible = true)
+    }
+
+    fun openEdit(mount: FileMount) {
+        _editor.value = MountEditorState(
+            visible = true,
+            editingId = mount.id,
+            mountPath = mount.mountPath,
+            bucket = mount.bucket,
+            prefix = mount.prefix.orEmpty(),
+            mode = mount.mode,
+            authRef = mount.authRef,
+            status = mount.status,
+        )
+    }
+
+    fun closeEditor() {
+        _editor.value = MountEditorState(visible = false)
+    }
+
+    fun onMountPathChanged(value: String) = _editor.update { it.copy(mountPath = value) }
+    fun onBucketChanged(value: String) = _editor.update { it.copy(bucket = value) }
+    fun onPrefixChanged(value: String) = _editor.update { it.copy(prefix = value) }
+    fun onModeChanged(value: String) = _editor.update { it.copy(mode = value) }
+    fun onAuthRefChanged(value: String) = _editor.update { it.copy(authRef = value) }
+    fun onStatusChanged(value: String) = _editor.update { it.copy(status = value) }
+
+    /**
+     * Validate the draft CLIENT-SIDE, then create or update. Invalid drafts populate inline errors and
+     * do NOT hit the network. On success the editor closes and the list refreshes.
+     */
+    fun save() {
+        val draft = _editor.value
+        val validation = validateMountDraft(
+            mountPath = draft.mountPath,
+            bucket = draft.bucket,
+            prefix = draft.prefix,
+            mode = draft.mode,
+            authRef = draft.authRef,
+            status = draft.status,
+        )
+        if (!validation.isValid) {
+            _editor.update { it.copy(errors = validation) }
+            return
+        }
+        _editor.update { it.copy(saving = true, errors = MountValidation(emptyList())) }
+        viewModelScope.launch {
+            val editingId = draft.editingId
+            val result = if (editingId == null) {
+                repository.createMount(
+                    buildCreateRequest(
+                        mountPath = draft.mountPath,
+                        bucket = draft.bucket,
+                        prefix = draft.prefix,
+                        mode = draft.mode,
+                        authRef = draft.authRef,
+                        status = draft.status,
+                    ),
+                )
+            } else {
+                repository.updateMount(
+                    editingId,
+                    FileMountUpdateRequest(
+                        mount_path = canonicalMountPath(draft.mountPath),
+                        bucket = draft.bucket.trim().lowercase(),
+                        prefix = canonicalPrefix(draft.prefix),
+                        mode = draft.mode.lowercase(),
+                        auth_ref = draft.authRef.trim(),
+                        status = draft.status.lowercase(),
+                    ),
+                )
+            }
+            when (result) {
+                is ApiResult.Success -> {
+                    _editor.value = MountEditorState(visible = false)
+                    emit(if (editingId == null) "Mount added" else "Mount updated")
+                    load(isRefresh = true)
+                }
+                is ApiResult.Failure -> {
+                    _editor.update { it.copy(saving = false) }
+                    emit(result.error.message)
+                }
+                is ApiResult.NetworkError -> {
+                    _editor.update { it.copy(saving = false) }
+                    emit("Network error")
+                }
+            }
+        }
+    }
+
+    /** Server-side connectivity check for [mount]; reports the returned status via a snackbar. */
+    fun validate(mount: FileMount) {
+        viewModelScope.launch {
+            when (val result = repository.validateMount(mount.id)) {
+                is ApiResult.Success -> {
+                    val status = result.data.status ?: "unknown"
+                    emit(if (result.data.ok) "Connection OK ($status)" else "Connection failed ($status)")
+                }
+                is ApiResult.Failure -> emit(result.error.message)
+                is ApiResult.NetworkError -> emit("Network error")
+            }
+        }
+    }
+
+    /** Delete [mount]; refreshes the list on success. */
+    fun delete(mount: FileMount) {
+        viewModelScope.launch {
+            when (val result = repository.deleteMount(mount.id)) {
+                is ApiResult.Success -> {
+                    emit("Mount removed")
+                    load(isRefresh = true)
+                }
+                is ApiResult.Failure -> emit(result.error.message)
+                is ApiResult.NetworkError -> emit("Network error")
+            }
+        }
+    }
+
+    private fun emit(text: String) {
+        viewModelScope.launch { _events.send(MountsEvent.Message(text)) }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/files/mounts/data/MountsDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/files/mounts/data/MountsDataModule.kt
@@ -1,0 +1,22 @@
+package com.testlogon.android.feature.files.mounts.data
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * FM-MOUNTS - binds the file-manager mount CRUD repository.
+ *
+ * [com.testlogon.android.core.network.files.FileMountsApi] is provided by the core-network
+ * FileMountsNetworkModule, so this module only binds the :app-side seam. No new dependency.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MountsDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindMountsRepository(impl: MountsRepositoryImpl): MountsRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/files/mounts/data/MountsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/files/mounts/data/MountsRepository.kt
@@ -1,0 +1,137 @@
+package com.testlogon.android.feature.files.mounts.data
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.model.files.FileMountCreateRequest
+import com.testlogon.android.core.model.files.FileMountDto
+import com.testlogon.android.core.model.files.FileMountUpdateRequest
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.files.FileMountsApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FM-MOUNTS - data layer for the file-manager S3 mount CRUD surface, over the [FileMountsApi].
+ *
+ * DEGRADE-ON-404 (and on the backend feature-gate 403): the mount surface is feature-flagged on the
+ * backend (`filemgr_s3_mounts_enabled`) and may be absent in a given environment. [listMounts] therefore
+ * folds a 404 (route absent) or 403 (feature disabled) into an EMPTY [MountList] with
+ * [MountList.available] = false, so the UI shows a graceful "not available here" state instead of an
+ * error. Genuine failures (422, 5xx, network) still surface as Failure / NetworkError. The mutating
+ * verbs surface their errors normally (the UI only offers them once list reports the surface available).
+ */
+interface MountsRepository {
+    suspend fun listMounts(): ApiResult<MountList>
+    suspend fun createMount(body: FileMountCreateRequest): ApiResult<FileMount>
+    suspend fun updateMount(mountId: String, body: FileMountUpdateRequest): ApiResult<FileMount>
+    suspend fun deleteMount(mountId: String): ApiResult<Boolean>
+    suspend fun validateMount(mountId: String): ApiResult<MountValidationResult>
+}
+
+/** A mount listing plus whether the surface is available in this environment (degrade-on-404/403). */
+data class MountList(
+    val mounts: List<FileMount>,
+    val available: Boolean,
+)
+
+/** The result of a server-side mount connectivity check (POST .../validate). */
+data class MountValidationResult(
+    val ok: Boolean,
+    val mountId: String?,
+    val status: String?,
+)
+
+@Singleton
+class MountsRepositoryImpl @Inject constructor(
+    private val api: FileMountsApi,
+    private val errorParser: ApiErrorParser,
+) : MountsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun listMounts(): ApiResult<MountList> = withContext(io) {
+        try {
+            val items = api.listMounts().items.map(FileMountDto::toDomain)
+            ApiResult.Success(MountList(mounts = items, available = true))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            val error = errorParser.from(e)
+            if (error.status == HTTP_NOT_FOUND || error.status == HTTP_FORBIDDEN) {
+                // Surface not enabled in this environment -> degrade to an empty, unavailable list.
+                ApiResult.Success(MountList(mounts = emptyList(), available = false))
+            } else {
+                ApiResult.Failure(error)
+            }
+        } catch (e: IOException) {
+            ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+        }
+    }
+
+    override suspend fun createMount(body: FileMountCreateRequest): ApiResult<FileMount> =
+        withContext(io) { call { api.createMount(body).toDomain() } }
+
+    override suspend fun updateMount(
+        mountId: String,
+        body: FileMountUpdateRequest,
+    ): ApiResult<FileMount> = withContext(io) { call { api.updateMount(mountId, body).toDomain() } }
+
+    override suspend fun deleteMount(mountId: String): ApiResult<Boolean> =
+        withContext(io) { call { api.deleteMount(mountId).deleted } }
+
+    override suspend fun validateMount(mountId: String): ApiResult<MountValidationResult> =
+        withContext(io) {
+            call {
+                val dto = api.validateMount(mountId)
+                MountValidationResult(ok = dto.ok, mountId = dto.mount_id, status = dto.status)
+            }
+        }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private companion object {
+        const val HTTP_NOT_FOUND = 404
+        const val HTTP_FORBIDDEN = 403
+    }
+}
+
+/** Domain model for a single S3 file mount (the fields the Mounts UI renders). */
+data class FileMount(
+    val id: String,
+    val provider: String,
+    val mountPath: String,
+    val bucket: String,
+    val prefix: String?,
+    val mode: String,
+    val authRef: String,
+    val status: String,
+    val lastError: String?,
+)
+
+/** Maps a wire [FileMountDto] to its domain [FileMount]. */
+fun FileMountDto.toDomain(): FileMount = FileMount(
+    id = id,
+    provider = provider,
+    mountPath = mount_path,
+    bucket = bucket,
+    prefix = prefix,
+    mode = mode,
+    authRef = auth_ref,
+    status = status,
+    lastError = last_error,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/files/ui/FilesScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/files/ui/FilesScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.outlined.ReceiptLong
+import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Folder
@@ -149,6 +150,7 @@ object FilesTestTags {
 
     /** AND-336 - the import-from-Google-Drive top-bar affordance. */
     const val DRIVE_IMPORT = "files_drive_import"
+    const val MOUNTS = "files_mounts"
 
     /** Per-breadcrumb tag: files_breadcrumb_<index>. */
     fun breadcrumb(index: Int): String = "files_breadcrumb_$index"
@@ -232,6 +234,9 @@ fun FilesRoute(
     // FE-170 - open the Trading Documents area (statements/1099s/confirmations). Defaults no-op so
     // existing call sites / tests are unaffected.
     onOpenTradingDocuments: () -> Unit = {},
+    // FM-MOUNTS - open the storage-mount management area (add/list/test/remove providers). Defaults
+    // no-op so existing call sites / tests are unaffected.
+    onOpenMounts: () -> Unit = {},
     viewModel: FilesViewModel = hiltViewModel(),
     uploadViewModel: com.testlogon.android.feature.files.upload.FilesUploadViewModel = hiltViewModel(),
     downloadViewModel: com.testlogon.android.feature.files.download.FileActionsViewModel = hiltViewModel(),
@@ -327,6 +332,8 @@ fun FilesRoute(
         onImportFromDrive = { onImportFromDrive(state.currentPath) },
         // FE-170 - the Trading Documents entry point (a tile at the files root).
         onOpenTradingDocuments = onOpenTradingDocuments,
+        // FM-MOUNTS - the storage-mounts entry point (a top-bar action).
+        onOpenMounts = onOpenMounts,
         // F13 - long-press CRUD context-menu actions wired to the existing FilesViewModel ops.
         onRename = { node, newName -> viewModel.rename(node.path, newName, node.type == FileNodeType.FOLDER) },
         onDelete = { node -> viewModel.delete(node.path, node.type == FileNodeType.FOLDER) },
@@ -401,6 +408,9 @@ fun FilesScreen(
     // FE-170 - Trading Documents entry point (null -> the tile is hidden, so existing FilesScreen
     // callers / tests are unaffected).
     onOpenTradingDocuments: (() -> Unit)? = null,
+    // FM-MOUNTS - storage-mounts entry point (null -> the action is hidden, so existing FilesScreen
+    // callers / tests are unaffected).
+    onOpenMounts: (() -> Unit)? = null,
     // F13 - long-press context-menu CRUD actions (defaulted no-op so existing callers / tests are
     // unaffected). Rename/Delete/New-folder are fully wired; Move targets a destination folder path.
     onRename: (FileNode, String) -> Unit = { _, _ -> },
@@ -464,6 +474,19 @@ fun FilesScreen(
                             Icon(
                                 Icons.Filled.CloudDownload,
                                 contentDescription = stringResource(R.string.drive_title),
+                            )
+                        }
+                    }
+                    // FM-MOUNTS - storage-mounts management affordance (only when the host wires it;
+                    // defaulted-off so existing callers / tests are unaffected).
+                    if (onOpenMounts != null && !state.isSearching) {
+                        IconButton(
+                            onClick = onOpenMounts,
+                            modifier = Modifier.testTag(FilesTestTags.MOUNTS),
+                        ) {
+                            Icon(
+                                Icons.Outlined.Storage,
+                                contentDescription = "Storage mounts",
                             )
                         }
                     }

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -214,6 +214,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         filesDestination(navController)
         // FE-170: Trading Documents area (statements/1099s/confirmations) reached from the file manager.
         tradingDocsDestination(navController)
+        // FM-MOUNTS: file-manager storage-mount management (list/add/edit/test/remove S3 mounts).
+        mountsDestination(navController)
         // Trading Blotter: native orders/fills/positions blotter (web parity; sample data + ticker).
         blotterDestination(navController)
         // Active Algos monitor: client-side TWAP / Iceberg algo progress + pause/cancel.

--- a/android/app/src/main/java/com/testlogon/android/navigation/FilesNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/FilesNavigation.kt
@@ -36,6 +36,11 @@ fun NavGraphBuilder.filesDestination(navController: NavHostController) {
             onOpenTradingDocuments = {
                 navController.navigate(TradingDocsDest.ROUTE) { launchSingleTop = true }
             },
+            // FM-MOUNTS - storage-mount management (add/list/test/remove providers) reachable from the
+            // file manager. Navigates to the mounts route (files feature graph).
+            onOpenMounts = {
+                navController.navigate(MountsDest.ROUTE) { launchSingleTop = true }
+            },
         )
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/navigation/MountsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MountsNavigation.kt
@@ -1,0 +1,23 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.files.mounts.MountsRoute
+
+/**
+ * FM-MOUNTS — the file-manager storage-mount management route (list / add / edit / test / remove S3
+ * mounts). Reached from the file-manager entry point. This route lives in the files feature graph (NOT
+ * the More catalog), so it does not touch MoreCatalog / RouteRegistry (mirrors the FE-170 TradingDocs
+ * pattern). Degrades to an "unavailable" state when the backend surface is not enabled (404/403).
+ */
+data object MountsDest {
+    const val ROUTE = "files/mounts"
+}
+
+/** FM-MOUNTS — registers the storage-mount management destination. */
+fun NavGraphBuilder.mountsDestination(navController: NavHostController) {
+    composable(MountsDest.ROUTE) {
+        MountsRoute(onBack = { navController.popBackStack() })
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/files/mounts/MountMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/files/mounts/MountMathTest.kt
@@ -1,0 +1,162 @@
+package com.testlogon.android.feature.files.mounts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** FM-MOUNTS - pure JVM tests for [MountMath] provider-config validation + normalisation. */
+class MountMathTest {
+
+    // ---- labels ----
+
+    @Test
+    fun modeLabels_areHumanReadable() {
+        assertEquals("Read only", mountModeLabel("read_only"))
+        assertEquals("Read / write", mountModeLabel("read_write"))
+    }
+
+    @Test
+    fun modeLabel_unknown_titleCasesRawCode() {
+        assertEquals("Weird Mode", mountModeLabel("weird_mode"))
+    }
+
+    @Test
+    fun statusLabels_areHumanReadable() {
+        assertEquals("Active", mountStatusLabel("active"))
+        assertEquals("Degraded", mountStatusLabel("degraded"))
+        assertEquals("Error", mountStatusLabel("error"))
+        assertEquals("Disabled", mountStatusLabel("disabled"))
+    }
+
+    // ---- canonicalisation ----
+
+    @Test
+    fun canonicalMountPath_addsLeadingSlash_andTrimsTrailing() {
+        assertEquals("/docs/reports", canonicalMountPath("docs/reports/"))
+    }
+
+    @Test
+    fun canonicalMountPath_collapsesDoubleSlashes() {
+        assertEquals("/a/b", canonicalMountPath("//a//b//"))
+    }
+
+    @Test
+    fun canonicalMountPath_blankBecomesRoot() {
+        assertEquals("/", canonicalMountPath("   "))
+        assertEquals("/", canonicalMountPath("/"))
+    }
+
+    @Test
+    fun canonicalPrefix_blankBecomesNull_elseTrimmed() {
+        assertNull(canonicalPrefix(""))
+        assertNull(canonicalPrefix("   "))
+        assertNull(canonicalPrefix(null))
+        assertEquals("team/", canonicalPrefix("  team/  "))
+    }
+
+    // ---- validation: happy path ----
+
+    @Test
+    fun validate_validDraft_hasNoErrors() {
+        val v = validateMountDraft(
+            mountPath = "/docs",
+            bucket = "my-bucket",
+            prefix = "team/",
+            mode = "read_only",
+            authRef = "cred-1",
+            status = "active",
+        )
+        assertTrue(v.isValid)
+        assertTrue(v.errors.isEmpty())
+    }
+
+    // ---- validation: field-level failures ----
+
+    @Test
+    fun validate_blankMountPath_reportsMountPathError() {
+        val v = validateMountDraft("   ", "my-bucket", null, "read_only", "cred", "active")
+        assertFalse(v.isValid)
+        assertEquals("Mount path is required", v.errorFor(MountField.MOUNT_PATH))
+    }
+
+    @Test
+    fun validate_shortBucket_reportsBucketError() {
+        val v = validateMountDraft("/d", "ab", null, "read_only", "cred", "active")
+        assertFalse(v.isValid)
+        assertTrue(v.errorFor(MountField.BUCKET)!!.contains("at least"))
+    }
+
+    @Test
+    fun validate_bucketWithUppercase_isRejected() {
+        val v = validateMountDraft("/d", "MyBucket", null, "read_only", "cred", "active")
+        assertFalse(v.isValid)
+        assertEquals(MountField.BUCKET, v.errors.first().field)
+    }
+
+    @Test
+    fun validate_bucketWithUnderscore_isRejected() {
+        val v = validateMountDraft("/d", "my_bucket", null, "read_only", "cred", "active")
+        assertFalse(v.isValid)
+        assertNotNull_(v.errorFor(MountField.BUCKET))
+    }
+
+    @Test
+    fun validate_badMode_reportsModeError() {
+        val v = validateMountDraft("/d", "my-bucket", null, "sideways", "cred", "active")
+        assertFalse(v.isValid)
+        assertNotNull_(v.errorFor(MountField.MODE))
+    }
+
+    @Test
+    fun validate_blankAuthRef_reportsAuthRefError() {
+        val v = validateMountDraft("/d", "my-bucket", null, "read_only", "  ", "active")
+        assertFalse(v.isValid)
+        assertNotNull_(v.errorFor(MountField.AUTH_REF))
+    }
+
+    @Test
+    fun validate_badStatus_reportsStatusError() {
+        val v = validateMountDraft("/d", "my-bucket", null, "read_only", "cred", "gone")
+        assertFalse(v.isValid)
+        assertNotNull_(v.errorFor(MountField.STATUS))
+    }
+
+    @Test
+    fun validate_accumulatesMultipleErrors() {
+        val v = validateMountDraft("", "x", null, "nope", "", "nope")
+        // mount_path, bucket, mode, auth_ref, status all fail.
+        assertTrue(v.errors.size >= 5)
+    }
+
+    // ---- build request ----
+
+    @Test
+    fun buildCreateRequest_normalisesFields() {
+        val req = buildCreateRequest(
+            mountPath = "docs/reports/",
+            bucket = "  My-Bucket  ",
+            prefix = "  team/  ",
+            mode = "READ_WRITE",
+            authRef = "  cred-9  ",
+            status = "ACTIVE",
+        )
+        assertEquals("/docs/reports", req.mount_path)
+        assertEquals("my-bucket", req.bucket)
+        assertEquals("team/", req.prefix)
+        assertEquals("read_write", req.mode)
+        assertEquals("cred-9", req.auth_ref)
+        assertEquals("active", req.status)
+    }
+
+    @Test
+    fun buildCreateRequest_blankPrefixBecomesNull() {
+        val req = buildCreateRequest("/d", "my-bucket", "  ", "read_only", "cred", "active")
+        assertNull(req.prefix)
+    }
+
+    private fun assertNotNull_(value: String?) {
+        assertTrue("expected a non-null error message", value != null)
+    }
+}

--- a/android/core-model/src/main/java/com/testlogon/android/core/model/files/FileMountDtos.kt
+++ b/android/core-model/src/main/java/com/testlogon/android/core/model/files/FileMountDtos.kt
@@ -1,0 +1,81 @@
+package com.testlogon.android.core.model.files
+
+/**
+ * FM-MOUNTS - transport DTOs for the file-manager S3 mount CRUD surface (`v1/fs/mounts` ...).
+ *
+ * RECONCILIATION NOTE (identical to the AND-331 FilesDtos): core-model has NO Moshi dependency and NO
+ * Moshi codegen, so these DTOs carry NO annotations. The production Moshi (core-network
+ * NetworkModule.provideMoshi) decodes them via the reflective KotlinJsonAdapterFactory, which maps Kotlin
+ * property names to JSON keys VERBATIM. Every property below is therefore named EXACTLY as the snake_case
+ * wire key (mount_path, auth_ref, created_at, updated_at, last_check_at, last_error, mount_id, ...). Zero
+ * annotations, zero new dependencies. Required wire fields have NO default so the reflective adapter
+ * throws JsonDataException when absent; optional wire fields are nullable (or default) so they decode
+ * leniently. Unknown extra wire keys are ignored by the reflective adapter by default.
+ *
+ * WIRE CONTRACT (backend app/routers/filemanager.py FileMountOut / FileMountCreateIn / FileMountUpdateIn,
+ * mirrored by the web frontend/src/api/endpoints/files.ts). The list envelope is `{ items: [...] }`
+ * (FileMountsListOut); create returns a single FileMountOut; delete returns `{ ok, deleted }`; validate
+ * returns `{ ok, mount_id, status }`.
+ */
+
+/**
+ * A single S3 file-mount record. Required wire fields: id, owner, provider, mount_path, bucket, mode,
+ * auth_ref, status, created_at, updated_at (NO default -> JsonDataException when absent). `prefix`,
+ * `last_check_at` and `last_error` are optional/nullable.
+ */
+data class FileMountDto(
+    val id: String,
+    val owner: String,
+    val provider: String,
+    val mount_path: String,
+    val bucket: String,
+    val prefix: String? = null,
+    val mode: String,
+    val auth_ref: String,
+    val status: String,
+    val created_at: String,
+    val updated_at: String,
+    val last_check_at: String? = null,
+    val last_error: String? = null,
+)
+
+/** GET v1/fs/mounts response envelope: { items: [FileMountDto] }. */
+data class FileMountsListDto(
+    val items: List<FileMountDto> = emptyList(),
+)
+
+/**
+ * Body for POST v1/fs/mounts. `mode` is one of "read_only" / "read_write" (default read_only);
+ * `status` is one of "active" / "degraded" / "error" / "disabled" (default active).
+ */
+data class FileMountCreateRequest(
+    val mount_path: String,
+    val bucket: String,
+    val prefix: String? = null,
+    val mode: String = "read_only",
+    val auth_ref: String,
+    val status: String = "active",
+)
+
+/** Body for PATCH v1/fs/mounts/{id}. Every field is optional (null = leave unchanged). */
+data class FileMountUpdateRequest(
+    val mount_path: String? = null,
+    val bucket: String? = null,
+    val prefix: String? = null,
+    val mode: String? = null,
+    val auth_ref: String? = null,
+    val status: String? = null,
+)
+
+/** DELETE v1/fs/mounts/{id} response: { ok, deleted }. */
+data class DeleteFileMountDto(
+    val ok: Boolean = false,
+    val deleted: Boolean = false,
+)
+
+/** POST v1/fs/mounts/{id}/validate response: { ok, mount_id, status }. */
+data class ValidateFileMountDto(
+    val ok: Boolean = false,
+    val mount_id: String? = null,
+    val status: String? = null,
+)

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/files/FileMountsApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/files/FileMountsApi.kt
@@ -1,0 +1,57 @@
+package com.testlogon.android.core.network.files
+
+import com.testlogon.android.core.model.files.DeleteFileMountDto
+import com.testlogon.android.core.model.files.FileMountCreateRequest
+import com.testlogon.android.core.model.files.FileMountDto
+import com.testlogon.android.core.model.files.FileMountUpdateRequest
+import com.testlogon.android.core.model.files.FileMountsListDto
+import com.testlogon.android.core.model.files.ValidateFileMountDto
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * FM-MOUNTS - Retrofit interface for the file-manager S3 mount CRUD surface (transport only), kept
+ * SEPARATE from [FilesApi] on purpose: mounts are a distinct storage-provider concern and a separate
+ * interface avoids widening [FilesApi] (which has four fake implementers in the test tree). Mirrors the
+ * web contract in frontend/src/api/endpoints/files.ts and the backend app/routers/filemanager.py mount
+ * routes.
+ *
+ * Paths have NO leading slash (relative to the shared Retrofit base URL, matching the rest of the
+ * codebase). All calls are suspend. Mutating verbs carry an explicit JSON Content-Type. Session cookies,
+ * Authorization Bearer and X-CSRF-Token are attached by the core-network interceptors.
+ *
+ * Idempotency: the GETs (list) are idempotent. The mutating verbs (POST create, PATCH update, DELETE,
+ * POST validate) are NON-idempotent and are NOT auto-retried by the shared RetryInterceptor. A 422
+ * surfaces as an HttpException carrying the FastAPI detail body; a 403 feature-gate or 404 (surface not
+ * enabled in this environment) is folded to a degrade-empty state in the repository. 401 is handled
+ * globally by the SessionAuthenticator.
+ */
+interface FileMountsApi {
+
+    /** GET v1/fs/mounts -> { items: [...] }. */
+    @GET("v1/fs/mounts")
+    suspend fun listMounts(): FileMountsListDto
+
+    @Headers("Content-Type: application/json")
+    @POST("v1/fs/mounts")
+    suspend fun createMount(@Body body: FileMountCreateRequest): FileMountDto
+
+    @Headers("Content-Type: application/json")
+    @PATCH("v1/fs/mounts/{id}")
+    suspend fun updateMount(
+        @Path("id") mountId: String,
+        @Body body: FileMountUpdateRequest,
+    ): FileMountDto
+
+    @DELETE("v1/fs/mounts/{id}")
+    suspend fun deleteMount(@Path("id") mountId: String): DeleteFileMountDto
+
+    /** POST v1/fs/mounts/{id}/validate -> { ok, mount_id, status } (test/connectivity check). */
+    @POST("v1/fs/mounts/{id}/validate")
+    suspend fun validateMount(@Path("id") mountId: String): ValidateFileMountDto
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/files/FileMountsNetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/files/FileMountsNetworkModule.kt
@@ -1,0 +1,25 @@
+package com.testlogon.android.core.network.files
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * FM-MOUNTS - Hilt wiring for the file-manager mount CRUD transport layer.
+ *
+ * Provides [FileMountsApi] from the shared singleton [Retrofit] (reusing the production OkHttp / Moshi /
+ * converter config; no new Retrofit, OkHttp or Moshi is built, and no new dependency is introduced). The
+ * mount DTOs decode via the reflective KotlinJsonAdapterFactory already registered in
+ * NetworkModule.provideMoshi. Mirrors the AND-331 FilesNetworkModule pattern.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object FileMountsNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideFileMountsApi(retrofit: Retrofit): FileMountsApi = retrofit.create(FileMountsApi::class.java)
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ const KycWorkloadPage = lazy(() => import("@/pages/admin/KycWorkloadPage"));
 const KycDocumentTemplatesPage = lazy(() => import("@/pages/admin/KycDocumentTemplatesPage"));
 const KycTranslationsPage = lazy(() => import("@/pages/admin/KycTranslationsPage"));
 const ShareLinksPage = lazy(() => import("@/pages/files/ShareLinksPage"));
+const MountsManagerPage = lazy(() => import("@/pages/files/MountsManagerPage"));
 const PublicDownloadPage = lazy(() => import("@/pages/files/PublicDownloadPage"));
 const ProjectsPage = lazy(() => import("@/pages/projects/ProjectsPage"));
 const ProjectDetailPage = lazy(() => import("@/pages/projects/ProjectDetailPage"));
@@ -552,6 +553,7 @@ export default function App() {
           <Route path="files" element={<FilesPage />} />
           <Route path="files/trading-documents" element={<TradingDocumentsPage />} />
           <Route path="files/share-links" element={<ShareLinksPage />} />
+          <Route path="files/mounts" element={<MountsManagerPage />} />
           <Route path="signing" element={<SigningPage />} />
           <Route path="signing/new" element={<CreateSignatureRequestPage />} />
           <Route path="signing/inbox" element={<SigningInboxPage />} />

--- a/frontend/src/api/endpoints/files.ts
+++ b/frontend/src/api/endpoints/files.ts
@@ -110,6 +110,126 @@ export const rotateICloudMount = (body: ICloudRotateReq) =>
 export const revokeICloudMount = (body: ICloudRevokeReq) =>
   api.post<ICloudRevokeResp>("/v1/fs/mounts/icloud/revoke", body);
 
+// ── Generic mount management (SFTP / Drive / OneDrive / S3) ──────────
+// Mirrors app/routers/filemanager.py:
+//   • S3-style FileMount CRUD  (POST/PATCH/DELETE /v1/fs/mounts, /validate)
+//   • host-based provider mounts (POST /v1/fs/mounts/{id}/test,
+//                                 POST /v1/fs/mounts/{id}/rotate-credential,
+//                                 POST /v1/fs/mounts/sftp)
+// All calls degrade gracefully on 404 (feature not enabled) at the call site.
+
+export type FileMountRecord = {
+  id: string;
+  owner: string;
+  provider?: string;
+  mount_path?: string;
+  bucket?: string;
+  prefix?: string | null;
+  mode?: string;
+  auth_ref?: string;
+  status: string;
+  created_at?: string;
+  updated_at?: string;
+  last_check_at?: string | null;
+  last_error?: string | null;
+};
+
+export type FileMountCreateBody = {
+  mount_path: string;
+  bucket: string;
+  prefix?: string | null;
+  mode?: "read_only" | "read_write";
+  auth_ref: string;
+  status?: "active" | "degraded" | "error" | "disabled";
+};
+
+export type FileMountUpdateBody = Partial<FileMountCreateBody>;
+
+// S3-style object-store mount CRUD ------------------------------------
+export const createFileMount = (body: FileMountCreateBody) =>
+  api.post<FileMountRecord>("/v1/fs/mounts", body);
+
+export const updateFileMount = (mountId: string, body: FileMountUpdateBody) =>
+  api.patch<FileMountRecord>(`/v1/fs/mounts/${encodeURIComponent(mountId)}`, body);
+
+export const deleteFileMount = (mountId: string) =>
+  api.del<{ ok: boolean; deleted: boolean }>(`/v1/fs/mounts/${encodeURIComponent(mountId)}`);
+
+export const validateFileMount = (mountId: string) =>
+  api.post<{ ok: boolean; mount_id: string; status: string }>(
+    `/v1/fs/mounts/${encodeURIComponent(mountId)}/validate`,
+  );
+
+// Host-based (SFTP/SCP/FTP) provider mount management -----------------
+export type SftpMountApi = {
+  id: string;
+  owner: string;
+  protocol: string;
+  host: string;
+  port: number;
+  auth_credential_ref: string;
+  remote_root: string;
+  read_only: boolean;
+  status: string;
+  created_at?: string;
+  updated_at?: string;
+  last_tested_at?: string | null;
+  last_status_change_at?: string | null;
+  last_error_code?: string | null;
+  last_error_message?: string | null;
+};
+
+export type SftpMountCreateBody = {
+  protocol?: "sftp" | "scp" | "ftp";
+  host: string;
+  port?: number;
+  auth_credential_ref: string;
+  remote_root: string;
+  read_only?: boolean;
+};
+
+export type SftpMountUpdateBody = {
+  protocol?: "sftp" | "scp" | "ftp";
+  host?: string;
+  port?: number;
+  auth_credential_ref?: string;
+  remote_root?: string;
+  read_only?: boolean;
+  status?: "healthy" | "degraded" | "auth_failed" | "unreachable" | "disabled";
+};
+
+export type SftpRotateCredentialBody = {
+  auth_mode: "password" | "private_key";
+  username: string;
+  password?: string | null;
+  private_key?: string | null;
+  private_key_passphrase?: string | null;
+  auth_credential_ref?: string | null;
+};
+
+export const createSftpMount = (body: SftpMountCreateBody) =>
+  api.post<{ ok: boolean; mount: SftpMountApi }>("/v1/fs/mounts/sftp", body);
+
+export const updateSftpMount = (mountId: string, body: SftpMountUpdateBody) =>
+  api.patch<{ ok: boolean; mount: SftpMountApi }>(
+    `/v1/fs/mounts/${encodeURIComponent(mountId)}`,
+    body,
+  );
+
+export const deleteSftpMount = (mountId: string) =>
+  api.del<{ ok: boolean; mount_id: string }>(`/v1/fs/mounts/${encodeURIComponent(mountId)}`);
+
+export const testMount = (mountId: string) =>
+  api.post<{ ok: boolean; mount: SftpMountApi }>(
+    `/v1/fs/mounts/${encodeURIComponent(mountId)}/test`,
+  );
+
+export const rotateMountCredential = (mountId: string, body: SftpRotateCredentialBody) =>
+  api.post<{ ok: boolean; mount: SftpMountApi; auth_credential_ref: string }>(
+    `/v1/fs/mounts/${encodeURIComponent(mountId)}/rotate-credential`,
+    body,
+  );
+
 export const uploadFile = (
   file: File,
   path: string,

--- a/frontend/src/lib/mountConfig.test.ts
+++ b/frontend/src/lib/mountConfig.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from "vitest";
+import {
+  providerMeta,
+  mountStatusBadge,
+  validateMountConfig,
+  buildCreateBody,
+  validateRotateCredential,
+  canTestMount,
+  SUPPORTED_PROVIDERS,
+} from "./mountConfig";
+
+describe("providerMeta", () => {
+  it("labels sftp as a host-based provider", () => {
+    const m = providerMeta("sftp");
+    expect(m.label).toMatch(/SFTP/);
+    expect(m.hostBased).toBe(true);
+  });
+
+  it("labels cloud object providers as non-host-based", () => {
+    expect(providerMeta("drive").hostBased).toBe(false);
+    expect(providerMeta("onedrive").hostBased).toBe(false);
+    expect(providerMeta("s3").hostBased).toBe(false);
+  });
+
+  it("falls back for unknown providers", () => {
+    expect(providerMeta("nope").label).toBe("Mount");
+    expect(providerMeta(null).iconKey).toBe("s3");
+  });
+
+  it("exposes all supported providers", () => {
+    expect(SUPPORTED_PROVIDERS).toEqual(["sftp", "drive", "onedrive", "s3"]);
+  });
+});
+
+describe("mountStatusBadge", () => {
+  it("maps healthy/active to success", () => {
+    expect(mountStatusBadge("healthy").severity).toBe("success");
+    expect(mountStatusBadge("active").severity).toBe("success");
+  });
+  it("maps failures to danger", () => {
+    expect(mountStatusBadge("auth_failed").severity).toBe("danger");
+    expect(mountStatusBadge("unreachable").severity).toBe("danger");
+    expect(mountStatusBadge("error").severity).toBe("danger");
+  });
+  it("maps degraded to warning and disabled to neutral", () => {
+    expect(mountStatusBadge("degraded").severity).toBe("warning");
+    expect(mountStatusBadge("disabled").severity).toBe("neutral");
+  });
+  it("falls back to neutral for unknown/empty", () => {
+    expect(mountStatusBadge(undefined).severity).toBe("neutral");
+    expect(mountStatusBadge("weird").label).toBe("weird");
+  });
+});
+
+describe("validateMountConfig — sftp", () => {
+  const good = {
+    provider: "sftp",
+    host: "sftp.example.com",
+    port: 22,
+    remote_root: "/home/u",
+    auth_credential_ref: "cred#1",
+    protocol: "sftp",
+  };
+
+  it("accepts a complete sftp config", () => {
+    expect(validateMountConfig(good).ok).toBe(true);
+  });
+
+  it("requires host, remote_root, and credential ref", () => {
+    const res = validateMountConfig({ provider: "sftp", port: 22 });
+    const fields = res.errors.map((e) => e.field);
+    expect(res.ok).toBe(false);
+    expect(fields).toEqual(expect.arrayContaining(["host", "remote_root", "auth_credential_ref"]));
+  });
+
+  it("rejects an out-of-range port", () => {
+    const res = validateMountConfig({ ...good, port: 70000 });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.field === "port")).toBe(true);
+  });
+
+  it("rejects a non-integer / missing port", () => {
+    expect(validateMountConfig({ ...good, port: "abc" }).ok).toBe(false);
+    expect(validateMountConfig({ ...good, port: "" }).ok).toBe(false);
+  });
+
+  it("rejects an unsupported protocol", () => {
+    const res = validateMountConfig({ ...good, protocol: "http" });
+    expect(res.errors.some((e) => e.field === "protocol")).toBe(true);
+  });
+});
+
+describe("validateMountConfig — s3/drive/onedrive", () => {
+  const good = {
+    provider: "s3" as const,
+    mount_path: "/cloud/a",
+    bucket: "my-bucket",
+    auth_ref: "secret#1",
+    mode: "read_only",
+  };
+
+  it("accepts a complete object-store config", () => {
+    expect(validateMountConfig(good).ok).toBe(true);
+    expect(validateMountConfig({ ...good, provider: "drive" }).ok).toBe(true);
+    expect(validateMountConfig({ ...good, provider: "onedrive" }).ok).toBe(true);
+  });
+
+  it("requires a mount_path, bucket, and auth_ref", () => {
+    const res = validateMountConfig({ provider: "drive" });
+    const fields = res.errors.map((e) => e.field);
+    expect(fields).toEqual(expect.arrayContaining(["mount_path", "bucket", "auth_ref"]));
+  });
+
+  it("rejects a too-short bucket name", () => {
+    const res = validateMountConfig({ ...good, bucket: "ab" });
+    expect(res.errors.some((e) => e.field === "bucket")).toBe(true);
+  });
+
+  it("rejects an invalid mode", () => {
+    const res = validateMountConfig({ ...good, mode: "sideways" });
+    expect(res.errors.some((e) => e.field === "mode")).toBe(true);
+  });
+});
+
+describe("validateMountConfig — provider gate", () => {
+  it("rejects an unknown provider", () => {
+    const res = validateMountConfig({ provider: "dropbox" });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.field === "provider")).toBe(true);
+  });
+});
+
+describe("buildCreateBody", () => {
+  it("builds the sftp body with defaults", () => {
+    const body = buildCreateBody({
+      provider: "sftp",
+      host: " h ",
+      remote_root: "/r",
+      auth_credential_ref: " c ",
+    });
+    expect(body).toMatchObject({
+      protocol: "sftp",
+      host: "h",
+      port: 22,
+      remote_root: "/r",
+      auth_credential_ref: "c",
+      read_only: false,
+    });
+  });
+
+  it("builds the object-store body with null prefix when empty", () => {
+    const body = buildCreateBody({
+      provider: "drive",
+      mount_path: "/d",
+      bucket: "bkt-name",
+      auth_ref: "s",
+    });
+    expect(body).toMatchObject({
+      mount_path: "/d",
+      bucket: "bkt-name",
+      prefix: null,
+      auth_ref: "s",
+      status: "active",
+    });
+  });
+
+  it("defaults mode from read_only flag", () => {
+    expect(buildCreateBody({ provider: "s3", read_only: true }).mode).toBe("read_only");
+    expect(buildCreateBody({ provider: "s3", read_only: false }).mode).toBe("read_write");
+  });
+});
+
+describe("validateRotateCredential", () => {
+  it("accepts password mode with a password", () => {
+    expect(
+      validateRotateCredential({ auth_mode: "password", username: "u", password: "p" }).ok,
+    ).toBe(true);
+  });
+  it("accepts private_key mode with a key", () => {
+    expect(
+      validateRotateCredential({ auth_mode: "private_key", username: "u", private_key: "KEY" }).ok,
+    ).toBe(true);
+  });
+  it("requires a password in password mode", () => {
+    const res = validateRotateCredential({ auth_mode: "password", username: "u" });
+    expect(res.errors.some((e) => e.field === "password")).toBe(true);
+  });
+  it("requires a key in private_key mode", () => {
+    const res = validateRotateCredential({ auth_mode: "private_key", username: "u" });
+    expect(res.errors.some((e) => e.field === "private_key")).toBe(true);
+  });
+  it("rejects a bad auth_mode and missing username", () => {
+    const res = validateRotateCredential({ auth_mode: "biometric" });
+    const fields = res.errors.map((e) => e.field);
+    expect(fields).toEqual(expect.arrayContaining(["auth_mode", "username"]));
+  });
+});
+
+describe("canTestMount", () => {
+  it("is true only for sftp", () => {
+    expect(canTestMount("sftp")).toBe(true);
+    expect(canTestMount("drive")).toBe(false);
+    expect(canTestMount(null)).toBe(false);
+  });
+});

--- a/frontend/src/lib/mountConfig.ts
+++ b/frontend/src/lib/mountConfig.ts
@@ -1,0 +1,232 @@
+// Pure, framework-free helpers for generic file-mount provider management.
+// No React / no network — safe to unit-test in isolation (vitest).
+//
+// Mirrors the backend filemanager mount contracts:
+//   • S3-style FileMount CRUD           (POST/PATCH/DELETE /v1/fs/mounts,
+//                                         POST /v1/fs/mounts/{id}/validate)
+//   • generic provider mounts (SFTP…)   (POST /v1/fs/mounts/{id}/test,
+//                                         POST /v1/fs/mounts/{id}/rotate-credential)
+//
+// The validation rules below intentionally match the backend Pydantic field
+// constraints so the UI can fail fast BEFORE issuing a request.
+
+export type MountProvider = "sftp" | "drive" | "onedrive" | "s3";
+
+/** Provider display metadata (no icon dependency — the UI maps iconKey). */
+export interface ProviderMeta {
+  label: string;
+  iconKey: "sftp" | "drive" | "onedrive" | "s3";
+  /** Whether this provider is a remote-host transport (needs host/port). */
+  hostBased: boolean;
+}
+
+export function providerMeta(
+  provider: MountProvider | string | null | undefined,
+): ProviderMeta {
+  switch (provider) {
+    case "sftp":
+      return { label: "SFTP / SCP / FTP", iconKey: "sftp", hostBased: true };
+    case "drive":
+      return { label: "Google Drive", iconKey: "drive", hostBased: false };
+    case "onedrive":
+      return { label: "Microsoft OneDrive", iconKey: "onedrive", hostBased: false };
+    case "s3":
+      return { label: "S3 bucket", iconKey: "s3", hostBased: false };
+    default:
+      return { label: "Mount", iconKey: "s3", hostBased: false };
+  }
+}
+
+export const SUPPORTED_PROVIDERS: MountProvider[] = ["sftp", "drive", "onedrive", "s3"];
+
+// ── Status badge mapping ───────────────────────────────────────────
+// Backend SFTP status enum: healthy|degraded|auth_failed|unreachable|disabled
+// Backend FileMount status enum: active|degraded|error|disabled
+export type BadgeSeverity = "success" | "warning" | "danger" | "neutral";
+
+export interface StatusBadge {
+  label: string;
+  severity: BadgeSeverity;
+}
+
+export function mountStatusBadge(
+  status: string | null | undefined,
+): StatusBadge {
+  switch (status) {
+    case "healthy":
+    case "active":
+      return { label: status === "active" ? "Active" : "Healthy", severity: "success" };
+    case "degraded":
+      return { label: "Degraded", severity: "warning" };
+    case "auth_failed":
+      return { label: "Auth failed", severity: "danger" };
+    case "unreachable":
+      return { label: "Unreachable", severity: "danger" };
+    case "error":
+      return { label: "Error", severity: "danger" };
+    case "disabled":
+      return { label: "Disabled", severity: "neutral" };
+    default:
+      return { label: status ? String(status) : "Unknown", severity: "neutral" };
+  }
+}
+
+// ── Draft config validation ────────────────────────────────────────
+
+/** A cross-provider mount config draft as edited in the UI. */
+export interface MountConfigDraft {
+  provider: MountProvider | string;
+  mount_path?: string;
+  // host-based (sftp)
+  protocol?: string;
+  host?: string;
+  port?: number | string;
+  remote_root?: string;
+  read_only?: boolean;
+  auth_credential_ref?: string;
+  // s3 / cloud object providers
+  bucket?: string;
+  prefix?: string;
+  mode?: string;
+  auth_ref?: string;
+}
+
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: FieldError[];
+}
+
+const SFTP_PROTOCOLS = ["sftp", "scp", "ftp"];
+
+function toPort(v: number | string | undefined): number | null {
+  if (v === undefined || v === null || v === "") return null;
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) return null;
+  return n;
+}
+
+/**
+ * Validate a mount config draft against the backend field constraints for its
+ * provider. Returns every field error (not just the first) so a form can show
+ * them all at once.
+ */
+export function validateMountConfig(draft: MountConfigDraft): ValidationResult {
+  const errors: FieldError[] = [];
+  const provider = draft.provider;
+
+  if (!provider || !SUPPORTED_PROVIDERS.includes(provider as MountProvider)) {
+    errors.push({ field: "provider", message: "Choose a supported provider." });
+  }
+
+  if (provider === "sftp") {
+    // mirrors CreateSftpMountIn
+    if (draft.protocol && !SFTP_PROTOCOLS.includes(draft.protocol)) {
+      errors.push({ field: "protocol", message: "Protocol must be sftp, scp, or ftp." });
+    }
+    if (!draft.host || !draft.host.trim()) {
+      errors.push({ field: "host", message: "Host is required." });
+    }
+    const port = toPort(draft.port);
+    if (port === null) {
+      errors.push({ field: "port", message: "Port is required." });
+    } else if (port < 1 || port > 65535) {
+      errors.push({ field: "port", message: "Port must be between 1 and 65535." });
+    }
+    if (!draft.remote_root || !draft.remote_root.trim()) {
+      errors.push({ field: "remote_root", message: "Remote root path is required." });
+    }
+    if (!draft.auth_credential_ref || !draft.auth_credential_ref.trim()) {
+      errors.push({ field: "auth_credential_ref", message: "A credential reference is required." });
+    }
+  } else if (provider === "s3" || provider === "drive" || provider === "onedrive") {
+    // mirrors FileMountCreateIn (bucket/prefix/mode/auth_ref/mount_path)
+    if (!draft.mount_path || draft.mount_path.trim().length < 1) {
+      errors.push({ field: "mount_path", message: "Mount path is required." });
+    } else if (draft.mount_path.length > 2048) {
+      errors.push({ field: "mount_path", message: "Mount path is too long." });
+    }
+    const bucket = (draft.bucket ?? "").trim();
+    if (bucket.length < 3 || bucket.length > 255) {
+      errors.push({ field: "bucket", message: "Bucket/container must be 3–255 characters." });
+    }
+    if (draft.prefix && draft.prefix.length > 2048) {
+      errors.push({ field: "prefix", message: "Prefix is too long." });
+    }
+    if (draft.mode && !["read_only", "read_write"].includes(draft.mode)) {
+      errors.push({ field: "mode", message: "Mode must be read_only or read_write." });
+    }
+    const authRef = (draft.auth_ref ?? "").trim();
+    if (authRef.length < 1 || authRef.length > 256) {
+      errors.push({ field: "auth_ref", message: "A credential reference is required." });
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/** Build the create-request body for the backend from a validated draft. */
+export function buildCreateBody(
+  draft: MountConfigDraft,
+): Record<string, unknown> {
+  if (draft.provider === "sftp") {
+    return {
+      protocol: draft.protocol || "sftp",
+      host: (draft.host ?? "").trim(),
+      port: toPort(draft.port) ?? 22,
+      auth_credential_ref: (draft.auth_credential_ref ?? "").trim(),
+      remote_root: (draft.remote_root ?? "").trim(),
+      read_only: !!draft.read_only,
+    };
+  }
+  // s3 / drive / onedrive
+  return {
+    mount_path: (draft.mount_path ?? "").trim(),
+    bucket: (draft.bucket ?? "").trim(),
+    prefix: draft.prefix ? draft.prefix.trim() : null,
+    mode: draft.mode || (draft.read_only ? "read_only" : "read_write"),
+    auth_ref: (draft.auth_ref ?? "").trim(),
+    status: "active",
+  };
+}
+
+// ── Credential rotation validation (SFTP-style rotate-credential) ───
+// mirrors RotateSftpMountCredentialIn
+export interface RotateCredentialDraft {
+  auth_mode: string;
+  username?: string;
+  password?: string;
+  private_key?: string;
+  private_key_passphrase?: string;
+  auth_credential_ref?: string;
+}
+
+export function validateRotateCredential(
+  draft: RotateCredentialDraft,
+): ValidationResult {
+  const errors: FieldError[] = [];
+  if (!["password", "private_key"].includes(draft.auth_mode)) {
+    errors.push({ field: "auth_mode", message: "Auth mode must be password or private_key." });
+  }
+  if (!draft.username || !draft.username.trim()) {
+    errors.push({ field: "username", message: "Username is required." });
+  }
+  if (draft.auth_mode === "password" && !(draft.password && draft.password.length > 0)) {
+    errors.push({ field: "password", message: "Password is required." });
+  }
+  if (draft.auth_mode === "private_key" && !(draft.private_key && draft.private_key.trim())) {
+    errors.push({ field: "private_key", message: "Private key is required." });
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/** Convenience: is a mount actionable for the given control? */
+export function canTestMount(provider: string | null | undefined): boolean {
+  // The backend exposes /test + /rotate-credential on the host-based (SFTP)
+  // family; S3/cloud object mounts use /validate instead.
+  return provider === "sftp";
+}

--- a/frontend/src/pages/files/MountsManagerPage.tsx
+++ b/frontend/src/pages/files/MountsManagerPage.tsx
@@ -1,0 +1,528 @@
+import React from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { HardDrive, Plus, RefreshCw, Trash2, KeyRound, PlugZap } from "lucide-react";
+
+import { PageHeader } from "@/components/shared/PageHeader";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ApiError } from "@/api/client";
+import {
+  listMounts,
+  createSftpMount,
+  createFileMount,
+  deleteSftpMount,
+  deleteFileMount,
+  testMount,
+  validateFileMount,
+  rotateMountCredential,
+  type FileMount,
+} from "@/api/endpoints/files";
+import {
+  SUPPORTED_PROVIDERS,
+  providerMeta,
+  mountStatusBadge,
+  validateMountConfig,
+  buildCreateBody,
+  validateRotateCredential,
+  canTestMount,
+  type MountProvider,
+  type MountConfigDraft,
+  type RotateCredentialDraft,
+  type BadgeSeverity,
+} from "@/lib/mountConfig";
+
+function is404(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+const badgeVariant: Record<BadgeSeverity, "success" | "warning" | "destructive" | "secondary"> = {
+  success: "success",
+  warning: "warning",
+  danger: "destructive",
+  neutral: "secondary",
+};
+
+function emptyDraft(): MountConfigDraft {
+  return {
+    provider: "sftp",
+    protocol: "sftp",
+    host: "",
+    port: 22,
+    remote_root: "/",
+    read_only: false,
+    auth_credential_ref: "",
+    mount_path: "/",
+    bucket: "",
+    prefix: "",
+    mode: "read_only",
+    auth_ref: "",
+  };
+}
+
+function emptyRotate(): RotateCredentialDraft {
+  return { auth_mode: "password", username: "", password: "", private_key: "" };
+}
+
+export default function MountsManagerPage() {
+  const qc = useQueryClient();
+  const [addOpen, setAddOpen] = React.useState(false);
+  const [draft, setDraft] = React.useState<MountConfigDraft>(emptyDraft);
+  const [rotateFor, setRotateFor] = React.useState<string | null>(null);
+  const [rotate, setRotate] = React.useState<RotateCredentialDraft>(emptyRotate);
+
+  const mountsQuery = useQuery({
+    queryKey: ["fs-mounts-manager"],
+    queryFn: () => listMounts(),
+    retry: (count, err) => !is404(err) && count < 2,
+  });
+
+  const featureDisabled = is404(mountsQuery.error);
+  const mounts: FileMount[] = Array.isArray(mountsQuery.data) ? mountsQuery.data : [];
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: ["fs-mounts-manager"] });
+
+  const createMut = useMutation({
+    mutationFn: async (d: MountConfigDraft) => {
+      const body = buildCreateBody(d);
+      if (d.provider === "sftp") return createSftpMount(body as never);
+      return createFileMount(body as never);
+    },
+    onSuccess: () => {
+      toast.success("Mount added");
+      setAddOpen(false);
+      setDraft(emptyDraft());
+      invalidate();
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiError ? err.detail : "Failed to add mount"),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: async (m: FileMount) => {
+      if (m.provider === "sftp") return deleteSftpMount(m.mount_id);
+      return deleteFileMount(m.mount_id);
+    },
+    onSuccess: () => {
+      toast.success("Mount removed");
+      invalidate();
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiError ? err.detail : "Failed to remove mount"),
+  });
+
+  const testMut = useMutation({
+    mutationFn: async (m: FileMount) => {
+      if (canTestMount(m.provider)) return testMount(m.mount_id);
+      return validateFileMount(m.mount_id);
+    },
+    onSuccess: (res) => {
+      const ok = (res as { ok?: boolean }).ok;
+      if (ok === false) toast.warning("Connection check reported a problem");
+      else toast.success("Connection OK");
+      invalidate();
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiError ? err.detail : "Connection test failed"),
+  });
+
+  const rotateMut = useMutation({
+    mutationFn: async (args: { mountId: string; body: RotateCredentialDraft }) =>
+      rotateMountCredential(args.mountId, {
+        auth_mode: args.body.auth_mode as "password" | "private_key",
+        username: args.body.username ?? "",
+        password: args.body.password || null,
+        private_key: args.body.private_key || null,
+        private_key_passphrase: args.body.private_key_passphrase || null,
+        auth_credential_ref: args.body.auth_credential_ref || null,
+      }),
+    onSuccess: () => {
+      toast.success("Credential rotated");
+      setRotateFor(null);
+      setRotate(emptyRotate());
+      invalidate();
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiError ? err.detail : "Failed to rotate credential"),
+  });
+
+  const draftErrors = validateMountConfig(draft);
+  const rotateErrors = validateRotateCredential(rotate);
+  const err = (field: string, res = draftErrors) =>
+    res.errors.find((e) => e.field === field)?.message;
+
+  const isHostBased = draft.provider === "sftp";
+
+  if (featureDisabled) {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Mounts" description="External storage providers" />
+        <EmptyState
+          icon={<HardDrive className="h-8 w-8" />}
+          title="Mounts are not enabled"
+          description="External mount management is not available in this environment."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Mounts"
+        description="Connect and manage external storage providers (SFTP, Google Drive, OneDrive, S3)."
+        actions={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => mountsQuery.refetch()}
+              disabled={mountsQuery.isFetching}
+            >
+              <RefreshCw className={`mr-2 h-4 w-4 ${mountsQuery.isFetching ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+            <Button size="sm" onClick={() => setAddOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add provider
+            </Button>
+          </>
+        }
+      />
+
+      {mounts.length === 0 && !mountsQuery.isLoading ? (
+        <EmptyState
+          icon={<HardDrive className="h-8 w-8" />}
+          title="No mounts yet"
+          description="Add an external provider to browse remote files alongside your own."
+          action={{ label: "Add provider", onClick: () => setAddOpen(true) }}
+        />
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Provider</TableHead>
+              <TableHead>Path</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {mounts.map((m) => {
+              const meta = providerMeta(m.provider);
+              const badge = mountStatusBadge(m.status);
+              return (
+                <TableRow key={m.mount_id}>
+                  <TableCell className="font-medium">{meta.label}</TableCell>
+                  <TableCell className="text-muted-foreground">{m.mount_path || "—"}</TableCell>
+                  <TableCell>
+                    <Badge variant={badgeVariant[badge.severity]}>{badge.label}</Badge>
+                  </TableCell>
+                  <TableCell className="text-right space-x-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => testMut.mutate(m)}
+                      disabled={testMut.isPending}
+                      title="Test connection"
+                    >
+                      <PlugZap className="h-4 w-4" />
+                    </Button>
+                    {canTestMount(m.provider) && (m.can_rotate ?? true) && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setRotate(emptyRotate());
+                          setRotateFor(m.mount_id);
+                        }}
+                        title="Rotate credential"
+                      >
+                        <KeyRound className="h-4 w-4" />
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        if (window.confirm("Remove this mount?")) deleteMut.mutate(m);
+                      }}
+                      disabled={deleteMut.isPending}
+                      title="Remove"
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Add provider dialog */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add a mount</DialogTitle>
+            <DialogDescription>
+              Configure an external storage provider. Credentials are stored by reference.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <Label>Provider</Label>
+              <Select
+                value={String(draft.provider)}
+                onValueChange={(v) => setDraft({ ...draft, provider: v as MountProvider })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SUPPORTED_PROVIDERS.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {providerMeta(p).label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {isHostBased ? (
+              <>
+                <div className="grid grid-cols-3 gap-2">
+                  <div className="col-span-1 space-y-1">
+                    <Label>Protocol</Label>
+                    <Select
+                      value={draft.protocol || "sftp"}
+                      onValueChange={(v) => setDraft({ ...draft, protocol: v })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="sftp">SFTP</SelectItem>
+                        <SelectItem value="scp">SCP</SelectItem>
+                        <SelectItem value="ftp">FTP</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="col-span-2 space-y-1">
+                    <Label>Host</Label>
+                    <Input
+                      value={draft.host ?? ""}
+                      onChange={(e) => setDraft({ ...draft, host: e.target.value })}
+                      placeholder="sftp.example.com"
+                    />
+                    {err("host") && <p className="text-xs text-destructive">{err("host")}</p>}
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="space-y-1">
+                    <Label>Port</Label>
+                    <Input
+                      type="number"
+                      value={String(draft.port ?? "")}
+                      onChange={(e) => setDraft({ ...draft, port: e.target.value })}
+                    />
+                    {err("port") && <p className="text-xs text-destructive">{err("port")}</p>}
+                  </div>
+                  <div className="space-y-1">
+                    <Label>Remote root</Label>
+                    <Input
+                      value={draft.remote_root ?? ""}
+                      onChange={(e) => setDraft({ ...draft, remote_root: e.target.value })}
+                      placeholder="/"
+                    />
+                    {err("remote_root") && (
+                      <p className="text-xs text-destructive">{err("remote_root")}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <Label>Credential reference</Label>
+                  <Input
+                    value={draft.auth_credential_ref ?? ""}
+                    onChange={(e) => setDraft({ ...draft, auth_credential_ref: e.target.value })}
+                    placeholder="secret-manager ref"
+                  />
+                  {err("auth_credential_ref") && (
+                    <p className="text-xs text-destructive">{err("auth_credential_ref")}</p>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="space-y-1">
+                  <Label>Mount path</Label>
+                  <Input
+                    value={draft.mount_path ?? ""}
+                    onChange={(e) => setDraft({ ...draft, mount_path: e.target.value })}
+                    placeholder="/cloud/my-drive"
+                  />
+                  {err("mount_path") && (
+                    <p className="text-xs text-destructive">{err("mount_path")}</p>
+                  )}
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="space-y-1">
+                    <Label>Bucket / container</Label>
+                    <Input
+                      value={draft.bucket ?? ""}
+                      onChange={(e) => setDraft({ ...draft, bucket: e.target.value })}
+                    />
+                    {err("bucket") && <p className="text-xs text-destructive">{err("bucket")}</p>}
+                  </div>
+                  <div className="space-y-1">
+                    <Label>Prefix (optional)</Label>
+                    <Input
+                      value={draft.prefix ?? ""}
+                      onChange={(e) => setDraft({ ...draft, prefix: e.target.value })}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <Label>Credential reference</Label>
+                  <Input
+                    value={draft.auth_ref ?? ""}
+                    onChange={(e) => setDraft({ ...draft, auth_ref: e.target.value })}
+                  />
+                  {err("auth_ref") && (
+                    <p className="text-xs text-destructive">{err("auth_ref")}</p>
+                  )}
+                </div>
+              </>
+            )}
+
+            <div className="flex items-center justify-between">
+              <Label htmlFor="ro">Read only</Label>
+              <Switch
+                id="ro"
+                checked={!!draft.read_only}
+                onCheckedChange={(v) =>
+                  setDraft({ ...draft, read_only: v, mode: v ? "read_only" : "read_write" })
+                }
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => createMut.mutate(draft)}
+              disabled={!draftErrors.ok || createMut.isPending}
+            >
+              Add mount
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Rotate credential dialog */}
+      <Dialog open={!!rotateFor} onOpenChange={(o) => !o && setRotateFor(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rotate credential</DialogTitle>
+            <DialogDescription>
+              Replace the stored credential for this mount.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <Label>Auth mode</Label>
+              <Select
+                value={rotate.auth_mode}
+                onValueChange={(v) => setRotate({ ...rotate, auth_mode: v })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="password">Password</SelectItem>
+                  <SelectItem value="private_key">Private key</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Username</Label>
+              <Input
+                value={rotate.username ?? ""}
+                onChange={(e) => setRotate({ ...rotate, username: e.target.value })}
+              />
+              {err("username", rotateErrors) && (
+                <p className="text-xs text-destructive">{err("username", rotateErrors)}</p>
+              )}
+            </div>
+            {rotate.auth_mode === "password" ? (
+              <div className="space-y-1">
+                <Label>Password</Label>
+                <Input
+                  type="password"
+                  value={rotate.password ?? ""}
+                  onChange={(e) => setRotate({ ...rotate, password: e.target.value })}
+                />
+                {err("password", rotateErrors) && (
+                  <p className="text-xs text-destructive">{err("password", rotateErrors)}</p>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-1">
+                <Label>Private key</Label>
+                <Input
+                  value={rotate.private_key ?? ""}
+                  onChange={(e) => setRotate({ ...rotate, private_key: e.target.value })}
+                  placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+                />
+                {err("private_key", rotateErrors) && (
+                  <p className="text-xs text-destructive">{err("private_key", rotateErrors)}</p>
+                )}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRotateFor(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => rotateFor && rotateMut.mutate({ mountId: rotateFor, body: rotate })}
+              disabled={!rotateErrors.ok || rotateMut.isPending}
+            >
+              Rotate
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## PAR-162 - file-manager mount management (web + Android)

Brings file-manager mount management to parity across web and Android.

### Web
- `MountsManagerPage` for viewing/managing file-manager mounts, routed in `App.tsx`
- `mountConfig` helper lib + unit tests
- `files` endpoint wiring for mounts

### Android
- New `files/mounts` feature: `MountsScreen`, `MountsViewModel`, repository + DI module, mount math
- `FileMountDtos` (core-model), `FileMountsApi` + network module (core-network)
- Wired into files navigation (`FilesNavigation`, `MountsNavigation`, `AuthenticatedGraph`)
- Unit coverage: `MountMathTest`

Built + gated. Unit tests added on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
