### PR TITLE
FE parity PAR-150 - Android agent execution (coder/QA/DevOps/architect/PM/docs)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunDataModule.kt
@@ -1,0 +1,17 @@
+package com.testlogon.android.data.agentrun
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** AGENT-RUN (web-parity) - binds the agent-run console data-layer implementation. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AgentRunDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAgentRunRepository(impl: AgentRunRepositoryImpl): AgentRunRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunDomain.kt
@@ -1,0 +1,149 @@
+package com.testlogon.android.data.agentrun
+
+import java.util.Locale
+
+/**
+ * AGENT-RUN (web-parity) - framework-free domain for the generic agent-run CONSOLE, the mobile mirror of the
+ * web *RunOutputPanel / DeploymentApprovalPanel family (frontend/src/pages/agents/{Coder,Qa,DevOps,Architect,
+ * Pm}RunOutputPanel + DeploymentApprovalPanel). One console drives the "eligible tickets -> claim -> execute
+ * -> view output/report/metrics" lifecycle across the six agent types; DevOps additionally exposes deployment
+ * approve/reject.
+ *
+ * There is deliberately NO shared "AgentRunOut" server model - each agent type has a bespoke output SHAPE
+ * (see app/models.py CoderOutputOut / QaOutputOut / DevOpsOutputOut / ArchitectOutputOut / PmOutputOut). To
+ * keep ONE transport + ONE screen the outputs are transported as free-form Map<String, Any?> (exactly like
+ * AgentConfigApi does for the config bodies) and projected here into a small, uniform, display-only
+ * [AgentRunOutput] via [AgentRunMath.parseOutput]. Only the fields the console renders are lifted; every
+ * type's map degrades safely when a field is absent.
+ *
+ * Times are epoch seconds where present. All parsing is PURE (no Android / coroutine deps) so it is
+ * JVM-unit-testable.
+ */
+
+/** The six executable agent types. [typeName] is the fixed URL segment (coder/qa/devops/architect/pm). */
+enum class AgentRunType(
+    val typeName: String,
+    val title: String,
+    /** True when this type surfaces a production-deployment approve/reject gate (DevOps only). */
+    val supportsApproval: Boolean = false,
+    /** True when this type has a markdown report endpoint (QA only). */
+    val hasReport: Boolean = false,
+    /** True when this type is driven by an operation selector rather than a ticket (PM only). */
+    val operationDriven: Boolean = false,
+) {
+    CODER("coder", "Coder Agent"),
+    QA("qa", "QA Agent", hasReport = true),
+    DEVOPS("devops", "DevOps / SRE Agent", supportsApproval = true),
+    ARCHITECT("architect", "Solution Architect Agent"),
+    PM("pm", "Project Manager Agent", operationDriven = true),
+    DOCS("docs", "Docs Agent");
+
+    companion object {
+        fun from(raw: String?): AgentRunType? =
+            entries.firstOrNull { it.typeName == raw?.lowercase(Locale.US) }
+    }
+}
+
+/** A PM operation the console can trigger (mirrors runPmOperation's operation_type union). */
+enum class PmOperation(val wire: String, val label: String) {
+    IDEA_TRIAGE("idea_triage", "Idea triage"),
+    BACKLOG_PRIORITIZE("backlog_prioritize", "Backlog reprioritize"),
+    BLOCKER_DETECT("blocker_detect", "Blocker detection"),
+    REPORT_GENERATE("report_generate", "Generate report");
+}
+
+/**
+ * The finite states of a single console run. Drives which controls the screen offers. The transitions are
+ * enforced by [AgentRunMath.nextState]; the console never lets the user execute before a ticket is claimed
+ * (except PM which is operation-driven), nor approve/reject a deployment that is not awaiting approval.
+ */
+enum class RunState {
+    /** No ticket selected yet (pick from eligible tickets). PM starts here too (pick an operation). */
+    IDLE,
+
+    /** A ticket has been claimed to this run; ready to execute. */
+    CLAIMED,
+
+    /** Execute in flight. */
+    EXECUTING,
+
+    /** Execution produced output that does NOT need approval - terminal-ish (can re-load output). */
+    COMPLETED,
+
+    /** DevOps deployment produced output that is awaiting a human approve/reject decision. */
+    AWAITING_APPROVAL,
+
+    /** Deployment approved (terminal). */
+    APPROVED,
+
+    /** Deployment rejected (terminal). */
+    REJECTED,
+
+    /** The run/output call 404'd (degrade-on-404: nothing to show, offer retry). */
+    NOT_FOUND,
+
+    /** A non-404 error (network / 403 forbidden / server). */
+    ERROR,
+}
+
+/** An eligible ticket the console can claim (union of the per-type eligible-ticket shapes). */
+data class EligibleTicket(
+    val ticketId: String,
+    val subject: String,
+    val labels: List<String>,
+    val complexity: String?,
+    val estimatedEffortHours: Int?,
+    val status: String?,
+)
+
+/** One test-result row lifted from a run output (coder test_results / qa regression counts). */
+data class RunTestResult(
+    val label: String,
+    val passed: Boolean,
+    val durationSeconds: Int?,
+)
+
+/**
+ * The uniform, display-only projection of ANY agent run output. Fields absent for a given type stay at their
+ * neutral default so the console renders a coherent card set regardless of which agent produced the output.
+ */
+data class AgentRunOutput(
+    val type: AgentRunType,
+    /** Headline line (branch name / deployment id / verdict / operation), never blank when there IS output. */
+    val headline: String,
+    /** A short status/verdict token (e.g. "pass", "fail", "success", "pending_approval"). */
+    val status: String,
+    val prUrl: String?,
+    val filesChanged: List<String>,
+    val insertions: Int,
+    val deletions: Int,
+    val testResults: List<RunTestResult>,
+    val totalDurationSeconds: Int,
+    val escalated: Boolean,
+    val escalationReason: String?,
+    /** True only when the parsed output represents a deployment awaiting a human approval decision. */
+    val awaitingApproval: Boolean,
+    /** Free-form extra key/value lines the console shows verbatim (per-type extras, e.g. PM counts). */
+    val extras: List<Pair<String, String>>,
+)
+
+/** Outcome of a deployment approve/reject decision. */
+data class DeploymentDecision(
+    val runId: String,
+    val deploymentId: String,
+    val approvalStatus: String,
+    val approvedBy: String,
+    val notes: String?,
+)
+
+/** A run's markdown report (QA). */
+data class RunReport(
+    val runId: String,
+    val verdict: String,
+    val markdown: String,
+)
+
+/** A compact metrics projection (union of the per-type metrics maps) rendered as labelled rows. */
+data class RunMetrics(
+    val rows: List<Pair<String, String>>,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunMath.kt
@@ -1,0 +1,312 @@
+package com.testlogon.android.data.agentrun
+
+import java.util.Locale
+
+/**
+ * AGENT-RUN (web-parity) - PURE, framework-free logic for the generic agent-run console: the run-state
+ * machine and the free-form-map -> [AgentRunOutput] projection. No Android / coroutine / network deps, so it
+ * is fully JVM-unit-testable (mirrors PrsCompletionMath).
+ *
+ * All map access is defensive: JSON decoded via the shared reflective Moshi yields Double for every number
+ * and String/Boolean/List/Map for the rest, so numeric reads go through [asInt] (which tolerates Double, Long,
+ * Int and numeric strings) and every field degrades to a neutral default when absent or the wrong type.
+ */
+object AgentRunMath {
+
+    // ---------------------------------------------------------------------
+    // Run-state machine
+    // ---------------------------------------------------------------------
+
+    /**
+     * The single allowed successor of [current] for [event]. Returns the SAME state when the event is not
+     * legal from [current] (the console simply ignores an illegal control), except that [RunEvent.Reset]
+     * always returns to IDLE and error/not-found events are always accepted.
+     */
+    fun nextState(current: RunState, event: RunEvent, awaitingApproval: Boolean = false): RunState =
+        when (event) {
+            RunEvent.Reset -> RunState.IDLE
+            RunEvent.NotFound -> RunState.NOT_FOUND
+            RunEvent.Error -> RunState.ERROR
+            RunEvent.ClaimTicket -> when (current) {
+                RunState.IDLE, RunState.NOT_FOUND, RunState.ERROR -> RunState.CLAIMED
+                else -> current
+            }
+            RunEvent.StartExecute -> when (current) {
+                // PM is operation-driven: it may execute straight from IDLE (no claim step).
+                RunState.CLAIMED, RunState.IDLE, RunState.COMPLETED,
+                RunState.NOT_FOUND, RunState.ERROR -> RunState.EXECUTING
+                else -> current
+            }
+            RunEvent.ExecuteDone -> when (current) {
+                RunState.EXECUTING ->
+                    if (awaitingApproval) RunState.AWAITING_APPROVAL else RunState.COMPLETED
+                else -> current
+            }
+            RunEvent.Approve -> if (current == RunState.AWAITING_APPROVAL) RunState.APPROVED else current
+            RunEvent.Reject -> if (current == RunState.AWAITING_APPROVAL) RunState.REJECTED else current
+        }
+
+    /** True when executing is a meaningful action from [state] for [type]. */
+    fun canExecute(state: RunState, type: AgentRunType): Boolean = when {
+        state == RunState.EXECUTING -> false
+        type.operationDriven -> state != RunState.AWAITING_APPROVAL
+        else -> state == RunState.CLAIMED || state == RunState.COMPLETED ||
+            state == RunState.NOT_FOUND || state == RunState.ERROR
+    }
+
+    /** True when the console should offer approve/reject controls. */
+    fun canDecide(state: RunState, type: AgentRunType): Boolean =
+        type.supportsApproval && state == RunState.AWAITING_APPROVAL
+
+    // ---------------------------------------------------------------------
+    // Run-id generation (client-side, mirrors the web crypto.randomUUID run ids)
+    // ---------------------------------------------------------------------
+
+    /**
+     * A stable, URL-safe run id from a monotonically-unique [seed] (e.g. System.currentTimeMillis()) and the
+     * [type]. Deterministic for a given seed so it is testable; the ViewModel supplies a real clock.
+     */
+    fun buildRunId(type: AgentRunType, seed: Long): String = "run_${type.typeName}_$seed"
+
+    // ---------------------------------------------------------------------
+    // Output projection
+    // ---------------------------------------------------------------------
+
+    /**
+     * Projects a raw agent-output map into the uniform [AgentRunOutput]. Never throws; unknown/absent fields
+     * degrade to neutral defaults. The [type] selects which headline/status keys are authoritative.
+     */
+    fun parseOutput(type: AgentRunType, raw: Map<String, Any?>): AgentRunOutput {
+        val prUrl = (raw["pr_url"] as? String)?.takeIf { it.isNotBlank() }
+        val filesChanged = stringList(raw["files_changed"])
+        val insertions = asInt(raw["insertions"])
+        val deletions = asInt(raw["deletions"])
+        val duration = asInt(raw["total_duration_seconds"])
+        val escalated = (raw["escalated"] as? Boolean) ?: false
+        val escalationReason = (raw["escalation_reason"] as? String)?.takeIf { it.isNotBlank() }
+
+        val headline: String
+        val status: String
+        val testResults: List<RunTestResult>
+        val awaiting: Boolean
+        val extras = mutableListOf<Pair<String, String>>()
+
+        when (type) {
+            AgentRunType.CODER -> {
+                headline = (raw["branch_name"] as? String)?.takeIf { it.isNotBlank() } ?: "Coder run"
+                testResults = coderTestResults(raw["test_results"])
+                status = if (escalated) "escalated" else if (allTestsPassed(testResults)) "pass" else "done"
+                awaiting = false
+                addInt(extras, "PR #", raw["pr_number"])
+                addInt(extras, "Retries", raw["test_retry_count"])
+            }
+            AgentRunType.QA -> {
+                val verdict = (raw["verdict"] as? String)?.takeIf { it.isNotBlank() } ?: "unknown"
+                headline = "Verdict: $verdict"
+                status = verdict
+                testResults = qaTestResults(raw)
+                awaiting = false
+                addInt(extras, "New tests", raw["new_tests_written"])
+                addInt(extras, "Regression run", raw["regression_tests_run"])
+                addInt(extras, "Regression failed", raw["regression_tests_fail"])
+                stringList(raw["bug_ticket_ids"]).takeIf { it.isNotEmpty() }
+                    ?.let { extras.add("Bugs filed" to it.joinToString(", ")) }
+            }
+            AgentRunType.DEVOPS -> {
+                val depId = (raw["deployment_id"] as? String)?.takeIf { it.isNotBlank() } ?: "deployment"
+                val st = (raw["status"] as? String)?.takeIf { it.isNotBlank() } ?: "unknown"
+                headline = depId
+                status = st
+                awaiting = isAwaitingApproval(st)
+                testResults = emptyList()
+                (raw["environment"] as? String)?.let { extras.add("Environment" to it) }
+                addInt(extras, "Steps done", raw["steps_completed"])
+                addInt(extras, "Steps total", raw["steps_total"])
+                (raw["version_deployed"] as? String)?.let { extras.add("Version" to it) }
+                if ((raw["rollback_executed"] as? Boolean) == true) extras.add("Rollback" to "executed")
+            }
+            AgentRunType.ARCHITECT -> {
+                val fid = (raw["feature_ticket_id"] as? String)?.takeIf { it.isNotBlank() }
+                headline = fid?.let { "Feature $it" } ?: "Decomposition"
+                val total = asInt(raw["total_tickets"])
+                status = if (total > 0) "decomposed" else "done"
+                testResults = emptyList()
+                awaiting = false
+                addInt(extras, "Tickets created", raw["total_tickets"])
+                addDouble(extras, "Est. hours", raw["total_estimated_hours"])
+                (raw["decomposition_summary"] as? String)?.takeIf { it.isNotBlank() }
+                    ?.let { extras.add("Summary" to it) }
+            }
+            AgentRunType.PM -> {
+                val op = (raw["operation_type"] as? String)?.takeIf { it.isNotBlank() } ?: "operation"
+                headline = op.replace('_', ' ')
+                status = "done"
+                testResults = emptyList()
+                awaiting = false
+                addInt(extras, "Ideas processed", raw["ideas_processed"])
+                addInt(extras, "Ideas accepted", raw["ideas_accepted"])
+                addInt(extras, "Reprioritized", raw["tickets_reprioritized"])
+                addInt(extras, "Blockers", raw["blockers_found"])
+                addInt(extras, "Escalations", raw["escalations_created"])
+                (raw["report_id"] as? String)?.let { extras.add("Report id" to it) }
+            }
+            AgentRunType.DOCS -> {
+                headline = "Docs run"
+                status = "done"
+                testResults = emptyList()
+                awaiting = false
+            }
+        }
+
+        return AgentRunOutput(
+            type = type,
+            headline = headline,
+            status = status,
+            prUrl = prUrl,
+            filesChanged = filesChanged,
+            insertions = insertions,
+            deletions = deletions,
+            testResults = testResults,
+            totalDurationSeconds = duration,
+            escalated = escalated,
+            escalationReason = escalationReason,
+            awaitingApproval = awaiting,
+            extras = extras,
+        )
+    }
+
+    /** Projects an eligible-tickets response map into the uniform ticket list. */
+    fun parseEligibleTickets(raw: Map<String, Any?>): List<EligibleTicket> {
+        val list = raw["tickets"] as? List<*> ?: return emptyList()
+        return list.mapNotNull { item ->
+            val m = item as? Map<*, *> ?: return@mapNotNull null
+            val id = (m["ticket_id"] as? String)?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            EligibleTicket(
+                ticketId = id,
+                subject = (m["subject"] as? String).orEmpty(),
+                labels = stringList(m["labels"]),
+                complexity = (m["complexity"] as? String)?.takeIf { it.isNotBlank() },
+                estimatedEffortHours = m["estimated_effort_hours"]?.let { asIntOrNull(it) },
+                status = (m["status"] as? String)?.takeIf { it.isNotBlank() },
+            )
+        }
+    }
+
+    /** Projects a metrics map into labelled rows (integers rendered cleanly, rates as percentages). */
+    fun parseMetrics(raw: Map<String, Any?>): RunMetrics {
+        val rows = mutableListOf<Pair<String, String>>()
+        for ((key, value) in raw) {
+            if (value == null) continue
+            val label = key.split('_').joinToString(" ") { it.replaceFirstChar { c -> c.uppercase(Locale.US) } }
+            val rendered = when {
+                key.endsWith("_rate") -> asDoubleOrNull(value)?.let { pct(it) } ?: value.toString()
+                value is Boolean -> if (value) "yes" else "no"
+                value is Double -> if (value % 1.0 == 0.0) value.toLong().toString() else trimDouble(value)
+                value is Map<*, *> -> value.entries.joinToString(", ") { "${it.key}=${it.value}" }
+                value is List<*> -> value.joinToString(", ")
+                else -> value.toString()
+            }
+            rows.add(label to rendered)
+        }
+        return RunMetrics(rows = rows)
+    }
+
+    /** Parses a deployment approve/reject response map. */
+    fun parseDecision(runId: String, raw: Map<String, Any?>): DeploymentDecision = DeploymentDecision(
+        runId = (raw["run_id"] as? String)?.takeIf { it.isNotBlank() } ?: runId,
+        deploymentId = (raw["deployment_id"] as? String).orEmpty(),
+        approvalStatus = (raw["approval_status"] as? String).orEmpty(),
+        approvedBy = (raw["approved_by"] as? String).orEmpty(),
+        notes = (raw["notes"] as? String)?.takeIf { it.isNotBlank() },
+    )
+
+    // ---------------------------------------------------------------------
+    // Internals
+    // ---------------------------------------------------------------------
+
+    private fun isAwaitingApproval(status: String): Boolean {
+        val s = status.trim().lowercase(Locale.US)
+        return s == "pending_approval" || s == "awaiting_approval" || s == "pending"
+    }
+
+    private fun allTestsPassed(results: List<RunTestResult>): Boolean =
+        results.isNotEmpty() && results.all { it.passed }
+
+    private fun coderTestResults(raw: Any?): List<RunTestResult> {
+        val list = raw as? List<*> ?: return emptyList()
+        return list.mapNotNull { item ->
+            val m = item as? Map<*, *> ?: return@mapNotNull null
+            val exit = asInt(m["exit_code"])
+            RunTestResult(
+                label = (m["command"] as? String)?.takeIf { it.isNotBlank() } ?: "test",
+                passed = exit == 0,
+                durationSeconds = m["duration_seconds"]?.let { asIntOrNull(it) },
+            )
+        }
+    }
+
+    private fun qaTestResults(raw: Map<String, Any?>): List<RunTestResult> {
+        val out = mutableListOf<RunTestResult>()
+        val newPass = asInt(raw["new_tests_pass_count"])
+        val newFail = asInt(raw["new_tests_fail_count"])
+        if (newPass + newFail > 0) {
+            out.add(RunTestResult("New tests: $newPass passed", newFail == 0, null))
+        }
+        val regPass = asInt(raw["regression_tests_pass"])
+        val regFail = asInt(raw["regression_tests_fail"])
+        if (regPass + regFail > 0) {
+            out.add(RunTestResult("Regression: $regPass/${regPass + regFail}", regFail == 0, null))
+        }
+        return out
+    }
+
+    private fun stringList(raw: Any?): List<String> =
+        (raw as? List<*>)?.mapNotNull { it?.toString()?.takeIf { s -> s.isNotBlank() } } ?: emptyList()
+
+    private fun addInt(into: MutableList<Pair<String, String>>, label: String, raw: Any?) {
+        asIntOrNull(raw)?.let { into.add(label to it.toString()) }
+    }
+
+    private fun addDouble(into: MutableList<Pair<String, String>>, label: String, raw: Any?) {
+        asDoubleOrNull(raw)?.let { into.add(label to trimDouble(it)) }
+    }
+
+    /** Tolerant int read (Double/Long/Int/numeric-String); non-numeric -> 0. */
+    fun asInt(raw: Any?): Int = asIntOrNull(raw) ?: 0
+
+    private fun asIntOrNull(raw: Any?): Int? = when (raw) {
+        is Int -> raw
+        is Long -> raw.toInt()
+        is Double -> raw.toInt()
+        is String -> raw.trim().toDoubleOrNull()?.toInt()
+        else -> null
+    }
+
+    private fun asDoubleOrNull(raw: Any?): Double? = when (raw) {
+        is Double -> raw
+        is Int -> raw.toDouble()
+        is Long -> raw.toDouble()
+        is String -> raw.trim().toDoubleOrNull()
+        else -> null
+    }
+
+    private fun pct(rate: Double): String {
+        val p = rate * 100.0
+        return if (p % 1.0 == 0.0) "${p.toLong()}%" else String.format(Locale.US, "%.1f%%", p)
+    }
+
+    private fun trimDouble(v: Double): String =
+        if (v % 1.0 == 0.0) v.toLong().toString() else v.toString()
+}
+
+/** Events that drive the [RunState] machine. */
+enum class RunEvent {
+    ClaimTicket,
+    StartExecute,
+    ExecuteDone,
+    Approve,
+    Reject,
+    NotFound,
+    Error,
+    Reset,
+}

--- a/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/agentrun/AgentRunRepository.kt
@@ -1,0 +1,204 @@
+package com.testlogon.android.data.agentrun
+
+import com.squareup.moshi.JsonDataException
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.agentrun.AgentRunApi
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * AGENT-RUN (web-parity) - data layer over [AgentRunApi] for the generic agent-run console. Routes each
+ * [AgentRunType] to the correct per-type eligible/claim/execute/output/metrics endpoint, projects every
+ * free-form response into a display model via [AgentRunMath], and wraps every call in [ApiResult]. A 403
+ * surfaces as ApiResult.Failure(status=403) (the VM renders Forbidden - expected for the non-operator test
+ * user); a 404 on OUTPUT is DEGRADE-ON-404 (surfaced as Success(null) so the console shows "no output yet"
+ * rather than an error).
+ */
+interface AgentRunRepository {
+
+    suspend fun eligibleTickets(type: AgentRunType, typeId: String, limit: Int): ApiResult<List<EligibleTicket>>
+
+    suspend fun claim(type: AgentRunType, runId: String, ticketId: String): ApiResult<Unit>
+
+    suspend fun execute(
+        type: AgentRunType,
+        typeId: String,
+        runId: String,
+        ticketId: String,
+        pmOperation: PmOperation?,
+    ): ApiResult<AgentRunOutput>
+
+    /** GET the persisted output. DEGRADE-ON-404: a 404 becomes Success(null) (no output yet). */
+    suspend fun output(type: AgentRunType, runId: String): ApiResult<AgentRunOutput?>
+
+    suspend fun report(runId: String): ApiResult<RunReport?>
+
+    suspend fun metrics(type: AgentRunType, typeId: String, periodDays: Int): ApiResult<RunMetrics>
+
+    suspend fun decide(
+        runId: String,
+        approve: Boolean,
+        notes: String?,
+    ): ApiResult<DeploymentDecision>
+}
+
+@Singleton
+class AgentRunRepositoryImpl @Inject constructor(
+    private val api: AgentRunApi,
+    private val errorParser: ApiErrorParser,
+) : AgentRunRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun eligibleTickets(
+        type: AgentRunType,
+        typeId: String,
+        limit: Int,
+    ): ApiResult<List<EligibleTicket>> = withContext(io) {
+        call {
+            val raw = when (type) {
+                AgentRunType.CODER -> api.coderEligibleTickets(typeId, limit)
+                AgentRunType.QA -> api.qaEligibleTickets(typeId, limit)
+                AgentRunType.DEVOPS -> api.devopsEligibleTickets(typeId, limit)
+                AgentRunType.ARCHITECT -> api.architectEligibleTickets(typeId, limit)
+                // PM is operation-driven and DOCS has no ticket queue: no eligible-tickets endpoint.
+                AgentRunType.PM, AgentRunType.DOCS -> emptyMap()
+            }
+            AgentRunMath.parseEligibleTickets(raw)
+        }
+    }
+
+    override suspend fun claim(
+        type: AgentRunType,
+        runId: String,
+        ticketId: String,
+    ): ApiResult<Unit> = withContext(io) {
+        val body = mapOf("ticket_id" to ticketId)
+        call {
+            when (type) {
+                AgentRunType.QA -> api.claimQaTicket(runId, body)
+                // Coder claim route is the generic claim-ticket; the other types execute without a claim step.
+                else -> api.claimCoderTicket(runId, body)
+            }
+            Unit
+        }
+    }
+
+    override suspend fun execute(
+        type: AgentRunType,
+        typeId: String,
+        runId: String,
+        ticketId: String,
+        pmOperation: PmOperation?,
+    ): ApiResult<AgentRunOutput> = withContext(io) {
+        call {
+            val raw = when (type) {
+                AgentRunType.CODER -> api.executeCoder(typeId, runId, mapOf("ticket_id" to ticketId))
+                AgentRunType.QA -> api.executeQa(
+                    typeId, runId, mapOf("ticket_id" to ticketId, "scenario" to "fail"),
+                )
+                AgentRunType.DEVOPS -> api.executeDevops(typeId, runId, mapOf("ticket_id" to ticketId))
+                AgentRunType.ARCHITECT -> api.decomposeArchitect(typeId, runId, mapOf("ticket_id" to ticketId))
+                AgentRunType.PM -> api.runPmOperation(
+                    typeId,
+                    runId,
+                    mapOf(
+                        "operation_type" to (pmOperation ?: PmOperation.IDEA_TRIAGE).wire,
+                        "report_type" to "daily",
+                    ),
+                )
+                AgentRunType.DOCS -> emptyMap()
+            }
+            AgentRunMath.parseOutput(type, raw)
+        }
+    }
+
+    override suspend fun output(type: AgentRunType, runId: String): ApiResult<AgentRunOutput?> =
+        withContext(io) {
+            callDegradable {
+                val raw = when (type) {
+                    AgentRunType.CODER -> api.coderOutput(runId)
+                    AgentRunType.QA -> api.qaOutput(runId)
+                    AgentRunType.DEVOPS -> api.devopsOutput(runId)
+                    AgentRunType.ARCHITECT -> api.architectOutput(runId)
+                    AgentRunType.PM -> api.pmOutput(runId)
+                    AgentRunType.DOCS -> emptyMap()
+                }
+                AgentRunMath.parseOutput(type, raw)
+            }
+        }
+
+    override suspend fun report(runId: String): ApiResult<RunReport?> = withContext(io) {
+        callDegradable {
+            val raw = api.qaReport(runId)
+            RunReport(
+                runId = (raw["run_id"] as? String)?.takeIf { it.isNotBlank() } ?: runId,
+                verdict = (raw["verdict"] as? String).orEmpty(),
+                markdown = (raw["report_markdown"] as? String).orEmpty(),
+            )
+        }
+    }
+
+    override suspend fun metrics(
+        type: AgentRunType,
+        typeId: String,
+        periodDays: Int,
+    ): ApiResult<RunMetrics> = withContext(io) {
+        call {
+            val raw = when (type) {
+                AgentRunType.CODER -> api.coderMetrics(typeId, periodDays)
+                AgentRunType.QA -> api.qaMetrics(typeId, periodDays)
+                AgentRunType.DEVOPS -> api.devopsMetrics(typeId, periodDays)
+                AgentRunType.ARCHITECT -> api.architectMetrics(typeId, periodDays)
+                AgentRunType.PM -> api.pmMetrics(typeId, periodDays)
+                AgentRunType.DOCS -> emptyMap()
+            }
+            AgentRunMath.parseMetrics(raw)
+        }
+    }
+
+    override suspend fun decide(
+        runId: String,
+        approve: Boolean,
+        notes: String?,
+    ): ApiResult<DeploymentDecision> = withContext(io) {
+        val body = mapOf<String, Any?>("approved" to approve, "approver_notes" to notes)
+        call {
+            val raw = if (approve) api.approveDeployment(runId, body) else api.rejectDeployment(runId, body)
+            AgentRunMath.parseDecision(runId, raw)
+        }
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    /** Like [call] but a 404 becomes Success(null) (degrade-on-404 for absent run output/report). */
+    private suspend fun <T> callDegradable(block: suspend () -> T): ApiResult<T?> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == 404) ApiResult.Success(null) else ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunConsoleScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunConsoleScreen.kt
@@ -1,0 +1,355 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.agents.run.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.agentrun.AgentRunOutput
+import com.testlogon.android.data.agentrun.AgentRunType
+import com.testlogon.android.data.agentrun.PmOperation
+import com.testlogon.android.data.agentrun.RunMetrics
+import com.testlogon.android.data.agentrun.RunState
+
+/**
+ * AGENT-RUN (web-parity) - the generic agent-run CONSOLE. One screen drives eligible-tickets -> claim ->
+ * execute -> output/report/metrics for any of the six agent types; DevOps additionally shows an
+ * approve/reject deployment gate (mobile mirror of the web DeploymentApprovalPanel). Operator-gated in the
+ * More catalog + backend-403 -> Forbidden notice.
+ */
+object AgentRunConsoleTestTags {
+    const val SCREEN = "agent_run_console_screen"
+    const val CLAIM = "agent_run_claim"
+    const val EXECUTE = "agent_run_execute"
+    const val APPROVE = "agent_run_approve"
+    const val REJECT = "agent_run_reject"
+    fun ticket(id: String) = "agent_run_ticket_$id"
+}
+
+@Composable
+fun AgentRunConsoleRoute(
+    onBack: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    viewModel: AgentRunConsoleViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                AgentRunEffect.NavigateToLogin -> onNavigateToLogin()
+            }
+        }
+    }
+    AgentRunConsoleScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onSelectTicket = viewModel::selectTicket,
+        onSelectPmOperation = viewModel::selectPmOperation,
+        onClaim = viewModel::claim,
+        onExecute = viewModel::execute,
+        onRefreshOutput = viewModel::refreshOutput,
+        onLoadMetrics = viewModel::loadMetrics,
+        onApprove = viewModel::approve,
+        onReject = viewModel::reject,
+        onDismissMessage = viewModel::dismissMessage,
+    )
+}
+
+@Composable
+fun AgentRunConsoleScreen(
+    state: AgentRunUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onSelectTicket: (String) -> Unit,
+    onSelectPmOperation: (PmOperation) -> Unit,
+    onClaim: () -> Unit,
+    onExecute: () -> Unit,
+    onRefreshOutput: () -> Unit,
+    onLoadMetrics: () -> Unit,
+    onApprove: (String?) -> Unit,
+    onReject: (String?) -> Unit,
+    onDismissMessage: () -> Unit,
+) {
+    val snackbar = remember { SnackbarHostState() }
+    val title = (state as? AgentRunUiState.Content)?.type?.title ?: "Agent run"
+
+    if (state is AgentRunUiState.Content && state.message != null) {
+        LaunchedEffect(state.message) {
+            snackbar.showSnackbar(state.message)
+            onDismissMessage()
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.testTag(AgentRunConsoleTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbar) },
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state) {
+            AgentRunUiState.Loading -> LoadingState(Modifier.padding(padding))
+            AgentRunUiState.Forbidden -> EmptyState(
+                title = "Operator access required",
+                body = "The agent-run console is available to admins/operators only.",
+                modifier = Modifier.padding(padding),
+            )
+            is AgentRunUiState.Error -> ErrorState(
+                message = state.message,
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            is AgentRunUiState.Content -> ConsoleContent(
+                state = state,
+                modifier = Modifier.padding(padding),
+                onSelectTicket = onSelectTicket,
+                onSelectPmOperation = onSelectPmOperation,
+                onClaim = onClaim,
+                onExecute = onExecute,
+                onRefreshOutput = onRefreshOutput,
+                onLoadMetrics = onLoadMetrics,
+                onApprove = onApprove,
+                onReject = onReject,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConsoleContent(
+    state: AgentRunUiState.Content,
+    modifier: Modifier,
+    onSelectTicket: (String) -> Unit,
+    onSelectPmOperation: (PmOperation) -> Unit,
+    onClaim: () -> Unit,
+    onExecute: () -> Unit,
+    onRefreshOutput: () -> Unit,
+    onLoadMetrics: () -> Unit,
+    onApprove: (String?) -> Unit,
+    onReject: (String?) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        SectionCard("Agent") {
+            Text("${state.type.title}  ·  type id: ${state.typeId}", style = MaterialTheme.typography.bodyMedium)
+            Text("State: ${state.runState.name}", style = MaterialTheme.typography.labelMedium)
+            state.runId?.let { Text("Run: $it", fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.labelSmall) }
+        }
+
+        if (state.type.operationDriven) {
+            SectionCard("Operation") {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    PmOperation.entries.forEach { op ->
+                        FilterChip(
+                            selected = state.pmOperation == op,
+                            onClick = { onSelectPmOperation(op) },
+                            label = { Text(op.label) },
+                        )
+                    }
+                }
+                Button(
+                    onClick = onExecute,
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth().testTag(AgentRunConsoleTestTags.EXECUTE),
+                ) { Text("Run operation") }
+            }
+        } else if (state.type != AgentRunType.DOCS) {
+            SectionCard("Eligible tickets") {
+                if (state.eligibleTickets.isEmpty()) {
+                    Text("No eligible tickets for this agent.", style = MaterialTheme.typography.bodySmall)
+                } else {
+                    state.eligibleTickets.forEach { t ->
+                        FilterChip(
+                            selected = state.selectedTicketId == t.ticketId,
+                            onClick = { onSelectTicket(t.ticketId) },
+                            label = { Text("${t.ticketId} · ${t.subject.take(40)}") },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(AgentRunConsoleTestTags.ticket(t.ticketId)),
+                        )
+                    }
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(
+                        onClick = onClaim,
+                        enabled = !state.busy && state.selectedTicketId != null,
+                        modifier = Modifier.weight(1f).testTag(AgentRunConsoleTestTags.CLAIM),
+                    ) { Text("Claim") }
+                    Button(
+                        onClick = onExecute,
+                        enabled = !state.busy && state.runState == RunState.CLAIMED ||
+                            !state.busy && state.runState == RunState.COMPLETED,
+                        modifier = Modifier.weight(1f).testTag(AgentRunConsoleTestTags.EXECUTE),
+                    ) { Text("Execute") }
+                }
+            }
+        }
+
+        state.output?.let { OutputCard(it, onRefreshOutput) }
+
+        if (state.type.supportsApproval && state.runState == RunState.AWAITING_APPROVAL) {
+            ApprovalCard(onApprove = onApprove, onReject = onReject, busy = state.busy)
+        }
+        state.decision?.let { d ->
+            SectionCard("Deployment decision") {
+                Text("Status: ${d.approvalStatus}", style = MaterialTheme.typography.bodyMedium)
+                if (d.deploymentId.isNotBlank()) Text("Deployment: ${d.deploymentId}")
+                d.notes?.let { Text("Notes: $it") }
+            }
+        }
+
+        state.report?.let { r ->
+            SectionCard("QA report (${r.verdict})") {
+                Text(
+                    text = r.markdown.ifBlank { "(empty report)" },
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+        }
+
+        MetricsCard(state.metrics, state.loadingMetrics, onLoadMetrics)
+    }
+}
+
+@Composable
+private fun OutputCard(output: AgentRunOutput, onRefresh: () -> Unit) {
+    SectionCard("Output") {
+        Text(output.headline, style = MaterialTheme.typography.titleSmall)
+        AssistChip(onClick = {}, label = { Text(output.status) })
+        output.prUrl?.let { Text(it, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodySmall) }
+        if (output.filesChanged.isNotEmpty()) {
+            HorizontalDivider()
+            Text("Files changed (+${output.insertions} / -${output.deletions})", style = MaterialTheme.typography.labelMedium)
+            output.filesChanged.take(30).forEach {
+                Text(it, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+        if (output.testResults.isNotEmpty()) {
+            HorizontalDivider()
+            output.testResults.forEach {
+                Text(
+                    "${if (it.passed) "PASS" else "FAIL"}  ${it.label}" + (it.durationSeconds?.let { d -> "  ${d}s" } ?: ""),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+        if (output.extras.isNotEmpty()) {
+            HorizontalDivider()
+            output.extras.forEach { (k, v) -> Text("$k: $v", style = MaterialTheme.typography.bodySmall) }
+        }
+        Text("Duration: ${output.totalDurationSeconds}s", style = MaterialTheme.typography.labelSmall)
+        if (output.escalated) {
+            Text("Escalated: ${output.escalationReason ?: "yes"}", style = MaterialTheme.typography.labelMedium)
+        }
+        OutlinedButton(onClick = onRefresh) { Text("Reload output") }
+    }
+}
+
+@Composable
+private fun ApprovalCard(onApprove: (String?) -> Unit, onReject: (String?) -> Unit, busy: Boolean) {
+    var notes by remember { mutableStateOf("") }
+    SectionCard("Deployment pending approval") {
+        OutlinedTextField(
+            value = notes,
+            onValueChange = { notes = it },
+            label = { Text("Approver notes") },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                onClick = { onApprove(notes) },
+                enabled = !busy,
+                modifier = Modifier.weight(1f).testTag(AgentRunConsoleTestTags.APPROVE),
+            ) { Text("Approve") }
+            OutlinedButton(
+                onClick = { onReject(notes) },
+                enabled = !busy,
+                modifier = Modifier.weight(1f).testTag(AgentRunConsoleTestTags.REJECT),
+            ) { Text("Reject") }
+        }
+    }
+}
+
+@Composable
+private fun MetricsCard(metrics: RunMetrics?, loading: Boolean, onLoad: () -> Unit) {
+    SectionCard("Metrics") {
+        when {
+            loading -> LoadingState(fullScreen = false)
+            metrics == null || metrics.rows.isEmpty() ->
+                OutlinedButton(onClick = onLoad) { Text("Load metrics") }
+            else -> metrics.rows.forEach { (k, v) ->
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text(k, style = MaterialTheme.typography.bodySmall)
+                    Text(v, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionCard(title: String, content: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            content()
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunConsoleViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunConsoleViewModel.kt
@@ -1,0 +1,245 @@
+package com.testlogon.android.feature.agents.run.ui
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.agentrun.AgentRunMath
+import com.testlogon.android.data.agentrun.AgentRunRepository
+import com.testlogon.android.data.agentrun.AgentRunType
+import com.testlogon.android.data.agentrun.PmOperation
+import com.testlogon.android.data.agentrun.RunEvent
+import com.testlogon.android.data.agentrun.RunState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * AGENT-RUN (web-parity) - drives the generic agent-run console. Reads {type,typeId} from the nav args, then
+ * exposes the eligible-tickets -> claim -> execute -> view output/report/metrics lifecycle over
+ * [AgentRunRepository]. DevOps additionally exposes approve/reject. State transitions go through the PURE
+ * [AgentRunMath.nextState] machine so the UI can never issue an illegal control. Degrade-on-404 (output/report
+ * absent -> a neutral "no output yet" rather than an error). Terminal 401 -> [AgentRunEffect.NavigateToLogin];
+ * a 403 on the initial load -> [AgentRunUiState.Forbidden] (operator-only). No poll loops.
+ */
+@HiltViewModel
+class AgentRunConsoleViewModel @Inject constructor(
+    private val repo: AgentRunRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val type: AgentRunType =
+        AgentRunType.from(savedStateHandle[ARG_TYPE]) ?: AgentRunType.CODER
+    private val typeId: String =
+        (savedStateHandle.get<String>(ARG_TYPE_ID)).orEmpty().ifBlank { type.typeName }
+
+    private val _uiState = MutableStateFlow<AgentRunUiState>(AgentRunUiState.Loading)
+    val uiState: StateFlow<AgentRunUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<AgentRunEffect>(Channel.BUFFERED)
+    val effects: Flow<AgentRunEffect> = _effects.receiveAsFlow()
+
+    private var loadJob: Job? = null
+
+    init { load() }
+
+    fun load() {
+        if (loadJob?.isActive == true) return
+        _uiState.value = AgentRunUiState.Loading
+        loadJob = viewModelScope.launch {
+            // PM/DOCS have no eligible-tickets queue; seed the console straight into IDLE with metrics.
+            if (type == AgentRunType.PM || type == AgentRunType.DOCS) {
+                _uiState.value = baseContent()
+                loadMetricsInto()
+                return@launch
+            }
+            when (val result = repo.eligibleTickets(type, typeId, limit = 20)) {
+                is ApiResult.Success -> {
+                    _uiState.value = baseContent().copy(eligibleTickets = result.data)
+                    loadMetricsInto()
+                }
+                is ApiResult.Failure ->
+                    if (result.error.status == HTTP_FORBIDDEN) {
+                        _uiState.value = AgentRunUiState.Forbidden
+                    } else {
+                        if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(AgentRunEffect.NavigateToLogin)
+                        _uiState.value = AgentRunUiState.Error(result.error.message)
+                    }
+                is ApiResult.NetworkError -> _uiState.value = AgentRunUiState.Error(OFFLINE)
+            }
+        }
+    }
+
+    fun onRetry() = load()
+
+    fun selectTicket(ticketId: String) {
+        val c = content() ?: return
+        _uiState.value = c.copy(selectedTicketId = ticketId, message = null)
+    }
+
+    fun selectPmOperation(operation: PmOperation) {
+        val c = content() ?: return
+        _uiState.value = c.copy(pmOperation = operation, message = null)
+    }
+
+    /** Claim the selected ticket to a fresh run id. */
+    fun claim() {
+        val c = content() ?: return
+        val ticketId = c.selectedTicketId ?: return
+        if (c.busy) return
+        val runId = AgentRunMath.buildRunId(type, System.currentTimeMillis())
+        _uiState.value = c.copy(busy = true, message = null, runId = runId)
+        viewModelScope.launch {
+            when (val r = repo.claim(type, runId, ticketId)) {
+                is ApiResult.Success -> transition(RunEvent.ClaimTicket) { it.copy(busy = false) }
+                is ApiResult.Failure -> failAction(r.error.status, r.error.message)
+                is ApiResult.NetworkError -> failAction(0, OFFLINE)
+            }
+        }
+    }
+
+    /** Execute (coder/qa/devops/architect) or run the PM operation. */
+    fun execute() {
+        val c = content() ?: return
+        if (c.busy || !AgentRunMath.canExecute(c.runState, type)) return
+        // Non-PM needs a claimed ticket (and a run id); PM executes to a fresh run id straight from IDLE.
+        val ticketId = c.selectedTicketId.orEmpty()
+        val runId = c.runId ?: AgentRunMath.buildRunId(type, System.currentTimeMillis())
+        _uiState.value = transitionState(c.copy(busy = true, message = null, runId = runId), RunEvent.StartExecute)
+        viewModelScope.launch {
+            when (val r = repo.execute(type, typeId, runId, ticketId, c.pmOperation)) {
+                is ApiResult.Success -> {
+                    val out = r.data
+                    _uiState.value = transitionState(
+                        (content() ?: c).copy(busy = false, output = out, message = null),
+                        RunEvent.ExecuteDone,
+                        awaitingApproval = out.awaitingApproval,
+                    )
+                    if (type.hasReport) loadReport(runId)
+                }
+                is ApiResult.Failure -> failExecute(r.error.status, r.error.message)
+                is ApiResult.NetworkError -> failExecute(0, OFFLINE)
+            }
+        }
+    }
+
+    /** Re-read the persisted output (degrade-on-404). */
+    fun refreshOutput() {
+        val c = content() ?: return
+        val runId = c.runId ?: return
+        if (c.busy) return
+        _uiState.value = c.copy(busy = true, message = null)
+        viewModelScope.launch {
+            when (val r = repo.output(type, runId)) {
+                is ApiResult.Success -> _uiState.value =
+                    (content() ?: c).copy(
+                        busy = false,
+                        output = r.data,
+                        message = if (r.data == null) "No output for this run yet." else null,
+                    )
+                is ApiResult.Failure -> failAction(r.error.status, r.error.message)
+                is ApiResult.NetworkError -> failAction(0, OFFLINE)
+            }
+        }
+    }
+
+    fun loadMetrics() {
+        val c = content() ?: return
+        if (c.loadingMetrics) return
+        _uiState.value = c.copy(loadingMetrics = true)
+        viewModelScope.launch { loadMetricsInto() }
+    }
+
+    fun approve(notes: String?) = decide(approve = true, notes = notes)
+    fun reject(notes: String?) = decide(approve = false, notes = notes)
+
+    fun dismissMessage() {
+        content()?.let { _uiState.value = it.copy(message = null) }
+    }
+
+    // ---- internals ----
+
+    private fun decide(approve: Boolean, notes: String?) {
+        val c = content() ?: return
+        val runId = c.runId ?: return
+        if (c.busy || !AgentRunMath.canDecide(c.runState, type)) return
+        _uiState.value = c.copy(busy = true, message = null)
+        viewModelScope.launch {
+            when (val r = repo.decide(runId, approve, notes?.trim()?.ifBlank { null })) {
+                is ApiResult.Success -> _uiState.value = transitionState(
+                    (content() ?: c).copy(busy = false, decision = r.data),
+                    if (approve) RunEvent.Approve else RunEvent.Reject,
+                )
+                is ApiResult.Failure -> failAction(r.error.status, r.error.message)
+                is ApiResult.NetworkError -> failAction(0, OFFLINE)
+            }
+        }
+    }
+
+    private fun loadReport(runId: String) {
+        viewModelScope.launch {
+            val r = repo.report(runId)
+            if (r is ApiResult.Success) {
+                content()?.let { _uiState.value = it.copy(report = r.data) }
+            }
+        }
+    }
+
+    private suspend fun loadMetricsInto() {
+        when (val r = repo.metrics(type, typeId, periodDays = 30)) {
+            is ApiResult.Success -> content()?.let {
+                _uiState.value = it.copy(metrics = r.data, loadingMetrics = false)
+            }
+            is ApiResult.Failure -> {
+                if (r.error.status == HTTP_UNAUTHORIZED) _effects.send(AgentRunEffect.NavigateToLogin)
+                content()?.let { _uiState.value = it.copy(loadingMetrics = false) }
+            }
+            is ApiResult.NetworkError -> content()?.let { _uiState.value = it.copy(loadingMetrics = false) }
+        }
+    }
+
+    private fun failAction(status: Int, message: String) {
+        if (status == HTTP_UNAUTHORIZED) viewModelScope.launch { _effects.send(AgentRunEffect.NavigateToLogin) }
+        content()?.let { _uiState.value = it.copy(busy = false, message = message) }
+    }
+
+    private fun failExecute(status: Int, message: String) {
+        if (status == HTTP_UNAUTHORIZED) viewModelScope.launch { _effects.send(AgentRunEffect.NavigateToLogin) }
+        content()?.let { _uiState.value = transitionState(it.copy(busy = false, message = message), RunEvent.Error) }
+    }
+
+    private inline fun transition(event: RunEvent, transform: (AgentRunUiState.Content) -> AgentRunUiState.Content) {
+        val c = content() ?: return
+        _uiState.value = transitionState(transform(c), event)
+    }
+
+    private fun transitionState(
+        c: AgentRunUiState.Content,
+        event: RunEvent,
+        awaitingApproval: Boolean = false,
+    ): AgentRunUiState.Content =
+        c.copy(runState = AgentRunMath.nextState(c.runState, event, awaitingApproval))
+
+    private fun content(): AgentRunUiState.Content? = _uiState.value as? AgentRunUiState.Content
+
+    private fun baseContent() = AgentRunUiState.Content(
+        type = type,
+        typeId = typeId,
+        runState = RunState.IDLE,
+    )
+
+    companion object {
+        const val ARG_TYPE = "type"
+        const val ARG_TYPE_ID = "typeId"
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+        private const val OFFLINE = "Couldn't reach the server. Tap retry."
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunHubScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunHubScreen.kt
@@ -1,0 +1,100 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.agents.run.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.SmartToy
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.testlogon.android.data.agentrun.AgentRunType
+
+/**
+ * AGENT-RUN (web-parity) - landing hub for the run console: lists the six executable agent types + an optional
+ * typeId override (defaults to the type name, matching the AgentConfig hub idiom), then drills into the ONE
+ * parametrized [AgentRunConsoleScreen] keyed by {type}/{typeId}.
+ */
+object AgentRunHubTestTags {
+    const val SCREEN = "agent_run_hub_screen"
+    fun row(typeName: String) = "agent_run_hub_row_$typeName"
+}
+
+@Composable
+fun AgentRunHubRoute(
+    onBack: () -> Unit,
+    onOpen: (type: String, typeId: String) -> Unit,
+) {
+    var typeId by remember { mutableStateOf("") }
+    Scaffold(
+        modifier = Modifier.testTag(AgentRunHubTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Agent run console") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Card(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Agent type id (optional)")
+                    OutlinedTextField(
+                        value = typeId,
+                        onValueChange = { typeId = it },
+                        placeholder = { Text("defaults to the type name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(AgentRunType.entries.toList(), key = { it.typeName }) { type ->
+                    val resolved = typeId.trim().ifBlank { type.typeName }
+                    ListItem(
+                        headlineContent = { Text(type.title) },
+                        supportingContent = { Text("type: ${type.typeName}") },
+                        leadingContent = { Icon(Icons.Outlined.SmartToy, contentDescription = null) },
+                        trailingContent = {
+                            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(AgentRunHubTestTags.row(type.typeName))
+                            .clickable { onOpen(type.typeName, resolved) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/run/ui/AgentRunUiState.kt
@@ -1,0 +1,46 @@
+package com.testlogon.android.feature.agents.run.ui
+
+import com.testlogon.android.data.agentrun.AgentRunOutput
+import com.testlogon.android.data.agentrun.AgentRunType
+import com.testlogon.android.data.agentrun.DeploymentDecision
+import com.testlogon.android.data.agentrun.EligibleTicket
+import com.testlogon.android.data.agentrun.PmOperation
+import com.testlogon.android.data.agentrun.RunMetrics
+import com.testlogon.android.data.agentrun.RunReport
+import com.testlogon.android.data.agentrun.RunState
+
+/**
+ * AGENT-RUN (web-parity) - UI state + effect for the generic agent-run console (mobile mirror of the web
+ * *RunOutputPanel / DeploymentApprovalPanel family). One [Content] state carries the whole run lifecycle for
+ * the chosen [type] + typeId.
+ */
+sealed interface AgentRunUiState {
+    data object Loading : AgentRunUiState
+
+    /** The backend 403'd every call (non-operator). Distinct so the console shows an operator-only notice. */
+    data object Forbidden : AgentRunUiState
+
+    data class Content(
+        val type: AgentRunType,
+        val typeId: String,
+        val runState: RunState,
+        val eligibleTickets: List<EligibleTicket> = emptyList(),
+        val loadingTickets: Boolean = false,
+        val selectedTicketId: String? = null,
+        val pmOperation: PmOperation = PmOperation.IDEA_TRIAGE,
+        val runId: String? = null,
+        val output: AgentRunOutput? = null,
+        val report: RunReport? = null,
+        val metrics: RunMetrics? = null,
+        val loadingMetrics: Boolean = false,
+        val decision: DeploymentDecision? = null,
+        val busy: Boolean = false,
+        val message: String? = null,
+    ) : AgentRunUiState
+
+    data class Error(val message: String) : AgentRunUiState
+}
+
+sealed interface AgentRunEffect {
+    data object NavigateToLogin : AgentRunEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/more/MoreCatalog.kt
@@ -889,6 +889,15 @@ class MoreCatalog @Inject constructor() {
             operatorOnly = true,
         ),
         MoreEntry(
+            id = "agent_run",
+            labelRes = R.string.more_entry_agent_run,
+            icon = Icons.Outlined.SmartToy,
+            route = MoreRoutes.AGENT_RUN,
+            hub = MoreHub.SUPPORT,
+            section = MoreSection.SUPPORT,
+            operatorOnly = true,
+        ),
+        MoreEntry(
             id = "agent_types",
             labelRes = R.string.more_entry_agent_types,
             icon = Icons.Outlined.SmartToy,

--- a/android/app/src/main/java/com/testlogon/android/navigation/AgentRunNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AgentRunNavigation.kt
@@ -1,0 +1,60 @@
+package com.testlogon.android.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.core.model.LogoutReason
+import com.testlogon.android.feature.agents.run.ui.AgentRunConsoleRoute
+import com.testlogon.android.feature.agents.run.ui.AgentRunConsoleViewModel
+import com.testlogon.android.feature.agents.run.ui.AgentRunHubRoute
+
+/**
+ * AGENT-RUN (web-parity) - destinations for the generic agent-run CONSOLE (mobile mirror of the web
+ * *RunOutputPanel / DeploymentApprovalPanel family). A hub ([AgentRunHubDest]) lists the six executable agent
+ * types + a typeId override; drilling in opens the ONE parametrized console ([AgentRunConsoleDest]) keyed by
+ * {type}/{typeId}. Reached from the More hub under Support (operator-gated: hidden from non-operators, and the
+ * backend 403s -> Forbidden state). Registered inside the existing agents feature graph (no new nav-route
+ * literal beyond these two, which live under the "agent-run" prefix).
+ */
+data object AgentRunHubDest {
+    const val ROUTE = "agent-run"
+}
+
+data object AgentRunConsoleDest {
+    const val ARG_TYPE = AgentRunConsoleViewModel.ARG_TYPE
+    const val ARG_TYPE_ID = AgentRunConsoleViewModel.ARG_TYPE_ID
+    const val ROUTE_BASE = "agent-run/console"
+    const val ROUTE = "$ROUTE_BASE/{$ARG_TYPE}/{$ARG_TYPE_ID}"
+
+    fun route(type: String, typeId: String): String =
+        "$ROUTE_BASE/$type/${typeId.ifBlank { type }}"
+}
+
+fun NavGraphBuilder.agentRunDestinations(navController: NavHostController) {
+    composable(AgentRunHubDest.ROUTE) {
+        AgentRunHubRoute(
+            onBack = { navController.popBackStack() },
+            onOpen = { type, typeId ->
+                navController.navigate(AgentRunConsoleDest.route(type, typeId)) { launchSingleTop = true }
+            },
+        )
+    }
+    composable(
+        route = AgentRunConsoleDest.ROUTE,
+        arguments = listOf(
+            navArgument(AgentRunConsoleDest.ARG_TYPE) { type = NavType.StringType },
+            navArgument(AgentRunConsoleDest.ARG_TYPE_ID) { type = NavType.StringType },
+        ),
+    ) {
+        AgentRunConsoleRoute(
+            onBack = { navController.popBackStack() },
+            onNavigateToLogin = {
+                navController.navigate(AuthDest.Login.build(LogoutReason.SESSION_EXPIRED.name)) {
+                    launchSingleTop = true
+                }
+            },
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AuthenticatedGraph.kt
@@ -425,6 +425,8 @@ fun NavGraphBuilder.authenticatedGraph(navController: NavHostController) {
         agentConfigDestinations(navController)
         // AGENTS-BASICS web-parity: workers (list/detail/create) + LLM keys + fleet + agent-types picker.
         agentsBasicsDestinations(navController)
+        // AGENT-RUN web-parity: generic agent-run console (hub -> per-type run console).
+        agentRunDestinations(navController)
         // B4 web-parity: Stylist / UI-design agent (overview + rules + review detail).
         stylistDestinations(navController)
         // B4 web-parity: Marketing content agent (dashboard + editor + calendar + engagement).

--- a/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/MoreRoutes.kt
@@ -251,6 +251,8 @@ object MoreRoutes {
     const val IDEAS = IdeasDest.ROUTE
     const val LICENSES = LicensesDest.ROUTE
     const val AGENT_CONFIGS = AgentConfigsHubDest.ROUTE
+    // AGENT-RUN web-parity: generic agent-run console hub (execute + approve/reject). operatorOnly.
+    const val AGENT_RUN = AgentRunHubDest.ROUTE
 
     // AGENTS-BASICS web-parity: workers (list/detail/sessions + create). require_ui_session (usable).
     val WORKERS: String get() = WorkersListDest.ROUTE
@@ -729,6 +731,7 @@ object MoreRoutes {
             IDEAS,
             LICENSES,
             AGENT_CONFIGS,
+            AGENT_RUN,
             WORKERS,
             LLM_KEYS,
             FLEET,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4820,6 +4820,7 @@
     <!-- web-route parity batch: ideas / licenses / watch-parties / bots -->
     <string name="more_entry_ideas">Ideas</string>
     <string name="more_entry_agent_configs">Agent Type Configs</string>
+    <string name="more_entry_agent_run">Agent Run Console</string>
     <string name="more_entry_workers">Agent Workers</string>
     <string name="more_entry_llm_keys">LLM Keys</string>
     <string name="more_entry_fleet">Agent Fleet</string>

--- a/android/app/src/test/java/com/testlogon/android/data/agentrun/AgentRunMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/agentrun/AgentRunMathTest.kt
@@ -1,0 +1,262 @@
+package com.testlogon.android.data.agentrun
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * AGENT-RUN (web-parity) - JVM unit tests for the PURE run-state machine + free-form-map output projection in
+ * [AgentRunMath]. No Android / coroutine / network deps.
+ */
+class AgentRunMathTest {
+
+    // ---- state machine ----
+
+    @Test
+    fun claimFromIdleGoesToClaimed() {
+        assertEquals(RunState.CLAIMED, AgentRunMath.nextState(RunState.IDLE, RunEvent.ClaimTicket))
+    }
+
+    @Test
+    fun executeFromClaimedGoesToExecuting() {
+        assertEquals(RunState.EXECUTING, AgentRunMath.nextState(RunState.CLAIMED, RunEvent.StartExecute))
+    }
+
+    @Test
+    fun executeDoneWithoutApprovalGoesToCompleted() {
+        assertEquals(
+            RunState.COMPLETED,
+            AgentRunMath.nextState(RunState.EXECUTING, RunEvent.ExecuteDone, awaitingApproval = false),
+        )
+    }
+
+    @Test
+    fun executeDoneWithApprovalGoesToAwaiting() {
+        assertEquals(
+            RunState.AWAITING_APPROVAL,
+            AgentRunMath.nextState(RunState.EXECUTING, RunEvent.ExecuteDone, awaitingApproval = true),
+        )
+    }
+
+    @Test
+    fun approveOnlyFromAwaiting() {
+        assertEquals(RunState.APPROVED, AgentRunMath.nextState(RunState.AWAITING_APPROVAL, RunEvent.Approve))
+        // illegal from COMPLETED -> unchanged
+        assertEquals(RunState.COMPLETED, AgentRunMath.nextState(RunState.COMPLETED, RunEvent.Approve))
+    }
+
+    @Test
+    fun rejectOnlyFromAwaiting() {
+        assertEquals(RunState.REJECTED, AgentRunMath.nextState(RunState.AWAITING_APPROVAL, RunEvent.Reject))
+    }
+
+    @Test
+    fun resetAlwaysReturnsToIdle() {
+        assertEquals(RunState.IDLE, AgentRunMath.nextState(RunState.AWAITING_APPROVAL, RunEvent.Reset))
+        assertEquals(RunState.IDLE, AgentRunMath.nextState(RunState.EXECUTING, RunEvent.Reset))
+    }
+
+    @Test
+    fun errorAndNotFoundAlwaysAccepted() {
+        assertEquals(RunState.ERROR, AgentRunMath.nextState(RunState.EXECUTING, RunEvent.Error))
+        assertEquals(RunState.NOT_FOUND, AgentRunMath.nextState(RunState.CLAIMED, RunEvent.NotFound))
+    }
+
+    @Test
+    fun canExecuteRules() {
+        assertTrue(AgentRunMath.canExecute(RunState.CLAIMED, AgentRunType.CODER))
+        assertFalse(AgentRunMath.canExecute(RunState.EXECUTING, AgentRunType.CODER))
+        assertFalse(AgentRunMath.canExecute(RunState.IDLE, AgentRunType.CODER))
+        // PM is operation-driven -> executable from IDLE
+        assertTrue(AgentRunMath.canExecute(RunState.IDLE, AgentRunType.PM))
+    }
+
+    @Test
+    fun canDecideOnlyDevopsAwaiting() {
+        assertTrue(AgentRunMath.canDecide(RunState.AWAITING_APPROVAL, AgentRunType.DEVOPS))
+        assertFalse(AgentRunMath.canDecide(RunState.AWAITING_APPROVAL, AgentRunType.CODER))
+        assertFalse(AgentRunMath.canDecide(RunState.COMPLETED, AgentRunType.DEVOPS))
+    }
+
+    @Test
+    fun pmExecutesFromIdle() {
+        assertEquals(RunState.EXECUTING, AgentRunMath.nextState(RunState.IDLE, RunEvent.StartExecute))
+    }
+
+    @Test
+    fun buildRunIdIsDeterministic() {
+        assertEquals("run_coder_42", AgentRunMath.buildRunId(AgentRunType.CODER, 42L))
+        assertEquals("run_devops_7", AgentRunMath.buildRunId(AgentRunType.DEVOPS, 7L))
+    }
+
+    // ---- output projection ----
+
+    @Test
+    fun parseCoderOutputLiftsBranchFilesAndTests() {
+        val raw = mapOf(
+            "branch_name" to "feat/ABC-1",
+            "pr_url" to "https://x/pr/9",
+            "pr_number" to 9.0,
+            "files_changed" to listOf("a.kt", "b.kt"),
+            "insertions" to 10.0,
+            "deletions" to 3.0,
+            "test_results" to listOf(
+                mapOf("command" to "just test", "exit_code" to 0.0, "duration_seconds" to 12.0),
+            ),
+            "total_duration_seconds" to 120.0,
+            "escalated" to false,
+        )
+        val out = AgentRunMath.parseOutput(AgentRunType.CODER, raw)
+        assertEquals("feat/ABC-1", out.headline)
+        assertEquals("https://x/pr/9", out.prUrl)
+        assertEquals(listOf("a.kt", "b.kt"), out.filesChanged)
+        assertEquals(10, out.insertions)
+        assertEquals(1, out.testResults.size)
+        assertTrue(out.testResults[0].passed)
+        assertEquals("pass", out.status)
+        assertTrue(out.extras.contains("PR #" to "9"))
+    }
+
+    @Test
+    fun parseCoderFailingTestGivesDoneStatus() {
+        val raw = mapOf(
+            "branch_name" to "b",
+            "test_results" to listOf(mapOf("command" to "t", "exit_code" to 1.0)),
+        )
+        val out = AgentRunMath.parseOutput(AgentRunType.CODER, raw)
+        assertFalse(out.testResults[0].passed)
+        assertEquals("done", out.status)
+    }
+
+    @Test
+    fun parseQaVerdictAndCounts() {
+        val raw = mapOf(
+            "verdict" to "fail",
+            "new_tests_pass_count" to 3.0,
+            "new_tests_fail_count" to 1.0,
+            "regression_tests_pass" to 40.0,
+            "regression_tests_fail" to 0.0,
+            "bug_ticket_ids" to listOf("BUG-1"),
+        )
+        val out = AgentRunMath.parseOutput(AgentRunType.QA, raw)
+        assertEquals("fail", out.status)
+        assertEquals("Verdict: fail", out.headline)
+        assertEquals(2, out.testResults.size)
+        assertTrue(out.extras.any { it.first == "Bugs filed" && it.second == "BUG-1" })
+    }
+
+    @Test
+    fun parseDevopsAwaitingApproval() {
+        val raw = mapOf(
+            "deployment_id" to "dep_1",
+            "status" to "pending_approval",
+            "environment" to "prod",
+            "steps_completed" to 2.0,
+            "steps_total" to 5.0,
+        )
+        val out = AgentRunMath.parseOutput(AgentRunType.DEVOPS, raw)
+        assertEquals("dep_1", out.headline)
+        assertTrue(out.awaitingApproval)
+        assertTrue(out.extras.contains("Environment" to "prod"))
+    }
+
+    @Test
+    fun parseDevopsSuccessNotAwaiting() {
+        val raw = mapOf("deployment_id" to "d", "status" to "success")
+        val out = AgentRunMath.parseOutput(AgentRunType.DEVOPS, raw)
+        assertFalse(out.awaitingApproval)
+        assertEquals("success", out.status)
+    }
+
+    @Test
+    fun parsePmCounts() {
+        val raw = mapOf(
+            "operation_type" to "idea_triage",
+            "ideas_processed" to 5.0,
+            "ideas_accepted" to 2.0,
+            "blockers_found" to 1.0,
+        )
+        val out = AgentRunMath.parseOutput(AgentRunType.PM, raw)
+        assertEquals("idea triage", out.headline)
+        assertTrue(out.extras.contains("Ideas processed" to "5"))
+        assertTrue(out.extras.contains("Blockers" to "1"))
+    }
+
+    @Test
+    fun parseArchitectSummary() {
+        val raw = mapOf(
+            "feature_ticket_id" to "FEAT-9",
+            "total_tickets" to 4.0,
+            "total_estimated_hours" to 12.5,
+            "decomposition_summary" to "split into 4",
+        )
+        val out = AgentRunMath.parseOutput(AgentRunType.ARCHITECT, raw)
+        assertEquals("Feature FEAT-9", out.headline)
+        assertEquals("decomposed", out.status)
+        assertTrue(out.extras.contains("Tickets created" to "4"))
+        assertTrue(out.extras.contains("Est. hours" to "12.5"))
+    }
+
+    @Test
+    fun parseOutputDegradesOnEmptyMap() {
+        val out = AgentRunMath.parseOutput(AgentRunType.CODER, emptyMap())
+        assertEquals("Coder run", out.headline)
+        assertEquals(0, out.insertions)
+        assertTrue(out.filesChanged.isEmpty())
+        assertNull(out.prUrl)
+    }
+
+    @Test
+    fun parseEligibleTicketsSkipsMalformed() {
+        val raw = mapOf(
+            "tickets" to listOf(
+                mapOf("ticket_id" to "T-1", "subject" to "s", "labels" to listOf("a"), "estimated_effort_hours" to 3.0),
+                mapOf("subject" to "no id"), // dropped
+                "not a map", // dropped
+            ),
+        )
+        val list = AgentRunMath.parseEligibleTickets(raw)
+        assertEquals(1, list.size)
+        assertEquals("T-1", list[0].ticketId)
+        assertEquals(3, list[0].estimatedEffortHours)
+        assertEquals(listOf("a"), list[0].labels)
+    }
+
+    @Test
+    fun parseMetricsRendersRatesAsPercent() {
+        val raw = mapOf(
+            "completed_count" to 12.0,
+            "failure_rate" to 0.25,
+            "avg_duration_seconds" to 90.5,
+        )
+        val rows = AgentRunMath.parseMetrics(raw).rows.toMap()
+        assertEquals("12", rows["Completed Count"])
+        assertEquals("25%", rows["Failure Rate"])
+        assertEquals("90.5", rows["Avg Duration Seconds"])
+    }
+
+    @Test
+    fun parseDecisionReadsFields() {
+        val raw = mapOf(
+            "run_id" to "run_x",
+            "deployment_id" to "dep_x",
+            "approval_status" to "approved",
+            "approved_by" to "op",
+            "notes" to "lgtm",
+        )
+        val d = AgentRunMath.parseDecision("fallback", raw)
+        assertEquals("run_x", d.runId)
+        assertEquals("approved", d.approvalStatus)
+        assertEquals("lgtm", d.notes)
+    }
+
+    @Test
+    fun asIntToleratesStringsAndDoubles() {
+        assertEquals(5, AgentRunMath.asInt("5"))
+        assertEquals(7, AgentRunMath.asInt(7.9))
+        assertEquals(0, AgentRunMath.asInt("nope"))
+        assertEquals(0, AgentRunMath.asInt(null))
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agentrun/AgentRunApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agentrun/AgentRunApi.kt
@@ -1,0 +1,193 @@
+package com.testlogon.android.core.network.agentrun
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * AGENT-RUN (web-parity) - Retrofit transport for the agent-run CONSOLE lifecycle across the six agent types
+ * (mirrors frontend/src/api/endpoints/{coder,qa,devops,architect,pm}Agent.ts). Transport only; the :app
+ * AgentRunRepository wraps every call into ApiResult and projects the free-form maps into display models.
+ *
+ * Like AgentConfigApi, every endpoint here is backend OPERATOR-gated (require_admin_or_root; the
+ * approve/reject and execute mutations are require_admin_or_root under CSRF). The signed-in non-operator test
+ * account gets 403 (surfaced as a Forbidden state). The shared authenticated OkHttp client attaches the
+ * session cookie + X-CSRF-Token via the global interceptors, so no per-call header is needed.
+ *
+ * The per-type output SHAPES diverge (CoderOutputOut vs QaOutputOut vs DevOpsOutputOut ...), so - exactly as
+ * AgentConfigApi does for config bodies - outputs / eligible-tickets / metrics are modeled as free-form
+ * Map<String, Any?> and projected by AgentRunMath. The one uniformly-shaped response (deployment
+ * approve/reject: { run_id, deployment_id, approval_status, approved_by, approved_at, notes }) is likewise a
+ * map so no per-type DTO is needed.
+ *
+ * Contract (relative paths, NO leading slash; {typeId} is the agent-type id):
+ *   GET  ui/agents/types/{typeId}/eligible-tickets?limit=            (coder)
+ *   GET  ui/agents/types/{typeId}/qa-eligible-tickets?limit=         (qa)
+ *   GET  ui/agents/types/{typeId}/devops-eligible-tickets?limit=     (devops)
+ *   GET  ui/agents/types/{typeId}/architect-eligible-tickets?limit=  (architect)
+ *   POST ui/agents/runs/{runId}/claim-ticket        { ticket_id }    (coder)
+ *   POST ui/agents/runs/{runId}/claim-qa-ticket     { ticket_id }    (qa)
+ *   POST ui/agents/types/{typeId}/runs/{runId}/execute       { ticket_id }              (coder)
+ *   POST ui/agents/types/{typeId}/runs/{runId}/execute-qa    { ticket_id, scenario }    (qa)
+ *   POST ui/agents/types/{typeId}/runs/{runId}/execute-devops{ ticket_id, ... }         (devops)
+ *   POST ui/agents/types/{typeId}/runs/{runId}/decompose     { ticket_id }              (architect)
+ *   POST ui/agents/types/{typeId}/runs/{runId}/pm-operation  { operation_type, ... }    (pm)
+ *   GET  ui/agents/runs/{runId}/{coder|qa|devops|architect|pm}-output
+ *   GET  ui/agents/runs/{runId}/qa-report
+ *   POST ui/agents/runs/{runId}/approve-deployment  { approved, approver_notes }
+ *   POST ui/agents/runs/{runId}/reject-deployment   { approved, approver_notes }
+ *   GET  ui/agents/{coder|qa|architect}/metrics?type_id=&period_days=
+ *   GET  ui/agents/{devops|pm}/metrics?type_id=&period_days=
+ */
+interface AgentRunApi {
+
+    // ---- Eligible tickets (per-type route) ----
+    @GET("ui/agents/types/{typeId}/eligible-tickets")
+    suspend fun coderEligibleTickets(
+        @Path("typeId") typeId: String,
+        @Query("limit") limit: Int,
+    ): Map<String, Any?>
+
+    @GET("ui/agents/types/{typeId}/qa-eligible-tickets")
+    suspend fun qaEligibleTickets(
+        @Path("typeId") typeId: String,
+        @Query("limit") limit: Int,
+    ): Map<String, Any?>
+
+    @GET("ui/agents/types/{typeId}/devops-eligible-tickets")
+    suspend fun devopsEligibleTickets(
+        @Path("typeId") typeId: String,
+        @Query("limit") limit: Int,
+    ): Map<String, Any?>
+
+    @GET("ui/agents/types/{typeId}/architect-eligible-tickets")
+    suspend fun architectEligibleTickets(
+        @Path("typeId") typeId: String,
+        @Query("limit") limit: Int,
+    ): Map<String, Any?>
+
+    // ---- Claim ----
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/runs/{runId}/claim-ticket")
+    suspend fun claimCoderTicket(
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/runs/{runId}/claim-qa-ticket")
+    suspend fun claimQaTicket(
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    // ---- Execute ----
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/types/{typeId}/runs/{runId}/execute")
+    suspend fun executeCoder(
+        @Path("typeId") typeId: String,
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/types/{typeId}/runs/{runId}/execute-qa")
+    suspend fun executeQa(
+        @Path("typeId") typeId: String,
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/types/{typeId}/runs/{runId}/execute-devops")
+    suspend fun executeDevops(
+        @Path("typeId") typeId: String,
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/types/{typeId}/runs/{runId}/decompose")
+    suspend fun decomposeArchitect(
+        @Path("typeId") typeId: String,
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/types/{typeId}/runs/{runId}/pm-operation")
+    suspend fun runPmOperation(
+        @Path("typeId") typeId: String,
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    // ---- Output (per-type route) ----
+    @GET("ui/agents/runs/{runId}/coder-output")
+    suspend fun coderOutput(@Path("runId") runId: String): Map<String, Any?>
+
+    @GET("ui/agents/runs/{runId}/qa-output")
+    suspend fun qaOutput(@Path("runId") runId: String): Map<String, Any?>
+
+    @GET("ui/agents/runs/{runId}/devops-output")
+    suspend fun devopsOutput(@Path("runId") runId: String): Map<String, Any?>
+
+    @GET("ui/agents/runs/{runId}/architect-output")
+    suspend fun architectOutput(@Path("runId") runId: String): Map<String, Any?>
+
+    @GET("ui/agents/runs/{runId}/pm-output")
+    suspend fun pmOutput(@Path("runId") runId: String): Map<String, Any?>
+
+    // ---- QA markdown report ----
+    @GET("ui/agents/runs/{runId}/qa-report")
+    suspend fun qaReport(@Path("runId") runId: String): Map<String, Any?>
+
+    // ---- DevOps deployment approve / reject ----
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/runs/{runId}/approve-deployment")
+    suspend fun approveDeployment(
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/agents/runs/{runId}/reject-deployment")
+    suspend fun rejectDeployment(
+        @Path("runId") runId: String,
+        @Body body: Map<String, Any?>,
+    ): Map<String, Any?>
+
+    // ---- Metrics (per-type route) ----
+    @GET("ui/agents/coder/metrics")
+    suspend fun coderMetrics(
+        @Query("type_id") typeId: String,
+        @Query("period_days") periodDays: Int,
+    ): Map<String, Any?>
+
+    @GET("ui/agents/qa/metrics")
+    suspend fun qaMetrics(
+        @Query("type_id") typeId: String,
+        @Query("period_days") periodDays: Int,
+    ): Map<String, Any?>
+
+    @GET("ui/agents/devops/metrics")
+    suspend fun devopsMetrics(
+        @Query("type_id") typeId: String,
+        @Query("period_days") periodDays: Int,
+    ): Map<String, Any?>
+
+    @GET("ui/agents/architect/metrics")
+    suspend fun architectMetrics(
+        @Query("type_id") typeId: String,
+        @Query("period_days") periodDays: Int,
+    ): Map<String, Any?>
+
+    @GET("ui/agents/pm/metrics")
+    suspend fun pmMetrics(
+        @Query("type_id") typeId: String,
+        @Query("period_days") periodDays: Int,
+    ): Map<String, Any?>
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agentrun/AgentRunNetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agentrun/AgentRunNetworkModule.kt
@@ -1,0 +1,23 @@
+package com.testlogon.android.core.network.agentrun
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * AGENT-RUN (web-parity) - Hilt wiring for the agent-run console transport. Provides [AgentRunApi] from the
+ * shared singleton [Retrofit] (reusing the global OkHttp cookie-jar / CSRF / 401-refresh + shared Moshi; no
+ * new Retrofit/OkHttp/Moshi/dependency). Mirrors AgentConfigNetworkModule.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object AgentRunNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideAgentRunApi(retrofit: Retrofit): AgentRunApi =
+        retrofit.create(AgentRunApi::class.java)
+}


### PR DESCRIPTION
## FE parity PAR-150 - Android agent execution

Brings the Android app to web parity for the agent-execution surface (coder / QA / DevOps / architect / PM / docs roles).

### What changed
- New agent-run hub + console screens with view model and UI state.
- Data, repository, and network layers for agent runs (with unit-tested math).
- Wired into the More catalog, navigation graph, routes, and strings behind the feature gate.

### Testing
- `:app:assembleDebug` and `:app:testDebugUnitTest` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
