### PR TITLE
FE parity PAR-152 - Android agent memory/feedback/PR/compliance

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/data/FeedbackDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/data/FeedbackDomain.kt
@@ -37,3 +37,12 @@ data class FeedbackRequest(
     /** Only a pending request can be responded to or skipped. */
     val isPending: Boolean get() = status == FeedbackStatus.PENDING
 }
+
+/** Recent terminal output for a worker (web getTerminalLog / TerminalOutputOut). */
+data class TerminalOutput(
+    val workerId: String,
+    val output: String,
+    val charCount: Int,
+) {
+    val isEmpty: Boolean get() = output.isBlank()
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/data/FeedbackMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/data/FeedbackMappers.kt
@@ -21,3 +21,9 @@ fun FeedbackRequestDto.toDomain(): FeedbackRequest = FeedbackRequest(
     timeoutAction = timeoutAction,
     createdAt = createdAt.takeIf { it > 0 },
 )
+
+fun com.testlogon.android.core.network.agents.TerminalOutputDto.toDomain(): TerminalOutput = TerminalOutput(
+    workerId = workerId,
+    output = output,
+    charCount = charCount,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/data/FeedbackRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/data/FeedbackRepository.kt
@@ -3,6 +3,7 @@ package com.testlogon.android.feature.agents.feedback.data
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonEncodingException
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.agents.CreateFeedbackRequest
 import com.testlogon.android.core.network.agents.FeedbackApi
 import com.testlogon.android.core.network.agents.FeedbackRespondRequest
 import com.testlogon.android.core.network.error.ApiErrorParser
@@ -19,11 +20,22 @@ import javax.inject.Singleton
  * AGENTS-BASICS (web-parity) - data layer for the FEEDBACK surface over [FeedbackApi]. Folds transport into
  * [ApiResult] via [call] (HTTP -> Failure preserving status; malformed JSON -> Failure; transport -> NetworkError;
  * cancellation re-thrown). Mirrors the WORKERS repository fold. No cache / Room.
+ *
+ * [create] raises a new feedback request for a worker (web createFeedbackRequest); [terminalLog] fetches the
+ * worker's recent terminal output (web getTerminalLog). Both mutations/reads degrade to [ApiResult] like the rest.
  */
 interface FeedbackRepository {
     suspend fun list(status: String? = null): ApiResult<List<FeedbackRequest>>
+    suspend fun create(
+        workerId: String,
+        ticketId: String,
+        question: String,
+        terminalContext: String = "",
+        detectedPattern: String = "",
+    ): ApiResult<FeedbackRequest>
     suspend fun respond(workerId: String, requestId: String, text: String): ApiResult<FeedbackRequest>
     suspend fun skip(workerId: String, requestId: String): ApiResult<FeedbackRequest>
+    suspend fun terminalLog(workerId: String, chars: Int? = null): ApiResult<TerminalOutput>
 }
 
 @Singleton
@@ -37,6 +49,27 @@ class DefaultFeedbackRepository @Inject constructor(
             call { api.list(status = status).requests.map { it.toDomain() } }
         }
 
+    override suspend fun create(
+        workerId: String,
+        ticketId: String,
+        question: String,
+        terminalContext: String,
+        detectedPattern: String,
+    ): ApiResult<FeedbackRequest> =
+        withContext(Dispatchers.IO) {
+            call {
+                api.create(
+                    workerId,
+                    CreateFeedbackRequest(
+                        ticketId = ticketId,
+                        question = question,
+                        terminalContext = terminalContext,
+                        detectedPattern = detectedPattern,
+                    ),
+                ).toDomain()
+            }
+        }
+
     override suspend fun respond(workerId: String, requestId: String, text: String): ApiResult<FeedbackRequest> =
         withContext(Dispatchers.IO) {
             call { api.respond(workerId, requestId, FeedbackRespondRequest(responseText = text)).toDomain() }
@@ -44,6 +77,9 @@ class DefaultFeedbackRepository @Inject constructor(
 
     override suspend fun skip(workerId: String, requestId: String): ApiResult<FeedbackRequest> =
         withContext(Dispatchers.IO) { call { api.skip(workerId, requestId).toDomain() } }
+
+    override suspend fun terminalLog(workerId: String, chars: Int?): ApiResult<TerminalOutput> =
+        withContext(Dispatchers.IO) { call { api.terminalLog(workerId, chars).toDomain() } }
 
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
         ApiResult.Success(block())

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/ui/FeedbackScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/ui/FeedbackScreen.kt
@@ -8,17 +8,24 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.MarkChatRead
+import androidx.compose.material.icons.outlined.Terminal
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -53,10 +60,15 @@ object FeedbackTestTags {
     const val SCREEN = "agent_feedback_screen"
     const val EMPTY = "agent_feedback_empty"
     const val ERROR_RETRY = "agent_feedback_error_retry"
+    const val CREATE_FAB = "agent_feedback_create_fab"
+    const val CREATE_DIALOG = "agent_feedback_create_dialog"
+    const val CREATE_SUBMIT = "agent_feedback_create_submit"
+    const val TERMINAL_DIALOG = "agent_feedback_terminal_dialog"
     fun row(id: String) = "agent_feedback_row_$id"
     fun respondField(id: String) = "agent_feedback_respond_$id"
     fun respondSend(id: String) = "agent_feedback_send_$id"
     fun skip(id: String) = "agent_feedback_skip_$id"
+    fun terminal(id: String) = "agent_feedback_terminal_$id"
 }
 
 @Composable
@@ -66,6 +78,7 @@ fun FeedbackRoute(
     viewModel: FeedbackViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val dialogs by viewModel.dialogState.collectAsStateWithLifecycle()
     LaunchedEffect(viewModel) {
         viewModel.effects.collect { effect ->
             when (effect) {
@@ -75,22 +88,34 @@ fun FeedbackRoute(
     }
     FeedbackScreen(
         state = state,
+        dialogs = dialogs,
         onBack = onBack,
         onRefresh = viewModel::refresh,
         onRetry = viewModel::onRetry,
         onRespond = viewModel::respond,
         onSkip = viewModel::skip,
+        onOpenCreate = viewModel::openCreate,
+        onDismissCreate = viewModel::dismissCreate,
+        onSubmitCreate = viewModel::create,
+        onOpenTerminal = viewModel::openTerminal,
+        onDismissTerminal = viewModel::dismissTerminal,
     )
 }
 
 @Composable
 fun FeedbackScreen(
     state: FeedbackUiState,
+    dialogs: FeedbackDialogState,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onRetry: () -> Unit,
     onRespond: (workerId: String, requestId: String, text: String) -> Unit,
     onSkip: (workerId: String, requestId: String) -> Unit,
+    onOpenCreate: () -> Unit,
+    onDismissCreate: () -> Unit,
+    onSubmitCreate: (workerId: String, ticketId: String, question: String) -> Unit,
+    onOpenTerminal: (workerId: String) -> Unit,
+    onDismissTerminal: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -104,6 +129,12 @@ fun FeedbackScreen(
                     }
                 },
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onOpenCreate,
+                modifier = Modifier.testTag(FeedbackTestTags.CREATE_FAB),
+            ) { Icon(Icons.Outlined.Add, contentDescription = "New request") }
         },
     ) { padding ->
         val isRefreshing = (state as? FeedbackUiState.Content)?.isRefreshing == true
@@ -148,6 +179,7 @@ fun FeedbackScreen(
                                     acting = state.actioningId == req.requestId,
                                     onRespond = { text -> onRespond(req.workerId, req.requestId, text) },
                                     onSkip = { onSkip(req.workerId, req.requestId) },
+                                    onViewTerminal = { onOpenTerminal(req.workerId) },
                                 )
                             }
                         }
@@ -155,6 +187,9 @@ fun FeedbackScreen(
             }
         }
     }
+
+    dialogs.create?.let { CreateFeedbackDialog(it, onDismissCreate, onSubmitCreate) }
+    dialogs.terminal?.let { TerminalLogDialog(it, onDismissTerminal) }
 }
 
 @Composable
@@ -163,6 +198,7 @@ private fun FeedbackCard(
     acting: Boolean,
     onRespond: (String) -> Unit,
     onSkip: () -> Unit,
+    onViewTerminal: () -> Unit,
 ) {
     var draft by rememberSaveable(request.requestId) { mutableStateOf("") }
     var showContext by remember(request.requestId) { mutableStateOf(false) }
@@ -183,6 +219,12 @@ private fun FeedbackCard(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                if (request.workerId.isNotBlank()) {
+                    IconButton(
+                        onClick = onViewTerminal,
+                        modifier = Modifier.testTag(FeedbackTestTags.terminal(request.requestId)),
+                    ) { Icon(Icons.Outlined.Terminal, contentDescription = "View terminal log") }
+                }
                 AssistChip(onClick = {}, label = { Text(request.statusWire.ifBlank { "unknown" }) })
             }
             Text(text = request.question, style = MaterialTheme.typography.bodyMedium)
@@ -237,4 +279,96 @@ private fun FeedbackCard(
             }
         }
     }
+}
+
+@Composable
+private fun CreateFeedbackDialog(
+    state: CreateFeedbackState,
+    onDismiss: () -> Unit,
+    onSubmit: (workerId: String, ticketId: String, question: String) -> Unit,
+) {
+    var workerId by rememberSaveable { mutableStateOf("") }
+    var ticketId by rememberSaveable { mutableStateOf("") }
+    var question by rememberSaveable { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = { if (!state.submitting) onDismiss() },
+        modifier = Modifier.testTag(FeedbackTestTags.CREATE_DIALOG),
+        title = { Text("New feedback request") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = workerId,
+                    onValueChange = { workerId = it },
+                    label = { Text("Worker ID") },
+                    singleLine = true,
+                    enabled = !state.submitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = ticketId,
+                    onValueChange = { ticketId = it },
+                    label = { Text("Ticket ID") },
+                    singleLine = true,
+                    enabled = !state.submitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = question,
+                    onValueChange = { question = it },
+                    label = { Text("Question") },
+                    enabled = !state.submitting,
+                    minLines = 2,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (state.error != null) {
+                    Text(
+                        text = state.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            OutlinedButton(
+                onClick = { onSubmit(workerId, ticketId, question) },
+                enabled = !state.submitting &&
+                    workerId.isNotBlank() && ticketId.isNotBlank() && question.isNotBlank(),
+                modifier = Modifier.testTag(FeedbackTestTags.CREATE_SUBMIT),
+            ) {
+                if (state.submitting) {
+                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
+                } else {
+                    Text("Create")
+                }
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss, enabled = !state.submitting) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun TerminalLogDialog(state: TerminalLogState, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag(FeedbackTestTags.TERMINAL_DIALOG),
+        title = { Text("Terminal log") },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth().heightIn(max = 320.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                when {
+                    state.loading -> CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(24.dp))
+                    state.error != null ->
+                        Text(state.error, color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall)
+                    state.output == null || state.output.isEmpty ->
+                        Text("No terminal output.", style = MaterialTheme.typography.bodySmall)
+                    else -> Text(state.output.output, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+    )
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/ui/FeedbackUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/ui/FeedbackUiState.kt
@@ -1,6 +1,7 @@
 package com.testlogon.android.feature.agents.feedback.ui
 
 import com.testlogon.android.feature.agents.feedback.data.FeedbackRequest
+import com.testlogon.android.feature.agents.feedback.data.TerminalOutput
 
 /** AGENTS-BASICS (web-parity) - UI state + effect for the FEEDBACK list screen (web /agents/feedback). */
 sealed interface FeedbackUiState {
@@ -14,6 +15,29 @@ sealed interface FeedbackUiState {
     data object Empty : FeedbackUiState
     data class Error(val message: String) : FeedbackUiState
 }
+
+/**
+ * Dialog state hoisted OUTSIDE the list state so create / terminal-log work from the empty state too
+ * (the empty list is precisely where you would raise the first request). Both dialogs are closed when null.
+ */
+data class FeedbackDialogState(
+    val create: CreateFeedbackState? = null,
+    val terminal: TerminalLogState? = null,
+)
+
+/** Transient state for the create-feedback dialog (web createFeedbackRequest). */
+data class CreateFeedbackState(
+    val submitting: Boolean = false,
+    val error: String? = null,
+)
+
+/** Transient state for the per-worker terminal-log viewer (web getTerminalLog). */
+data class TerminalLogState(
+    val workerId: String,
+    val loading: Boolean = false,
+    val output: TerminalOutput? = null,
+    val error: String? = null,
+)
 
 /** One-shot effects for the feedback ViewModel. */
 sealed interface FeedbackEffect {

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/ui/FeedbackViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/feedback/ui/FeedbackViewModel.kt
@@ -19,6 +19,9 @@ import javax.inject.Inject
  * AGENTS-BASICS (web-parity) - drives the FEEDBACK list (web /agents/feedback). A single GET loads all feedback
  * requests; pull-to-refresh re-reads. Per-item respond / skip set an [actioningId] flag and re-load on success.
  * A terminal 401 -> [FeedbackEffect.NavigateToLogin]. No poll loop (the web page polls; we re-read on refresh).
+ *
+ * [dialogState] is a SEPARATE flow for the create-request + terminal-log dialogs so they work from the empty
+ * state too. [create] mirrors web createFeedbackRequest; [loadTerminal] mirrors web getTerminalLog.
  */
 @HiltViewModel
 class FeedbackViewModel @Inject constructor(
@@ -27,6 +30,9 @@ class FeedbackViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<FeedbackUiState>(FeedbackUiState.Loading)
     val uiState: StateFlow<FeedbackUiState> = _uiState.asStateFlow()
+
+    private val _dialogState = MutableStateFlow(FeedbackDialogState())
+    val dialogState: StateFlow<FeedbackDialogState> = _dialogState.asStateFlow()
 
     private val _effects = Channel<FeedbackEffect>(Channel.BUFFERED)
     val effects: Flow<FeedbackEffect> = _effects.receiveAsFlow()
@@ -78,18 +84,84 @@ class FeedbackViewModel @Inject constructor(
         _uiState.value = current.copy(actioningId = requestId, actionError = null)
         viewModelScope.launch {
             when (val result = block()) {
-                is ApiResult.Success -> when (val reload = repo.list()) {
-                    is ApiResult.Success ->
-                        _uiState.value = if (reload.data.isEmpty()) FeedbackUiState.Empty
-                        else FeedbackUiState.Content(items = reload.data)
-                    else -> clearActioning(null)
-                }
+                is ApiResult.Success -> reloadAfterAction()
                 is ApiResult.Failure -> {
                     if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(FeedbackEffect.NavigateToLogin)
                     clearActioning(result.error.message)
                 }
                 is ApiResult.NetworkError -> clearActioning(OFFLINE)
             }
+        }
+    }
+
+    // ---- Create feedback request (web createFeedbackRequest) ----
+
+    fun openCreate() { _dialogState.value = _dialogState.value.copy(create = CreateFeedbackState()) }
+
+    fun dismissCreate() { _dialogState.value = _dialogState.value.copy(create = null) }
+
+    fun create(workerId: String, ticketId: String, question: String) {
+        if (workerId.isBlank() || ticketId.isBlank() || question.isBlank()) {
+            _dialogState.value = _dialogState.value.copy(
+                create = CreateFeedbackState(error = "Worker, ticket and question are all required."),
+            )
+            return
+        }
+        val cur = _dialogState.value.create ?: CreateFeedbackState()
+        if (cur.submitting) return
+        _dialogState.value = _dialogState.value.copy(create = cur.copy(submitting = true, error = null))
+        viewModelScope.launch {
+            when (val result = repo.create(workerId.trim(), ticketId.trim(), question.trim())) {
+                is ApiResult.Success -> {
+                    _dialogState.value = _dialogState.value.copy(create = null)
+                    reloadAfterAction()
+                }
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(FeedbackEffect.NavigateToLogin)
+                    _dialogState.value = _dialogState.value.copy(
+                        create = CreateFeedbackState(error = result.error.message),
+                    )
+                }
+                is ApiResult.NetworkError ->
+                    _dialogState.value = _dialogState.value.copy(create = CreateFeedbackState(error = OFFLINE))
+            }
+        }
+    }
+
+    // ---- Terminal log (web getTerminalLog) ----
+
+    fun openTerminal(workerId: String) {
+        if (workerId.isBlank()) return
+        _dialogState.value = _dialogState.value.copy(terminal = TerminalLogState(workerId = workerId, loading = true))
+        viewModelScope.launch {
+            when (val result = repo.terminalLog(workerId)) {
+                is ApiResult.Success ->
+                    updateTerminal(workerId) { it.copy(loading = false, output = result.data, error = null) }
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(FeedbackEffect.NavigateToLogin)
+                    updateTerminal(workerId) { it.copy(loading = false, error = result.error.message) }
+                }
+                is ApiResult.NetworkError ->
+                    updateTerminal(workerId) { it.copy(loading = false, error = OFFLINE) }
+            }
+        }
+    }
+
+    fun dismissTerminal() { _dialogState.value = _dialogState.value.copy(terminal = null) }
+
+    private inline fun updateTerminal(workerId: String, transform: (TerminalLogState) -> TerminalLogState) {
+        val t = _dialogState.value.terminal
+        if (t != null && t.workerId == workerId) {
+            _dialogState.value = _dialogState.value.copy(terminal = transform(t))
+        }
+    }
+
+    private suspend fun reloadAfterAction() {
+        when (val reload = repo.list()) {
+            is ApiResult.Success ->
+                _uiState.value = if (reload.data.isEmpty()) FeedbackUiState.Empty
+                else FeedbackUiState.Content(items = reload.data)
+            else -> clearActioning(null)
         }
     }
 

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsCompletionMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsCompletionMath.kt
@@ -1,0 +1,53 @@
+package com.testlogon.android.feature.agents.prs.data
+
+/**
+ * AGENTS-BASICS (web-parity) - framework-free PURE logic for agent work-completion. No Android / coroutine deps
+ * so it is unit-testable on the JVM. Mirrors how the web CompletionResult panel summarises a WorkSummary.
+ *
+ * The backend's WorkSummary.test_results is an opaque map of label -> count (e.g. {"passed":42,"failed":0}).
+ * These helpers normalise it into a stable outcome without assuming any particular key set, degrading safely
+ * when the map is empty or contains unexpected keys.
+ */
+object PrsCompletionMath {
+
+    /** Keys (case-insensitively) treated as failing test buckets. */
+    private val FAILING_KEYS = setOf("failed", "failing", "error", "errors", "broken")
+
+    /** Sum of ALL test-result counts (negatives clamped to 0 so a bad server value can't underflow a total). */
+    fun totalTests(testResults: List<Pair<String, Int>>): Int =
+        testResults.sumOf { it.second.coerceAtLeast(0) }
+
+    /** Sum of counts under any failing-bucket key. */
+    fun failingTests(testResults: List<Pair<String, Int>>): Int =
+        testResults.filter { it.first.trim().lowercase() in FAILING_KEYS }
+            .sumOf { it.second.coerceAtLeast(0) }
+
+    /** Passing = total - failing (never negative). */
+    fun passingTests(testResults: List<Pair<String, Int>>): Int =
+        (totalTests(testResults) - failingTests(testResults)).coerceAtLeast(0)
+
+    /** True only when at least one test ran AND nothing failed. An empty map is NOT "green". */
+    fun allPassed(testResults: List<Pair<String, Int>>): Boolean =
+        totalTests(testResults) > 0 && failingTests(testResults) == 0
+
+    /**
+     * A compact human label for the completion, e.g. "3 files - 42/42 tests passed", "no tests reported".
+     * Deterministic and locale-free so it is safe to assert on in a unit test.
+     */
+    fun summaryLabel(summary: WorkSummary): String {
+        val fileCount = summary.filesChanged.size
+        val filePart = when (fileCount) {
+            0 -> "no files changed"
+            1 -> "1 file"
+            else -> "$fileCount files"
+        }
+        val total = totalTests(summary.testResults)
+        val testPart = if (total == 0) {
+            "no tests reported"
+        } else {
+            val passing = passingTests(summary.testResults)
+            "$passing/$total tests passed"
+        }
+        return "$filePart - $testPart"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsDomain.kt
@@ -35,3 +35,21 @@ data class AgentPr(
     val createdAt: Long?,
     val mergedAt: Long?,
 )
+
+/** The work-summary produced by an agent work-completion. Mirrors the web WorkSummary. */
+data class WorkSummary(
+    val ticketId: String,
+    val text: String,
+    val filesChanged: List<String>,
+    val decisions: List<String>,
+    val testResults: List<Pair<String, Int>>,
+)
+
+/** The result of completing agent work (web AgentCompletion). [pr] is null when no branch was pushed. */
+data class AgentCompletion(
+    val ticketId: String,
+    val summary: WorkSummary,
+    val pr: AgentPr?,
+    val newStatus: String,
+    val nextAgentType: String,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsMappers.kt
@@ -1,6 +1,8 @@
 package com.testlogon.android.feature.agents.prs.data
 
+import com.testlogon.android.core.network.agents.AgentCompletionDto
 import com.testlogon.android.core.network.agents.AgentPrDto
+import com.testlogon.android.core.network.agents.WorkSummaryDto
 
 /** AGENTS-BASICS (web-parity) - DTO -> domain mapper for the agent-PR surface. Epoch-0 sentinels map to null. */
 fun AgentPrDto.toDomain(): AgentPr = AgentPr(
@@ -19,4 +21,22 @@ fun AgentPrDto.toDomain(): AgentPr = AgentPr(
     statusWire = status,
     createdAt = createdAt.takeIf { it > 0 },
     mergedAt = mergedAt.takeIf { it > 0 },
+)
+
+/** DTO -> domain mapper for the agent work-summary. */
+fun WorkSummaryDto.toDomain(): WorkSummary = WorkSummary(
+    ticketId = ticketId,
+    text = text,
+    filesChanged = filesChanged,
+    decisions = decisions,
+    testResults = testResults.entries.map { it.key to it.value },
+)
+
+/** DTO -> domain mapper for a work-completion result. A null PR maps to null. */
+fun AgentCompletionDto.toDomain(): AgentCompletion = AgentCompletion(
+    ticketId = ticketId,
+    summary = summary.toDomain(),
+    pr = pr?.toDomain(),
+    newStatus = newStatus,
+    nextAgentType = nextAgentType,
 )

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/prs/data/PrsRepository.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonEncodingException
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.core.network.agents.AgentPrApi
+import com.testlogon.android.core.network.agents.AgentWorkCompleteRequest
 import com.testlogon.android.core.network.error.ApiErrorParser
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -15,12 +16,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * AGENTS-BASICS (web-parity) - READ-ONLY data layer for the agent-PR surface over [AgentPrApi]. Folds transport
- * into [ApiResult] via [call]. Mirrors the WORKERS repository fold. No cache / Room.
+ * AGENTS-BASICS (web-parity) - data layer for the agent-PR surface over [AgentPrApi]. Folds transport into
+ * [ApiResult] via [call]. Mirrors the WORKERS repository fold. No cache / Room. [complete] runs the
+ * work-completion pipeline (web completeWork) and is excluded from auto-retry by the interceptor.
  */
 interface PrsRepository {
     suspend fun list(): ApiResult<List<AgentPr>>
     suspend fun get(prId: String): ApiResult<AgentPr>
+    suspend fun complete(workerId: String, ticketId: String): ApiResult<AgentCompletion>
 }
 
 @Singleton
@@ -34,6 +37,11 @@ class DefaultPrsRepository @Inject constructor(
 
     override suspend fun get(prId: String): ApiResult<AgentPr> =
         withContext(Dispatchers.IO) { call { api.get(prId).toDomain() } }
+
+    override suspend fun complete(workerId: String, ticketId: String): ApiResult<AgentCompletion> =
+        withContext(Dispatchers.IO) {
+            call { api.complete(workerId, AgentWorkCompleteRequest(ticketId = ticketId)).toDomain() }
+        }
 
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
         ApiResult.Success(block())

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/prs/ui/PrDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/prs/ui/PrDetailScreen.kt
@@ -7,12 +7,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -32,12 +36,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.testlogon.android.core.ui.state.ErrorState
 import com.testlogon.android.core.ui.state.LoadingState
-import com.testlogon.android.feature.agents.prs.data.AgentPr
+import com.testlogon.android.feature.agents.prs.data.AgentCompletion
+import com.testlogon.android.feature.agents.prs.data.PrsCompletionMath
 
 /** AGENTS-BASICS - stable testTags for the agent-PR detail. */
 object PrDetailTestTags {
     const val SCREEN = "agent_pr_detail_screen"
     const val OPEN_PR = "agent_pr_open_external"
+    const val COMPLETE = "agent_pr_complete"
+    const val COMPLETION = "agent_pr_completion_result"
 }
 
 @Composable
@@ -54,7 +61,12 @@ fun PrDetailRoute(
             }
         }
     }
-    PrDetailScreen(state = state, onBack = onBack, onRetry = viewModel::onRetry)
+    PrDetailScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onComplete = viewModel::completeWork,
+    )
 }
 
 @Composable
@@ -62,6 +74,7 @@ fun PrDetailScreen(
     state: PrDetailUiState,
     onBack: () -> Unit,
     onRetry: () -> Unit,
+    onComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -102,13 +115,19 @@ fun PrDetailScreen(
             is PrDetailUiState.Loading -> LoadingState(modifier = Modifier.padding(padding))
             is PrDetailUiState.Error ->
                 ErrorState(modifier = Modifier.padding(padding), message = state.message, onRetry = onRetry)
-            is PrDetailUiState.Content -> PrDetailContent(pr = state.pr, modifier = Modifier.padding(padding))
+            is PrDetailUiState.Content ->
+                PrDetailContent(state = state, onComplete = onComplete, modifier = Modifier.padding(padding))
         }
     }
 }
 
 @Composable
-private fun PrDetailContent(pr: AgentPr, modifier: Modifier = Modifier) {
+private fun PrDetailContent(
+    state: PrDetailUiState.Content,
+    onComplete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val pr = state.pr
     Column(
         modifier = modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -134,6 +153,54 @@ private fun PrDetailContent(pr: AgentPr, modifier: Modifier = Modifier) {
             Text("Files changed (${pr.filesChanged.size})", style = MaterialTheme.typography.titleSmall)
             pr.filesChanged.forEach { file ->
                 Text(file, style = MaterialTheme.typography.bodySmall, modifier = Modifier.fillMaxWidth())
+            }
+        }
+        HorizontalDivider()
+        if (state.completion != null) {
+            CompletionCard(state.completion)
+        } else {
+            Button(
+                onClick = onComplete,
+                enabled = !state.completing && pr.workerId.isNotBlank() && pr.ticketId.isNotBlank(),
+                modifier = Modifier.fillMaxWidth().testTag(PrDetailTestTags.COMPLETE),
+            ) {
+                if (state.completing) {
+                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(20.dp))
+                } else {
+                    Text("Complete work")
+                }
+            }
+            if (state.completeError != null) {
+                Text(
+                    text = state.completeError,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompletionCard(completion: AgentCompletion) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(PrDetailTestTags.COMPLETION)) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text("Work completed", style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = PrsCompletionMath.summaryLabel(completion.summary),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (completion.summary.text.isNotBlank()) {
+                Text(completion.summary.text, style = MaterialTheme.typography.bodySmall)
+            }
+            if (completion.newStatus.isNotBlank()) DetailRow("New status", completion.newStatus)
+            if (completion.nextAgentType.isNotBlank()) DetailRow("Next agent", completion.nextAgentType)
+            if (completion.summary.decisions.isNotEmpty()) {
+                Text("Decisions", style = MaterialTheme.typography.labelMedium)
+                completion.summary.decisions.forEach { Text("- $it", style = MaterialTheme.typography.bodySmall) }
             }
         }
     }

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/prs/ui/PrDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/prs/ui/PrDetailViewModel.kt
@@ -18,6 +18,10 @@ import javax.inject.Inject
 /**
  * AGENTS-BASICS (web-parity) - loads a single agent-PR detail (web /agents/prs -> row). Reads the prId nav arg
  * from [SavedStateHandle]. A terminal 401 -> [PrsEffect.NavigateToLogin].
+ *
+ * [completeWork] mirrors the web completeWork action: runs the completion pipeline for the PR's
+ * (workerId, ticketId), surfacing the returned summary/new-status inline. Guarded against double-submit and
+ * only invocable once the PR detail has loaded (so workerId/ticketId are known).
  */
 @HiltViewModel
 class PrDetailViewModel @Inject constructor(
@@ -51,9 +55,47 @@ class PrDetailViewModel @Inject constructor(
 
     fun onRetry() = load()
 
+    /** Run the completion pipeline for the loaded PR. No-op unless a PR with a worker + ticket is loaded. */
+    fun completeWork() {
+        val current = _uiState.value as? PrDetailUiState.Content ?: return
+        if (current.completing || current.completion != null) return
+        val workerId = current.pr.workerId
+        val ticketId = current.pr.ticketId
+        if (workerId.isBlank() || ticketId.isBlank()) {
+            _uiState.value = current.copy(completeError = CANNOT_COMPLETE)
+            return
+        }
+        _uiState.value = current.copy(completing = true, completeError = null)
+        viewModelScope.launch {
+            when (val result = repo.complete(workerId, ticketId)) {
+                is ApiResult.Success ->
+                    (_uiState.value as? PrDetailUiState.Content)?.let {
+                        _uiState.value = it.copy(completing = false, completion = result.data, completeError = null)
+                    }
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(PrsEffect.NavigateToLogin)
+                    (_uiState.value as? PrDetailUiState.Content)?.let {
+                        _uiState.value = it.copy(completing = false, completeError = result.error.message)
+                    }
+                }
+                is ApiResult.NetworkError ->
+                    (_uiState.value as? PrDetailUiState.Content)?.let {
+                        _uiState.value = it.copy(completing = false, completeError = OFFLINE)
+                    }
+            }
+        }
+    }
+
+    fun dismissCompleteError() {
+        (_uiState.value as? PrDetailUiState.Content)?.let {
+            if (it.completeError != null) _uiState.value = it.copy(completeError = null)
+        }
+    }
+
     companion object {
         const val ARG_PR_ID = "prId"
         private const val HTTP_UNAUTHORIZED = 401
         private const val OFFLINE = "Couldn't reach the server. Tap retry."
+        private const val CANNOT_COMPLETE = "This PR has no linked worker + ticket to complete."
     }
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/prs/ui/PrsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/prs/ui/PrsUiState.kt
@@ -1,5 +1,6 @@
 package com.testlogon.android.feature.agents.prs.ui
 
+import com.testlogon.android.feature.agents.prs.data.AgentCompletion
 import com.testlogon.android.feature.agents.prs.data.AgentPr
 
 /** AGENTS-BASICS (web-parity) - UI state + effect for the agent-PR list & detail (web /agents/prs). */
@@ -12,7 +13,12 @@ sealed interface PrsListUiState {
 
 sealed interface PrDetailUiState {
     data object Loading : PrDetailUiState
-    data class Content(val pr: AgentPr) : PrDetailUiState
+    data class Content(
+        val pr: AgentPr,
+        val completing: Boolean = false,
+        val completion: AgentCompletion? = null,
+        val completeError: String? = null,
+    ) : PrDetailUiState
     data class Error(val message: String) : PrDetailUiState
 }
 

--- a/android/app/src/test/java/com/testlogon/android/feature/agents/feedback/TerminalOutputMapperTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/agents/feedback/TerminalOutputMapperTest.kt
@@ -1,0 +1,40 @@
+package com.testlogon.android.feature.agents.feedback
+
+import com.testlogon.android.core.network.agents.TerminalOutputDto
+import com.testlogon.android.feature.agents.feedback.data.toDomain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * AGENTS-BASICS - JVM tests for the TerminalOutput DTO -> domain mapper (web getTerminalLog / TerminalOutputOut),
+ * including the isEmpty convenience used by the terminal-log dialog.
+ */
+class TerminalOutputMapperTest {
+
+    @Test
+    fun mapsFields() {
+        val d = TerminalOutputDto(workerId = "w1", output = "hello\nworld", charCount = 11).toDomain()
+        assertEquals("w1", d.workerId)
+        assertEquals("hello\nworld", d.output)
+        assertEquals(11, d.charCount)
+    }
+
+    @Test
+    fun isEmpty_trueForBlankOutput() {
+        assertTrue(TerminalOutputDto(workerId = "w", output = "   ", charCount = 0).toDomain().isEmpty)
+    }
+
+    @Test
+    fun isEmpty_falseForRealOutput() {
+        assertFalse(TerminalOutputDto(workerId = "w", output = "x", charCount = 1).toDomain().isEmpty)
+    }
+
+    @Test
+    fun defaults_areEmpty() {
+        val d = TerminalOutputDto().toDomain()
+        assertEquals("", d.output)
+        assertTrue(d.isEmpty)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/agents/prs/AgentCompletionMapperTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/agents/prs/AgentCompletionMapperTest.kt
@@ -1,0 +1,68 @@
+package com.testlogon.android.feature.agents.prs
+
+import com.testlogon.android.core.network.agents.AgentCompletionDto
+import com.testlogon.android.core.network.agents.AgentPrDto
+import com.testlogon.android.core.network.agents.WorkSummaryDto
+import com.testlogon.android.feature.agents.prs.data.toDomain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * AGENTS-BASICS - JVM tests for the DTO -> domain mappers of the work-completion result (web AgentCompletion).
+ * Verifies the null-PR path, test_results map -> ordered pairs, and nested summary mapping.
+ */
+class AgentCompletionMapperTest {
+
+    @Test
+    fun completion_withNullPr_mapsPrToNull() {
+        val dto = AgentCompletionDto(
+            ticketId = "T-9",
+            summary = WorkSummaryDto(ticketId = "T-9", text = "done", filesChanged = listOf("x.kt")),
+            pr = null,
+            newStatus = "in_review",
+            nextAgentType = "reviewer",
+        )
+        val d = dto.toDomain()
+        assertNull(d.pr)
+        assertEquals("T-9", d.ticketId)
+        assertEquals("in_review", d.newStatus)
+        assertEquals("reviewer", d.nextAgentType)
+        assertEquals(listOf("x.kt"), d.summary.filesChanged)
+    }
+
+    @Test
+    fun completion_withPr_mapsPr() {
+        val dto = AgentCompletionDto(
+            ticketId = "T-9",
+            summary = WorkSummaryDto(),
+            pr = AgentPrDto(prId = "PR-1", prNumber = 42, status = "open"),
+            newStatus = "done",
+        )
+        val d = dto.toDomain()
+        assertNotNull(d.pr)
+        assertEquals("PR-1", d.pr!!.prId)
+        assertEquals(42, d.pr!!.prNumber)
+    }
+
+    @Test
+    fun workSummary_testResultsMapToPairs() {
+        val dto = WorkSummaryDto(
+            ticketId = "T-1",
+            testResults = linkedMapOf("passed" to 5, "failed" to 1),
+        )
+        val d = dto.toDomain()
+        assertEquals(2, d.testResults.size)
+        assertEquals(5, d.testResults.toMap()["passed"])
+        assertEquals(1, d.testResults.toMap()["failed"])
+    }
+
+    @Test
+    fun workSummary_defaultsAreEmpty() {
+        val d = WorkSummaryDto().toDomain()
+        assertEquals(emptyList<String>(), d.filesChanged)
+        assertEquals(emptyList<String>(), d.decisions)
+        assertEquals(0, d.testResults.size)
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/feature/agents/prs/PrsCompletionMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/agents/prs/PrsCompletionMathTest.kt
@@ -1,0 +1,93 @@
+package com.testlogon.android.feature.agents.prs
+
+import com.testlogon.android.feature.agents.prs.data.PrsCompletionMath
+import com.testlogon.android.feature.agents.prs.data.WorkSummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * AGENTS-BASICS - JVM unit tests for the PURE [PrsCompletionMath] logic (no Android / Moshi types). Covers
+ * total/failing/passing counting (with negative clamping + case-insensitive failing keys), the all-passed
+ * predicate (empty map is NOT green), and the deterministic summaryLabel choke point.
+ */
+class PrsCompletionMathTest {
+
+    private fun summary(
+        files: List<String> = emptyList(),
+        tests: List<Pair<String, Int>> = emptyList(),
+        decisions: List<String> = emptyList(),
+    ) = WorkSummary(ticketId = "T-1", text = "did work", filesChanged = files, decisions = decisions, testResults = tests)
+
+    @Test
+    fun totalTests_sumsAllBuckets() {
+        assertEquals(52, PrsCompletionMath.totalTests(listOf("passed" to 40, "failed" to 2, "skipped" to 10)))
+    }
+
+    @Test
+    fun totalTests_emptyIsZero() {
+        assertEquals(0, PrsCompletionMath.totalTests(emptyList()))
+    }
+
+    @Test
+    fun totalTests_clampsNegativeCounts() {
+        assertEquals(40, PrsCompletionMath.totalTests(listOf("passed" to 40, "weird" to -5)))
+    }
+
+    @Test
+    fun failingTests_matchesFailingKeysCaseInsensitively() {
+        val r = listOf("Passed" to 30, "FAILED" to 3, "Errors" to 2, "skipped" to 1)
+        assertEquals(5, PrsCompletionMath.failingTests(r))
+    }
+
+    @Test
+    fun failingTests_noneWhenNoFailingBuckets() {
+        assertEquals(0, PrsCompletionMath.failingTests(listOf("passed" to 10, "skipped" to 2)))
+    }
+
+    @Test
+    fun passingTests_isTotalMinusFailing() {
+        val r = listOf("passed" to 40, "failed" to 2)
+        assertEquals(40, PrsCompletionMath.passingTests(r))
+    }
+
+    @Test
+    fun passingTests_neverNegative() {
+        // failing exceeds accounted total only if keys overlap oddly; still clamps to 0
+        val r = listOf("failed" to 5)
+        assertEquals(0, PrsCompletionMath.passingTests(r))
+    }
+
+    @Test
+    fun allPassed_trueWhenTestsRanAndNoneFailed() {
+        assertTrue(PrsCompletionMath.allPassed(listOf("passed" to 12)))
+    }
+
+    @Test
+    fun allPassed_falseWhenSomethingFailed() {
+        assertFalse(PrsCompletionMath.allPassed(listOf("passed" to 12, "failed" to 1)))
+    }
+
+    @Test
+    fun allPassed_falseForEmptyMap() {
+        assertFalse(PrsCompletionMath.allPassed(emptyList()))
+    }
+
+    @Test
+    fun summaryLabel_noFilesNoTests() {
+        assertEquals("no files changed - no tests reported", PrsCompletionMath.summaryLabel(summary()))
+    }
+
+    @Test
+    fun summaryLabel_oneFileSingular() {
+        val s = summary(files = listOf("A.kt"), tests = listOf("passed" to 3))
+        assertEquals("1 file - 3/3 tests passed", PrsCompletionMath.summaryLabel(s))
+    }
+
+    @Test
+    fun summaryLabel_multipleFilesAndMixedTests() {
+        val s = summary(files = listOf("A.kt", "B.kt", "C.kt"), tests = listOf("passed" to 40, "failed" to 2))
+        assertEquals("3 files - 40/42 tests passed", PrsCompletionMath.summaryLabel(s))
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agents/AgentPrApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agents/AgentPrApi.kt
@@ -1,6 +1,8 @@
 package com.testlogon.android.core.network.agents
 
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -9,8 +11,9 @@ import retrofit2.http.Query
  * the :app repository folds these into ApiResult. Mirrors frontend/src/api/endpoints/agentPrIntegration.ts +
  * backend app/routers/agent_pr_integration.py (prefix ui/agent/pr, require_ui_session).
  *
- * This BASICS wave is READ-ONLY (list + detail): [list] and [get] are idempotent GETs. The create/complete
- * mutations + the admin ui/admin/agent/prs list (admin-gated) are intentionally out of scope for the basics.
+ * [list] and [get] are idempotent GETs. [complete] (POST ui/agent/pr/{workerId}/complete) runs the
+ * work-completion pipeline (summary + optional PR + status transition) and is a non-idempotent mutation
+ * excluded from auto-retry. The admin ui/admin/agent/prs list + status-flow config remain out of scope.
  * Paths have NO leading slash (relative to the shared authenticated Retrofit base URL).
  */
 interface AgentPrApi {
@@ -24,4 +27,10 @@ interface AgentPrApi {
 
     @GET("ui/agent/pr/{prId}")
     suspend fun get(@Path("prId") prId: String): AgentPrDto
+
+    @POST("ui/agent/pr/{workerId}/complete")
+    suspend fun complete(
+        @Path("workerId") workerId: String,
+        @Body body: AgentWorkCompleteRequest,
+    ): AgentCompletionDto
 }

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agents/AgentsBasicsDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agents/AgentsBasicsDtos.kt
@@ -215,3 +215,47 @@ data class CreateDocTemplateRequest(
     @Json(name = "template_body") val templateBody: String,
     @Json(name = "required_sections") val requiredSections: List<String> = emptyList(),
 )
+
+// ------------------------------------------------------------------ AGENT PR — WORK COMPLETION
+
+/** Body for POST ui/agent/pr/{workerId}/complete. Mirrors AgentWorkCompleteIn (ticket_id only). */
+data class AgentWorkCompleteRequest(
+    @Json(name = "ticket_id") val ticketId: String,
+)
+
+/** The work-summary embedded in a completion result. Mirrors the web WorkSummary. */
+data class WorkSummaryDto(
+    @Json(name = "ticket_id") val ticketId: String = "",
+    @Json(name = "text") val text: String = "",
+    @Json(name = "files_changed") val filesChanged: List<String> = emptyList(),
+    @Json(name = "decisions") val decisions: List<String> = emptyList(),
+    @Json(name = "test_results") val testResults: Map<String, Int> = emptyMap(),
+)
+
+/** Result of POST ui/agent/pr/{workerId}/complete. Mirrors the web AgentCompletion (pr may be null). */
+data class AgentCompletionDto(
+    @Json(name = "ticket_id") val ticketId: String = "",
+    @Json(name = "summary") val summary: WorkSummaryDto = WorkSummaryDto(),
+    @Json(name = "pr") val pr: AgentPrDto? = null,
+    @Json(name = "new_status") val newStatus: String = "",
+    @Json(name = "next_agent_type") val nextAgentType: String = "",
+)
+
+// ------------------------------------------------------------------ FEEDBACK — CREATE + TERMINAL LOG
+
+/** Body for POST ui/agent/feedback/{workerId} (create a feedback request). Mirrors CreateFeedbackRequestIn. */
+data class CreateFeedbackRequest(
+    @Json(name = "ticket_id") val ticketId: String,
+    @Json(name = "question") val question: String,
+    @Json(name = "terminal_context") val terminalContext: String = "",
+    @Json(name = "detected_pattern") val detectedPattern: String = "",
+    @Json(name = "timeout_seconds") val timeoutSeconds: Int = 14400,
+    @Json(name = "timeout_action") val timeoutAction: String = "skip",
+)
+
+/** GET ui/agent/feedback/{workerId}/terminal-log. Mirrors TerminalOutputOut. */
+data class TerminalOutputDto(
+    @Json(name = "worker_id") val workerId: String = "",
+    @Json(name = "output") val output: String = "",
+    @Json(name = "char_count") val charCount: Int = 0,
+)

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agents/FeedbackApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agents/FeedbackApi.kt
@@ -11,13 +11,27 @@ import retrofit2.http.Query
  * only; the :app repository folds these into ApiResult. Mirrors frontend/src/api/endpoints/agentFeedback.ts +
  * backend app/routers/agent_feedback.py (prefix ui/agent/feedback, require_ui_session).
  *
- * Paths have NO leading slash (relative to the shared authenticated Retrofit base URL). [list] is an idempotent
- * GET; [respond] and [skip] are non-idempotent mutations excluded from auto-retry.
+ * Paths have NO leading slash (relative to the shared authenticated Retrofit base URL). [list] and
+ * [terminalLog] are idempotent GETs; [create], [respond] and [skip] are non-idempotent mutations excluded
+ * from auto-retry. NOTE: the backend registers POST /{worker_id} (create) BEFORE the catch-all
+ * /{worker_id}/{request_id} routes, so the plain worker path is the create endpoint.
  */
 interface FeedbackApi {
 
     @GET("ui/agent/feedback")
     suspend fun list(@Query("status") status: String? = null): FeedbackListDto
+
+    @POST("ui/agent/feedback/{workerId}")
+    suspend fun create(
+        @Path("workerId") workerId: String,
+        @Body body: CreateFeedbackRequest,
+    ): FeedbackRequestDto
+
+    @GET("ui/agent/feedback/{workerId}/terminal-log")
+    suspend fun terminalLog(
+        @Path("workerId") workerId: String,
+        @Query("chars") chars: Int? = null,
+    ): TerminalOutputDto
 
     @POST("ui/agent/feedback/{workerId}/{requestId}/respond")
     suspend fun respond(


### PR DESCRIPTION
## FE parity PAR-152 - Android agent memory/feedback/PR/compliance

Brings the Android agent surfaces to parity with the web frontend across the
feedback, PR detail, and completion-math flows.

### Changes
- Feedback domain/mappers/repository + UI state/screen/viewmodel updates
- PR detail domain/mappers/repository + completion-math helper (PrsCompletionMath)
- core-network agent DTO + API alignment (AgentPrApi, AgentsBasicsDtos, FeedbackApi)
- New unit test coverage for the agent flows

Built + gated. Unit tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
