### PR TITLE
FE parity PAR-141 - Android CRM projects/events/campaigns

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmDataModule.kt
@@ -20,6 +20,19 @@ object CrmApiModule {
     @Provides
     @Singleton
     fun provideSalesApi(retrofit: Retrofit): SalesApi = retrofit.create(SalesApi::class.java)
+
+    // CRM-AND-PEC — projects / events / campaigns APIs on the same shared Retrofit.
+    @Provides
+    @Singleton
+    fun provideCrmProjectsApi(retrofit: Retrofit): CrmProjectsApi = retrofit.create(CrmProjectsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCrmEventsApi(retrofit: Retrofit): CrmEventsApi = retrofit.create(CrmEventsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCrmCampaignsApi(retrofit: Retrofit): CrmCampaignsApi = retrofit.create(CrmCampaignsApi::class.java)
 }
 
 /** CRM-AND-1 — binds the CRM repositories to their implementations. */
@@ -34,4 +47,17 @@ abstract class CrmDataModule {
     @Binds
     @Singleton
     abstract fun bindSalesRepository(impl: SalesRepositoryImpl): SalesRepository
+
+    // CRM-AND-PEC
+    @Binds
+    @Singleton
+    abstract fun bindCrmProjectsRepository(impl: CrmProjectsRepositoryImpl): CrmProjectsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCrmEventsRepository(impl: CrmEventsRepositoryImpl): CrmEventsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCrmCampaignsRepository(impl: CrmCampaignsRepositoryImpl): CrmCampaignsRepository
 }

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
@@ -1,0 +1,88 @@
+package com.testlogon.android.data.crm
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * CRM-AND-PEC — Retrofit interfaces for the SuiteCRM Projects / Events / Campaigns surfaces. Paths are
+ * relative; cookies / Authorization / X-CSRF-Token are attached by the core-network interceptor chain.
+ *
+ * Each backend module is feature-gated and returns 404 when off; the repositories map that to a
+ * degraded/empty result. Verified against the web contracts:
+ *   crmProjects.ts (/v1/crm/projects) · crmEvents.ts (/ui/crm/events) · crmCampaigns.ts
+ *   (/ui/crm-marketing/campaigns).
+ *
+ * MVP scope: projects list/detail (+ tasks) + create; events list/get/create (+ capacity);
+ * campaigns list/detail (+ attribution). Members / templates / invitees / registrations / A-B / send
+ * / email-templates are deferred (noted in the repository).
+ */
+
+// ─── Projects: prefix /v1/crm/projects ───────────────────────────────────────
+
+interface CrmProjectsApi {
+
+    @GET("v1/crm/projects")
+    suspend fun listProjects(
+        @Query("status") status: String? = null,
+        @Query("name_query") nameQuery: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmProjectListRespDto
+
+    @GET("v1/crm/projects/{projectId}")
+    suspend fun getProject(@Path("projectId") projectId: String): CrmProjectDto
+
+    @POST("v1/crm/projects")
+    suspend fun createProject(@Body body: CrmProjectCreateInDto): CrmProjectDto
+
+    @GET("v1/crm/projects/{projectId}/tasks")
+    suspend fun listTasks(
+        @Path("projectId") projectId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmProjectTaskListRespDto
+}
+
+// ─── Events: prefix /ui/crm/events ───────────────────────────────────────────
+
+interface CrmEventsApi {
+
+    // list is @router.get("") on the prefix → /ui/crm/events (no trailing slash).
+    @GET("ui/crm/events")
+    suspend fun listEvents(
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmEventListRespDto
+
+    @GET("ui/crm/events/{eventId}")
+    suspend fun getEvent(@Path("eventId") eventId: String): CrmEventDto
+
+    // create is @router.post("/") on the prefix → /ui/crm/events/ (trailing slash required).
+    @POST("ui/crm/events/")
+    suspend fun createEvent(@Body body: CrmEventCreateInDto): CrmEventDto
+
+    @GET("ui/crm/events/{eventId}/capacity")
+    suspend fun getCapacity(@Path("eventId") eventId: String): CrmEventCapacityDto
+}
+
+// ─── Campaigns: prefix /ui/crm-marketing ─────────────────────────────────────
+
+interface CrmCampaignsApi {
+
+    @GET("ui/crm-marketing/campaigns")
+    suspend fun listCampaigns(
+        @Query("campaign_type") campaignType: String? = null,
+        @Query("status") status: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmCampaignListRespDto
+
+    @GET("ui/crm-marketing/campaigns/{campaignId}")
+    suspend fun getCampaign(@Path("campaignId") campaignId: String): CrmCampaignDto
+
+    @GET("ui/crm-marketing/campaigns/{campaignId}/attribution")
+    suspend fun getAttribution(@Path("campaignId") campaignId: String): CrmCampaignAttributionDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
@@ -1,0 +1,142 @@
+package com.testlogon.android.data.crm
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * CRM-AND-PEC — wire DTOs for the SuiteCRM Projects (/v1/crm/projects), Events (/ui/crm/events) and
+ * Marketing Campaigns (/ui/crm-marketing/campaigns) surfaces.
+ *
+ * Field names mirror the LIVE web contracts:
+ *   frontend/src/api/endpoints/crmProjects.ts   (app/routers/crm_projects.py)
+ *   frontend/src/api/endpoints/crmEvents.ts     (app/routers/crm_events.py)
+ *   frontend/src/api/endpoints/crmCampaigns.ts  (app/routers/crm_campaigns.py)
+ *
+ * Every field is nullable / defaulted so a partial or drifted server body decodes rather than
+ * throwing; unknown fields are ignored by Moshi.
+ */
+
+// ───────────────────────────  PROJECTS  ───────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectDto(
+    @Json(name = "id") val id: String = "",
+    @Json(name = "owner_sub") val ownerSub: String? = null,
+    @Json(name = "name") val name: String = "",
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "status") val status: String = "draft",
+    @Json(name = "priority") val priority: Int = 0,
+    @Json(name = "start_date") val startDate: Long? = null,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "assigned_user_sub") val assignedUserSub: String? = null,
+    @Json(name = "account_id") val accountId: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectListRespDto(
+    @Json(name = "items") val items: List<CrmProjectDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectCreateInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "priority") val priority: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectTaskDto(
+    @Json(name = "id") val id: String = "",
+    @Json(name = "project_id") val projectId: String = "",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "task_order") val taskOrder: Int = 0,
+    @Json(name = "duration_days") val durationDays: Int = 0,
+    @Json(name = "start_date") val startDate: Long? = null,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "percent_complete") val percentComplete: Int = 0,
+    @Json(name = "is_milestone") val isMilestone: Boolean = false,
+    @Json(name = "assigned_user_sub") val assignedUserSub: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectTaskListRespDto(
+    @Json(name = "items") val items: List<CrmProjectTaskDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+// ───────────────────────────  EVENTS  ─────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmEventDto(
+    @Json(name = "event_id") val eventId: String = "",
+    @Json(name = "owner_sub") val ownerSub: String? = null,
+    @Json(name = "name") val name: String = "",
+    @Json(name = "description") val description: String = "",
+    @Json(name = "calendar_event_id") val calendarEventId: String? = null,
+    @Json(name = "max_attendance") val maxAttendance: Int? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEventListRespDto(
+    @Json(name = "events") val events: List<CrmEventDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEventCreateInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "max_attendance") val maxAttendance: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEventCapacityDto(
+    @Json(name = "event_id") val eventId: String = "",
+    @Json(name = "max_attendance") val maxAttendance: Int? = null,
+    @Json(name = "accepted_count") val acceptedCount: Int = 0,
+    @Json(name = "waitlisted_count") val waitlistedCount: Int = 0,
+    @Json(name = "available_spots") val availableSpots: Int? = null,
+)
+
+// ──────────────────────────  CAMPAIGNS  ───────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmCampaignDto(
+    @Json(name = "campaign_id") val campaignId: String = "",
+    @Json(name = "owner_id") val ownerId: String? = null,
+    @Json(name = "name") val name: String = "",
+    @Json(name = "status") val status: String = "",
+    @Json(name = "objective") val objective: String? = null,
+    @Json(name = "budget_cents") val budgetCents: Long = 0,
+    @Json(name = "tracking_code") val trackingCode: String? = null,
+    @Json(name = "campaign_type") val campaignType: String = "email",
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmCampaignListRespDto(
+    @Json(name = "campaigns") val campaigns: List<CrmCampaignDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+    @Json(name = "count") val count: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmCampaignAttributionDto(
+    @Json(name = "campaign_id") val campaignId: String = "",
+    @Json(name = "total_sent") val totalSent: Int = 0,
+    @Json(name = "email_sent") val emailSent: Int = 0,
+    @Json(name = "open_count") val openCount: Int = 0,
+    @Json(name = "open_rate") val openRate: Double = 0.0,
+    @Json(name = "click_count") val clickCount: Int = 0,
+    @Json(name = "click_rate") val clickRate: Double = 0.0,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecMath.kt
@@ -1,0 +1,200 @@
+package com.testlogon.android.data.crm
+
+/**
+ * CRM-AND-PEC — PURE, framework-free logic for the CRM Projects / Events / Campaigns surfaces.
+ * No Android / java.time-formatting types leak in, so every function is JVM-unit-testable
+ * (mirrors the CrmSalesMath idiom).
+ *
+ * Responsibilities:
+ *  - project status classification + label (mirror CrmProjectStatus in crmProjects.ts).
+ *  - event capacity state (full / waitlisting / open) from a CrmCapacity roll-up.
+ *  - campaign status/type labels + budget cents formatting + open/click-rate percent formatting.
+ *  - epoch-timestamp → "YYYY-MM-DD" date formatting (UTC, no locale/Android dependency), tolerant
+ *    of BOTH epoch-seconds and epoch-millis (the backend uses seconds; guard against ms drift).
+ *
+ * Degrade, never throw: null / malformed inputs render as a neutral placeholder rather than raising,
+ * so a 404 (module disabled) or dev-host drift shows cleanly.
+ */
+object CrmPecMath {
+
+    const val EM_DASH: String = "—"
+
+    // ── Project status (mirror CrmProjectStatus) ──────────────────────────────
+
+    const val PROJECT_DRAFT = "draft"
+    const val PROJECT_IN_REVIEW = "in_review"
+    const val PROJECT_UNDERWAY = "underway"
+    const val PROJECT_COMPLETED = "completed"
+    const val PROJECT_DEFERRED = "deferred"
+
+    /** Ordered, curated status list used by the create/edit chip row. */
+    val PROJECT_STATUSES: List<String> = listOf(
+        PROJECT_DRAFT, PROJECT_IN_REVIEW, PROJECT_UNDERWAY, PROJECT_COMPLETED, PROJECT_DEFERRED,
+    )
+
+    fun isProjectClosed(status: String?): Boolean =
+        status == PROJECT_COMPLETED || status == PROJECT_DEFERRED
+
+    fun isProjectActive(status: String?): Boolean =
+        status == PROJECT_UNDERWAY || status == PROJECT_IN_REVIEW
+
+    /** Human label for a project status key. Unknown keys are title-cased from snake_case. */
+    fun projectStatusLabel(status: String?): String = when (status) {
+        PROJECT_DRAFT -> "Draft"
+        PROJECT_IN_REVIEW -> "In review"
+        PROJECT_UNDERWAY -> "Underway"
+        PROJECT_COMPLETED -> "Completed"
+        PROJECT_DEFERRED -> "Deferred"
+        null -> EM_DASH
+        else -> titleCaseSnake(status)
+    }
+
+    /**
+     * Clamp a raw percent-complete (0..100) for a progress bar. Out-of-range / negative degrades
+     * into the valid band rather than overflowing the bar.
+     */
+    fun clampPercent(percent: Int): Int = percent.coerceIn(0, 100)
+
+    // ── Event capacity state ──────────────────────────────────────────────────
+
+    enum class CapacityState { UNLIMITED, OPEN, FULL }
+
+    /**
+     * Derive the coarse capacity state from a capacity roll-up.
+     *
+     * A null / non-positive [maxAttendance] means uncapped → UNLIMITED. Otherwise FULL when the
+     * available spots are zero-or-fewer (or accepted has met/exceeded the cap), else OPEN.
+     */
+    fun capacityState(maxAttendance: Int?, acceptedCount: Int, availableSpots: Int?): CapacityState {
+        if (maxAttendance == null || maxAttendance <= 0) return CapacityState.UNLIMITED
+        val remaining = availableSpots ?: (maxAttendance - acceptedCount)
+        return if (remaining <= 0 || acceptedCount >= maxAttendance) CapacityState.FULL else CapacityState.OPEN
+    }
+
+    /** Short "3 / 10" style attendance label; uncapped shows "N going". */
+    fun capacityLabel(maxAttendance: Int?, acceptedCount: Int): String =
+        if (maxAttendance == null || maxAttendance <= 0) {
+            "$acceptedCount going"
+        } else {
+            "$acceptedCount / $maxAttendance"
+        }
+
+    // ── Campaign status / type ────────────────────────────────────────────────
+
+    fun campaignStatusLabel(status: String?): String =
+        if (status.isNullOrBlank()) EM_DASH else titleCaseSnake(status)
+
+    fun campaignTypeLabel(type: String?): String = when (type) {
+        "email" -> "Email"
+        "phone" -> "Phone"
+        "mail" -> "Mail"
+        "fax" -> "Fax"
+        "sms" -> "SMS"
+        null -> EM_DASH
+        else -> titleCaseSnake(type)
+    }
+
+    // ── Money / rate formatting ───────────────────────────────────────────────
+
+    /** Integer cents → "$1,234.56". Negative preserved as "-$…". */
+    fun formatCents(cents: Long): String {
+        val negative = cents < 0
+        val abs = if (negative) -cents else cents
+        val dollars = abs / 100
+        val remainder = (abs % 100).toInt()
+        val grouped = groupThousands(dollars)
+        val centsStr = remainder.toString().padStart(2, '0')
+        return (if (negative) "-$" else "$") + "$grouped.$centsStr"
+    }
+
+    /** A 0.0..1.0 rate → "42.5%". Out-of-range clamps into 0..100%. Handles the drift where the
+     *  backend already returns a 0..100 percentage by treating any value > 1.0 as already-percent. */
+    fun formatRate(rate: Double): String {
+        val pct = when {
+            rate.isNaN() -> 0.0
+            rate <= 1.0 -> rate * 100.0
+            else -> rate
+        }.coerceIn(0.0, 100.0)
+        // one decimal place, trimming a trailing ".0"
+        val rounded = kotlin.math.round(pct * 10.0) / 10.0
+        val s = if (rounded == rounded.toLong().toDouble()) rounded.toLong().toString() else rounded.toString()
+        return "$s%"
+    }
+
+    // ── Date formatting ───────────────────────────────────────────────────────
+
+    private val DAYS_IN_MONTH = intArrayOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+
+    /**
+     * Format an epoch timestamp as an ISO "YYYY-MM-DD" UTC date. Accepts null (→ em-dash) and is
+     * tolerant of both epoch-SECONDS and epoch-MILLIS: any magnitude ≥ 1e12 is treated as millis.
+     * Pure integer/calendar math — no java.time, no locale — so it is deterministic under test.
+     */
+    fun formatDate(epoch: Long?): String {
+        if (epoch == null || epoch <= 0) return EM_DASH
+        val seconds = if (epoch >= 1_000_000_000_000L) epoch / 1000 else epoch
+        var days = Math.floorDiv(seconds, 86_400L)
+        // days since 1970-01-01
+        var year = 1970
+        while (true) {
+            val yearDays = if (isLeap(year)) 366 else 365
+            if (days >= yearDays) {
+                days -= yearDays
+                year++
+            } else {
+                break
+            }
+        }
+        var month = 0
+        while (month < 12) {
+            var dim = DAYS_IN_MONTH[month].toLong()
+            if (month == 1 && isLeap(year)) dim = 29
+            if (days >= dim) {
+                days -= dim
+                month++
+            } else {
+                break
+            }
+        }
+        val day = (days + 1).toInt()
+        val mm = (month + 1).toString().padStart(2, '0')
+        val dd = day.toString().padStart(2, '0')
+        return "$year-$mm-$dd"
+    }
+
+    /** A "start → end" date-range label, degrading each side to em-dash. Returns em-dash if both absent. */
+    fun dateRange(start: Long?, end: Long?): String {
+        if ((start == null || start <= 0) && (end == null || end <= 0)) return EM_DASH
+        return "${formatDate(start)} → ${formatDate(end)}"
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private fun isLeap(y: Int): Boolean = (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)
+
+    private fun groupThousands(value: Long): String {
+        val s = value.toString()
+        if (s.length <= 3) return s
+        val sb = StringBuilder()
+        val firstGroup = s.length % 3
+        var i = 0
+        if (firstGroup > 0) {
+            sb.append(s, 0, firstGroup)
+            i = firstGroup
+        }
+        while (i < s.length) {
+            if (sb.isNotEmpty()) sb.append(',')
+            sb.append(s, i, i + 3)
+            i += 3
+        }
+        return sb.toString()
+    }
+
+    private fun titleCaseSnake(raw: String): String =
+        raw.split('_', ' ')
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { part ->
+                part.replaceFirstChar { c -> c.uppercaseChar() }
+            }
+            .ifBlank { EM_DASH }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
@@ -1,0 +1,140 @@
+package com.testlogon.android.data.crm
+
+/**
+ * CRM-AND-PEC — domain models + DTO→domain mappers for the Projects / Events / Campaigns surfaces.
+ * Raw DTOs never leak into the UI.
+ */
+
+// ─── Projects ────────────────────────────────────────────────────────────────
+
+data class CrmProject(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val status: String,
+    val priority: Int,
+    val startDate: Long?,
+    val endDate: Long?,
+    val assignedUserSub: String?,
+    val accountId: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class CrmProjectTask(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val taskOrder: Int,
+    val durationDays: Int,
+    val startDate: Long?,
+    val endDate: Long?,
+    val percentComplete: Int,
+    val isMilestone: Boolean,
+)
+
+// ─── Events ──────────────────────────────────────────────────────────────────
+
+data class CrmEvent(
+    val eventId: String,
+    val name: String,
+    val description: String,
+    val maxAttendance: Int?,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class CrmEventCapacity(
+    val maxAttendance: Int?,
+    val acceptedCount: Int,
+    val waitlistedCount: Int,
+    val availableSpots: Int?,
+)
+
+// ─── Campaigns ───────────────────────────────────────────────────────────────
+
+data class CrmCampaign(
+    val campaignId: String,
+    val name: String,
+    val status: String,
+    val objective: String?,
+    val budgetCents: Long,
+    val trackingCode: String?,
+    val campaignType: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class CrmCampaignAttribution(
+    val totalSent: Int,
+    val emailSent: Int,
+    val openCount: Int,
+    val openRate: Double,
+    val clickCount: Int,
+    val clickRate: Double,
+)
+
+// ─── Mappers ─────────────────────────────────────────────────────────────────
+
+fun CrmProjectDto.toDomain(): CrmProject = CrmProject(
+    id = id,
+    name = name,
+    description = description,
+    status = status,
+    priority = priority,
+    startDate = startDate,
+    endDate = endDate,
+    assignedUserSub = assignedUserSub,
+    accountId = accountId,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun CrmProjectTaskDto.toDomain(): CrmProjectTask = CrmProjectTask(
+    id = id,
+    name = name,
+    description = description,
+    taskOrder = taskOrder,
+    durationDays = durationDays,
+    startDate = startDate,
+    endDate = endDate,
+    percentComplete = percentComplete,
+    isMilestone = isMilestone,
+)
+
+fun CrmEventDto.toDomain(): CrmEvent = CrmEvent(
+    eventId = eventId,
+    name = name,
+    description = description,
+    maxAttendance = maxAttendance,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun CrmEventCapacityDto.toDomain(): CrmEventCapacity = CrmEventCapacity(
+    maxAttendance = maxAttendance,
+    acceptedCount = acceptedCount,
+    waitlistedCount = waitlistedCount,
+    availableSpots = availableSpots,
+)
+
+fun CrmCampaignDto.toDomain(): CrmCampaign = CrmCampaign(
+    campaignId = campaignId,
+    name = name,
+    status = status,
+    objective = objective,
+    budgetCents = budgetCents,
+    trackingCode = trackingCode,
+    campaignType = campaignType,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun CrmCampaignAttributionDto.toDomain(): CrmCampaignAttribution = CrmCampaignAttribution(
+    totalSent = totalSent,
+    emailSent = emailSent,
+    openCount = openCount,
+    openRate = openRate,
+    clickCount = clickCount,
+    clickRate = clickRate,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
@@ -1,0 +1,195 @@
+package com.testlogon.android.data.crm
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// ── Aggregate results (each carries a module-disabled flag for degrade-on-404) ──
+
+data class CrmProjectsPage(
+    val projects: List<CrmProject>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
+data class CrmProjectDetail(
+    val project: CrmProject,
+    val tasks: List<CrmProjectTask>,
+)
+
+data class CrmEventsPage(
+    val events: List<CrmEvent>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
+data class CrmCampaignsPage(
+    val campaigns: List<CrmCampaign>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
+data class CrmCampaignDetail(
+    val campaign: CrmCampaign,
+    val attribution: CrmCampaignAttribution?,
+)
+
+// ───────────────────────────  PROJECTS  ──────────────────────────────
+
+interface CrmProjectsRepository {
+    suspend fun list(status: String? = null): ApiResult<CrmProjectsPage>
+    suspend fun detail(projectId: String): ApiResult<CrmProjectDetail>
+    suspend fun create(body: CrmProjectCreateInDto): ApiResult<CrmProject>
+}
+
+@Singleton
+class CrmProjectsRepositoryImpl @Inject constructor(
+    private val api: CrmProjectsApi,
+    private val errorParser: ApiErrorParser,
+) : CrmProjectsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun list(status: String?): ApiResult<CrmProjectsPage> = withContext(io) {
+        when (val r = call { api.listProjects(status = status) }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmProjectsPage(r.data.items.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure ->
+                if (r.error.status == 404) ApiResult.Success(CrmProjectsPage(emptyList(), null, moduleDisabled = true))
+                else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun detail(projectId: String): ApiResult<CrmProjectDetail> = withContext(io) {
+        when (val proj = call { api.getProject(projectId).toDomain() }) {
+            is ApiResult.Success -> {
+                // Tasks are best-effort; a failure/degradation renders an empty task list.
+                val tasks = (call { api.listTasks(projectId) } as? ApiResult.Success)
+                    ?.data?.items?.map { it.toDomain() }?.sortedBy { it.taskOrder } ?: emptyList()
+                ApiResult.Success(CrmProjectDetail(proj.data, tasks))
+            }
+            is ApiResult.Failure -> proj
+            is ApiResult.NetworkError -> proj
+        }
+    }
+
+    override suspend fun create(body: CrmProjectCreateInDto): ApiResult<CrmProject> = withContext(io) {
+        call { api.createProject(body).toDomain() }
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)
+}
+
+// ───────────────────────────  EVENTS  ────────────────────────────────
+
+interface CrmEventsRepository {
+    suspend fun list(): ApiResult<CrmEventsPage>
+    suspend fun get(eventId: String): ApiResult<CrmEvent>
+    suspend fun capacity(eventId: String): ApiResult<CrmEventCapacity?>
+    suspend fun create(body: CrmEventCreateInDto): ApiResult<CrmEvent>
+}
+
+@Singleton
+class CrmEventsRepositoryImpl @Inject constructor(
+    private val api: CrmEventsApi,
+    private val errorParser: ApiErrorParser,
+) : CrmEventsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun list(): ApiResult<CrmEventsPage> = withContext(io) {
+        when (val r = call { api.listEvents() }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmEventsPage(r.data.events.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure ->
+                if (r.error.status == 404) ApiResult.Success(CrmEventsPage(emptyList(), null, moduleDisabled = true))
+                else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun get(eventId: String): ApiResult<CrmEvent> = withContext(io) {
+        call { api.getEvent(eventId).toDomain() }
+    }
+
+    override suspend fun capacity(eventId: String): ApiResult<CrmEventCapacity?> = withContext(io) {
+        when (val r = call { api.getCapacity(eventId).toDomain() }) {
+            is ApiResult.Success -> r
+            is ApiResult.Failure -> if (r.error.status == 404) ApiResult.Success(null) else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun create(body: CrmEventCreateInDto): ApiResult<CrmEvent> = withContext(io) {
+        call { api.createEvent(body).toDomain() }
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)
+}
+
+// ──────────────────────────  CAMPAIGNS  ──────────────────────────────
+
+interface CrmCampaignsRepository {
+    suspend fun list(status: String? = null): ApiResult<CrmCampaignsPage>
+    suspend fun detail(campaignId: String): ApiResult<CrmCampaignDetail>
+}
+
+@Singleton
+class CrmCampaignsRepositoryImpl @Inject constructor(
+    private val api: CrmCampaignsApi,
+    private val errorParser: ApiErrorParser,
+) : CrmCampaignsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun list(status: String?): ApiResult<CrmCampaignsPage> = withContext(io) {
+        when (val r = call { api.listCampaigns(status = status) }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmCampaignsPage(r.data.campaigns.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure ->
+                if (r.error.status == 404) ApiResult.Success(CrmCampaignsPage(emptyList(), null, moduleDisabled = true))
+                else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun detail(campaignId: String): ApiResult<CrmCampaignDetail> = withContext(io) {
+        when (val camp = call { api.getCampaign(campaignId).toDomain() }) {
+            is ApiResult.Success -> {
+                // Attribution is best-effort (analytics can be off even when the campaign exists).
+                val attribution = (call { api.getAttribution(campaignId).toDomain() } as? ApiResult.Success)?.data
+                ApiResult.Success(CrmCampaignDetail(camp.data, attribution))
+            }
+            is ApiResult.Failure -> camp
+            is ApiResult.NetworkError -> camp
+        }
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)
+}
+
+// ── Shared error-mapping helper (mirrors the LeadsRepository `call` body). ──
+private suspend fun <T> runCatchingApi(
+    errorParser: ApiErrorParser,
+    block: suspend () -> T,
+): ApiResult<T> = try {
+    ApiResult.Success(block())
+} catch (e: CancellationException) {
+    throw e
+} catch (e: HttpException) {
+    ApiResult.Failure(errorParser.from(e))
+} catch (e: IOException) {
+    ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsScreens.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsScreens.kt
@@ -1,0 +1,227 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.crm.CrmCampaign
+import com.testlogon.android.data.crm.CrmPecMath
+
+object CrmCampaignsTestTags {
+    const val SCREEN = "crm_campaigns_screen"
+    const val CONTENT = "crm_campaigns_content"
+    const val LOADING = "crm_campaigns_loading"
+    const val ERROR = "crm_campaigns_error"
+    const val DETAIL = "crm_campaign_detail"
+}
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+@Composable
+fun CrmCampaignsRoute(
+    onCampaignClick: (String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmCampaignsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmCampaignsScreen(
+        state = state,
+        onCampaignClick = onCampaignClick,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CrmCampaignsScreen(
+    state: CrmCampaignsUiState,
+    onCampaignClick: (String) -> Unit,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(CrmCampaignsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Campaigns") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmCampaignsUiState.Phase.Loading -> LoadingState(
+                modifier = Modifier.padding(padding).testTag(CrmCampaignsTestTags.LOADING),
+            )
+            CrmCampaignsUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load campaigns.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding).testTag(CrmCampaignsTestTags.ERROR),
+            )
+            CrmCampaignsUiState.Phase.Content -> PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.moduleDisabled) InfoBanner("The Marketing module is not enabled for this account.")
+                    if (state.campaigns.isEmpty()) {
+                        EmptyState(
+                            title = if (state.moduleDisabled) "Campaigns unavailable" else "No campaigns yet",
+                            body = if (state.moduleDisabled) null else "Create campaigns from the web console.",
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize().testTag(CrmCampaignsTestTags.CONTENT),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(state.campaigns, key = { it.campaignId }) { c ->
+                                CampaignRow(c, onClick = { onCampaignClick(c.campaignId) })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CampaignRow(campaign: CrmCampaign, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(campaign.name.ifBlank { "(untitled)" }, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "${CrmPecMath.campaignTypeLabel(campaign.campaignType)} · ${CrmPecMath.formatCents(campaign.budgetCents)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            AssistChip(onClick = onClick, label = { Text(CrmPecMath.campaignStatusLabel(campaign.status)) })
+        }
+    }
+}
+
+// ─── Detail (read-only) ─────────────────────────────────────────────────────
+
+@Composable
+fun CrmCampaignDetailRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmCampaignDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmCampaignDetailScreen(state = state, onBack = onBack, onRetry = viewModel::onRetry, modifier = modifier)
+}
+
+@Composable
+fun CrmCampaignDetailScreen(
+    state: CrmCampaignDetailUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(CrmCampaignsTestTags.DETAIL),
+        topBar = {
+            TopAppBar(
+                title = { Text(state.campaign?.name?.ifBlank { "Campaign" } ?: "Campaign") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmCampaignDetailUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            CrmCampaignDetailUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load this campaign.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            CrmCampaignDetailUiState.Phase.Content -> {
+                val campaign = state.campaign
+                Column(
+                    modifier = Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (campaign != null) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            AssistChip(onClick = {}, label = { Text(CrmPecMath.campaignStatusLabel(campaign.status)) })
+                            AssistChip(onClick = {}, label = { Text(CrmPecMath.campaignTypeLabel(campaign.campaignType)) })
+                        }
+                        LabeledValue("Budget", CrmPecMath.formatCents(campaign.budgetCents))
+                        if (!campaign.objective.isNullOrBlank()) LabeledValue("Objective", campaign.objective)
+                        if (!campaign.trackingCode.isNullOrBlank()) LabeledValue("Tracking code", campaign.trackingCode)
+                    }
+                    val attr = state.attribution
+                    if (attr != null) {
+                        Text("Performance", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        LabeledValue("Sent", attr.totalSent.toString())
+                        LabeledValue("Opens", "${attr.openCount} (${CrmPecMath.formatRate(attr.openRate)})")
+                        LabeledValue("Clicks", "${attr.clickCount} (${CrmPecMath.formatRate(attr.clickRate)})")
+                    } else {
+                        Text(
+                            "Full campaign editing and A/B testing live in the web console.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsViewModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsViewModels.kt
@@ -1,0 +1,158 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CrmCampaign
+import com.testlogon.android.data.crm.CrmCampaignAttribution
+import com.testlogon.android.data.crm.CrmCampaignsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// ─── Campaigns list ───────────────────────────────────────────────────────────
+
+data class CrmCampaignsUiState(
+    val phase: Phase = Phase.Loading,
+    val campaigns: List<CrmCampaign> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-PEC — CRM marketing campaigns list (read-mostly; the web editor is rich). Pulls
+ * GET /ui/crm-marketing/campaigns; a 404 (module disabled) degrades to an empty, non-error state.
+ */
+@HiltViewModel
+class CrmCampaignsViewModel @Inject constructor(
+    private val repository: CrmCampaignsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CrmCampaignsUiState())
+    val uiState: StateFlow<CrmCampaignsUiState> = _uiState.asStateFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    private fun load(fromUser: Boolean) {
+        val hasContent = _uiState.value.campaigns.isNotEmpty()
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent) it.phase else CrmCampaignsUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repository.list()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = CrmCampaignsUiState.Phase.Content,
+                        campaigns = r.data.campaigns,
+                        moduleDisabled = r.data.moduleDisabled,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.campaigns.isNotEmpty()) CrmCampaignsUiState.Phase.Content else CrmCampaignsUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.campaigns.isNotEmpty()) CrmCampaignsUiState.Phase.Content else CrmCampaignsUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ─── Campaign detail ──────────────────────────────────────────────────────────
+
+data class CrmCampaignDetailUiState(
+    val phase: Phase = Phase.Loading,
+    val campaign: CrmCampaign? = null,
+    val attribution: CrmCampaignAttribution? = null,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+@HiltViewModel
+class CrmCampaignDetailViewModel @Inject constructor(
+    private val repository: CrmCampaignsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val campaignId: String = checkNotNull(savedStateHandle[ARG_CAMPAIGN_ID]) {
+        "CrmCampaignDetailViewModel requires a $ARG_CAMPAIGN_ID nav arg"
+    }
+
+    private val _uiState = MutableStateFlow(CrmCampaignDetailUiState())
+    val uiState: StateFlow<CrmCampaignDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update {
+            it.copy(phase = if (it.campaign == null) CrmCampaignDetailUiState.Phase.Loading else it.phase)
+        }
+        viewModelScope.launch {
+            when (val r = repository.detail(campaignId)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = CrmCampaignDetailUiState.Phase.Content,
+                        campaign = r.data.campaign,
+                        attribution = r.data.attribution,
+                        isOffline = false,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.campaign != null) CrmCampaignDetailUiState.Phase.Content else CrmCampaignDetailUiState.Phase.Error,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.campaign != null) CrmCampaignDetailUiState.Phase.Content else CrmCampaignDetailUiState.Phase.Error,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_CAMPAIGN_ID: String = "campaignId"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventsScreen.kt
@@ -1,0 +1,234 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.crm.CrmEvent
+import com.testlogon.android.data.crm.CrmPecMath
+
+object CrmEventsTestTags {
+    const val SCREEN = "crm_events_screen"
+    const val CONTENT = "crm_events_content"
+    const val LOADING = "crm_events_loading"
+    const val ERROR = "crm_events_error"
+    const val FAB = "crm_events_fab"
+}
+
+@Composable
+fun CrmEventsRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmEventsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmEventsScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onCreate = viewModel::createEvent,
+        onClearCreateError = viewModel::clearCreateError,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CrmEventsScreen(
+    state: CrmEventsUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onCreate: (String, String?, Int?, (String) -> Unit) -> Unit,
+    onClearCreateError: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showCreate by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmEventsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Events") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showCreate = true },
+                modifier = Modifier.testTag(CrmEventsTestTags.FAB),
+            ) { Icon(Icons.Filled.Add, contentDescription = "New event") }
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmEventsUiState.Phase.Loading -> LoadingState(
+                modifier = Modifier.padding(padding).testTag(CrmEventsTestTags.LOADING),
+            )
+            CrmEventsUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load events.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding).testTag(CrmEventsTestTags.ERROR),
+            )
+            CrmEventsUiState.Phase.Content -> PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.moduleDisabled) InfoBanner("The Events module is not enabled for this account.")
+                    if (state.events.isEmpty()) {
+                        EmptyState(
+                            title = if (state.moduleDisabled) "Events unavailable" else "No events yet",
+                            body = if (state.moduleDisabled) null else "Tap + to create your first event.",
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize().testTag(CrmEventsTestTags.CONTENT),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(state.events, key = { it.eventId }) { event -> EventRow(event) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        CreateEventSheet(
+            submitting = state.createSubmitting,
+            error = state.createError,
+            onDismiss = {
+                showCreate = false
+                onClearCreateError()
+            },
+            onSubmit = { name, desc, maxAtt ->
+                onCreate(name, desc, maxAtt) { _ -> showCreate = false }
+            },
+        )
+    }
+}
+
+@Composable
+private fun EventRow(event: CrmEvent) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(event.name.ifBlank { "(untitled)" }, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                if (event.description.isNotBlank()) {
+                    Text(
+                        event.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                    )
+                }
+                Text(CrmPecMath.formatDate(event.createdAt), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            AssistChip(
+                onClick = {},
+                label = {
+                    Text(
+                        if (event.maxAttendance != null && event.maxAttendance > 0) "Cap ${event.maxAttendance}" else "Open",
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CreateEventSheet(
+    submitting: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onSubmit: (name: String, description: String?, maxAttendance: Int?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var maxAtt by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = { if (!submitting) onDismiss() },
+        title = { Text("New event") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(name, { name = it }, label = { Text("Name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(description, { description = it }, label = { Text("Description (optional)") }, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(
+                    maxAtt,
+                    { input -> maxAtt = input.filter { it.isDigit() } },
+                    label = { Text("Max attendance (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (error != null) {
+                    Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = !submitting, onClick = { onSubmit(name, description, maxAtt.toIntOrNull()) }) {
+                if (submitting) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Create")
+            }
+        },
+        dismissButton = { TextButton(enabled = !submitting, onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventsViewModel.kt
@@ -1,0 +1,123 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CrmEvent
+import com.testlogon.android.data.crm.CrmEventCreateInDto
+import com.testlogon.android.data.crm.CrmEventsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class CrmEventsUiState(
+    val phase: Phase = Phase.Loading,
+    val events: List<CrmEvent> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+    val createSubmitting: Boolean = false,
+    val createError: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-PEC — CRM events list + inline create. Pulls GET /ui/crm/events; a 404 (module disabled)
+ * degrades to an empty, non-error state with a banner. Create posts then re-loads.
+ */
+@HiltViewModel
+class CrmEventsViewModel @Inject constructor(
+    private val repository: CrmEventsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CrmEventsUiState())
+    val uiState: StateFlow<CrmEventsUiState> = _uiState.asStateFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    private fun load(fromUser: Boolean) {
+        val hasContent = _uiState.value.events.isNotEmpty()
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent) it.phase else CrmEventsUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repository.list()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = CrmEventsUiState.Phase.Content,
+                        events = r.data.events,
+                        moduleDisabled = r.data.moduleDisabled,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.events.isNotEmpty()) CrmEventsUiState.Phase.Content else CrmEventsUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.events.isNotEmpty()) CrmEventsUiState.Phase.Content else CrmEventsUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    fun createEvent(
+        name: String,
+        description: String?,
+        maxAttendance: Int?,
+        onCreated: (String) -> Unit,
+    ) {
+        if (name.isBlank()) {
+            _uiState.update { it.copy(createError = "An event name is required.") }
+            return
+        }
+        _uiState.update { it.copy(createSubmitting = true, createError = null) }
+        viewModelScope.launch {
+            val body = CrmEventCreateInDto(
+                name = name.trim(),
+                description = description?.trim()?.ifBlank { null },
+                maxAttendance = maxAttendance,
+            )
+            when (val r = repository.create(body)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createSubmitting = false, createError = null) }
+                    onCreated(r.data.eventId)
+                    load(fromUser = false)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun clearCreateError() = _uiState.update { it.copy(createError = null) }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsScreens.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsScreens.kt
@@ -1,0 +1,335 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.crm.CrmProject
+import com.testlogon.android.data.crm.CrmProjectTask
+import com.testlogon.android.data.crm.CrmPecMath
+
+object CrmProjectsTestTags {
+    const val SCREEN = "crm_projects_screen"
+    const val CONTENT = "crm_projects_content"
+    const val LOADING = "crm_projects_loading"
+    const val ERROR = "crm_projects_error"
+    const val FAB = "crm_projects_fab"
+    const val DETAIL = "crm_project_detail"
+}
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+@Composable
+fun CrmProjectsRoute(
+    onProjectClick: (String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmProjectsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmProjectsScreen(
+        state = state,
+        onProjectClick = onProjectClick,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onCreate = viewModel::createProject,
+        onClearCreateError = viewModel::clearCreateError,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CrmProjectsScreen(
+    state: CrmProjectsUiState,
+    onProjectClick: (String) -> Unit,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onCreate: (String, String?, String?, (String) -> Unit) -> Unit,
+    onClearCreateError: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showCreate by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmProjectsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Projects") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showCreate = true },
+                modifier = Modifier.testTag(CrmProjectsTestTags.FAB),
+            ) { Icon(Icons.Filled.Add, contentDescription = "New project") }
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmProjectsUiState.Phase.Loading -> LoadingState(
+                modifier = Modifier.padding(padding).testTag(CrmProjectsTestTags.LOADING),
+            )
+            CrmProjectsUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load projects.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding).testTag(CrmProjectsTestTags.ERROR),
+            )
+            CrmProjectsUiState.Phase.Content -> PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.moduleDisabled) InfoBanner("The Projects module is not enabled for this account.")
+                    if (state.projects.isEmpty()) {
+                        EmptyState(
+                            title = if (state.moduleDisabled) "Projects unavailable" else "No projects yet",
+                            body = if (state.moduleDisabled) null else "Tap + to create your first project.",
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize().testTag(CrmProjectsTestTags.CONTENT),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(state.projects, key = { it.id }) { project ->
+                                ProjectRow(project = project, onClick = { onProjectClick(project.id) })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        CreateProjectSheet(
+            submitting = state.createSubmitting,
+            error = state.createError,
+            onDismiss = {
+                showCreate = false
+                onClearCreateError()
+            },
+            onSubmit = { name, desc, status ->
+                onCreate(name, desc, status) { _ -> showCreate = false }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ProjectRow(project: CrmProject, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(project.name.ifBlank { "(untitled)" }, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                val range = CrmPecMath.dateRange(project.startDate, project.endDate)
+                if (range != CrmPecMath.EM_DASH) {
+                    Text(range, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            AssistChip(onClick = onClick, label = { Text(CrmPecMath.projectStatusLabel(project.status)) })
+        }
+    }
+}
+
+// ─── Detail ───────────────────────────────────────────────────────────────────
+
+@Composable
+fun CrmProjectDetailRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmProjectDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmProjectDetailScreen(state = state, onBack = onBack, onRetry = viewModel::onRetry, modifier = modifier)
+}
+
+@Composable
+fun CrmProjectDetailScreen(
+    state: CrmProjectDetailUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(CrmProjectsTestTags.DETAIL),
+        topBar = {
+            TopAppBar(
+                title = { Text(state.project?.name?.ifBlank { "Project" } ?: "Project") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmProjectDetailUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            CrmProjectDetailUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load this project.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            CrmProjectDetailUiState.Phase.Content -> {
+                val project = state.project
+                Column(
+                    modifier = Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (project != null) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            AssistChip(onClick = {}, label = { Text(CrmPecMath.projectStatusLabel(project.status)) })
+                            AssistChip(onClick = {}, label = { Text("Priority ${project.priority}") })
+                        }
+                        LabeledValue("Dates", CrmPecMath.dateRange(project.startDate, project.endDate))
+                        if (!project.description.isNullOrBlank()) {
+                            LabeledValue("Description", project.description)
+                        }
+                    }
+                    Text("Tasks", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    if (state.tasks.isEmpty()) {
+                        Text("No tasks.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    } else {
+                        state.tasks.forEach { TaskRow(it) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaskRow(task: CrmProjectTask) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                (if (task.isMilestone) "◆ " else "") + task.name.ifBlank { "(untitled task)" },
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            val pct = CrmPecMath.clampPercent(task.percentComplete)
+            LinearProgressIndicator(progress = { pct / 100f }, modifier = Modifier.fillMaxWidth())
+            Text("$pct% · ${CrmPecMath.dateRange(task.startDate, task.endDate)}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+internal fun LabeledValue(label: String, value: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+// ─── Create sheet ───────────────────────────────────────────────────────────
+
+@Composable
+private fun CreateProjectSheet(
+    submitting: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onSubmit: (name: String, description: String?, status: String?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var status by remember { mutableStateOf(CrmPecMath.PROJECT_DRAFT) }
+
+    AlertDialog(
+        onDismissRequest = { if (!submitting) onDismiss() },
+        title = { Text("New project") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(name, { name = it }, label = { Text("Name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(description, { description = it }, label = { Text("Description (optional)") }, modifier = Modifier.fillMaxWidth())
+                Text("Status", style = MaterialTheme.typography.labelMedium)
+                Row(
+                    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    CrmPecMath.PROJECT_STATUSES.forEach { s ->
+                        FilterChip(
+                            selected = s == status,
+                            onClick = { status = s },
+                            label = { Text(CrmPecMath.projectStatusLabel(s)) },
+                        )
+                    }
+                }
+                if (error != null) {
+                    Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = !submitting, onClick = { onSubmit(name, description, status) }) {
+                if (submitting) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Create")
+            }
+        },
+        dismissButton = { TextButton(enabled = !submitting, onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsViewModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsViewModels.kt
@@ -1,0 +1,196 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CrmProject
+import com.testlogon.android.data.crm.CrmProjectCreateInDto
+import com.testlogon.android.data.crm.CrmProjectTask
+import com.testlogon.android.data.crm.CrmProjectsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// ─── Projects list ────────────────────────────────────────────────────────────
+
+data class CrmProjectsUiState(
+    val phase: Phase = Phase.Loading,
+    val projects: List<CrmProject> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+    val createSubmitting: Boolean = false,
+    val createError: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-PEC — CRM projects list + inline create. Pulls GET /v1/crm/projects; a 404 (module
+ * disabled) degrades to an empty, non-error state with a banner. Create posts then re-loads.
+ */
+@HiltViewModel
+class CrmProjectsViewModel @Inject constructor(
+    private val repository: CrmProjectsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CrmProjectsUiState())
+    val uiState: StateFlow<CrmProjectsUiState> = _uiState.asStateFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    private fun load(fromUser: Boolean) {
+        val hasContent = _uiState.value.projects.isNotEmpty()
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent) it.phase else CrmProjectsUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repository.list()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = CrmProjectsUiState.Phase.Content,
+                        projects = r.data.projects,
+                        moduleDisabled = r.data.moduleDisabled,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.projects.isNotEmpty()) CrmProjectsUiState.Phase.Content else CrmProjectsUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.projects.isNotEmpty()) CrmProjectsUiState.Phase.Content else CrmProjectsUiState.Phase.Error,
+                        isRefreshing = false,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    fun createProject(
+        name: String,
+        description: String?,
+        status: String?,
+        onCreated: (String) -> Unit,
+    ) {
+        if (name.isBlank()) {
+            _uiState.update { it.copy(createError = "A project name is required.") }
+            return
+        }
+        _uiState.update { it.copy(createSubmitting = true, createError = null) }
+        viewModelScope.launch {
+            val body = CrmProjectCreateInDto(
+                name = name.trim(),
+                description = description?.trim()?.ifBlank { null },
+                status = status?.ifBlank { null },
+            )
+            when (val r = repository.create(body)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createSubmitting = false, createError = null) }
+                    onCreated(r.data.id)
+                    load(fromUser = false)
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(createSubmitting = false, createError = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun clearCreateError() = _uiState.update { it.copy(createError = null) }
+}
+
+// ─── Project detail ───────────────────────────────────────────────────────────
+
+data class CrmProjectDetailUiState(
+    val phase: Phase = Phase.Loading,
+    val project: CrmProject? = null,
+    val tasks: List<CrmProjectTask> = emptyList(),
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+@HiltViewModel
+class CrmProjectDetailViewModel @Inject constructor(
+    private val repository: CrmProjectsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val projectId: String = checkNotNull(savedStateHandle[ARG_PROJECT_ID]) {
+        "CrmProjectDetailViewModel requires a $ARG_PROJECT_ID nav arg"
+    }
+
+    private val _uiState = MutableStateFlow(CrmProjectDetailUiState())
+    val uiState: StateFlow<CrmProjectDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update {
+            it.copy(phase = if (it.project == null) CrmProjectDetailUiState.Phase.Loading else it.phase)
+        }
+        viewModelScope.launch {
+            when (val r = repository.detail(projectId)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = CrmProjectDetailUiState.Phase.Content,
+                        project = r.data.project,
+                        tasks = r.data.tasks,
+                        isOffline = false,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.project != null) CrmProjectDetailUiState.Phase.Content else CrmProjectDetailUiState.Phase.Error,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.project != null) CrmProjectDetailUiState.Phase.Content else CrmProjectDetailUiState.Phase.Error,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_PROJECT_ID: String = "projectId"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -740,6 +740,31 @@ class MoreCatalog @Inject constructor() {
             hub = MoreHub.GROWTH,
             section = MoreSection.APP,
         ),
+        // CRM-AND-PEC: SuiteCRM projects / events / marketing-campaigns surfaces (degrade-on-404).
+        MoreEntry(
+            id = "crm_projects",
+            labelRes = R.string.more_entry_crm_projects,
+            icon = Icons.Outlined.FolderOpen,
+            route = MoreRoutes.CRM_PROJECTS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "crm_events",
+            labelRes = R.string.more_entry_crm_events,
+            icon = Icons.Outlined.EventNote,
+            route = MoreRoutes.CRM_EVENTS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.APP,
+        ),
+        MoreEntry(
+            id = "crm_campaigns",
+            labelRes = R.string.more_entry_crm_campaigns,
+            icon = Icons.Outlined.Campaign,
+            route = MoreRoutes.CRM_CAMPAIGNS,
+            hub = MoreHub.GROWTH,
+            section = MoreSection.APP,
+        ),
         MoreEntry(
             id = "videos",
             labelRes = R.string.more_entry_videos,

--- a/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
@@ -10,6 +10,13 @@ import com.testlogon.android.feature.crm.LeadDetailRoute
 import com.testlogon.android.feature.crm.LeadDetailViewModel
 import com.testlogon.android.feature.crm.LeadsListRoute
 import com.testlogon.android.feature.crm.PipelineRoute
+import com.testlogon.android.feature.crm.CrmProjectsRoute
+import com.testlogon.android.feature.crm.CrmProjectDetailRoute
+import com.testlogon.android.feature.crm.CrmProjectDetailViewModel
+import com.testlogon.android.feature.crm.CrmEventsRoute
+import com.testlogon.android.feature.crm.CrmCampaignsRoute
+import com.testlogon.android.feature.crm.CrmCampaignDetailRoute
+import com.testlogon.android.feature.crm.CrmCampaignDetailViewModel
 
 /** CRM-AND-1 — the CRM leads list route (reached from the More hub / Growth). */
 data object CrmLeadsDest {
@@ -27,6 +34,37 @@ data object CrmLeadDetailDest {
 /** CRM-AND-1 — the sales-pipeline board route. */
 data object CrmPipelineDest {
     const val ROUTE = "crm/pipeline"
+}
+
+/** CRM-AND-PEC — the CRM projects list route (Growth hub). */
+data object CrmProjectsDest {
+    const val ROUTE = "crm/projects"
+}
+
+/** CRM-AND-PEC — the CRM project detail route; the arg is the STRING project id (path param). */
+data object CrmProjectDetailDest {
+    const val ARG_PROJECT_ID = CrmProjectDetailViewModel.ARG_PROJECT_ID
+    const val ROUTE = "crm/projects/{$ARG_PROJECT_ID}"
+
+    fun build(projectId: String): String = "crm/projects/${Uri.encode(projectId)}"
+}
+
+/** CRM-AND-PEC — the CRM events list route (Growth hub). */
+data object CrmEventsDest {
+    const val ROUTE = "crm/events"
+}
+
+/** CRM-AND-PEC — the CRM marketing campaigns list route (Growth hub). */
+data object CrmCampaignsDest {
+    const val ROUTE = "crm/campaigns"
+}
+
+/** CRM-AND-PEC — the CRM campaign detail route; the arg is the STRING campaign id (path param). */
+data object CrmCampaignDetailDest {
+    const val ARG_CAMPAIGN_ID = CrmCampaignDetailViewModel.ARG_CAMPAIGN_ID
+    const val ROUTE = "crm/campaigns/{$ARG_CAMPAIGN_ID}"
+
+    fun build(campaignId: String): String = "crm/campaigns/${Uri.encode(campaignId)}"
 }
 
 /** CRM-AND-1 — registers the CRM leads list + detail + pipeline destinations in the authenticated graph. */
@@ -49,5 +87,41 @@ fun NavGraphBuilder.crmDestinations(navController: NavHostController) {
     }
     composable(CrmPipelineDest.ROUTE) {
         PipelineRoute(onBack = { navController.popBackStack() })
+    }
+    // CRM-AND-PEC destinations
+    composable(CrmProjectsDest.ROUTE) {
+        CrmProjectsRoute(
+            onProjectClick = { id ->
+                navController.navigate(CrmProjectDetailDest.build(id)) { launchSingleTop = true }
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable(
+        route = CrmProjectDetailDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmProjectDetailDest.ARG_PROJECT_ID) { type = NavType.StringType },
+        ),
+    ) {
+        CrmProjectDetailRoute(onBack = { navController.popBackStack() })
+    }
+    composable(CrmEventsDest.ROUTE) {
+        CrmEventsRoute(onBack = { navController.popBackStack() })
+    }
+    composable(CrmCampaignsDest.ROUTE) {
+        CrmCampaignsRoute(
+            onCampaignClick = { id ->
+                navController.navigate(CrmCampaignDetailDest.build(id)) { launchSingleTop = true }
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable(
+        route = CrmCampaignDetailDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmCampaignDetailDest.ARG_CAMPAIGN_ID) { type = NavType.StringType },
+        ),
+    ) {
+        CrmCampaignDetailRoute(onBack = { navController.popBackStack() })
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -59,6 +59,12 @@ object MoreRoutes {
     val CRM_LEADS: String get() = CrmLeadsDest.ROUTE
     val CRM_PIPELINE: String get() = CrmPipelineDest.ROUTE
 
+    // CRM-AND-PEC: SuiteCRM projects (/v1/crm/projects), events (/ui/crm/events) and marketing
+    // campaigns (/ui/crm-marketing/campaigns). Each degrades-on-404 when the module is off.
+    val CRM_PROJECTS: String get() = CrmProjectsDest.ROUTE
+    val CRM_EVENTS: String get() = CrmEventsDest.ROUTE
+    val CRM_CAMPAIGNS: String get() = CrmCampaignsDest.ROUTE
+
     // AND-189: the caller's videos library grid.
     val VIDEOS: String get() = VideosLibraryDest.ROUTE
 
@@ -660,6 +666,9 @@ object MoreRoutes {
             ACHIEVEMENTS,
             CRM_LEADS,
             CRM_PIPELINE,
+            CRM_PROJECTS,
+            CRM_EVENTS,
+            CRM_CAMPAIGNS,
             VIDEOS,
             VOD_CATALOG,
             VOD_RENTALS,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -96,6 +96,9 @@
     <string name="more_entry_achievements">Achievements</string>
     <string name="more_entry_crm_leads">Leads</string>
     <string name="more_entry_crm_pipeline">Sales pipeline</string>
+    <string name="more_entry_crm_projects">CRM projects</string>
+    <string name="more_entry_crm_events">CRM events</string>
+    <string name="more_entry_crm_campaigns">CRM campaigns</string>
     <string name="more_entry_videos">My videos</string>
     <string name="more_entry_vod_catalog">Browse videos</string>
     <string name="more_entry_clips">Clips</string>

--- a/android/app/src/test/java/com/testlogon/android/data/crm/CrmPecMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/crm/CrmPecMathTest.kt
@@ -1,0 +1,146 @@
+package com.testlogon.android.data.crm
+
+import com.testlogon.android.data.crm.CrmPecMath.CapacityState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * CRM-AND-PEC — JVM unit tests for the pure Projects / Events / Campaigns logic (status classification,
+ * capacity state, money/rate formatting, epoch→date formatting). No Android types; degrade-on-bad-input
+ * is asserted so the UI never crashes on a 404 (module disabled) or dev-host drift.
+ */
+class CrmPecMathTest {
+
+    // ── Project status ────────────────────────────────────────────────────────
+
+    @Test
+    fun projectStatusLabel_knownKeys() {
+        assertEquals("Draft", CrmPecMath.projectStatusLabel("draft"))
+        assertEquals("In review", CrmPecMath.projectStatusLabel("in_review"))
+        assertEquals("Underway", CrmPecMath.projectStatusLabel("underway"))
+        assertEquals("Completed", CrmPecMath.projectStatusLabel("completed"))
+        assertEquals("Deferred", CrmPecMath.projectStatusLabel("deferred"))
+    }
+
+    @Test
+    fun projectStatusLabel_unknownAndNullDegrade() {
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.projectStatusLabel(null))
+        assertEquals("On Hold", CrmPecMath.projectStatusLabel("on_hold"))
+    }
+
+    @Test
+    fun projectClassification_closedActive() {
+        assertTrue(CrmPecMath.isProjectClosed("completed"))
+        assertTrue(CrmPecMath.isProjectClosed("deferred"))
+        assertFalse(CrmPecMath.isProjectClosed("underway"))
+        assertTrue(CrmPecMath.isProjectActive("underway"))
+        assertTrue(CrmPecMath.isProjectActive("in_review"))
+        assertFalse(CrmPecMath.isProjectActive("draft"))
+    }
+
+    @Test
+    fun clampPercent_bounds() {
+        assertEquals(0, CrmPecMath.clampPercent(-10))
+        assertEquals(0, CrmPecMath.clampPercent(0))
+        assertEquals(55, CrmPecMath.clampPercent(55))
+        assertEquals(100, CrmPecMath.clampPercent(140))
+    }
+
+    // ── Event capacity ────────────────────────────────────────────────────────
+
+    @Test
+    fun capacityState_unlimitedWhenNoCap() {
+        assertEquals(CapacityState.UNLIMITED, CrmPecMath.capacityState(null, 5, null))
+        assertEquals(CapacityState.UNLIMITED, CrmPecMath.capacityState(0, 5, null))
+        assertEquals(CapacityState.UNLIMITED, CrmPecMath.capacityState(-3, 5, null))
+    }
+
+    @Test
+    fun capacityState_openAndFull() {
+        assertEquals(CapacityState.OPEN, CrmPecMath.capacityState(10, 3, 7))
+        assertEquals(CapacityState.FULL, CrmPecMath.capacityState(10, 10, 0))
+        // availableSpots absent -> derived from cap - accepted
+        assertEquals(CapacityState.OPEN, CrmPecMath.capacityState(10, 3, null))
+        assertEquals(CapacityState.FULL, CrmPecMath.capacityState(10, 12, null))
+    }
+
+    @Test
+    fun capacityLabel_formats() {
+        assertEquals("3 going", CrmPecMath.capacityLabel(null, 3))
+        assertEquals("3 / 10", CrmPecMath.capacityLabel(10, 3))
+    }
+
+    // ── Campaign labels ─────────────────────────────────────────────────────────
+
+    @Test
+    fun campaignTypeLabel_knownAndUnknown() {
+        assertEquals("Email", CrmPecMath.campaignTypeLabel("email"))
+        assertEquals("SMS", CrmPecMath.campaignTypeLabel("sms"))
+        assertEquals("Mail", CrmPecMath.campaignTypeLabel("mail"))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.campaignTypeLabel(null))
+        assertEquals("Push Notify", CrmPecMath.campaignTypeLabel("push_notify"))
+    }
+
+    @Test
+    fun campaignStatusLabel_blankDegrades() {
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.campaignStatusLabel(""))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.campaignStatusLabel(null))
+        assertEquals("In Progress", CrmPecMath.campaignStatusLabel("in_progress"))
+    }
+
+    // ── Money / rate formatting ─────────────────────────────────────────────────
+
+    @Test
+    fun formatCents_groupsAndPads() {
+        assertEquals("$0.00", CrmPecMath.formatCents(0))
+        assertEquals("$1.05", CrmPecMath.formatCents(105))
+        assertEquals("$1,234.56", CrmPecMath.formatCents(123456))
+        assertEquals("$1,000,000.00", CrmPecMath.formatCents(100_000_000))
+        assertEquals("-$1.50", CrmPecMath.formatCents(-150))
+    }
+
+    @Test
+    fun formatRate_handlesFractionAndPercentAndClamp() {
+        assertEquals("42.5%", CrmPecMath.formatRate(0.425))
+        assertEquals("50%", CrmPecMath.formatRate(0.5))
+        assertEquals("0%", CrmPecMath.formatRate(0.0))
+        // already-percent drift (> 1.0) is treated as percent
+        assertEquals("73%", CrmPecMath.formatRate(73.0))
+        // out of range clamps
+        assertEquals("100%", CrmPecMath.formatRate(250.0))
+    }
+
+    // ── Date formatting ──────────────────────────────────────────────────────────
+
+    @Test
+    fun formatDate_epochSeconds() {
+        // 2021-01-01T00:00:00Z = 1609459200
+        assertEquals("2021-01-01", CrmPecMath.formatDate(1_609_459_200L))
+        // 1970-01-01
+        assertEquals("1970-01-01", CrmPecMath.formatDate(1L))
+        // a leap-year date: 2020-02-29T12:00:00Z = 1582977600
+        assertEquals("2020-02-29", CrmPecMath.formatDate(1_582_977_600L))
+    }
+
+    @Test
+    fun formatDate_epochMillisTolerated() {
+        // same instant expressed in millis must yield the same date
+        assertEquals("2021-01-01", CrmPecMath.formatDate(1_609_459_200_000L))
+    }
+
+    @Test
+    fun formatDate_nullAndNonPositiveDegrade() {
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.formatDate(null))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.formatDate(0L))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.formatDate(-5L))
+    }
+
+    @Test
+    fun dateRange_formatsAndDegrades() {
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.dateRange(null, null))
+        assertEquals("2021-01-01 → ${CrmPecMath.EM_DASH}", CrmPecMath.dateRange(1_609_459_200L, null))
+        assertEquals("2021-01-01 → 2021-01-01", CrmPecMath.dateRange(1_609_459_200L, 1_609_459_200L))
+    }
+}


### PR DESCRIPTION
## FE parity PAR-141 - Android CRM projects/events/campaigns

Brings the Android client to web parity for the CRM projects, events, and campaigns surfaces.

### What's included
- CRM PEC (projects/events/campaigns) data layer: API, DTOs, models, repository, and math helpers.
- New Compose screens + view models for projects, events, and campaigns.
- Wiring through the CRM data module, CRM navigation, More routes, and the More catalog.
- Unit coverage for the PEC math helpers. Feature-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
