### PR TITLE
FE parity PAR-161 - Android Jira integration

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/jira/JiraMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/jira/JiraMath.kt
@@ -1,0 +1,146 @@
+package com.testlogon.android.data.jira
+
+import com.testlogon.android.core.network.jira.JiraConstants
+
+/**
+ * JIRA-AND-1 - PURE, framework-free logic + model for the Jira integration surface. No Android / java.time /
+ * Moshi types, so every function here is JVM-unit-testable (mirrors the KbMath / PurchaseHistoryMath idiom).
+ *
+ * Responsibilities:
+ *  - normalize the RAW wire sync_state token into a closed [JiraLinkState] (unknown-safe -> UNKNOWN, never throws).
+ *  - normalize the RAW connection status into "connected?" (any active connection counts).
+ *  - derive the user-facing [JiraSyncSummary] (a link-state + label + whether the ticket is actionable, i.e.
+ *    conflict needs resolution / failed needs retry).
+ *  - the CONFLICT-RESOLUTION model: pair up the per-field local vs remote values so the UI can show a diff, and
+ *    map the chosen [JiraConflictChoice] to the wire action token.
+ *  - degrade-on-404: a not-connected / not-linked status is a first-class honest-empty value, NOT an error.
+ */
+object JiraMath {
+
+    /** The closed set of link states derived from the RAW server sync_state token. */
+    enum class JiraLinkState { NOT_LINKED, QUEUED, IN_SYNC, CONFLICT, FAILED, UNKNOWN }
+
+    /** The user's conflict-resolution choice (maps to the wire action token). */
+    enum class JiraConflictChoice { KEEP_INTERNAL, KEEP_JIRA }
+
+    /** One field's local-vs-remote diff row for the conflict UI. */
+    data class JiraConflictRow(
+        val field: String,
+        val localValue: String,
+        val remoteValue: String,
+    )
+
+    /** The derived, render-ready summary of a ticket's Jira sync status. */
+    data class JiraSyncSummary(
+        val linked: Boolean,
+        val state: JiraLinkState,
+        val rawState: String,
+        val issueKey: String?,
+        val jiraStatus: String?,
+        /** True when the state requires user action (conflict -> resolve, failed -> retry). */
+        val needsAttention: Boolean,
+        val conflictRows: List<JiraConflictRow>,
+    )
+
+    /**
+     * Map a RAW wire sync_state token to the closed [JiraLinkState]. Blank / null / unknown -> UNKNOWN
+     * (never throws). Case- and surrounding-whitespace-insensitive.
+     */
+    fun linkState(rawState: String?): JiraLinkState = when (rawState?.trim()?.lowercase()) {
+        JiraConstants.SyncState.NOT_LINKED -> JiraLinkState.NOT_LINKED
+        JiraConstants.SyncState.QUEUED -> JiraLinkState.QUEUED
+        JiraConstants.SyncState.IN_SYNC -> JiraLinkState.IN_SYNC
+        JiraConstants.SyncState.CONFLICT -> JiraLinkState.CONFLICT
+        JiraConstants.SyncState.FAILED -> JiraLinkState.FAILED
+        null, "" -> JiraLinkState.NOT_LINKED
+        else -> JiraLinkState.UNKNOWN
+    }
+
+    /** True when the state warrants an explicit user action (resolve a conflict / retry a failure). */
+    fun needsAttention(state: JiraLinkState): Boolean =
+        state == JiraLinkState.CONFLICT || state == JiraLinkState.FAILED
+
+    /**
+     * True when ANY connection in the status list is active. Degrade-on-404 supplies an empty list, which is
+     * honestly not-connected (false), never an error.
+     */
+    fun isConnected(connectionStatuses: List<String?>): Boolean =
+        connectionStatuses.any { (it ?: "").trim().equals(JiraConstants.ConnectionStatus.ACTIVE, ignoreCase = true) }
+
+    /** Map the user's conflict choice to the wire action token. */
+    fun conflictAction(choice: JiraConflictChoice): String = when (choice) {
+        JiraConflictChoice.KEEP_INTERNAL -> JiraConstants.ResolveAction.KEEP_INTERNAL
+        JiraConflictChoice.KEEP_JIRA -> JiraConstants.ResolveAction.KEEP_JIRA
+    }
+
+    /**
+     * Build the ordered per-field conflict diff. Fields come from [conflictFields] (server-authoritative order);
+     * missing values render as an empty string. Values are stringified defensively (null -> "").
+     */
+    fun conflictRows(
+        conflictFields: List<String>,
+        localValues: Map<String, Any?>,
+        remoteValues: Map<String, Any?>,
+    ): List<JiraConflictRow> = conflictFields
+        .filter { it.isNotBlank() }
+        .map { field ->
+            JiraConflictRow(
+                field = field,
+                localValue = stringify(localValues[field]),
+                remoteValue = stringify(remoteValues[field]),
+            )
+        }
+
+    /**
+     * Fold a sync-status into a render-ready [JiraSyncSummary]. This is the single choke point the ViewModel
+     * uses: it normalizes the state, decides attention, and precomputes the conflict rows (empty unless the
+     * state is CONFLICT).
+     */
+    fun summarize(
+        linked: Boolean,
+        rawState: String?,
+        issueKey: String?,
+        jiraStatus: String?,
+        conflictFields: List<String>,
+        localValues: Map<String, Any?>,
+        remoteValues: Map<String, Any?>,
+    ): JiraSyncSummary {
+        val state = linkState(rawState)
+        val rows = if (state == JiraLinkState.CONFLICT) {
+            conflictRows(conflictFields, localValues, remoteValues)
+        } else {
+            emptyList()
+        }
+        return JiraSyncSummary(
+            linked = linked && state != JiraLinkState.NOT_LINKED,
+            state = state,
+            rawState = (rawState ?: "").trim(),
+            issueKey = issueKey?.takeIf { it.isNotBlank() },
+            jiraStatus = jiraStatus?.takeIf { it.isNotBlank() },
+            needsAttention = needsAttention(state),
+            conflictRows = rows,
+        )
+    }
+
+    /**
+     * Validate a user-entered Jira issue key for the link-existing flow (client-side pre-gate ONLY; the server
+     * is the authority). A Jira key is PROJECT-123: 1+ uppercase letters, a hyphen, 1+ digits. Returns the
+     * normalized (trimmed, upper-cased) key, or null when invalid.
+     */
+    fun normalizeIssueKey(raw: String?): String? {
+        val trimmed = raw?.trim()?.uppercase() ?: return null
+        if (trimmed.isEmpty()) return null
+        return if (ISSUE_KEY_REGEX.matches(trimmed)) trimmed else null
+    }
+
+    /** True when [raw] is a syntactically-valid Jira issue key. */
+    fun isValidIssueKey(raw: String?): Boolean = normalizeIssueKey(raw) != null
+
+    private val ISSUE_KEY_REGEX = Regex("^[A-Z][A-Z0-9]*-[0-9]+$")
+
+    private fun stringify(value: Any?): String = when (value) {
+        null -> ""
+        is String -> value
+        else -> value.toString()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/jira/data/JiraDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/jira/data/JiraDataModule.kt
@@ -1,0 +1,22 @@
+package com.testlogon.android.feature.jira.data
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * JIRA-AND-1 - Hilt wiring for the Jira integration feature. Binds the repository seam to its default impl. The
+ * impl consumes the [com.testlogon.android.core.network.jira.JiraApi] and the shared
+ * [com.testlogon.android.core.network.error.ApiErrorParser]. NO new endpoint module, migration, or dependency is
+ * added here. Mirrors the AND-372 TicketsDataModule pattern.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class JiraDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindJiraRepository(impl: JiraRepositoryImpl): JiraRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/jira/data/JiraRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/jira/data/JiraRepository.kt
@@ -1,0 +1,256 @@
+package com.testlogon.android.feature.jira.data
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.jira.JiraApi
+import com.testlogon.android.core.network.jira.JiraConnectReq
+import com.testlogon.android.core.network.jira.JiraConnectResp
+import com.testlogon.android.core.network.jira.JiraConflictResolveReq
+import com.testlogon.android.core.network.jira.JiraConflictResolveResp
+import com.testlogon.android.core.network.jira.JiraDisconnectReq
+import com.testlogon.android.core.network.jira.JiraLinkExistingReq
+import com.testlogon.android.core.network.jira.JiraLinkResp
+import com.testlogon.android.core.network.jira.JiraPreferencesReq
+import com.testlogon.android.core.network.jira.JiraPreferencesResp
+import com.testlogon.android.core.network.jira.JiraProjectsResp
+import com.testlogon.android.core.network.jira.JiraStatusResp
+import com.testlogon.android.core.network.jira.JiraUnlinkResp
+import com.testlogon.android.core.network.jira.TicketSyncStatusResp
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * JIRA-AND-1 - data layer for the Jira integration surface over the [JiraApi]. Folds each RAW DTO return into
+ * [ApiResult] via [call] (mirrors the AND-372 TicketsRepositoryImpl). Transport / HTTP / JSON failures are
+ * classified exactly like the tickets repo.
+ *
+ * DEGRADE-ON-404: the READ surfaces ([status], [projects], [getPreferences], [syncStatus]) map a 404 (feature
+ * flag off / not connected / not linked) to an HONEST not-connected empty value ([JiraStatusResp] connected=false,
+ * empty projects, empty preferences, not_linked sync-status) rather than a Failure. Every OTHER status (401 /
+ * 403 / 409 / 5xx) still surfaces as Failure so the ViewModel can act (re-auth / show the server message).
+ *
+ * The MUTATION surfaces (connect / disconnect / putPreferences / linkExisting / unlink / resolveConflict) do NOT
+ * degrade a 404 - a 404 there is a real error (unknown ticket / link) and surfaces as Failure.
+ */
+interface JiraRepository {
+
+    /** GET connection status for a workspace; 404 -> honest not-connected empty. */
+    suspend fun status(workspaceId: String): ApiResult<JiraStatusResp>
+
+    /** POST begin an OAuth connect; returns the authorize URL + state to open in a Custom Tab. */
+    suspend fun connect(workspaceId: String, redirectUri: String): ApiResult<JiraConnectResp>
+
+    /** POST disconnect a connection. */
+    suspend fun disconnect(workspaceId: String, connectionId: String): ApiResult<Unit>
+
+    /** GET discover projects for a cloud; 404 -> empty. */
+    suspend fun projects(workspaceId: String, cloudId: String): ApiResult<JiraProjectsResp>
+
+    /** GET saved project-key preferences; 404 -> empty preferences for that cloud. */
+    suspend fun getPreferences(workspaceId: String, cloudId: String): ApiResult<JiraPreferencesResp>
+
+    /** PUT project-key preferences. */
+    suspend fun putPreferences(
+        workspaceId: String,
+        cloudId: String,
+        projectKeys: List<String>,
+    ): ApiResult<JiraPreferencesResp>
+
+    /** GET a ticket's sync status; 404 -> not_linked. */
+    suspend fun syncStatus(ticketId: String): ApiResult<TicketSyncStatusResp>
+
+    /** POST link an existing Jira issue to a ticket (idempotency key generated per attempt). */
+    suspend fun linkExisting(
+        ticketId: String,
+        workspaceId: String,
+        issueKey: String,
+        linkMode: String = "bidirectional",
+    ): ApiResult<JiraLinkResp>
+
+    /** DELETE unlink an external link from a ticket. */
+    suspend fun unlink(ticketId: String, linkId: String): ApiResult<JiraUnlinkResp>
+
+    /** POST resolve a sync conflict. */
+    suspend fun resolveConflict(
+        ticketId: String,
+        linkId: String,
+        workspaceId: String,
+        action: String,
+        currentTicket: Map<String, Any?> = emptyMap(),
+    ): ApiResult<JiraConflictResolveResp>
+
+    companion object {
+        /**
+         * JIRA-AND-1 - build a fresh Idempotency-Key for a link attempt (>=8 chars, server-required). Mirrors
+         * the web `ui-link-<ts>-<rand>` shape. Pure enough to keep here; the impl calls it.
+         */
+        fun newIdempotencyKey(now: Long, nonce: String): String = "ui-link-$now-$nonce"
+    }
+}
+
+@Singleton
+class JiraRepositoryImpl @Inject constructor(
+    private val api: JiraApi,
+    private val errorParser: ApiErrorParser,
+) : JiraRepository {
+
+    override suspend fun status(workspaceId: String): ApiResult<JiraStatusResp> =
+        withContext(Dispatchers.IO) {
+            callOrEmptyOn404(fallback = { JiraStatusResp(connected = false, items = emptyList()) }) {
+                api.status(workspaceId)
+            }
+        }
+
+    override suspend fun connect(workspaceId: String, redirectUri: String): ApiResult<JiraConnectResp> =
+        withContext(Dispatchers.IO) {
+            call { api.connect(JiraConnectReq(workspaceId = workspaceId, redirectUri = redirectUri)) }
+        }
+
+    override suspend fun disconnect(workspaceId: String, connectionId: String): ApiResult<Unit> =
+        withContext(Dispatchers.IO) {
+            call {
+                api.disconnect(JiraDisconnectReq(workspaceId = workspaceId, connectionId = connectionId))
+                Unit
+            }
+        }
+
+    override suspend fun projects(workspaceId: String, cloudId: String): ApiResult<JiraProjectsResp> =
+        withContext(Dispatchers.IO) {
+            callOrEmptyOn404(fallback = { JiraProjectsResp(items = emptyList(), nextCursor = null) }) {
+                api.projects(workspaceId = workspaceId, cloudId = cloudId)
+            }
+        }
+
+    override suspend fun getPreferences(workspaceId: String, cloudId: String): ApiResult<JiraPreferencesResp> =
+        withContext(Dispatchers.IO) {
+            callOrEmptyOn404(
+                fallback = { JiraPreferencesResp(workspaceId = workspaceId, cloudId = cloudId, projectKeys = emptyList()) },
+            ) {
+                api.getPreferences(workspaceId = workspaceId, cloudId = cloudId)
+            }
+        }
+
+    override suspend fun putPreferences(
+        workspaceId: String,
+        cloudId: String,
+        projectKeys: List<String>,
+    ): ApiResult<JiraPreferencesResp> =
+        withContext(Dispatchers.IO) {
+            call {
+                api.putPreferences(
+                    JiraPreferencesReq(workspaceId = workspaceId, cloudId = cloudId, projectKeys = projectKeys),
+                )
+            }
+        }
+
+    override suspend fun syncStatus(ticketId: String): ApiResult<TicketSyncStatusResp> =
+        withContext(Dispatchers.IO) {
+            callOrEmptyOn404(
+                fallback = { TicketSyncStatusResp(ticketId = ticketId, linked = false, provider = null, syncState = "not_linked") },
+            ) {
+                api.ticketSyncStatus(ticketId)
+            }
+        }
+
+    override suspend fun linkExisting(
+        ticketId: String,
+        workspaceId: String,
+        issueKey: String,
+        linkMode: String,
+    ): ApiResult<JiraLinkResp> =
+        withContext(Dispatchers.IO) {
+            val key = JiraRepository.newIdempotencyKey(
+                now = System.currentTimeMillis(),
+                nonce = java.util.UUID.randomUUID().toString().replace("-", "").take(10),
+            )
+            call {
+                api.linkExisting(
+                    ticketId = ticketId,
+                    idempotencyKey = key,
+                    body = JiraLinkExistingReq(
+                        workspaceId = workspaceId,
+                        externalIssueKey = issueKey,
+                        linkMode = linkMode,
+                    ),
+                )
+            }
+        }
+
+    override suspend fun unlink(ticketId: String, linkId: String): ApiResult<JiraUnlinkResp> =
+        withContext(Dispatchers.IO) {
+            call { api.unlink(ticketId = ticketId, linkId = linkId) }
+        }
+
+    override suspend fun resolveConflict(
+        ticketId: String,
+        linkId: String,
+        workspaceId: String,
+        action: String,
+        currentTicket: Map<String, Any?>,
+    ): ApiResult<JiraConflictResolveResp> =
+        withContext(Dispatchers.IO) {
+            call {
+                api.resolveConflict(
+                    ticketId = ticketId,
+                    linkId = linkId,
+                    body = JiraConflictResolveReq(
+                        workspaceId = workspaceId,
+                        action = action,
+                        currentTicket = currentTicket,
+                    ),
+                )
+            }
+        }
+
+    /**
+     * Folds a block into [ApiResult]. HTTP errors -> Failure (via [ApiErrorParser], status preserved); malformed
+     * JSON -> Failure; transport failures -> NetworkError. Cancellation is re-thrown. Mirrors TicketsRepositoryImpl.
+     */
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    /**
+     * Like [call], but a 404 degrades to Success([fallback]) - the honest not-connected / not-linked empty. Every
+     * other HTTP status still surfaces as Failure. Transport / JSON failures classify exactly like [call].
+     */
+    private suspend fun <T> callOrEmptyOn404(
+        fallback: () -> T,
+        block: suspend () -> T,
+    ): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == HTTP_NOT_FOUND) ApiResult.Success(fallback())
+        else ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private companion object {
+        const val HTTP_NOT_FOUND = 404
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/jira/ui/JiraSyncScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/jira/ui/JiraSyncScreen.kt
@@ -1,0 +1,310 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.jira.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.jira.JiraMath
+
+/** JIRA-AND-1 - stable testTags for the Jira sync screen. */
+object JiraSyncTestTags {
+    const val SCREEN = "jira_sync_screen"
+    const val CONNECT = "jira_connect_button"
+    const val ISSUE_KEY_INPUT = "jira_issue_key_input"
+    const val LINK = "jira_link_button"
+    const val UNLINK = "jira_unlink_button"
+    const val KEEP_INTERNAL = "jira_keep_internal"
+    const val KEEP_JIRA = "jira_keep_jira"
+    const val STATE_LABEL = "jira_state_label"
+}
+
+/**
+ * JIRA-AND-1 - the default redirect URI supplied to the OAuth connect call. The dev backend echoes it into the
+ * authorize URL; the user returns to the app manually after consent and re-loads the status (there is NO
+ * app-registered deep-link scheme this wave - the AndroidManifest is intentionally untouched).
+ */
+private const val JIRA_REDIRECT_URI = "https://testlogon.local/integrations/jira/callback"
+
+/**
+ * JIRA-AND-1 - route-level entry for the Jira sync surface of a ticket. Collects the state, opens the OAuth
+ * authorize URL in a Chrome Custom Tab on [JiraSyncEffect.OpenConnectUrl] (reusing the androidx.browser idiom;
+ * never a WebView), and routes the terminal-401 to login.
+ */
+@Composable
+fun JiraSyncRoute(
+    onBack: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    viewModel: JiraSyncViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is JiraSyncEffect.NavigateToLogin -> onNavigateToLogin()
+                is JiraSyncEffect.OpenConnectUrl -> openCustomTab(context, effect.url)
+            }
+        }
+    }
+
+    JiraSyncScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::load,
+        onConnect = { viewModel.onConnect(JIRA_REDIRECT_URI) },
+        onIssueKeyChanged = viewModel::onIssueKeyChanged,
+        onLink = viewModel::onLinkExisting,
+        onUnlink = viewModel::onUnlink,
+        onResolve = viewModel::onResolveConflict,
+    )
+}
+
+/** Opens [url] in a Custom Tab with an ACTION_VIEW fallback (mirrors the SSO / calendar launchers). */
+private fun openCustomTab(context: android.content.Context, url: String) {
+    val uri = Uri.parse(url)
+    try {
+        val intent = CustomTabsIntent.Builder().setShowTitle(true).build()
+        intent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.launchUrl(context, uri)
+    } catch (_: ActivityNotFoundException) {
+        try {
+            context.startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        } catch (_: ActivityNotFoundException) {
+            // No browser available; nothing more to do.
+        }
+    }
+}
+
+/** JIRA-AND-1 - stateless Jira sync surface. */
+@Composable
+fun JiraSyncScreen(
+    state: JiraSyncUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onConnect: () -> Unit,
+    onIssueKeyChanged: (String) -> Unit,
+    onLink: () -> Unit,
+    onUnlink: () -> Unit,
+    onResolve: (JiraMath.JiraConflictChoice) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(JiraSyncTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Jira sync") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when {
+            state.loading -> LoadingState(modifier = Modifier.padding(padding))
+            state.error != null -> ErrorState(
+                modifier = Modifier.padding(padding),
+                message = state.error.message,
+                onRetry = onRefresh,
+            )
+            else -> JiraSyncBody(
+                state = state,
+                modifier = Modifier.padding(padding),
+                onConnect = onConnect,
+                onIssueKeyChanged = onIssueKeyChanged,
+                onLink = onLink,
+                onUnlink = onUnlink,
+                onResolve = onResolve,
+            )
+        }
+    }
+}
+
+@Composable
+private fun JiraSyncBody(
+    state: JiraSyncUiState,
+    modifier: Modifier,
+    onConnect: () -> Unit,
+    onIssueKeyChanged: (String) -> Unit,
+    onLink: () -> Unit,
+    onUnlink: () -> Unit,
+    onResolve: (JiraMath.JiraConflictChoice) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // --- Connection card ---
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Connection", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    if (state.connected) "Connected to Jira" else "Not connected",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                if (!state.connected) {
+                    Button(
+                        onClick = onConnect,
+                        enabled = !state.working,
+                        modifier = Modifier.testTag(JiraSyncTestTags.CONNECT),
+                    ) {
+                        Text("Connect Jira")
+                    }
+                }
+            }
+        }
+
+        // --- Sync-status card ---
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Ticket sync", style = MaterialTheme.typography.titleMedium)
+                val summary = state.summary
+                if (summary == null || !summary.linked) {
+                    Text(
+                        "This ticket is not linked to a Jira issue yet.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.testTag(JiraSyncTestTags.STATE_LABEL),
+                    )
+                    if (state.connected) {
+                        OutlinedTextField(
+                            value = state.issueKeyDraft,
+                            onValueChange = onIssueKeyChanged,
+                            label = { Text("Jira issue key (e.g. ABC-123)") },
+                            singleLine = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(JiraSyncTestTags.ISSUE_KEY_INPUT),
+                        )
+                        Button(
+                            onClick = onLink,
+                            enabled = !state.working && state.issueKeyDraft.isNotBlank(),
+                            modifier = Modifier.testTag(JiraSyncTestTags.LINK),
+                        ) {
+                            Text("Link issue")
+                        }
+                    }
+                } else {
+                    LinkedSummary(summary = summary)
+                    HorizontalDivider()
+                    OutlinedButton(
+                        onClick = onUnlink,
+                        enabled = !state.working,
+                        modifier = Modifier.testTag(JiraSyncTestTags.UNLINK),
+                    ) {
+                        Text("Unlink")
+                    }
+                    if (summary.state == JiraMath.JiraLinkState.CONFLICT) {
+                        ConflictSection(summary = summary, working = state.working, onResolve = onResolve)
+                    }
+                }
+                if (state.actionError != null) {
+                    Text(
+                        state.actionError,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                if (state.working) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LinkedSummary(summary: JiraMath.JiraSyncSummary) {
+    Text(
+        "Linked to ${summary.issueKey ?: "issue"}",
+        style = MaterialTheme.typography.bodyLarge,
+        fontWeight = FontWeight.SemiBold,
+    )
+    Text(
+        "Sync state: ${summary.rawState}",
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.testTag(JiraSyncTestTags.STATE_LABEL),
+    )
+    if (summary.jiraStatus != null) {
+        Text("Jira status: ${summary.jiraStatus}", style = MaterialTheme.typography.bodySmall)
+    }
+}
+
+@Composable
+private fun ConflictSection(
+    summary: JiraMath.JiraSyncSummary,
+    working: Boolean,
+    onResolve: (JiraMath.JiraConflictChoice) -> Unit,
+) {
+    HorizontalDivider()
+    Text("Conflict", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.error)
+    summary.conflictRows.forEach { row ->
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(row.field, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.SemiBold)
+            Text("Yours: ${row.localValue}", style = MaterialTheme.typography.bodySmall)
+            Text("Jira: ${row.remoteValue}", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OutlinedButton(
+            onClick = { onResolve(JiraMath.JiraConflictChoice.KEEP_INTERNAL) },
+            enabled = !working,
+            modifier = Modifier.testTag(JiraSyncTestTags.KEEP_INTERNAL),
+        ) {
+            Text("Keep yours")
+        }
+        Button(
+            onClick = { onResolve(JiraMath.JiraConflictChoice.KEEP_JIRA) },
+            enabled = !working,
+            modifier = Modifier.testTag(JiraSyncTestTags.KEEP_JIRA),
+        ) {
+            Text("Keep Jira")
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/jira/ui/JiraSyncViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/jira/ui/JiraSyncViewModel.kt
@@ -1,0 +1,246 @@
+package com.testlogon.android.feature.jira.ui
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.jira.JiraConstants
+import com.testlogon.android.data.jira.JiraMath
+import com.testlogon.android.feature.jira.data.JiraRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * JIRA-AND-1 - drives the Jira sync surface for one ticket (screen reachable from the ticket thread). It shows
+ * the connection status, the per-ticket sync summary (via [JiraMath.summarize]), and mediates the link / unlink /
+ * connect / resolve-conflict actions. The workspace scope is the ticket's SPACE id (nav arg), matching how the
+ * web caller supplies a workspace_id.
+ *
+ * Effects are one-shot: [JiraSyncEffect.OpenConnectUrl] hands the OAuth authorize URL to the screen (which opens
+ * a Custom Tab via the shared SsoTabLauncher) and [JiraSyncEffect.NavigateToLogin] is the terminal-401 re-auth
+ * handoff. Everything else is reflected in [JiraSyncUiState].
+ *
+ * DEGRADE-ON-404: the repository already maps a 404 status / sync-status to honest not-connected / not_linked, so
+ * the loaded state renders a clean "connect Jira" / "no link yet" surface rather than an error.
+ */
+@HiltViewModel
+class JiraSyncViewModel @Inject constructor(
+    private val repository: JiraRepository,
+    savedState: SavedStateHandle,
+) : ViewModel() {
+
+    val spaceId: String = checkNotNull(savedState[ARG_SPACE_ID]) { "missing $ARG_SPACE_ID nav arg" }
+    val ticketId: String = checkNotNull(savedState[ARG_TICKET_ID]) { "missing $ARG_TICKET_ID nav arg" }
+
+    /** The workspace scope used for every Jira call for this ticket. */
+    private val workspaceId: String get() = spaceId
+
+    private val _uiState = MutableStateFlow(JiraSyncUiState())
+    val uiState: StateFlow<JiraSyncUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<JiraSyncEffect>(Channel.BUFFERED)
+    val effects: Flow<JiraSyncEffect> = _effects.receiveAsFlow()
+
+    init {
+        load()
+    }
+
+    /** Load both the connection status and the ticket sync status. */
+    fun load() {
+        _uiState.update { it.copy(loading = true, error = null) }
+        viewModelScope.launch {
+            when (val statusRes = repository.status(workspaceId)) {
+                is ApiResult.Success -> {
+                    val connected = JiraMath.isConnected(statusRes.data.items.map { it.status })
+                    val cloudId = statusRes.data.items.firstOrNull { (it.status ?: "") == JiraConstants.ConnectionStatus.ACTIVE }?.cloudId
+                    _uiState.update {
+                        it.copy(
+                            connected = connected,
+                            connectionCount = statusRes.data.items.size,
+                            cloudId = cloudId,
+                        )
+                    }
+                }
+                is ApiResult.Failure -> if (handleTerminal(statusRes.error)) return@launch
+                is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(loading = false, error = ApiError(status = ApiError.STATUS_NETWORK, message = "offline")) }
+                    return@launch
+                }
+            }
+            refreshSyncStatus(setLoadingFalse = true)
+        }
+    }
+
+    private suspend fun refreshSyncStatus(setLoadingFalse: Boolean) {
+        when (val res = repository.syncStatus(ticketId)) {
+            is ApiResult.Success -> {
+                val d = res.data
+                val summary = JiraMath.summarize(
+                    linked = d.linked,
+                    rawState = d.syncState,
+                    issueKey = d.externalIssueKey,
+                    jiraStatus = d.jiraStatus,
+                    conflictFields = d.conflictFields,
+                    localValues = d.conflictLocalValues,
+                    remoteValues = d.conflictRemoteValues,
+                )
+                _uiState.update {
+                    it.copy(
+                        loading = if (setLoadingFalse) false else it.loading,
+                        summary = summary,
+                        linkId = d.linkId,
+                        error = null,
+                    )
+                }
+            }
+            is ApiResult.Failure -> if (!handleTerminal(res.error)) {
+                _uiState.update { it.copy(loading = false, error = res.error) }
+            }
+            is ApiResult.NetworkError ->
+                _uiState.update { it.copy(loading = false, error = ApiError(status = ApiError.STATUS_NETWORK, message = "offline")) }
+        }
+    }
+
+    /** Update the issue-key draft; clears any prior action error. */
+    fun onIssueKeyChanged(value: String) {
+        _uiState.update { it.copy(issueKeyDraft = value, actionError = null) }
+    }
+
+    /**
+     * Link the entered EXISTING Jira issue key to this ticket. The key is client-validated first (server is the
+     * authority). On success the sync status is re-read so the summary reflects the new link.
+     */
+    fun onLinkExisting() {
+        val key = JiraMath.normalizeIssueKey(_uiState.value.issueKeyDraft)
+        if (key == null) {
+            _uiState.update { it.copy(actionError = "Enter a valid Jira issue key, e.g. ABC-123") }
+            return
+        }
+        if (_uiState.value.working) return
+        _uiState.update { it.copy(working = true, actionError = null) }
+        viewModelScope.launch {
+            when (val res = repository.linkExisting(ticketId = ticketId, workspaceId = workspaceId, issueKey = key)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(working = false, issueKeyDraft = "") }
+                    refreshSyncStatus(setLoadingFalse = false)
+                }
+                is ApiResult.Failure -> if (!handleTerminal(res.error)) {
+                    _uiState.update { it.copy(working = false, actionError = res.error.message) }
+                }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(working = false, actionError = "offline") }
+            }
+        }
+    }
+
+    /** Unlink the current external link, then re-read the (now not_linked) status. */
+    fun onUnlink() {
+        val linkId = _uiState.value.linkId ?: return
+        if (_uiState.value.working) return
+        _uiState.update { it.copy(working = true, actionError = null) }
+        viewModelScope.launch {
+            when (val res = repository.unlink(ticketId = ticketId, linkId = linkId)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(working = false, linkId = null) }
+                    refreshSyncStatus(setLoadingFalse = false)
+                }
+                is ApiResult.Failure -> if (!handleTerminal(res.error)) {
+                    _uiState.update { it.copy(working = false, actionError = res.error.message) }
+                }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(working = false, actionError = "offline") }
+            }
+        }
+    }
+
+    /** Begin the OAuth connect flow; on success emit the authorize URL for the screen to open in a Custom Tab. */
+    fun onConnect(redirectUri: String) {
+        if (_uiState.value.working) return
+        _uiState.update { it.copy(working = true, actionError = null) }
+        viewModelScope.launch {
+            when (val res = repository.connect(workspaceId = workspaceId, redirectUri = redirectUri)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(working = false, pendingState = res.data.state) }
+                    _effects.send(JiraSyncEffect.OpenConnectUrl(res.data.connectUrl))
+                }
+                is ApiResult.Failure -> if (!handleTerminal(res.error)) {
+                    _uiState.update { it.copy(working = false, actionError = res.error.message) }
+                }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(working = false, actionError = "offline") }
+            }
+        }
+    }
+
+    /** Resolve the current conflict with the chosen action (keep_internal / keep_jira). */
+    fun onResolveConflict(choice: JiraMath.JiraConflictChoice) {
+        val linkId = _uiState.value.linkId ?: return
+        if (_uiState.value.working) return
+        _uiState.update { it.copy(working = true, actionError = null) }
+        viewModelScope.launch {
+            when (
+                val res = repository.resolveConflict(
+                    ticketId = ticketId,
+                    linkId = linkId,
+                    workspaceId = workspaceId,
+                    action = JiraMath.conflictAction(choice),
+                )
+            ) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(working = false) }
+                    refreshSyncStatus(setLoadingFalse = false)
+                }
+                is ApiResult.Failure -> if (!handleTerminal(res.error)) {
+                    _uiState.update { it.copy(working = false, actionError = res.error.message) }
+                }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(working = false, actionError = "offline") }
+            }
+        }
+    }
+
+    /**
+     * A terminal 401 -> emit NavigateToLogin and return true (caller aborts). Any other status returns false
+     * (the caller surfaces it inline).
+     */
+    private fun handleTerminal(error: ApiError): Boolean {
+        if (error.status == HTTP_UNAUTHORIZED) {
+            _uiState.update { it.copy(loading = false, working = false) }
+            viewModelScope.launch { _effects.send(JiraSyncEffect.NavigateToLogin) }
+            return true
+        }
+        return false
+    }
+
+    companion object {
+        const val ARG_SPACE_ID = "spaceId"
+        const val ARG_TICKET_ID = "ticketId"
+        private const val HTTP_UNAUTHORIZED = 401
+    }
+}
+
+/** JIRA-AND-1 - the Jira sync screen state. */
+data class JiraSyncUiState(
+    val loading: Boolean = true,
+    val connected: Boolean = false,
+    val connectionCount: Int = 0,
+    val cloudId: String? = null,
+    val summary: JiraMath.JiraSyncSummary? = null,
+    val linkId: String? = null,
+    val issueKeyDraft: String = "",
+    val working: Boolean = false,
+    val pendingState: String? = null,
+    val error: ApiError? = null,
+    val actionError: String? = null,
+)
+
+/** JIRA-AND-1 - one-shot effects. */
+sealed interface JiraSyncEffect {
+    data class OpenConnectUrl(val url: String) : JiraSyncEffect
+    data object NavigateToLogin : JiraSyncEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/tickets/ui/TicketThreadScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/tickets/ui/TicketThreadScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.material.icons.outlined.Sync
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -62,6 +63,9 @@ object TicketThreadTestTags {
     const val REPLY_ERROR = "ticket_reply_error"
     const val REPLY_DISABLED_CAPTION = "ticket_reply_disabled_caption"
 
+    // JIRA-AND-1 - the TopAppBar action that opens the Jira sync surface.
+    const val JIRA_SYNC_ACTION = "ticket_jira_sync_action"
+
     fun message(index: Int) = "ticket_msg_$index"
 
     /** AND-373 - per-optimistic-message send-state indicator tag. */
@@ -76,6 +80,7 @@ object TicketThreadTestTags {
 fun TicketThreadRoute(
     onBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onOpenJiraSync: () -> Unit = {},
     viewModel: TicketThreadViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -96,6 +101,7 @@ fun TicketThreadRoute(
         onDraftChanged = viewModel::onDraftChanged,
         onSend = viewModel::onSend,
         onRetrySend = viewModel::onRetry,
+        onOpenJiraSync = onOpenJiraSync,
     )
 }
 
@@ -115,6 +121,7 @@ fun TicketThreadScreen(
     onDraftChanged: (String) -> Unit = {},
     onSend: () -> Unit = {},
     onRetrySend: (String) -> Unit = {},
+    onOpenJiraSync: () -> Unit = {},
 ) {
     Scaffold(
         modifier = modifier.testTag(TicketThreadTestTags.SCREEN),
@@ -126,6 +133,18 @@ fun TicketThreadScreen(
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.tickets_back),
+                        )
+                    }
+                },
+                actions = {
+                    // JIRA-AND-1 - open the Jira sync surface for this ticket.
+                    IconButton(
+                        onClick = onOpenJiraSync,
+                        modifier = Modifier.testTag(TicketThreadTestTags.JIRA_SYNC_ACTION),
+                    ) {
+                        Icon(
+                            Icons.Outlined.Sync,
+                            contentDescription = stringResource(R.string.tickets_jira_sync_action),
                         )
                     }
                 },

--- a/android/app/src/main/java/com/testlogon/android/navigation/TicketsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/TicketsNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.testlogon.android.core.model.LogoutReason
+import com.testlogon.android.feature.jira.ui.JiraSyncRoute
 import com.testlogon.android.feature.tickets.ui.SpacesListRoute
 import com.testlogon.android.feature.tickets.ui.TicketListRoute
 import com.testlogon.android.feature.tickets.ui.TicketThreadRoute
@@ -34,6 +35,20 @@ data object TicketThreadDest {
 
     fun build(spaceId: String, ticketId: String): String =
         "tickets/space/${Uri.encode(spaceId)}/ticket/${Uri.encode(ticketId)}"
+}
+
+/**
+ * JIRA-AND-1 - the Jira sync surface for one ticket, reachable from the ticket THREAD. Lives INSIDE the existing
+ * tickets nav graph (no new top-level feature graph). Its ViewModel reads {spaceId} (the workspace scope) +
+ * {ticketId} from SavedStateHandle.
+ */
+data object TicketJiraSyncDest {
+    const val ARG_SPACE_ID = "spaceId"
+    const val ARG_TICKET_ID = "ticketId"
+    const val ROUTE = "tickets/space/{$ARG_SPACE_ID}/ticket/{$ARG_TICKET_ID}/jira"
+
+    fun build(spaceId: String, ticketId: String): String =
+        "tickets/space/${Uri.encode(spaceId)}/ticket/${Uri.encode(ticketId)}/jira"
 }
 
 /**
@@ -76,7 +91,26 @@ fun NavGraphBuilder.ticketsDestinations(navController: NavHostController) {
             navArgument(TicketThreadDest.ARG_TICKET_ID) { type = NavType.StringType },
         ),
     ) {
+        val spaceId = it.arguments?.getString(TicketThreadDest.ARG_SPACE_ID).orEmpty()
+        val ticketId = it.arguments?.getString(TicketThreadDest.ARG_TICKET_ID).orEmpty()
         TicketThreadRoute(
+            onBack = { navController.popBackStack() },
+            onNavigateToLogin = { navController.navigateToTicketsReauth() },
+            onOpenJiraSync = {
+                navController.navigate(TicketJiraSyncDest.build(spaceId, ticketId)) {
+                    launchSingleTop = true
+                }
+            },
+        )
+    }
+    composable(
+        route = TicketJiraSyncDest.ROUTE,
+        arguments = listOf(
+            navArgument(TicketJiraSyncDest.ARG_SPACE_ID) { type = NavType.StringType },
+            navArgument(TicketJiraSyncDest.ARG_TICKET_ID) { type = NavType.StringType },
+        ),
+    ) {
+        JiraSyncRoute(
             onBack = { navController.popBackStack() },
             onNavigateToLogin = { navController.navigateToTicketsReauth() },
         )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4262,6 +4262,7 @@
     <string name="more_entry_tickets">Support tickets</string>
     <string name="more_entry_support">Help &amp; support</string>
     <string name="tickets_back">Back</string>
+    <string name="tickets_jira_sync_action">Jira sync</string>
     <string name="tickets_spaces_title">Ticket spaces</string>
     <string name="tickets_spaces_empty_title">No ticket spaces yet</string>
     <string name="tickets_spaces_empty_body">Support spaces you can access will appear here.</string>

--- a/android/app/src/test/java/com/testlogon/android/data/jira/JiraMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/jira/JiraMathTest.kt
@@ -1,0 +1,168 @@
+package com.testlogon.android.data.jira
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JIRA-AND-1 - JVM unit tests for the PURE [JiraMath] logic (no Android / Moshi types). Covers state
+ * normalization (incl. unknown-safe + blank -> not_linked), connection detection, conflict-choice -> action
+ * mapping, conflict-row building, issue-key validation/normalization, and the [JiraMath.summarize] choke point
+ * (including that conflict rows are only produced in the CONFLICT state).
+ */
+class JiraMathTest {
+
+    @Test
+    fun linkState_mapsKnownTokens() {
+        assertEquals(JiraMath.JiraLinkState.QUEUED, JiraMath.linkState("queued"))
+        assertEquals(JiraMath.JiraLinkState.IN_SYNC, JiraMath.linkState("in_sync"))
+        assertEquals(JiraMath.JiraLinkState.CONFLICT, JiraMath.linkState("conflict"))
+        assertEquals(JiraMath.JiraLinkState.FAILED, JiraMath.linkState("failed"))
+        assertEquals(JiraMath.JiraLinkState.NOT_LINKED, JiraMath.linkState("not_linked"))
+    }
+
+    @Test
+    fun linkState_isCaseAndWhitespaceInsensitive() {
+        assertEquals(JiraMath.JiraLinkState.IN_SYNC, JiraMath.linkState("  IN_SYNC "))
+    }
+
+    @Test
+    fun linkState_blankOrNull_isNotLinked() {
+        assertEquals(JiraMath.JiraLinkState.NOT_LINKED, JiraMath.linkState(null))
+        assertEquals(JiraMath.JiraLinkState.NOT_LINKED, JiraMath.linkState(""))
+        assertEquals(JiraMath.JiraLinkState.NOT_LINKED, JiraMath.linkState("   "))
+    }
+
+    @Test
+    fun linkState_unknownToken_isUnknown() {
+        assertEquals(JiraMath.JiraLinkState.UNKNOWN, JiraMath.linkState("banana"))
+    }
+
+    @Test
+    fun needsAttention_onlyConflictAndFailed() {
+        assertTrue(JiraMath.needsAttention(JiraMath.JiraLinkState.CONFLICT))
+        assertTrue(JiraMath.needsAttention(JiraMath.JiraLinkState.FAILED))
+        assertFalse(JiraMath.needsAttention(JiraMath.JiraLinkState.IN_SYNC))
+        assertFalse(JiraMath.needsAttention(JiraMath.JiraLinkState.QUEUED))
+        assertFalse(JiraMath.needsAttention(JiraMath.JiraLinkState.NOT_LINKED))
+    }
+
+    @Test
+    fun isConnected_trueWhenAnyActive() {
+        assertTrue(JiraMath.isConnected(listOf("revoked", "active")))
+        assertTrue(JiraMath.isConnected(listOf("ACTIVE")))
+    }
+
+    @Test
+    fun isConnected_falseWhenNoneActiveOrEmpty() {
+        assertFalse(JiraMath.isConnected(emptyList()))
+        assertFalse(JiraMath.isConnected(listOf("revoked", null, "")))
+    }
+
+    @Test
+    fun conflictAction_mapsChoiceToWireToken() {
+        assertEquals("keep_internal", JiraMath.conflictAction(JiraMath.JiraConflictChoice.KEEP_INTERNAL))
+        assertEquals("keep_jira", JiraMath.conflictAction(JiraMath.JiraConflictChoice.KEEP_JIRA))
+    }
+
+    @Test
+    fun conflictRows_pairsLocalAndRemote_defaultsBlank() {
+        val rows = JiraMath.conflictRows(
+            conflictFields = listOf("summary", "status", ""),
+            localValues = mapOf("summary" to "Local title", "status" to "open"),
+            remoteValues = mapOf("summary" to "Remote title"),
+        )
+        assertEquals(2, rows.size) // blank field filtered
+        assertEquals("summary", rows[0].field)
+        assertEquals("Local title", rows[0].localValue)
+        assertEquals("Remote title", rows[0].remoteValue)
+        assertEquals("open", rows[1].localValue)
+        assertEquals("", rows[1].remoteValue) // missing remote -> blank
+    }
+
+    @Test
+    fun conflictRows_stringifiesNonStringValues() {
+        val rows = JiraMath.conflictRows(
+            conflictFields = listOf("priority"),
+            localValues = mapOf("priority" to 3),
+            remoteValues = mapOf("priority" to null),
+        )
+        assertEquals("3", rows[0].localValue)
+        assertEquals("", rows[0].remoteValue)
+    }
+
+    @Test
+    fun normalizeIssueKey_validKeysUpperCased() {
+        assertEquals("ABC-123", JiraMath.normalizeIssueKey("abc-123"))
+        assertEquals("ABC-123", JiraMath.normalizeIssueKey("  ABC-123 "))
+        assertEquals("PROJ2-7", JiraMath.normalizeIssueKey("proj2-7"))
+    }
+
+    @Test
+    fun normalizeIssueKey_invalidReturnsNull() {
+        assertNull(JiraMath.normalizeIssueKey(null))
+        assertNull(JiraMath.normalizeIssueKey(""))
+        assertNull(JiraMath.normalizeIssueKey("nodash"))
+        assertNull(JiraMath.normalizeIssueKey("ABC-"))
+        assertNull(JiraMath.normalizeIssueKey("-123"))
+        assertNull(JiraMath.normalizeIssueKey("1ABC-2")) // must start with a letter
+    }
+
+    @Test
+    fun isValidIssueKey_matchesNormalization() {
+        assertTrue(JiraMath.isValidIssueKey("ABC-1"))
+        assertFalse(JiraMath.isValidIssueKey("bad key"))
+    }
+
+    @Test
+    fun summarize_conflict_populatesRowsAndAttention() {
+        val s = JiraMath.summarize(
+            linked = true,
+            rawState = "conflict",
+            issueKey = "ABC-123",
+            jiraStatus = "In Progress",
+            conflictFields = listOf("summary"),
+            localValues = mapOf("summary" to "L"),
+            remoteValues = mapOf("summary" to "R"),
+        )
+        assertTrue(s.linked)
+        assertEquals(JiraMath.JiraLinkState.CONFLICT, s.state)
+        assertTrue(s.needsAttention)
+        assertEquals(1, s.conflictRows.size)
+        assertEquals("ABC-123", s.issueKey)
+        assertEquals("In Progress", s.jiraStatus)
+    }
+
+    @Test
+    fun summarize_inSync_hasNoConflictRows() {
+        val s = JiraMath.summarize(
+            linked = true,
+            rawState = "in_sync",
+            issueKey = "ABC-1",
+            jiraStatus = null,
+            conflictFields = listOf("summary"),
+            localValues = mapOf("summary" to "L"),
+            remoteValues = mapOf("summary" to "R"),
+        )
+        assertTrue(s.conflictRows.isEmpty())
+        assertFalse(s.needsAttention)
+        assertNull(s.jiraStatus)
+    }
+
+    @Test
+    fun summarize_notLinked_isUnlinkedEvenIfLinkedFlagTrue() {
+        val s = JiraMath.summarize(
+            linked = true,
+            rawState = "not_linked",
+            issueKey = null,
+            jiraStatus = null,
+            conflictFields = emptyList(),
+            localValues = emptyMap(),
+            remoteValues = emptyMap(),
+        )
+        assertFalse(s.linked)
+        assertEquals(JiraMath.JiraLinkState.NOT_LINKED, s.state)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/jira/JiraRepositoryTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/jira/JiraRepositoryTest.kt
@@ -1,0 +1,179 @@
+package com.testlogon.android.feature.jira
+
+import com.squareup.moshi.Moshi
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.jira.JiraApi
+import com.testlogon.android.core.network.jira.JiraConflictResolveReq
+import com.testlogon.android.core.network.jira.JiraConflictResolveResp
+import com.testlogon.android.core.network.jira.JiraConnectReq
+import com.testlogon.android.core.network.jira.JiraConnectResp
+import com.testlogon.android.core.network.jira.JiraDisconnectReq
+import com.testlogon.android.core.network.jira.JiraLinkExistingReq
+import com.testlogon.android.core.network.jira.JiraLinkResp
+import com.testlogon.android.core.network.jira.JiraPreferencesReq
+import com.testlogon.android.core.network.jira.JiraPreferencesResp
+import com.testlogon.android.core.network.jira.JiraProjectsResp
+import com.testlogon.android.core.network.jira.JiraStatusResp
+import com.testlogon.android.core.network.jira.JiraUnlinkResp
+import com.testlogon.android.core.network.jira.TicketSyncStatusResp
+import com.testlogon.android.feature.jira.data.JiraRepository
+import com.testlogon.android.feature.jira.data.JiraRepositoryImpl
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+/**
+ * JIRA-AND-1 - tests for [JiraRepositoryImpl]. The key behaviour is DEGRADE-ON-404: the READ surfaces
+ * (status / projects / preferences / syncStatus) map a 404 to an honest not-connected / empty / not_linked
+ * Success, while non-404 errors surface as Failure. Also checks a successful link + idempotency-key length,
+ * and that mutation 404s do NOT degrade.
+ */
+class JiraRepositoryTest {
+
+    private fun parser() = ApiErrorParser(Moshi.Builder().build())
+    private fun repo(api: JiraApi) = JiraRepositoryImpl(api = api, errorParser = parser())
+
+    private fun http(code: Int): HttpException =
+        HttpException(Response.error<Any>(code, "{}".toResponseBody("application/json".toMediaType())))
+
+    @Test
+    fun status_success_passesThrough() = runTest {
+        val api = FakeJiraApi(statusResp = { JiraStatusResp(connected = true) })
+        val res = repo(api).status("ws1")
+        assertTrue(res is ApiResult.Success)
+        assertTrue((res as ApiResult.Success).data.connected)
+    }
+
+    @Test
+    fun status_404_degradesToNotConnected() = runTest {
+        val api = FakeJiraApi(statusResp = { throw http(404) })
+        val res = repo(api).status("ws1")
+        assertTrue(res is ApiResult.Success)
+        assertFalse((res as ApiResult.Success).data.connected)
+        assertTrue(res.data.items.isEmpty())
+    }
+
+    @Test
+    fun status_500_isFailure() = runTest {
+        val api = FakeJiraApi(statusResp = { throw http(500) })
+        val res = repo(api).status("ws1")
+        assertTrue(res is ApiResult.Failure)
+        assertEquals(500, (res as ApiResult.Failure).error.status)
+    }
+
+    @Test
+    fun projects_404_degradesToEmpty() = runTest {
+        val api = FakeJiraApi(projectsResp = { throw http(404) })
+        val res = repo(api).projects("ws1", "cloud1")
+        assertTrue(res is ApiResult.Success)
+        assertTrue((res as ApiResult.Success).data.items.isEmpty())
+    }
+
+    @Test
+    fun preferences_404_degradesToEmptyForCloud() = runTest {
+        val api = FakeJiraApi(prefsResp = { throw http(404) })
+        val res = repo(api).getPreferences("ws1", "cloud1")
+        assertTrue(res is ApiResult.Success)
+        assertEquals("cloud1", (res as ApiResult.Success).data.cloudId)
+        assertTrue(res.data.projectKeys.isEmpty())
+    }
+
+    @Test
+    fun syncStatus_404_degradesToNotLinked() = runTest {
+        val api = FakeJiraApi(syncResp = { throw http(404) })
+        val res = repo(api).syncStatus("t1")
+        assertTrue(res is ApiResult.Success)
+        val d = (res as ApiResult.Success).data
+        assertFalse(d.linked)
+        assertEquals("not_linked", d.syncState)
+    }
+
+    @Test
+    fun linkExisting_sendsIdempotencyKeyOfAdequateLength() = runTest {
+        val api = FakeJiraApi(linkResp = { JiraLinkResp(linkId = "l1", externalIssueKey = "ABC-1", syncState = "queued") })
+        val res = repo(api).linkExisting("t1", "ws1", "ABC-1")
+        assertTrue(res is ApiResult.Success)
+        assertEquals("l1", (res as ApiResult.Success).data.linkId)
+        assertTrue((api.lastIdempotencyKey?.length ?: 0) >= 8)
+    }
+
+    @Test
+    fun linkExisting_404_isFailure_notDegraded() = runTest {
+        val api = FakeJiraApi(linkResp = { throw http(404) })
+        val res = repo(api).linkExisting("t1", "ws1", "ABC-1")
+        assertTrue(res is ApiResult.Failure)
+        assertEquals(404, (res as ApiResult.Failure).error.status)
+    }
+
+    @Test
+    fun unlink_success() = runTest {
+        val api = FakeJiraApi(unlinkResp = { JiraUnlinkResp(linkId = "l1", syncState = "not_linked") })
+        val res = repo(api).unlink("t1", "l1")
+        assertTrue(res is ApiResult.Success)
+    }
+
+    @Test
+    fun disconnect_success_mapsToUnit() = runTest {
+        val api = FakeJiraApi(disconnectResp = { mapOf("ok" to true) })
+        val res = repo(api).disconnect("ws1", "conn1")
+        assertTrue(res is ApiResult.Success)
+    }
+
+    @Test
+    fun connect_success_returnsUrlAndState() = runTest {
+        val api = FakeJiraApi(connectResp = { JiraConnectResp(connectUrl = "https://x/auth", state = "st1") })
+        val res = repo(api).connect("ws1", "https://cb")
+        assertTrue(res is ApiResult.Success)
+        assertEquals("st1", (res as ApiResult.Success).data.state)
+    }
+
+    @Test
+    fun resolveConflict_success() = runTest {
+        val api = FakeJiraApi(resolveResp = { JiraConflictResolveResp(linkId = "l1", syncState = "in_sync") })
+        val res = repo(api).resolveConflict("t1", "l1", "ws1", "keep_jira")
+        assertTrue(res is ApiResult.Success)
+        assertEquals("in_sync", (res as ApiResult.Success).data.syncState)
+    }
+}
+
+/**
+ * A recording fake of [JiraApi]: each call delegates to a lambda (default returns a benign empty response). The
+ * link call records the Idempotency-Key so the repo test can assert its length.
+ */
+private class FakeJiraApi(
+    private val statusResp: () -> JiraStatusResp = { JiraStatusResp() },
+    private val connectResp: () -> JiraConnectResp = { JiraConnectResp("", "") },
+    private val disconnectResp: () -> Map<String, Any?> = { emptyMap() },
+    private val projectsResp: () -> JiraProjectsResp = { JiraProjectsResp() },
+    private val prefsResp: () -> JiraPreferencesResp = { JiraPreferencesResp() },
+    private val putPrefsResp: () -> JiraPreferencesResp = { JiraPreferencesResp() },
+    private val syncResp: () -> TicketSyncStatusResp = { TicketSyncStatusResp(ticketId = "t1") },
+    private val linkResp: () -> JiraLinkResp = { JiraLinkResp() },
+    private val unlinkResp: () -> JiraUnlinkResp = { JiraUnlinkResp() },
+    private val resolveResp: () -> JiraConflictResolveResp = { JiraConflictResolveResp() },
+) : JiraApi {
+    var lastIdempotencyKey: String? = null
+
+    override suspend fun status(workspaceId: String): JiraStatusResp = statusResp()
+    override suspend fun connect(body: JiraConnectReq): JiraConnectResp = connectResp()
+    override suspend fun callback(code: String, state: String) =
+        com.testlogon.android.core.network.jira.JiraCallbackResp(status = "connected")
+    override suspend fun disconnect(body: JiraDisconnectReq): Map<String, Any?> = disconnectResp()
+    override suspend fun projects(workspaceId: String, cloudId: String, limit: Int, cursor: String?): JiraProjectsResp = projectsResp()
+    override suspend fun getPreferences(workspaceId: String, cloudId: String): JiraPreferencesResp = prefsResp()
+    override suspend fun putPreferences(body: JiraPreferencesReq): JiraPreferencesResp = putPrefsResp()
+    override suspend fun ticketSyncStatus(ticketId: String): TicketSyncStatusResp = syncResp()
+    override suspend fun linkExisting(ticketId: String, idempotencyKey: String, body: JiraLinkExistingReq): JiraLinkResp {
+        lastIdempotencyKey = idempotencyKey
+        return linkResp()
+    }
+    override suspend fun unlink(ticketId: String, linkId: String): JiraUnlinkResp = unlinkResp()
+    override suspend fun resolveConflict(ticketId: String, linkId: String, body: JiraConflictResolveReq): JiraConflictResolveResp = resolveResp()
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/jira/JiraApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/jira/JiraApi.kt
@@ -1,0 +1,101 @@
+package com.testlogon.android.core.network.jira
+
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.PUT
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * JIRA-AND-1 - Retrofit interface for the Jira integration surface. Transport only; the repository layer wraps
+ * these RAW DTO returns into ApiResult and maps 404 to an honest not-connected empty. Mirrors the verified web
+ * contract in frontend/src/api/endpoints/jira.ts.
+ *
+ * Paths have NO leading slash (relative to the shared authenticated Retrofit base URL, matching the rest of the
+ * codebase). @Path token is EXACTLY {ticketId} / {linkId}. Retrofit drops a null @Query, so optional queries
+ * (cursor / q) are sent only when non-null.
+ *
+ * The link / link-existing POSTs require an Idempotency-Key header (the web sends one per attempt); the caller
+ * generates it. NON-idempotent POSTs / DELETE are excluded from the global GET-only retry backoff.
+ */
+interface JiraApi {
+
+    /** GET the caller's Jira connections for a workspace. */
+    @GET("integrations/jira/status")
+    suspend fun status(
+        @Query("workspace_id") workspaceId: String,
+    ): JiraStatusResp
+
+    /** POST begin an OAuth connect; returns the authorize URL + opaque state. */
+    @POST("integrations/jira/connect")
+    suspend fun connect(
+        @Body body: JiraConnectReq,
+    ): JiraConnectResp
+
+    /** GET complete the OAuth callback (code + state echoed from the redirect). */
+    @GET("integrations/jira/callback")
+    suspend fun callback(
+        @Query("code") code: String,
+        @Query("state") state: String,
+    ): JiraCallbackResp
+
+    /** POST disconnect a connection. */
+    @POST("integrations/jira/disconnect")
+    suspend fun disconnect(
+        @Body body: JiraDisconnectReq,
+    ): Map<String, Any?>
+
+    /** GET discover projects for a connected cloud. */
+    @GET("integrations/jira/projects")
+    suspend fun projects(
+        @Query("workspace_id") workspaceId: String,
+        @Query("cloud_id") cloudId: String,
+        @Query("limit") limit: Int = 100,
+        @Query("cursor") cursor: String? = null,
+    ): JiraProjectsResp
+
+    /** GET the saved project-key preferences for a cloud. */
+    @GET("integrations/jira/preferences")
+    suspend fun getPreferences(
+        @Query("workspace_id") workspaceId: String,
+        @Query("cloud_id") cloudId: String,
+    ): JiraPreferencesResp
+
+    /** PUT the project-key preferences for a cloud. */
+    @PUT("integrations/jira/preferences")
+    suspend fun putPreferences(
+        @Body body: JiraPreferencesReq,
+    ): JiraPreferencesResp
+
+    /** GET the current sync status for a ticket (not_linked when unlinked). */
+    @GET("tickets/{ticketId}/sync-status")
+    suspend fun ticketSyncStatus(
+        @Path("ticketId") ticketId: String,
+    ): TicketSyncStatusResp
+
+    /** POST link an EXISTING Jira issue to a ticket (requires an Idempotency-Key). */
+    @POST("tickets/{ticketId}/external-links/jira/link-existing")
+    suspend fun linkExisting(
+        @Path("ticketId") ticketId: String,
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Body body: JiraLinkExistingReq,
+    ): JiraLinkResp
+
+    /** DELETE unlink an external link from a ticket. */
+    @DELETE("tickets/{ticketId}/external-links/{linkId}")
+    suspend fun unlink(
+        @Path("ticketId") ticketId: String,
+        @Path("linkId") linkId: String,
+    ): JiraUnlinkResp
+
+    /** POST resolve a sync conflict (keep_internal / keep_jira). */
+    @POST("tickets/{ticketId}/external-links/{linkId}/resolve-conflict")
+    suspend fun resolveConflict(
+        @Path("ticketId") ticketId: String,
+        @Path("linkId") linkId: String,
+        @Body body: JiraConflictResolveReq,
+    ): JiraConflictResolveResp
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/jira/JiraDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/jira/JiraDtos.kt
@@ -1,0 +1,185 @@
+package com.testlogon.android.core.network.jira
+
+import com.squareup.moshi.Json
+
+/**
+ * JIRA-AND-1 - transport DTOs for the Jira integration surface (connection status / OAuth connect + callback /
+ * project discovery + preferences / per-ticket external link + sync-status + conflict resolution). Mirrors the
+ * verified web contract in frontend/src/api/endpoints/jira.ts.
+ *
+ * CODEGEN NOTE (identical to the AND-371 TicketDtos): core-network does NOT apply the Moshi KSP codegen plugin,
+ * so these DTOs decode via the reflective KotlinJsonAdapterFactory registered on the shared Moshi. Every wire
+ * key is pinned with an explicit @Json(name = ...); @JsonClass(generateAdapter = true) is intentionally OMITTED.
+ *
+ * ENUM-LIKE FIELDS: status / sync_state / provider / link_mode are decoded as RAW Strings (see [JiraConstants]),
+ * so an unknown server token never fails deserialization. Unknown wire keys are tolerated leniently.
+ *
+ * DEGRADE-ON-404: when the Jira feature is not enabled / the caller is not connected the server may 404; the
+ * repository maps that to an honest not-connected empty result (never a crash).
+ */
+
+/** One connected Jira workspace connection (embedded in [JiraStatusResp.items]). */
+data class JiraConnectionDto(
+    @Json(name = "connection_id") val connectionId: String,
+    @Json(name = "workspace_id") val workspaceId: String? = null,
+    @Json(name = "cloud_id") val cloudId: String? = null,
+    @Json(name = "site_url") val siteUrl: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "scopes") val scopes: List<String> = emptyList(),
+    @Json(name = "updated_at") val updatedAt: Long? = null,
+)
+
+/** GET /integrations/jira/status -> connection status envelope. */
+data class JiraStatusResp(
+    @Json(name = "connected") val connected: Boolean = false,
+    @Json(name = "items") val items: List<JiraConnectionDto> = emptyList(),
+)
+
+/** POST /integrations/jira/connect body. */
+data class JiraConnectReq(
+    @Json(name = "workspace_id") val workspaceId: String,
+    @Json(name = "redirect_uri") val redirectUri: String,
+)
+
+/** POST /integrations/jira/connect -> the OAuth authorize URL + the opaque state to echo back. */
+data class JiraConnectResp(
+    @Json(name = "connect_url") val connectUrl: String,
+    @Json(name = "state") val state: String,
+)
+
+/** GET /integrations/jira/callback -> connected / failed. */
+data class JiraCallbackResp(
+    @Json(name = "status") val status: String,
+    @Json(name = "connection_id") val connectionId: String? = null,
+    @Json(name = "error_code") val errorCode: String? = null,
+)
+
+/** POST /integrations/jira/disconnect body. */
+data class JiraDisconnectReq(
+    @Json(name = "workspace_id") val workspaceId: String,
+    @Json(name = "connection_id") val connectionId: String,
+)
+
+/** One discoverable Jira project (embedded in [JiraProjectsResp.items]). */
+data class JiraProjectDto(
+    @Json(name = "cloud_id") val cloudId: String? = null,
+    @Json(name = "project_id") val projectId: String? = null,
+    @Json(name = "project_key") val projectKey: String,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "is_private") val isPrivate: Boolean = false,
+)
+
+/** GET /integrations/jira/projects -> paginated project envelope. */
+data class JiraProjectsResp(
+    @Json(name = "items") val items: List<JiraProjectDto> = emptyList(),
+    @Json(name = "next_cursor") val nextCursor: String? = null,
+)
+
+/** GET/PUT /integrations/jira/preferences -> the selected project keys for a cloud. */
+data class JiraPreferencesResp(
+    @Json(name = "workspace_id") val workspaceId: String? = null,
+    @Json(name = "cloud_id") val cloudId: String? = null,
+    @Json(name = "project_keys") val projectKeys: List<String> = emptyList(),
+    @Json(name = "updated_at") val updatedAt: Long? = null,
+)
+
+/** PUT /integrations/jira/preferences body. */
+data class JiraPreferencesReq(
+    @Json(name = "workspace_id") val workspaceId: String,
+    @Json(name = "cloud_id") val cloudId: String,
+    @Json(name = "project_keys") val projectKeys: List<String>,
+)
+
+/** POST .../external-links/jira/link-existing body. */
+data class JiraLinkExistingReq(
+    @Json(name = "workspace_id") val workspaceId: String,
+    @Json(name = "external_issue_key") val externalIssueKey: String? = null,
+    @Json(name = "external_issue_id") val externalIssueId: String? = null,
+    @Json(name = "link_mode") val linkMode: String = "bidirectional",
+)
+
+/** POST .../external-links/jira/link-existing (and create) -> the created link. */
+data class JiraLinkResp(
+    @Json(name = "ticket_id") val ticketId: String? = null,
+    @Json(name = "link_id") val linkId: String? = null,
+    @Json(name = "provider") val provider: String? = null,
+    @Json(name = "external_issue_id") val externalIssueId: String? = null,
+    @Json(name = "external_issue_key") val externalIssueKey: String? = null,
+    @Json(name = "link_mode") val linkMode: String? = null,
+    @Json(name = "sync_state") val syncState: String? = null,
+)
+
+/** DELETE .../external-links/{link_id} -> unlink confirmation. */
+data class JiraUnlinkResp(
+    @Json(name = "ticket_id") val ticketId: String? = null,
+    @Json(name = "link_id") val linkId: String? = null,
+    @Json(name = "sync_state") val syncState: String? = null,
+)
+
+/** GET /tickets/{id}/sync-status -> the current external-link sync status. */
+data class TicketSyncStatusResp(
+    @Json(name = "ticket_id") val ticketId: String,
+    @Json(name = "linked") val linked: Boolean = false,
+    @Json(name = "provider") val provider: String? = null,
+    @Json(name = "sync_state") val syncState: String = "not_linked",
+    @Json(name = "link_id") val linkId: String? = null,
+    @Json(name = "external_issue_id") val externalIssueId: String? = null,
+    @Json(name = "external_issue_key") val externalIssueKey: String? = null,
+    @Json(name = "jira_status") val jiraStatus: String? = null,
+    @Json(name = "last_synced_at") val lastSyncedAt: Long? = null,
+    @Json(name = "conflict_fields") val conflictFields: List<String> = emptyList(),
+    @Json(name = "conflict_local_values") val conflictLocalValues: Map<String, Any?> = emptyMap(),
+    @Json(name = "conflict_remote_values") val conflictRemoteValues: Map<String, Any?> = emptyMap(),
+)
+
+/** POST .../external-links/{link_id}/resolve-conflict body. */
+data class JiraConflictResolveReq(
+    @Json(name = "workspace_id") val workspaceId: String,
+    @Json(name = "action") val action: String,
+    @Json(name = "current_ticket") val currentTicket: Map<String, Any?> = emptyMap(),
+)
+
+/** POST .../resolve-conflict -> the resolved link (sync_state is always "in_sync"). */
+data class JiraConflictResolveResp(
+    @Json(name = "ticket_id") val ticketId: String? = null,
+    @Json(name = "link_id") val linkId: String? = null,
+    @Json(name = "action") val action: String? = null,
+    @Json(name = "resolved_fields") val resolvedFields: List<String> = emptyList(),
+    @Json(name = "sync_state") val syncState: String? = null,
+    @Json(name = "follow_up_tasks") val followUpTasks: Int = 0,
+)
+
+/**
+ * JIRA-AND-1 - the documented RAW-String constants for the enum-like wire fields. These are NOT Kotlin enums
+ * (unknown-safe): a value not listed here still decodes fine and the UI falls back to the raw token.
+ */
+object JiraConstants {
+    object SyncState {
+        const val NOT_LINKED = "not_linked"
+        const val QUEUED = "queued"
+        const val IN_SYNC = "in_sync"
+        const val CONFLICT = "conflict"
+        const val FAILED = "failed"
+    }
+
+    object LinkMode {
+        const val PUSH_ONLY = "push_only"
+        const val PULL_ONLY = "pull_only"
+        const val BIDIRECTIONAL = "bidirectional"
+    }
+
+    object ConnectionStatus {
+        const val ACTIVE = "active"
+    }
+
+    object ResolveAction {
+        const val KEEP_INTERNAL = "keep_internal"
+        const val KEEP_JIRA = "keep_jira"
+    }
+
+    /** The OAuth callback result tokens. */
+    object CallbackStatus {
+        const val CONNECTED = "connected"
+        const val FAILED = "failed"
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/jira/JiraNetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/jira/JiraNetworkModule.kt
@@ -1,0 +1,25 @@
+package com.testlogon.android.core.network.jira
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * JIRA-AND-1 - Hilt wiring for the Jira integration transport layer.
+ *
+ * Provides [JiraApi] from the shared singleton [Retrofit] (reusing the production OkHttp / Moshi / converter
+ * config; NO new Retrofit, OkHttp, Moshi, or dependency is introduced). The Jira DTOs decode with the reflective
+ * KotlinJsonAdapterFactory already on the shared Moshi. Mirrors the AND-371 TicketsNetworkModule pattern.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object JiraNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideJiraApi(retrofit: Retrofit): JiraApi =
+        retrofit.create(JiraApi::class.java)
+}


### PR DESCRIPTION
## FE parity PAR-161 - Android Jira integration

Brings the Android tickets surface to parity by adding Jira integration.

### Changes
- Network layer: JiraApi, JiraDtos, JiraNetworkModule (core-network).
- Data layer: JiraRepository + JiraDataModule DI wiring, JiraMath helper.
- UI: JiraSyncScreen + JiraSyncViewModel, wired into TicketThreadScreen and TicketsNavigation.
- Strings added for the new surface.

### Testing
- JiraMathTest and JiraRepositoryTest unit tests included.
- Feature is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
