### PR TITLE
FE parity PAR-172 - Android admin email + financial-products consoles

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailApi.kt
@@ -1,0 +1,142 @@
+package com.testlogon.android.data.admin.email
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface + Moshi DTOs for the ADMIN-EMAIL management surface (router
+ * app/routers/admin_email.py, prefix `/ui/admin/email`, all `require_admin_or_root`).
+ *
+ * Mirrors the web adminEmail endpoints. This adds ONLY the parts NOT already covered by the AND-404
+ * READ-ONLY delivery dashboard (`com.testlogon.android.data.admin.MessagingDashboardApi`, which already
+ * serves `/dashboard/stats` + `/deliveries`): namely the campaign-EMAIL-TEMPLATE CRUD and the
+ * SUPPRESSED-list management (list + admin unsuppress), plus the plain `/stats` window used here for a
+ * compact header. Do NOT duplicate the AND-404 dashboard.
+ *
+ * All routes are admin-gated on the server (`require_admin_or_root`) so a non-admin gets 403; the
+ * template routes additionally `_require_campaign_templates_enabled()` -> 404 when the flag is off, so
+ * the repo degrades-on-404 (reads honest-empty). Session cookie / Bearer / X-CSRF-Token are attached by
+ * the shared interceptors; paths are relative (base URL carries the trailing slash). Timestamps are
+ * epoch-SECONDS (Long).
+ */
+interface AdminEmailApi {
+
+    // ---- Stats (compact header; days window) ----
+
+    @GET("ui/admin/email/stats")
+    suspend fun getStats(@Query("days") days: Int = DEFAULT_DAYS): EmailStatsRawDto
+
+    // ---- Suppressed list ----
+
+    @GET("ui/admin/email/suppressed")
+    suspend fun listSuppressed(@Query("limit") limit: Int = DEFAULT_LIMIT): SuppressionListDto
+
+    /** Admin override: remove an address from the suppression list. `email` is a `{email:path}` arg. */
+    @DELETE("ui/admin/email/suppressed/{email}")
+    suspend fun unsuppress(@Path("email", encoded = true) email: String): UnsuppressRespDto
+
+    // ---- Campaign email templates (CRUD) ----
+
+    @GET("ui/admin/email/campaign-templates")
+    suspend fun listTemplates(): List<CampaignTemplateDto>
+
+    @POST("ui/admin/email/campaign-templates")
+    suspend fun createTemplate(@Body body: CampaignTemplateCreateDto): CampaignTemplateDto
+
+    @PATCH("ui/admin/email/campaign-templates/{templateId}")
+    suspend fun updateTemplate(
+        @Path("templateId") templateId: String,
+        @Body body: CampaignTemplateUpdateDto,
+    ): CampaignTemplateDto
+
+    @DELETE("ui/admin/email/campaign-templates/{templateId}")
+    suspend fun deleteTemplate(@Path("templateId") templateId: String)
+
+    companion object {
+        const val DEFAULT_DAYS = 7
+        const val DEFAULT_LIMIT = 100
+    }
+}
+
+// ---- Stats DTO (get_delivery_stats shape; rates are 0-100 percentages) ----
+
+@JsonClass(generateAdapter = true)
+data class EmailStatsRawDto(
+    @Json(name = "sent") val sent: Int = 0,
+    @Json(name = "delivered") val delivered: Int = 0,
+    @Json(name = "bounced") val bounced: Int = 0,
+    @Json(name = "complained") val complained: Int = 0,
+    @Json(name = "failed") val failed: Int = 0,
+    @Json(name = "suppressed") val suppressed: Int = 0,
+    @Json(name = "total") val total: Int = 0,
+    @Json(name = "delivery_rate") val deliveryRate: Double = 0.0,
+    @Json(name = "bounce_rate") val bounceRate: Double = 0.0,
+    @Json(name = "complaint_rate") val complaintRate: Double = 0.0,
+    @Json(name = "period_days") val periodDays: Int = AdminEmailApi.DEFAULT_DAYS,
+)
+
+// ---- Suppression DTOs (SUPPRESS# item: email/reason/status/suppressed_at) ----
+
+@JsonClass(generateAdapter = true)
+data class SuppressionItemDto(
+    @Json(name = "email") val email: String? = null,
+    @Json(name = "reason") val reason: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "suppressed_at") val suppressedAt: Long? = null,
+    @Json(name = "created_at") val createdAt: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class SuppressionListDto(
+    @Json(name = "items") val items: List<SuppressionItemDto> = emptyList(),
+    @Json(name = "count") val count: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class UnsuppressRespDto(
+    @Json(name = "ok") val ok: Boolean = false,
+    @Json(name = "email") val email: String? = null,
+)
+
+// ---- Campaign template DTOs (CampaignEmailTemplateOut = base template + campaign fields) ----
+
+@JsonClass(generateAdapter = true)
+data class CampaignTemplateDto(
+    @Json(name = "template_id") val templateId: String = "",
+    @Json(name = "channel") val channel: String = "campaign",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "subject") val subject: String? = null,
+    @Json(name = "body") val body: String = "",
+    @Json(name = "variables") val variables: List<String>? = null,
+    @Json(name = "active") val active: Boolean = true,
+    @Json(name = "campaign_id") val campaignId: String? = null,
+    @Json(name = "merge_fields") val mergeFields: List<String>? = null,
+    @Json(name = "updated_at") val updatedAt: Long? = null,
+    @Json(name = "updated_by") val updatedBy: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CampaignTemplateCreateDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "subject") val subject: String,
+    @Json(name = "body") val body: String,
+    @Json(name = "campaign_id") val campaignId: String? = null,
+    @Json(name = "merge_fields") val mergeFields: List<String> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class CampaignTemplateUpdateDto(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "subject") val subject: String? = null,
+    @Json(name = "body") val body: String? = null,
+    @Json(name = "campaign_id") val campaignId: String? = null,
+    @Json(name = "merge_fields") val mergeFields: List<String>? = null,
+    @Json(name = "active") val active: Boolean? = null,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailDataModule.kt
@@ -1,0 +1,30 @@
+package com.testlogon.android.data.admin.email
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Provides [AdminEmailApi] on the shared (authenticated) Retrofit. */
+@Module
+@InstallIn(SingletonComponent::class)
+object AdminEmailApiModule {
+
+    @Provides
+    @Singleton
+    fun provideAdminEmailApi(retrofit: Retrofit): AdminEmailApi =
+        retrofit.create(AdminEmailApi::class.java)
+}
+
+/** Binds the admin-email data-layer implementation. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AdminEmailDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAdminEmailRepository(impl: AdminEmailRepositoryImpl): AdminEmailRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailDomain.kt
@@ -1,0 +1,86 @@
+package com.testlogon.android.data.admin.email
+
+/**
+ * Framework-free domain models + total DTO -> domain mappers for the ADMIN-EMAIL surface.
+ * Timestamps are epoch-seconds.
+ */
+
+data class EmailStats(
+    val sent: Int,
+    val delivered: Int,
+    val bounced: Int,
+    val complained: Int,
+    val failed: Int,
+    val suppressed: Int,
+    val total: Int,
+    val deliveryRatePercent: Double,
+    val bounceRatePercent: Double,
+    val complaintRatePercent: Double,
+    val periodDays: Int,
+) {
+    val summaryLabel: String get() = AdminEmailMath.summaryLine(sent, deliveryRatePercent)
+    val deliveryRateLabel: String get() = AdminEmailMath.formatRate(deliveryRatePercent)
+    val bounceRateLabel: String get() = AdminEmailMath.formatRate(bounceRatePercent)
+    val complaintRateLabel: String get() = AdminEmailMath.formatRate(complaintRatePercent)
+}
+
+data class SuppressedEmail(
+    val email: String,
+    val reason: String?,
+    val status: String?,
+    val suppressedAtSeconds: Long?,
+) {
+    val reasonLabel: String get() = reason?.takeIf { it.isNotBlank() } ?: "—"
+}
+
+data class CampaignTemplate(
+    val id: String,
+    val name: String,
+    val subject: String?,
+    val body: String,
+    val active: Boolean,
+    val campaignId: String?,
+    val mergeFields: List<String>,
+    val updatedAtSeconds: Long?,
+) {
+    val subjectLabel: String get() = subject?.takeIf { it.isNotBlank() } ?: "(no subject)"
+    val mergeFieldsLabel: String
+        get() = if (mergeFields.isEmpty()) "No merge fields" else mergeFields.joinToString(", ")
+}
+
+// ---- Mappers (DTO -> domain) ----
+
+internal fun EmailStatsRawDto.toDomain(): EmailStats = EmailStats(
+    sent = sent,
+    delivered = delivered,
+    bounced = bounced,
+    complained = complained,
+    failed = failed,
+    suppressed = suppressed,
+    total = total,
+    deliveryRatePercent = deliveryRate,
+    bounceRatePercent = bounceRate,
+    complaintRatePercent = complaintRate,
+    periodDays = periodDays,
+)
+
+internal fun SuppressionItemDto.toDomain(): SuppressedEmail? {
+    val addr = email?.takeIf { it.isNotBlank() } ?: return null
+    return SuppressedEmail(
+        email = addr,
+        reason = reason?.takeIf { it.isNotBlank() },
+        status = status?.takeIf { it.isNotBlank() },
+        suppressedAtSeconds = suppressedAt ?: createdAt,
+    )
+}
+
+internal fun CampaignTemplateDto.toDomain(): CampaignTemplate = CampaignTemplate(
+    id = templateId,
+    name = name.ifBlank { templateId },
+    subject = subject?.takeIf { it.isNotBlank() },
+    body = body,
+    active = active,
+    campaignId = campaignId?.takeIf { it.isNotBlank() },
+    mergeFields = mergeFields.orEmpty(),
+    updatedAtSeconds = updatedAt,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailMath.kt
@@ -1,0 +1,127 @@
+package com.testlogon.android.data.admin.email
+
+import java.util.Locale
+
+/**
+ * Framework-free pure logic for the ADMIN-EMAIL surface:
+ *  - display formatters for the delivery stats header (percentages 0-100, compact counts),
+ *  - merge-field name validation (a 1:1 mirror of the backend `CampaignEmailTemplateCreate`
+ *    `_validate_merge_fields` regex `[a-zA-Z0-9_]{1,64}`),
+ *  - campaign-template create-form validation mirroring the server field bounds.
+ *
+ * Nothing here touches Android, Retrofit or coroutines, so it is fully unit-testable on the JVM.
+ */
+object AdminEmailMath {
+
+    // Server field bounds (CampaignEmailTemplateCreate in app/models.py).
+    const val NAME_MAX = 100
+    const val SUBJECT_MAX = 200
+    const val BODY_MAX = 50_000
+    const val MERGE_FIELD_MAX = 64
+
+    private val MERGE_FIELD_RE = Regex("[a-zA-Z0-9_]{1,$MERGE_FIELD_MAX}")
+
+    /**
+     * Format a rate that the backend already expresses as a PERCENTAGE 0-100, e.g. 98.7 -> "98.7%",
+     * 100.0 -> "100%", 0.0 -> "0%". Clamps to [0, 100] and drops a trailing ".0".
+     */
+    fun formatRate(percent: Double): String {
+        if (percent.isNaN() || percent.isInfinite()) return "0%"
+        val clamped = percent.coerceIn(0.0, 100.0)
+        val rounded = Math.round(clamped * 10.0) / 10.0
+        val body = if (rounded % 1.0 == 0.0) rounded.toLong().toString()
+        else String.format(Locale.US, "%.1f", rounded)
+        return "$body%"
+    }
+
+    /** Compact count formatting (1_500 -> "1.5K", 2_000_000 -> "2M", 42 -> "42"). Negatives -> "0". */
+    fun formatCount(count: Int): String {
+        if (count <= 0) return "0"
+        return when {
+            count < 1_000 -> count.toString()
+            count < 1_000_000 -> trimTenth(count / 1_000.0) + "K"
+            else -> trimTenth(count / 1_000_000.0) + "M"
+        }
+    }
+
+    /**
+     * One-line summary of the delivery window, e.g. "1,240 sent · 98.7% delivered" for the header.
+     * Uses grouped thousands for the send volume and the delivery rate percentage.
+     */
+    fun summaryLine(sent: Int, deliveryRatePercent: Double): String {
+        val volume = groupThousands(sent.coerceAtLeast(0).toLong())
+        return "$volume sent · ${formatRate(deliveryRatePercent)} delivered"
+    }
+
+    /** True when [field] is a valid merge-field name (mirrors the backend regex). */
+    fun isValidMergeField(field: String): Boolean = MERGE_FIELD_RE.matches(field)
+
+    /**
+     * Parse a comma / whitespace separated merge-field string into a clean, de-duplicated, ordered list,
+     * returning null when ANY token is invalid (so the form can block submit with an error), or an empty
+     * list when the input is blank. Preserves first-seen order.
+     */
+    fun parseMergeFields(input: String): List<String>? {
+        val tokens = input.split(',', ' ', '\n', '\t')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+        if (tokens.isEmpty()) return emptyList()
+        val seen = LinkedHashSet<String>()
+        for (t in tokens) {
+            if (!isValidMergeField(t)) return null
+            seen.add(t)
+        }
+        return seen.toList()
+    }
+
+    /** Reasons a create-template form is not submittable (empty when valid). Mirrors server bounds. */
+    fun templateFormErrors(name: String, subject: String, body: String, mergeRaw: String): List<String> {
+        val errors = mutableListOf<String>()
+        val n = name.trim()
+        val s = subject.trim()
+        when {
+            n.isEmpty() -> errors.add("Name is required")
+            n.length > NAME_MAX -> errors.add("Name too long (max $NAME_MAX)")
+        }
+        when {
+            s.isEmpty() -> errors.add("Subject is required")
+            s.length > SUBJECT_MAX -> errors.add("Subject too long (max $SUBJECT_MAX)")
+        }
+        when {
+            body.isEmpty() -> errors.add("Body is required")
+            body.length > BODY_MAX -> errors.add("Body too long (max $BODY_MAX)")
+        }
+        if (parseMergeFields(mergeRaw) == null) errors.add("Invalid merge field name")
+        return errors
+    }
+
+    /** True when the create-template form passes all validation. */
+    fun canSubmitTemplate(name: String, subject: String, body: String, mergeRaw: String): Boolean =
+        templateFormErrors(name, subject, body, mergeRaw).isEmpty()
+
+    // ---- internal helpers ----
+
+    private fun trimTenth(v: Double): String {
+        val rounded = Math.round(v * 10.0) / 10.0
+        return if (rounded % 1.0 == 0.0) rounded.toLong().toString()
+        else String.format(Locale.US, "%.1f", rounded)
+    }
+
+    private fun groupThousands(n: Long): String {
+        val s = n.toString()
+        if (s.length <= 3) return s
+        val sb = StringBuilder()
+        val first = s.length % 3
+        if (first > 0) {
+            sb.append(s, 0, first)
+            if (s.length > first) sb.append(',')
+        }
+        var i = first
+        while (i < s.length) {
+            sb.append(s, i, i + 3)
+            if (i + 3 < s.length) sb.append(',')
+            i += 3
+        }
+        return sb.toString()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/admin/email/AdminEmailRepository.kt
@@ -1,0 +1,137 @@
+package com.testlogon.android.data.admin.email
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.data.admin.AdminRoleProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.URLEncoder
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer over [AdminEmailApi] for the ADMIN-EMAIL surface (stats + suppressed + campaign templates).
+ *
+ * Gating: reuses the AND-403 [AdminRoleProvider] client pre-check ([isAdmin]); the backend
+ * `require_admin_or_root` 403 remains the authority. Degrade-on-404: the campaign-template routes 404
+ * when the CAMPAIGN_TEMPLATES flag is off, so template reads fold a 404 into an honest-EMPTY list;
+ * mutations surface the failure so the user sees "not enabled". Every call is wrapped in [ApiResult].
+ */
+interface AdminEmailRepository {
+    fun isAdmin(): Boolean
+
+    suspend fun loadStats(days: Int = AdminEmailApi.DEFAULT_DAYS): ApiResult<EmailStats>
+    suspend fun loadSuppressed(): ApiResult<List<SuppressedEmail>>
+    suspend fun unsuppress(email: String): ApiResult<Unit>
+
+    suspend fun loadTemplates(): ApiResult<List<CampaignTemplate>>
+    suspend fun createTemplate(
+        name: String,
+        subject: String,
+        body: String,
+        mergeFields: List<String>,
+    ): ApiResult<CampaignTemplate>
+    suspend fun setTemplateActive(templateId: String, active: Boolean): ApiResult<CampaignTemplate>
+    suspend fun deleteTemplate(templateId: String): ApiResult<Unit>
+}
+
+@Singleton
+class AdminEmailRepositoryImpl @Inject constructor(
+    private val api: AdminEmailApi,
+    private val errorParser: ApiErrorParser,
+    private val roleProvider: AdminRoleProvider,
+) : AdminEmailRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override fun isAdmin(): Boolean = roleProvider.mayAttemptAdminReads()
+
+    override suspend fun loadStats(days: Int): ApiResult<EmailStats> = withContext(io) {
+        readOrDefault(EMPTY_STATS) { api.getStats(days).toDomain() }
+    }
+
+    override suspend fun loadSuppressed(): ApiResult<List<SuppressedEmail>> = withContext(io) {
+        readOrDefault(emptyList()) {
+            api.listSuppressed().items.mapNotNull { it.toDomain() }
+        }
+    }
+
+    override suspend fun unsuppress(email: String): ApiResult<Unit> = withContext(io) {
+        call {
+            api.unsuppress(URLEncoder.encode(email, "UTF-8"))
+            Unit
+        }
+    }
+
+    override suspend fun loadTemplates(): ApiResult<List<CampaignTemplate>> = withContext(io) {
+        readOrDefault(emptyList()) { api.listTemplates().map { it.toDomain() } }
+    }
+
+    override suspend fun createTemplate(
+        name: String,
+        subject: String,
+        body: String,
+        mergeFields: List<String>,
+    ): ApiResult<CampaignTemplate> = withContext(io) {
+        call {
+            api.createTemplate(
+                CampaignTemplateCreateDto(
+                    name = name.trim(),
+                    subject = subject.trim(),
+                    body = body,
+                    mergeFields = mergeFields,
+                ),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun setTemplateActive(
+        templateId: String,
+        active: Boolean,
+    ): ApiResult<CampaignTemplate> = withContext(io) {
+        call {
+            api.updateTemplate(templateId, CampaignTemplateUpdateDto(active = active)).toDomain()
+        }
+    }
+
+    override suspend fun deleteTemplate(templateId: String): ApiResult<Unit> = withContext(io) {
+        call {
+            api.deleteTemplate(templateId)
+            Unit
+        }
+    }
+
+    private suspend fun <T> readOrDefault(empty: T, block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == HTTP_NOT_FOUND) ApiResult.Success(empty) else ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private companion object {
+        private const val HTTP_NOT_FOUND = 404
+        private val EMPTY_STATS = EmailStats(0, 0, 0, 0, 0, 0, 0, 0.0, 0.0, 0.0, AdminEmailApi.DEFAULT_DAYS)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsApi.kt
@@ -1,0 +1,197 @@
+package com.testlogon.android.data.financialproducts
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface + Moshi DTOs for the CUS-004 Financial Products + Collections surface (router
+ * app/routers/financial_products.py, prefix `/ui/financial-products`, all `require_admin_or_root`).
+ *
+ * Mirrors the web `frontend/src/api/endpoints/bankCustomers.ts` (CUS-004 section). The whole router
+ * 404s unless BOTH `open_bank_project_enabled` AND `financial_products_enabled` are set (`_require_flag`),
+ * so the repo degrades-on-404 (reads honest-empty). Admin-gated: a non-admin gets 403.
+ *
+ * Route-order note (server): collections + attribute sub-routes are declared BEFORE `/{product_code}` to
+ * avoid capture; the client just calls the concrete paths. Session cookie / Bearer / X-CSRF-Token are
+ * attached by the shared interceptors; paths are relative (base URL carries the trailing slash).
+ * Timestamps are epoch-SECONDS (Long).
+ */
+interface FinancialProductsApi {
+
+    // ---- Products ----
+
+    @GET("ui/financial-products")
+    suspend fun listProducts(
+        @Query("category") category: String? = null,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int = DEFAULT_LIMIT,
+    ): FinancialProductListDto
+
+    @GET("ui/financial-products/{productCode}")
+    suspend fun getProduct(@Path("productCode") productCode: String): FinancialProductDto
+
+    @POST("ui/financial-products")
+    suspend fun createProduct(@Body body: FinancialProductCreateDto): FinancialProductDto
+
+    @PATCH("ui/financial-products/{productCode}")
+    suspend fun patchProduct(
+        @Path("productCode") productCode: String,
+        @Body body: FinancialProductPatchDto,
+    ): FinancialProductDto
+
+    // ---- Product attributes ----
+
+    @GET("ui/financial-products/{productCode}/attributes")
+    suspend fun listAttributes(@Path("productCode") productCode: String): ProductAttributeListDto
+
+    @PUT("ui/financial-products/{productCode}/attributes")
+    suspend fun setAttribute(
+        @Path("productCode") productCode: String,
+        @Body body: ProductAttributeSetDto,
+    ): ProductAttributeDto
+
+    @DELETE("ui/financial-products/{productCode}/attributes/{attributeId}")
+    suspend fun deleteAttribute(
+        @Path("productCode") productCode: String,
+        @Path("attributeId") attributeId: String,
+    )
+
+    // ---- Collections ----
+
+    @GET("ui/financial-products/collections")
+    suspend fun listCollections(
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int = DEFAULT_LIMIT,
+    ): ProductCollectionListDto
+
+    @GET("ui/financial-products/collections/{collectionCode}")
+    suspend fun getCollection(@Path("collectionCode") collectionCode: String): ProductCollectionDto
+
+    /** Upsert (PUT) a collection: create-or-replace by code. Used for the create-collection form. */
+    @PUT("ui/financial-products/collections/{collectionCode}")
+    suspend fun upsertCollection(
+        @Path("collectionCode") collectionCode: String,
+        @Body body: ProductCollectionUpsertDto,
+    ): ProductCollectionDto
+
+    @POST("ui/financial-products/collections/{collectionCode}/members")
+    suspend fun addToCollection(
+        @Path("collectionCode") collectionCode: String,
+        @Body body: ProductCollectionMemberDto,
+    ): ProductCollectionDto
+
+    @DELETE("ui/financial-products/collections/{collectionCode}/members/{productCode}")
+    suspend fun removeFromCollection(
+        @Path("collectionCode") collectionCode: String,
+        @Path("productCode") productCode: String,
+    ): ProductCollectionDto
+
+    companion object {
+        const val DEFAULT_LIMIT = 50
+    }
+}
+
+// ---- Product DTOs ----
+
+@JsonClass(generateAdapter = true)
+data class FinancialProductDto(
+    @Json(name = "product_code") val productCode: String = "",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "parent_product_code") val parentProductCode: String? = null,
+    @Json(name = "category") val category: String? = null,
+    @Json(name = "family") val family: String? = null,
+    @Json(name = "super_family") val superFamily: String? = null,
+    @Json(name = "more_info_url") val moreInfoUrl: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+    @Json(name = "version") val version: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class FinancialProductListDto(
+    @Json(name = "items") val items: List<FinancialProductDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class FinancialProductCreateDto(
+    @Json(name = "product_code") val productCode: String,
+    @Json(name = "name") val name: String,
+    @Json(name = "parent_product_code") val parentProductCode: String? = null,
+    @Json(name = "category") val category: String? = null,
+    @Json(name = "family") val family: String? = null,
+    @Json(name = "super_family") val superFamily: String? = null,
+    @Json(name = "more_info_url") val moreInfoUrl: String? = null,
+    @Json(name = "description") val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class FinancialProductPatchDto(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "parent_product_code") val parentProductCode: String? = null,
+    @Json(name = "category") val category: String? = null,
+    @Json(name = "family") val family: String? = null,
+    @Json(name = "super_family") val superFamily: String? = null,
+    @Json(name = "more_info_url") val moreInfoUrl: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "expected_version") val expectedVersion: Int,
+)
+
+// ---- Attribute DTOs ----
+
+@JsonClass(generateAdapter = true)
+data class ProductAttributeDto(
+    @Json(name = "attribute_id") val attributeId: String = "",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "type") val type: String = "",
+    @Json(name = "value") val value: String = "",
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class ProductAttributeListDto(
+    @Json(name = "attributes") val attributes: List<ProductAttributeDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class ProductAttributeSetDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "type") val type: String,
+    @Json(name = "value") val value: String,
+)
+
+// ---- Collection DTOs ----
+
+@JsonClass(generateAdapter = true)
+data class ProductCollectionDto(
+    @Json(name = "collection_code") val collectionCode: String = "",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "product_codes") val productCodes: List<String> = emptyList(),
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class ProductCollectionListDto(
+    @Json(name = "items") val items: List<ProductCollectionDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ProductCollectionUpsertDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "product_codes") val productCodes: List<String> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class ProductCollectionMemberDto(
+    @Json(name = "product_code") val productCode: String,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsDataModule.kt
@@ -1,0 +1,30 @@
+package com.testlogon.android.data.financialproducts
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Provides [FinancialProductsApi] on the shared (authenticated) Retrofit. */
+@Module
+@InstallIn(SingletonComponent::class)
+object FinancialProductsApiModule {
+
+    @Provides
+    @Singleton
+    fun provideFinancialProductsApi(retrofit: Retrofit): FinancialProductsApi =
+        retrofit.create(FinancialProductsApi::class.java)
+}
+
+/** Binds the financial-products data-layer implementation. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class FinancialProductsDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindFinancialProductsRepository(impl: FinancialProductsRepositoryImpl): FinancialProductsRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsDomain.kt
@@ -1,0 +1,73 @@
+package com.testlogon.android.data.financialproducts
+
+/**
+ * Framework-free domain models + total DTO -> domain mappers for CUS-004 Financial Products.
+ * Timestamps are epoch-seconds.
+ */
+
+data class FinancialProduct(
+    val code: String,
+    val name: String,
+    val parentCode: String?,
+    val category: String?,
+    val family: String?,
+    val superFamily: String?,
+    val description: String?,
+    val version: Int,
+    val updatedAtSeconds: Long,
+) {
+    val familyLabel: String get() = FinancialProductsMath.familyLabel(category, family, superFamily)
+}
+
+data class ProductAttribute(
+    val id: String,
+    val name: String,
+    val type: FinancialProductsMath.AttributeType?,
+    val typeRaw: String,
+    val value: String,
+) {
+    val typeLabel: String get() = type?.label ?: typeRaw
+}
+
+data class ProductCollection(
+    val code: String,
+    val name: String,
+    val productCodes: List<String>,
+    val updatedAtSeconds: Long,
+) {
+    val memberCountLabel: String
+        get() = when (val n = productCodes.size) {
+            0 -> "No products"
+            1 -> "1 product"
+            else -> "$n products"
+        }
+}
+
+// ---- Mappers (DTO -> domain) ----
+
+internal fun FinancialProductDto.toDomain(): FinancialProduct = FinancialProduct(
+    code = productCode,
+    name = name.ifBlank { productCode },
+    parentCode = parentProductCode?.takeIf { it.isNotBlank() },
+    category = category?.takeIf { it.isNotBlank() },
+    family = family?.takeIf { it.isNotBlank() },
+    superFamily = superFamily?.takeIf { it.isNotBlank() },
+    description = description?.takeIf { it.isNotBlank() },
+    version = version,
+    updatedAtSeconds = updatedAt,
+)
+
+internal fun ProductAttributeDto.toDomain(): ProductAttribute = ProductAttribute(
+    id = attributeId,
+    name = name,
+    type = FinancialProductsMath.AttributeType.from(type),
+    typeRaw = type,
+    value = value,
+)
+
+internal fun ProductCollectionDto.toDomain(): ProductCollection = ProductCollection(
+    code = collectionCode,
+    name = name.ifBlank { collectionCode },
+    productCodes = productCodes,
+    updatedAtSeconds = updatedAt,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsMath.kt
@@ -1,0 +1,118 @@
+package com.testlogon.android.data.financialproducts
+
+/**
+ * Framework-free pure logic for the CUS-004 Financial Products surface:
+ *  - the product-code pattern gate (a 1:1 mirror of the backend `FinancialProductCreateIn.product_code`
+ *    regex `^[a-zA-Z0-9_\-]{1,64}$`),
+ *  - attribute-type enumeration + typed VALUE validation (mirrors `ProductAttributeSetIn.type`
+ *    `Literal["STRING","INTEGER","DOUBLE","DATE_WITH_DAY"]` and the 2048-char value cap),
+ *  - create-form validators used to gate submit.
+ *
+ * Nothing here touches Android, Retrofit or coroutines, so it is fully unit-testable on the JVM.
+ */
+object FinancialProductsMath {
+
+    const val PRODUCT_CODE_MAX = 64
+    const val ATTRIBUTE_VALUE_MAX = 2048
+
+    private val PRODUCT_CODE_RE = Regex("[a-zA-Z0-9_\\-]{1,$PRODUCT_CODE_MAX}")
+    private val DATE_RE = Regex("\\d{4}-\\d{2}-\\d{2}")
+
+    /** The server-supported attribute value types (mirrors the backend Literal). */
+    enum class AttributeType(val wire: String, val label: String) {
+        STRING("STRING", "Text"),
+        INTEGER("INTEGER", "Integer"),
+        DOUBLE("DOUBLE", "Decimal"),
+        DATE_WITH_DAY("DATE_WITH_DAY", "Date");
+
+        companion object {
+            val ALL: List<AttributeType> = entries
+
+            fun from(raw: String?): AttributeType? = when (raw?.uppercase()) {
+                "STRING" -> STRING
+                "INTEGER" -> INTEGER
+                "DOUBLE" -> DOUBLE
+                "DATE_WITH_DAY" -> DATE_WITH_DAY
+                else -> null
+            }
+        }
+    }
+
+    /** True when [code] matches the backend product-code pattern (alnum + `_` + `-`, 1..64). */
+    fun isValidProductCode(code: String): Boolean = PRODUCT_CODE_RE.matches(code)
+
+    /**
+     * True when [value] is a valid literal for the attribute [type] and within the length cap.
+     * STRING accepts anything non-empty (<= cap); INTEGER a signed integer; DOUBLE a finite number;
+     * DATE_WITH_DAY an ISO `YYYY-MM-DD` date. Blank is always invalid (server requires a value).
+     */
+    fun isValidAttributeValue(type: AttributeType, value: String): Boolean {
+        val trimmed = value.trim()
+        if (trimmed.isEmpty() || trimmed.length > ATTRIBUTE_VALUE_MAX) return false
+        return when (type) {
+            AttributeType.STRING -> true
+            AttributeType.INTEGER -> trimmed.toLongOrNull() != null
+            AttributeType.DOUBLE -> trimmed.toDoubleOrNull()?.let { it.isFinite() } == true
+            AttributeType.DATE_WITH_DAY -> isValidIsoDate(trimmed)
+        }
+    }
+
+    /** ISO `YYYY-MM-DD` with real month/day ranges (no full calendar check; matches the web widget). */
+    fun isValidIsoDate(value: String): Boolean {
+        if (!DATE_RE.matches(value)) return false
+        val month = value.substring(5, 7).toIntOrNull() ?: return false
+        val day = value.substring(8, 10).toIntOrNull() ?: return false
+        return month in 1..12 && day in 1..31
+    }
+
+    /** Reasons a create-product form is not submittable (empty when valid). */
+    fun productFormErrors(productCode: String, name: String): List<String> {
+        val errors = mutableListOf<String>()
+        val code = productCode.trim()
+        when {
+            code.isEmpty() -> errors.add("Product code is required")
+            !isValidProductCode(code) -> errors.add("Invalid product code (a-z, 0-9, _ , -; max $PRODUCT_CODE_MAX)")
+        }
+        if (name.trim().isEmpty()) errors.add("Name is required")
+        return errors
+    }
+
+    fun canSubmitProduct(productCode: String, name: String): Boolean =
+        productFormErrors(productCode, name).isEmpty()
+
+    /** Reasons a create-collection form is not submittable (empty when valid). */
+    fun collectionFormErrors(collectionCode: String, name: String): List<String> {
+        val errors = mutableListOf<String>()
+        val code = collectionCode.trim()
+        when {
+            code.isEmpty() -> errors.add("Collection code is required")
+            !isValidProductCode(code) -> errors.add("Invalid collection code (a-z, 0-9, _ , -; max $PRODUCT_CODE_MAX)")
+        }
+        if (name.trim().isEmpty()) errors.add("Name is required")
+        return errors
+    }
+
+    fun canSubmitCollection(collectionCode: String, name: String): Boolean =
+        collectionFormErrors(collectionCode, name).isEmpty()
+
+    /** Reasons a set-attribute form is not submittable (empty when valid). */
+    fun attributeFormErrors(name: String, type: AttributeType, value: String): List<String> {
+        val errors = mutableListOf<String>()
+        if (name.trim().isEmpty()) errors.add("Attribute name is required")
+        if (!isValidAttributeValue(type, value)) errors.add("Value is not a valid ${type.label}")
+        return errors
+    }
+
+    fun canSubmitAttribute(name: String, type: AttributeType, value: String): Boolean =
+        attributeFormErrors(name, type, value).isEmpty()
+
+    /** Human label for a product's family chain (e.g. "Deposits › Savings"), or "—" when empty. */
+    fun familyLabel(category: String?, family: String?, superFamily: String?): String {
+        val parts = listOfNotNull(
+            superFamily?.takeIf { it.isNotBlank() },
+            family?.takeIf { it.isNotBlank() },
+            category?.takeIf { it.isNotBlank() },
+        )
+        return if (parts.isEmpty()) "—" else parts.joinToString(" › ")
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/financialproducts/FinancialProductsRepository.kt
@@ -1,0 +1,156 @@
+package com.testlogon.android.data.financialproducts
+
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.data.admin.AdminRoleProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data layer over [FinancialProductsApi] for CUS-004 Financial Products + Collections.
+ *
+ * Gating: reuses the AND-403 [AdminRoleProvider] client pre-check ([isAdmin]); the backend
+ * `require_admin_or_root` 403 is the authority. Degrade-on-404: the whole router 404s when the OBP /
+ * financial-products flags are off, so reads fold a 404 into honest-EMPTY; mutations surface the failure
+ * so the user sees "not enabled". Every call is wrapped in [ApiResult].
+ */
+interface FinancialProductsRepository {
+    fun isAdmin(): Boolean
+
+    suspend fun loadProducts(): ApiResult<List<FinancialProduct>>
+    suspend fun createProduct(
+        productCode: String,
+        name: String,
+        category: String?,
+        description: String?,
+    ): ApiResult<FinancialProduct>
+
+    suspend fun loadAttributes(productCode: String): ApiResult<List<ProductAttribute>>
+    suspend fun setAttribute(
+        productCode: String,
+        name: String,
+        type: FinancialProductsMath.AttributeType,
+        value: String,
+    ): ApiResult<ProductAttribute>
+    suspend fun deleteAttribute(productCode: String, attributeId: String): ApiResult<Unit>
+
+    suspend fun loadCollections(): ApiResult<List<ProductCollection>>
+    suspend fun createCollection(
+        collectionCode: String,
+        name: String,
+        productCodes: List<String>,
+    ): ApiResult<ProductCollection>
+}
+
+@Singleton
+class FinancialProductsRepositoryImpl @Inject constructor(
+    private val api: FinancialProductsApi,
+    private val errorParser: ApiErrorParser,
+    private val roleProvider: AdminRoleProvider,
+) : FinancialProductsRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override fun isAdmin(): Boolean = roleProvider.mayAttemptAdminReads()
+
+    override suspend fun loadProducts(): ApiResult<List<FinancialProduct>> = withContext(io) {
+        readOrEmpty(emptyList()) { api.listProducts().items.map { it.toDomain() } }
+    }
+
+    override suspend fun createProduct(
+        productCode: String,
+        name: String,
+        category: String?,
+        description: String?,
+    ): ApiResult<FinancialProduct> = withContext(io) {
+        call {
+            api.createProduct(
+                FinancialProductCreateDto(
+                    productCode = productCode.trim(),
+                    name = name.trim(),
+                    category = category?.trim()?.takeIf { it.isNotEmpty() },
+                    description = description?.trim()?.takeIf { it.isNotEmpty() },
+                ),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun loadAttributes(productCode: String): ApiResult<List<ProductAttribute>> =
+        withContext(io) {
+            readOrEmpty(emptyList()) { api.listAttributes(productCode).attributes.map { it.toDomain() } }
+        }
+
+    override suspend fun setAttribute(
+        productCode: String,
+        name: String,
+        type: FinancialProductsMath.AttributeType,
+        value: String,
+    ): ApiResult<ProductAttribute> = withContext(io) {
+        call {
+            api.setAttribute(
+                productCode,
+                ProductAttributeSetDto(name = name.trim(), type = type.wire, value = value.trim()),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun deleteAttribute(productCode: String, attributeId: String): ApiResult<Unit> =
+        withContext(io) {
+            call {
+                api.deleteAttribute(productCode, attributeId)
+                Unit
+            }
+        }
+
+    override suspend fun loadCollections(): ApiResult<List<ProductCollection>> = withContext(io) {
+        readOrEmpty(emptyList()) { api.listCollections().items.map { it.toDomain() } }
+    }
+
+    override suspend fun createCollection(
+        collectionCode: String,
+        name: String,
+        productCodes: List<String>,
+    ): ApiResult<ProductCollection> = withContext(io) {
+        call {
+            api.upsertCollection(
+                collectionCode.trim(),
+                ProductCollectionUpsertDto(name = name.trim(), productCodes = productCodes),
+            ).toDomain()
+        }
+    }
+
+    private suspend fun <T> readOrEmpty(empty: T, block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == HTTP_NOT_FOUND) ApiResult.Success(empty) else ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: com.squareup.moshi.JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    private companion object {
+        private const val HTTP_NOT_FOUND = 404
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/adminemail/AdminEmailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminemail/AdminEmailScreen.kt
@@ -1,0 +1,361 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.adminemail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.admin.email.CampaignTemplate
+import com.testlogon.android.data.admin.email.EmailStats
+import com.testlogon.android.data.admin.email.SuppressedEmail
+
+object AdminEmailTestTags {
+    const val SCREEN = "admin_email_screen"
+    const val LOADING = "admin_email_loading"
+    const val EMPTY = "admin_email_empty"
+    const val ERROR = "admin_email_error"
+    const val OFFLINE = "admin_email_offline"
+    const val FORBIDDEN = "admin_email_forbidden"
+    const val FAB = "admin_email_fab"
+    const val TAB_PREFIX = "admin_email_tab_"
+    const val TEMPLATE_PREFIX = "admin_email_template_"
+    const val SUPPRESSED_PREFIX = "admin_email_suppressed_"
+    const val CREATE_FORM = "admin_email_create_form"
+    const val CREATE_SUBMIT = "admin_email_create_submit"
+}
+
+@Composable
+fun AdminEmailRoute(
+    onBack: () -> Unit,
+    onSessionExpired: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AdminEmailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is AdminEmailEffect.ShowMessage ->
+                    snackbarHostState.showSnackbar(context.getString(effect.resId))
+                is AdminEmailEffect.ShowText ->
+                    snackbarHostState.showSnackbar(effect.text)
+            }
+        }
+    }
+    LaunchedEffect(state.phase) {
+        if (state.phase == AdminEmailUiState.Phase.SessionExpired) onSessionExpired()
+    }
+
+    AdminEmailScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onSelectTab = viewModel::onSelectTab,
+        onOpenCreateTemplate = viewModel::onOpenCreateTemplate,
+        onDismissCreateTemplate = viewModel::onDismissCreateTemplate,
+        onTemplateNameChange = viewModel::onTemplateNameChange,
+        onTemplateSubjectChange = viewModel::onTemplateSubjectChange,
+        onTemplateBodyChange = viewModel::onTemplateBodyChange,
+        onTemplateMergeFieldsChange = viewModel::onTemplateMergeFieldsChange,
+        onSubmitCreateTemplate = viewModel::onSubmitCreateTemplate,
+        onDeactivateTemplate = viewModel::onDeactivateTemplate,
+        onUnsuppress = viewModel::onUnsuppress,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun AdminEmailScreen(
+    state: AdminEmailUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onSelectTab: (AdminEmailTab) -> Unit,
+    onOpenCreateTemplate: () -> Unit,
+    onDismissCreateTemplate: () -> Unit,
+    onTemplateNameChange: (String) -> Unit,
+    onTemplateSubjectChange: (String) -> Unit,
+    onTemplateBodyChange: (String) -> Unit,
+    onTemplateMergeFieldsChange: (String) -> Unit,
+    onSubmitCreateTemplate: () -> Unit,
+    onDeactivateTemplate: (CampaignTemplate) -> Unit,
+    onUnsuppress: (SuppressedEmail) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(AdminEmailTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Email admin") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            if (state.phase == AdminEmailUiState.Phase.Content && state.tab == AdminEmailTab.TEMPLATES) {
+                Button(onClick = onOpenCreateTemplate, modifier = Modifier.testTag(AdminEmailTestTags.FAB)) {
+                    Icon(Icons.Outlined.Add, contentDescription = null)
+                    Text("New template")
+                }
+            }
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            if (state.phase == AdminEmailUiState.Phase.Content) {
+                state.stats?.let { StatsHeader(it) }
+                TabRow(selectedTabIndex = state.tab.ordinal) {
+                    AdminEmailTab.entries.forEach { tab ->
+                        Tab(
+                            selected = state.tab == tab,
+                            onClick = { onSelectTab(tab) },
+                            text = { Text(tab.label) },
+                            modifier = Modifier.testTag(AdminEmailTestTags.TAB_PREFIX + tab.name),
+                        )
+                    }
+                }
+            }
+
+            when (state.phase) {
+                AdminEmailUiState.Phase.Loading ->
+                    LoadingState(modifier = Modifier.testTag(AdminEmailTestTags.LOADING))
+                AdminEmailUiState.Phase.Forbidden ->
+                    EmptyState(
+                        title = "Admins only",
+                        body = "You do not have access to email administration.",
+                        imageVector = Icons.Outlined.Lock,
+                        modifier = Modifier.testTag(AdminEmailTestTags.FORBIDDEN),
+                    )
+                AdminEmailUiState.Phase.Error ->
+                    ErrorState(
+                        message = "Something went wrong.",
+                        onRetry = onRetry,
+                        modifier = Modifier.testTag(AdminEmailTestTags.ERROR),
+                    )
+                AdminEmailUiState.Phase.Offline ->
+                    OfflineBanner(onRetry = onRetry, modifier = Modifier.testTag(AdminEmailTestTags.OFFLINE))
+                AdminEmailUiState.Phase.SessionExpired -> Unit
+                AdminEmailUiState.Phase.Content ->
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = onRefresh,
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        TabContent(
+                            state = state,
+                            onDeactivateTemplate = onDeactivateTemplate,
+                            onUnsuppress = onUnsuppress,
+                        )
+                    }
+            }
+        }
+    }
+
+    if (state.createTemplate.isOpen) {
+        CreateTemplateDialog(
+            form = state.createTemplate,
+            onDismiss = onDismissCreateTemplate,
+            onNameChange = onTemplateNameChange,
+            onSubjectChange = onTemplateSubjectChange,
+            onBodyChange = onTemplateBodyChange,
+            onMergeFieldsChange = onTemplateMergeFieldsChange,
+            onSubmit = onSubmitCreateTemplate,
+        )
+    }
+}
+
+@Composable
+private fun StatsHeader(stats: EmailStats) {
+    Card(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                "Last ${stats.periodDays} days",
+                style = MaterialTheme.typography.labelMedium,
+            )
+            Text(stats.summaryLabel, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                "Bounce ${stats.bounceRateLabel} · Complaint ${stats.complaintRateLabel}",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TabContent(
+    state: AdminEmailUiState,
+    onDeactivateTemplate: (CampaignTemplate) -> Unit,
+    onUnsuppress: (SuppressedEmail) -> Unit,
+) {
+    if (state.isEmptyForTab) {
+        val (title, body) = when (state.tab) {
+            AdminEmailTab.TEMPLATES -> "No campaign templates" to "Create a template to reuse in campaigns."
+            AdminEmailTab.SUPPRESSED -> "No suppressed addresses" to "Bounced/complained recipients appear here."
+        }
+        EmptyState(title = title, body = body, modifier = Modifier.testTag(AdminEmailTestTags.EMPTY))
+        return
+    }
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        when (state.tab) {
+            AdminEmailTab.TEMPLATES -> items(state.templates, key = { it.id }) { t ->
+                TemplateCard(t, busy = state.busyId == t.id, onDeactivate = onDeactivateTemplate)
+            }
+            AdminEmailTab.SUPPRESSED -> items(state.suppressed, key = { it.email }) { s ->
+                SuppressedCard(s, busy = state.busyId == s.email, onUnsuppress = onUnsuppress)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TemplateCard(
+    template: CampaignTemplate,
+    busy: Boolean,
+    onDeactivate: (CampaignTemplate) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(AdminEmailTestTags.TEMPLATE_PREFIX + template.id)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(template.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(template.subjectLabel, style = MaterialTheme.typography.bodyMedium)
+            Text(template.mergeFieldsLabel, style = MaterialTheme.typography.bodySmall)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AssistChip(onClick = {}, label = { Text(if (template.active) "active" else "inactive") })
+                if (template.active) {
+                    OutlinedButton(onClick = { onDeactivate(template) }, enabled = !busy) { Text("Deactivate") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuppressedCard(
+    entry: SuppressedEmail,
+    busy: Boolean,
+    onUnsuppress: (SuppressedEmail) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(AdminEmailTestTags.SUPPRESSED_PREFIX + entry.email)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(entry.email, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(entry.reasonLabel, style = MaterialTheme.typography.bodySmall)
+            OutlinedButton(onClick = { onUnsuppress(entry) }, enabled = !busy) { Text("Unsuppress") }
+        }
+    }
+}
+
+@Composable
+private fun CreateTemplateDialog(
+    form: CreateTemplateFormState,
+    onDismiss: () -> Unit,
+    onNameChange: (String) -> Unit,
+    onSubjectChange: (String) -> Unit,
+    onBodyChange: (String) -> Unit,
+    onMergeFieldsChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(modifier = Modifier.testTag(AdminEmailTestTags.CREATE_FORM)) {
+            Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("New campaign template", style = MaterialTheme.typography.titleLarge)
+                OutlinedTextField(
+                    value = form.name,
+                    onValueChange = onNameChange,
+                    label = { Text("Name") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.subject,
+                    onValueChange = onSubjectChange,
+                    label = { Text("Subject") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.body,
+                    onValueChange = onBodyChange,
+                    label = { Text("Body") },
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.mergeFields,
+                    onValueChange = onMergeFieldsChange,
+                    label = { Text("Merge fields (comma separated)") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.align(Alignment.End)) {
+                    TextButton(onClick = onDismiss, enabled = !form.isSubmitting) { Text("Cancel") }
+                    Button(
+                        onClick = onSubmit,
+                        enabled = form.canSubmit,
+                        modifier = Modifier.testTag(AdminEmailTestTags.CREATE_SUBMIT),
+                    ) { Text("Create") }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/adminemail/AdminEmailUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminemail/AdminEmailUiState.kt
@@ -1,0 +1,54 @@
+package com.testlogon.android.feature.adminemail
+
+import androidx.annotation.StringRes
+import com.testlogon.android.data.admin.email.AdminEmailMath
+import com.testlogon.android.data.admin.email.CampaignTemplate
+import com.testlogon.android.data.admin.email.EmailStats
+import com.testlogon.android.data.admin.email.SuppressedEmail
+
+/** Top-level tabs of the admin-email hub (templates / suppressed). Stats render as a header on both. */
+enum class AdminEmailTab(val label: String) {
+    TEMPLATES("Templates"),
+    SUPPRESSED("Suppressed"),
+}
+
+/** Render-ready state for the admin-email management hub. */
+data class AdminEmailUiState(
+    val phase: Phase = Phase.Loading,
+    val tab: AdminEmailTab = AdminEmailTab.TEMPLATES,
+    val stats: EmailStats? = null,
+    val templates: List<CampaignTemplate> = emptyList(),
+    val suppressed: List<SuppressedEmail> = emptyList(),
+    val isRefreshing: Boolean = false,
+    val busyId: String? = null,
+    val createTemplate: CreateTemplateFormState = CreateTemplateFormState(),
+) {
+    enum class Phase { Loading, Content, Forbidden, SessionExpired, Error, Offline }
+
+    val isEmptyForTab: Boolean
+        get() = when (tab) {
+            AdminEmailTab.TEMPLATES -> templates.isEmpty()
+            AdminEmailTab.SUPPRESSED -> suppressed.isEmpty()
+        }
+}
+
+/** Create-campaign-template form. Mirrors the backend field bounds via [AdminEmailMath]. */
+data class CreateTemplateFormState(
+    val isOpen: Boolean = false,
+    val name: String = "",
+    val subject: String = "",
+    val body: String = "",
+    val mergeFields: String = "",
+    val isSubmitting: Boolean = false,
+) {
+    val validationErrors: List<String>
+        get() = AdminEmailMath.templateFormErrors(name, subject, body, mergeFields)
+    val canSubmit: Boolean
+        get() = !isSubmitting && validationErrors.isEmpty()
+}
+
+/** One-shot side effects. */
+sealed interface AdminEmailEffect {
+    data class ShowMessage(@StringRes val resId: Int) : AdminEmailEffect
+    data class ShowText(val text: String) : AdminEmailEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/adminemail/AdminEmailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/adminemail/AdminEmailViewModel.kt
@@ -1,0 +1,198 @@
+package com.testlogon.android.feature.adminemail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.R
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.admin.email.AdminEmailMath
+import com.testlogon.android.data.admin.email.AdminEmailRepository
+import com.testlogon.android.data.admin.email.CampaignTemplate
+import com.testlogon.android.data.admin.email.SuppressedEmail
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives [AdminEmailUiState] from [AdminEmailRepository]. Loads stats + campaign templates + the
+ * suppressed list on first composition + pull-to-refresh. Templates support create + deactivate;
+ * suppressed entries support admin unsuppress. Gating: a verified non-admin -> Forbidden with NO
+ * network calls (client pre-check); the backend 403 is authoritative. Degrade-on-404: template reads
+ * fold to honest-empty when the flag is off, mutations surface errors.
+ */
+@HiltViewModel
+class AdminEmailViewModel @Inject constructor(
+    private val repository: AdminEmailRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AdminEmailUiState())
+    val uiState: StateFlow<AdminEmailUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<AdminEmailEffect>(Channel.BUFFERED)
+    val effects: Flow<AdminEmailEffect> = _effects.receiveAsFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onResumed() = load(fromUser = false, force = true)
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    fun onSelectTab(tab: AdminEmailTab) {
+        if (_uiState.value.tab == tab) return
+        _uiState.update { it.copy(tab = tab) }
+    }
+
+    // ---- create template ----
+    fun onOpenCreateTemplate() =
+        _uiState.update { it.copy(createTemplate = CreateTemplateFormState(isOpen = true)) }
+
+    fun onDismissCreateTemplate() {
+        if (_uiState.value.createTemplate.isSubmitting) return
+        _uiState.update { it.copy(createTemplate = CreateTemplateFormState(isOpen = false)) }
+    }
+
+    fun onTemplateNameChange(v: String) =
+        _uiState.update { it.copy(createTemplate = it.createTemplate.copy(name = v)) }
+    fun onTemplateSubjectChange(v: String) =
+        _uiState.update { it.copy(createTemplate = it.createTemplate.copy(subject = v)) }
+    fun onTemplateBodyChange(v: String) =
+        _uiState.update { it.copy(createTemplate = it.createTemplate.copy(body = v)) }
+    fun onTemplateMergeFieldsChange(v: String) =
+        _uiState.update { it.copy(createTemplate = it.createTemplate.copy(mergeFields = v)) }
+
+    fun onSubmitCreateTemplate() {
+        val form = _uiState.value.createTemplate
+        val merge = AdminEmailMath.parseMergeFields(form.mergeFields)
+        if (!form.canSubmit || merge == null) return
+        _uiState.update { it.copy(createTemplate = it.createTemplate.copy(isSubmitting = true)) }
+        viewModelScope.launch {
+            when (val r = repository.createTemplate(form.name, form.subject, form.body, merge)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createTemplate = CreateTemplateFormState(isOpen = false)) }
+                    _effects.send(AdminEmailEffect.ShowMessage(R.string.admin_email_template_created))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> {
+                    _uiState.update { it.copy(createTemplate = it.createTemplate.copy(isSubmitting = false)) }
+                    handleMutationFailure(r.error.status, r.error.message)
+                }
+                is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(createTemplate = it.createTemplate.copy(isSubmitting = false)) }
+                    _effects.send(AdminEmailEffect.ShowMessage(R.string.admin_email_action_failed))
+                }
+            }
+        }
+    }
+
+    fun onDeactivateTemplate(template: CampaignTemplate) {
+        if (_uiState.value.busyId != null) return
+        _uiState.update { it.copy(busyId = template.id) }
+        viewModelScope.launch {
+            val r = repository.deleteTemplate(template.id)
+            _uiState.update { it.copy(busyId = null) }
+            when (r) {
+                is ApiResult.Success -> {
+                    _effects.send(AdminEmailEffect.ShowMessage(R.string.admin_email_template_deactivated))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> handleMutationFailure(r.error.status, r.error.message)
+                is ApiResult.NetworkError ->
+                    _effects.send(AdminEmailEffect.ShowMessage(R.string.admin_email_action_failed))
+            }
+        }
+    }
+
+    // ---- unsuppress ----
+    fun onUnsuppress(entry: SuppressedEmail) {
+        if (_uiState.value.busyId != null) return
+        _uiState.update { it.copy(busyId = entry.email) }
+        viewModelScope.launch {
+            val r = repository.unsuppress(entry.email)
+            _uiState.update { it.copy(busyId = null) }
+            when (r) {
+                is ApiResult.Success -> {
+                    _effects.send(AdminEmailEffect.ShowMessage(R.string.admin_email_unsuppressed))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> handleMutationFailure(r.error.status, r.error.message)
+                is ApiResult.NetworkError ->
+                    _effects.send(AdminEmailEffect.ShowMessage(R.string.admin_email_action_failed))
+            }
+        }
+    }
+
+    private suspend fun handleMutationFailure(status: Int, message: String) {
+        when (status) {
+            HTTP_UNAUTHORIZED -> _uiState.update { it.copy(phase = AdminEmailUiState.Phase.SessionExpired) }
+            HTTP_FORBIDDEN -> _uiState.update { it.copy(phase = AdminEmailUiState.Phase.Forbidden) }
+            else -> _effects.send(AdminEmailEffect.ShowText(message))
+        }
+    }
+
+    // ---- load ----
+    private fun load(fromUser: Boolean, force: Boolean = false) {
+        val hasContent = _uiState.value.phase == AdminEmailUiState.Phase.Content
+        if (_uiState.value.isRefreshing && !force) return
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent && !force) it.phase else AdminEmailUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            // Client-side role pre-check: a verified non-admin emits Forbidden with ZERO network calls.
+            if (!repository.isAdmin()) {
+                _uiState.update { it.copy(phase = AdminEmailUiState.Phase.Forbidden, isRefreshing = false) }
+                return@launch
+            }
+
+            val statsR = repository.loadStats()
+            val templatesR = repository.loadTemplates()
+            val suppressedR = repository.loadSuppressed()
+            val results = listOf(statsR, templatesR, suppressedR)
+
+            if (results.any { it is ApiResult.Failure && it.error.status == HTTP_FORBIDDEN }) {
+                _uiState.update { it.copy(phase = AdminEmailUiState.Phase.Forbidden, isRefreshing = false) }
+                return@launch
+            }
+            if (results.any { it is ApiResult.Failure && it.error.status == HTTP_UNAUTHORIZED }) {
+                _uiState.update { it.copy(phase = AdminEmailUiState.Phase.SessionExpired, isRefreshing = false) }
+                return@launch
+            }
+
+            val anyNetworkError = results.any { it is ApiResult.NetworkError }
+            val stats = (statsR as? ApiResult.Success)?.data
+            val templates = (templatesR as? ApiResult.Success)?.data.orEmpty()
+            val suppressed = (suppressedR as? ApiResult.Success)?.data.orEmpty()
+            val allFailed = results.none { it is ApiResult.Success }
+            val phase = when {
+                allFailed && anyNetworkError -> AdminEmailUiState.Phase.Offline
+                allFailed -> AdminEmailUiState.Phase.Error
+                else -> AdminEmailUiState.Phase.Content
+            }
+
+            _uiState.update {
+                it.copy(
+                    phase = phase,
+                    stats = stats ?: it.stats,
+                    templates = templates,
+                    suppressed = suppressed,
+                    isRefreshing = false,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/financialproducts/FinancialProductsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/financialproducts/FinancialProductsScreen.kt
@@ -1,0 +1,377 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.financialproducts
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.financialproducts.FinancialProduct
+import com.testlogon.android.data.financialproducts.ProductCollection
+
+object FinancialProductsTestTags {
+    const val SCREEN = "finprod_screen"
+    const val LOADING = "finprod_loading"
+    const val EMPTY = "finprod_empty"
+    const val ERROR = "finprod_error"
+    const val OFFLINE = "finprod_offline"
+    const val FORBIDDEN = "finprod_forbidden"
+    const val FAB = "finprod_fab"
+    const val TAB_PREFIX = "finprod_tab_"
+    const val PRODUCT_PREFIX = "finprod_product_"
+    const val COLLECTION_PREFIX = "finprod_collection_"
+    const val CREATE_FORM = "finprod_create_form"
+    const val CREATE_SUBMIT = "finprod_create_submit"
+}
+
+@Composable
+fun FinancialProductsRoute(
+    onBack: () -> Unit,
+    onSessionExpired: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: FinancialProductsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is FinancialProductsEffect.ShowMessage ->
+                    snackbarHostState.showSnackbar(context.getString(effect.resId))
+                is FinancialProductsEffect.ShowText ->
+                    snackbarHostState.showSnackbar(effect.text)
+            }
+        }
+    }
+    LaunchedEffect(state.phase) {
+        if (state.phase == FinancialProductsUiState.Phase.SessionExpired) onSessionExpired()
+    }
+
+    FinancialProductsScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onSelectTab = viewModel::onSelectTab,
+        onOpenCreateProduct = viewModel::onOpenCreateProduct,
+        onDismissCreateProduct = viewModel::onDismissCreateProduct,
+        onProductCodeChange = viewModel::onProductCodeChange,
+        onProductNameChange = viewModel::onProductNameChange,
+        onProductCategoryChange = viewModel::onProductCategoryChange,
+        onProductDescriptionChange = viewModel::onProductDescriptionChange,
+        onSubmitCreateProduct = viewModel::onSubmitCreateProduct,
+        onOpenCreateCollection = viewModel::onOpenCreateCollection,
+        onDismissCreateCollection = viewModel::onDismissCreateCollection,
+        onCollectionCodeChange = viewModel::onCollectionCodeChange,
+        onCollectionNameChange = viewModel::onCollectionNameChange,
+        onSubmitCreateCollection = viewModel::onSubmitCreateCollection,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun FinancialProductsScreen(
+    state: FinancialProductsUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onSelectTab: (FinancialProductsTab) -> Unit,
+    onOpenCreateProduct: () -> Unit,
+    onDismissCreateProduct: () -> Unit,
+    onProductCodeChange: (String) -> Unit,
+    onProductNameChange: (String) -> Unit,
+    onProductCategoryChange: (String) -> Unit,
+    onProductDescriptionChange: (String) -> Unit,
+    onSubmitCreateProduct: () -> Unit,
+    onOpenCreateCollection: () -> Unit,
+    onDismissCreateCollection: () -> Unit,
+    onCollectionCodeChange: (String) -> Unit,
+    onCollectionNameChange: (String) -> Unit,
+    onSubmitCreateCollection: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(FinancialProductsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Financial products") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            if (state.phase == FinancialProductsUiState.Phase.Content) {
+                Button(
+                    onClick = {
+                        if (state.tab == FinancialProductsTab.PRODUCTS) onOpenCreateProduct() else onOpenCreateCollection()
+                    },
+                    modifier = Modifier.testTag(FinancialProductsTestTags.FAB),
+                ) {
+                    Icon(Icons.Outlined.Add, contentDescription = null)
+                    Text(if (state.tab == FinancialProductsTab.PRODUCTS) "New product" else "New collection")
+                }
+            }
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            if (state.phase == FinancialProductsUiState.Phase.Content) {
+                TabRow(selectedTabIndex = state.tab.ordinal) {
+                    FinancialProductsTab.entries.forEach { tab ->
+                        Tab(
+                            selected = state.tab == tab,
+                            onClick = { onSelectTab(tab) },
+                            text = { Text(tab.label) },
+                            modifier = Modifier.testTag(FinancialProductsTestTags.TAB_PREFIX + tab.name),
+                        )
+                    }
+                }
+            }
+
+            when (state.phase) {
+                FinancialProductsUiState.Phase.Loading ->
+                    LoadingState(modifier = Modifier.testTag(FinancialProductsTestTags.LOADING))
+                FinancialProductsUiState.Phase.Forbidden ->
+                    EmptyState(
+                        title = "Admins only",
+                        body = "You do not have access to financial-product administration.",
+                        imageVector = Icons.Outlined.Lock,
+                        modifier = Modifier.testTag(FinancialProductsTestTags.FORBIDDEN),
+                    )
+                FinancialProductsUiState.Phase.Error ->
+                    ErrorState(
+                        message = "Something went wrong.",
+                        onRetry = onRetry,
+                        modifier = Modifier.testTag(FinancialProductsTestTags.ERROR),
+                    )
+                FinancialProductsUiState.Phase.Offline ->
+                    OfflineBanner(onRetry = onRetry, modifier = Modifier.testTag(FinancialProductsTestTags.OFFLINE))
+                FinancialProductsUiState.Phase.SessionExpired -> Unit
+                FinancialProductsUiState.Phase.Content ->
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = onRefresh,
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        TabContent(state = state)
+                    }
+            }
+        }
+    }
+
+    if (state.createProduct.isOpen) {
+        CreateProductDialog(
+            form = state.createProduct,
+            onDismiss = onDismissCreateProduct,
+            onCodeChange = onProductCodeChange,
+            onNameChange = onProductNameChange,
+            onCategoryChange = onProductCategoryChange,
+            onDescriptionChange = onProductDescriptionChange,
+            onSubmit = onSubmitCreateProduct,
+        )
+    }
+    if (state.createCollection.isOpen) {
+        CreateCollectionDialog(
+            form = state.createCollection,
+            onDismiss = onDismissCreateCollection,
+            onCodeChange = onCollectionCodeChange,
+            onNameChange = onCollectionNameChange,
+            onSubmit = onSubmitCreateCollection,
+        )
+    }
+}
+
+@Composable
+private fun TabContent(state: FinancialProductsUiState) {
+    if (state.isEmptyForTab) {
+        val (title, body) = when (state.tab) {
+            FinancialProductsTab.PRODUCTS -> "No products yet" to "Create a financial product to get started."
+            FinancialProductsTab.COLLECTIONS -> "No collections yet" to "Group products into a collection."
+        }
+        EmptyState(title = title, body = body, modifier = Modifier.testTag(FinancialProductsTestTags.EMPTY))
+        return
+    }
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        when (state.tab) {
+            FinancialProductsTab.PRODUCTS -> items(state.products, key = { it.code }) { p -> ProductCard(p) }
+            FinancialProductsTab.COLLECTIONS -> items(state.collections, key = { it.code }) { c -> CollectionCard(c) }
+        }
+    }
+}
+
+@Composable
+private fun ProductCard(product: FinancialProduct) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(FinancialProductsTestTags.PRODUCT_PREFIX + product.code)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(product.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(product.code, style = MaterialTheme.typography.bodySmall)
+            Text(product.familyLabel, style = MaterialTheme.typography.bodyMedium)
+            product.description?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+            AssistChip(onClick = {}, label = { Text("v${product.version}") })
+        }
+    }
+}
+
+@Composable
+private fun CollectionCard(collection: ProductCollection) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(FinancialProductsTestTags.COLLECTION_PREFIX + collection.code)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(collection.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(collection.code, style = MaterialTheme.typography.bodySmall)
+            Text(collection.memberCountLabel, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun CreateProductDialog(
+    form: CreateProductFormState,
+    onDismiss: () -> Unit,
+    onCodeChange: (String) -> Unit,
+    onNameChange: (String) -> Unit,
+    onCategoryChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(modifier = Modifier.testTag(FinancialProductsTestTags.CREATE_FORM)) {
+            Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("New product", style = MaterialTheme.typography.titleLarge)
+                OutlinedTextField(
+                    value = form.productCode,
+                    onValueChange = onCodeChange,
+                    label = { Text("Product code") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.name,
+                    onValueChange = onNameChange,
+                    label = { Text("Name") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.category,
+                    onValueChange = onCategoryChange,
+                    label = { Text("Category (optional)") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.description,
+                    onValueChange = onDescriptionChange,
+                    label = { Text("Description (optional)") },
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.align(Alignment.End)) {
+                    TextButton(onClick = onDismiss, enabled = !form.isSubmitting) { Text("Cancel") }
+                    Button(
+                        onClick = onSubmit,
+                        enabled = form.canSubmit,
+                        modifier = Modifier.testTag(FinancialProductsTestTags.CREATE_SUBMIT),
+                    ) { Text("Create") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateCollectionDialog(
+    form: CreateCollectionFormState,
+    onDismiss: () -> Unit,
+    onCodeChange: (String) -> Unit,
+    onNameChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(modifier = Modifier.testTag(FinancialProductsTestTags.CREATE_FORM)) {
+            Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("New collection", style = MaterialTheme.typography.titleLarge)
+                OutlinedTextField(
+                    value = form.collectionCode,
+                    onValueChange = onCodeChange,
+                    label = { Text("Collection code") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = form.name,
+                    onValueChange = onNameChange,
+                    label = { Text("Name") },
+                    singleLine = true,
+                    enabled = !form.isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.align(Alignment.End)) {
+                    TextButton(onClick = onDismiss, enabled = !form.isSubmitting) { Text("Cancel") }
+                    Button(
+                        onClick = onSubmit,
+                        enabled = form.canSubmit,
+                        modifier = Modifier.testTag(FinancialProductsTestTags.CREATE_SUBMIT),
+                    ) { Text("Create") }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/financialproducts/FinancialProductsUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/financialproducts/FinancialProductsUiState.kt
@@ -1,0 +1,64 @@
+package com.testlogon.android.feature.financialproducts
+
+import androidx.annotation.StringRes
+import com.testlogon.android.data.financialproducts.FinancialProduct
+import com.testlogon.android.data.financialproducts.FinancialProductsMath
+import com.testlogon.android.data.financialproducts.ProductCollection
+
+/** Top-level tabs of the financial-products hub (web CUS-004: products / collections). */
+enum class FinancialProductsTab(val label: String) {
+    PRODUCTS("Products"),
+    COLLECTIONS("Collections"),
+}
+
+/** Render-ready state for the financial-products hub. */
+data class FinancialProductsUiState(
+    val phase: Phase = Phase.Loading,
+    val tab: FinancialProductsTab = FinancialProductsTab.PRODUCTS,
+    val products: List<FinancialProduct> = emptyList(),
+    val collections: List<ProductCollection> = emptyList(),
+    val isRefreshing: Boolean = false,
+    val busyId: String? = null,
+    val createProduct: CreateProductFormState = CreateProductFormState(),
+    val createCollection: CreateCollectionFormState = CreateCollectionFormState(),
+) {
+    enum class Phase { Loading, Content, Forbidden, SessionExpired, Error, Offline }
+
+    val isEmptyForTab: Boolean
+        get() = when (tab) {
+            FinancialProductsTab.PRODUCTS -> products.isEmpty()
+            FinancialProductsTab.COLLECTIONS -> collections.isEmpty()
+        }
+}
+
+/** Create-product form. Mirrors the backend `product_code` pattern + required name. */
+data class CreateProductFormState(
+    val isOpen: Boolean = false,
+    val productCode: String = "",
+    val name: String = "",
+    val category: String = "",
+    val description: String = "",
+    val isSubmitting: Boolean = false,
+) {
+    val validationErrors: List<String>
+        get() = FinancialProductsMath.productFormErrors(productCode, name)
+    val canSubmit: Boolean get() = !isSubmitting && validationErrors.isEmpty()
+}
+
+/** Create-collection form. Code + name required; members are added later via the members endpoint. */
+data class CreateCollectionFormState(
+    val isOpen: Boolean = false,
+    val collectionCode: String = "",
+    val name: String = "",
+    val isSubmitting: Boolean = false,
+) {
+    val validationErrors: List<String>
+        get() = FinancialProductsMath.collectionFormErrors(collectionCode, name)
+    val canSubmit: Boolean get() = !isSubmitting && validationErrors.isEmpty()
+}
+
+/** One-shot side effects. */
+sealed interface FinancialProductsEffect {
+    data class ShowMessage(@StringRes val resId: Int) : FinancialProductsEffect
+    data class ShowText(val text: String) : FinancialProductsEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/financialproducts/FinancialProductsViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/financialproducts/FinancialProductsViewModel.kt
@@ -1,0 +1,185 @@
+package com.testlogon.android.feature.financialproducts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.R
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.financialproducts.FinancialProductsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives [FinancialProductsUiState] from [FinancialProductsRepository]. Loads products + collections on
+ * first composition + pull-to-refresh. Products + collections support create. Gating: a verified
+ * non-admin -> Forbidden with NO network calls; the backend 403 is authoritative. Degrade-on-404: reads
+ * fold to honest-empty when the OBP/financial-products flags are off; mutations surface errors.
+ */
+@HiltViewModel
+class FinancialProductsViewModel @Inject constructor(
+    private val repository: FinancialProductsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(FinancialProductsUiState())
+    val uiState: StateFlow<FinancialProductsUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<FinancialProductsEffect>(Channel.BUFFERED)
+    val effects: Flow<FinancialProductsEffect> = _effects.receiveAsFlow()
+
+    init {
+        load(fromUser = false)
+    }
+
+    fun onResumed() = load(fromUser = false, force = true)
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    fun onSelectTab(tab: FinancialProductsTab) {
+        if (_uiState.value.tab == tab) return
+        _uiState.update { it.copy(tab = tab) }
+    }
+
+    // ---- create product ----
+    fun onOpenCreateProduct() =
+        _uiState.update { it.copy(createProduct = CreateProductFormState(isOpen = true)) }
+    fun onDismissCreateProduct() {
+        if (_uiState.value.createProduct.isSubmitting) return
+        _uiState.update { it.copy(createProduct = CreateProductFormState(isOpen = false)) }
+    }
+    fun onProductCodeChange(v: String) =
+        _uiState.update { it.copy(createProduct = it.createProduct.copy(productCode = v)) }
+    fun onProductNameChange(v: String) =
+        _uiState.update { it.copy(createProduct = it.createProduct.copy(name = v)) }
+    fun onProductCategoryChange(v: String) =
+        _uiState.update { it.copy(createProduct = it.createProduct.copy(category = v)) }
+    fun onProductDescriptionChange(v: String) =
+        _uiState.update { it.copy(createProduct = it.createProduct.copy(description = v)) }
+
+    fun onSubmitCreateProduct() {
+        val form = _uiState.value.createProduct
+        if (!form.canSubmit) return
+        _uiState.update { it.copy(createProduct = it.createProduct.copy(isSubmitting = true)) }
+        viewModelScope.launch {
+            when (val r = repository.createProduct(form.productCode, form.name, form.category, form.description)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createProduct = CreateProductFormState(isOpen = false)) }
+                    _effects.send(FinancialProductsEffect.ShowMessage(R.string.finprod_product_created))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> {
+                    _uiState.update { it.copy(createProduct = it.createProduct.copy(isSubmitting = false)) }
+                    handleMutationFailure(r.error.status, r.error.message)
+                }
+                is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(createProduct = it.createProduct.copy(isSubmitting = false)) }
+                    _effects.send(FinancialProductsEffect.ShowMessage(R.string.finprod_action_failed))
+                }
+            }
+        }
+    }
+
+    // ---- create collection ----
+    fun onOpenCreateCollection() =
+        _uiState.update { it.copy(createCollection = CreateCollectionFormState(isOpen = true)) }
+    fun onDismissCreateCollection() {
+        if (_uiState.value.createCollection.isSubmitting) return
+        _uiState.update { it.copy(createCollection = CreateCollectionFormState(isOpen = false)) }
+    }
+    fun onCollectionCodeChange(v: String) =
+        _uiState.update { it.copy(createCollection = it.createCollection.copy(collectionCode = v)) }
+    fun onCollectionNameChange(v: String) =
+        _uiState.update { it.copy(createCollection = it.createCollection.copy(name = v)) }
+
+    fun onSubmitCreateCollection() {
+        val form = _uiState.value.createCollection
+        if (!form.canSubmit) return
+        _uiState.update { it.copy(createCollection = it.createCollection.copy(isSubmitting = true)) }
+        viewModelScope.launch {
+            when (val r = repository.createCollection(form.collectionCode, form.name, emptyList())) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(createCollection = CreateCollectionFormState(isOpen = false)) }
+                    _effects.send(FinancialProductsEffect.ShowMessage(R.string.finprod_collection_created))
+                    load(fromUser = true)
+                }
+                is ApiResult.Failure -> {
+                    _uiState.update { it.copy(createCollection = it.createCollection.copy(isSubmitting = false)) }
+                    handleMutationFailure(r.error.status, r.error.message)
+                }
+                is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(createCollection = it.createCollection.copy(isSubmitting = false)) }
+                    _effects.send(FinancialProductsEffect.ShowMessage(R.string.finprod_action_failed))
+                }
+            }
+        }
+    }
+
+    private suspend fun handleMutationFailure(status: Int, message: String) {
+        when (status) {
+            HTTP_UNAUTHORIZED -> _uiState.update { it.copy(phase = FinancialProductsUiState.Phase.SessionExpired) }
+            HTTP_FORBIDDEN -> _uiState.update { it.copy(phase = FinancialProductsUiState.Phase.Forbidden) }
+            else -> _effects.send(FinancialProductsEffect.ShowText(message))
+        }
+    }
+
+    // ---- load ----
+    private fun load(fromUser: Boolean, force: Boolean = false) {
+        val hasContent = _uiState.value.phase == FinancialProductsUiState.Phase.Content
+        if (_uiState.value.isRefreshing && !force) return
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent && !force) it.phase else FinancialProductsUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            if (!repository.isAdmin()) {
+                _uiState.update { it.copy(phase = FinancialProductsUiState.Phase.Forbidden, isRefreshing = false) }
+                return@launch
+            }
+
+            val productsR = repository.loadProducts()
+            val collectionsR = repository.loadCollections()
+            val results = listOf(productsR, collectionsR)
+
+            if (results.any { it is ApiResult.Failure && it.error.status == HTTP_FORBIDDEN }) {
+                _uiState.update { it.copy(phase = FinancialProductsUiState.Phase.Forbidden, isRefreshing = false) }
+                return@launch
+            }
+            if (results.any { it is ApiResult.Failure && it.error.status == HTTP_UNAUTHORIZED }) {
+                _uiState.update { it.copy(phase = FinancialProductsUiState.Phase.SessionExpired, isRefreshing = false) }
+                return@launch
+            }
+
+            val anyNetworkError = results.any { it is ApiResult.NetworkError }
+            val products = (productsR as? ApiResult.Success)?.data.orEmpty()
+            val collections = (collectionsR as? ApiResult.Success)?.data.orEmpty()
+            val allFailed = results.none { it is ApiResult.Success }
+            val phase = when {
+                allFailed && anyNetworkError -> FinancialProductsUiState.Phase.Offline
+                allFailed -> FinancialProductsUiState.Phase.Error
+                else -> FinancialProductsUiState.Phase.Content
+            }
+
+            _uiState.update {
+                it.copy(
+                    phase = phase,
+                    products = products,
+                    collections = collections,
+                    isRefreshing = false,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -1910,6 +1910,28 @@ class MoreCatalog @Inject constructor() {
             section = MoreSection.SECURITY,
             operatorOnly = true,
         ),
+        // Admin EMAIL management: campaign-template CRUD + suppressed-list mgmt + delivery-stats header
+        // (router /ui/admin/email). Self-gates via AdminRoleProvider + backend 403; a non-admin sees no data.
+        MoreEntry(
+            id = "admin_email_manage",
+            labelRes = R.string.more_entry_admin_email_manage,
+            icon = Icons.Outlined.Email,
+            route = MoreRoutes.ADMIN_EMAIL_MANAGE,
+            hub = MoreHub.ACCOUNT,
+            section = MoreSection.SECURITY,
+            operatorOnly = true,
+        ),
+        // CUS-004 Financial Products + Collections admin (router /ui/financial-products). Self-gates via
+        // AdminRoleProvider + backend 403; a non-admin sees no data.
+        MoreEntry(
+            id = "financial_products",
+            labelRes = R.string.more_entry_financial_products,
+            icon = Icons.Outlined.AccountBalance,
+            route = MoreRoutes.FINANCIAL_PRODUCTS,
+            hub = MoreHub.ACCOUNT,
+            section = MoreSection.SECURITY,
+            operatorOnly = true,
+        ),
         // AND-374: projects (paged list -> detail + account-scoped Google Drive provider connect flow).
         MoreEntry(
             id = "projects",

--- a/android/app/src/main/java/com/testlogon/android/navigation/AdminEmailNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AdminEmailNavigation.kt
@@ -1,0 +1,30 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.adminemail.AdminEmailRoute
+
+/**
+ * Admin-EMAIL management hub (router app/routers/admin_email.py, prefix `/ui/admin/email`, all
+ * `require_admin_or_root`). Covers the campaign-email-TEMPLATE CRUD + SUPPRESSED-list management +
+ * a compact delivery-stats header. DISTINCT from [MessagingDashboardDest] (the AND-404 READ-ONLY
+ * email/SMS delivery dashboard) — this is the MANAGEMENT surface (create/deactivate templates,
+ * unsuppress addresses).
+ *
+ * operator-only in the More catalog; self-gates via the client [AdminRoleProvider] pre-check + the
+ * backend 403 -> Forbidden state. Template reads degrade to empty when the campaign-templates flag is
+ * off; mutations surface a "not enabled" error.
+ */
+data object AdminEmailDest {
+    const val ROUTE = "admin/email"
+}
+
+fun NavGraphBuilder.adminEmailDestinations(navController: NavHostController) {
+    composable(AdminEmailDest.ROUTE) {
+        AdminEmailRoute(
+            onBack = { navController.popBackStack() },
+            onSessionExpired = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -430,6 +430,10 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         // B4 web-parity: Marketing content agent (dashboard + editor + calendar + engagement).
         marketingDestinations(navController)
         marketingCampaignsDestinations(navController)
+        // Admin EMAIL management (templates + suppressed + stats header). operator-only; self-gates.
+        adminEmailDestinations(navController)
+        // CUS-004 Financial Products + Collections admin. operator-only; self-gates.
+        financialProductsDestinations(navController)
         // B4 web-parity: Accountant/cost agent (overview + breakdown + budgets + alerts).
         costsDestinations(navController)
         // B4 web-parity: Compliance/Security agent (findings + audits + compliance + trends).

--- a/android/app/src/main/java/com/testlogon/android/navigation/FinancialProductsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/FinancialProductsNavigation.kt
@@ -1,0 +1,29 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.testlogon.android.feature.financialproducts.FinancialProductsRoute
+
+/**
+ * CUS-004 Financial Products + Collections admin hub (router app/routers/financial_products.py, prefix
+ * `/ui/financial-products`, all `require_admin_or_root`). Mirrors the web
+ * `frontend/src/api/endpoints/bankCustomers.ts` (CUS-004 section): products list/create + collections
+ * list/create.
+ *
+ * operator-only in the More catalog; self-gates via the client [AdminRoleProvider] pre-check + the
+ * backend 403 -> Forbidden state. The whole router 404s unless the OBP + financial-products flags are on,
+ * so reads degrade to empty; mutations surface a "not enabled" error.
+ */
+data object FinancialProductsDest {
+    const val ROUTE = "admin/financial-products"
+}
+
+fun NavGraphBuilder.financialProductsDestinations(navController: NavHostController) {
+    composable(FinancialProductsDest.ROUTE) {
+        FinancialProductsRoute(
+            onBack = { navController.popBackStack() },
+            onSessionExpired = { navController.popBackStack() },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -480,6 +480,15 @@ object MoreRoutes {
     const val ADMIN_EMAIL_DASHBOARD = MessagingDashboardDest.EMAIL_ROUTE
     const val ADMIN_SMS_DASHBOARD = MessagingDashboardDest.SMS_ROUTE
 
+    // Admin EMAIL management (router app/routers/admin_email.py, /ui/admin/email; require_admin_or_root):
+    // campaign-template CRUD + suppressed-list mgmt + delivery-stats header. DISTINCT from the AND-404
+    // READ-ONLY delivery dashboard above. operatorOnly; self-gates via AdminRoleProvider + backend 403.
+    const val ADMIN_EMAIL_MANAGE = AdminEmailDest.ROUTE
+
+    // CUS-004 Financial Products + Collections admin (router app/routers/financial_products.py,
+    // /ui/financial-products; require_admin_or_root). operatorOnly; self-gates via AdminRoleProvider + 403.
+    const val FINANCIAL_PRODUCTS = FinancialProductsDest.ROUTE
+
     // B5: admin content-moderation board (queue + ticket detail + claim/decision/resolve).
     const val ADMIN_MODERATION = ModerationBoardDest.ROUTE
 
@@ -804,6 +813,8 @@ object MoreRoutes {
             ACTIVITY_CENTER,
             ADMIN_EMAIL_DASHBOARD,
             ADMIN_SMS_DASHBOARD,
+            ADMIN_EMAIL_MANAGE,
+            FINANCIAL_PRODUCTS,
             ADMIN_MODERATION,
             ADMIN_AD_CREATIVE_REVIEW,
             ADMIN_AD_FRAUD,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5201,6 +5201,16 @@
     <string name="more_entry_stylist">Design (Stylist)</string>
     <string name="more_entry_marketing">Marketing</string>
     <string name="more_entry_marketing_campaigns">Marketing campaigns</string>
+    <!-- Admin email management + financial products (operator-only More entries + snackbars) -->
+    <string name="more_entry_admin_email_manage">Email admin</string>
+    <string name="more_entry_financial_products">Financial products</string>
+    <string name="admin_email_template_created">Template created</string>
+    <string name="admin_email_template_deactivated">Template deactivated</string>
+    <string name="admin_email_unsuppressed">Address unsuppressed</string>
+    <string name="admin_email_action_failed">Action failed</string>
+    <string name="finprod_product_created">Product created</string>
+    <string name="finprod_collection_created">Collection created</string>
+    <string name="finprod_action_failed">Action failed</string>
     <!-- Marketing campaigns (OFBiz MKT) hub -->
     <string name="mktc_campaign_created">Campaign created</string>
     <string name="mktc_list_created">List created</string>

--- a/android/app/src/test/java/com/testlogon/android/data/admin/email/AdminEmailMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/admin/email/AdminEmailMathTest.kt
@@ -1,0 +1,120 @@
+package com.testlogon.android.data.admin.email
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** JVM unit tests for [AdminEmailMath] (pure helpers: rate/count formatting + merge-field/template validation). */
+class AdminEmailMathTest {
+
+    // ---- formatRate ----
+
+    @Test
+    fun formatRate_dropsTrailingZero() {
+        assertEquals("100%", AdminEmailMath.formatRate(100.0))
+        assertEquals("0%", AdminEmailMath.formatRate(0.0))
+    }
+
+    @Test
+    fun formatRate_keepsOneDecimal() {
+        assertEquals("98.7%", AdminEmailMath.formatRate(98.72))
+    }
+
+    @Test
+    fun formatRate_clampsOutOfRange() {
+        assertEquals("100%", AdminEmailMath.formatRate(150.0))
+        assertEquals("0%", AdminEmailMath.formatRate(-5.0))
+    }
+
+    @Test
+    fun formatRate_handlesNaN() {
+        assertEquals("0%", AdminEmailMath.formatRate(Double.NaN))
+        assertEquals("0%", AdminEmailMath.formatRate(Double.POSITIVE_INFINITY))
+    }
+
+    // ---- formatCount ----
+
+    @Test
+    fun formatCount_smallAndCompact() {
+        assertEquals("0", AdminEmailMath.formatCount(0))
+        assertEquals("0", AdminEmailMath.formatCount(-3))
+        assertEquals("42", AdminEmailMath.formatCount(42))
+        assertEquals("1.5K", AdminEmailMath.formatCount(1_500))
+        assertEquals("2M", AdminEmailMath.formatCount(2_000_000))
+    }
+
+    // ---- summaryLine ----
+
+    @Test
+    fun summaryLine_groupsThousandsAndRate() {
+        assertEquals("1,240 sent · 98.7% delivered", AdminEmailMath.summaryLine(1240, 98.7))
+        assertEquals("0 sent · 0% delivered", AdminEmailMath.summaryLine(0, 0.0))
+    }
+
+    // ---- merge field validation ----
+
+    @Test
+    fun mergeField_validAndInvalid() {
+        assertTrue(AdminEmailMath.isValidMergeField("first_name"))
+        assertTrue(AdminEmailMath.isValidMergeField("A1_b2"))
+        assertFalse(AdminEmailMath.isValidMergeField("first name"))
+        assertFalse(AdminEmailMath.isValidMergeField("bad-field"))
+        assertFalse(AdminEmailMath.isValidMergeField(""))
+    }
+
+    @Test
+    fun mergeField_rejectsTooLong() {
+        assertTrue(AdminEmailMath.isValidMergeField("a".repeat(64)))
+        assertFalse(AdminEmailMath.isValidMergeField("a".repeat(65)))
+    }
+
+    @Test
+    fun parseMergeFields_blankIsEmpty() {
+        assertEquals(emptyList<String>(), AdminEmailMath.parseMergeFields("   "))
+        assertEquals(emptyList<String>(), AdminEmailMath.parseMergeFields(""))
+    }
+
+    @Test
+    fun parseMergeFields_splitsDedupesAndKeepsOrder() {
+        assertEquals(
+            listOf("first_name", "last_name", "plan"),
+            AdminEmailMath.parseMergeFields("first_name, last_name first_name plan"),
+        )
+    }
+
+    @Test
+    fun parseMergeFields_returnsNullOnInvalidToken() {
+        assertNull(AdminEmailMath.parseMergeFields("ok, bad-field"))
+    }
+
+    // ---- template form validation ----
+
+    @Test
+    fun templateForm_validPasses() {
+        assertTrue(AdminEmailMath.canSubmitTemplate("Welcome", "Hi", "Body", "first_name"))
+        assertTrue(AdminEmailMath.templateFormErrors("Welcome", "Hi", "Body", "").isEmpty())
+    }
+
+    @Test
+    fun templateForm_reportsMissingFields() {
+        val errors = AdminEmailMath.templateFormErrors("", "", "", "")
+        assertTrue(errors.any { it.contains("Name") })
+        assertTrue(errors.any { it.contains("Subject") })
+        assertTrue(errors.any { it.contains("Body") })
+        assertFalse(AdminEmailMath.canSubmitTemplate("", "s", "b", ""))
+    }
+
+    @Test
+    fun templateForm_reportsInvalidMergeField() {
+        val errors = AdminEmailMath.templateFormErrors("N", "S", "B", "bad-field")
+        assertTrue(errors.any { it.contains("merge field", ignoreCase = true) })
+    }
+
+    @Test
+    fun templateForm_reportsTooLong() {
+        val longName = "a".repeat(AdminEmailMath.NAME_MAX + 1)
+        assertTrue(AdminEmailMath.templateFormErrors(longName, "S", "B", "").any { it.contains("Name too long") })
+    }
+}

--- a/android/app/src/test/java/com/testlogon/android/data/financialproducts/FinancialProductsMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/financialproducts/FinancialProductsMathTest.kt
@@ -1,0 +1,114 @@
+package com.testlogon.android.data.financialproducts
+
+import com.testlogon.android.data.financialproducts.FinancialProductsMath.AttributeType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** JVM unit tests for [FinancialProductsMath] (product-code + typed-attribute validation, family label). */
+class FinancialProductsMathTest {
+
+    // ---- product code ----
+
+    @Test
+    fun productCode_validAndInvalid() {
+        assertTrue(FinancialProductsMath.isValidProductCode("SAV_01"))
+        assertTrue(FinancialProductsMath.isValidProductCode("chk-account"))
+        assertFalse(FinancialProductsMath.isValidProductCode("has space"))
+        assertFalse(FinancialProductsMath.isValidProductCode("bad/slash"))
+        assertFalse(FinancialProductsMath.isValidProductCode(""))
+    }
+
+    @Test
+    fun productCode_lengthCap() {
+        assertTrue(FinancialProductsMath.isValidProductCode("a".repeat(64)))
+        assertFalse(FinancialProductsMath.isValidProductCode("a".repeat(65)))
+    }
+
+    // ---- attribute type parsing ----
+
+    @Test
+    fun attributeType_fromWire() {
+        assertEquals(AttributeType.STRING, AttributeType.from("STRING"))
+        assertEquals(AttributeType.DATE_WITH_DAY, AttributeType.from("date_with_day"))
+        assertNull(AttributeType.from("BOGUS"))
+        assertNull(AttributeType.from(null))
+    }
+
+    // ---- typed value validation ----
+
+    @Test
+    fun attributeValue_string() {
+        assertTrue(FinancialProductsMath.isValidAttributeValue(AttributeType.STRING, "anything"))
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.STRING, "   "))
+    }
+
+    @Test
+    fun attributeValue_integer() {
+        assertTrue(FinancialProductsMath.isValidAttributeValue(AttributeType.INTEGER, "-42"))
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.INTEGER, "4.2"))
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.INTEGER, "abc"))
+    }
+
+    @Test
+    fun attributeValue_double() {
+        assertTrue(FinancialProductsMath.isValidAttributeValue(AttributeType.DOUBLE, "3.14"))
+        assertTrue(FinancialProductsMath.isValidAttributeValue(AttributeType.DOUBLE, "5"))
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.DOUBLE, "NaN"))
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.DOUBLE, "x"))
+    }
+
+    @Test
+    fun attributeValue_date() {
+        assertTrue(FinancialProductsMath.isValidAttributeValue(AttributeType.DATE_WITH_DAY, "2026-01-31"))
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.DATE_WITH_DAY, "2026-13-01"))
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.DATE_WITH_DAY, "01-01-2026"))
+    }
+
+    @Test
+    fun attributeValue_lengthCap() {
+        val huge = "a".repeat(FinancialProductsMath.ATTRIBUTE_VALUE_MAX + 1)
+        assertFalse(FinancialProductsMath.isValidAttributeValue(AttributeType.STRING, huge))
+    }
+
+    // ---- form validation ----
+
+    @Test
+    fun productForm_errors() {
+        assertTrue(FinancialProductsMath.canSubmitProduct("SAV_01", "Savings"))
+        assertFalse(FinancialProductsMath.canSubmitProduct("", "Savings"))
+        val errors = FinancialProductsMath.productFormErrors("bad code", "")
+        assertTrue(errors.any { it.contains("product code", ignoreCase = true) })
+        assertTrue(errors.any { it.contains("Name") })
+    }
+
+    @Test
+    fun collectionForm_errors() {
+        assertTrue(FinancialProductsMath.canSubmitCollection("CORE", "Core products"))
+        assertFalse(FinancialProductsMath.canSubmitCollection("bad code", "x"))
+        assertFalse(FinancialProductsMath.canSubmitCollection("CORE", ""))
+    }
+
+    @Test
+    fun attributeForm_errors() {
+        assertTrue(FinancialProductsMath.canSubmitAttribute("rate", AttributeType.DOUBLE, "1.5"))
+        assertFalse(FinancialProductsMath.canSubmitAttribute("", AttributeType.DOUBLE, "1.5"))
+        assertFalse(FinancialProductsMath.canSubmitAttribute("rate", AttributeType.INTEGER, "1.5"))
+    }
+
+    // ---- family label ----
+
+    @Test
+    fun familyLabel_composesAndFallsBack() {
+        // order is superFamily › family › category
+        assertEquals(
+            "Deposits › Savings › Basic",
+            FinancialProductsMath.familyLabel(category = "Basic", family = "Savings", superFamily = "Deposits"),
+        )
+        assertEquals("—", FinancialProductsMath.familyLabel(null, null, null))
+        assertEquals("Deposits", FinancialProductsMath.familyLabel(null, null, "Deposits"))
+        assertEquals("Savings", FinancialProductsMath.familyLabel(null, "Savings", "  "))
+    }
+}


### PR DESCRIPTION
## PAR-172 - Android admin email + financial-products consoles

Frontend parity work bringing two admin/console surfaces to Android:

- Admin email console (data/repository/API, view model, screen, navigation, unit tests)
- Financial-products console (data/repository/API, view model, screen, navigation, unit tests)
- More-hub catalog entries, route wiring, and string resources

Feature-gated and built. Unit tests included for the math/domain layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
